### PR TITLE
sql/stats: remove extended sentry reporting for an error

### DIFF
--- a/pkg/sql/stats/BUILD.bazel
+++ b/pkg/sql/stats/BUILD.bazel
@@ -57,7 +57,6 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
-        "//pkg/util/sentryutil",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",

--- a/pkg/sql/stats/forecast.go
+++ b/pkg/sql/stats/forecast.go
@@ -7,12 +7,8 @@ package stats
 
 import (
 	"context"
-	"crypto/md5"
-	"encoding/json"
-	"fmt"
 	"math"
 	"slices"
-	"strconv"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
@@ -20,11 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/sentryutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -336,61 +329,6 @@ func forecastColumnStatistics(
 		}
 		forecast.HistogramData = &histData
 		forecast.setHistogramBuckets(hist)
-
-		// Verify that the first two buckets (the initial NULL bucket and the first
-		// non-NULL bucket) both have NumRange=0 and DistinctRange=0. (We must check
-		// this after calling setHistogramBuckets to account for rounding.) See
-		// #93892.
-		for _, bucket := range forecast.Histogram {
-			if bucket.NumRange != 0 || bucket.DistinctRange != 0 {
-				// Build a JSON representation of the first several buckets in each
-				// observed histogram so that we can figure out what happened.
-				const debugBucketCount = 5
-				jsonStats := make([]*JSONStatistic, 0, len(observed))
-
-				addStat := func(stat *TableStatistic) {
-					jsonStat := &JSONStatistic{
-						Name:          stat.Name,
-						CreatedAt:     stat.CreatedAt.String(),
-						Columns:       []string{strconv.FormatInt(int64(stat.ColumnIDs[0]), 10)},
-						RowCount:      stat.RowCount,
-						DistinctCount: stat.DistinctCount,
-						NullCount:     stat.NullCount,
-						AvgSize:       stat.AvgSize,
-					}
-					if err := jsonStat.SetHistogram(stat.HistogramData); err == nil &&
-						len(jsonStat.HistogramBuckets) > debugBucketCount {
-						// Limit the histogram to the first several buckets.
-						jsonStat.HistogramBuckets = jsonStat.HistogramBuckets[0:debugBucketCount]
-					}
-					// Replace UpperBounds with a hash.
-					for i := range jsonStat.HistogramBuckets {
-						hash := md5.Sum([]byte(jsonStat.HistogramBuckets[i].UpperBound))
-						jsonStat.HistogramBuckets[i].UpperBound = fmt.Sprintf("_%x", hash)
-					}
-					jsonStats = append(jsonStats, jsonStat)
-				}
-				addStat(forecast)
-				for i := range observed {
-					addStat(observed[i])
-				}
-				var debugging redact.SafeString
-				if j, err := json.Marshal(jsonStats); err == nil {
-					debugging = redact.SafeString(j)
-				}
-				err := errorutil.UnexpectedWithIssueErrorf(
-					93892,
-					"forecasted histogram had first bucket with non-zero NumRange or DistinctRange: %s",
-					debugging,
-				)
-				sentryutil.SendReport(ctx, &st.SV, err)
-				return nil, err
-			}
-			if bucket.UpperBound != tree.DNull {
-				// Stop checking after the first non-NULL bucket.
-				break
-			}
-		}
 	}
 
 	return forecast, nil


### PR DESCRIPTION
This commit reverts 85500f06cba564b6b89d4e3caf3e0943f532a7f7. I think we fixed the root cause of the "first bucket should have NumRange=0" in 10a2ffea3df9c0bf16a9f388e7deeedc0a9f9310, so we no longer need the extended sentry reporting (which also didn't quite work in all cases).

Informs: #93892.
Epic: None
Release note: None