### PR TITLE
cspann: make vector delete work during incremental splits

### DIFF
--- a/pkg/sql/vecindex/cspann/fixup_split.go
+++ b/pkg/sql/vecindex/cspann/fixup_split.go
@@ -245,7 +245,7 @@ func (fw *fixupWorker) splitPartition(
 			// This is the root partition, so remove all of its vectors rather than
 			// delete the root partition itself. Note that the vectors have already
 			// been copied to the two target partitions.
-			err = fw.clearPartition(ctx, partitionKey, partition)
+			err = fw.clearPartition(ctx, partitionKey, *partition.Metadata())
 			if err != nil {
 				return err
 			}
@@ -374,29 +374,28 @@ func (fw *fixupWorker) addToPartition(
 	return nil
 }
 
-// clearPartition removes all vectors and associated data from the given
-// partition, leaving it empty, on the condition that the partition's state has
-// not changed unexpectedly. If that's the case, it returns errFixupAborted.
+// clearPartition removes all vectors from the given partition. This only
+// happens if the partition's metadata has not changed. If it has changed,
+// clearPartition returns errFixupAborted.
 func (fw *fixupWorker) clearPartition(
-	ctx context.Context, partitionKey PartitionKey, partition *Partition,
+	ctx context.Context, partitionKey PartitionKey, metadata PartitionMetadata,
 ) (err error) {
-	if partition.Metadata().StateDetails.State.AllowAddOrRemove() {
+	if metadata.StateDetails.State.AllowAddOrRemove() {
 		return errors.AssertionFailedf("cannot clear partition in state that allows adds/removes")
 	}
 
 	// Remove all children in the partition.
-	removed, err := fw.index.store.TryRemoveFromPartition(ctx, fw.treeKey,
-		partitionKey, partition.ChildKeys(), *partition.Metadata())
+	count, err := fw.index.store.TryClearPartition(ctx, fw.treeKey, partitionKey, metadata)
 	if err != nil {
 		metadata, err := suppressRaceErrors(err)
 		if err == nil {
 			// Another worker raced to update the metadata, so abort.
 			return errors.Wrapf(errFixupAborted,
-				"clearing % vectors from partition, %d expected %s, found %s", partition.Count(),
+				"clearing vectors from partition %d, expected %s, found %s",
 				partitionKey, metadata.StateDetails.String(), metadata.StateDetails.String())
 		}
 		return errors.Wrap(err, "clearing vectors")
-	} else if fw.singleStep && removed {
+	} else if fw.singleStep && count > 0 {
 		return errFixupAborted
 	}
 
@@ -549,7 +548,7 @@ func (fw *fixupWorker) addToParentPartition(
 func (fw *fixupWorker) deletePartition(
 	ctx context.Context, parentPartitionKey, partitionKey PartitionKey,
 ) (err error) {
-	const format = "deleting partition %d, with parent partition %d (state=%d)"
+	const format = "deleting partition %d (parent=%d, state=%d)"
 	var parentMetadata PartitionMetadata
 
 	defer func() {

--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -253,6 +253,18 @@ func (p *Partition) Find(childKey ChildKey) int {
 	return -1
 }
 
+// Clear removes all vectors from the partition and returns the number of
+// vectors that were cleared. The centroid stays the same.
+func (p *Partition) Clear() int {
+	count := len(p.childKeys)
+	p.quantizedSet.Clear(p.quantizedSet.GetCentroid())
+	clear(p.childKeys)
+	p.childKeys = p.childKeys[:0]
+	clear(p.valueBytes)
+	p.valueBytes = p.valueBytes[:0]
+	return count
+}
+
 // CreateEmptyPartition returns an empty partition for the given quantizer and
 // level.
 func CreateEmptyPartition(quantizer quantize.Quantizer, metadata PartitionMetadata) *Partition {

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -237,6 +237,22 @@ func TestPartition(t *testing.T) {
 		require.Equal(t, -1, partition.Find(childKey40))
 		require.False(t, partition.ReplaceWithLastByKey(childKey40))
 	})
+
+	t.Run("test Clear", func(t *testing.T) {
+		partition := newTestPartition()
+		require.Equal(t, 3, partition.Clear())
+		require.Equal(t, 0, partition.Count())
+		require.Equal(t, []ChildKey{}, partition.ChildKeys())
+		require.Equal(t, []ValueBytes{}, partition.ValueBytes())
+		require.Equal(t, []float32{4, 3.33}, testutils.RoundFloats(partition.Centroid(), 2))
+
+		// Clear empty partition.
+		require.Equal(t, 0, partition.Clear())
+		require.Equal(t, 0, partition.Count())
+		require.Equal(t, []ChildKey{}, partition.ChildKeys())
+		require.Equal(t, []ValueBytes{}, partition.ValueBytes())
+		require.Equal(t, []float32{4, 3.33}, testutils.RoundFloats(partition.Centroid(), 2))
+	})
 }
 
 func roundResults(results SearchResults, prec int) SearchResults {

--- a/pkg/sql/vecindex/cspann/store.go
+++ b/pkg/sql/vecindex/cspann/store.go
@@ -163,6 +163,18 @@ type Store interface {
 		childKeys []ChildKey,
 		expected PartitionMetadata,
 	) (removed bool, err error)
+
+	// TryClearPartition removes all vectors in the specified partition and
+	// returns the number of vectors that were cleared. It returns
+	// ErrPartitionNotFound if the partition does not exist.
+	//
+	// Before performing any action, TryClearPartition checks the partition's
+	// metadata and returns a ConditionFailedError if it is not the same as the
+	// expected metadata. If the partition does not exist, it returns
+	// ErrPartitionNotFound.
+	TryClearPartition(
+		ctx context.Context, treeKey TreeKey, partitionKey PartitionKey, expected PartitionMetadata,
+	) (count int, err error)
 }
 
 // Txn enables callers to make changes to the stored index in a transactional

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -595,3 +595,182 @@ force-split partition-key=2 parent-partition-key=1
     ├───• vec5 (10, 5)
     ├───• vec2 (7, 4)
     └───• vec7 (8, 8)
+
+# ----------------------------------------------------------------------
+# Delete from the tree when the root is in splitting states.
+# ----------------------------------------------------------------------
+
+load-index min-partition-size=1 max-partition-size=4 beam-size=2 discard-fixups new-fixups
+• 1 (0, 0)
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+├───• vec9 (6, 5)
+└───• vec10 (5, 8)
+----
+Loaded 10 vectors.
+
+# Delete vector in Splitting state.
+force-split partition-key=1 steps=1
+----
+• 1 (0, 0) [Splitting:2,3]
+│
+├───• vec1 (1, 2)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+├───• vec9 (6, 5)
+└───• vec10 (5, 8)
+
+delete discard-fixups
+vec1
+----
+• 1 (0, 0) [Splitting:2,3]
+│
+├───• vec10 (5, 8)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+└───• vec9 (6, 5)
+
+# Delete vector in DrainingForSplit state where the sub-partitions are still
+# empty. This will result in a dangling vector in the root partition, since the
+# full vector is deleted in the primary index.
+force-split partition-key=1 steps=3
+----
+• 1 (0, 0) [DrainingForSplit:2,3]
+│
+├───• vec10 (5, 8)
+├───• vec2 (7, 4)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+└───• vec9 (6, 5)
+
+delete discard-fixups
+vec2
+----
+• 1 (0, 0) [DrainingForSplit:2,3]
+│
+├───• vec10 (5, 8)
+├───• vec2 (MISSING)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+└───• vec9 (6, 5)
+
+# Delete vector after vectors have been copied to sub-partitions. This should
+# delete the vector in sub-partition #2, but leave it danging in the root
+# partition.
+force-split partition-key=1 steps=4
+----
+• 1 (0, 0) [DrainingForSplit:2,3]
+│
+├───• vec10 (5, 8)
+├───• vec2 (MISSING)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+└───• vec9 (6, 5)
+
+format-tree root=2
+----
+• 2 (5.3333, 6.6667)
+│
+├───• vec10 (5, 8)
+├───• vec3 (4, 3)
+├───• vec4 (8, 11)
+├───• vec7 (3, 5)
+└───• vec8 (6, 8)
+
+delete discard-fixups
+vec3
+----
+• 1 (0, 0) [DrainingForSplit:2,3]
+│
+├───• vec10 (5, 8)
+├───• vec2 (MISSING)
+├───• vec3 (MISSING)
+├───• vec4 (8, 11)
+├───• vec5 (14, 1)
+├───• vec6 (8, 6)
+├───• vec7 (3, 5)
+├───• vec8 (6, 8)
+└───• vec9 (6, 5)
+
+format-tree root=2
+----
+• 2 (5.3333, 6.6667)
+│
+├───• vec10 (5, 8)
+├───• vec8 (6, 8)
+├───• vec4 (8, 11)
+└───• vec7 (3, 5)
+
+# Delete vector after vectors have been cleared in the root. This should remove
+# the vector from sub-partition #3.
+force-split partition-key=1 steps=1
+----
+• 1 (0, 0) [DrainingForSplit:2,3]
+
+delete discard-fixups root=3
+vec4
+----
+• 3 (9.6667, 3.6667)
+│
+├───• vec9 (6, 5)
+├───• vec5 (14, 1)
+└───• vec6 (8, 6)
+
+# Delete vector in AddingLevel state. This should remove the vector from
+# sub-partition #3.
+force-split partition-key=1 steps=1
+----
+• 1 (0, 0) [AddingLevel:2,3]
+
+delete discard-fixups root=3
+vec5
+----
+• 3 (9.6667, 3.6667)
+│
+├───• vec9 (6, 5)
+└───• vec6 (8, 6)
+
+# Finish split of root partition.
+force-split partition-key=1
+----
+• 1 (0, 0)
+│
+├───• 2 (5.3333, 6.6667)
+│   │
+│   ├───• vec10 (5, 8)
+│   ├───• vec8 (6, 8)
+│   └───• vec7 (3, 5)
+│
+└───• 3 (9.6667, 3.6667)
+    │
+    ├───• vec9 (6, 5)
+    └───• vec6 (8, 6)

--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -293,6 +293,17 @@ func (s *Store) TryRemoveFromPartition(
 	return false, errors.AssertionFailedf("TryRemoveFromPartition is not yet implemented")
 }
 
+// TryClearPartition is part of the cspann.Store interface. It removes vectors
+// from an existing partition.
+func (s *Store) TryClearPartition(
+	ctx context.Context,
+	treeKey cspann.TreeKey,
+	partitionKey cspann.PartitionKey,
+	expected cspann.PartitionMetadata,
+) (count int, err error) {
+	return -1, errors.AssertionFailedf("TryRemoveFromPartition is not yet implemented")
+}
+
 // encodePartitionKey takes a partition key and creates a KV key to read that
 // partition's metadata. Vector data can be read by scanning from the metadata
 // to the next partition's metadata.

--- a/pkg/sql/vecindex/vecstore/store_test.go
+++ b/pkg/sql/vecindex/vecstore/store_test.go
@@ -85,7 +85,6 @@ func TestStore(t *testing.T) {
 		tbl++
 		tblName := fmt.Sprintf("t%d", tbl)
 
-		//runner.Exec(t, "DROP TABLE IF EXISTS t")
 		runner.Exec(t, "CREATE TABLE "+tblName+" (id INT PRIMARY KEY, prefix INT NOT NULL, v VECTOR(2))")
 
 		// TODO(andyk): Pre-insert the values that the common tests will insert


### PR DESCRIPTION
The new split code performs splits of vector index K-means trees using an incremental series of non-transactional steps. This commit ensures that any deletes from the vector index work as expected during all of these steps. In particular, in the DrainingForSplit phase, a partition does not allow vectors to be deleted. Instead, the vector needs to be deleted from one of the target partitions of the split (i.e. the two partitions between which the vectors are divided).

Epic: CRDB-42943

Release note: None