### PR TITLE
logstore: rm MaybeInlineSideloadedRaftCommand alloc

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -740,19 +740,13 @@ func LoadEntries(
 		}
 		expectedIndex++
 
-		typ, _, err := raftlog.EncodingOf(ent)
-		if err != nil {
+		if typ, _, err := raftlog.EncodingOf(ent); err != nil {
 			return err
-		}
-		if typ.IsSideloaded() {
-			newEnt, err := MaybeInlineSideloadedRaftCommand(
+		} else if typ.IsSideloaded() {
+			if ent, err = MaybeInlineSideloadedRaftCommand(
 				ctx, rangeID, ent, sideloaded, eCache,
-			)
-			if err != nil {
+			); err != nil {
 				return err
-			}
-			if newEnt != nil {
-				ent = *newEnt
 			}
 		}
 

--- a/pkg/kv/kvserver/logstore/sideload.go
+++ b/pkg/kv/kvserver/logstore/sideload.go
@@ -149,8 +149,8 @@ func MaybeSideloadEntries(
 
 // MaybeInlineSideloadedRaftCommand takes an entry and inspects it. If its
 // command encoding version indicates a sideloaded entry, it uses the entryCache
-// or SideloadStorage to inline the payload, returning a new entry (which must
-// be treated as immutable by the caller) or nil (if inlining does not apply)
+// or SideloadStorage to inline the payload, and returns a new entry (which must
+// be treated as immutable by the caller).
 //
 // If a payload is missing, returns an error whose Cause() is
 // errSideloadedFileNotFound.
@@ -160,31 +160,24 @@ func MaybeInlineSideloadedRaftCommand(
 	ent raftpb.Entry,
 	sideloaded SideloadStorage,
 	entryCache *raftentry.Cache,
-) (*raftpb.Entry, error) {
+) (raftpb.Entry, error) {
 	typ, pri, err := raftlog.EncodingOf(ent)
-	if err != nil {
-		return nil, err
-	}
-	if !typ.IsSideloaded() {
-		return nil, nil
+	if err != nil || !typ.IsSideloaded() {
+		return ent, err
 	}
 	log.Event(ctx, "inlining sideloaded SSTable")
 	// We could unmarshal this yet again, but if it's committed we are very likely
 	// to have appended it recently, in which case we can save work.
 	if entry, hit := entryCache.Get(rangeID, kvpb.RaftIndex(ent.Index)); hit {
 		log.Event(ctx, "using cache hit")
-		return &entry, nil
+		return entry, nil
 	}
-
-	// Make a shallow copy.
-	entCpy := ent
-	ent = entCpy
 
 	log.Event(ctx, "inlined entry not cached")
 	// (Bad) luck, for whatever reason the inlined proposal isn't in the cache.
 	e, err := raftlog.NewEntry(ent)
 	if err != nil {
-		return nil, err
+		return ent, err
 	}
 
 	if len(e.Cmd.ReplicatedEvalResult.AddSSTable.Data) > 0 {
@@ -196,12 +189,12 @@ func MaybeInlineSideloadedRaftCommand(
 		// be as a result of log entries that are very old, written
 		// when sending the log with snapshots was still possible).
 		log.Event(ctx, "entry already inlined")
-		return &ent, nil
+		return ent, nil
 	}
 
 	sideloadedData, err := sideloaded.Get(ctx, kvpb.RaftIndex(ent.Index), kvpb.RaftTerm(ent.Term))
 	if err != nil {
-		return nil, errors.Wrap(err, "loading sideloaded data")
+		return ent, errors.Wrap(err, "loading sideloaded data")
 	}
 	e.Cmd.ReplicatedEvalResult.AddSSTable.Data = sideloadedData
 	// TODO(tbg): there should be a helper that properly encodes a command, given
@@ -211,11 +204,11 @@ func MaybeInlineSideloadedRaftCommand(
 		raftlog.EncodeRaftCommandPrefix(data[:raftlog.RaftCommandPrefixLen], typ, e.ID, pri)
 		_, err := protoutil.MarshalToSizedBuffer(&e.Cmd, data[raftlog.RaftCommandPrefixLen:])
 		if err != nil {
-			return nil, err
+			return ent, err
 		}
 		ent.Data = data
 	}
-	return &ent, nil
+	return ent, nil
 }
 
 // AssertSideloadedRaftCommandInlined asserts that if the provided entry is a

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -451,11 +451,7 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 		} else {
 			mustEntryEq(t, thinCopy, test.thin)
 		}
-
-		if newEnt == nil {
-			newEnt = &thinCopy
-		}
-		mustEntryEq(t, *newEnt, test.fat)
+		mustEntryEq(t, newEnt, test.fat)
 
 		if dump := getRecAndFinish().String(); test.expTrace != "" {
 			if ok, err := regexp.MatchString(test.expTrace, dump); err != nil {

--- a/pkg/kv/kvserver/logstore/sideload_test.go
+++ b/pkg/kv/kvserver/logstore/sideload_test.go
@@ -13,7 +13,6 @@ import (
 	"os"
 	"path/filepath"
 	"reflect"
-	"regexp"
 	"sort"
 	"strconv"
 	"strings"
@@ -368,7 +367,20 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 	v1, v2 := raftlog.EntryEncodingStandardWithAC, raftlog.EntryEncodingSideloadedWithAC
 	rangeID := roachpb.RangeID(1)
 
-	type testCase struct {
+	sstFat := kvserverpb.ReplicatedEvalResult_AddSSTable{
+		Data:  []byte("foo"),
+		CRC32: 0, // not checked
+	}
+	sstThin := kvserverpb.ReplicatedEvalResult_AddSSTable{
+		CRC32: 0, // not checked
+	}
+
+	putOnDisk := func(_ *raftentry.Cache, ss SideloadStorage) {
+		require.NoError(t, ss.Put(context.Background(), 5, 6, sstFat.Data))
+	}
+
+	for _, test := range []struct {
+		name string
 		// Entry passed into maybeInlineSideloadedRaftCommand and the entry
 		// after having (perhaps) been modified.
 		thin, fat raftpb.Entry
@@ -378,97 +390,69 @@ func TestRaftSSTableSideloadingInline(t *testing.T) {
 		expErr string
 		// If nonempty, a regex that the recorded trace span must match.
 		expTrace string
-	}
-
-	sstFat := kvserverpb.ReplicatedEvalResult_AddSSTable{
-		Data:  []byte("foo"),
-		CRC32: 0, // not checked
-	}
-	sstThin := kvserverpb.ReplicatedEvalResult_AddSSTable{
-		CRC32: 0, // not checked
-	}
-
-	putOnDisk := func(ec *raftentry.Cache, ss SideloadStorage) {
-		if err := ss.Put(context.Background(), 5, 6, sstFat.Data); err != nil {
-			t.Fatal(err)
-		}
-	}
-
-	testCases := map[string]testCase{
+	}{
 		// Plain old v1 Raft command without payload. Don't touch.
-		"v1-no-payload": {thin: mkEnt(v1, 5, 6, &sstThin), fat: mkEnt(v1, 5, 6, &sstThin)},
+		{name: "v1-no-payload", thin: mkEnt(v1, 5, 6, &sstThin), fat: mkEnt(v1, 5, 6, &sstThin)},
 		// With payload, but command is v1. Don't touch. Note that the
 		// first of the two shouldn't happen in practice or we have a
 		// huge problem once we try to apply this entry.
-		"v1-slim-with-payload": {thin: mkEnt(v1, 5, 6, &sstThin), fat: mkEnt(v1, 5, 6, &sstThin)},
-		"v1-with-payload":      {thin: mkEnt(v1, 5, 6, &sstFat), fat: mkEnt(v1, 5, 6, &sstFat)},
+		{name: "v1-slim-with-payload", thin: mkEnt(v1, 5, 6, &sstThin), fat: mkEnt(v1, 5, 6, &sstThin)},
+		{name: "v1-with-payload", thin: mkEnt(v1, 5, 6, &sstFat), fat: mkEnt(v1, 5, 6, &sstFat)},
 		// v2 with payload, but payload is AWOL. This would be fatal in practice.
-		"v2-with-payload-missing-file": {
+		{
+			name: "v2-with-payload-missing-file",
 			thin: mkEnt(v2, 5, 6, &sstThin), fat: mkEnt(v2, 5, 6, &sstThin),
 			expErr: "not found",
 		},
 		// v2 with payload that's actually there. The request we'll see in
 		// practice.
-		"v2-with-payload-with-file-no-cache": {
+		{
+			name: "v2-with-payload-with-file-no-cache",
 			thin: mkEnt(v2, 5, 6, &sstThin), fat: mkEnt(v2, 5, 6, &sstFat),
 			setup: putOnDisk, expTrace: "inlined entry not cached",
 		},
-		"v2-with-payload-with-file-with-cache": {
+		{
+			name: "v2-with-payload-with-file-with-cache",
 			thin: mkEnt(v2, 5, 6, &sstThin), fat: mkEnt(v2, 5, 6, &sstFat),
 			setup: func(ec *raftentry.Cache, ss SideloadStorage) {
 				putOnDisk(ec, ss)
 				ec.Add(rangeID, []raftpb.Entry{mkEnt(v2, 5, 6, &sstFat)}, true)
 			}, expTrace: "using cache hit",
 		},
-		"v2-fat-without-file": {
+		{
+			name: "v2-fat-without-file",
 			thin: mkEnt(v2, 5, 6, &sstFat), fat: mkEnt(v2, 5, 6, &sstFat),
 			setup:    func(ec *raftentry.Cache, ss SideloadStorage) {},
 			expTrace: "already inlined",
 		},
-	}
+	} {
+		t.Run(test.name, func(t *testing.T) {
+			ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(
+				context.Background(), tracing.NewTracer(), "test-recording")
+			defer getRecAndFinish()
 
-	runOne := func(k string, test testCase) {
-		ctx, getRecAndFinish := tracing.ContextWithRecordingSpan(
-			context.Background(), tracing.NewTracer(), "test-recording")
-		defer getRecAndFinish()
-
-		eng := storage.NewDefaultInMemForTesting()
-		defer eng.Close()
-		ss := newTestingSideloadStorage(eng)
-		ec := raftentry.NewCache(1024) // large enough
-		if test.setup != nil {
-			test.setup(ec, ss)
-		}
-
-		thinCopy := *(protoutil.Clone(&test.thin).(*raftpb.Entry))
-		newEnt, err := MaybeInlineSideloadedRaftCommand(ctx, rangeID, thinCopy, ss, ec)
-		if err != nil {
-			if test.expErr == "" || !testutils.IsError(err, test.expErr) {
-				t.Fatalf("%s: %+v", k, err)
+			eng := storage.NewDefaultInMemForTesting()
+			defer eng.Close()
+			ss := newTestingSideloadStorage(eng)
+			ec := raftentry.NewCache(1024) // large enough
+			if test.setup != nil {
+				test.setup(ec, ss)
 			}
-		} else if test.expErr != "" {
-			t.Fatalf("%s: success, but expected error: %s", k, test.expErr)
-		} else {
-			mustEntryEq(t, thinCopy, test.thin)
-		}
-		mustEntryEq(t, newEnt, test.fat)
 
-		if dump := getRecAndFinish().String(); test.expTrace != "" {
-			if ok, err := regexp.MatchString(test.expTrace, dump); err != nil {
-				t.Fatalf("%s: %+v", k, err)
-			} else if !ok {
-				t.Fatalf("%s: expected trace matching:\n%s\n\nbut got\n%s", k, test.expTrace, dump)
+			thinCopy := *(protoutil.Clone(&test.thin).(*raftpb.Entry))
+			newEnt, err := MaybeInlineSideloadedRaftCommand(ctx, rangeID, thinCopy, ss, ec)
+			if want := test.expErr; want != "" {
+				require.ErrorContains(t, err, want)
+			} else {
+				require.NoError(t, err)
+				mustEntryEq(t, thinCopy, test.thin)
 			}
-		}
-	}
+			mustEntryEq(t, newEnt, test.fat)
 
-	keys := make([]string, 0, len(testCases))
-	for k := range testCases {
-		keys = append(keys, k)
-	}
-	sort.Strings(keys)
-	for _, k := range keys {
-		runOne(k, testCases[k])
+			if want := test.expTrace; want != "" {
+				require.Contains(t, getRecAndFinish().String(), want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
This change makes `MaybeInlineSideloadedRaftCommand` use the single-entry `raftentry.Cache.Get()` instead of a scan, and eliminates unnecessary allocations in this path.

Epic: none
Release note: none