### PR TITLE
backup: checkpoint after online restore link phase

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -61,6 +61,8 @@ var onlineRestoreLayerLimit = settings.RegisterIntSetting(
 	settings.WithVisibility(settings.Reserved),
 )
 
+const linkCompleteKey = "link_complete"
+
 // splitAndScatter runs through all entries produced by genSpans splitting and
 // scattering the key-space designated by the passed rewriter such that if all
 // files in the entries in those spans were ingested the amount ingested between


### PR DESCRIPTION
This patch will prevent online restore from rerunning the link flow if it has already completed. This will be useful for restore with experimental copy, which runs the download phase in the same job as the link phase. At some point in the future, we could add finer grain checkpointing to the link phase, but that would require more work and thought.

Epic: none

Release note: none