### PR TITLE
kvnemesis: test buffered writes for SSI transactions

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/kv/kvbase",
         "//pkg/kv/kvclient",
         "//pkg/kv/kvclient/rangecache",
+        "//pkg/kv/kvnemesis/kvnemesisutil",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvnemesis/kvnemesisutil"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -1094,11 +1095,11 @@ func (rr requestRecord) toResp(
 		// The condition was satisfied; buffer the write and return a
 		// synthesized response.
 		ru.MustSetInner(&kvpb.ConditionalPutResponse{})
-		twb.addToBuffer(req.Key, req.Value, req.Sequence)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq)
 
 	case *kvpb.PutRequest:
 		ru.MustSetInner(&kvpb.PutResponse{})
-		twb.addToBuffer(req.Key, req.Value, req.Sequence)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq)
 
 	case *kvpb.DeleteRequest:
 		// To correctly populate FoundKey in the response, we must prefer any
@@ -1133,7 +1134,7 @@ func (rr requestRecord) toResp(
 		ru.MustSetInner(&kvpb.DeleteResponse{
 			FoundKey: foundKey,
 		})
-		twb.addToBuffer(req.Key, roachpb.Value{}, req.Sequence)
+		twb.addToBuffer(req.Key, roachpb.Value{}, req.Sequence, req.KVNemesisSeq)
 
 	case *kvpb.GetRequest:
 		val, served := twb.maybeServeRead(req.Key, req.Sequence)
@@ -1195,7 +1196,9 @@ func (rr requestRecords) Empty() bool {
 }
 
 // addToBuffer adds a write to the given key to the buffer.
-func (twb *txnWriteBuffer) addToBuffer(key roachpb.Key, val roachpb.Value, seq enginepb.TxnSeq) {
+func (twb *txnWriteBuffer) addToBuffer(
+	key roachpb.Key, val roachpb.Value, seq enginepb.TxnSeq, kvNemSeq kvnemesisutil.Container,
+) {
 	it := twb.buffer.MakeIter()
 	seek := twb.seekItemForSpan(key, nil)
 
@@ -1203,7 +1206,7 @@ func (twb *txnWriteBuffer) addToBuffer(key roachpb.Key, val roachpb.Value, seq e
 	if it.Valid() {
 		// We've already seen a write for this key.
 		bw := it.Cur()
-		val := bufferedValue{val: val, seq: seq}
+		val := bufferedValue{val: val, seq: seq, kvNemesisSeq: kvNemSeq}
 		bw.vals = append(bw.vals, val)
 		twb.bufferSize += val.size()
 	} else {
@@ -1211,7 +1214,7 @@ func (twb *txnWriteBuffer) addToBuffer(key roachpb.Key, val roachpb.Value, seq e
 		bw := &bufferedWrite{
 			id:   twb.bufferIDAlloc,
 			key:  key,
-			vals: []bufferedValue{{val: val, seq: seq}},
+			vals: []bufferedValue{{val: val, seq: seq, kvNemesisSeq: kvNemSeq}},
 		}
 		twb.buffer.Set(bw)
 		twb.bufferSize += bw.size()
@@ -1354,8 +1357,11 @@ const bufferedValueStructOverhead = int64(unsafe.Sizeof(bufferedValue{}))
 
 // bufferedValue is a value written to a key at a given sequence number.
 type bufferedValue struct {
-	val roachpb.Value
-	seq enginepb.TxnSeq
+	// NB: Keep this at the start of the struct so that it is zero (size) cost in
+	// production.
+	kvNemesisSeq kvnemesisutil.Container
+	val          roachpb.Value
+	seq          enginepb.TxnSeq
 }
 
 // valPtr returns a pointer to the buffered value.
@@ -1406,6 +1412,7 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 		putAlloc.put.Key = bw.key
 		putAlloc.put.Value = val.val
 		putAlloc.put.Sequence = val.seq
+		putAlloc.put.KVNemesisSeq = val.kvNemesisSeq
 		putAlloc.union.Put = &putAlloc.put
 		ru.Value = &putAlloc.union
 	} else {
@@ -1415,6 +1422,7 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 		})
 		delAlloc.del.Key = bw.key
 		delAlloc.del.Sequence = val.seq
+		delAlloc.del.KVNemesisSeq = val.kvNemesisSeq
 		delAlloc.union.Delete = &delAlloc.del
 		ru.Value = &delAlloc.union
 	}

--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -82,6 +82,7 @@ go_test(
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/apply",
+        "//pkg/kv/kvserver/concurrency",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",

--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -155,6 +155,7 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 			if err := txn.SetIsoLevel(o.IsoLevel); err != nil {
 				panic(err)
 			}
+			txn.SetBufferedWritesEnabled(o.BufferedWrites)
 			if savedTxn != nil && txn.TestingCloneTxn().Epoch == 0 {
 				// If the txn's current epoch is 0 and we've run at least one prior
 				// iteration, we were just aborted.

--- a/pkg/kv/kvnemesis/operations.go
+++ b/pkg/kv/kvnemesis/operations.go
@@ -175,6 +175,10 @@ func (op Operation) format(w *strings.Builder, fctx formatCtx) {
 		w.WriteString(newFctx.indent)
 		w.WriteString(newFctx.receiver)
 		fmt.Fprintf(w, `.SetIsoLevel(isolation.%s)`, o.IsoLevel)
+		w.WriteString("\n")
+		w.WriteString(newFctx.indent)
+		w.WriteString(newFctx.receiver)
+		fmt.Fprintf(w, `.SetBufferedWritesEnabled(%v)`, o.BufferedWrites)
 		formatOps(w, newFctx, o.Ops)
 		if o.CommitInBatch != nil {
 			newFctx.receiver = `b`

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -33,6 +33,7 @@ message ClosureTxnOperation {
   cockroach.kv.kvserver.concurrency.isolation.Level iso_level = 7;
   Result result = 5 [(gogoproto.nullable) = false];
   roachpb.Transaction txn = 6;
+  bool buffered_writes = 8;
 }
 
 message GetOperation {

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-batch
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-batch
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   b := &kv.Batch{}
   b.Get(tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-mixed
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-commit-mixed
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   {
     b := &kv.Batch{}

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-delrange
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-delrange
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */) // @<ts> <nil>
   return nil
 }) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-err
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */)
   return nil
 }) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-release-savepoint
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-release-savepoint
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(0)) // @<ts> <nil>
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(5), sv(2)) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-rollback
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-rollback
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-rollback-savepoint
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-rollback-savepoint
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(0)) // @<ts> <nil>
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(5), sv(2)) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-savepoint
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-si-savepoint
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(0)) // @<ts> <nil>
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(5), sv(2)) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-batch
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-batch
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   b := &kv.Batch{}
   b.Get(tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-mixed
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-commit-mixed
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   {
     b := &kv.Batch{}

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-delrange
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-delrange
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */) // @<ts> <nil>
   return nil
 }) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-err
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-err
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(2), tk(4), true /* @s1 */)
   return nil
 }) // context canceled

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-release-savepoint
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-release-savepoint
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(0)) // @<ts> <nil>
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(5), sv(2)) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-rollback
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-rollback
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(5)) // @<ts> <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-rollback-savepoint
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-rollback-savepoint
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(0)) // @<ts> <nil>
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(5), sv(2)) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-savepoint
+++ b/pkg/kv/kvnemesis/testdata/TestApplier/txn-ssi-savepoint
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(5), sv(0)) // @<ts> <nil>
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(5), sv(2)) // @<ts> <nil>

--- a/pkg/kv/kvnemesis/testdata/TestOperationsFormat/3
+++ b/pkg/kv/kvnemesis/testdata/TestOperationsFormat/3
@@ -2,6 +2,7 @@ echo
 ----
 ···db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 ···  txn.SetIsoLevel(isolation.Serializable)
+···  txn.SetBufferedWritesEnabled(false)
 ···  {
 ···    b := &kv.Batch{}
 ···    b.Get(tk(7))

--- a/pkg/kv/kvnemesis/testdata/TestOperationsFormat/5
+++ b/pkg/kv/kvnemesis/testdata/TestOperationsFormat/5
@@ -2,6 +2,7 @@ echo
 ----
 ···db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
 ···  txn.SetIsoLevel(isolation.Serializable)
+···  txn.SetBufferedWritesEnabled(false)
 ···  txn.CreateSavepoint(ctx, 0)
 ···  txn.Put(ctx, tk(9), sv(3))
 ···  txn.ReleaseSavepoint(ctx, 0)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed_but_wrong_seq
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_del-del_transaction_committed_but_wrong_seq
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed_but_has_validation_error
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_committed_but_has_validation_error
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_did_not_commit
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-del_transaction_did_not_commit
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed_but_has_validation_error
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_committed_but_has_validation_error
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_did_not_commit
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/ambiguous_put-put_transaction_did_not_commit
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/nested_savepoint_release
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/nested_savepoint_release
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_delete_with_expected_write_after_write_transaction_with_shadowed_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_delete_with_expected_write_after_write_transaction_with_shadowed_delete
@@ -4,6 +4,7 @@ db0.Del(ctx, tk(1) /* @s1 */) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(3)) // <nil>
   txn.Del(ctx, tk(1) /* @s4 */) // <nil>
   txn.Put(ctx, tk(1), sv(5)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // (/Table/100/"0000000000000001", <nil>)
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_extra_deletion
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_extra_deletion
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_missing_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_missing_write
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 (/Table/100/"0000000000000001", <nil>)
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_returning_wrong_value
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_returning_wrong_value
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 <nil>
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_with_spurious_deletion
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_write_with_spurious_deletion
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // @0.000000002,0 (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000002,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000004,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_and_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_and_delete
@@ -6,6 +6,7 @@ db0.Del(ctx, tk(1) /* @s3 */) // @0.000000004,0 <nil>
 db0.Put(ctx, tk(1), sv(4)) // @0.000000005,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s5 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_incorrectly_deleting_keys_outside_span_boundary
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_incorrectly_deleting_keys_outside_span_boundary
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(4), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000004", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_returning_keys_outside_span_boundary
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_returning_keys_outside_span_boundary
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(4), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000004", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_missing_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_missing_write
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil
 }) // @0.000000004,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_deleterange_after_writes_with_write_timestamp_disagreement
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", /Table/100/"0000000000000003", <nil>)
   return nil
 }) // @0.000000004,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_savepoint_and_one_put
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_savepoint_and_one_put
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_savepoint_and_release
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_savepoint_and_release
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_savepoint_and_rollback
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_savepoint_and_rollback
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_scan_after_writes_and_delete_returning_missing_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_scan_after_writes_and_delete_returning_missing_key
@@ -2,12 +2,14 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000002":v2, <nil>)
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_tranactional_scan_after_write_and_delete_returning_extra_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_tranactional_scan_after_write_and_delete_returning_extra_key
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_delete_with_write_on_another_key_after_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_delete_with_write_on_another_key_after_delete
@@ -3,6 +3,7 @@ echo
 db0.Del(ctx, tk(1) /* @s1 */) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // (/Table/100/"0000000000000001", <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_deleterange_followed_by_put_after_writes_with_write_timestamp_disagreement
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(3), true /* @s2 */) // (/Table/100/"0000000000000001", <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_shadowed_by_deleterange_after_writes_with_write_timestamp_disagreement
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   txn.DelRange(ctx, tk(1), tk(3), true /* @s3 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000002", <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_correct_commit_time
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_correct_commit_time
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_incorrect_commit_time
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_put_with_incorrect_commit_time
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_outside_time_range
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_outside_time_range
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_within_time_range
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactional_scan_followed_by_delete_within_time_range
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_first_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_first_write_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_second_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_second_write_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_the_correct_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_the_correct_writes
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_delete_with_write_timestamp_disagreement
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(2) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_first_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_first_write_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_second_write_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_second_write_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_the_correct_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_the_correct_writes
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return nil
 }) // @0.000000001,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_write_timestamp_disagreement
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_committed_put_with_write_timestamp_disagreement
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_delete_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_delete_with_write_correctly_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   {
     b := &kv.Batch{}
     b.Del(tk(1) /* @s1 */) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_put_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_batch_put_with_write_correctly_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   {
     b := &kv.Batch{}
     b.Put(tk(1), sv(1)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_correctly_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_incorrectly_present
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_delete_with_write_incorrectly_present
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_correctly_missing
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_correctly_missing
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_incorrectly_present
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/one_transactionally_rolled_back_put_with_write_incorrectly_present
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   return errors.New("rollback")
 }) // rollback

--- a/pkg/kv/kvnemesis/testdata/TestValidate/savepoint_release_and_rollback
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/savepoint_release_and_rollback
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/savepoint_with_no_last_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/savepoint_with_no_last_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.CreateSavepoint(ctx, 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/savepoint_with_no_last_write_and_existing_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/savepoint_with_no_last_write_and_existing_write
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.CreateSavepoint(ctx, 1) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   txn.Get(ctx, tk(1)) // (v2, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_delete
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_after_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_delete
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_read_before_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_after_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_before_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_incorrect_scan_before_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_delete
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_delete
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_read_before_and_after_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_scan_before_and_after_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transaction_with_scan_before_and_after_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_read_and_write_with_non-empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_empty_time_overlap
@@ -4,12 +4,14 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   txn.Del(ctx, tk(2) /* @s4 */) // <nil>
   return nil
 }) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Get(ctx, tk(2)) // (v2, <nil>)
   txn.Get(ctx, tk(3)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_after_writes_and_deletes_with_non-empty_time_overlap
@@ -6,6 +6,7 @@ db0.Del(ctx, tk(1) /* @s3 */) // @0.000000003,0 <nil>
 db0.Del(ctx, tk(2) /* @s4 */) // @0.000000004,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Get(ctx, tk(2)) // (v2, <nil>)
   txn.Get(ctx, tk(3)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_empty_time_overlap
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_and_deletes_after_write_with_non-empty_time_overlap
@@ -3,6 +3,7 @@ echo
 db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (<nil>, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_one_missing_with_non-empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (<nil>, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_empty_time_overlap
@@ -6,6 +6,7 @@ db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_reads_with_non-empty_time_overlap
@@ -6,6 +6,7 @@ db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Get(ctx, tk(2)) // (v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scan_and_write_with_non-empty_time_overlap
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Put(ctx, tk(2), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_empty_time_overlap
@@ -6,6 +6,7 @@ db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Del(ctx, tk(2) /* @s4 */) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_after_delete_with_non-empty_time_overlap
@@ -7,6 +7,7 @@ db0.Del(ctx, tk(2) /* @s4 */) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(5)) // @0.000000004,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_one_missing_with_non-empty_time_overlap
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_empty_time_overlap
@@ -6,6 +6,7 @@ db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // (/Table/100/"0000000000000002":v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_non-empty_time_overlap
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/transactional_scans_with_non-empty_time_overlap
@@ -6,6 +6,7 @@ db0.Put(ctx, tk(2), sv(3)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(4)) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Scan(ctx, tk(2), tk(4), 0) // (/Table/100/"0000000000000002":v3, <nil>)
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_closed_nested_savepoint_rollbacks
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_closed_nested_savepoint_rollbacks
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_nested_savepoint_rollbacks
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_nested_savepoint_rollbacks
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.CreateSavepoint(ctx, 2) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_non-nested_savepoints_rollbacks
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_non-nested_savepoints_rollbacks
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.CreateSavepoint(ctx, 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactional_deletes_with_out_of_order_commit_times
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactional_deletes_with_out_of_order_commit_times
@@ -4,6 +4,7 @@ db0.Del(ctx, tk(1) /* @s1 */) // @0.000000002,0 <nil>
 db0.Del(ctx, tk(2) /* @s2 */) // @0.000000003,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s3 */) // <nil>
   txn.Del(ctx, tk(2) /* @s4 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key_with_extra_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_deletes_of_the_same_key_with_extra_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_incorrect_read
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_incorrect_read
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_reads
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_put_delete_ops_of_the_same_key_with_reads
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_extra_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_extra_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_reads
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_reads
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Get(ctx, tk(1)) // (v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_scans
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_puts_of_the_same_key_with_scans
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // <nil>
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, <nil>)

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_delete_put_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_delete_put_of_the_same_key
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Del(ctx, tk(1) /* @s1 */) // <nil>
   txn.Put(ctx, tk(1), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key_with_extra_write
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/two_transactionally_committed_writes_put_delete_of_the_same_key_with_extra_write
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Serializable)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Del(ctx, tk(1) /* @s2 */) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_get
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_get
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.GetForShareGuaranteedDurability(ctx, tk(1)) // (v2, <nil>)
   txn.Put(ctx, tk(3), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_get_and_missing_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_get_and_missing_key
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.GetForShareGuaranteedDurability(ctx, tk(1)) // (<nil>, <nil>)
   txn.Put(ctx, tk(3), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_scan
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_scan
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.ScanForShareGuaranteedDurability(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v2, /Table/100/"0000000000000002":v3, <nil>)
   txn.Put(ctx, tk(3), sv(4)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_scan_and_missing_key
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_locking_replicated_scan_and_missing_key
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.ScanForShareGuaranteedDurability(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v2, <nil>)
   txn.Put(ctx, tk(3), sv(4)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_atomic_writes
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_deleterange
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_deleterange
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(2), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(3), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.DelRange(ctx, tk(1), tk(4), true /* @s4 */) // (/Table/100/"0000000000000001", /Table/100/"0000000000000003", <nil>)
   return nil
 }) // @0.000000003,0 <nil>

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_replicated_get
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_replicated_get
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.GetForShareGuaranteedDurability(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(3), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_replicated_scan
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_replicated_scan
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.ScanForShareGuaranteedDurability(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Put(ctx, tk(3), sv(4)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_unreplicated_get
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_unreplicated_get
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.GetForShare(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(3), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_unreplicated_scan
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_locking_unreplicated_scan
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.ScanForShare(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Put(ctx, tk(3), sv(4)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_non-locking_get
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_non-locking_get
@@ -4,6 +4,7 @@ db0.Put(ctx, tk(1), sv(1)) // @0.000000001,0 <nil>
 db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Get(ctx, tk(1)) // (v1, <nil>)
   txn.Put(ctx, tk(3), sv(3)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_non-locking_scan
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_non-locking_scan
@@ -5,6 +5,7 @@ db0.Put(ctx, tk(1), sv(2)) // @0.000000002,0 <nil>
 db0.Put(ctx, tk(2), sv(3)) // @0.000000001,0 <nil>
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Scan(ctx, tk(1), tk(3), 0) // (/Table/100/"0000000000000001":v1, /Table/100/"0000000000000002":v3, <nil>)
   txn.Put(ctx, tk(3), sv(4)) // <nil>
   return nil

--- a/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_writes
+++ b/pkg/kv/kvnemesis/testdata/TestValidate/weak_isolation_transaction_with_non-atomic_writes
@@ -2,6 +2,7 @@ echo
 ----
 db0.Txn(ctx, func(ctx context.Context, txn *kv.Txn) error {
   txn.SetIsoLevel(isolation.Snapshot)
+  txn.SetBufferedWritesEnabled(false)
   txn.Put(ctx, tk(1), sv(1)) // <nil>
   txn.Put(ctx, tk(2), sv(2)) // <nil>
   return nil


### PR DESCRIPTION
This provides a new configuration option to enable write buffering for some SSI transactions during KVNemesis runs and adds a new test configuration that enables write buffering at a 70% probability.

To facilitate this, the write buffer now also tracks the KVNemesisSequence.

We only do this for SSI transactions as there are known issues with RC and SI transactions and write buffering.

Fixes #143893

Release note: None