### PR TITLE
jsonpath: return unknown instead of error for exists, comparisons

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1157,3 +1157,34 @@ query T
 SELECT jsonb_path_query('["ab", 1]', 'strict $ starts with $var', '{"var": "abc"}');
 ----
 null
+
+query T
+SELECT jsonb_path_query('{}', 'exists(2 + "3")');
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', '2 / 0 > 0');
+----
+null
+
+query T rowsort
+SELECT jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'lax $.g ? ((exists (@.x + "3")) is unknown)');
+----
+{"x": 2}
+{"y": 3}
+
+query T
+SELECT jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'strict $.g[*] ? ((exists (@.x)) is unknown)');
+----
+{"y": 3}
+
+query T
+SELECT jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'strict $.g ? ((exists (@[*].x)) is unknown)');
+----
+[{"x": 2}, {"y": 3}]
+
+query T
+SELECT jsonb_path_query('[1,2,0,3]', '$[*] ? ((2 / @ > 0) is unknown)');
+----
+0

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -141,7 +141,7 @@ func (ctx *jsonpathCtx) evalExists(
 	// We can optimize this by short-circuiting in lax mode.
 	l, err := ctx.evalAndUnwrapResult(op.Left, jsonValue, false /* unwrap */)
 	if err != nil {
-		return jsonpathBoolUnknown, err
+		return jsonpathBoolUnknown, nil //nolint:returnerrcheck
 	}
 	if len(l) == 0 {
 		return jsonpathBoolFalse, nil
@@ -255,14 +255,14 @@ func (ctx *jsonpathCtx) evalPredicate(
 	// The left argument results are always auto-unwrapped.
 	left, err := ctx.evalAndUnwrapResult(op.Left, jsonValue, true /* unwrap */)
 	if err != nil {
-		return jsonpathBoolUnknown, err
+		return jsonpathBoolUnknown, nil //nolint:returnerrcheck
 	}
 	var right []json.JSON
 	if evalRight {
 		// The right argument results are conditionally evaluated and unwrapped.
 		right, err = ctx.evalAndUnwrapResult(op.Right, jsonValue, unwrapRight)
 		if err != nil {
-			return jsonpathBoolUnknown, err
+			return jsonpathBoolUnknown, nil //nolint:returnerrcheck
 		}
 	} else {
 		// If we don't want to evaluate the right argument, we need to call


### PR DESCRIPTION
This commit modifies JSONPath query evaluation to return unknown instead of propagating errors for invalid operations in exists and comparison functions. This matches postgres behaviour with these operations. Test cases were found from pg_regress.

Fixes: #143949
Release note: None