### PR TITLE
roachtest: Add unit labels in clusterstatscollector aggregate output

### DIFF
--- a/pkg/cmd/roachtest/clusterstats/BUILD.bazel
+++ b/pkg/cmd/roachtest/clusterstats/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
         "@com_github_prometheus_client_golang//api/prometheus/v1:prometheus",
         "@com_github_prometheus_common//model",
         "@com_github_stretchr_testify//require",
+        "//pkg/cmd/roachtest/roachtestutil",
     ],
 )
 

--- a/pkg/cmd/roachtest/clusterstats/openmetrics_expected.txt
+++ b/pkg/cmd/roachtest/clusterstats/openmetrics_expected.txt
@@ -1,7 +1,7 @@
 # TYPE t1 gauge
-t1{cloud="gce",owner="roachtest_mock",test="mock_name",test_run_id="mock_id"} 203.000000 1727690493
+t1{cloud="gce",owner="roachtest_mock",test="mock_name",test_run_id="mock_id",unit="count",is_higher_better="true"} 203.000000 1727690493
 # TYPE t3 gauge
-t3{cloud="gce",owner="roachtest_mock",test="mock_name",test_run_id="mock_id"} 404.000000 1727690493
+t3{cloud="gce",owner="roachtest_mock",test="mock_name",test_run_id="mock_id",unit="count",is_higher_better="true"} 404.000000 1727690493
 # TYPE foo_count gauge
 foo_count{cloud="gce",owner="roachtest_mock",test="mock_name",test_run_id="mock_id",agg_tag="sum(foo)"} 123.000000 1608854400
 foo_count{cloud="gce",owner="roachtest_mock",test="mock_name",test_run_id="mock_id",agg_tag="sum(foo)"} 246.000000 1608854410

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
@@ -395,28 +396,46 @@ func runAllocationBenchSample(
 		true, /* dryRun */
 		startTime, endTime,
 		joinSummaryQueries(resourceMinMaxSummary, overloadMaxSummary, rebalanceCostSummary),
-		func(stats map[string]clusterstats.StatSummary) (string, float64) {
+		func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
 			ret, name := 0.0, "cpu(%)"
 			if stat, ok := stats[cpuStat.Query]; ok {
 				ret = roundFraction(arithmeticMean(stat.Value), 1, 2)
 			}
-			return name, ret
+			return &roachtestutil.AggregatedMetric{
+				Name:             name,
+				Value:            roachtestutil.MetricPoint(ret),
+				Unit:             "percent",
+				IsHigherBetter:   false,
+				AdditionalLabels: nil,
+			}
 		},
-		func(stats map[string]clusterstats.StatSummary) (string, float64) {
+		func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
 			ret, name := 0.0, "write(%)"
 			if stat, ok := stats[ioWriteStat.Query]; ok {
 				ret = roundFraction(arithmeticMean(stat.Value), 1, 2)
 			}
-			return name, ret
+			return &roachtestutil.AggregatedMetric{
+				Name:             name,
+				Value:            roachtestutil.MetricPoint(ret),
+				Unit:             "percent",
+				IsHigherBetter:   false,
+				AdditionalLabels: nil,
+			}
 		},
-		func(stats map[string]clusterstats.StatSummary) (string, float64) {
+		func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
 			rebalanceMb := 0.0
 			values := stats[rebalanceSnapshotSentStat.Query].Value
 			if len(values) > 0 {
 				startMB, endMB := values[0], values[len(values)-1]
 				rebalanceMb = roundFraction(endMB-startMB, 1024, 2)
 			}
-			return "cost(gb)", rebalanceMb
+			return &roachtestutil.AggregatedMetric{
+				Name:             "cost(gb)",
+				Value:            roachtestutil.MetricPoint(rebalanceMb),
+				Unit:             "GB",
+				IsHigherBetter:   false,
+				AdditionalLabels: nil,
+			}
 		},
 	)
 }

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -120,11 +120,25 @@ func registerAllocator(r registry.Registry) {
 				// up-replication began, until the last rebalance action taken.
 				// The up replication time, is the time taken to up-replicate
 				// alone, not considering post up-replication rebalancing.
-				func(stats map[string]clusterstats.StatSummary) (string, float64) {
-					return "t-balance(s)", endTime.Sub(startTime).Seconds() - allocatorStableSeconds
+				func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+					balanceTime := endTime.Sub(startTime).Seconds() - allocatorStableSeconds
+					return &roachtestutil.AggregatedMetric{
+						Name:             "t-balance(s)",
+						Value:            roachtestutil.MetricPoint(balanceTime),
+						Unit:             "seconds",
+						IsHigherBetter:   false,
+						AdditionalLabels: nil,
+					}
 				},
-				func(stats map[string]clusterstats.StatSummary) (string, float64) {
-					return "t-uprepl(s)", replicateTime.Sub(startTime).Seconds()
+				func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
+					upReplTime := replicateTime.Sub(startTime).Seconds()
+					return &roachtestutil.AggregatedMetric{
+						Name:             "t-uprepl(s)",
+						Value:            roachtestutil.MetricPoint(upReplTime),
+						Unit:             "seconds",
+						IsHigherBetter:   false,
+						AdditionalLabels: nil,
+					}
 				},
 			)
 			return err

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -143,7 +143,7 @@ func (ct *cdcTester) startStatsCollection() func() {
 			startTime,
 			endTime,
 			[]clusterstats.AggQuery{sqlServiceLatencyAgg, changefeedThroughputAgg, cpuUsageAgg},
-			func(stats map[string]clusterstats.StatSummary) (string, float64) {
+			func(stats map[string]clusterstats.StatSummary) *roachtestutil.AggregatedMetric {
 				// TODO(jayant): update this metric to be more accurate.
 				// It may be worth plugging in real latency values from the latency
 				// verifier here in the future for more accuracy. However, it may not be
@@ -151,7 +151,14 @@ func (ct *cdcTester) startStatsCollection() func() {
 				// up as roachtest failures, we don't need to make them very apparent in
 				// roachperf. Note that other roachperf stats, such as the aggregate stats
 				// above, will be accurate.
-				return "Total Run Time (mins)", endTime.Sub(startTime).Minutes()
+				duration := endTime.Sub(startTime).Minutes()
+				return &roachtestutil.AggregatedMetric{
+					Name:             "Total Run Time (mins)",
+					Value:            roachtestutil.MetricPoint(duration),
+					Unit:             "minutes",
+					IsHigherBetter:   false,
+					AdditionalLabels: nil,
+				}
 			},
 		)
 		if err != nil {


### PR DESCRIPTION
This change enhances the clusterstatscollector's aggregated metrics by adding two new descriptive fields, Unit and is_higher_better, which are used in plotting aggregated metrics.

Updates the way BenchmarkFns are specified in tests, those are the ones responsible for generating one summarized value for one test run.

Epic: none
Fixes: CRDB-48909