### PR TITLE
release-25.1: memo: check `insert_fast_path` for staleness

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -203,6 +203,7 @@ type Memo struct {
 	preferBoundedCardinality                   bool
 	minRowCount                                float64
 	checkInputMinRowCount                      float64
+	useInsertFastPath                          bool
 	internal                                   bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
@@ -299,6 +300,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		preferBoundedCardinality:                   evalCtx.SessionData().OptimizerPreferBoundedCardinality,
 		minRowCount:                                evalCtx.SessionData().OptimizerMinRowCount,
 		checkInputMinRowCount:                      evalCtx.SessionData().OptimizerCheckInputMinRowCount,
+		useInsertFastPath:                          evalCtx.SessionData().InsertFastPath,
 		internal:                                   evalCtx.SessionData().Internal,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
@@ -472,6 +474,7 @@ func (m *Memo) IsStale(
 		m.preferBoundedCardinality != evalCtx.SessionData().OptimizerPreferBoundedCardinality ||
 		m.minRowCount != evalCtx.SessionData().OptimizerMinRowCount ||
 		m.checkInputMinRowCount != evalCtx.SessionData().OptimizerCheckInputMinRowCount ||
+		m.useInsertFastPath != evalCtx.SessionData().InsertFastPath ||
 		m.internal != evalCtx.SessionData().Internal ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -553,6 +553,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerCheckInputMinRowCount = 0
 	notStale()
 
+	evalCtx.SessionData().InsertFastPath = true
+	stale()
+	evalCtx.SessionData().InsertFastPath = false
+	notStale()
+
 	evalCtx.SessionData().Internal = true
 	stale()
 	evalCtx.SessionData().Internal = false


### PR DESCRIPTION
Backport 1/1 commits from #143868.

/cc @cockroachdb/release

---

Since we consult the value of `insert_fast_path` session variable in `CanUseUniqueChecksForInsertFastPath` (which is called during the exploration), we need to check the value for memo staleness, and this has been missing.

Epic: None

Release note: None

Release justification: low-risk bug fix.