### PR TITLE
[DNM] kvcoord: don't consider connection health for follower reads

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -2600,10 +2600,12 @@ func (ds *DistSender) sendToReplicas(
 	// NB: upgrade the connection class to SYSTEM, for critical ranges. Set it to
 	// DEFAULT if the class is unknown, to handle mixed-version states gracefully.
 	// Other kinds of overrides are possible, see rpc.ConnectionClassForKey().
+	isFollowerRead := !routeToLeaseholder
+	followerReadsUnhealthy := FollowerReadsUnhealthy.Get(&ds.st.SV)
 	opts := SendOptions{
 		class:                  rpc.ConnectionClassForKey(desc.RSpan().Key, ba.ConnectionClass),
 		metrics:                &ds.metrics,
-		dontConsiderConnHealth: ds.dontConsiderConnHealth,
+		dontConsiderConnHealth: ds.dontConsiderConnHealth || (isFollowerRead && followerReadsUnhealthy),
 	}
 	transport := ds.transportFactory(opts, replicas)
 	defer transport.Release()


### PR DESCRIPTION
This commit reuses the `kv.dist_sender.follower_reads_unhealthy.enabled` cluster setting to determine whether connection health should be taken into consideration while sorting replicas.

Informs: #142194

Release note: None