### PR TITLE
logical: implement crud sql writer

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "purgatory.go",
         "range_stats.go",
         "replication_statements.go",
+        "sql_crud_writer.go",
         "sql_row_reader.go",
         "sql_row_writer.go",
         "table_batch_handler.go",

--- a/pkg/crosscluster/logical/event_decoder.go
+++ b/pkg/crosscluster/logical/event_decoder.go
@@ -6,10 +6,34 @@
 package logical
 
 import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/errors"
 )
+
+// eventDecoder takes a KV from the source cluster and decodes it into datums
+// that are appropriate for the destination table.
+type eventDecoder struct {
+	decoder   cdcevent.Decoder
+	srcToDest map[descpb.ID]destinationTable
+
+	// TODO(jeffswenson): clean this interface up. There's a problem with
+	// layering that requires the event decoder to know about the most recent
+	// row. If a batch fails to process, its broken up into batches of size 1 and
+	// those are retried until they succeed or are DLQ'd. The batch handler is
+	// responsible for decoding rows, but the distsql processor is responsible
+	// for calling the batch handler and adding rows to the DLQ.
+	lastRow cdcevent.Row
+}
 
 // decodedEvent is constructed from a replication stream event. The replication
 // stream event is encoded using the source table descriptor. The decoded must
@@ -36,4 +60,125 @@ type decodedEvent struct {
 	// The datums in prevRow are in col id order for the destination table. nil
 	// prevRow may still lose LWW if there is a recent tombstone.
 	prevRow tree.Datums
+}
+
+func newEventDecoder(
+	ctx context.Context,
+	descriptors descs.DB,
+	settings *cluster.Settings,
+	procConfigByDestID map[descpb.ID]sqlProcessorTableConfig,
+) (*eventDecoder, error) {
+	srcToDest := make(map[descpb.ID]destinationTable, len(procConfigByDestID))
+	err := descriptors.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		for dstID, s := range procConfigByDestID {
+			descriptor, err := txn.Descriptors().GetLeasedImmutableTableByID(ctx, txn.KV(), dstID)
+			if err != nil {
+				return err
+			}
+
+			columns := getPhysicalColumnsSchema(descriptor)
+			columnNames := make([]string, 0, len(columns))
+			for _, column := range columns {
+				columnNames = append(columnNames, column.column.GetName())
+			}
+
+			srcToDest[s.srcDesc.GetID()] = destinationTable{
+				id:      dstID,
+				columns: columnNames,
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	decoder, err := newCdcEventDecoder(ctx, procConfigByDestID, settings)
+	if err != nil {
+		return nil, err
+	}
+
+	return &eventDecoder{
+		decoder:   decoder,
+		srcToDest: srcToDest,
+	}, nil
+}
+
+func (d *eventDecoder) decodeEvent(
+	ctx context.Context, event streampb.StreamEvent_KV,
+) (decodedEvent, error) {
+	decodedRow, err := d.decoder.DecodeKV(ctx, event.KeyValue, cdcevent.CurrentRow, event.KeyValue.Value.Timestamp, false)
+	if err != nil {
+		return decodedEvent{}, err
+	}
+
+	dstTable, ok := d.srcToDest[decodedRow.TableID]
+	if !ok {
+		return decodedEvent{}, errors.AssertionFailedf("table %d not found", decodedRow.TableID)
+	}
+
+	row := make(tree.Datums, 0, len(dstTable.columns))
+	row, err = appendDatums(row, decodedRow, dstTable.columns)
+	if err != nil {
+		return decodedEvent{}, err
+	}
+	d.lastRow = decodedRow
+
+	var prevKV roachpb.KeyValue
+	prevKV.Key = event.KeyValue.Key
+	prevKV.Value = event.PrevValue
+
+	decodedPrevRow, err := d.decoder.DecodeKV(ctx, prevKV, cdcevent.PrevRow, event.PrevValue.Timestamp, false)
+	if err != nil {
+		return decodedEvent{}, err
+	}
+
+	prevRow := make(tree.Datums, 0, len(dstTable.columns))
+	prevRow, err = appendDatums(prevRow, decodedPrevRow, dstTable.columns)
+	if err != nil {
+		return decodedEvent{}, err
+	}
+
+	return decodedEvent{
+		dstDescID:       dstTable.id,
+		isDelete:        decodedRow.IsDeleted(),
+		originTimestamp: event.KeyValue.Value.Timestamp,
+		row:             row,
+		prevRow:         prevRow,
+	}, nil
+}
+
+// appendDatums appends datums for the specified column names from the cdcevent.Row
+// to the datums slice and returns the updated slice.
+func appendDatums(datums tree.Datums, row cdcevent.Row, columnNames []string) (tree.Datums, error) {
+	it, err := row.DatumsNamed(columnNames)
+	if err != nil {
+		return nil, err
+	}
+
+	if err := it.Datum(func(d tree.Datum, col cdcevent.ResultColumn) error {
+		if dEnum, ok := d.(*tree.DEnum); ok {
+			// Override the type to Unknown to avoid a mismatched type OID error
+			// during execution. Note that Unknown is the type used by default
+			// when a SQL statement is executed without type hints.
+			//
+			// TODO(jeffswenson): this feels like the wrong place to do this,
+			// but its inspired by the implementation in queryBuilder.AddRow.
+			//
+			// Really we should be mapping from the source datum type to the
+			// destination datum type.
+			dEnum.EnumTyp = types.Unknown
+		}
+		datums = append(datums, d)
+		return nil
+	}); err != nil {
+		return nil, err
+	}
+
+	return datums, nil
+}
+
+type destinationTable struct {
+	id      descpb.ID
+	columns []string
 }

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -1403,13 +1403,13 @@ func TestTombstoneUpdate(t *testing.T) {
 
 	// 5. Replicate the delete from 'src-a' -> 'dst'
 	var jobIDSrcA jobspb.JobID
-	dst.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH MODE = VALIDATED, CURSOR = $2",
+	dst.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH CURSOR = $2",
 		urlSrcA, start.AsOfSystemTime()).Scan(&jobIDSrcA)
 	WaitUntilReplicatedTime(t, s.Clock().Now(), dst, jobIDSrcA)
 
 	// 6. Replicate the update from 'src-b' -> 'dst'
 	var jobIDSrcB jobspb.JobID
-	dst.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH MODE = VALIDATED, CURSOR = $2",
+	dst.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE tab ON $1 INTO TABLE tab WITH CURSOR = $2",
 		urlSrcB, start.AsOfSystemTime()).Scan(&jobIDSrcB)
 	WaitUntilReplicatedTime(t, s.Clock().Now(), dst, jobIDSrcB)
 

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -104,16 +104,20 @@ const (
 	// is deprecated because it does not support the full set of features of the
 	// SQL writer.
 	writerTypeLegacyKV writerType = "legacy-kv"
+
+	// writerTypeCRUD is the shiny new sql writer that uses explicit reads,
+	// inserts, updates, and deletes instead of upserts.
+	writerTypeCRUD writerType = "crud"
 )
 
 var immediateModeWriter = settings.RegisterStringSetting(
 	settings.ApplicationLevel,
 	"logical_replication.consumer.immediate_mode_writer",
 	"the writer to use when in immediate mode",
-	metamorphic.ConstantWithTestChoice("logical_replication.consumer.immediate_mode_writer", string(writerTypeSQL), string(writerTypeLegacyKV)),
+	metamorphic.ConstantWithTestChoice("logical_replication.consumer.immediate_mode_writer", string(writerTypeSQL), string(writerTypeLegacyKV), string(writerTypeCRUD)),
 	settings.WithValidateString(func(sv *settings.Values, val string) error {
-		if val != string(writerTypeSQL) && val != string(writerTypeLegacyKV) {
-			return errors.Newf("immediate mode writer must be either 'sql' or 'legacy-kv', got '%s'", val)
+		if val != string(writerTypeSQL) && val != string(writerTypeLegacyKV) && val != string(writerTypeCRUD) {
+			return errors.Newf("immediate mode writer must be either 'sql', 'legacy-kv', or 'crud', got '%s'", val)
 		}
 		return nil
 	}),
@@ -475,7 +479,11 @@ func (lrw *logicalReplicationWriterProcessor) close() {
 	}
 
 	for _, b := range lrw.bh {
-		b.Close(lrw.Ctx())
+		// The batch handler may be nil if the context was cancelled during
+		// initialization.
+		if b != nil {
+			b.Close(lrw.Ctx())
+		}
 	}
 
 	// Update the global retry queue gauges to reflect that this queue is going
@@ -747,6 +755,11 @@ func (lrw *logicalReplicationWriterProcessor) setupBatchHandlers(ctx context.Con
 			}
 		case writerTypeLegacyKV:
 			rp, err = newKVRowProcessor(ctx, flowCtx.Cfg, flowCtx.EvalCtx, lrw.spec, lrw.configByTable)
+			if err != nil {
+				return err
+			}
+		case writerTypeCRUD:
+			rp, err = newCrudSqlWriter(ctx, flowCtx.Cfg, flowCtx.EvalCtx, sd, lrw.spec.Discard, lrw.configByTable, jobspb.JobID(lrw.spec.JobID))
 			if err != nil {
 				return err
 			}
@@ -1120,7 +1133,6 @@ func (lrw *logicalReplicationWriterProcessor) shouldRetryLater(
 		return tooOld
 	}
 
-	// TODO(dt): maybe this should only be constraint violation errors?
 	return retryAllowed
 }
 

--- a/pkg/crosscluster/logical/replication_statements.go
+++ b/pkg/crosscluster/logical/replication_statements.go
@@ -394,7 +394,7 @@ func newBulkSelectStatement(
 }
 
 func toParsedStatement(stmt tree.Statement) (statements.Statement[tree.Statement], error) {
-	// TODO(jeffswenson): do I have to round trip through the string or can I
-	// safely construct the statement directly?
-	return parser.ParseOne(stmt.String())
+	// User Serialize instead of String to ensure the type casts use fully
+	// qualified names.
+	return parser.ParseOne(tree.Serialize(stmt))
 }

--- a/pkg/crosscluster/logical/sql_crud_writer.go
+++ b/pkg/crosscluster/logical/sql_crud_writer.go
@@ -1,0 +1,179 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+	"sort"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdcevent"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/stats"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+// sqlCrudWriter is a batch writer that implements the BatchHandler interface
+// using simple update, delete, and insert statements that assert the expected
+// previous value of the row.
+//
+// The sqlCrudWriter decodes the events, but it relies on per-table handlers to
+// process the batches.
+type sqlCrudWriter struct {
+	decoder  *eventDecoder
+	handlers map[descpb.ID]*tableHandler
+	settings *cluster.Settings
+	discard  jobspb.LogicalReplicationDetails_Discard
+}
+
+var _ BatchHandler = &sqlCrudWriter{}
+
+func newCrudSqlWriter(
+	ctx context.Context,
+	cfg *execinfra.ServerConfig,
+	evalCtx *eval.Context,
+	sd *sessiondata.SessionData,
+	discard jobspb.LogicalReplicationDetails_Discard,
+	procConfigByDestID map[descpb.ID]sqlProcessorTableConfig,
+	jobID jobspb.JobID,
+) (*sqlCrudWriter, error) {
+	decoder, err := newEventDecoder(ctx, cfg.DB, evalCtx.Settings, procConfigByDestID)
+	if err != nil {
+		return nil, err
+	}
+
+	handlers := make(map[descpb.ID]*tableHandler)
+	for dstDescID := range procConfigByDestID {
+		handler, err := newTableHandler(
+			ctx,
+			dstDescID,
+			cfg.DB,
+			cfg.Codec,
+			sd,
+			jobID,
+			cfg.LeaseManager.(*lease.Manager),
+			evalCtx.Settings,
+		)
+		if err != nil {
+			return nil, err
+		}
+		handlers[dstDescID] = handler
+	}
+
+	return &sqlCrudWriter{
+		decoder:  decoder,
+		handlers: handlers,
+		settings: evalCtx.Settings,
+		discard:  discard,
+	}, nil
+}
+
+func (c *sqlCrudWriter) HandleBatch(
+	ctx context.Context, batch []streampb.StreamEvent_KV,
+) (b batchStats, err error) {
+	ctx, sp := tracing.ChildSpan(ctx, "crudBatcher.HandleBatch")
+	defer sp.Finish()
+
+	sortedEvents, err := c.decodeAndSortEvents(ctx, batch)
+	if err != nil {
+		return batchStats{}, err
+	}
+
+	var combinedStats batchStats
+	for _, events := range eventsByTable(sortedEvents) {
+		handler := c.handlers[events[0].dstDescID]
+		stats, err := handler.handleDecodedBatch(ctx, events)
+		if err != nil {
+			return batchStats{}, err
+		}
+		stats.AddTo(&combinedStats)
+	}
+
+	return combinedStats, nil
+}
+
+// decodeAndSortEvents returns the decoded events sorted by destination
+// descriptor ID. This grouping allows `eventsByTable` to produce a single
+// group for each table.
+func (c *sqlCrudWriter) decodeAndSortEvents(
+	ctx context.Context, batch []streampb.StreamEvent_KV,
+) ([]decodedEvent, error) {
+	events := make([]decodedEvent, 0, len(batch))
+	for _, event := range batch {
+		if c.discard == jobspb.LogicalReplicationDetails_DiscardAllDeletes && len(event.KeyValue.Value.RawBytes) == 0 {
+			continue
+		}
+		decoded, err := c.decoder.decodeEvent(ctx, event)
+		if err != nil {
+			return nil, err
+		}
+		events = append(events, decoded)
+	}
+	sort.SliceStable(events, func(i, j int) bool {
+		return events[i].dstDescID < events[j].dstDescID
+	})
+	return events, nil
+}
+
+// eventsByTable is an iterator that groups events by their destination
+// descriptor ID. For optimal batching  input events should be sorted by
+// destination descriptor ID because the iterator groups runs of events with
+// the same destination.
+func eventsByTable(events []decodedEvent) func(yield func(descpb.ID, []decodedEvent) bool) {
+	return func(yield func(descpb.ID, []decodedEvent) bool) {
+		if len(events) == 0 {
+			return
+		}
+
+		start := 0
+		for i, event := range events {
+			if 1 <= i && events[i-1].dstDescID != event.dstDescID {
+				if !yield(events[start].dstDescID, events[start:i]) {
+					return
+				}
+				start = i
+			}
+		}
+
+		_ = yield(events[start].dstDescID, events[start:])
+	}
+}
+
+// Close implements BatchHandler.
+func (c *sqlCrudWriter) Close(ctx context.Context) {
+}
+
+// GetLastRow implements BatchHandler.
+func (c *sqlCrudWriter) GetLastRow() cdcevent.Row {
+	return c.decoder.lastRow
+}
+
+// ReleaseLeases implements BatchHandler.
+func (c *sqlCrudWriter) ReleaseLeases(ctx context.Context) {
+	for _, handler := range c.handlers {
+		handler.ReleaseLeases(ctx)
+	}
+}
+
+// ReportMutations implements BatchHandler.
+func (c *sqlCrudWriter) ReportMutations(*stats.Refresher) {
+}
+
+// SetSyntheticFailurePercent implements BatchHandler.
+func (c *sqlCrudWriter) SetSyntheticFailurePercent(uint32) {
+
+}
+
+// BatchSize implements BatchHandler.
+func (c *sqlCrudWriter) BatchSize() int {
+	return int(flushBatchSize.Get(&c.settings.SV))
+}

--- a/pkg/crosscluster/logical/sql_row_reader_test.go
+++ b/pkg/crosscluster/logical/sql_row_reader_test.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -52,12 +53,12 @@ func TestSQLRowReader(t *testing.T) {
 
 	// Create sqlRowReader for source table
 	srcDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "a", "tab")
-	srcReader, err := newSQLRowReader(srcDesc)
+	srcReader, err := newSQLRowReader(srcDesc, sessiondata.InternalExecutorOverride{})
 	require.NoError(t, err)
 
 	// Create sqlRowReader for destination table
 	dstDesc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "b", "tab")
-	dstReader, err := newSQLRowReader(dstDesc)
+	dstReader, err := newSQLRowReader(dstDesc, sessiondata.InternalExecutorOverride{})
 	require.NoError(t, err)
 
 	// Create test rows to look up

--- a/pkg/crosscluster/logical/sql_row_writer_test.go
+++ b/pkg/crosscluster/logical/sql_row_writer_test.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -50,7 +51,7 @@ func TestSQLRowWriter(t *testing.T) {
 
 	// Create a row writer
 	desc := cdctest.GetHydratedTableDescriptor(t, s.ApplicationLayer().ExecutorConfig(), "test_table")
-	writer, err := newSQLRowWriter(desc)
+	writer, err := newSQLRowWriter(desc, sessiondata.InternalExecutorOverride{})
 	require.NoError(t, err)
 
 	// Test InsertRow

--- a/pkg/crosscluster/logical/table_batch_handler_test.go
+++ b/pkg/crosscluster/logical/table_batch_handler_test.go
@@ -83,7 +83,7 @@ func newTestTableHandler(
 	t *testing.T, descID descpb.ID, s serverutils.ApplicationLayerInterface,
 ) *tableHandler {
 	sd := sql.NewInternalSessionData(context.Background(), s.ClusterSettings(), "" /* opName */)
-	handler, err := newTableHandler(descID, s.InternalDB().(descs.DB), s.Codec(), sd, s.LeaseManager().(*lease.Manager), s.ClusterSettings())
+	handler, err := newTableHandler(context.Background(), descID, s.InternalDB().(descs.DB), s.Codec(), sd, 1337, s.LeaseManager().(*lease.Manager), s.ClusterSettings())
 	require.NoError(t, err)
 	return handler
 }

--- a/pkg/crosscluster/logical/testdata/ldr_statements
+++ b/pkg/crosscluster/logical/testdata/ldr_statements
@@ -174,4 +174,4 @@ DELETE FROM [112 AS replication_target] WHERE (((((id IS NOT DISTINCT FROM $1::U
 
 show-select table=user_events
 ----
-SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.user_id, replication_target.event_type, replication_target.event_data, replication_target.created_at, replication_target.region FROM ROWS FROM (unnest($1::UUID[], $2::@100110[])) WITH ORDINALITY AS key_list (key1, key2, index) INNER LOOKUP JOIN [112 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.region = key_list.key2)
+SELECT key_list.index, replication_target.crdb_internal_origin_timestamp, replication_target.crdb_internal_mvcc_timestamp, replication_target.id, replication_target.user_id, replication_target.event_type, replication_target.event_data, replication_target.created_at, replication_target.region FROM ROWS FROM (unnest($1::UUID[], $2::@100111)) WITH ORDINALITY AS key_list (key1, key2, index) INNER LOOKUP JOIN [112 AS replication_target] ON (replication_target.id = key_list.key1) AND (replication_target.region = key_list.key2)


### PR DESCRIPTION
This adds the new 'crud' sql writer that is intended to replace the
current sql writer and the kv writer. The crud writer will be switched
to the default after performance testing demonstrates it is at least as
fast as the current sql writer.

Release note: none
Epic: [CRDB-48647](https://cockroachlabs.atlassian.net/browse/CRDB-48647)