### PR TITLE
explain: harden RU reporting for read-only queries

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/query_ru_estimate_test.go
@@ -72,7 +72,6 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	tenantID := serverutils.TestTenantID()
 	tenant1, tenantDB1 := serverutils.StartTenant(t, s, base.TestTenantArgs{
 		TenantID: tenantID,
-		Settings: st,
 		TestingKnobs: base.TestingKnobs{
 			SQLEvalContext: &eval.TestingKnobs{
 				// We disable the randomization of some batch sizes because with
@@ -196,7 +195,7 @@ func TestEstimateQueryRUConsumption(t *testing.T) {
 	const deltaFraction = 0.25
 	allowedDelta := tenantMeasuredRUs * deltaFraction
 	require.InDeltaf(t, tenantMeasuredRUs, tenantEstimatedRUs, allowedDelta,
-		"estimated RUs (%d) were not within %f RUs of the expected value (%f)",
+		"estimated RUs (%.2f) were not within %.2f RUs of the expected value (%.2f)",
 		tenantEstimatedRUs,
 		allowedDelta,
 		tenantMeasuredRUs,

--- a/pkg/sql/plan_node_to_row_source.go
+++ b/pkg/sql/plan_node_to_row_source.go
@@ -274,8 +274,11 @@ func (p *planNodeToRowSource) trailingMetaCallback() []execinfrapb.ProducerMetad
 
 // execStatsForTrace implements ProcessorBase.ExecStatsForTrace.
 func (p *planNodeToRowSource) execStatsForTrace() *execinfrapb.ComponentStats {
-	// Propagate contention time and RUs from IO requests for mutations.
-	if _, ok := p.node.(mutationPlanNode); !ok {
+	// Propagate contention time and RUs from IO requests.
+	if p.contentionEventsListener.GetContentionTime() == 0 &&
+		p.contentionEventsListener.GetLockWaitTime() == 0 &&
+		p.contentionEventsListener.GetLatchWaitTime() == 0 &&
+		p.tenantConsumptionListener.GetConsumedRU() == 0 {
 		return nil
 	}
 	return &execinfrapb.ComponentStats{


### PR DESCRIPTION
In a recent change 365dfa42bdbab0079d64281b7bceff03a609be0d we made it possible to no longer report RU estimate in `planNodeToRowSource` if it wraps a non-mutation planNode. That change was a de-flaking fix that was later super-seded by 66065df9bdb56be3be641eaa8d42b6dcd241bbdd, so we can revert the former. I think it makes the code more bullet-proof even though AFAICT we report consumed RUs for only for mutation planNodes.

Also this commit makes some minor fixes to `TestEstimateQueryRUConsumption` which is skipped unconditionally.

Epic: None
Release note: None