### PR TITLE
release-24.3: explain: show "execution time" on EXPLAIN ANALYZE output

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/explain_call_plpgsql
@@ -155,6 +155,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 
@@ -177,6 +178,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/ccl/logictestccl/testdata/logic_test/generic
+++ b/pkg/ccl/logictestccl/testdata/logic_test/generic
@@ -55,6 +55,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -109,6 +110,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -166,6 +168,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -220,6 +223,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -357,6 +361,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -373,6 +378,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_a_idx
     │ equality: ($1) = (a)
@@ -381,6 +387,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 2 columns, 1 row
 
 # The generic plan can be reused with different placeholder values.
@@ -408,6 +415,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -424,6 +432,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_a_idx
     │ equality: ($1) = (a)
@@ -432,6 +441,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 2 columns, 1 row
 
 statement ok
@@ -457,6 +467,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 2
 │
 └── • index join (streamer)
@@ -521,6 +532,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -536,6 +548,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_t_idx
     │ equality: (column11) = (t)
@@ -544,6 +557,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 # The generic plan can be reused.
@@ -571,6 +585,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: t@t_pkey
 │ equality: (k) = (k)
@@ -586,6 +601,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: t@t_t_idx
     │ equality: (column11) = (t)
@@ -594,6 +610,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 statement ok
@@ -622,6 +639,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: s LIKE 'foo%'
 │
 └── • scan
@@ -665,6 +683,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 1
 │
 └── • scan
@@ -705,6 +724,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 1
 │
 └── • scan
@@ -754,6 +774,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: (b = 2) AND (c = 3)
 │
 └── • index join (streamer)
@@ -819,6 +840,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 0
+│ execution time: 0µs
 │ filter: c = 20000
 │
 └── • index join (streamer)
@@ -891,6 +913,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
@@ -904,6 +927,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: c@c_a_idx
     │ equality: (k) = (a)
@@ -912,6 +936,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │ filter: c = 20000
         │
         └── • index join (streamer)
@@ -969,6 +994,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
@@ -982,6 +1008,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: c@c_a_idx
     │ equality: (k) = (a)
@@ -995,6 +1022,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t@t_pkey
         │ equality: (k) = (k)
@@ -1011,6 +1039,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t@t_a_idx
             │ equality: ($1) = (a)
@@ -1019,6 +1048,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 2 columns, 1 row
 
 # On the seventh execution the generic plan is reused.
@@ -1046,6 +1076,7 @@ quality of service: regular
 │ KV rows decoded: 0
 │ KV bytes read: 0 B
 │ KV gRPC calls: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: g@g_a_b_idx
 │ equality: (k) = (a)
@@ -1059,6 +1090,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: c@c_a_idx
     │ equality: (k) = (a)
@@ -1072,6 +1104,7 @@ quality of service: regular
         │ KV rows decoded: 0
         │ KV bytes read: 0 B
         │ KV gRPC calls: 0
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ table: t@t_pkey
         │ equality: (k) = (k)
@@ -1088,6 +1121,7 @@ quality of service: regular
             │ KV rows decoded: 0
             │ KV bytes read: 0 B
             │ KV gRPC calls: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: t@t_a_idx
             │ equality: ($1) = (a)
@@ -1096,6 +1130,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 1
+                  execution time: 0µs
                   size: 2 columns, 1 row
 
 statement ok
@@ -1178,6 +1213,7 @@ quality of service: regular
     │ KV rows decoded: 0
     │ KV bytes read: 0 B
     │ KV gRPC calls: 0
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ table: g@g_a_b_idx
@@ -1187,6 +1223,7 @@ quality of service: regular
           sql nodes: <hidden>
           regions: <hidden>
           actual row count: 1
+          execution time: 0µs
           size: 1 column, 1 row
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers_explain
@@ -124,6 +124,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 1
 │ vectorized batch count: 0
+│ execution time: 0µs
 │ estimated row count: 0 (missing stats)
 │ table: xy
 │ set: x, y
@@ -146,6 +147,7 @@ quality of service: regular
         │ regions: <hidden>
         │ actual row count: 0
         │ vectorized batch count: 0
+        │ execution time: 0µs
         │ estimated row count: 10 (missing stats)
         │ filter: f IS DISTINCT FROM NULL
         │
@@ -182,6 +184,7 @@ quality of service: regular
                     │ regions: <hidden>
                     │ actual row count: 0
                     │ vectorized batch count: 0
+                    │ execution time: 0µs
                     │ estimated row count: 10 (missing stats)
                     │ filter: y = 2
                     │
@@ -338,6 +341,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -347,6 +351,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 0
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
@@ -355,6 +360,7 @@ quality of service: regular
 │           │ regions: <hidden>
 │           │ actual row count: 0
 │           │ vectorized batch count: 0
+│           │ execution time: 0µs
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -411,6 +417,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ from: xy
 │   │
@@ -420,6 +427,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 1
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • filter
@@ -428,6 +436,7 @@ quality of service: regular
 │           │ regions: <hidden>
 │           │ actual row count: 1
 │           │ vectorized batch count: 0
+│           │ execution time: 0µs
 │           │ estimated row count: 10 (missing stats)
 │           │ filter: y = 2
 │           │
@@ -478,6 +487,7 @@ quality of service: regular
                       regions: <hidden>
                       actual row count: 1
                       vectorized batch count: 0
+                      execution time: 0µs
                       estimated row count: 1
                       label: buffer 1000000
 
@@ -683,6 +693,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -693,6 +704,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 0
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -755,6 +767,7 @@ quality of service: regular
 │   │ regions: <hidden>
 │   │ actual row count: 1
 │   │ vectorized batch count: 0
+│   │ execution time: 0µs
 │   │ estimated row count: 0 (missing stats)
 │   │ table: parent
 │   │ set: k
@@ -765,6 +778,7 @@ quality of service: regular
 │       │ regions: <hidden>
 │       │ actual row count: 1
 │       │ vectorized batch count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -805,6 +819,7 @@ quality of service: regular
         │   │ regions: <hidden>
         │   │ actual row count: 0
         │   │ vectorized batch count: 0
+        │   │ execution time: 0µs
         │   │ estimated row count: 0 (missing stats)
         │   │ table: child
         │   │ set: fk
@@ -818,6 +833,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 1
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • filter
@@ -826,6 +842,7 @@ quality of service: regular
         │           │ regions: <hidden>
         │           │ actual row count: 1
         │           │ vectorized batch count: 0
+        │           │ execution time: 0µs
         │           │ estimated row count: 3 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -865,6 +882,7 @@ quality of service: regular
         │                           │ regions: <hidden>
         │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
+        │                           │ execution time: 0µs
         │                           │ estimated max memory allocated: 0 B
         │                           │ estimated max sql temp disk usage: 0 B
         │                           │ estimated row count: 3 (missing stats)
@@ -896,6 +914,7 @@ quality of service: regular
         │                               │ regions: <hidden>
         │                               │ actual row count: 1
         │                               │ vectorized batch count: 0
+        │                               │ execution time: 0µs
         │                               │ estimated row count: 0
         │                               │ filter: k IS DISTINCT FROM k_new
         │                               │
@@ -905,6 +924,7 @@ quality of service: regular
         │                                     regions: <hidden>
         │                                     actual row count: 1
         │                                     vectorized batch count: 0
+        │                                     execution time: 0µs
         │                                     estimated row count: 1
         │                                     label: buffer 1000000
         │
@@ -916,6 +936,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 0
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │
         │       └── • lookup join (anti)
         │           │ columns: (fk_new)
@@ -930,6 +951,7 @@ quality of service: regular
         │           │ KV pairs read: 2
         │           │ KV bytes read: 8 B
         │           │ KV gRPC calls: 1
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ MVCC step count (ext/int): 0/0
         │           │ MVCC seek count (ext/int): 0/0
@@ -944,6 +966,7 @@ quality of service: regular
         │               │ regions: <hidden>
         │               │ actual row count: 1
         │               │ vectorized batch count: 0
+        │               │ execution time: 0µs
         │               │ estimated row count: 3 (missing stats)
         │               │ filter: fk_new IS NOT NULL
         │               │
@@ -956,6 +979,7 @@ quality of service: regular
         │                         regions: <hidden>
         │                         actual row count: 1
         │                         vectorized batch count: 0
+        │                         execution time: 0µs
         │                         estimated row count: 3 (missing stats)
         │                         label: buffer 1
         │
@@ -990,6 +1014,7 @@ quality of service: regular
                               regions: <hidden>
                               actual row count: 1
                               vectorized batch count: 0
+                              execution time: 0µs
                               estimated row count: 1
                               label: buffer 1000000
 
@@ -1024,6 +1049,7 @@ quality of service: regular
 │     regions: <hidden>
 │     actual row count: 1
 │     vectorized batch count: 0
+│     execution time: 0µs
 │     estimated row count: 0 (missing stats)
 │     from: parent
 │     spans: /2/0
@@ -1040,6 +1066,7 @@ quality of service: regular
         │   │ regions: <hidden>
         │   │ actual row count: 0
         │   │ vectorized batch count: 0
+        │   │ execution time: 0µs
         │   │ estimated row count: 0 (missing stats)
         │   │ from: child
         │   │
@@ -1052,6 +1079,7 @@ quality of service: regular
         │       │ regions: <hidden>
         │       │ actual row count: 1
         │       │ vectorized batch count: 0
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • filter
@@ -1060,6 +1088,7 @@ quality of service: regular
         │           │ regions: <hidden>
         │           │ actual row count: 1
         │           │ vectorized batch count: 0
+        │           │ execution time: 0µs
         │           │ estimated row count: 10 (missing stats)
         │           │ filter: f IS DISTINCT FROM NULL
         │           │
@@ -1090,6 +1119,7 @@ quality of service: regular
         │                           │ regions: <hidden>
         │                           │ actual row count: 1
         │                           │ vectorized batch count: 0
+        │                           │ execution time: 0µs
         │                           │ estimated row count: 10 (missing stats)
         │                           │ filter: fk = 2
         │                           │
@@ -1140,6 +1170,7 @@ quality of service: regular
                               regions: <hidden>
                               actual row count: 1
                               vectorized batch count: 0
+                              execution time: 0µs
                               estimated row count: 1
                               label: buffer 1000000
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -1060,6 +1060,7 @@ func (m execNodeTraceMetadata) annotateExplain(
 				nodeStats.SeekCount.MaybeAdd(stats.KV.NumInterfaceSeeks)
 				nodeStats.InternalSeekCount.MaybeAdd(stats.KV.NumInternalSeeks)
 				nodeStats.VectorizedBatchCount.MaybeAdd(stats.Output.NumBatches)
+				nodeStats.ExecTime.MaybeAdd(stats.Exec.ExecTime)
 				nodeStats.MaxAllocatedMem.MaybeAdd(stats.Exec.MaxAllocatedMem)
 				nodeStats.MaxAllocatedDisk.MaybeAdd(stats.Exec.MaxAllocatedDisk)
 				if noMutations && !makeDeterministic {

--- a/pkg/sql/opt/exec/execbuilder/testdata/call
+++ b/pkg/sql/opt/exec/execbuilder/testdata/call
@@ -149,6 +149,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 
@@ -171,6 +172,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 0
+  execution time: 0µs
   estimated row count: 0
   procedure: foo(3)
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/cascade
+++ b/pkg/sql/opt/exec/execbuilder/testdata/cascade
@@ -1062,12 +1062,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ from: loop_a
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • scan
@@ -1095,18 +1097,21 @@ quality of service: regular
         │   │ sql nodes: <hidden>
         │   │ regions: <hidden>
         │   │ actual row count: 0
+        │   │ execution time: 0µs
         │   │ from: loop_b
         │   │
         │   └── • buffer
         │       │ sql nodes: <hidden>
         │       │ regions: <hidden>
         │       │ actual row count: 1
+        │       │ execution time: 0µs
         │       │ label: buffer 1
         │       │
         │       └── • hash join (semi)
         │           │ sql nodes: <hidden>
         │           │ regions: <hidden>
         │           │ actual row count: 1
+        │           │ execution time: 0µs
         │           │ estimated max memory allocated: 0 B
         │           │ estimated max sql temp disk usage: 0 B
         │           │ equality: (cascade_delete) = (id)
@@ -1131,6 +1136,7 @@ quality of service: regular
         │                 sql nodes: <hidden>
         │                 regions: <hidden>
         │                 actual row count: 1
+        │                 execution time: 0µs
         │                 estimated row count: 1
         │                 label: buffer 1000000
         │
@@ -1143,12 +1149,14 @@ quality of service: regular
                 │   │ sql nodes: <hidden>
                 │   │ regions: <hidden>
                 │   │ actual row count: 0
+                │   │ execution time: 0µs
                 │   │ from: loop_a
                 │   │
                 │   └── • buffer
                 │       │ sql nodes: <hidden>
                 │       │ regions: <hidden>
                 │       │ actual row count: 1
+                │       │ execution time: 0µs
                 │       │ label: buffer 1
                 │       │
                 │       └── • lookup join
@@ -1162,6 +1170,7 @@ quality of service: regular
                 │           │ KV pairs read: 2
                 │           │ KV bytes read: 8 B
                 │           │ KV gRPC calls: 1
+                │           │ execution time: 0µs
                 │           │ estimated max memory allocated: 0 B
                 │           │ table: loop_a@loop_a_cascade_delete_idx
                 │           │ equality: (id) = (cascade_delete)
@@ -1170,6 +1179,7 @@ quality of service: regular
                 │               │ sql nodes: <hidden>
                 │               │ regions: <hidden>
                 │               │ actual row count: 1
+                │               │ execution time: 0µs
                 │               │ estimated max memory allocated: 0 B
                 │               │ estimated max sql temp disk usage: 0 B
                 │               │ estimated row count: 1
@@ -1179,6 +1189,7 @@ quality of service: regular
                 │                     sql nodes: <hidden>
                 │                     regions: <hidden>
                 │                     actual row count: 1
+                │                     execution time: 0µs
                 │                     estimated row count: 1
                 │                     label: buffer 1000000
                 │

--- a/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
+++ b/pkg/sql/opt/exec/execbuilder/testdata/dist_vectorize
@@ -69,6 +69,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 1
+│ execution time: 0µs
 │
 └── • scan
       sql nodes: <hidden>
@@ -108,6 +109,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ equality: (k) = (k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -2254,6 +2254,7 @@ quality of service: regular
   sql nodes: <hidden>
   regions: <hidden>
   actual row count: 1
+  execution time: 0µs
   size: 1 column, 1 row
 
 # Tests for EXPLAIN (OPT, MEMO).

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_plans
@@ -78,6 +78,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ group by: k
 │ ordered: +k
 │
@@ -85,6 +86,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ equality: (k) = (k)
@@ -146,6 +148,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ order: +w
@@ -154,6 +157,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ distinct on: w
@@ -162,6 +166,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 5
+        │ execution time: 0µs
         │ estimated max memory allocated: 0 B
         │ estimated max sql temp disk usage: 0 B
         │ equality: (k) = (w)
@@ -222,6 +227,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 25
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │
@@ -229,6 +235,7 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 5
+│   │ execution time: 0µs
 │   │
 │   └── • scan
 │         sql nodes: <hidden>
@@ -250,6 +257,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 5
+    │ execution time: 0µs
     │
     └── • scan
           sql nodes: <hidden>
@@ -311,6 +319,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 5
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │
@@ -394,18 +403,21 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: child(c, p)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • values
 │             sql nodes: <hidden>
 │             regions: <hidden>
 │             actual row count: 1
+│             execution time: 0µs
 │             size: 2 columns, 1 row
 │
 ├── • subquery
@@ -417,6 +429,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 1
+│       │ execution time: 0µs
 │       │
 │       └── • scan
 │             sql nodes: <hidden>
@@ -441,6 +454,7 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • lookup join (anti)
             │ sql nodes: <hidden>
@@ -453,6 +467,7 @@ quality of service: regular
             │ KV pairs read: 2
             │ KV bytes read: 8 B
             │ KV gRPC calls: 1
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ table: parent@parent_pkey
             │ equality: (column2) = (p)
@@ -462,6 +477,7 @@ quality of service: regular
                 │ sql nodes: <hidden>
                 │ regions: <hidden>
                 │ actual row count: 1
+                │ execution time: 0µs
                 │ estimated row count: 1
                 │ filter: column2 IS NOT NULL
                 │
@@ -469,6 +485,7 @@ quality of service: regular
                       sql nodes: <hidden>
                       regions: <hidden>
                       actual row count: 1
+                      execution time: 0µs
                       estimated row count: 1
                       label: buffer 1
 ·

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze_read_committed
@@ -81,6 +81,7 @@ quality of service: regular
 │ regions: <hidden>
 │ actual row count: 2
 │ vectorized batch count: 0
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ estimated row count: 990 (missing stats)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_geospatial
@@ -39,6 +39,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ order: +k
@@ -47,6 +48,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -68,6 +70,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
@@ -134,6 +137,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ order: +k
@@ -142,6 +146,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -163,6 +168,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key
@@ -213,6 +219,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ order: +k
@@ -221,6 +228,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ filter: st_intersects('010100002026690000000000000C6A18410000008081844E41', geom)
     │
     └── • index join (streamer)
@@ -242,6 +250,7 @@ quality of service: regular
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 2
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ inverted column: geom_inverted_key

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -326,6 +326,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ estimated max memory allocated: 0 B
 │       │ estimated max sql temp disk usage: 0 B
 │       │ group by: lk
@@ -339,6 +340,7 @@ quality of service: regular
 │           │ KV rows decoded: 0
 │           │ KV bytes read: 0 B
 │           │ KV gRPC calls: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ table: rtable@rtable_pkey
 │           │ equality: (rk1, rk2) = (rk1, rk2)
@@ -354,6 +356,7 @@ quality of service: regular
 │               │ KV rows decoded: 0
 │               │ KV bytes read: 0 B
 │               │ KV gRPC calls: 0
+│               │ execution time: 0µs
 │               │ estimated max memory allocated: 0 B
 │               │ estimated max sql temp disk usage: 0 B
 │               │ table: rtable@geom_index
@@ -362,6 +365,7 @@ quality of service: regular
 │                     sql nodes: <hidden>
 │                     regions: <hidden>
 │                     actual row count: 0
+│                     execution time: 0µs
 │                     label: buffer 1 (q)
 │
 ├── • subquery
@@ -373,6 +377,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │ label: buffer 1 (q)
 │       │
 │       └── • scan
@@ -399,11 +404,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 1
+        │ execution time: 0µs
         │
         └── • scan buffer
               sql nodes: <hidden>
               regions: <hidden>
               actual row count: 0
+              execution time: 0µs
               label: buffer 1 (q)
 
 # Anti joins are also converted to paired joins by the optimizer.

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_limit
@@ -96,6 +96,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 1
+    │ execution time: 0µs
     │
     ├── • index join (streamer)
     │   │ sql nodes: <hidden>
@@ -350,6 +351,7 @@ quality of service: regular
     │ KV pairs read: 2
     │ KV bytes read: 8 B
     │ KV gRPC calls: 1
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ table: b@b_pkey
     │ equality: (x) = (x)
@@ -448,6 +450,7 @@ quality of service: regular
     │ KV pairs read: 4
     │ KV bytes read: 16 B
     │ KV gRPC calls: 2
+    │ execution time: 0µs
     │ estimated max memory allocated: 0 B
     │ estimated max sql temp disk usage: 0 B
     │ table: xy@xy_pkey

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -620,12 +620,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: uniq_fk_parent(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -634,6 +636,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -642,11 +645,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (a) = (column1)
@@ -672,6 +677,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -681,11 +687,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (right semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (b, c) = (column2, column3)
@@ -711,6 +719,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 2
+                  execution time: 0µs
                   estimated row count: 2
                   label: buffer 1
 
@@ -738,12 +747,14 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ into: uniq_fk_child(a, b, c, rowid)
 │   │
 │   └── • buffer
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -752,6 +763,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 size: 3 columns, 2 rows
 │
 ├── • constraint-check
@@ -760,11 +772,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right semi)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (c) = (column3)
@@ -790,6 +804,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -799,11 +814,13 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 0
+│       │ execution time: 0µs
 │       │
 │       └── • hash join (right anti)
 │           │ sql nodes: <hidden>
 │           │ regions: <hidden>
 │           │ actual row count: 0
+│           │ execution time: 0µs
 │           │ estimated max memory allocated: 0 B
 │           │ estimated max sql temp disk usage: 0 B
 │           │ equality: (b, c) = (column2, column3)
@@ -828,6 +845,7 @@ quality of service: regular
 │                 sql nodes: <hidden>
 │                 regions: <hidden>
 │                 actual row count: 2
+│                 execution time: 0µs
 │                 estimated row count: 2
 │                 label: buffer 1
 │
@@ -837,11 +855,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (right anti)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (a) = (column1)
@@ -866,6 +886,7 @@ quality of service: regular
                   sql nodes: <hidden>
                   regions: <hidden>
                   actual row count: 2
+                  execution time: 0µs
                   estimated row count: 2
                   label: buffer 1
 
@@ -2624,6 +2645,7 @@ quality of service: regular
 │   │ sql nodes: <hidden>
 │   │ regions: <hidden>
 │   │ actual row count: 1
+│   │ execution time: 0µs
 │   │ table: uniq_fk_parent
 │   │ set: c
 │   │
@@ -2631,6 +2653,7 @@ quality of service: regular
 │       │ sql nodes: <hidden>
 │       │ regions: <hidden>
 │       │ actual row count: 2
+│       │ execution time: 0µs
 │       │ label: buffer 1
 │       │
 │       └── • render
@@ -2661,6 +2684,7 @@ quality of service: regular
 │       │   │ sql nodes: <hidden>
 │       │   │ regions: <hidden>
 │       │   │ actual row count: 0
+│       │   │ execution time: 0µs
 │       │   │ table: uniq_fk_child
 │       │   │ set: b, c
 │       │   │
@@ -2668,12 +2692,14 @@ quality of service: regular
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
 │       │       │ actual row count: 2
+│       │       │ execution time: 0µs
 │       │       │ label: buffer 1
 │       │       │
 │       │       └── • hash join
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
 │       │           │ actual row count: 2
+│       │           │ execution time: 0µs
 │       │           │ estimated max memory allocated: 0 B
 │       │           │ estimated max sql temp disk usage: 0 B
 │       │           │ equality: (b, c) = (b, c)
@@ -2698,6 +2724,7 @@ quality of service: regular
 │       │               │ sql nodes: <hidden>
 │       │               │ regions: <hidden>
 │       │               │ actual row count: 2
+│       │               │ execution time: 0µs
 │       │               │ estimated row count: 1
 │       │               │ filter: (b IS DISTINCT FROM b) OR (c IS DISTINCT FROM c_new)
 │       │               │
@@ -2705,6 +2732,7 @@ quality of service: regular
 │       │                     sql nodes: <hidden>
 │       │                     regions: <hidden>
 │       │                     actual row count: 2
+│       │                     execution time: 0µs
 │       │                     estimated row count: 2
 │       │                     label: buffer 1000000
 │       │
@@ -2714,11 +2742,13 @@ quality of service: regular
 │       │       │ sql nodes: <hidden>
 │       │       │ regions: <hidden>
 │       │       │ actual row count: 0
+│       │       │ execution time: 0µs
 │       │       │
 │       │       └── • hash join (right semi)
 │       │           │ sql nodes: <hidden>
 │       │           │ regions: <hidden>
 │       │           │ actual row count: 0
+│       │           │ execution time: 0µs
 │       │           │ estimated max memory allocated: 0 B
 │       │           │ estimated max sql temp disk usage: 0 B
 │       │           │ equality: (c) = (c_new)
@@ -2744,6 +2774,7 @@ quality of service: regular
 │       │                 sql nodes: <hidden>
 │       │                 regions: <hidden>
 │       │                 actual row count: 2
+│       │                 execution time: 0µs
 │       │                 label: buffer 1
 │       │
 │       └── • constraint-check
@@ -2752,11 +2783,13 @@ quality of service: regular
 │               │ sql nodes: <hidden>
 │               │ regions: <hidden>
 │               │ actual row count: 0
+│               │ execution time: 0µs
 │               │
 │               └── • hash join (right anti)
 │                   │ sql nodes: <hidden>
 │                   │ regions: <hidden>
 │                   │ actual row count: 0
+│                   │ execution time: 0µs
 │                   │ estimated max memory allocated: 0 B
 │                   │ estimated max sql temp disk usage: 0 B
 │                   │ equality: (b, c) = (b, c_new)
@@ -2781,12 +2814,14 @@ quality of service: regular
 │                       │ sql nodes: <hidden>
 │                       │ regions: <hidden>
 │                       │ actual row count: 2
+│                       │ execution time: 0µs
 │                       │ filter: (b IS NOT NULL) AND (c_new IS NOT NULL)
 │                       │
 │                       └── • scan buffer
 │                             sql nodes: <hidden>
 │                             regions: <hidden>
 │                             actual row count: 2
+│                             execution time: 0µs
 │                             label: buffer 1
 │
 └── • constraint-check
@@ -2795,11 +2830,13 @@ quality of service: regular
         │ sql nodes: <hidden>
         │ regions: <hidden>
         │ actual row count: 0
+        │ execution time: 0µs
         │
         └── • hash join (semi)
             │ sql nodes: <hidden>
             │ regions: <hidden>
             │ actual row count: 0
+            │ execution time: 0µs
             │ estimated max memory allocated: 0 B
             │ estimated max sql temp disk usage: 0 B
             │ equality: (b, c_new) = (b, c)
@@ -2809,6 +2846,7 @@ quality of service: regular
             │     sql nodes: <hidden>
             │     regions: <hidden>
             │     actual row count: 2
+            │     execution time: 0µs
             │     label: buffer 1
             │
             └── • scan

--- a/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vectorize_local
@@ -96,6 +96,7 @@ quality of service: regular
 │ KV pairs read: 2
 │ KV bytes read: 8 B
 │ KV gRPC calls: 1
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ table: d@d_pkey
 │ equality: (b) = (b)
@@ -143,6 +144,7 @@ quality of service: regular
     │ sql nodes: <hidden>
     │ regions: <hidden>
     │ actual row count: 2
+    │ execution time: 0µs
     │ table: d@d_pkey
     │ equality: (b) = (b)
     │
@@ -222,6 +224,7 @@ quality of service: regular
 │ sql nodes: <hidden>
 │ regions: <hidden>
 │ actual row count: 2
+│ execution time: 0µs
 │ estimated max memory allocated: 0 B
 │ estimated max sql temp disk usage: 0 B
 │ equality: (a) = (b)

--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -536,6 +536,9 @@ func (e *emitter) emitNodeAttributes(n *Node) error {
 		if s.KVBatchRequestsIssued.HasValue() {
 			e.ob.AddField("KV gRPC calls", string(humanizeutil.Count(s.KVBatchRequestsIssued.Value())))
 		}
+		if s.ExecTime.HasValue() {
+			e.ob.AddField("execution time", string(humanizeutil.Duration(s.ExecTime.Value())))
+		}
 		if s.MaxAllocatedMem.HasValue() {
 			e.ob.AddField("estimated max memory allocated", humanize.IBytes(s.MaxAllocatedMem.Value()))
 		}

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -523,6 +523,7 @@ type ExecutionStats struct {
 	SeekCount         optional.Uint
 	InternalSeekCount optional.Uint
 
+	ExecTime         optional.Duration
 	MaxAllocatedMem  optional.Uint
 	MaxAllocatedDisk optional.Uint
 	SQLCPUTime       optional.Duration


### PR DESCRIPTION
Backport 1/1 commits from #143857.

/cc @cockroachdb/release

---

We've been tracking "execution time" statistic for most operators (except for vectorized KV-reading ones which get separate "KV time" stat) for many years now, but for some reason we only reported it on the DistSQL diagram.  This commit fixes that oversight so that the stat is now included on `EXPLAIN ANALYZE` output when available.

Fixes: #143443.

Release note (sql change): New statistic `execution time` is now reported on EXPLAIN ANALYZE output for most operators. It was previously only available on the DistSQL diagrams (included in `EXPLAIN ANALYZE (DISTSQL)` output).

Release justification: low-risk observability improvement.