### PR TITLE
kvcoord: fix CPut handling for intra-batch conflicts

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1109,11 +1109,11 @@ func TestTxnWriteBufferDecomposesConditionalPuts(t *testing.T) {
 			require.IsType(t, &kvpb.ConditionFailedError{}, pErr.GoError())
 		}
 
-		// Lastly, commit the transaction. A put should only be flushed if the condition
-		// evaluated successfully.
+		// Lastly, commit or rollback the transaction. A put should only be
+		// flushed if the condition evaluated successfully.
 		ba = &kvpb.BatchRequest{}
 		ba.Header = kvpb.Header{Txn: &txn}
-		ba.Add(&kvpb.EndTxnRequest{Commit: true})
+		ba.Add(&kvpb.EndTxnRequest{Commit: condEvalSuccessful})
 
 		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 			if condEvalSuccessful {

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -2011,6 +2011,7 @@ func TestTxnBufferedWritesConditionalPuts(t *testing.T) {
 				if expErr {
 					require.Error(t, err)
 					require.IsType(t, &kvpb.ConditionFailedError{}, err)
+					return err
 				} else {
 					require.NoError(t, err)
 				}
@@ -2022,11 +2023,10 @@ func TestTxnBufferedWritesConditionalPuts(t *testing.T) {
 				}
 			})
 
-			if commit {
+			if commit && !expErr {
 				require.NoError(t, err)
 			} else {
 				require.Error(t, err)
-				testutils.IsError(err, "abort")
 			}
 
 			// Verify the values are visible only if the transaction commited

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -82,3 +82,47 @@ query II
 SELECT * FROM t1
 ----
 1 1
+
+statement ok
+CREATE TABLE t2 (k INT PRIMARY KEY);
+
+statement ok
+BEGIN;
+
+statement error pgcode 23505 duplicate key value violates unique constraint "t2_pkey"
+INSERT INTO t2 VALUES (1), (1);
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t2 VALUES (1);
+
+statement error pgcode 23505 duplicate key value violates unique constraint "t2_pkey"
+INSERT INTO t2 VALUES (1);
+
+statement ok
+ROLLBACK;
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO t2 VALUES (1);
+
+statement ok
+DELETE FROM t2 WHERE k = 1;
+
+statement ok
+INSERT INTO t2 VALUES (1);
+
+statement ok
+COMMIT;
+
+query I
+SELECT * FROM t2
+----
+1


### PR DESCRIPTION
Previously, for condition evaluation part of CPuts, we would ignore writes that were performed within the same KV batch. That was the case since we performed the read from the buffer when applying the transformation but would actually buffer writes after the KV server response comes back, so previous writes within the same KV batch would be invisible. This is now fixed by buffering the write when applying the transformation.

Also avoid flushing any buffered writes when rolling back the txn.

Epic: None
Release note: None