### PR TITLE
mixedversion: fix MinBootstrapVersion bugs

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -974,6 +974,20 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			return []*clusterupgrade.Version{pred}, nil
 		}
 
+		// If the predecessor same series as the minimum supported version,
+		// we need to check that it isn't the only possible upgrade where
+		// user steps can run. If it is, don't allow a skip upgrade or else
+		// we will generate a plan with zero upgrades that are able to run user hooks.
+		if pred.Series() == t.options.minimumSupportedVersion.Series() {
+			maxTestUpgrades, err := release.MajorReleasesBetween(&t.options.minimumSupportedVersion.Version, &currentVersion.Version)
+			if err != nil {
+				return nil, err
+			}
+			if maxTestUpgrades == 1 {
+				return []*clusterupgrade.Version{pred}, nil
+			}
+		}
+
 		predPred, err := t.options.predecessorFunc(t.prng, pred, t.options.minimumSupportedVersion, t.options.minimumBootstrapVersion)
 		if err != nil {
 			return nil, err
@@ -1499,8 +1513,9 @@ func assertValidTest(test *Test, fatalFunc func(...interface{})) {
 
 	currentVersion := clusterupgrade.CurrentVersion()
 	msv := test.options.minimumSupportedVersion
-	// The minimum supported version should be strictly less than the current version
-	validVersion := currentVersion.AtLeast(msv) && !currentVersion.Equal(msv)
+	// The current version should be at least one release series newer from
+	// the minimum supported version.
+	validVersion := currentVersion.CompareSeries(msv.Version) == 1
 
 	if !validVersion {
 		fail(

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -1572,8 +1572,8 @@ func assertValidTest(test *Test, fatalFunc func(...interface{})) {
 		}
 		if maxUpgradesFromBootstrapVersion < minUpgrades {
 			fail(errors.Newf(
-				"invalid test options: minimum bootstrap version (%s) does not allow for min %d upgrades",
-				minBootstrapVersion, minUpgrades,
+				"invalid test options: minimum bootstrap version (%s) does not allow for min %d upgrades to %s, max is %d",
+				minBootstrapVersion, minUpgrades, currentVersion, maxUpgradesFromBootstrapVersion,
 			))
 		}
 		// Override the max upgrades if the minimum bootstrap version does not allow for that

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -347,7 +347,7 @@ type (
 
 	CustomOption func(*testOptions)
 
-	predecessorFunc func(*rand.Rand, *clusterupgrade.Version, *clusterupgrade.Version) (*clusterupgrade.Version, error)
+	predecessorFunc func(*rand.Rand, *clusterupgrade.Version, *clusterupgrade.Version, *clusterupgrade.Version) (*clusterupgrade.Version, error)
 
 	// Test is the main struct callers of this package interact with.
 	Test struct {
@@ -953,18 +953,18 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 	// function to change in case the rules around what upgrades are
 	// possible in CRDB change.
 	possiblePredecessorsFor := func(v *clusterupgrade.Version) ([]*clusterupgrade.Version, error) {
-		pred, err := t.options.predecessorFunc(t.prng, v, t.options.minimumSupportedVersion)
+		pred, err := t.options.predecessorFunc(t.prng, v, t.options.minimumSupportedVersion, t.options.minimumBootstrapVersion)
 		if err != nil {
 			return nil, err
+		}
+
+		if !isAvailable(pred) {
+			return nil, nil
 		}
 
 		// If the predecessor is older than the minimum bootstrap version,
 		// then it is not a legal predecessor.
 		if isOlderThanMinimumBootstrapVersion(pred) {
-			return nil, nil
-		}
-
-		if !isAvailable(pred) {
 			return nil, nil
 		}
 
@@ -974,7 +974,7 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			return []*clusterupgrade.Version{pred}, nil
 		}
 
-		predPred, err := t.options.predecessorFunc(t.prng, pred, t.options.minimumSupportedVersion)
+		predPred, err := t.options.predecessorFunc(t.prng, pred, t.options.minimumSupportedVersion, t.options.minimumBootstrapVersion)
 		if err != nil {
 			return nil, err
 		}
@@ -1098,7 +1098,7 @@ func (t *Test) deploymentMode() DeploymentMode {
 // always picks the latest predecessor for the given release version,
 // ignoring the minimum supported version declared by the test.
 func latestPredecessor(
-	_ *rand.Rand, v, minSupported *clusterupgrade.Version,
+	_ *rand.Rand, v, minSupported, minBootstrap *clusterupgrade.Version,
 ) (*clusterupgrade.Version, error) {
 	predecessor, err := release.LatestPredecessor(&v.Version)
 	if err != nil {
@@ -1112,47 +1112,100 @@ func latestPredecessor(
 // picks a random predecessor for the given release version. If we are
 // choosing a predecessor in the same series as the minimum supported
 // version, special care is taken to select a random predecessor that
-// is more recent that the minimum supported version.
+// is more recent that the minimum supported version. Similarly, the
+// same is done for the minimum bootstrap version. minSupported must be
+// set but minBootstrap can be nil.
 func randomPredecessor(
-	rng *rand.Rand, v, minSupported *clusterupgrade.Version,
+	rng *rand.Rand, v, minSupported, minBootstrap *clusterupgrade.Version,
 ) (*clusterupgrade.Version, error) {
 	predecessor, err := release.RandomPredecessor(rng, &v.Version)
 	if err != nil {
 		return nil, err
 	}
 
-	// If the minimum supported version is from a different release
-	// series, we can pick any random patch release.
 	predV := clusterupgrade.MustParseVersion(predecessor)
-	if predV.Series() != minSupported.Series() {
+	// minVersion the minimum version we make sure our selected predecessor satisfies.
+	// When choosing a predecessor version, we want to make sure we can run test hooks
+	// if possible on that release series.
+	minVersion := minSupported
+	// minBootstrapSeries is the release series of the minimum bootstrap version, is empty
+	// string if one is not set.
+	var minBootstrapSeries string
+	if minBootstrap != nil {
+		minBootstrapSeries = minBootstrap.Series()
+	}
+
+	// The minimum bootstrap version (mbv) is guaranteed to be older than or the same
+	// version as the minimum supported version (msv). This gives us the ordering of
+	// minBootstrap <= minSupported < currentVersion and the following 4 cases for what
+	// minVersion should be set to:
+	//
+	// 1. The predecessor series is a different series than the mbv and msv series, we can
+	// pick any random patch release.
+	// 2. The predecessor series is the same as the msv series, validate against the msv.
+	// 3. The predecessor series is the same as the mbv series, validate against the mbv.
+	// 4. The predecessor series is the same as both the mbv and msv series, validate against
+	// the msv since it's older.
+	//
+	// For example, consider a minimum bootstrap version (mbv) of v23.1.3 and a minimum
+	// supported version of v24.1.5 (msv). The framework may pick an upgrade path of:
+	// v23.1 -> v23.2 -> v24.1 -> 24.2. When picking a predecessor for:
+	//
+	//		1. v23.1: This is the same series as our mbv, so our predecessor needs to be
+	//		at least v23.1.3 or the plan will not be valid. In this case, minVersion is
+	//    set to the mbv. We can ignore the msv here since it is an older series so
+	//		no patch release could satisfy it.
+	//
+	//		2. v23.2: This isn't the same series as either the msv or mbv, so we can ignore
+	//		minVersion and pick any random patch release. Any patch from a series older than
+	//		the msb/msv will never satisfy it, while any patch from a series older always
+	//	 	satisfies it.
+	//
+	//		3. v24.1: This is the same series as our msv, so our predecessor needs to be
+	//		at least v24.1.5. We could pick a patch older than that (e.g. v24.1.4) but then
+	//		user hooks will not be run, and we lose out on testing coverage. In this case,
+	//		minVersion is set to the msv.
+	//
+	//		4. v24.2: This is the same as v23.2 where neither the msv and mbv are the same
+	//		series, so we can pick any random patch release.
+	if predV.Series() != minSupported.Series() && predV.Series() != minBootstrapSeries {
+		// If the predecessor version is from a different release series than both the minimum
+		// supported version and minimum bootstrap version, we can pick any random patch release.
+		// Case 1 above.
 		return predV, nil
+	} else if predV.Series() == minSupported.Series() {
+		// Case 2 and 4 above.
+		minVersion = minSupported
+	} else {
+		// Case 3 above.
+		minVersion = minBootstrap
 	}
 
 	// If the latest release of a series is a pre-release, we validate
 	// whether the minimum supported version is valid.
-	if predV.IsPrerelease() && !predV.AtLeast(minSupported) {
+	if predV.IsPrerelease() && !predV.AtLeast(minVersion) {
 		return nil, fmt.Errorf(
 			"latest release for %s (%s) is not sufficient for minimum supported version (%s)",
-			predV.Series(), predV, minSupported.Version,
+			predV.Series(), predV, minVersion.Version,
 		)
 	}
 
-	// If the patch version of `minSupported` is 0, it means that we
+	// If the patch version of `minVersion` is 0, it means that we
 	// can choose any patch release in the predecessor series. It is
 	// also safe to return `predV` here if the `minSupported` version is
 	// a pre-release: we already validated that `predV`is at least
 	// `minSupported` in check above.
-	if minSupported.Patch() == 0 {
+	if minVersion.Patch() == 0 {
 		return predV, nil
 	}
 
-	latestPred, err := latestPredecessor(rng, v, minSupported)
+	latestPred, err := latestPredecessor(rng, v, minVersion, minBootstrap)
 	if err != nil {
 		return nil, err
 	}
 
 	var supportedPatchReleases []*clusterupgrade.Version
-	for j := minSupported.Patch(); j <= latestPred.Patch(); j++ {
+	for j := minVersion.Patch(); j <= latestPred.Patch(); j++ {
 		supportedV := clusterupgrade.MustParseVersion(
 			fmt.Sprintf("%s.%d", predV.Major().String(), j),
 		)
@@ -1528,6 +1581,11 @@ func assertValidTest(test *Test, fatalFunc func(...interface{})) {
 		if maxUpgrades > maxUpgradesFromBootstrapVersion {
 			test.logger.Printf("WARN: overriding maxUpgrades, minimum bootstrap version (%s) allows for at most %d upgrades", minBootstrapVersion, maxUpgradesFromBootstrapVersion)
 			test.options.maxUpgrades = maxUpgradesFromBootstrapVersion
+		}
+
+		if msv.LessThan(minBootstrapVersion) {
+			test.logger.Printf("WARN: overriding minSupportedVersion, cannot be older than minimum bootstrap version (%s)", minBootstrapVersion)
+			test.options.minimumSupportedVersion = minBootstrapVersion
 		}
 	}
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -931,6 +931,9 @@ func (t *Test) runCommandFunc(nodes option.NodeListOption, cmd string) stepFunc 
 // ARM64 builds are only available on v22.2.0+.
 func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 	skipVersions := t.prng.Float64() < t.options.skipVersionProbability
+	numUpgrades := t.numUpgrades()
+	currentVersion := clusterupgrade.CurrentVersion()
+
 	isAvailable := func(v *clusterupgrade.Version) bool {
 		if t.clusterArch() != vm.ArchARM64 {
 			return true
@@ -938,8 +941,11 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 
 		return v.AtLeast(minSupportedARM64Version)
 	}
+	isOlderThanMinimumBootstrapVersion := func(v *clusterupgrade.Version) bool {
+		return t.options.minimumBootstrapVersion != nil && v.LessThan(t.options.minimumBootstrapVersion)
+	}
 
-	var numSkips int
+	forceSkipVersion := true
 	// possiblePredecessorsFor returns a list of possible predecessors
 	// for the given release `v`. If skip-version is enabled and
 	// supported, this function will return both the immediate
@@ -950,6 +956,12 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 		pred, err := t.options.predecessorFunc(t.prng, v, t.options.minimumSupportedVersion)
 		if err != nil {
 			return nil, err
+		}
+
+		// If the predecessor is older than the minimum bootstrap version,
+		// then it is not a legal predecessor.
+		if isOlderThanMinimumBootstrapVersion(pred) {
+			return nil, nil
 		}
 
 		if !isAvailable(pred) {
@@ -967,12 +979,18 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			return nil, err
 		}
 
+		// If the skip upgrade predecessor is older than the minimum bootstrap version,
+		// then it is not a legal predecessor.
+		if isOlderThanMinimumBootstrapVersion(predPred) {
+			return []*clusterupgrade.Version{pred}, nil
+		}
+
 		// If we haven't performed a skip-version upgrade yet, do it. This logic
 		// makes sure that, when skip-version upgrades are enabled, it happens
 		// when upgrading to the current release, which is the most important
 		// upgrade to be tested on any release branch.
-		if numSkips == 0 {
-			numSkips++
+		if forceSkipVersion {
+			forceSkipVersion = false
 			return []*clusterupgrade.Version{predPred}, nil
 		}
 
@@ -983,7 +1001,7 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 
 	// possibleUpgradePathsMap maps a version to the possible upgrade paths that
 	// can be taken with exactly n upgrades.
-	possibleUpgradePathsMap := make(map[*clusterupgrade.Version]map[int][][]*clusterupgrade.Version)
+	possibleUpgradePathsMap := make(map[string]map[int][][]*clusterupgrade.Version)
 	// findPossibleUpgradePaths finds all legal upgrade paths ending at version `v` with
 	// exactly `numUpgrades` upgrades.
 	var findPossibleUpgradePaths func(v *clusterupgrade.Version, numUpgrades int) ([][]*clusterupgrade.Version, error)
@@ -993,9 +1011,9 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			return [][]*clusterupgrade.Version{{v}}, nil
 		}
 		// Check if we have already computed the possible upgrade paths for this version.
-		if _, ok := possibleUpgradePathsMap[v]; !ok {
-			possibleUpgradePathsMap[v] = make(map[int][][]*clusterupgrade.Version)
-		} else if paths, ok := possibleUpgradePathsMap[v][numUpgrades]; ok {
+		if _, ok := possibleUpgradePathsMap[v.String()]; !ok {
+			possibleUpgradePathsMap[v.String()] = make(map[int][][]*clusterupgrade.Version)
+		} else if paths, ok := possibleUpgradePathsMap[v.String()][numUpgrades]; ok {
 			return paths, nil
 		}
 
@@ -1008,11 +1026,6 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			return nil, err
 		}
 		for _, pred := range predecessors {
-			// If the predecessor is older than the minimum bootstrapped version, then
-			// it's not a legal upgrade path.
-			if t.options.minimumBootstrapVersion != nil && pred.LessThan(t.options.minimumBootstrapVersion) {
-				continue
-			}
 			predPaths, err := findPossibleUpgradePaths(pred, numUpgrades-1)
 			if err != nil {
 				return nil, err
@@ -1022,13 +1035,11 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			}
 		}
 
-		possibleUpgradePathsMap[v][numUpgrades] = paths
+		possibleUpgradePathsMap[v.String()][numUpgrades] = paths
 		return paths, nil
 	}
 
-	currentVersion := clusterupgrade.CurrentVersion()
 	var upgradePath []*clusterupgrade.Version
-	numUpgrades := t.numUpgrades()
 
 	// Best effort to find a valid upgrade path with exactly numUpgrades. If one is
 	// not found because some release is not available for the cluster architecture,
@@ -1046,13 +1057,21 @@ func (t *Test) chooseUpgradePath() ([]*clusterupgrade.Version, error) {
 			upgradePath = possibleUpgradePaths[t.prng.Intn(len(possibleUpgradePaths))]
 			break
 		}
+		forceSkipVersion = true
 	}
 
-	if len(upgradePath) < numUpgrades {
-		if t.clusterArch() != vm.ArchARM64 {
+	if len(upgradePath) < (numUpgrades + 1) {
+		warnMsg := "WARNING: %d upgrades requested but found plan with only %d upgrades"
+		if skipVersions {
+			t.logger.Printf("%s: prioritizing running at least one skip version upgrade", warnMsg)
+		} else if t.clusterArch() == vm.ArchARM64 {
+			t.logger.Printf("%s: ARM64 is only supported on %s+", warnMsg, minSupportedARM64Version)
+		} else {
 			return nil, errors.Newf("unable to find a valid upgrade path with %d upgrades", numUpgrades)
 		}
-		t.logger.Printf("WARNING: skipping upgrades as ARM64 is only supported on %s+", minSupportedARM64Version)
+	}
+	if skipVersions && forceSkipVersion {
+		t.logger.Printf("WARNING: skip version upgrades were enabled but were not performed because the minimum supported or bootstrap version did not allow")
 	}
 	return upgradePath, nil
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion_test.go
@@ -222,7 +222,7 @@ func Test_assertValidTest(t *testing.T) {
 	assertValidTest(mvt, fatalFunc())
 	require.Error(t, fatalErr)
 	require.Equal(t,
-		`mixedversion.NewTest: invalid test options: minimum bootstrap version (v21.2.0) does not allow for min 10 upgrades`,
+		`mixedversion.NewTest: invalid test options: minimum bootstrap version (v21.2.0) does not allow for min 10 upgrades to v23.1.2, max is 3`,
 		fatalErr.Error(),
 	)
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -10,8 +10,10 @@ import (
 	"fmt"
 	"io"
 	"math/rand"
+	"reflect"
 	"strconv"
 	"testing"
+	"testing/quick"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
@@ -20,6 +22,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/release"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/version"
@@ -933,4 +937,163 @@ func Test_SeparateProcessUsesLatestPred(t *testing.T) {
 		require.NoError(t, err)
 		require.Equal(t, latestVersion, version)
 	}
+}
+
+func Test_ChooseUpgradePathInvariants(t *testing.T) {
+	rng, _ := randutil.NewTestRand()
+	defer withTestBuildVersion("v25.1.0")()
+
+	newestPossibleVersion := clusterupgrade.MustParseVersion("v25.1.0")
+	oldestVersionWithReleaseData := clusterupgrade.MustParseVersion("v22.1.0")
+	maxPossibleUpgrades, err := release.MajorReleasesBetween(&newestPossibleVersion.Version, &oldestVersionWithReleaseData.Version)
+	require.NoError(t, err)
+
+	randomNthPredecessor := func(rng *rand.Rand, v *clusterupgrade.Version, n int) *clusterupgrade.Version {
+		curVersion := v.Version
+		for range n {
+			versionStr, err := release.RandomPredecessor(rng, &curVersion)
+			require.NoError(t, err)
+			clusterupgradeVersion, err := clusterupgrade.ParseVersion(versionStr)
+			require.NoError(t, err)
+			curVersion = clusterupgradeVersion.Version
+		}
+		return &clusterupgrade.Version{Version: curVersion}
+	}
+
+	generator := func(values []reflect.Value, rng *rand.Rand) {
+		// We don't always want to upgrade into the latest release (v25.1) so pick a release
+		// n predecessors older.
+		finalVersionOffset := rng.Intn(maxPossibleUpgrades)
+		finalVersion := randomNthPredecessor(rng, newestPossibleVersion, finalVersionOffset)
+		values[0] = reflect.ValueOf(finalVersion.Version.String())
+
+		maxUpgrades := rng.Intn(maxPossibleUpgrades-finalVersionOffset) + 1
+		upgradesRemaining := maxUpgrades - finalVersionOffset
+
+		// We force the minSupportedVersion to be at least one release series older, otherwise we
+		// aren't testing anything interesting (e.g. no upgrades will be possible).
+		minSupportedVersionOffset := 1
+		if upgradesRemaining > 0 {
+			minSupportedVersionOffset = rng.Intn(upgradesRemaining) + 1
+		}
+		upgradesRemaining -= minSupportedVersionOffset
+		minSupportedVersion := randomNthPredecessor(rng, finalVersion, minSupportedVersionOffset)
+		values[1] = reflect.ValueOf(minSupportedVersion.Version.String())
+
+		// The minBootstrapVersion can be any version less than or equal to minSupportedVersion.
+		minBootstrapVersionOffset := 0
+		if upgradesRemaining > 0 {
+			minBootstrapVersionOffset = rng.Intn(upgradesRemaining)
+		}
+		upgradesRemaining -= minBootstrapVersionOffset
+		minBootstrapVersion := randomNthPredecessor(rng, minSupportedVersion, minBootstrapVersionOffset)
+		values[2] = reflect.ValueOf(minBootstrapVersion.Version.String())
+
+		// Find the maximum amount of possible upgrades from the minBootstrapVersion
+		// and pick a random value [1, maxUpgradesFromMBV] to set numUpgrades to.
+		maxUpgradesFromMBV, err := release.MajorReleasesBetween(&finalVersion.Version, &minBootstrapVersion.Version)
+		require.NoError(t, err)
+
+		numUpgrades := rng.Intn(maxUpgradesFromMBV) + 1
+		values[3] = reflect.ValueOf(numUpgrades)
+
+		values[4] = reflect.ValueOf(rng.Float64() > 0.5)
+	}
+
+	cfg := quick.Config{
+		MaxCount: 100,
+		Rand:     rng,
+		Values:   generator,
+	}
+
+	var fatalErr error
+	fatalFunc := func() func(...interface{}) {
+		fatalErr = nil
+		return func(args ...interface{}) {
+			require.Len(t, args, 1)
+			err, isErr := args[0].(error)
+			require.True(t, isErr)
+
+			fatalErr = err
+		}
+	}
+
+	verifyPlan := func(
+		finalVersion string, minSupportedVersion string, minBootstrapVersion string, numUpgrades int, skipVersions bool,
+	) bool {
+		// The top level withTestBuildVersion will take care of resetting this for us.
+		_ = withTestBuildVersion(finalVersion)
+
+		// Set up our test plan using the generated values.
+		mvt := newTest(
+			NumUpgrades(numUpgrades),
+			MinimumSupportedVersion(minSupportedVersion),
+			MinimumBootstrapVersion(minBootstrapVersion),
+		)
+		if skipVersions {
+			mvt.options.skipVersionProbability = 1
+		}
+		mvt.options.predecessorFunc = randomPredecessor
+
+		assertValidTest(mvt, fatalFunc())
+		if fatalErr != nil {
+			t.Log(fatalErr)
+			return false
+		}
+
+		plan, err := mvt.plan()
+		logAndFail := func(format string, args ...any) bool {
+			t.Logf(format, args)
+			t.Log(plan.PrettyPrint())
+			return false
+		}
+		if err != nil {
+			return logAndFail(err.Error())
+		}
+
+		// It is possible for the number of total upgrades generated to be less than the
+		// number requested if:
+		//
+		// 1. The requested number of upgrades is greater than the number of possible upgrades
+		// from the minBootstrapVersion to the current version. mvt.numUpgrades should reflect
+		// this upper bound.
+		// 2. Skip upgrades are enabled. The framework will prioritize testing at least one
+		// skip upgrade over matching the exact number of upgrades requested.
+		assertNumUpgrades := func() bool {
+			numUpgradesGenerated := len(plan.allUpgrades())
+			expectedUpgrades := mvt.numUpgrades()
+			if numUpgradesGenerated != expectedUpgrades {
+				if skipVersions && numUpgradesGenerated == expectedUpgrades-1 {
+					return true
+				}
+				return logAndFail("expected %d upgrades, got %d", expectedUpgrades, numUpgradesGenerated)
+			}
+			return true
+		}
+
+		// randomPredecessor should take special care to pick a predecessor that is newer
+		// than the minimum supported version and minimum bootstrap version if they are in
+		// the same series as the predecessor.
+		assertRandomPredecessorRespectsMinVersion := func() bool {
+			msvSeries := mvt.options.minimumSupportedVersion.Series()
+			mbvSeries := mvt.options.minimumBootstrapVersion.Series()
+			for _, v := range plan.Versions() {
+				if v.Series() == msvSeries {
+					if v.LessThan(mvt.options.minimumSupportedVersion) {
+						return logAndFail("randomPredecessor should have picked predecessor newer than minimum supported version")
+					}
+				}
+				if v.Series() == mbvSeries {
+					if v.LessThan(mvt.options.minimumBootstrapVersion) {
+						return logAndFail("randomPredecessor should have picked predecessor newer than minimum bootstrap version")
+					}
+				}
+			}
+			return true
+		}
+
+		return assertNumUpgrades() && assertRandomPredecessorRespectsMinVersion()
+	}
+
+	require.NoError(t, quick.Check(verifyPlan, &cfg))
 }

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -438,7 +438,7 @@ func boolP(b bool) *bool {
 // deterministic even as changes continue to happen in the
 // cockroach_releases.yaml file.
 func testPredecessorFunc(
-	rng *rand.Rand, v, _ *clusterupgrade.Version,
+	rng *rand.Rand, v, _, _ *clusterupgrade.Version,
 ) (*clusterupgrade.Version, error) {
 	pred, ok := testPredecessorMapping[v.Series()]
 	if !ok {
@@ -512,7 +512,7 @@ func createDataDrivenMixedVersionTest(t *testing.T, args []datadriven.CmdArg) *T
 		mvt._isLocal = isLocal
 	}
 	if predecessors != nil {
-		mvt.options.predecessorFunc = func(_ *rand.Rand, v, _ *clusterupgrade.Version) (*clusterupgrade.Version, error) {
+		mvt.options.predecessorFunc = func(_ *rand.Rand, v, _, _ *clusterupgrade.Version) (*clusterupgrade.Version, error) {
 			if v.IsCurrent() {
 				return predecessors[len(predecessors)-1], nil
 			}


### PR DESCRIPTION
[mixedversion: check minBootstrapVersion when deciding to skip versions](https://github.com/cockroachdb/cockroach/commit/1aafa87cfb276c12ff0ee6ab9f02af1be5ba094c) 

Previously the minBootstrapVersion check was done after the predecessors were picked. However, this ignored the special case where if it was the first time a skip upgrade was happening, it would force the plan to take the skip. This meant that if the skip upgrade was forced but was older than the minBootstrapVersion, the framework would reject it and we would get an invalid plan.

This change moves the minBootstrapVersion check into the logic where we decide if we want to skip versions or not.

[mixedversion: respect minimum bootstrap version when choosing predecessor](https://github.com/cockroachdb/cockroach/commit/6a5ee7205be6d0ceb060cc5321de64b6f0bd6edb) 

Previously, randomPredecessor would respect the minimum supported version when choosing a predecessor but not the minimum bootstrap version. This meant that it was possible for it to pick a non supported version and have the framework reject it later on. Instead, this change now passes the minimum bootstrap version to randomPredecessor and takes special care to pick a version that is supported.

[mixedversion: add quick test for generating valid plans](https://github.com/cockroachdb/cockroach/pull/144005/commits/77bc8a82af97aa3c4550b1e6e4689a685c3a00ef)
This change adds a quick test to generate random plans with various options and asserts that certain variants hold.

[mixedversion: fix skip upgrade minSupportedVersion edge case](https://github.com/cockroachdb/cockroach/pull/144005/commits/98fd143c2766fbd28861c62125ed0407ead6d89d)
This change adds a check before skipping upgrades that doing so will still generate at least one upgrade that can allow user hooks to run. This happens if the minimum supported version is one skippable version behind the current version.

Informs: https://github.com/cockroachdb/cockroach/issues/139201
Release note: none
Epic: none
