### PR TITLE
cspann: fix partition data sorting bug

### DIFF
--- a/pkg/sql/vecindex/cspann/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "childkey_dedup_test.go",
         "cspannpb_test.go",
         "fixup_processor_test.go",
+        "fixup_split_test.go",
         "fixup_worker_test.go",
         "index_stats_test.go",
         "index_test.go",

--- a/pkg/sql/vecindex/cspann/fixup_split_test.go
+++ b/pkg/sql/vecindex/cspann/fixup_split_test.go
@@ -1,0 +1,123 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package cspann
+
+import (
+	"slices"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/workspace"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/stretchr/testify/require"
+)
+
+func TestSplitPartitionData(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	var workspace workspace.T
+	vectors := vector.MakeSetFromRawData([]float32{
+		0, 0,
+		1, 1,
+		2, 3,
+		3, 3,
+		4, 4,
+		5, 5,
+		6, 6,
+	}, 2)
+
+	childKeys := []ChildKey{
+		{KeyBytes: KeyBytes("vec1")},
+		{KeyBytes: KeyBytes("vec2")},
+		{KeyBytes: KeyBytes("vec3")},
+		{KeyBytes: KeyBytes("vec4")},
+		{KeyBytes: KeyBytes("vec5")},
+		{KeyBytes: KeyBytes("vec6")},
+		{KeyBytes: KeyBytes("vec7")},
+	}
+	valueBytes := []ValueBytes{
+		{1, 1}, {2, 2}, {3, 3}, {4, 4}, {5, 5}, {6, 6}, {7, 7},
+	}
+
+	testCases := []struct {
+		desc          string
+		leftOffsets   []uint64
+		rightOffsets  []uint64
+		expectedLeft  []uint64
+		expectedRight []uint64
+	}{
+		{
+			desc:         "no reordering",
+			leftOffsets:  []uint64{0, 1, 2, 3},
+			rightOffsets: []uint64{4, 5, 6},
+		},
+		{
+			desc:         "only one on left",
+			leftOffsets:  []uint64{1},
+			rightOffsets: []uint64{0, 2, 3, 4, 5, 6},
+		},
+		{
+			desc:         "only one on right",
+			leftOffsets:  []uint64{0, 1, 2, 4, 5, 6},
+			rightOffsets: []uint64{3},
+		},
+		{
+			desc:         "interleaved",
+			leftOffsets:  []uint64{0, 2, 4, 6},
+			rightOffsets: []uint64{1, 3, 5},
+		},
+		{
+			desc:         "another interleaved",
+			leftOffsets:  []uint64{1, 4, 5},
+			rightOffsets: []uint64{0, 2, 3, 6},
+		},
+		{
+			desc:         "reversed",
+			leftOffsets:  []uint64{4, 5, 6},
+			rightOffsets: []uint64{0, 1, 2, 3},
+		},
+		{
+			desc:         "out of order",
+			leftOffsets:  []uint64{5, 4, 6},
+			rightOffsets: []uint64{3, 0, 1, 2},
+		},
+	}
+
+	findKey := func(allKeys []ChildKey, toFind ChildKey) int {
+		for i, key := range allKeys {
+			if key.Equal(toFind) {
+				return i
+			}
+		}
+		return -1
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			tempVectors := vectors.Clone()
+			tempChildKeys := slices.Clone(childKeys)
+			tempValueBytes := slices.Clone(valueBytes)
+			splitPartitionData(&workspace,
+				tempVectors, tempChildKeys, tempValueBytes, tc.leftOffsets, tc.rightOffsets)
+
+			// Ensure that partition data is on the correct side.
+			for originalOffset := range childKeys {
+				newOffset := findKey(tempChildKeys, childKeys[originalOffset])
+
+				if newOffset < len(tc.leftOffsets) {
+					require.Contains(t, tc.leftOffsets, uint64(originalOffset))
+				} else {
+					require.Contains(t, tc.rightOffsets, uint64(originalOffset))
+				}
+
+				require.Equal(t, tempVectors.At(newOffset), vectors.At(originalOffset))
+				require.Equal(t, tempValueBytes[newOffset], valueBytes[originalOffset])
+			}
+		})
+	}
+}

--- a/pkg/sql/vecindex/cspann/fixup_worker.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker.go
@@ -278,7 +278,7 @@ func (fw *fixupWorker) oldSplitPartition(
 	tempLeftOffsets, tempRightOffsets := kmeans.ComputeCentroids(
 		vectors, tempLeftCentroid, tempRightCentroid, false /* pinLeftCentroid */, tempOffsets)
 
-	leftSplit, rightSplit := splitPartitionData(
+	leftSplit, rightSplit := oldSplitPartitionData(
 		&fw.workspace, fw.index.quantizer, partition, vectors,
 		tempLeftOffsets, tempRightOffsets)
 
@@ -424,7 +424,7 @@ func (fw *fixupWorker) oldSplitPartition(
 // NOTE: The vectors set will be updated in-place, via a partial sort that moves
 // vectors in the left partition to the left side of the set. However, the split
 // partition is not modified.
-func splitPartitionData(
+func oldSplitPartitionData(
 	w *workspace.T,
 	quantizer quantize.Quantizer,
 	splitPartition *Partition,

--- a/pkg/sql/vecindex/cspann/fixup_worker_test.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker_test.go
@@ -17,7 +17,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestSplitPartitionData(t *testing.T) {
+func TestOldSplitPartitionData(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -132,7 +132,7 @@ func TestSplitPartitionData(t *testing.T) {
 		t.Run(tc.desc, func(t *testing.T) {
 			tempVectors := vector.MakeSet(2)
 			tempVectors.AddSet(vectors)
-			leftSplit, rightSplit := splitPartitionData(
+			leftSplit, rightSplit := oldSplitPartitionData(
 				&workspace, quantizer, splitPartition, tempVectors, tc.leftOffsets, tc.rightOffsets)
 
 			validate(&leftSplit, tc.expectedLeft)

--- a/pkg/sql/vecindex/cspann/kmeans.go
+++ b/pkg/sql/vecindex/cspann/kmeans.go
@@ -110,7 +110,7 @@ func (km *BalancedKmeans) ComputeCentroids(
 		maxIterations = 16
 	}
 
-	for i := 0; i < maxIterations; i++ {
+	for range maxIterations {
 		// Assign vectors to one of the partitions.
 		leftOffsets, rightOffsets = km.AssignPartitions(
 			vectors, leftCentroid, rightCentroid, tempOffsets)
@@ -153,7 +153,7 @@ func (km *BalancedKmeans) AssignPartitions(
 
 	// Calculate difference between squared distance of each vector to the left
 	// and right centroids.
-	for i := 0; i < count; i++ {
+	for i := range count {
 		tempDistances[i] = num32.L2SquaredDistance(vectors.At(i), leftCentroid) -
 			num32.L2SquaredDistance(vectors.At(i), rightCentroid)
 		offsets[i] = uint64(i)
@@ -225,7 +225,7 @@ func (km *BalancedKmeans) selectInitialRightCentroid(
 
 	// Calculate distance of each vector in the set from the left centroid.
 	var distanceSum float32
-	for i := 0; i < count; i++ {
+	for i := range count {
 		tempDistances[i] = num32.L2SquaredDistance(vectors.At(i), leftCentroid)
 		distanceSum += tempDistances[i]
 	}
@@ -242,7 +242,7 @@ func (km *BalancedKmeans) selectInitialRightCentroid(
 		rnd = rand.Float32()
 	}
 	rightOffset := 0
-	for i := 0; i < len(tempDistances); i++ {
+	for i := range len(tempDistances) {
 		cum += tempDistances[i]
 		if rnd < cum {
 			rightOffset = i
@@ -289,7 +289,7 @@ func (km *BalancedKmeans) calculateMeanOfVariances(vectors vector.Set) float32 {
 	num32.Zero(tempCompensation)
 
 	// Compute the first term and part of second term.
-	for i := 0; i < vectors.Count; i++ {
+	for i := range vectors.Count {
 		// First: x[i]
 		vector := vectors.At(i)
 		// First: x[i] - mean(x)

--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -94,8 +94,8 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │
 ├───• 3 (10.5, 2.5) [Updating:2]
 │   │
-│   ├───• vec2 (7, 4)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
 └───• 4 (2.5, 2.5) [Updating:2]
 
@@ -113,12 +113,12 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │
 ├───• 3 (10.5, 2.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
 └───• 4 (2.5, 2.5) [Updating:2]
 
-# Add ~1/2 vectors to left sub-partition #3.
+# Add ~1/2 vectors to right sub-partition #4.
 force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
@@ -132,13 +132,13 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │
 ├───• 3 (10.5, 2.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
 └───• 4 (2.5, 2.5) [Updating:2]
     │
-    ├───• vec1 (1, 2)
-    └───• vec3 (4, 3)
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
 
 # Update left sub-partition #4 to Ready state.
 force-split partition-key=2 parent-partition-key=1 steps=1
@@ -154,13 +154,13 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │
 ├───• 3 (10.5, 2.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
 └───• 4 (2.5, 2.5)
     │
-    ├───• vec1 (1, 2)
-    └───• vec3 (4, 3)
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
 
 # Remove splitting partition #2 from parent and delete it.
 force-split partition-key=2 parent-partition-key=1 steps=1
@@ -169,13 +169,13 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 │
 ├───• 4 (2.5, 2.5)
 │   │
-│   ├───• vec1 (1, 2)
-│   └───• vec3 (4, 3)
+│   ├───• vec3 (4, 3)
+│   └───• vec1 (1, 2)
 │
 └───• 3 (10.5, 2.5)
     │
-    ├───• vec2 (7, 4)
-    └───• vec5 (14, 1)
+    ├───• vec5 (14, 1)
+    └───• vec2 (7, 4)
 
 format-tree root=2
 ----
@@ -316,13 +316,12 @@ force-split partition-key=2 parent-partition-key=1 steps=7
 │
 └───• 7 (5.5, 6.25)
     │
-    ├───• 4 (5, 6) [Splitting:5,6]
-    │   │
-    │   ├───• vec2 (3, 5)
-    │   ├───• vec3 (6, 8)
-    │   └───• vec4 (6, 5)
-    │
-    └───• 5 (6, 6.5) [Updating:4]
+    ├───• 5 (6, 6.5) [Updating:4]
+    └───• 4 (5, 6) [Splitting:5,6]
+        │
+        ├───• vec2 (3, 5)
+        ├───• vec3 (6, 8)
+        └───• vec4 (6, 5)
 
 # Now split of child #4 should be able to continue with new parent #7. Notice
 # that partition #7's centroid is not exact, since it was computed while child
@@ -339,14 +338,14 @@ force-split partition-key=4 parent-partition-key=7 steps=7
 │
 └───• 7 (5.5, 6.25)
     │
+    ├───• 5 (6, 6.5)
+    │   │
+    │   ├───• vec4 (6, 5)
+    │   └───• vec3 (6, 8)
+    │
     ├───• 4 (5, 6) [DrainingForSplit:5,6]
     │   │
     │   ├───• vec2 (3, 5)
-    │   ├───• vec3 (6, 8)
-    │   └───• vec4 (6, 5)
-    │
-    ├───• 5 (6, 6.5)
-    │   │
     │   ├───• vec3 (6, 8)
     │   └───• vec4 (6, 5)
     │
@@ -367,14 +366,14 @@ force-split partition-key=7 parent-partition-key=1 steps=10
 │
 ├───• 7 (5.5, 6.25) [DrainingForSplit:9,10]
 │   │
+│   ├───• 5 (6, 6.5)
+│   │   │
+│   │   ├───• vec4 (6, 5)
+│   │   └───• vec3 (6, 8)
+│   │
 │   ├───• 4 (5, 6) [DrainingForSplit:5,6]
 │   │   │
 │   │   ├───• vec2 (3, 5)
-│   │   ├───• vec3 (6, 8)
-│   │   └───• vec4 (6, 5)
-│   │
-│   ├───• 5 (6, 6.5)
-│   │   │
 │   │   ├───• vec3 (6, 8)
 │   │   └───• vec4 (6, 5)
 │   │
@@ -384,14 +383,14 @@ force-split partition-key=7 parent-partition-key=1 steps=10
 │
 ├───• 9 (5.5, 6.25)
 │   │
-│   ├───• 4 (5, 6) [DrainingForSplit:5,6]
+│   ├───• 5 (6, 6.5)
 │   │   │
-│   │   ├───• vec2 (3, 5)
-│   │   ├───• vec3 (6, 8)
-│   │   └───• vec4 (6, 5)
+│   │   ├───• vec4 (6, 5)
+│   │   └───• vec3 (6, 8)
 │   │
-│   └───• 5 (6, 6.5)
+│   └───• 4 (5, 6) [DrainingForSplit:5,6]
 │       │
+│       ├───• vec2 (3, 5)
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
@@ -415,14 +414,14 @@ force-split partition-key=4 parent-partition-key=7 steps=2
 │
 ├───• 7 (5.5, 6.25) [DrainingForSplit:9,10]
 │   │
+│   ├───• 5 (6, 6.5)
+│   │   │
+│   │   ├───• vec4 (6, 5)
+│   │   └───• vec3 (6, 8)
+│   │
 │   ├───• 4 (5, 6) [DrainingForSplit:5,6]
 │   │   │
 │   │   ├───• vec2 (3, 5)
-│   │   ├───• vec3 (6, 8)
-│   │   └───• vec4 (6, 5)
-│   │
-│   ├───• 5 (6, 6.5)
-│   │   │
 │   │   ├───• vec3 (6, 8)
 │   │   └───• vec4 (6, 5)
 │   │
@@ -432,14 +431,14 @@ force-split partition-key=4 parent-partition-key=7 steps=2
 │
 ├───• 9 (5.5, 6.25)
 │   │
-│   ├───• 4 (5, 6) [DrainingForSplit:5,6]
+│   ├───• 5 (6, 6.5)
 │   │   │
-│   │   ├───• vec2 (3, 5)
-│   │   ├───• vec3 (6, 8)
-│   │   └───• vec4 (6, 5)
+│   │   ├───• vec4 (6, 5)
+│   │   └───• vec3 (6, 8)
 │   │
-│   └───• 5 (6, 6.5)
+│   └───• 4 (5, 6) [DrainingForSplit:5,6]
 │       │
+│       ├───• vec2 (3, 5)
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
@@ -468,14 +467,14 @@ force-split partition-key=7 parent-partition-key=1 steps=2
 │
 └───• 9 (5.5, 6.25)
     │
-    ├───• 4 (5, 6) [DrainingForSplit:5,6]
+    ├───• 5 (6, 6.5)
     │   │
-    │   ├───• vec2 (3, 5)
-    │   ├───• vec3 (6, 8)
-    │   └───• vec4 (6, 5)
+    │   ├───• vec4 (6, 5)
+    │   └───• vec3 (6, 8)
     │
-    └───• 5 (6, 6.5)
+    └───• 4 (5, 6) [DrainingForSplit:5,6]
         │
+        ├───• vec2 (3, 5)
         ├───• vec3 (6, 8)
         └───• vec4 (6, 5)
 
@@ -500,8 +499,8 @@ force-split partition-key=4 parent-partition-key=9 steps=2
     │
     └───• 5 (6, 6.5)
         │
-        ├───• vec3 (6, 8)
-        └───• vec4 (6, 5)
+        ├───• vec4 (6, 5)
+        └───• vec3 (6, 8)
 
 # ----------------------------------------------------------------------
 # Try to split a non-leaf partition with only 1 vector.
@@ -804,20 +803,28 @@ format-tree
 │
 ├───• 12 (0.5, -7.25)
 │   │
-│   ├───• 4 (0, -8) [DrainingForSplit:8,9]
-│   │   │
-│   │   └───• vec2 (0, -8)
-│   │
-│   ├───• 6 (2, -5)
-│   │   │
-│   │   └───• vec3 (2, -5)
-│   │
 │   ├───• 8 (0, -8)
 │   │   │
 │   │   └───• vec2 (0, -8)
 │   │
-│   └───• 9 (0, -8)
+│   ├───• 9 (0, -8)
+│   ├───• 4 (0, -8) [DrainingForSplit:8,9]
+│   │   │
+│   │   └───• vec2 (0, -8)
+│   │
+│   └───• 6 (2, -5)
+│       │
+│       └───• vec3 (2, -5)
+│
 └───• 13 (3, -1.8333)
+    │
+    ├───• 5 (4, 0) [DrainingForSplit:10,11]
+    │   │
+    │   └───• vec1 (4, 0)
+    │
+    ├───• 7 (2, -3)
+    │   │
+    │   └───• vec4 (2, -3)
     │
     ├───• 2 (2, -4) [DrainingForSplit:4,5]
     │   │
@@ -827,14 +834,6 @@ format-tree
     ├───• 3 (2, -4) [DrainingForSplit:6,7]
     │   │
     │   ├───• vec3 (2, -5)
-    │   └───• vec4 (2, -3)
-    │
-    ├───• 5 (4, 0) [DrainingForSplit:10,11]
-    │   │
-    │   └───• vec1 (4, 0)
-    │
-    ├───• 7 (2, -3)
-    │   │
     │   └───• vec4 (2, -3)
     │
     ├───• 10 (4, 0)
@@ -858,11 +857,14 @@ format-tree
 │
 ├───• 17 (1, -6.5)
 │   │
-│   ├───• 6 (2, -5)
+│   ├───• 4 (0, -8) [DrainingForSplit:8,9]
 │   │   │
-│   │   └───• vec3 (2, -5)
+│   │   └───• vec2 (0, -8)
 │   │
-│   └───• 9 (0, -8)
+│   └───• 6 (2, -5)
+│       │
+│       └───• vec3 (2, -5)
+│
 ├───• 15 (4, 0)
 │   │
 │   ├───• 5 (4, 0) [DrainingForSplit:10,11]
@@ -879,29 +881,27 @@ format-tree
 │
 ├───• 14 (2, -3.6667)
 │   │
-│   ├───• 2 (2, -4) [DrainingForSplit:4,5]
-│   │   │
-│   │   ├───• vec1 (4, 0)
-│   │   └───• vec2 (0, -8)
-│   │
 │   ├───• 3 (2, -4) [DrainingForSplit:6,7]
 │   │   │
 │   │   ├───• vec3 (2, -5)
 │   │   └───• vec4 (2, -3)
 │   │
-│   └───• 7 (2, -3)
+│   ├───• 7 (2, -3)
+│   │   │
+│   │   └───• vec4 (2, -3)
+│   │
+│   └───• 2 (2, -4) [DrainingForSplit:4,5]
 │       │
-│       └───• vec4 (2, -3)
+│       ├───• vec1 (4, 0)
+│       └───• vec2 (0, -8)
 │
 └───• 16 (0, -8)
     │
-    ├───• 4 (0, -8) [DrainingForSplit:8,9]
+    ├───• 8 (0, -8)
     │   │
     │   └───• vec2 (0, -8)
     │
-    └───• 8 (0, -8)
-        │
-        └───• vec2 (0, -8)
+    └───• 9 (0, -8)
 
 # And finally once more, since all partitions should now be right-sized.
 search beam-size=16
@@ -918,31 +918,31 @@ format-tree
 │   │
 │   ├───• 17 (1, -6.5)
 │   │   │
-│   │   ├───• 6 (2, -5)
-│   │   │   │
-│   │   │   └───• vec3 (2, -5)
-│   │   │
-│   │   └───• 9 (0, -8)
+│   │   └───• 6 (2, -5)
+│   │       │
+│   │       └───• vec3 (2, -5)
+│   │
 │   └───• 16 (0, -8)
 │       │
-│       └───• 8 (0, -8)
-│           │
-│           └───• vec2 (0, -8)
-│
+│       ├───• 8 (0, -8)
+│       │   │
+│       │   └───• vec2 (0, -8)
+│       │
+│       └───• 9 (0, -8)
 └───• 19 (3, -1.8333)
     │
-    ├───• 15 (4, 0)
+    ├───• 14 (2, -3.6667)
     │   │
-    │   ├───• 11 (4, 0)
-    │   │   │
-    │   │   └───• vec5 (2, -4)
-    │   │
-    │   └───• 10 (4, 0)
+    │   └───• 7 (2, -3)
     │       │
-    │       └───• vec1 (4, 0)
+    │       └───• vec4 (2, -3)
     │
-    └───• 14 (2, -3.6667)
+    └───• 15 (4, 0)
         │
-        └───• 7 (2, -3)
+        ├───• 11 (4, 0)
+        │   │
+        │   └───• vec5 (2, -4)
+        │
+        └───• 10 (4, 0)
             │
-            └───• vec4 (2, -3)
+            └───• vec1 (4, 0)

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -47,32 +47,32 @@ force-split partition-key=1 root=2 steps=1
 ----
 • 2 (10.5, 2.5) [Updating:1]
 │
-├───• vec2 (7, 4)
-└───• vec5 (14, 1)
+├───• vec5 (14, 1)
+└───• vec2 (7, 4)
 
 # Update left sub-partition #2 to Ready state.
 force-split partition-key=1 root=2 steps=1
 ----
 • 2 (10.5, 2.5)
 │
-├───• vec2 (7, 4)
-└───• vec5 (14, 1)
+├───• vec5 (14, 1)
+└───• vec2 (7, 4)
 
 # Add ~1/2 vectors to right sub-partition #3.
 force-split partition-key=1 root=3 steps=1
 ----
 • 3 (2.5, 2.5) [Updating:1]
 │
-├───• vec1 (1, 2)
-└───• vec3 (4, 3)
+├───• vec3 (4, 3)
+└───• vec1 (1, 2)
 
 # Update right sub-partition #3 to Ready state.
 force-split partition-key=1 root=3 steps=1
 ----
 • 3 (2.5, 2.5)
 │
-├───• vec1 (1, 2)
-└───• vec3 (4, 3)
+├───• vec3 (4, 3)
+└───• vec1 (1, 2)
 
 # Remove children from root partition.
 force-split partition-key=1 steps=1
@@ -91,8 +91,8 @@ force-split partition-key=1 steps=1
 │
 └───• 2 (10.5, 2.5)
     │
-    ├───• vec2 (7, 4)
-    └───• vec5 (14, 1)
+    ├───• vec5 (14, 1)
+    └───• vec2 (7, 4)
 
 # Add right sub-partition #3 to root partition.
 force-split partition-key=1 steps=1
@@ -101,13 +101,13 @@ force-split partition-key=1 steps=1
 │
 ├───• 2 (10.5, 2.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
 └───• 3 (2.5, 2.5)
     │
-    ├───• vec1 (1, 2)
-    └───• vec3 (4, 3)
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
 
 # Update splitting root partition to Ready state.
 force-split partition-key=1 steps=1
@@ -116,13 +116,13 @@ force-split partition-key=1 steps=1
 │
 ├───• 2 (10.5, 2.5)
 │   │
-│   ├───• vec2 (7, 4)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
 └───• 3 (2.5, 2.5)
     │
-    ├───• vec1 (1, 2)
-    └───• vec3 (4, 3)
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
 
 # ----------------------------------------------------------------------
 # Try to split a root partition with only 1 vector.
@@ -483,8 +483,8 @@ force-split partition-key=1 steps=4 root=2
 • 2 (10.5, 2.5)
 │
 ├───• vec5 (10, 5)
-├───• vec2 (7, 4)
-└───• vec3 (14, 1)
+├───• vec3 (14, 1)
+└───• vec2 (7, 4)
 
 # Insert vector that should be redirected to sub-partition #3.
 search-for-insert discard-fixups
@@ -518,8 +518,8 @@ vec7: (8, 8)
 • 2 (10.5, 2.5)
 │
 ├───• vec5 (10, 5)
-├───• vec2 (7, 4)
 ├───• vec3 (14, 1)
+├───• vec2 (7, 4)
 └───• vec7 (8, 8)
 
 # Move to the AddingLevel state in the root partition.
@@ -534,8 +534,8 @@ force-split partition-key=2 parent-partition-key=1 steps=10 root=2
 • 2 (10.5, 2.5) [Splitting:4,5]
 │
 ├───• vec5 (10, 5)
-├───• vec2 (7, 4)
 ├───• vec3 (14, 1)
+├───• vec2 (7, 4)
 └───• vec7 (8, 8)
 
 # Insert another vector that should be redirected to sub-partition #2.
@@ -550,8 +550,8 @@ vec8: (15, 5)
 • 2 (10.5, 2.5) [Splitting:4,5]
 │
 ├───• vec5 (10, 5)
-├───• vec2 (7, 4)
 ├───• vec3 (14, 1)
+├───• vec2 (7, 4)
 ├───• vec7 (8, 8)
 └───• vec8 (15, 5)
 
@@ -563,8 +563,8 @@ force-split partition-key=1 steps=3
 ├───• 2 (10.5, 2.5) [Splitting:4,5]
 │   │
 │   ├───• vec5 (10, 5)
-│   ├───• vec2 (7, 4)
 │   ├───• vec3 (14, 1)
+│   ├───• vec2 (7, 4)
 │   ├───• vec7 (8, 8)
 │   └───• vec8 (15, 5)
 │
@@ -579,10 +579,11 @@ force-split partition-key=2 parent-partition-key=1
 ----
 • 1 (6.8, 4.2)
 │
-├───• 5 (14.5, 3)
+├───• 5 (8.3333, 5.6667)
 │   │
-│   ├───• vec3 (14, 1)
-│   └───• vec8 (15, 5)
+│   ├───• vec2 (7, 4)
+│   ├───• vec7 (8, 8)
+│   └───• vec5 (10, 5)
 │
 ├───• 3 (-1, 4)
 │   │
@@ -590,11 +591,10 @@ force-split partition-key=2 parent-partition-key=1
 │   ├───• vec4 (-3, 6)
 │   └───• vec6 (0, 0)
 │
-└───• 4 (7.5, 6)
+└───• 4 (12, 3)
     │
-    ├───• vec5 (10, 5)
-    ├───• vec2 (7, 4)
-    └───• vec7 (8, 8)
+    ├───• vec8 (15, 5)
+    └───• vec3 (14, 1)
 
 # ----------------------------------------------------------------------
 # Delete from the tree when the root is in splitting states.
@@ -701,9 +701,9 @@ format-tree root=2
 • 2 (5.3333, 6.6667)
 │
 ├───• vec10 (5, 8)
+├───• vec7 (3, 5)
 ├───• vec3 (4, 3)
 ├───• vec4 (8, 11)
-├───• vec7 (3, 5)
 └───• vec8 (6, 8)
 
 delete discard-fixups
@@ -726,9 +726,9 @@ format-tree root=2
 • 2 (5.3333, 6.6667)
 │
 ├───• vec10 (5, 8)
+├───• vec7 (3, 5)
 ├───• vec8 (6, 8)
-├───• vec4 (8, 11)
-└───• vec7 (3, 5)
+└───• vec4 (8, 11)
 
 # Delete vector after vectors have been cleared in the root. This should remove
 # the vector from sub-partition #3.
@@ -741,9 +741,9 @@ vec4
 ----
 • 3 (9.6667, 3.6667)
 │
+├───• vec6 (8, 6)
 ├───• vec9 (6, 5)
-├───• vec5 (14, 1)
-└───• vec6 (8, 6)
+└───• vec5 (14, 1)
 
 # Delete vector in AddingLevel state. This should remove the vector from
 # sub-partition #3.
@@ -756,8 +756,8 @@ vec5
 ----
 • 3 (9.6667, 3.6667)
 │
-├───• vec9 (6, 5)
-└───• vec6 (8, 6)
+├───• vec6 (8, 6)
+└───• vec9 (6, 5)
 
 # Finish split of root partition.
 force-split partition-key=1
@@ -767,10 +767,10 @@ force-split partition-key=1
 ├───• 2 (5.3333, 6.6667)
 │   │
 │   ├───• vec10 (5, 8)
-│   ├───• vec8 (6, 8)
-│   └───• vec7 (3, 5)
+│   ├───• vec7 (3, 5)
+│   └───• vec8 (6, 8)
 │
 └───• 3 (9.6667, 3.6667)
     │
-    ├───• vec9 (6, 5)
-    └───• vec6 (8, 6)
+    ├───• vec6 (8, 6)
+    └───• vec9 (6, 5)


### PR DESCRIPTION
When sorting partition data into left and right groupings, vectors can be sorted in a different order than associated child keys and value bytes. This commit updates the logic to operate on all the partition data at once, not just the vectors.

Epic: CRDB-42943

Release note: None