### PR TITLE
roachprod: support C4 VM family options

### DIFF
--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -341,6 +341,7 @@ type ProviderOpts struct {
 	// multiple projects or a single one.
 	MachineType      string
 	MinCPUPlatform   string
+	BootDiskType     string
 	Zones            []string
 	Image            string
 	SSDCount         int
@@ -1096,6 +1097,8 @@ func (o *ProviderOpts) ConfigureCreateFlags(flags *pflag.FlagSet) {
 
 	flags.StringVar(&o.MachineType, ProviderName+"-machine-type", "n2-standard-4",
 		"Machine type (see https://cloud.google.com/compute/docs/machine-types)")
+	flags.StringVar(&o.BootDiskType, ProviderName+"-boot-disk-type", "pd-ssd",
+		"Type of the boot disk volume")
 	flags.StringVar(&o.MinCPUPlatform, ProviderName+"-min-cpu-platform", "Intel Ice Lake",
 		"Minimum CPU platform (see https://cloud.google.com/compute/docs/instances/specify-min-cpu-platform)")
 	flags.StringVar(&o.Image, ProviderName+"-image", DefaultImage,
@@ -1390,7 +1393,7 @@ func (p *Provider) computeInstanceArgs(
 		"--scopes", "cloud-platform",
 		"--image", image,
 		"--image-project", imageProject,
-		"--boot-disk-type", "pd-ssd",
+		"--boot-disk-type", providerOpts.BootDiskType,
 	}
 
 	if project == p.defaultProject && providerOpts.ServiceAccount == "" {


### PR DESCRIPTION
Previously, the default boot disk type was pd-ssd. This change allows the user
to specify a different boot disk type, e.g. "hyperdisk-balanced".

In order to create "c4-standard-8" instance type clusters, we need to use the
"hyperdisk-balanced" boot disk type.

Additionally, add the turbo mode and threads per core options.
These options are supported by the C4 VM family, and are used to configure the
instance to run microbenchmark.

Epic: None
Release note: None