### PR TITLE
release-24.3: release-25.1: crosscluster/logical: fix ALTER .. SET REPLICATION READ VIRTUAL CLUSTER

### DIFF
--- a/pkg/ccl/crosscluster/physical/alter_replication_job.go
+++ b/pkg/ccl/crosscluster/physical/alter_replication_job.go
@@ -112,7 +112,7 @@ func (r *resolvedTenantReplicationOptions) GetExpirationWindow() (time.Duration,
 }
 
 func (r *resolvedTenantReplicationOptions) DestinationOptionsSet() bool {
-	return r != nil && (r.retention != nil || r.resumeTimestamp.IsSet())
+	return r != nil && (r.retention != nil || r.resumeTimestamp.IsSet() || r.enableReaderTenant)
 }
 
 func (r *resolvedTenantReplicationOptions) ReaderTenantEnabled() bool {
@@ -249,7 +249,7 @@ func alterReplicationJobHook(
 		if !alterTenantStmt.Options.IsDefault() {
 			// If the statement contains options, then the user provided the ALTER
 			// TENANT ... SET REPLICATION [options] form of the command.
-			return alterTenantSetReplication(ctx, p.InternalSQLTxn(), jobRegistry, options, tenInfo)
+			return alterTenantSetReplication(ctx, p, p.InternalSQLTxn(), jobRegistry, options, tenInfo)
 		}
 		if err := checkForActiveIngestionJob(tenInfo); err != nil {
 			return err
@@ -287,6 +287,7 @@ func alterReplicationJobHook(
 
 func alterTenantSetReplication(
 	ctx context.Context,
+	p sql.PlanHookState,
 	txn isql.Txn,
 	jobRegistry *jobs.Registry,
 	options *resolvedTenantReplicationOptions,
@@ -302,7 +303,7 @@ func alterTenantSetReplication(
 		if err := checkForActiveIngestionJob(tenInfo); err != nil {
 			return err
 		}
-		if err := alterTenantConsumerOptions(ctx, txn, jobRegistry, options, tenInfo); err != nil {
+		if err := alterTenantConsumerOptions(ctx, p, txn, jobRegistry, options, tenInfo); err != nil {
 			return err
 		}
 	}
@@ -404,7 +405,7 @@ func alterTenantRestartReplication(
 		revertTo = tenInfo.PreviousSourceTenant.CutoverAsOf
 	}
 
-	readerID, err := createReaderTenant(ctx, p, tenInfo.Name, dstTenantID, options)
+	readerID, err := createReaderTenant(ctx, p, tenInfo.Name, dstTenantID, options, false)
 	if err != nil {
 		return err
 	}
@@ -650,16 +651,38 @@ func alterTenantExpirationWindow(
 
 func alterTenantConsumerOptions(
 	ctx context.Context,
+	p sql.PlanHookState,
 	txn isql.Txn,
 	jobRegistry *jobs.Registry,
 	options *resolvedTenantReplicationOptions,
 	tenInfo *mtinfopb.TenantInfo,
 ) error {
+
 	return jobRegistry.UpdateJobWithTxn(ctx, tenInfo.PhysicalReplicationConsumerJobID, txn,
 		func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			var readerID roachpb.TenantID
+			if options.enableReaderTenant {
+				// If the replicating tenant already has a resolved tiemstamp, we can
+				// create the reader tenant directly to its ready state rather than in
+				// the add state that replies on the replication job to activate it when
+				// its frontier advances for the first time. If we don't have a resolved
+				// timestamp, we'll fallback to creating it inactive and just let the
+				// job do it later, which it does since we record the reader's ID below.
+				ready := md.Progress.GetStreamIngest().ReplicatedTime.IsSet()
+				var err error
+				if readerID, err = createReaderTenant(ctx, p, tenInfo.Name, roachpb.MustMakeTenantID(tenInfo.ID), options, ready); err != nil {
+					return err
+				}
+			}
+
 			streamIngestionDetails := md.Payload.GetStreamIngestion()
 			if ret, ok := options.GetRetention(); ok {
 				streamIngestionDetails.ReplicationTTLSeconds = ret
+			}
+			// Record the reader ID; this is used in the job to start the reader if
+			// needed when the first frontier advance is recorded.
+			if readerID != (roachpb.TenantID{}) {
+				streamIngestionDetails.ReadTenantID = readerID
 			}
 			ju.UpdatePayload(md.Payload)
 			return nil

--- a/pkg/ccl/crosscluster/physical/alter_replication_job_test.go
+++ b/pkg/ccl/crosscluster/physical/alter_replication_job_test.go
@@ -111,6 +111,30 @@ func TestAlterTenantCompleteToLatest(t *testing.T) {
 	c.CompareResult(`SELECT * FROM d.t2`)
 }
 
+func TestAlterTenantAddReader(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := replicationtestutils.DefaultTenantStreamingClustersArgs
+
+	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
+
+	jobutils.WaitForJobToRun(t, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(t, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+
+	c.WaitUntilReplicatedTime(c.SrcCluster.Server(0).Clock().Now(), jobspb.JobID(ingestionJobID))
+	c.DestSysSQL.CheckQueryResults(t, "SELECT name FROM [SHOW TENANTS] ORDER BY name",
+		[][]string{{"destination"}, {"system"}},
+	)
+	c.DestSysSQL.Exec(t, "ALTER TENANT $1 SET REPLICATION READ VIRTUAL CLUSTER", args.DestTenantName)
+	c.DestSysSQL.CheckQueryResults(t, "SELECT name, data_state FROM [SHOW TENANTS] ORDER BY name",
+		[][]string{{"destination", "replicating"}, {"destination-readonly", "ready"}, {"system", "ready"}},
+	)
+}
+
 func TestAlterTenantPauseResume(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/crosscluster/physical/stream_ingestion_planning.go
+++ b/pkg/ccl/crosscluster/physical/stream_ingestion_planning.go
@@ -187,7 +187,7 @@ func ingestionPlanHook(
 			return nil
 		}
 
-		readerID, err := createReaderTenant(ctx, p, tenantInfo.Name, destinationTenantID, options)
+		readerID, err := createReaderTenant(ctx, p, tenantInfo.Name, destinationTenantID, options, false)
 		if err != nil {
 			return err
 		}
@@ -302,11 +302,17 @@ func createReaderTenant(
 	tenantName roachpb.TenantName,
 	destinationTenantID roachpb.TenantID,
 	options *resolvedTenantReplicationOptions,
+	ready bool,
 ) (roachpb.TenantID, error) {
 	var readerID roachpb.TenantID
 	if options.ReaderTenantEnabled() {
 		var readerInfo mtinfopb.TenantInfoWithUsage
-		readerInfo.DataState = mtinfopb.DataStateAdd
+		if ready {
+			readerInfo.DataState = mtinfopb.DataStateReady
+			readerInfo.ServiceMode = mtinfopb.ServiceModeShared
+		} else {
+			readerInfo.DataState = mtinfopb.DataStateAdd
+		}
 		readerInfo.Name = tenantName + "-readonly"
 		readerInfo.ReadFromTenant = &destinationTenantID
 


### PR DESCRIPTION
Backport 1/1 commits from #143853.

/cc @cockroachdb/release

---

Backport 1/1 commits from #143752.

/cc @cockroachdb/release

---

This is in the syntax but the ALTER function was not handling this option if it was set -- the statement would silently succeed without even attempting to create a reader cluster.

This statement now attempts to create a readder cluster. If one already exists, or another virtual cluster has otherwise been created with the reader's default name, the statement will fail.

Release note (bug fix): The ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER syntax is now supported for adding a reader virtual cluster for an existing PCR standby.
Epic: none.

