### PR TITLE
roachtest: add operation to toggle kv prober setting on drt clusters

### DIFF
--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -83,6 +83,16 @@ func registerClusterSettings(r registry.Registry) {
 			Owner:     registry.OwnerKV,
 		},
 		{
+			Name:      "kv.prober.read.enabled",
+			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 24*3*time.Hour),
+			Owner:     registry.OwnerKV,
+		},
+		{
+			Name:      "kv.prober.write.enabled",
+			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 24*3*time.Hour),
+			Owner:     registry.OwnerKV,
+		},
+		{
 			// Change the fraction of replicas that run leader leases.
 			Name: "kv.raft.leader_fortification.fraction_enabled",
 			Generator: timeBasedRandomValue(timeutil.Now, 6*time.Hour, func(rng *rand.Rand) string {


### PR DESCRIPTION
Currently, kv prober is not tested in long-lived testing clusters. We would like to improve quality of coverage for kv prober due to incident.

resolves: #102034
Release note: None
Epic: None