### PR TITLE
roachtest/backup_restore: Use a schedule for backup layers.

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/testutils/fingerprintutils",
         "//pkg/util/hlc",
         "//pkg/util/randutil",
+        "//pkg/util/retry",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",


### PR DESCRIPTION
This puts down a protected timestamp, so we can't GC needed data while a previous backup is running.

Epic: none

Release note: None