### PR TITLE
memo: check `insert_fast_path` for staleness

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -205,6 +205,7 @@ type Memo struct {
 	minRowCount                                float64
 	checkInputMinRowCount                      float64
 	planLookupJoinsWithReverseScans            bool
+	useInsertFastPath                          bool
 	internal                                   bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
@@ -302,6 +303,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		minRowCount:                                evalCtx.SessionData().OptimizerMinRowCount,
 		checkInputMinRowCount:                      evalCtx.SessionData().OptimizerCheckInputMinRowCount,
 		planLookupJoinsWithReverseScans:            evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans,
+		useInsertFastPath:                          evalCtx.SessionData().InsertFastPath,
 		internal:                                   evalCtx.SessionData().Internal,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
@@ -476,6 +478,7 @@ func (m *Memo) IsStale(
 		m.minRowCount != evalCtx.SessionData().OptimizerMinRowCount ||
 		m.checkInputMinRowCount != evalCtx.SessionData().OptimizerCheckInputMinRowCount ||
 		m.planLookupJoinsWithReverseScans != evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans ||
+		m.useInsertFastPath != evalCtx.SessionData().InsertFastPath ||
 		m.internal != evalCtx.SessionData().Internal ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -559,6 +559,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans = false
 	notStale()
 
+	evalCtx.SessionData().InsertFastPath = true
+	stale()
+	evalCtx.SessionData().InsertFastPath = false
+	notStale()
+
 	evalCtx.SessionData().Internal = true
 	stale()
 	evalCtx.SessionData().Internal = false


### PR DESCRIPTION
Since we consult the value of `insert_fast_path` session variable in `CanUseUniqueChecksForInsertFastPath` (which is called during the exploration), we need to check the value for memo staleness, and this has been missing.

Epic: None

Release note: None