### PR TITLE
explain: fix rare flake in recently added test

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -89,6 +89,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",


### PR DESCRIPTION
Recently added `TestMaximumMemoryUsage` can encounter a rare flake when some metamorphic variables are set - the ComponentStats proto might be dropped from the trace, so we won't have "maximum memory usage" stat that the test expects. Fix this by adding a retry loop.

Fixes: #143833.

Release note: None