### PR TITLE
release-25.1: stats: harden bucket adjustment for over-estimates

### DIFF
--- a/pkg/sql/stats/histogram_test.go
+++ b/pkg/sql/stats/histogram_test.go
@@ -940,6 +940,31 @@ func TestAdjustCounts(t *testing.T) {
 				{NumRange: 0, NumEq: 100, DistinctRange: 0, UpperBound: d(-60)},
 			},
 		},
+		{ // Over-estimate of distinct count for bools when both values were
+			// already sampled.
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: tree.DBoolFalse},
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: tree.DBoolTrue},
+			},
+			rowCount:      4,
+			distinctCount: 4,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 2, DistinctRange: 0, UpperBound: tree.DBoolFalse},
+				{NumRange: 0, NumEq: 2, DistinctRange: 0, UpperBound: tree.DBoolTrue},
+			},
+		},
+		{ // Over-estimate of distinct count for bools when only 'false' was
+			// already sampled (#142022).
+			h: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 1, DistinctRange: 0, UpperBound: tree.DBoolFalse},
+			},
+			rowCount:      4,
+			distinctCount: 4,
+			expected: []cat.HistogramBucket{
+				{NumRange: 0, NumEq: 2, DistinctRange: 0, UpperBound: tree.DBoolFalse},
+				{NumRange: 0, NumEq: 2, DistinctRange: 0, UpperBound: tree.DBoolTrue},
+			},
+		},
 	}
 
 	ctx := context.Background()


### PR DESCRIPTION
Backport 1/1 commits from #143858 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

We recently saw a case where we produced histogram buckets that contained NaNs. This happened because we had an over-estimate of the distinct count which was impossible to satisfy (3+ distinct count for boolean column). This commit hardens the bucket adjustment code to avoid generating NaNs in such scenarios. In particular, it audits all division arithmetic we do when building histograms to ensure that we never attempt to divide by zero - I found only one spot where it seems plausible in such "impossible to satisfy" request.

Fixes: #142022.

Release note: None

----

Release justification: low-risk edge case bug fix.