### PR TITLE
kvclient: metamorphically enable write buffering

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant
@@ -1,5 +1,8 @@
 # LogicTest: 3node-tenant
 
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 # Create a table, write a row, lock it, then switch users.
 statement ok
 CREATE TABLE t (k STRING PRIMARY KEY, v STRING, FAMILY (k,v))
@@ -34,6 +37,9 @@ let $root_session
 SHOW session_id
 
 user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
 
 let $testuser_session
 SHOW session_id

--- a/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant_write_buffering
+++ b/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant_write_buffering
@@ -1,0 +1,267 @@
+# LogicTest: 3node-tenant
+
+# Create a table, write a row, lock it, then switch users.
+statement ok
+CREATE TABLE t (k STRING PRIMARY KEY, v STRING, FAMILY (k,v))
+
+statement ok
+GRANT ALL ON t TO testuser
+
+statement ok
+INSERT INTO t VALUES ('a', 'val1'), ('b', 'val2'), ('c', 'val3'), ('l', 'val4'), ('m', 'val5'), ('p', 'val6'), ('s', 'val7'), ('t', 'val8'), ('z', 'val9')
+
+# Also create an additional user with VIEWACTIVITYREDACTED, with only permissions on t
+statement ok
+CREATE USER testuser2 WITH VIEWACTIVITYREDACTED
+
+statement ok
+GRANT ALL ON t TO testuser2
+
+statement ok
+CREATE TABLE t2 (k STRING PRIMARY KEY, v STRING, FAMILY (k,v))
+
+statement ok
+INSERT INTO t2 VALUES ('a', 'val1'), ('b', 'val2')
+
+# Start txn1 where we acquire replicated locks
+statement ok
+BEGIN PRIORITY HIGH
+
+statement ok
+UPDATE t SET v = '_updated' WHERE k >= 'b' AND k < 'x'
+
+let $root_session
+SHOW session_id
+
+user testuser
+
+let $testuser_session
+SHOW session_id
+
+statement ok
+BEGIN
+
+# switch back to root, collect data needed for validation
+user root
+
+let $txn1
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$root_session'
+
+let $txn2
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$testuser_session'
+
+user testuser
+
+query TT async,rowsort readReq
+SELECT * FROM t
+----
+a   val1
+b   _updated
+c   _updated
+l   _updated
+m   _updated
+p   _updated
+s   _updated
+t   _updated
+z   val9
+
+user root
+
+query TTT colnames,retry
+SELECT user_name, query, phase FROM crdb_internal.cluster_queries WHERE txn_id='$txn2'
+----
+user_name   query             phase
+testuser    SELECT * FROM t   executing
+
+# looking at each transaction separately, validate the expected results in the lock table
+query TTTTTTTBB colnames,rowsort,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
+FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn1'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true     true
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"l"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"m"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"p"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"s"/0  Intent          Replicated   SERIALIZABLE      true     false
+test          public      t           /Table/106/1/"t"/0  Intent          Replicated   SERIALIZABLE      true     false
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
+FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn2'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
+test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+
+# check that we can't see keys, potentially revealing PII, with VIEWACTIVITYREDACTED
+user testuser2
+
+query TTTTTTTBB colnames,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
+FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn1'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+
+user root
+
+query I
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+8
+
+statement ok
+COMMIT
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+0
+
+user testuser
+
+awaitquery readReq
+
+statement ok
+COMMIT
+
+user root
+
+# start txn3
+statement ok
+BEGIN
+
+user testuser
+
+# start txn4
+statement ok
+BEGIN
+
+user root
+
+query TT rowsort
+SELECT * FROM t FOR UPDATE
+----
+a   val1
+b   _updated
+c   _updated
+l   _updated
+m   _updated
+p   _updated
+s   _updated
+t   _updated
+z   val9
+
+let $txn3
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$root_session'
+
+let $txn4
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$testuser_session'
+
+user testuser
+
+statement async deleteReq count 7
+DELETE FROM t WHERE k >= 'b' AND k < 'x'
+
+user root
+
+query TTT colnames,retry
+SELECT user_name, query, phase FROM crdb_internal.cluster_queries WHERE txn_id='$txn4'
+----
+user_name  query                                         phase
+testuser   DELETE FROM t WHERE (k >= 'b') AND (k < 'x')  executing
+
+# looking at each transaction separately, validate the expected results in the lock table
+query TTTTTTTBB colnames,rowsort,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn3'
+----
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"a"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"z"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+
+query TTTTTTTBB colnames,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn4'
+----
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     false    true
+
+query I
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+10
+
+statement ok
+ROLLBACK
+
+user testuser
+
+awaitstatement deleteReq
+
+statement ok
+COMMIT
+
+user root
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+0
+
+# validate that only locks on keys in privileged tables can be seen
+statement ok
+BEGIN
+
+query TT rowsort
+SELECT * FROM t FOR UPDATE
+----
+a   val1
+z   val9
+
+query TT rowsort
+SELECT * FROM t2 FOR UPDATE
+----
+a   val1
+b   val2
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name IN ('t','t2')
+----
+4
+
+user testuser
+
+query error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+
+user testuser2
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name IN ('t', 't2')
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability    isolation_level   granted contended
+test          public      t           ·                   Exclusive       Unreplicated  SERIALIZABLE      true    false
+test          public      t           ·                   Exclusive       Unreplicated  SERIALIZABLE      true    false
+
+user root
+
+statement ok
+ROLLBACK
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name IN ('t','t2')
+----
+0

--- a/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant_write_buffering
+++ b/pkg/ccl/logictestccl/testdata/logic_test/cluster_locks_tenant_write_buffering
@@ -1,5 +1,8 @@
 # LogicTest: 3node-tenant
 
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
 # Create a table, write a row, lock it, then switch users.
 statement ok
 CREATE TABLE t (k STRING PRIMARY KEY, v STRING, FAMILY (k,v))
@@ -34,6 +37,9 @@ let $root_session
 SHOW session_id
 
 user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
 
 let $testuser_session
 SHOW session_id
@@ -78,21 +84,21 @@ query TTTTTTTBB colnames,rowsort,retry
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
 FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn1'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
-test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true     true
-test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"l"/0  Intent          Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"m"/0  Intent          Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"p"/0  Intent          Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"s"/0  Intent          Replicated   SERIALIZABLE      true     false
-test          public      t           /Table/106/1/"t"/0  Intent          Replicated   SERIALIZABLE      true     false
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query TTTTTTTBB colnames
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
 FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn2'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
-test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  None           Unreplicated  SERIALIZABLE     false    true
 
 # check that we can't see keys, potentially revealing PII, with VIEWACTIVITYREDACTED
 user testuser2
@@ -101,14 +107,14 @@ query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended
 FROM crdb_internal.cluster_locks WHERE table_name='t' AND txn_id='$txn1'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted  contended
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    true
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability    isolation_level  granted  contended
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 user root
 

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2724,6 +2724,13 @@ func TestTenantLogicCCL_cluster_locks_tenant(
 	runCCLLogicTest(t, "cluster_locks_tenant")
 }
 
+func TestTenantLogicCCL_cluster_locks_tenant_write_buffering(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "cluster_locks_tenant_write_buffering")
+}
+
 func TestTenantLogicCCL_crdb_internal_tenant(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -398,6 +398,13 @@ func TestReadCommittedLogic_cluster_locks(
 	runLogicTest(t, "cluster_locks")
 }
 
+func TestReadCommittedLogic_cluster_locks_write_buffering(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cluster_locks_write_buffering")
+}
+
 func TestReadCommittedLogic_cluster_settings(
 	t *testing.T,
 ) {

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
+        "//pkg/util/log",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/capabilities_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -53,6 +54,7 @@ import (
 // update.
 func TestDataDriven(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
 	datadriven.Walk(t, datapathutils.TestDataPath(t), func(t *testing.T, path string) {
 		ctx := context.Background()
 

--- a/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
+++ b/pkg/ccl/multitenantccl/tenantcapabilitiesccl/testdata/can_prepare_txns
@@ -3,6 +3,12 @@ SELECT * FROM [SHOW TENANT [10] WITH CAPABILITIES] WHERE capability_name = 'can_
 ----
 10 cluster-10 ready external can_prepare_txns false
 
+# TODO(#144252): remove this.
+exec-sql-tenant
+SET kv_transaction_buffered_writes_enabled = false
+----
+ok
+
 exec-sql-tenant
 CREATE TABLE t(a INT PRIMARY KEY)
 ----

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/errors"
 )
 
@@ -31,7 +32,7 @@ var BufferedWritesEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.enabled",
 	"if enabled, transactional writes are buffered on the client",
-	false,
+	metamorphic.ConstantWithTestBool("kv.transactional.write_buffering.enabled", false /* defaultValue */),
 	settings.WithPublic,
 )
 

--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -95,7 +95,6 @@ func (ex *connExecutor) maybeAdjustTxnForDDL(ctx context.Context, stmt Statement
 	if tree.CanModifySchema(ast) {
 		if ex.state.mu.txn.BufferedWritesEnabled() {
 			ex.state.mu.txn.SetBufferedWritesEnabled(false /* enabled */)
-			p.BufferClientNotice(ctx, pgnotice.Newf("disabling buffered writes on the current txn due to schema change"))
 		}
 	}
 	return nil

--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -1782,6 +1782,9 @@ func TestAbortedTxnLocks(t *testing.T) {
 	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
 
+	// TODO(#146238): either remove this or leave a comment for why it's ok.
+	s.SQLConn(t).QueryRow("SET CLUSTER SETTING kv.transaction.write_buffering.enabled = false")
+
 	var TransactionStatus string
 
 	conn1, err := s.SQLConn(t).Conn(ctx)

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks
@@ -1,5 +1,8 @@
 # LogicTest: local-read-committed
 
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 # This test uses local-read-committed so that it can also test locking behavior
 # with READ COMMITTED transactions. However, we'll use a default of SERIALIZABLE
 # for all transactions.
@@ -55,6 +58,9 @@ let $root_session
 SHOW session_id
 
 user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
 
 statement ok
 SET default_transaction_isolation = 'SERIALIZABLE'

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks_write_buffering
@@ -1,0 +1,427 @@
+# LogicTest: local-read-committed
+
+# This test uses local-read-committed so that it can also test locking behavior
+# with READ COMMITTED transactions. However, we'll use a default of SERIALIZABLE
+# for all transactions.
+statement ok
+SET default_transaction_isolation = 'SERIALIZABLE'
+
+# Create a table, write a row, lock it, then switch users.
+statement ok
+CREATE TABLE t (k STRING PRIMARY KEY, v STRING, FAMILY (k,v))
+
+statement ok
+GRANT ALL ON t TO testuser
+
+statement ok
+INSERT INTO t VALUES ('a', 'val1'), ('b', 'val2'), ('c', 'val3'), ('l', 'val4'), ('m', 'val5'), ('p', 'val6'), ('s', 'val7'), ('t', 'val8'), ('z', 'val9')
+
+query TTT colnames,nosort
+ALTER TABLE t SPLIT AT VALUES ('d'), ('r')
+----
+key                   pretty  split_enforced_until
+[242 137 18 100 0 1]  /"d"    2262-04-11 23:47:16.854776 +0000 +0000
+[242 137 18 114 0 1]  /"r"    2262-04-11 23:47:16.854776 +0000 +0000
+
+query TTTI colnames,rowsort
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE t WITH DETAILS]
+----
+start_key           end_key       replicas  lease_holder
+<before:/Table/72>  …/1/"d"       {1}       1
+…/1/"d"             …/1/"r"       {1}       1
+…/1/"r"             <after:/Max>  {1}       1
+
+# Also create an additional user with VIEWACTIVITYREDACTED, with only permissions on t
+statement ok
+CREATE USER testuser2 WITH VIEWACTIVITYREDACTED
+
+statement ok
+GRANT ALL ON t TO testuser2
+
+statement ok
+CREATE TABLE t2 (k STRING PRIMARY KEY, v STRING, FAMILY (k,v))
+
+statement ok
+INSERT INTO t2 VALUES ('a', 'val1'), ('b', 'val2')
+
+# Start txn1 where we acquire replicated locks
+statement ok
+BEGIN PRIORITY HIGH
+
+statement ok
+UPDATE t SET v = '_updated' WHERE k >= 'b' AND k < 'x'
+
+let $root_session
+SHOW session_id
+
+user testuser
+
+statement ok
+SET default_transaction_isolation = 'SERIALIZABLE'
+
+let $testuser_session
+SHOW session_id
+
+statement ok
+BEGIN
+
+# switch back to root, collect data needed for validation
+user root
+
+let $txn1
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$root_session'
+
+let $txn2
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$testuser_session'
+
+let $r1
+SELECT range_id FROM [SHOW RANGES FROM TABLE t] WHERE end_key LIKE '%/"d"'
+
+let $r2
+SELECT range_id FROM [SHOW RANGES FROM TABLE t] WHERE end_key LIKE '%/"r"'
+
+let $r3
+SELECT range_id FROM [SHOW RANGES FROM TABLE t] WHERE end_key LIKE '%Max%'
+
+user testuser
+
+query TT async,rowsort readReq
+SELECT * FROM t
+----
+a   val1
+b   _updated
+c   _updated
+l   _updated
+m   _updated
+p   _updated
+s   _updated
+t   _updated
+z   val9
+
+user root
+
+query TTT colnames,retry
+SELECT user_name, query, phase FROM crdb_internal.cluster_queries WHERE txn_id='$txn2'
+----
+user_name   query             phase
+testuser    SELECT * FROM t   executing
+
+# looking at each range and transaction separately, validate the expected results in the lock table
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn2'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+
+# since SQL incorporates limits which disables parallel batches, the select from txn2 will not reach subsequent ranges.
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r2 AND txn_id='$txn1'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r2 AND txn_id='$txn2'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r3 AND txn_id='$txn1'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r3 AND txn_id='$txn2'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+
+# check that we can't see keys, potentially revealing PII, with VIEWACTIVITYREDACTED
+user testuser2
+
+query TTTTTTTBB colnames,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+
+user root
+
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name='test'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_id='t'::regclass::oid::int
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE contended=true AND lock_key_pretty LIKE '/Table/106%'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+
+query TTTTTTTBB colnames,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE contended=false AND lock_key_pretty LIKE '/Table/106%'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+
+query I
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+3
+
+statement ok
+COMMIT
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+0
+
+user testuser
+
+awaitquery readReq
+
+statement ok
+COMMIT
+
+user root
+
+# start txn3
+statement ok
+BEGIN
+
+user testuser
+
+# start txn4
+statement ok
+BEGIN
+
+user root
+
+query TT rowsort
+SELECT * FROM t FOR UPDATE
+----
+a   val1
+b   _updated
+c   _updated
+l   _updated
+m   _updated
+p   _updated
+s   _updated
+t   _updated
+z   val9
+
+let $txn3
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$root_session'
+
+let $txn4
+SELECT txns.id FROM crdb_internal.cluster_transactions txns WHERE txns.session_id = '$testuser_session'
+
+user testuser
+
+statement async deleteReq count 7
+DELETE FROM t WHERE k >= 'b' AND k < 'x'
+
+user root
+
+query TTT colnames,retry
+SELECT user_name, query, phase FROM crdb_internal.cluster_queries WHERE txn_id='$txn4'
+----
+user_name   query                                         phase
+testuser    DELETE FROM t WHERE (k >= 'b') AND (k < 'x')  executing
+
+# looking at each range and transaction separately, validate the expected results in the lock table
+query TTTTTTTBB colnames,retry,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn3'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability     isolation_level   granted contended
+test          public      t           /Table/106/1/"a"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"b"/0  Exclusive       Unreplicated   SERIALIZABLE      true    true
+test          public      t           /Table/106/1/"c"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn4'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability    isolation_level   granted contended
+test          public      t           /Table/106/1/"b"/0  Exclusive       Unreplicated  SERIALIZABLE      false   true
+
+query TTTTTTTBB colnames,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r2 AND txn_id='$txn3'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability     isolation_level   granted contended
+test          public      t           /Table/106/1/"l"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"m"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"p"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r2 AND txn_id='$txn4'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability     isolation_level   granted contended
+
+query TTTTTTTBB colnames,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r3 AND txn_id='$txn3'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability     isolation_level   granted contended
+test          public      t           /Table/106/1/"s"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"t"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+test          public      t           /Table/106/1/"z"/0  Exclusive       Unreplicated   SERIALIZABLE      true    false
+
+query TTTTTTTBB colnames
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r3 AND txn_id='$txn4'
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability     isolation_level   granted contended
+
+query I
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+10
+
+statement ok
+ROLLBACK
+
+user testuser
+
+awaitstatement deleteReq
+
+statement ok
+COMMIT
+
+user root
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+0
+
+# validate that only locks on keys in privileged tables can be seen
+statement ok
+BEGIN
+
+query TT rowsort
+SELECT * FROM t FOR UPDATE
+----
+a   val1
+z   val9
+
+query TT rowsort
+SELECT * FROM t2 FOR UPDATE
+----
+a   val1
+b   val2
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name IN ('t','t2')
+----
+4
+
+user testuser
+
+query error pq: user testuser does not have VIEWACTIVITY or VIEWACTIVITYREDACTED privilege
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks
+
+user testuser2
+
+query TTTTTTTBB colnames,rowsort
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name IN ('t', 't2')
+----
+database_name schema_name table_name  lock_key_pretty     lock_strength   durability     isolation_level   granted contended
+test          public      t           ·                   Exclusive       Unreplicated   SERIALIZABLE      true    false
+test          public      t           ·                   Exclusive       Unreplicated   SERIALIZABLE      true    false
+
+user root
+
+statement ok
+ROLLBACK
+
+query I retry
+SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name IN ('t','t2')
+----
+0
+
+# Test with different isolation levels.
+
+statement ok
+SET CLUSTER SETTING sql.txn.repeatable_read_isolation.enabled = true
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+SELECT * FROM t WHERE k = 'a' FOR UPDATE;
+
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
+
+statement async iso1
+SELECT * FROM t WHERE k = 'a' FOR UPDATE;
+
+user root
+
+query TTTTTTTBB colnames,rowsort,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, regexp_replace(isolation_level, 'READ COMMITTED', 'READ_COMMITTED') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability  isolation_level  granted  contended
+test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  READ_COMMITTED   true     true
+test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  SERIALIZABLE     false    true
+
+statement ok
+COMMIT
+
+user testuser
+
+awaitstatement iso1
+
+statement ok
+COMMIT
+
+user root
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL REPEATABLE READ;
+SELECT * FROM t WHERE k = 'a' FOR UPDATE;
+
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
+
+statement async iso2
+SELECT * FROM t WHERE k = 'a' FOR UPDATE;
+
+user root
+
+query TTTTTTTBB colnames,rowsort,retry
+SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, regexp_replace(isolation_level, ' ', '_') AS isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_name = 't'
+----
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability  isolation_level  granted  contended
+test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  REPEATABLE_READ  true     true
+test           public       t           /Table/106/1/"a"/0  Exclusive      Replicated  READ_COMMITTED   false    true
+
+statement ok
+COMMIT
+
+user testuser
+
+awaitstatement iso2
+
+statement ok
+COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/cluster_locks_write_buffering
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_locks_write_buffering
@@ -1,5 +1,8 @@
 # LogicTest: local-read-committed
 
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
 # This test uses local-read-committed so that it can also test locking behavior
 # with READ COMMITTED transactions. However, we'll use a default of SERIALIZABLE
 # for all transactions.
@@ -57,6 +60,9 @@ SHOW session_id
 user testuser
 
 statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
+statement ok
 SET default_transaction_isolation = 'SERIALIZABLE'
 
 let $testuser_session
@@ -110,32 +116,37 @@ testuser    SELECT * FROM t   executing
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
-test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query TTTTTTTBB colnames
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn2'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  None           Unreplicated  SERIALIZABLE     false    true
 
 # since SQL incorporates limits which disables parallel batches, the select from txn2 will not reach subsequent ranges.
 
-query TTTTTTTBB colnames
+query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r2 AND txn_id='$txn1'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query TTTTTTTBB colnames
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r2 AND txn_id='$txn2'
 ----
 database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
 
-query TTTTTTTBB colnames
+query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r3 AND txn_id='$txn1'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query TTTTTTTBB colnames
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r3 AND txn_id='$txn2'
@@ -148,45 +159,60 @@ user testuser2
 query TTTTTTTBB colnames,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE range_id=$r1 AND txn_id='$txn1'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    true
-test          public      t           ·                   Intent          Replicated   SERIALIZABLE      true    false
+database_name  schema_name  table_name  lock_key_pretty  lock_strength  durability    isolation_level  granted  contended
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           ·                Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 user root
 
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE database_name='test'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
-test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
-test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"b"/0  None           Unreplicated  SERIALIZABLE     false    true
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE table_id='t'::regclass::oid::int
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
-test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
-test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"b"/0  None           Unreplicated  SERIALIZABLE     false    true
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE contended=true AND lock_key_pretty LIKE '/Table/106%'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"b"/0  Intent          Replicated   SERIALIZABLE      true    true
-test          public      t           /Table/106/1/"b"/0  None            Replicated   SERIALIZABLE      false   true
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"b"/0  Exclusive      Unreplicated  SERIALIZABLE     true     true
+test           public       t           /Table/106/1/"b"/0  None           Unreplicated  SERIALIZABLE     false    true
 
-query TTTTTTTBB colnames,retry
+query TTTTTTTBB colnames,retry,rowsort
 SELECT database_name, schema_name, table_name, lock_key_pretty, lock_strength, durability, isolation_level, granted, contended FROM crdb_internal.cluster_locks WHERE contended=false AND lock_key_pretty LIKE '/Table/106%'
 ----
-database_name schema_name table_name  lock_key_pretty     lock_strength   durability   isolation_level   granted contended
-test          public      t           /Table/106/1/"c"/0  Intent          Replicated   SERIALIZABLE      true    false
+database_name  schema_name  table_name  lock_key_pretty     lock_strength  durability    isolation_level  granted  contended
+test           public       t           /Table/106/1/"c"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"l"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"m"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"p"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"s"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
+test           public       t           /Table/106/1/"t"/0  Exclusive      Unreplicated  SERIALIZABLE     true     false
 
 query I
 SELECT count(*) FROM crdb_internal.cluster_locks WHERE table_name = 't'
 ----
-3
+8
 
 statement ok
 COMMIT

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -1,3 +1,7 @@
+# TODO(#144279): remove this.
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;

--- a/pkg/sql/logictest/testdata/logic_test/dist_vectorize
+++ b/pkg/sql/logictest/testdata/logic_test/dist_vectorize
@@ -102,10 +102,10 @@ SELECT 1::INT2, s COLLATE en FROM t66306;
 ----
 1  foo
 
-# Always enable the direct columnar scans to make the output below
+# Always disable the direct columnar scans to make the output below
 # deterministic.
 statement ok
-SET direct_columnar_scans_enabled = true
+SET direct_columnar_scans_enabled = false
 
 # Sanity check that the wrapped processor is planned for the query above. If it
 # no longer is, we should adjust the query here and above.
@@ -119,7 +119,7 @@ EXPLAIN (VEC) SELECT 1::INT2, s COLLATE en FROM t66306;
   └ *colrpc.Outbox
     └ *colexecbase.castIntInt2Op
       └ *rowexec.noopProcessor
-        └ *colfetcher.ColBatchDirectScan
+        └ *colfetcher.ColBatchScan
 
 statement ok
 RESET direct_columnar_scans_enabled

--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -68,10 +68,10 @@ start_key                 end_key       replicas  lease_holder
 <before:/Table/109/1/20>  …/1/0         {3}       3
 …/1/20                    <after:/Max>  {3}       3
 
-# Always enable the direct columnar scans to make the output below
+# Always disable the direct columnar scans to make the output below
 # deterministic.
 statement ok
-SET direct_columnar_scans_enabled = true
+SET direct_columnar_scans_enabled = false
 
 # Ensure that the join readers are planned on the remote nodes.
 query T
@@ -82,7 +82,7 @@ SELECT t1.x from t1 INNER LOOKUP JOIN t2 ON t1.x=t2.x WHERE t2.y='hello'
 ├ Node 1
 │ └ *colexec.ParallelUnorderedSynchronizer
 │   ├ *rowexec.joinReader
-│   │ └ *colfetcher.ColBatchDirectScan
+│   │ └ *colfetcher.ColBatchScan
 │   ├ *colrpc.Inbox
 │   └ *colrpc.Inbox
 ├ Node 2

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -3906,7 +3906,8 @@ WHERE
       'multiple_active_portals_enabled',
       'autocommit_before_ddl',
       'default_transaction_isolation',
-      'transaction_isolation'
+      'transaction_isolation',
+      'kv_transaction_buffered_writes_enabled'
     )
 ORDER BY variable
 ----
@@ -3998,7 +3999,6 @@ is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB
-kv_transaction_buffered_writes_enabled                     off
 large_full_scan_rows                                       0
 lc_collate                                                 C.UTF-8
 lc_ctype                                                   C.UTF-8

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2910,7 +2910,16 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem', 'copy_fast_path_enabled', 'direct_columnar_scans_enabled', 'multiple_active_portals_enabled')
+  name NOT IN (
+    'optimizer',
+    'crdb_version',
+    'session_id',
+    'distsql_workmem',
+    'copy_fast_path_enabled',
+    'direct_columnar_scans_enabled',
+    'multiple_active_portals_enabled',
+    'kv_transaction_buffered_writes_enabled'
+  )
 ORDER BY name
 ----
 name                                                       setting             category  short_desc  extra_desc  vartype
@@ -3004,7 +3013,6 @@ is_superuser                                               on                  N
 join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL      NULL        NULL        string
 join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL      NULL        NULL        string
 join_reader_ordering_strategy_batch_size                   100 KiB             NULL      NULL        NULL        string
-kv_transaction_buffered_writes_enabled                     off                 NULL      NULL        NULL        string
 large_full_scan_rows                                       0                   NULL      NULL        NULL        string
 lc_collate                                                 C.UTF-8             NULL      NULL        NULL        string
 lc_ctype                                                   C.UTF-8             NULL      NULL        NULL        string
@@ -3131,7 +3139,16 @@ SELECT
 FROM
   pg_catalog.pg_settings
 WHERE
-  name NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem', 'copy_fast_path_enabled', 'direct_columnar_scans_enabled', 'multiple_active_portals_enabled')
+  name NOT IN (
+    'optimizer',
+    'crdb_version',
+    'session_id',
+    'distsql_workmem',
+    'copy_fast_path_enabled',
+    'direct_columnar_scans_enabled',
+    'multiple_active_portals_enabled',
+    'kv_transaction_buffered_writes_enabled'
+  )
 ORDER BY name
 ----
 name                                                       setting             unit  context  enumvals  boot_val            reset_val
@@ -3225,7 +3242,6 @@ is_superuser                                               on                  N
 join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL  user     NULL      4.0 MiB             4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL  user     NULL      2.0 MiB             2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB             NULL  user     NULL      100 KiB             100 KiB
-kv_transaction_buffered_writes_enabled                     off                 NULL  user     NULL      off                 off
 large_full_scan_rows                                       0                   NULL  user     NULL      0                   0
 lc_collate                                                 C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
 lc_ctype                                                   C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,3 +1,7 @@
+# TODO(#144279): remove this.
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 subtest lost_table_data
 
 # This test will intentionally corrupt descriptors, so the initial version

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -23,7 +23,17 @@ UTF8                1
 query TT colnames
 SELECT *
 FROM [SHOW ALL]
-WHERE variable NOT IN ('optimizer', 'crdb_version', 'session_id', 'distsql_workmem', 'copy_fast_path_enabled', 'direct_columnar_scans_enabled', 'multiple_active_portals_enabled')
+WHERE
+  variable NOT IN (
+    'optimizer',
+    'crdb_version',
+    'session_id',
+    'distsql_workmem',
+    'copy_fast_path_enabled',
+    'direct_columnar_scans_enabled',
+    'multiple_active_portals_enabled',
+    'kv_transaction_buffered_writes_enabled'
+  )
 ORDER BY variable
 ----
 variable                                                   value
@@ -117,7 +127,6 @@ is_superuser                                               on
 join_reader_index_join_strategy_batch_size                 4.0 MiB
 join_reader_no_ordering_strategy_batch_size                2.0 MiB
 join_reader_ordering_strategy_batch_size                   100 KiB
-kv_transaction_buffered_writes_enabled                     off
 large_full_scan_rows                                       0
 lc_collate                                                 C.UTF-8
 lc_ctype                                                   C.UTF-8

--- a/pkg/sql/logictest/testdata/logic_test/two_phase_commit
+++ b/pkg/sql/logictest/testdata/logic_test/two_phase_commit
@@ -1,5 +1,9 @@
 # LogicTest: !3node-tenant-default-configs !local-mixed-24.3
 
+# TODO(#144252): remove this.
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 query T
 SHOW max_prepared_transactions
 ----

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -1,3 +1,7 @@
+# TODO(#144278): remove this or adjust the test.
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 # Check that we auto-retry pushed transactions which can't be refreshed - if
 # they're pushed while we can still auto-retry them.
 subtest autoretry-on-push-first-batch

--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -52,6 +52,14 @@ SET CLUSTER SETTING kv.raft.command.max_size='4MiB';
 
 user root
 
+# We lowered max raft command size. If we were to keep the default value of
+# max buffer size of write buffering, we would hit an error when attempting to
+# flush the buffer along with the BatchRequest that would put it above the limit.
+# To prevent that, we reduce the max buffer size to be "in sync" with the max
+# raft command size.
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '1MiB';
+
 statement ok
 CREATE TABLE src (s STRING);
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/autocommit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/autocommit
@@ -6,6 +6,10 @@
 # Any change to the kv batches produced by these statements should be treated
 # with care.
 
+# Write buffering changes the trace, so we unconditionally enable it.
+statement ok
+SET kv_transaction_buffered_writes_enabled = true
+
 statement ok
 CREATE TABLE ab (a INT PRIMARY KEY, b INT, FAMILY f1 (a, b))
 
@@ -93,7 +97,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%QueryTxn%'
   AND message NOT LIKE '%ResolveIntent%'
 ----
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -170,8 +174,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
@@ -258,7 +262,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%QueryTxn%'
   AND message NOT LIKE '%ResolveIntent%'
 ----
-dist sender send  r74: sending batch 2 Put to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -310,8 +314,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 2 Put to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # Upsert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -337,8 +341,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 2 Put to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
@@ -403,7 +407,6 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%ResolveIntent%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 2 Put to (n1,s1):1
 
 statement ok
 ROLLBACK
@@ -457,8 +460,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 2 Put to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # Update with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -485,8 +487,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 2 Put to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 # Another way to test the scenario above: generate an error and ensure that the
 # mutation was not committed.
@@ -627,8 +628,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 2 Del to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 # Insert with RETURNING statement with side-effects should not auto-commit.
 # In this case division can (in principle) error out.
@@ -655,8 +655,7 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 2 Del to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 statement ok
 INSERT INTO ab VALUES (12, 0);
@@ -706,9 +705,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
 dist sender send  r74: sending batch 2 Get to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 2 Put, 1 EndTxn to (n1,s1):1
 
 query B
 SELECT count(*) > 0 FROM [
@@ -733,9 +732,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 1 Put to (n1,s1):1
 dist sender send  r74: sending batch 1 Get to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 1 Get to (n1,s1):1
+dist sender send  r74: sending batch 1 Put, 1 EndTxn to (n1,s1):1
 
 query B
 SELECT count(*) > 0 FROM [
@@ -761,9 +760,8 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND operation NOT LIKE '%async%'
 ----
 dist sender send  r74: sending batch 1 Get to (n1,s1):1
-dist sender send  r74: sending batch 1 Del to (n1,s1):1
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 1 Del, 1 EndTxn to (n1,s1):1
 
 # Test with a single cascade, which should use autocommit.
 statement ok
@@ -794,9 +792,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 1 Del to (n1,s1):1
+dist sender send  r74: sending batch 1 Get to (n1,s1):1
 dist sender send  r74: sending batch 1 Scan to (n1,s1):1
-dist sender send  r74: sending batch 1 Del, 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Del, 1 EndTxn to (n1,s1):1
 
 # -----------------------
 # Multiple mutation tests
@@ -827,9 +825,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 4 Put, 1 EndTxn to (n1,s1):1
 
 query B
 SELECT count(*) > 0 FROM [
@@ -855,9 +853,9 @@ WHERE message       LIKE '%r$rangeid: sending batch%'
   AND message   NOT LIKE '%ResolveIntent%'
   AND operation NOT LIKE '%async%'
 ----
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
-dist sender send  r74: sending batch 2 CPut to (n1,s1):1
-dist sender send  r74: sending batch 1 EndTxn to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 2 Get to (n1,s1):1
+dist sender send  r74: sending batch 4 Put, 1 EndTxn to (n1,s1):1
 
 # Check that the statement can still be auto-committed when the txn rows written
 # erring guardrail is enabled.

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -1,6 +1,10 @@
 # LogicTest: local
 # knob-opt: sync-event-log
 
+# Write buffering changes the trace, so we unconditionally enable it.
+statement ok
+SET kv_transaction_buffered_writes_enabled = true
+
 # Check SHOW KV TRACE FOR SESSION.
 
 let $trace_query
@@ -327,7 +331,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%PushTxn%'
   AND message NOT LIKE '%QueryTxn%'
 ----
-dist sender send  r76: sending batch 1 CPut to (n1,s1):1
+dist sender send  r76: sending batch 1 Get to (n1,s1):1
 dist sender send  r76: sending batch 1 EndTxn to (n1,s1):1
 dist sender send  r76: sending batch 2 CPut, 1 EndTxn to (n1,s1):1
 
@@ -359,7 +363,7 @@ WHERE message     LIKE '%r$rangeid: sending batch%'
   AND message NOT LIKE '%QueryTxn%'
 ----
 dist sender send  r76: sending batch 4 CPut, 1 EndTxn to (n1,s1):1
-dist sender send  r76: sending batch 5 CPut to (n1,s1):1
+dist sender send  r76: sending batch 5 Get to (n1,s1):1
 dist sender send  r76: sending batch 1 EndTxn to (n1,s1):1
 
 # make a table with some big strings in it.

--- a/pkg/sql/opt/exec/execbuilder/testdata/triggers
+++ b/pkg/sql/opt/exec/execbuilder/testdata/triggers
@@ -740,6 +740,13 @@ statement ok
 INSERT INTO parent VALUES (1);
 INSERT INTO child VALUES (1, 1);
 
+# Write buffering can influence whether a BatchRequest makes it to the KV server
+# where we populate "kv nodes" information (which determines whether this
+# information is shown on EXPLAIN ANALYZE), so we unconditionally disable it
+# just for this statement.
+statement ok
+SET kv_transaction_buffered_writes_enabled = false
+
 query T
 EXPLAIN ANALYZE (VERBOSE) UPDATE parent SET k = 2 WHERE k = 1;
 ----
@@ -1012,6 +1019,8 @@ quality of service: regular
                               estimated row count: 1
                               label: buffer 1000000
 
+statement ok
+RESET kv_transaction_buffered_writes_enabled;
 
 # Ensure that the intent on 'parent' is resolved so that we don't see any
 # contention time reported for 'delete range' below.


### PR DESCRIPTION
This PR contains several commit that address most of the remaining failures when enabling write buffering by default (i.e. it adjusts the tests to be either agnostic to write buffering or explicitly controls write buffering). The last commit changes the default value of the cluster setting to be metamorphic in tests. A handful of tests haven't been looked at - those are tracked via #146238.

See each commit for more details.

Fixes: #144866.
