### PR TITLE
release-25.1: explain: show "execution time" on EXPLAIN ANALYZE output

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
@@ -155,6 +155,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 
@@ -177,6 +178,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -124,6 +124,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 1
 │ vectorized batch count: 0
+│ execution time: 0µs
 │ estimated row count: 0 (missing stats)
 │ table: xy
 │ set: x, y
@@ -146,6 +147,7 @@ quality of service: regular
         │ regions: <hidden>
         │ actual row count: 0
         │ vectorized batch count: 0
+        │ execution time: 0µs
         │ estimated row count: 10 (missing stats)
         │ filter: f IS DISTINCT FROM NULL
         │
@@ -182,6 +184,7 @@ quality of service: regular
                     │ regions: <hidden>
                     │ actual row count: 0
                     │ vectorized batch count: 0
+                    │ execution time: 0µs
                     │ estimated row count: 10 (missing stats)
                     │ filter: y = 2
                     │
@@ -338,6 +341,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -347,6 +351,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 0
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
@@ -355,6 +360,7 @@ quality of service: regular
 │           │ regions: <hidden>
 │           │ actual row count: 0
 │           │ vectorized batch count: 0
+│           │ execution time: 0µs
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -412,6 +418,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -421,6 +428,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 1
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
@@ -429,6 +437,7 @@ quality of service: regular
 │           │ regions: <hidden>
 │           │ actual row count: 1
 │           │ vectorized batch count: 0
+│           │ execution time: 0µs
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -479,6 +488,7 @@ quality of service: regular
                       regions: <hidden>
                       actual row count: 1
                       vectorized batch count: 0
+                      execution time: 0µs
                       estimated row count: 1
                       label: buffer 1000000
 
@@ -684,6 +694,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -694,6 +705,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 0
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -757,6 +769,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -767,6 +780,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 1
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -807,6 +821,7 @@ quality of service: regular
         │   │ regions: <hidden>
         │   │ actual row count: 0
         │   │ vectorized batch count: 0
+        │   │ execution time: 0µs
         │   │ estimated row count: 0 (missing stats)
         │   │ table: child
         │   │ set: fk
@@ -820,6 +835,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 1
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • filter
@@ -828,6 +844,7 @@ quality of service: regular
         │           │ regions: <hidden>
         │           │ actual row count: 1
         │           │ vectorized batch count: 0
+        │           │ execution time: 0µs
         │           │ estimated row count: 3 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -867,6 +884,7 @@ quality of service: regular
         │                           │ regions: <hidden>
         │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
+        │                           │ execution time: 0µs
         │                           │ estimated max memory allocated: 0 B
         │                           │ estimated row count: 3 (missing stats)
         │                           │ equality: (fk) = (k)
@@ -897,6 +915,7 @@ quality of service: regular
         │                               │ regions: <hidden>
         │                               │ actual row count: 1
         │                               │ vectorized batch count: 0
+        │                               │ execution time: 0µs
         │                               │ estimated row count: 0
         │                               │ filter: k IS DISTINCT FROM k_new
         │                               │
@@ -906,6 +925,7 @@ quality of service: regular
         │                                     regions: <hidden>
         │                                     actual row count: 1
         │                                     vectorized batch count: 0
+        │                                     execution time: 0µs
         │                                     estimated row count: 1
         │                                     label: buffer 1000000
         │
@@ -917,6 +937,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 0
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │
         │       └── • lookup join (anti)
         │           │ columns: (fk_new)
@@ -931,6 +952,7 @@ quality of service: regular
         │           │ KV pairs read: 2
         │           │ KV bytes read: 8 B
         │           │ KV gRPC calls: 1
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ MVCC step count (ext/int): 0/0
         │           │ MVCC seek count (ext/int): 0/0
@@ -945,6 +967,7 @@ quality of service: regular
         │               │ regions: <hidden>
         │               │ actual row count: 1
         │               │ vectorized batch count: 0
+        │               │ execution time: 0µs
         │               │ estimated row count: 3 (missing stats)
         │               │ filter: fk_new IS NOT NULL
         │               │
@@ -957,6 +980,7 @@ quality of service: regular
         │                         regions: <hidden>
         │                         actual row count: 1
         │                         vectorized batch count: 0
+        │                         execution time: 0µs
         │                         estimated row count: 3 (missing stats)
         │                         label: buffer 1
         │
@@ -991,6 +1015,7 @@ quality of service: regular
                               regions: <hidden>
                               actual row count: 1
                               vectorized batch count: 0
+                              execution time: 0µs
                               estimated row count: 1
                               label: buffer 1000000
 
@@ -1025,6 +1050,7 @@ quality of service: regular
 │     regions: <hidden>
 │     actual row count: 1
 │     vectorized batch count: 0
+│     execution time: 0µs
 │     estimated row count: 0 (missing stats)
 │     from: parent
 │     spans: /2/0
@@ -1041,6 +1067,7 @@ quality of service: regular
         │   │ regions: <hidden>
         │   │ actual row count: 0
         │   │ vectorized batch count: 0
+        │   │ execution time: 0µs
         │   │ estimated row count: 0 (missing stats)
         │   │ from: child
         │   │
@@ -1053,6 +1080,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 1
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • filter
@@ -1061,6 +1089,7 @@ quality of service: regular
         │           │ regions: <hidden>
         │           │ actual row count: 1
         │           │ vectorized batch count: 0
+        │           │ execution time: 0µs
         │           │ estimated row count: 10 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -1091,6 +1120,7 @@ quality of service: regular
         │                           │ regions: <hidden>
         │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
+        │                           │ execution time: 0µs
         │                           │ estimated row count: 10 (missing stats)
         │                           │ filter: fk = 2
         │                           │
@@ -1141,6 +1171,7 @@ quality of service: regular
                               regions: <hidden>
                               actual row count: 1
                               vectorized batch count: 0
+                              execution time: 0µs
                               estimated row count: 1
                               label: buffer 1000000
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -1067,6 +1067,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 				nodeStats.SeekCount.MaybeAdd(stats.KV.NumInterfaceSeeks)
 				nodeStats.InternalSeekCount.MaybeAdd(stats.KV.NumInternalSeeks)
 				nodeStats.VectorizedBatchCount.MaybeAdd(stats.Output.NumBatches)
+				nodeStats.ExecTime.MaybeAdd(stats.Exec.ExecTime)
 				nodeStats.MaxAllocatedMem.MaybeAdd(stats.Exec.MaxAllocatedMem)
 				nodeStats.MaxAllocatedDisk.MaybeAdd(stats.Exec.MaxAllocatedDisk)
 				if noMutations && !makeDeterministic {

--- a/pkg/sql/logictest/testdata/logic_test/generic
+++ b/pkg/sql/logictest/testdata/logic_test/generic
@@ -55,6 +55,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -109,6 +110,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -166,6 +168,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -220,6 +223,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -357,6 +361,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -373,6 +378,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_a_idx
     │ equality: ($1) = (a)
@@ -381,6 +387,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 2 columns, 1 row
 
 # The generic plan can be reused with different placeholder values.
@@ -408,6 +415,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -424,6 +432,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_a_idx
     │ equality: ($1) = (a)
@@ -432,6 +441,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 2 columns, 1 row
 
 statement ok
@@ -457,6 +467,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 2
 │
 └── • index join (streamer)
@@ -521,6 +532,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -536,6 +548,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_t_idx
     │ equality: (column11) = (t)
@@ -544,6 +557,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 # The generic plan can be reused.
@@ -571,6 +585,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -586,6 +601,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_t_idx
     │ equality: (column11) = (t)
@@ -594,6 +610,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 statement ok
@@ -622,6 +639,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: s LIKE 'foo%'
 │
 └── • scan
@@ -665,6 +683,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 1
 │
 └── • scan
@@ -705,6 +724,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 1
 │
 └── • scan
@@ -754,6 +774,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -819,6 +840,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 20000
 │
 └── • index join (streamer)
@@ -891,6 +913,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
@@ -904,6 +927,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: c@c_a_idx
     │ equality: (k) = (a)
@@ -912,6 +936,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │ filter: c = 20000
         │
         └── • index join (streamer)
@@ -969,6 +994,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
@@ -982,6 +1008,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: c@c_a_idx
     │ equality: (k) = (a)
@@ -995,6 +1022,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t@t_pkey
         │ equality: (k) = (k)
@@ -1011,6 +1039,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t@t_a_idx
             │ equality: ($1) = (a)
@@ -1019,6 +1048,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 2 columns, 1 row
 
 # On the seventh execution the generic plan is reused.
@@ -1046,6 +1076,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
@@ -1059,6 +1090,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: c@c_a_idx
     │ equality: (k) = (a)
@@ -1072,6 +1104,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t@t_pkey
         │ equality: (k) = (k)
@@ -1088,6 +1121,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t@t_a_idx
             │ equality: ($1) = (a)
@@ -1096,6 +1130,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 2 columns, 1 row
 
 statement ok
@@ -1178,6 +1213,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ table: g@g_a_b_idx
@@ -1187,6 +1223,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -149,6 +149,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 
@@ -171,6 +172,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1067,12 +1067,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ from: loop_a
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • scan
@@ -1101,18 +1103,21 @@ quality of service: regular
         │   │ sql nodes: <hidden>
         │   │ regions: <hidden>
         │   │ actual row count: 0
+        │   │ execution time: 0µs
         │   │ from: loop_b
         │   │
         │   └── • buffer
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
         │       │ actual row count: 1
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • hash join (semi)
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
         │           │ actual row count: 1
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ equality: (cascade_delete) = (id)
         │           │
@@ -1136,6 +1141,7 @@ quality of service: regular
         │                 sql nodes: <hidden>
         │                 regions: <hidden>
         │                 actual row count: 1
+        │                 execution time: 0µs
         │                 estimated row count: 1
         │                 label: buffer 1000000
         │
@@ -1148,12 +1154,14 @@ quality of service: regular
                 │   │ sql nodes: <hidden>
                 │   │ regions: <hidden>
                 │   │ actual row count: 0
+                │   │ execution time: 0µs
                 │   │ from: loop_a
                 │   │
                 │   └── • buffer
                 │       │ sql nodes: <hidden>
                 │       │ regions: <hidden>
                 │       │ actual row count: 1
+                │       │ execution time: 0µs
                 │       │ label: buffer 1
                 │       │
                 │       └── • lookup join
@@ -1167,6 +1175,7 @@ quality of service: regular
                 │           │ KV pairs read: 2
                 │           │ KV bytes read: 8 B
                 │           │ KV gRPC calls: 1
+                │           │ execution time: 0µs
                 │           │ estimated max memory allocated: 0 B
                 │           │ table: loop_a@loop_a_cascade_delete_idx
                 │           │ equality: (id) = (cascade_delete)
@@ -1175,6 +1184,7 @@ quality of service: regular
                 │               │ sql nodes: <hidden>
                 │               │ regions: <hidden>
                 │               │ actual row count: 1
+                │               │ execution time: 0µs
                 │               │ estimated max memory allocated: 0 B
                 │               │ estimated row count: 1
                 │               │ distinct on: id
@@ -1183,6 +1193,7 @@ quality of service: regular
                 │                     sql nodes: <hidden>
                 │                     regions: <hidden>
                 │                     actual row count: 1
+                │                     execution time: 0µs
                 │                     estimated row count: 1
                 │                     label: buffer 1000000
                 │
@@ -1471,18 +1482,21 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ from: p138974
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ filter: v = 1
 │           │
 │           └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -492,6 +492,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ from: t137352
 │ auto commit
 │
@@ -505,6 +506,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t137352@t137352_pkey
     │ equality: ($1) = (k)
@@ -515,6 +517,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 statement ok
@@ -542,6 +545,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ from: t137352
 │ auto commit
 │
@@ -554,6 +558,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t137352@t137352_pkey
     │ equality: (k) = (k)
@@ -570,6 +575,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_a_idx
         │ equality: ($1) = (a)
@@ -579,4 +585,5 @@ quality of service: regular
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -69,6 +69,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │
 └── • scan
       sql nodes: <hidden>
@@ -108,6 +109,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ equality: (k) = (k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2257,6 +2257,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 1
+  execution time: 0µs
   size: 1 column, 1 row
 
 # Tests for EXPLAIN (OPT, MEMO).

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -78,6 +78,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ group by: k
 │ ordered: +k
 │
@@ -85,6 +86,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ equality: (k) = (k)
@@ -146,6 +148,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +w
 │
@@ -153,6 +156,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ distinct on: w
     │
@@ -160,6 +164,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 5
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ equality: (k) = (w)
         │ left cols are key
@@ -219,6 +224,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 25
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │
@@ -226,6 +232,7 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 5
+│   │ execution time: 0µs
 │   │
 │   └── • scan
 │         sql nodes: <hidden>
@@ -247,6 +254,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │
     └── • scan
           sql nodes: <hidden>
@@ -308,6 +316,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │
@@ -391,18 +400,21 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: child(c, p)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • values
 │             sql nodes: <hidden>
 │             regions: <hidden>
 │             actual row count: 1
+│             execution time: 0µs
 │             size: 2 columns, 1 row
 │
 ├── • subquery
@@ -414,6 +426,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
@@ -438,6 +451,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • lookup join (anti)
             │ sql nodes: <hidden>
@@ -450,6 +464,7 @@ quality of service: regular
             │ KV pairs read: 2
             │ KV bytes read: 8 B
             │ KV gRPC calls: 1
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: parent@parent_pkey
             │ equality: (column2) = (p)
@@ -459,6 +474,7 @@ quality of service: regular
                 │ sql nodes: <hidden>
                 │ regions: <hidden>
                 │ actual row count: 1
+                │ execution time: 0µs
                 │ estimated row count: 1
                 │ filter: column2 IS NOT NULL
                 │
@@ -466,6 +482,7 @@ quality of service: regular
                       sql nodes: <hidden>
                       regions: <hidden>
                       actual row count: 1
+                      execution time: 0µs
                       estimated row count: 1
                       label: buffer 1
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
@@ -81,6 +81,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 2
 │ vectorized batch count: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated row count: 990 (missing stats)
 │ equality: (v) = (a)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -39,6 +39,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +k
 │
@@ -46,6 +47,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -67,6 +69,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
@@ -133,6 +136,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +k
 │
@@ -140,6 +144,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -161,6 +166,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
@@ -211,6 +217,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ order: +k
 │
@@ -218,6 +225,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -239,6 +247,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -326,6 +326,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ estimated max memory allocated: 0 B
 │       │ estimated max sql temp disk usage: 0 B
 │       │ group by: lk
@@ -339,6 +340,7 @@ quality of service: regular
 │           │ KV rows decoded: 0
 │           │ KV bytes read: 0 B
 │           │ KV gRPC calls: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ table: rtable@rtable_pkey
 │           │ equality: (rk1, rk2) = (rk1, rk2)
@@ -354,6 +356,7 @@ quality of service: regular
 │               │ KV rows decoded: 0
 │               │ KV bytes read: 0 B
 │               │ KV gRPC calls: 0
+│               │ execution time: 0µs
 │               │ estimated max memory allocated: 0 B
 │               │ estimated max sql temp disk usage: 0 B
 │               │ table: rtable@geom_index
@@ -362,6 +365,7 @@ quality of service: regular
 │                     sql nodes: <hidden>
 │                     regions: <hidden>
 │                     actual row count: 0
+│                     execution time: 0µs
 │                     label: buffer 1 (q)
 │
 ├── • subquery
@@ -373,6 +377,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1 (q)
 │       │
 │       └── • scan
@@ -399,11 +404,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 1
+        │ execution time: 0µs
         │
         └── • scan buffer
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 0
+              execution time: 0µs
               label: buffer 1 (q)
 
 # Anti joins are also converted to paired joins by the optimizer.

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -96,6 +96,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 1
+    │ execution time: 0µs
     │
     ├── • index join (streamer)
     │   │ sql nodes: <hidden>
@@ -350,6 +351,7 @@ quality of service: regular
     │ KV pairs read: 2
     │ KV bytes read: 8 B
     │ KV gRPC calls: 1
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: b@b_pkey
     │ equality: (x) = (x)
@@ -448,6 +450,7 @@ quality of service: regular
     │ KV pairs read: 4
     │ KV bytes read: 16 B
     │ KV gRPC calls: 2
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ table: xy@xy_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -620,12 +620,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: uniq_fk_parent(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -634,6 +636,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -642,11 +645,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (a) = (column1)
@@ -672,6 +677,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -681,11 +687,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (right semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (b, c) = (column2, column3)
@@ -711,6 +719,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 2
+                  execution time: 0µs
                   estimated row count: 2
                   label: buffer 1
 
@@ -738,12 +747,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: uniq_fk_child(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -752,6 +763,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -760,11 +772,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (c) = (column3)
@@ -790,6 +804,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -799,11 +814,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right anti)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ equality: (b, c) = (column2, column3)
 │           │
@@ -827,6 +844,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -836,11 +854,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (right anti)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ equality: (a) = (column1)
             │
@@ -864,6 +884,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 2
+                  execution time: 0µs
                   estimated row count: 2
                   label: buffer 1
 
@@ -2622,6 +2643,7 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ table: uniq_fk_parent
 │   │ set: c
 │   │
@@ -2629,6 +2651,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -2659,6 +2682,7 @@ quality of service: regular
 │       │   │ sql nodes: <hidden>
 │       │   │ regions: <hidden>
 │       │   │ actual row count: 0
+│       │   │ execution time: 0µs
 │       │   │ table: uniq_fk_child
 │       │   │ set: b, c
 │       │   │
@@ -2666,12 +2690,14 @@ quality of service: regular
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
 │       │       │ actual row count: 2
+│       │       │ execution time: 0µs
 │       │       │ label: buffer 1
 │       │       │
 │       │       └── • hash join
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
 │       │           │ actual row count: 2
+│       │           │ execution time: 0µs
 │       │           │ estimated max memory allocated: 0 B
 │       │           │ equality: (b, c) = (b, c)
 │       │           │
@@ -2695,6 +2721,7 @@ quality of service: regular
 │       │               │ sql nodes: <hidden>
 │       │               │ regions: <hidden>
 │       │               │ actual row count: 2
+│       │               │ execution time: 0µs
 │       │               │ estimated row count: 1
 │       │               │ filter: (b IS DISTINCT FROM b) OR (c IS DISTINCT FROM c_new)
 │       │               │
@@ -2702,6 +2729,7 @@ quality of service: regular
 │       │                     sql nodes: <hidden>
 │       │                     regions: <hidden>
 │       │                     actual row count: 2
+│       │                     execution time: 0µs
 │       │                     estimated row count: 2
 │       │                     label: buffer 1000000
 │       │
@@ -2711,11 +2739,13 @@ quality of service: regular
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
 │       │       │ actual row count: 0
+│       │       │ execution time: 0µs
 │       │       │
 │       │       └── • hash join (right semi)
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
 │       │           │ actual row count: 0
+│       │           │ execution time: 0µs
 │       │           │ estimated max memory allocated: 0 B
 │       │           │ estimated max sql temp disk usage: 0 B
 │       │           │ equality: (c) = (c_new)
@@ -2741,6 +2771,7 @@ quality of service: regular
 │       │                 sql nodes: <hidden>
 │       │                 regions: <hidden>
 │       │                 actual row count: 2
+│       │                 execution time: 0µs
 │       │                 label: buffer 1
 │       │
 │       └── • constraint-check
@@ -2749,11 +2780,13 @@ quality of service: regular
 │               │ sql nodes: <hidden>
 │               │ regions: <hidden>
 │               │ actual row count: 0
+│               │ execution time: 0µs
 │               │
 │               └── • hash join (right anti)
 │                   │ sql nodes: <hidden>
 │                   │ regions: <hidden>
 │                   │ actual row count: 0
+│                   │ execution time: 0µs
 │                   │ estimated max memory allocated: 0 B
 │                   │ equality: (b, c) = (b, c_new)
 │                   │
@@ -2777,12 +2810,14 @@ quality of service: regular
 │                       │ sql nodes: <hidden>
 │                       │ regions: <hidden>
 │                       │ actual row count: 2
+│                       │ execution time: 0µs
 │                       │ filter: (b IS NOT NULL) AND (c_new IS NOT NULL)
 │                       │
 │                       └── • scan buffer
 │                             sql nodes: <hidden>
 │                             regions: <hidden>
 │                             actual row count: 2
+│                             execution time: 0µs
 │                             label: buffer 1
 │
 └── • constraint-check
@@ -2791,11 +2826,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (b, c_new) = (b, c)
@@ -2805,6 +2842,7 @@ quality of service: regular
             │     sql nodes: <hidden>
             │     regions: <hidden>
             │     actual row count: 2
+            │     execution time: 0µs
             │     label: buffer 1
             │
             └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1013,6 +1013,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1029,6 +1030,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: ($1) = (k)
@@ -1039,6 +1041,7 @@ quality of service: regular
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               size: 1 column, 1 row
 
 statement ok
@@ -1066,6 +1069,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1081,6 +1085,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
@@ -1097,6 +1102,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t137352@t137352_a_idx
             │ equality: ($1) = (a)
@@ -1106,6 +1112,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 1 column, 1 row
 
 statement ok
@@ -1134,6 +1141,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1150,6 +1158,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: ($1) = (k)
@@ -1160,6 +1169,7 @@ quality of service: regular
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 1
+              execution time: 0µs
               size: 1 column, 1 row
 
 statement ok
@@ -1200,6 +1210,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ table: t137352
 │ set: b
 │ auto commit
@@ -1218,6 +1229,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated row count: 10
             │ table: t137352@t137352_pkey
@@ -1233,6 +1245,7 @@ quality of service: regular
                 │ KV rows decoded: 0
                 │ KV bytes read: 0 B
                 │ KV gRPC calls: 0
+                │ execution time: 0µs
                 │ estimated max memory allocated: 0 B
                 │ estimated row count: 10
                 │ table: t137352@t137352_a_idx
@@ -1249,6 +1262,7 @@ quality of service: regular
                     │ KV rows decoded: 0
                     │ KV bytes read: 0 B
                     │ KV gRPC calls: 0
+                    │ execution time: 0µs
                     │ estimated max memory allocated: 0 B
                     │ estimated row count: 1
                     │ table: t137352@t137352_pkey
@@ -1259,4 +1273,5 @@ quality of service: regular
                           sql nodes: <hidden>
                           regions: <hidden>
                           actual row count: 1
+                          execution time: 0µs
                           size: 1 column, 1 row

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1182,6 +1182,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ into: t137352(k, a, b)
 │ auto commit
 │ arbiter indexes: t137352_pkey
@@ -1196,6 +1197,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t137352@t137352_pkey
     │ equality: (column1) = (k)
@@ -1206,6 +1208,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 3 columns, 1 row
 
 statement ok
@@ -1234,6 +1237,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │ into: t137352(k, a, b)
 │ auto commit
 │ arbiter indexes: t137352_a_key
@@ -1251,6 +1255,7 @@ quality of service: regular
         │ KV pairs read: 2
         │ KV bytes read: 8 B
         │ KV gRPC calls: 1
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t137352@t137352_pkey
         │ equality: (k) = (k)
@@ -1268,6 +1273,7 @@ quality of service: regular
             │ KV pairs read: 2
             │ KV bytes read: 8 B
             │ KV gRPC calls: 1
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t137352@t137352_a_key
             │ equality: (column2) = (a)
@@ -1278,6 +1284,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 3 columns, 1 row
 
 # Regression test for #136458. The canary column ordinal should be correctly

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -96,6 +96,7 @@ quality of service: regular
 │ KV pairs read: 2
 │ KV bytes read: 8 B
 │ KV gRPC calls: 1
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: d@d_pkey
 │ equality: (b) = (b)
@@ -143,6 +144,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ table: d@d_pkey
     │ equality: (b) = (b)
     │
@@ -222,6 +224,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ equality: (a) = (b)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -539,6 +539,9 @@ func (e *emitter) emitNodeAttributes(ctx context.Context, evalCtx *eval.Context,
 		if s.KVBatchRequestsIssued.HasValue() {
 			e.ob.AddField("KV gRPC calls", string(humanizeutil.Count(s.KVBatchRequestsIssued.Value())))
 		}
+		if s.ExecTime.HasValue() {
+			e.ob.AddField("execution time", string(humanizeutil.Duration(s.ExecTime.Value())))
+		}
 		if s.MaxAllocatedMem.HasValue() {
 			e.ob.AddField("estimated max memory allocated", humanize.IBytes(s.MaxAllocatedMem.Value()))
 		}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -522,6 +522,7 @@ type ExecutionStats struct {
 	SeekCount         optional.Uint
 	InternalSeekCount optional.Uint
 
+	ExecTime         optional.Duration
 	MaxAllocatedMem  optional.Uint
 	MaxAllocatedDisk optional.Uint
 	SQLCPUTime       optional.Duration


### PR DESCRIPTION
Backport 1/1 commits from #143857.

/cc @cockroachdb/release

---

We've been tracking "execution time" statistic for most operators (except for vectorized KV-reading ones which get separate "KV time" stat) for many years now, but for some reason we only reported it on the DistSQL diagram.  This commit fixes that oversight so that the stat is now included on `EXPLAIN ANALYZE` output when available.

Fixes: #143443.

Release note (sql change): New statistic `execution time` is now reported on EXPLAIN ANALYZE output for most operators. It was previously only available on the DistSQL diagrams (included in `EXPLAIN ANALYZE (DISTSQL)` output).

Release justification: low-risk observability improvement.