### PR TITLE
cspann: fix race conditions in index split operation

### DIFF
--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -99,7 +99,7 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │
 └───• 4 (2.5, 2.5) [Updating:2]
 
-# Update left sub-partition #3 to Ready state.
+# Add ~1/2 vectors to right sub-partition #3.
 force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
@@ -111,14 +111,17 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │   ├───• vec3 (4, 3)
 │   └───• vec5 (14, 1)
 │
-├───• 3 (10.5, 2.5)
+├───• 3 (10.5, 2.5) [Updating:2]
 │   │
 │   ├───• vec5 (14, 1)
 │   └───• vec2 (7, 4)
 │
 └───• 4 (2.5, 2.5) [Updating:2]
+    │
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
 
-# Add ~1/2 vectors to right sub-partition #4.
+# Update left sub-partition #3 to Ready state.
 force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
@@ -140,7 +143,7 @@ force-split partition-key=2 parent-partition-key=1 steps=1
     ├───• vec3 (4, 3)
     └───• vec1 (1, 2)
 
-# Update left sub-partition #4 to Ready state.
+# Update right sub-partition #4 to Ready state.
 force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
@@ -532,7 +535,7 @@ force-split partition-key=2 parent-partition-key=1 steps=8
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
-├───• 4 (5, 6)
+├───• 4 (5, 6) [Updating:2]
 │   │
 │   └───• 3 (5, 6)
 │       │
@@ -541,6 +544,12 @@ force-split partition-key=2 parent-partition-key=1 steps=8
 │       └───• vec4 (6, 5)
 │
 └───• 5 (5, 6) [Updating:2]
+    │
+    └───• 3 (5, 6)
+        │
+        ├───• vec2 (3, 5)
+        ├───• vec3 (6, 8)
+        └───• vec4 (6, 5)
 
 # Next steps should duplicate the last remaining vector in sub-partition #5
 # rather than leave it empty. An empty non-leaf partition is a violation of a
@@ -638,7 +647,7 @@ force-split partition-key=2 parent-partition-key=1 steps=10
     └───• vec1 (4, 0)
 
 # Run split of partition #3 until it's also in DrainingForSplit state.
-force-split partition-key=3 parent-partition-key=1 steps=10
+force-split partition-key=3 parent-partition-key=1 steps=8
 ----
 • 1 (2, -4)
 │
@@ -660,11 +669,11 @@ force-split partition-key=3 parent-partition-key=1 steps=10
 │   │
 │   └───• vec1 (4, 0)
 │
-├───• 6 (2, -5)
+├───• 6 (2, -5) [Updating:3]
 │   │
 │   └───• vec3 (2, -5)
 │
-└───• 7 (2, -3)
+└───• 7 (2, -3) [Updating:3]
     │
     └───• vec4 (2, -3)
 
@@ -691,11 +700,11 @@ force-split partition-key=4 parent-partition-key=1 steps=6
 │   │
 │   └───• vec1 (4, 0)
 │
-├───• 6 (2, -5)
+├───• 6 (2, -5) [Updating:3]
 │   │
 │   └───• vec3 (2, -5)
 │
-├───• 7 (2, -3)
+├───• 7 (2, -3) [Updating:3]
 │   │
 │   └───• vec4 (2, -3)
 │
@@ -725,11 +734,11 @@ force-split partition-key=5 parent-partition-key=1 steps=6
 │   │
 │   └───• vec1 (4, 0)
 │
-├───• 6 (2, -5)
+├───• 6 (2, -5) [Updating:3]
 │   │
 │   └───• vec3 (2, -5)
 │
-├───• 7 (2, -3)
+├───• 7 (2, -3) [Updating:3]
 │   │
 │   └───• vec4 (2, -3)
 │
@@ -738,17 +747,15 @@ force-split partition-key=5 parent-partition-key=1 steps=6
 ├───• 10 (4, 0) [Updating:5]
 └───• 11 (4, 0) [Updating:5]
 
-# Search for vector that exactly matches the centroid for partitions #4 and #5.
+# Search for vector that exactly matches the centroid for partitions #2 and #3.
 # However, both of these partitions are in a state that does not allow adds or
-# removes, so SearchForInsert will have to fall back on the target partitions
-# for partition #2. But both of those are in the draining state as well. So
-# SearchForInsert finally falls back to partition #11.
+# removes, so SearchForInsert falls back to partition #6.
 search-for-insert discard-fixups
 (2, -4)
 ----
-partition 11, centroid=(4, 0), sqdist=20
+partition 6, centroid=(2, -5), sqdist=1
 
-# Perform the insert into partition #11.
+# Perform the insert into partition #6.
 insert discard-fixups
 vec5: (2, -4)
 ----
@@ -772,11 +779,12 @@ vec5: (2, -4)
 │   │
 │   └───• vec1 (4, 0)
 │
-├───• 6 (2, -5)
+├───• 6 (2, -5) [Updating:3]
 │   │
-│   └───• vec3 (2, -5)
+│   ├───• vec3 (2, -5)
+│   └───• vec5 (2, -4)
 │
-├───• 7 (2, -3)
+├───• 7 (2, -3) [Updating:3]
 │   │
 │   └───• vec4 (2, -3)
 │
@@ -784,8 +792,6 @@ vec5: (2, -4)
 ├───• 9 (0, -8) [Updating:4]
 ├───• 10 (4, 0) [Updating:5]
 └───• 11 (4, 0) [Updating:5]
-    │
-    └───• vec5 (2, -4)
 
 # Search all partitions, which will enqueue fixups for partitions #2, #3, #4,
 # and #5. However, it will also enqueue a fixup for the oversized partition #1,
@@ -794,7 +800,7 @@ vec5: (2, -4)
 search beam-size=16
 (2, -4)
 ----
-vec5: 0 (centroid=4.47)
+vec5: 0 (centroid=1)
 9 leaf vectors, 19 vectors, 3 full vectors, 11 partitions
 
 format-tree
@@ -814,7 +820,8 @@ format-tree
 │   │
 │   └───• 6 (2, -5)
 │       │
-│       └───• vec3 (2, -5)
+│       ├───• vec3 (2, -5)
+│       └───• vec5 (2, -4)
 │
 └───• 13 (3, -1.8333)
     │
@@ -841,14 +848,12 @@ format-tree
     │   └───• vec1 (4, 0)
     │
     └───• 11 (4, 0)
-        │
-        └───• vec5 (2, -4)
 
 # Search again, triggering more fixups.
 search beam-size=16
 (2, -4)
 ----
-vec5: 0 (centroid=4.47)
+vec5: 0 (centroid=1)
 11 leaf vectors, 23 vectors, 3 full vectors, 13 partitions
 
 format-tree
@@ -863,7 +868,8 @@ format-tree
 │   │
 │   └───• 6 (2, -5)
 │       │
-│       └───• vec3 (2, -5)
+│       ├───• vec3 (2, -5)
+│       └───• vec5 (2, -4)
 │
 ├───• 15 (4, 0)
 │   │
@@ -876,9 +882,6 @@ format-tree
 │   │   └───• vec1 (4, 0)
 │   │
 │   └───• 11 (4, 0)
-│       │
-│       └───• vec5 (2, -4)
-│
 ├───• 14 (2, -3.6667)
 │   │
 │   ├───• 3 (2, -4) [DrainingForSplit:6,7]
@@ -907,7 +910,7 @@ format-tree
 search beam-size=16
 (2, -4)
 ----
-vec5: 0 (centroid=4.47)
+vec5: 0 (centroid=1)
 11 leaf vectors, 25 vectors, 3 full vectors, 15 partitions
 
 format-tree
@@ -920,7 +923,8 @@ format-tree
 │   │   │
 │   │   └───• 6 (2, -5)
 │   │       │
-│   │       └───• vec3 (2, -5)
+│   │       ├───• vec3 (2, -5)
+│   │       └───• vec5 (2, -4)
 │   │
 │   └───• 16 (0, -8)
 │       │
@@ -940,9 +944,132 @@ format-tree
     └───• 15 (4, 0)
         │
         ├───• 11 (4, 0)
-        │   │
-        │   └───• vec5 (2, -4)
-        │
         └───• 10 (4, 0)
             │
             └───• vec1 (4, 0)
+
+# ----------------------------------------------------------------------
+# Attempt to split the target partition of another split.
+# ----------------------------------------------------------------------
+
+load-index min-partition-size=1 max-partition-size=4 beam-size=3 new-fixups
+• 1 (6.8, 4.2)
+│
+└───• 2 (6.8, 4.2)
+    │
+    ├───• vec1 (1, 2)
+    ├───• vec2 (7, 4)
+    ├───• vec3 (4, 3)
+    ├───• vec4 (-3, 2)
+    └───• vec5 (14, 1)
+----
+Loaded 5 vectors.
+
+# Split partition #2, to the point where it's about to be removed from its
+# parent.
+force-split partition-key=2 parent-partition-key=1 steps=10
+----
+• 1 (6.8, 4.2)
+│
+├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
+│   │
+│   ├───• vec1 (1, 2)
+│   ├───• vec2 (7, 4)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (-3, 2)
+│   └───• vec5 (14, 1)
+│
+├───• 3 (-1, 2)
+│   │
+│   ├───• vec1 (1, 2)
+│   ├───• vec4 (-3, 2)
+│   └───• vec3 (4, 3)
+│
+└───• 4 (10.5, 2.5)
+    │
+    ├───• vec2 (7, 4)
+    └───• vec5 (14, 1)
+
+# Split partition #3 in this state, so that the DrainingForSplit target now
+# points to a non-existent partition.
+force-split partition-key=3 parent-partition-key=1
+----
+• 1 (6.8, 4.2)
+│
+├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
+│   │
+│   ├───• vec1 (1, 2)
+│   ├───• vec2 (7, 4)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (-3, 2)
+│   └───• vec5 (14, 1)
+│
+├───• 6 (2.5, 2.5)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec3 (4, 3)
+│
+├───• 4 (10.5, 2.5)
+│   │
+│   ├───• vec2 (7, 4)
+│   └───• vec5 (14, 1)
+│
+└───• 5 (-3, 2)
+    │
+    └───• vec4 (-3, 2)
+
+# Insert vector that would go to partition #2, except that it's in a state that
+# does not allow insert.
+insert
+vec6: (7, 4)
+----
+• 1 (6.8, 4.2)
+│
+├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
+│   │
+│   ├───• vec1 (1, 2)
+│   ├───• vec2 (7, 4)
+│   ├───• vec3 (4, 3)
+│   ├───• vec4 (-3, 2)
+│   └───• vec5 (14, 1)
+│
+├───• 6 (2.5, 2.5)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec3 (4, 3)
+│
+├───• 4 (10.5, 2.5)
+│   │
+│   ├───• vec2 (7, 4)
+│   ├───• vec5 (14, 1)
+│   └───• vec6 (7, 4)
+│
+└───• 5 (-3, 2)
+    │
+    └───• vec4 (-3, 2)
+
+# Trigger completion of partition #2 split.
+search
+(7, 4)
+----
+vec2: 0 (centroid=0.28)
+10 leaf vectors, 14 vectors, 3 full vectors, 4 partitions
+
+format-tree
+----
+• 1 (6.8, 4.2)
+│
+├───• 5 (-3, 2)
+│   │
+│   └───• vec4 (-3, 2)
+│
+├───• 6 (2.5, 2.5)
+│   │
+│   ├───• vec1 (1, 2)
+│   └───• vec3 (4, 3)
+│
+└───• 4 (10.5, 2.5)
+    │
+    ├───• vec2 (7, 4)
+    ├───• vec5 (14, 1)
+    └───• vec6 (7, 4)

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -50,14 +50,6 @@ force-split partition-key=1 root=2 steps=1
 ├───• vec5 (14, 1)
 └───• vec2 (7, 4)
 
-# Update left sub-partition #2 to Ready state.
-force-split partition-key=1 root=2 steps=1
-----
-• 2 (10.5, 2.5)
-│
-├───• vec5 (14, 1)
-└───• vec2 (7, 4)
-
 # Add ~1/2 vectors to right sub-partition #3.
 force-split partition-key=1 root=3 steps=1
 ----
@@ -65,6 +57,14 @@ force-split partition-key=1 root=3 steps=1
 │
 ├───• vec3 (4, 3)
 └───• vec1 (1, 2)
+
+# Update left sub-partition #2 to Ready state.
+force-split partition-key=1 root=2 steps=1
+----
+• 2 (10.5, 2.5)
+│
+├───• vec5 (14, 1)
+└───• vec2 (7, 4)
 
 # Update right sub-partition #3 to Ready state.
 force-split partition-key=1 root=3 steps=1
@@ -140,9 +140,9 @@ load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
 Loaded 2 vectors.
 
 # Step to point where partition #2 is copied to target sub-partition #3.
-force-split partition-key=1 root=3 steps=6
+force-split partition-key=1 root=3 steps=5
 ----
-• 3 (2.5, 2.5)
+• 3 (2.5, 2.5) [Updating:1]
 │
 └───• 2 (2.5, 2.5)
     │
@@ -152,9 +152,9 @@ force-split partition-key=1 root=3 steps=6
 # Next steps should duplicate the last remaining vector in partition #1 and also
 # add it to partition #4. This will prevent partition #4 from being empty, which
 # would be a violation of the constraint that the K-means tree must be balanced.
-force-split partition-key=1 root=4 steps=2
+force-split partition-key=1 root=4 steps=1
 ----
-• 4 (2.5, 2.5)
+• 4 (2.5, 2.5) [Updating:1]
 │
 └───• 2 (2.5, 2.5)
     │
@@ -162,7 +162,7 @@ force-split partition-key=1 root=4 steps=2
     └───• vec2 (4, 3)
 
 # Finish the split, with partition #2 a child of both sub-partitions.
-force-split partition-key=1 steps=5
+force-split partition-key=1
 ----
 • 1 (6.8, 4.2)
 │


### PR DESCRIPTION
This commit fixes two race conditions in the index split operation:

1. After setting the state of the left sub-partition to Ready, say that the split unexpectedly fails. Now say that the left sub- partition itself splits and is deleted. When the original split resumes, it will not be able to get the centroid for the left sub-partition, which is needed to run the K-means clustering algorithm.

2. As described by 1, it's possible that a splitting partition references target sub-partitions that are now missing from the index. This will trigger PartitionNotFound errors in insert code paths.

The fixes are:

1. Update the logic so that vectors are first copied to the left and right sub-partitions before either sub-partition's state is updated from Updating to Ready. Only Ready sub-partitions can be split, so this should prevent race condition 1.

2. Update the insert logic so that searches of non-root partitions return multiple results, to make it extremely likely that a suitable insert partition will be found. For root partitions, check split target sub-partitions instead, since the splitting partition does not share a parent with its sub-partitions.

Epic: CRDB-42943

Release note: None