### PR TITLE
storage: use block properties implementation defined in cockroachkvs

### DIFF
--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -212,6 +212,7 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_cockroachdb_pebble//cockroachkvs",
         "@com_github_cockroachdb_pebble//objstorage",
         "@com_github_cockroachdb_pebble//objstorage/objstorageprovider",
         "@com_github_cockroachdb_pebble//sstable",


### PR DESCRIPTION
The MVCC time interval block properties implementation has been copied into pebble/cockroachkvs so that the Pebble metamorphic tests may make use of it. Use that implementation and remove the pkg/storage copy.

Epic: none
Release note: none