### PR TITLE
server: allow for filtering hot ranges by node id

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3598,6 +3598,7 @@ of ranges currently considered “hot” by the node(s).
 | page_size | [int32](#cockroach.server.serverpb.HotRangesRequest-int32) |  |  | [reserved](#support-status) |
 | page_token | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 | tenant_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
+| nodes | [string](#cockroach.server.serverpb.HotRangesRequest-string) | repeated |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -542,6 +542,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -497,7 +497,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 		requestedNodes = []roachpb.NodeID{requestedNodeID}
 	}
 
-	remoteRequest := serverpb.HotRangesRequest{NodeID: "local"}
+	remoteRequest := serverpb.HotRangesRequest{Nodes: []string{"local"}}
 	nodeFn := func(ctx context.Context, status serverpb.StatusClient, nodeID roachpb.NodeID) ([]hotRangeInfo, error) {
 		resp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil || resp == nil {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1383,6 +1383,10 @@ message HotRangesRequest {
     (gogoproto.customname) = "TenantID",
     (gogoproto.nullable) = true
   ];
+  repeated string nodes = 5 [
+    (gogoproto.customname) = "Nodes",
+    (gogoproto.nullable) = true
+  ];
 }
 
 // HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -2886,13 +2886,23 @@ func (s *systemStatusServer) HotRangesV2(
 		ErrorsByNodeID: make(map[roachpb.NodeID]string),
 	}
 
-	var requestedNodes []roachpb.NodeID
-	if len(req.NodeID) > 0 {
-		requestedNodeID, local, err := s.parseNodeID(req.NodeID)
+	nodes := req.Nodes
+	if req.NodeID != "" {
+		nodes = append(nodes, req.NodeID)
+	}
+	requestedNodes := []roachpb.NodeID{}
+	for _, nodeID := range nodes {
+		requestedNodeID, _, err := s.parseNodeID(nodeID)
 		if err != nil {
 			return nil, err
 		}
-		if local {
+		// Only execute the local call if the node is explicitly the local string.
+		if localRE.Match([]byte(nodeID)) {
+			// can only call one node if the local string is set.
+			if len(req.Nodes) > 1 {
+				return nil, errors.New("cannot call 'local' mixed with other nodes")
+			}
+
 			resp, err := s.localHotRanges(ctx, tenantID, requestedNodeID)
 			if err != nil {
 				return nil, err
@@ -2909,10 +2919,11 @@ func (s *systemStatusServer) HotRangesV2(
 			response.Ranges = append(response.Ranges, resp.Ranges...)
 			return response, nil
 		}
-		requestedNodes = []roachpb.NodeID{requestedNodeID}
+
+		requestedNodes = append(requestedNodes, requestedNodeID)
 	}
 
-	remoteRequest := serverpb.HotRangesRequest{NodeID: "local", TenantID: req.TenantID}
+	remoteRequest := serverpb.HotRangesRequest{Nodes: []string{"local"}, TenantID: req.TenantID}
 	nodeFn := func(ctx context.Context, status serverpb.StatusClient, nodeID roachpb.NodeID) ([]*serverpb.HotRangesResponseV2_HotRange, error) {
 		nodeResp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil {

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -147,11 +147,14 @@ func (s *hotRangesLoggingScheduler) shouldLog() bool {
 // logHotRanges collects the hot ranges from this node's status server and
 // sends them to the TELEMETRY log channel.
 func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	req := &serverpb.HotRangesRequest{NodeID: "local", PageSize: ReportTopHottestRanges}
+	req := &serverpb.HotRangesRequest{}
+
 	// if we are running in single tenant mode, only log the ranges on the status server.
 	if !s.multiTenant {
-		req.NodeID = "local"
+		req.Nodes = []string{"local"}
+		req.PageSize = ReportTopHottestRanges
 	}
+
 	resp, err := s.sServer.HotRangesV2(ctx, req)
 	if err != nil {
 		log.Warningf(ctx, "failed to get hot ranges: %s", err)

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -30,7 +30,7 @@ const HotRanges = (props: HotRangesProps) => {
 
   useEffect(() => {
     const request = new cockroach.server.serverpb.HotRangesRequest({
-      node_id: nodeId,
+      nodes: [nodeId],
       page_size: pageSize,
       page_token: pageToken,
     });


### PR DESCRIPTION
server: allow for filtering hot ranges by node id

Right now, each call within the Hot Ranges page relies on front end filtering to prune out the nodes which are specified in the page's filter.

This filter should be applied on the back end, to minimize the number of outbound calls the system needs to make.

Fixes: #142594
Epic: CRDB-43150

Release note: none