### PR TITLE
roachtest: add operation to query crdb_internal.probe_ranges

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "network_partition.go",
         "node_kill.go",
         "pause_job.go",
+        "probe_ranges.go",
         "register.go",
         "resize.go",
         "session_vars.go",

--- a/pkg/cmd/roachtest/operations/probe_ranges.go
+++ b/pkg/cmd/roachtest/operations/probe_ranges.go
@@ -1,0 +1,61 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations/helpers"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+func runProbeRanges(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	rng, _ := randutil.NewPseudoRand()
+
+	nodes := c.All()
+	nid := nodes[rng.Intn(len(nodes))]
+
+	conn := c.Conn(ctx, o.L(), nid, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	dbName := helpers.PickRandomDB(ctx, o, conn, helpers.SystemDBs)
+	tableName := helpers.PickRandomTable(ctx, o, conn, dbName)
+	sid := helpers.PickRandomStore(ctx, o, conn, nid)
+
+	compactionStmt := fmt.Sprintf(`SELECT crdb_internal.compact_engine_span(
+				%d, %d,
+				(SELECT raw_start_key FROM [SHOW RANGES FROM TABLE %s.%s WITH KEYS] LIMIT 1),
+				(SELECT raw_end_key FROM [SHOW RANGES FROM TABLE %s.%s WITH KEYS] LIMIT 1))`,
+		nid, sid, dbName, tableName, dbName, tableName)
+	o.Status(fmt.Sprintf("compacting a range for table %s.%s in n%d, s%d",
+		dbName, tableName, nid, sid))
+	_, err := conn.ExecContext(ctx, compactionStmt)
+	if err != nil {
+		o.Fatal(err)
+	}
+	return nil
+}
+
+func registerProbeRanges(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:               "Probe ranges",
+		Owner:              registry.OwnerSRE,
+		Timeout:            30 * time.Minute,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnavailableRanges},
+		Run:                runProbeRanges,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -24,6 +24,7 @@ func RegisterOperations(r registry.Registry) {
 	registerManualCompaction(r)
 	registerResize(r)
 	registerPauseLDRJob(r)
+	registerProbeRanges(r)
 	registerLicenseThrottle(r)
 	registerSessionVariables(r)
 	registerDebugZip(r)

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -31,6 +31,7 @@ const (
 	OwnerProductSecurity    Owner = `product-security`
 	OwnerReleaseEng         Owner = `release-eng`
 	OwnerSQLQueries         Owner = `sql-queries`
+	OwnerSRE                Owner = `sre`
 	OwnerStorage            Owner = `storage`
 	OwnerTestEng            Owner = `test-eng`
 	OwnerDevInf             Owner = `dev-inf`

--- a/pkg/cmd/roachtest/registry/owners.go
+++ b/pkg/cmd/roachtest/registry/owners.go
@@ -31,11 +31,11 @@ const (
 	OwnerProductSecurity    Owner = `product-security`
 	OwnerReleaseEng         Owner = `release-eng`
 	OwnerSQLQueries         Owner = `sql-queries`
-	OwnerSRE                Owner = `sre`
 	OwnerStorage            Owner = `storage`
 	OwnerTestEng            Owner = `test-eng`
 	OwnerDevInf             Owner = `dev-inf`
 	OwnerFieldEng           Owner = `field-engineering`
+	OwnerSRE                Owner = `sre`
 )
 
 // IsValid returns true if the owner is valid, i.e. it has a corresponding team


### PR DESCRIPTION
Since SRE uses crdb_internal.probe_ranges to test for prod cluster health, we would like to add this as a roach operation to make the DRT cluster as realistic as possible, and test for potential issues with crdb_internal.probe_ranges.

Fixes: #102034
Release note: None
Epic: None