### PR TITLE
sql: support BYPASSRLS role option for RLS policies

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -2919,4 +2919,175 @@ DROP ROLE test_role1;
 statement ok
 DROP ROLE test_role2;
 
+# Ensure that if a role has the BYPASSRLS option or privilege set, that it's
+# exempt from policies.
+subtest bypassrls
+
+statement ok
+CREATE TABLE bypassrls (id INT PRIMARY KEY, val TEXT);
+
+statement ok
+CREATE USER bypassrls_user;
+
+statement ok
+GRANT ALL ON bypassrls TO bypassrls_user;
+
+statement ok
+ALTER TABLE bypassrls ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY pol1 ON bypassrls TO bypassrls_user USING (val like 'visible: %');
+
+statement ok
+CREATE FUNCTION insert_policy_violation_as_session_user(id INT) RETURNS TABLE(id INT, description TEXT)
+LANGUAGE SQL AS
+$$
+ INSERT INTO bypassrls VALUES (id, 'hidden: value') RETURNING id, val
+$$;
+
+# This function is like the above, except it will always be run as admin since
+# it uses SECURITY DEFINER.
+statement ok
+CREATE FUNCTION insert_policy_violation_as_admin(id INT) RETURNS TABLE(id INT, description TEXT)
+LANGUAGE SQL AS
+$$
+ INSERT INTO bypassrls VALUES (id, 'hidden: value') RETURNING id, val
+$$ SECURITY DEFINER;
+
+statement ok
+INSERT INTO bypassrls VALUES (0, 'visible: 0'), (1, 'hidden: 1'), (2, 'visible: 2');
+
+query IT
+SELECT * FROM insert_policy_violation_as_admin(10);
+----
+10 hidden: value
+
+query IT
+SELECT * FROM insert_policy_violation_as_session_user(11);
+----
+11 hidden: value
+
+query IT
+SELECT * FROM bypassrls ORDER BY id;
+----
+0 visible: 0
+1 hidden: 1
+2 visible: 2
+10 hidden: value
+11 hidden: value
+
+statement ok
+SET ROLE bypassrls_user;
+
+query IT
+SELECT * FROM bypassrls ORDER BY id;
+----
+0 visible: 0
+2 visible: 2
+
+query IT
+SELECT * FROM insert_policy_violation_as_admin(20);
+----
+20 hidden: value
+
+statement error pq: new row violates row-level security policy for table "bypassrls"
+SELECT * FROM insert_policy_violation_as_session_user(21);
+
+statement ok
+SET ROLE root;
+
+statement error pq: conflicting role options
+ALTER ROLE bypassrls_user BYPASSRLS NOBYPASSRLS;
+
+statement ok
+ALTER ROLE bypassrls_user BYPASSRLS;
+
+statement ok
+SET ROLE bypassrls_user;
+
+query IT
+SELECT * FROM bypassrls ORDER BY id;
+----
+0 visible: 0
+1 hidden: 1
+2 visible: 2
+10 hidden: value
+11 hidden: value
+20 hidden: value
+
+query IT
+SELECT * FROM insert_policy_violation_as_admin(30);
+----
+30 hidden: value
+
+query IT
+SELECT * FROM insert_policy_violation_as_session_user(31);
+----
+31 hidden: value
+
+statement ok
+SET ROLE root
+
+statement ok
+ALTER ROLE bypassrls_user NOBYPASSRLS;
+
+statement ok
+GRANT SYSTEM BYPASSRLS TO bypassrls_user;
+
+query TTB colnames
+SELECT * FROM [SHOW SYSTEM GRANTS] WHERE privilege_type = 'BYPASSRLS';
+----
+grantee         privilege_type  is_grantable
+bypassrls_user  BYPASSRLS             false
+
+statement ok
+SET ROLE bypassrls_user;
+
+query IT
+SELECT * FROM bypassrls ORDER BY id;
+----
+0   visible: 0
+1   hidden: 1
+2   visible: 2
+10  hidden: value
+11  hidden: value
+20  hidden: value
+30  hidden: value
+31  hidden: value
+
+query IT
+SELECT * FROM insert_policy_violation_as_session_user(40);
+----
+40 hidden: value
+
+statement ok
+SET ROLE root;
+
+statement ok
+REVOKE SYSTEM BYPASSRLS FROM bypassrls_user;
+
+statement ok
+SET ROLE bypassrls_user;
+
+query IT
+SELECT * FROM bypassrls ORDER BY id;
+----
+0 visible: 0
+2 visible: 2
+
+statement error pq: new row violates row-level security policy for table "bypassrls"
+SELECT * FROM insert_policy_violation_as_session_user(50);
+
+statement ok
+SET ROLE root;
+
+statement ok
+DROP FUNCTION insert_policy_violation_as_admin, insert_policy_violation_as_session_user
+
+statement ok
+DROP TABLE bypassrls;
+
+statement ok
+DROP USER bypassrls_user;
+
 subtest end

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -241,6 +241,10 @@ type Catalog interface {
 	// NOLOGIN instead of LOGIN.
 	HasRoleOption(ctx context.Context, roleOption roleoption.Option) (bool, error)
 
+	// UserHasGlobalPrivilegeOrRoleOption returns a bool representing whether the given user
+	// has a global privilege or the corresponding legacy role option.
+	UserHasGlobalPrivilegeOrRoleOption(ctx context.Context, privilege privilege.Kind, user username.SQLUsername) (bool, error)
+
 	// FullyQualifiedName retrieves the fully qualified name of a data source.
 	// Note that:
 	//  - this call may involve a database operation so it shouldn't be used in

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -463,7 +463,7 @@ func (b *Builder) maybeAnnotatePolicyInfo(node exec.Node, e memo.RelExpr) {
 			policiesApplied, found := rlsMeta.PoliciesApplied[tabID]
 			if found {
 				val := exec.RLSPoliciesApplied{
-					PoliciesSkippedForRole: rlsMeta.HasAdminRole || policiesApplied.NoForceExempt,
+					PoliciesSkippedForRole: rlsMeta.HasAdminRole || policiesApplied.NoForceExempt || policiesApplied.BypassRLS,
 				}
 				if applyFilterExpr {
 					val.Policies = policiesApplied.Filter

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -634,7 +634,8 @@ func TestMemoIsStale(t *testing.T) {
 
 	// User changes (with RLS)
 	o.Memo().Metadata().SetRLSEnabled(evalCtx.SessionData().User(), true, /* admin */
-		1 /* tableID */, false /* isTableOwnerAndNotForced */)
+		1 /* tableID */, false, /* isTableOwnerAndNotForced */
+		false /* bypassRLS */)
 	notStale()
 	evalCtx.SessionData().UserProto = newUser
 	stale()

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -54,10 +54,13 @@ func (r *RowLevelSecurityMeta) Clear() {
 // AddTableUse indicates that an RLS-enabled table was encountered while
 // building the query plan. If any policies are in use, they will be added
 // via the AddPolicyUse call.
-func (r *RowLevelSecurityMeta) AddTableUse(tableID TableID, isTableOwnerAndNotForced bool) {
+func (r *RowLevelSecurityMeta) AddTableUse(
+	tableID TableID, isTableOwnerAndNotForced, bypassRLS bool,
+) {
 	if _, found := r.PoliciesApplied[tableID]; !found {
 		r.PoliciesApplied[tableID] = PoliciesApplied{
 			NoForceExempt: isTableOwnerAndNotForced,
+			BypassRLS:     bypassRLS,
 			Filter:        PolicyIDSet{},
 			Check:         PolicyIDSet{},
 		}
@@ -87,6 +90,11 @@ type PoliciesApplied struct {
 	// NoForceExempt is true if the policies were exempt because they were the
 	// table owner and force RLS wasn't set.
 	NoForceExempt bool
+	// BypassRLS is true if the policies were bypassed because the user had the
+	// BYPASSRLS option/privilege. There is an argument to combine the two bools
+	// for exemption. However, the memo staleness checks have different handling
+	// for when these exemptions change, so they need to be stored separately.
+	BypassRLS bool
 	// Filter is the set of policy IDs that were applied to filter out existing
 	// rows. The USING expression in each policy is used to derive the filter.
 	Filter PolicyIDSet
@@ -99,6 +107,7 @@ type PoliciesApplied struct {
 func (p *PoliciesApplied) Copy() PoliciesApplied {
 	return PoliciesApplied{
 		NoForceExempt: p.NoForceExempt,
+		BypassRLS:     p.BypassRLS,
 		Filter:        p.Filter.Copy(),
 		Check:         p.Check.Copy(),
 	}

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -336,6 +336,13 @@ func (tc *Catalog) HasRoleOption(ctx context.Context, roleOption roleoption.Opti
 	return true, nil
 }
 
+// UserHasGlobalPrivilegeOrRoleOption is part of the cat.Catalog interface.
+func (tc *Catalog) UserHasGlobalPrivilegeOrRoleOption(
+	ctx context.Context, privilege privilege.Kind, user username.SQLUsername,
+) (bool, error) {
+	return false, nil
+}
+
 // FullyQualifiedName is part of the cat.Catalog interface.
 func (tc *Catalog) FullyQualifiedName(
 	ctx context.Context, ds cat.DataSource,

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -470,6 +470,13 @@ func (oc *optCatalog) HasRoleOption(
 	return oc.planner.HasRoleOption(ctx, roleOption)
 }
 
+// UserHasGlobalPrivilegeOrRoleOption is part of the cat.Catalog interface.
+func (oc *optCatalog) UserHasGlobalPrivilegeOrRoleOption(
+	ctx context.Context, privilege privilege.Kind, user username.SQLUsername,
+) (bool, error) {
+	return oc.planner.UserHasGlobalPrivilegeOrRoleOption(ctx, privilege, user)
+}
+
 // FullyQualifiedName is part of the cat.Catalog interface.
 func (oc *optCatalog) FullyQualifiedName(
 	ctx context.Context, ds cat.DataSource,

--- a/pkg/sql/roleoption/BUILD.bazel
+++ b/pkg/sql/roleoption/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/tree",
-        "//pkg/util/errorutil/unimplemented",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
@@ -117,6 +116,8 @@ var toSQLStmts = map[Option]string{
 	VIEWCLUSTERSETTING:     `INSERT INTO system.role_options (username, option, user_id) VALUES ($1, 'VIEWCLUSTERSETTING', $2) ON CONFLICT DO NOTHING`,
 	NOVIEWCLUSTERSETTING:   `DELETE FROM system.role_options WHERE username = $1 AND user_id = $2 AND option = 'VIEWCLUSTERSETTING'`,
 	SUBJECT:                `UPSERT INTO system.role_options (username, option, value, user_id) VALUES ($1, 'SUBJECT', $2::string, $3)`,
+	BYPASSRLS:              `INSERT INTO system.role_options (username, option, user_id) VALUES ($1, 'BYPASSRLS', $2) ON CONFLICT DO NOTHING`,
+	NOBYPASSRLS:            `DELETE FROM system.role_options WHERE username = $1 AND user_id = $2 AND option = 'BYPASSRLS'`,
 }
 
 // Mask returns the bitmask for a given role option.
@@ -261,10 +262,6 @@ func (rol List) GetSQLStmts(onRoleOption func(Option)) (map[string]*RoleOption, 
 		if ro.Option == PASSWORD {
 			continue
 		}
-		if ro.Option == BYPASSRLS || ro.Option == NOBYPASSRLS {
-			return nil, unimplemented.NewWithIssuef(
-				136910, "the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported")
-		}
 
 		stmt := toSQLStmts[ro.Option]
 		stmts[stmt] = ro
@@ -330,7 +327,9 @@ func (rol List) CheckRoleOptionConflicts() error {
 		(roleOptionBits&VIEWCLUSTERSETTING.Mask() != 0 &&
 			roleOptionBits&NOVIEWCLUSTERSETTING.Mask() != 0) ||
 		(roleOptionBits&REPLICATION.Mask() != 0 &&
-			roleOptionBits&NOREPLICATION.Mask() != 0) {
+			roleOptionBits&NOREPLICATION.Mask() != 0) ||
+		(roleOptionBits&BYPASSRLS.Mask() != 0 &&
+			roleOptionBits&NOBYPASSRLS.Mask() != 0) {
 		return pgerror.Newf(pgcode.Syntax, "conflicting role options")
 	}
 	return nil


### PR DESCRIPTION
Previously, attempts to use the BYPASSRLS role option with row-level security (RLS) policies resulted in an unimplemented error. This change lifts those restrictions and adds proper support for roles or system privileges with the BYPASSRLS flag, allowing them to bypass RLS policies on tables where it is enabled.

Closes #136910

Epic: CRDB-11724
Release note: none