### PR TITLE
roachtest/sysbench: Fix labels passed in aggregated metrics

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/metric_utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils.go
@@ -433,7 +433,7 @@ func processMetricLine(line string, metric *HistogramSummaryMetricPoint) ([]*Lab
 		return nil, errors.New("error parsing metric line")
 	}
 
-	labels, err := getLabels(matches[2])
+	labels, err := GetLabels(matches[2])
 	if err != nil {
 		return nil, err
 	}
@@ -478,7 +478,7 @@ func processMetricLine(line string, metric *HistogramSummaryMetricPoint) ([]*Lab
 	return labels, nil
 }
 
-func getLabels(labels string) ([]*Label, error) {
+func GetLabels(labels string) ([]*Label, error) {
 	labelSlice := strings.Split(labels, ",")
 	var finalLabels []*Label
 

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -570,10 +570,14 @@ func exportSysbenchResults(
 
 		aggregatedBuf := &bytes.Buffer{}
 
+		labels, err := roachtestutil.GetLabels(labelString)
+		if err != nil {
+			return errors.Wrap(err, "failed to get labels")
+		}
 		// Convert aggregated metrics to OpenMetrics format
 		if err := roachtestutil.GetAggregatedMetricBytes(
 			aggregatedMetrics,
-			[]*roachtestutil.Label{{Name: "test", Value: t.Name()}},
+			labels,
 			timeutil.Now(),
 			aggregatedBuf,
 		); err != nil {


### PR DESCRIPTION
Fix the labels being passed to aggregated metrics in sysbench

Fixes: none
Epic: none