### PR TITLE
builtins: add `jsonb_path_query_array`, `jsonb_path_query_first`, `jsonb_path_match`

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1291,6 +1291,21 @@ The vars argument must be a JSON object, and its fields provide named values
 to be substituted into the jsonpath expression. If the silent argument is true,
 the function suppresses the following errors: missing object field or array
 element, unexpected JSON item type, datetime and numeric errors.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query_array"></a><code>jsonb_path_query_array(target: jsonb, path: jsonpath) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the
+specified JSON value, as a JSON array.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query_array"></a><code>jsonb_path_query_array(target: jsonb, path: jsonpath, vars: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the
+specified JSON value, as a JSON array. The vars argument must be a
+JSON object, and its fields provide named values to be substituted
+into the jsonpath expression.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query_array"></a><code>jsonb_path_query_array(target: jsonb, path: jsonpath, vars: jsonb, silent: <a href="bool.html">bool</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the
+specified JSON value, as a JSON array. The vars argument must be a
+JSON object, and its fields provide named values to be substituted
+into the jsonpath expression. If the silent argument is true, the
+function suppresses the following errors: missing object field or
+array element, unexpected JSON item type, datetime and numeric errors.</p>
 </span></td><td>Immutable</td></tr></tbody>
 </table>
 

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1280,6 +1280,29 @@ argument is true, the function suppresses the following errors:
 missing object field or array element, unexpected JSON item type,
 datetime and numeric errors.</p>
 </span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_match"></a><code>jsonb_path_match(target: jsonb, path: jsonpath) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns the SQL boolean result of a JSON path predicate check
+for the specified JSON value. (This is useful only with predicate check
+expressions, not SQL-standard JSON path expressions, since it will
+either fail or return NULL if the path result is not a single boolean
+value.)</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_match"></a><code>jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns the SQL boolean result of a JSON path predicate check
+for the specified JSON value. (This is useful only with predicate check
+expressions, not SQL-standard JSON path expressions, since it will
+either fail or return NULL if the path result is not a single boolean
+value.) The vars argument must be a JSON object, and its fields provide
+named values to be substituted into the jsonpath expression.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_match"></a><code>jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb, silent: <a href="bool.html">bool</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns the SQL boolean result of a JSON path predicate check
+for the specified JSON value. (This is useful only with predicate check
+expressions, not SQL-standard JSON path expressions, since it will
+either fail or return NULL if the path result is not a single boolean
+value.) The vars argument must be a JSON object, and its fields provide
+named values to be substituted into the jsonpath expression. If the
+silent argument is true, the function suppresses the following errors:
+missing object field or array element, unexpected JSON item type,
+datetime and numeric errors.</p>
+</span></td><td>Immutable</td></tr>
 <tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.</p>
 </span></td><td>Immutable</td></tr>
 <tr><td><a name="jsonb_path_query"></a><code>jsonb_path_query(target: jsonb, path: jsonpath, vars: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns all JSON items returned by the JSON path for the specified JSON value.

--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -1306,6 +1306,21 @@ JSON object, and its fields provide named values to be substituted
 into the jsonpath expression. If the silent argument is true, the
 function suppresses the following errors: missing object field or
 array element, unexpected JSON item type, datetime and numeric errors.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query_first"></a><code>jsonb_path_query_first(target: jsonb, path: jsonpath) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the first JSON item returned by the JSON path for the
+specified JSON value, or NULL if there are no results.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query_first"></a><code>jsonb_path_query_first(target: jsonb, path: jsonpath, vars: jsonb) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the first JSON item returned by the JSON path for the
+specified JSON value, or NULL if there are no results. The vars
+argument must be a JSON object, and its fields provide named values
+to be substituted into the jsonpath expression.</p>
+</span></td><td>Immutable</td></tr>
+<tr><td><a name="jsonb_path_query_first"></a><code>jsonb_path_query_first(target: jsonb, path: jsonpath, vars: jsonb, silent: <a href="bool.html">bool</a>) &rarr; jsonb</code></td><td><span class="funcdesc"><p>Returns the first JSON item returned by the JSON path for the
+specified JSON value, or NULL if there are no results. The vars
+argument must be a JSON object, and its fields provide named values
+to be substituted into the jsonpath expression. If the silent argument is true, the
+function suppresses the following errors: missing object field or
+array element, unexpected JSON item type, datetime and numeric errors.</p>
 </span></td><td>Immutable</td></tr></tbody>
 </table>
 

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1170,6 +1170,13 @@ func TestTenantLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestTenantLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestTenantLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1177,6 +1177,13 @@ func TestTenantLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestTenantLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestTenantLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1184,6 +1184,13 @@ func TestTenantLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestTenantLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestTenantLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1182,6 +1182,13 @@ func TestReadCommittedLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestReadCommittedLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestReadCommittedLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1189,6 +1189,13 @@ func TestReadCommittedLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestReadCommittedLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestReadCommittedLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1175,6 +1175,13 @@ func TestReadCommittedLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestReadCommittedLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestReadCommittedLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1182,6 +1182,13 @@ func TestRepeatableReadLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestRepeatableReadLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestRepeatableReadLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1168,6 +1168,13 @@ func TestRepeatableReadLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestRepeatableReadLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestRepeatableReadLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1175,6 +1175,13 @@ func TestRepeatableReadLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestRepeatableReadLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestRepeatableReadLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_match
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_match
@@ -1,0 +1,27 @@
+# LogicTest: !local-mixed-24.3 !local-mixed-25.1
+
+query B
+SELECT jsonb_path_match('{}', '1 + 1 == 2');
+----
+true
+
+query B
+SELECT jsonb_path_match('{}', '"abc" starts with "b"');
+----
+false
+
+query T
+SELECT jsonb_path_match('{}', 'strict $', '{}', true);
+----
+NULL
+
+statement error pgcode 22038 pq: jsonb_path_match\(\): single boolean result is expected
+SELECT jsonb_path_match('{}', 'strict $', '{}', false);
+
+query T
+SELECT jsonb_path_match('{}', '$', '{}', true);
+----
+NULL
+
+statement error pgcode 22038 pq: jsonb_path_match\(\): single boolean result is expected
+SELECT jsonb_path_match('{}', '$', '{}', false);

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_array
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_array
@@ -1,0 +1,34 @@
+# LogicTest: !local-mixed-24.3 !local-mixed-25.1
+
+query T
+SELECT jsonb_path_query_array('{}', '$')
+----
+[{}]
+
+query T
+SELECT jsonb_path_query_array('{"a": [1, 2, {"b": [4, 5]}, null, [true, false]]}', '$.a[*]')
+----
+[1, 2, {"b": [4, 5]}, null, [true, false]]
+
+query T
+SELECT jsonb_path_query_array('{"a": [[{"b": 1, "c": "hello"}, {"b": 2, "c": "world"}, {"b": 1, "c": "!"}], [{"b": 1, "c": "hello"}, {"b": 2, "c": "world"}, {"b": 1, "c": "!"}]]}', '$.a ? (@.b == 1)');
+----
+[[{"b": 1, "c": "hello"}, {"b": 2, "c": "world"}, {"b": 1, "c": "!"}], [{"b": 1, "c": "hello"}, {"b": 2, "c": "world"}, {"b": 1, "c": "!"}]]
+
+query T
+SELECT jsonb_path_query_array('{}', 'strict $.a', '{}', true);
+----
+[]
+
+statement error pgcode 2203A pq: jsonb_path_query_array\(\): JSON object does not contain key "a"
+SELECT jsonb_path_query_array('{}', 'strict $.a', '{}', false);
+
+query T
+SELECT jsonb_path_query_array('{}', '$.a', '{}', true);
+----
+[]
+
+query T
+SELECT jsonb_path_query_array('{}', '$.a', '{}', false);
+----
+[]

--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_first
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query_first
@@ -1,0 +1,34 @@
+# LogicTest: !local-mixed-24.3 !local-mixed-25.1
+
+query T
+SELECT jsonb_path_query_first('[1, 2, 3]', '$[*]');
+----
+1
+
+query T
+SELECT jsonb_path_query_first('[2, 3]', '$[*]');
+----
+2
+
+query T
+SELECT jsonb_path_query_first('[]', '$[*]');
+----
+NULL
+
+query T
+SELECT jsonb_path_query_first('{}', 'strict $.a', '{}', true);
+----
+NULL
+
+statement error pgcode 2203A pq: jsonb_path_query_first\(\): JSON object does not contain key "a"
+SELECT jsonb_path_query_first('{}', 'strict $.a', '{}', false);
+
+query T
+SELECT jsonb_path_query_first('{}', '$.a', '{}', true);
+----
+NULL
+
+query T
+SELECT jsonb_path_query_first('{}', '$.a', '{}', false);
+----
+NULL

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1144,6 +1144,13 @@ func TestLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1151,6 +1151,13 @@ func TestLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1137,6 +1137,13 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1144,6 +1144,13 @@ func TestLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1151,6 +1151,13 @@ func TestLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1137,6 +1137,13 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1144,6 +1144,13 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1151,6 +1151,13 @@ func TestLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1158,6 +1158,13 @@ func TestLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1123,6 +1123,13 @@ func TestLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1130,6 +1130,13 @@ func TestLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1116,6 +1116,13 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1158,6 +1158,13 @@ func TestLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1151,6 +1151,13 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1165,6 +1165,13 @@ func TestLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1284,6 +1284,13 @@ func TestLogic_jsonb_path_query_array(
 	runLogicTest(t, "jsonb_path_query_array")
 }
 
+func TestLogic_jsonb_path_query_first(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_first")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1270,6 +1270,13 @@ func TestLogic_jsonb_path_exists(
 	runLogicTest(t, "jsonb_path_exists")
 }
 
+func TestLogic_jsonb_path_match(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_match")
+}
+
 func TestLogic_jsonb_path_query(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -1277,6 +1277,13 @@ func TestLogic_jsonb_path_query(
 	runLogicTest(t, "jsonb_path_query")
 }
 
+func TestLogic_jsonb_path_query_array(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jsonb_path_query_array")
+}
+
 func TestLogic_jsonpath(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4228,7 +4228,50 @@ value if you rely on the HLC for accuracy.`,
 			Volatility: volatility.Immutable,
 		},
 	),
-	"jsonb_path_query_first": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
+	"jsonb_path_query_first": makeBuiltin(jsonpathProps(),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+			},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn:         makeJsonpathQueryFirst,
+			Info: `Returns the first JSON item returned by the JSON path for the
+			specified JSON value, or NULL if there are no results.`,
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+				{Name: "vars", Typ: types.Jsonb},
+			},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn:         makeJsonpathQueryFirst,
+			Info: `Returns the first JSON item returned by the JSON path for the
+			specified JSON value, or NULL if there are no results. The vars
+			argument must be a JSON object, and its fields provide named values
+			to be substituted into the jsonpath expression.`,
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+				{Name: "vars", Typ: types.Jsonb},
+				{Name: "silent", Typ: types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn:         makeJsonpathQueryFirst,
+			Info: `Returns the first JSON item returned by the JSON path for the
+			specified JSON value, or NULL if there are no results. The vars
+			argument must be a JSON object, and its fields provide named values
+			to be substituted into the jsonpath expression. If the silent argument is true, the
+			function suppresses the following errors: missing object field or
+			array element, unexpected JSON item type, datetime and numeric errors.`,
+			Volatility: volatility.Immutable,
+		},
+	),
 
 	"json_remove_path": makeBuiltin(jsonProps(),
 		tree.Overload{
@@ -12276,4 +12319,14 @@ func makeJsonpathQueryArray(
 		return nil, err
 	}
 	return &j, nil
+}
+
+func makeJsonpathQueryFirst(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (tree.Datum, error) {
+	target, path, vars, silent, err := jsonpathArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	return jsonpath.JsonpathQueryFirst(target, path, vars, silent)
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4181,10 +4181,53 @@ value if you rely on the HLC for accuracy.`,
 			Volatility: volatility.Immutable,
 		},
 	),
-	"jsonb_path_exists_opr":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
-	"jsonb_path_match":       makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
-	"jsonb_path_match_opr":   makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
-	"jsonb_path_query_array": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
+	"jsonb_path_exists_opr": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
+	"jsonb_path_match":      makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
+	"jsonb_path_match_opr":  makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
+	"jsonb_path_query_array": makeBuiltin(jsonpathProps(),
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+			},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn:         makeJsonpathQueryArray,
+			Info: `Returns all JSON items returned by the JSON path for the
+			specified JSON value, as a JSON array.`,
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+				{Name: "vars", Typ: types.Jsonb},
+			},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn:         makeJsonpathQueryArray,
+			Info: `Returns all JSON items returned by the JSON path for the
+			specified JSON value, as a JSON array. The vars argument must be a
+			JSON object, and its fields provide named values to be substituted
+			into the jsonpath expression.`,
+			Volatility: volatility.Immutable,
+		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "target", Typ: types.Jsonb},
+				{Name: "path", Typ: types.Jsonpath},
+				{Name: "vars", Typ: types.Jsonb},
+				{Name: "silent", Typ: types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Jsonb),
+			Fn:         makeJsonpathQueryArray,
+			Info: `Returns all JSON items returned by the JSON path for the
+			specified JSON value, as a JSON array. The vars argument must be a
+			JSON object, and its fields provide named values to be substituted
+			into the jsonpath expression. If the silent argument is true, the
+			function suppresses the following errors: missing object field or
+			array element, unexpected JSON item type, datetime and numeric errors.`,
+			Volatility: volatility.Immutable,
+		},
+	),
 	"jsonb_path_query_first": makeBuiltin(tree.FunctionProperties{UnsupportedWithIssue: 22513, Category: builtinconstants.CategoryJsonpath}),
 
 	"json_remove_path": makeBuiltin(jsonProps(),
@@ -12189,20 +12232,48 @@ func makeTimestampStatementBuiltinOverload(withOutputTZ bool, withInputTZ bool) 
 	}
 }
 
-func makeJsonpathExists(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-	target := tree.MustBeDJSON(args[0])
-	path := tree.MustBeDJsonpath(args[1])
-	vars := tree.EmptyDJSON
-	silent := tree.DBool(false)
+func jsonpathArgs(
+	args tree.Datums,
+) (target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool, err error) {
+	target = tree.MustBeDJSON(args[0])
+	path = tree.MustBeDJsonpath(args[1])
+	vars = tree.EmptyDJSON
+	silent = tree.DBool(false)
 	if len(args) > 2 {
 		vars = tree.MustBeDJSON(args[2])
+		if vars.Type() != json.ObjectJSONType {
+			err = pgerror.Newf(pgcode.InvalidParameterValue, `"vars" argument is not an object`)
+			return
+		}
 	}
 	if len(args) > 3 {
 		silent = tree.MustBeDBool(args[3])
+	}
+	return target, path, vars, silent, nil
+}
+
+func makeJsonpathExists(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
+	target, path, vars, silent, err := jsonpathArgs(args)
+	if err != nil {
+		return nil, err
 	}
 	exists, err := jsonpath.JsonpathExists(target, path, vars, silent)
 	if err != nil {
 		return nil, err
 	}
 	return tree.MakeDBool(exists), nil
+}
+
+func makeJsonpathQueryArray(
+	_ context.Context, _ *eval.Context, args tree.Datums,
+) (tree.Datum, error) {
+	target, path, vars, silent, err := jsonpathArgs(args)
+	if err != nil {
+		return nil, err
+	}
+	j, err := jsonpath.JsonpathQueryArray(target, path, vars, silent)
+	if err != nil {
+		return nil, err
+	}
+	return &j, nil
 }

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2656,6 +2656,9 @@ var builtinOidsArray = []string{
 	2693: `jsonb_path_query_array(target: jsonb, path: jsonpath) -> jsonb`,
 	2694: `jsonb_path_query_array(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
 	2695: `jsonb_path_query_array(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
+	2696: `jsonb_path_query_first(target: jsonb, path: jsonpath) -> jsonb`,
+	2697: `jsonb_path_query_first(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
+	2698: `jsonb_path_query_first(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2653,6 +2653,9 @@ var builtinOidsArray = []string{
 	2690: `jsonb_path_exists(target: jsonb, path: jsonpath, vars: jsonb) -> bool`,
 	2691: `jsonb_path_exists(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> bool`,
 	2692: `st_3dlength(geometry: geometry) -> float`,
+	2693: `jsonb_path_query_array(target: jsonb, path: jsonpath) -> jsonb`,
+	2694: `jsonb_path_query_array(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
+	2695: `jsonb_path_query_array(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2659,6 +2659,9 @@ var builtinOidsArray = []string{
 	2696: `jsonb_path_query_first(target: jsonb, path: jsonpath) -> jsonb`,
 	2697: `jsonb_path_query_first(target: jsonb, path: jsonpath, vars: jsonb) -> jsonb`,
 	2698: `jsonb_path_query_first(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> jsonb`,
+	2699: `jsonb_path_match(target: jsonb, path: jsonpath) -> bool`,
+	2700: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb) -> bool`,
+	2701: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -1694,18 +1694,9 @@ type jsonPathQueryGenerator struct {
 func makeJsonpathQueryGenerator(
 	_ context.Context, _ *eval.Context, args tree.Datums,
 ) (eval.ValueGenerator, error) {
-	target := tree.MustBeDJSON(args[0])
-	path := tree.MustBeDJsonpath(args[1])
-	vars := tree.EmptyDJSON
-	silent := tree.DBool(false)
-	if len(args) > 2 {
-		vars = tree.MustBeDJSON(args[2])
-		if vars.Type() != json.ObjectJSONType {
-			return nil, pgerror.Newf(pgcode.InvalidParameterValue, `"vars" argument is not an object`)
-		}
-	}
-	if len(args) > 3 {
-		silent = tree.MustBeDBool(args[3])
+	target, path, vars, silent, err := jsonpathArgs(args)
+	if err != nil {
+		return nil, err
 	}
 	return &jsonPathQueryGenerator{
 		target: target,

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -58,21 +58,7 @@ func maybeThrowError(ctx *jsonpathCtx, err error) error {
 func JsonpathQuery(
 	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
 ) ([]tree.DJSON, error) {
-	parsedPath, err := parser.Parse(string(path))
-	if err != nil {
-		return nil, err
-	}
-	expr := parsedPath.AST
-
-	ctx := &jsonpathCtx{
-		root:                 target.JSON,
-		vars:                 vars.JSON,
-		strict:               expr.Strict,
-		silent:               bool(silent),
-		innermostArrayLength: -1,
-	}
-
-	j, err := ctx.eval(expr.Path, ctx.root, !ctx.strict /* unwrap */)
+	j, err := jsonpathQuery(target, path, vars, silent)
 	if err != nil {
 		return nil, err
 	}
@@ -86,11 +72,46 @@ func JsonpathQuery(
 func JsonpathExists(
 	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
 ) (tree.DBool, error) {
-	j, err := JsonpathQuery(target, path, vars, silent)
+	j, err := jsonpathQuery(target, path, vars, silent)
 	if err != nil {
 		return false, err
 	}
 	return len(j) > 0, nil
+}
+
+func JsonpathQueryArray(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) (tree.DJSON, error) {
+	j, err := jsonpathQuery(target, path, vars, silent)
+	if err != nil {
+		return tree.DJSON{}, err
+	}
+
+	b := json.NewArrayBuilder(len(j))
+	for _, j := range j {
+		b.Add(j)
+	}
+	return tree.DJSON{JSON: b.Build()}, nil
+}
+
+func jsonpathQuery(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) ([]json.JSON, error) {
+	parsedPath, err := parser.Parse(string(path))
+	if err != nil {
+		return []json.JSON{}, err
+	}
+	expr := parsedPath.AST
+
+	ctx := &jsonpathCtx{
+		root:                 target.JSON,
+		vars:                 vars.JSON,
+		strict:               expr.Strict,
+		silent:               bool(silent),
+		innermostArrayLength: -1,
+	}
+
+	return ctx.eval(expr.Path, ctx.root, !ctx.strict /* unwrap */)
 }
 
 func (ctx *jsonpathCtx) eval(

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -94,6 +94,19 @@ func JsonpathQueryArray(
 	return tree.DJSON{JSON: b.Build()}, nil
 }
 
+func JsonpathQueryFirst(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) (tree.Datum, error) {
+	j, err := jsonpathQuery(target, path, vars, silent)
+	if err != nil {
+		return nil, err
+	}
+	if len(j) == 0 {
+		return tree.DNull, nil
+	}
+	return &tree.DJSON{JSON: j[0]}, nil
+}
+
 func jsonpathQuery(
 	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
 ) ([]json.JSON, error) {

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -6,6 +6,8 @@
 package eval
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
@@ -15,8 +17,9 @@ import (
 )
 
 var (
-	errUnimplemented = unimplemented.NewWithIssue(22513, "unimplemented")
-	errInternal      = errors.New("internal error")
+	errUnimplemented         = unimplemented.NewWithIssue(22513, "unimplemented")
+	errInternal              = errors.New("internal error")
+	errSingleBooleanRequired = pgerror.Newf(pgcode.SingletonSQLJSONItemRequired, "single boolean result is expected")
 )
 
 type jsonpathCtx struct {
@@ -105,6 +108,28 @@ func JsonpathQueryFirst(
 		return tree.DNull, nil
 	}
 	return &tree.DJSON{JSON: j[0]}, nil
+}
+
+func JsonpathMatch(
+	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
+) (tree.Datum, error) {
+	j, err := jsonpathQuery(target, path, vars, silent)
+	if err != nil {
+		return nil, err
+	}
+
+	if len(j) == 1 {
+		if b, ok := j[0].AsBool(); ok {
+			return tree.MakeDBool(tree.DBool(b)), nil
+		}
+		if j[0].Type() == json.NullJSONType {
+			return tree.DNull, nil
+		}
+	}
+	if !silent {
+		return nil, errSingleBooleanRequired
+	}
+	return tree.DNull, nil
 }
 
 func jsonpathQuery(


### PR DESCRIPTION
#### builtins: add jsonb_path_query_array

This commit adds the `jsonb_path_query_array` function, which wraps
`jsonb_path_query` and returns a json array containing all the items
returned from the query.

Informs: #22513
Release note (sql change): Add the `jsonb_path_query_array` function,
which returns the result of `jsonb_path_query` wrapped in a JSON array.

#### builtins: add jsonb_path_query_first

This commit adds the `jsonb_path_query_first` function, which wraps
`jsonb_path_query` and returns the first element that was returned from
the function.

Informs: #22513
Release note (sql change): Add the `jsonb_path_query_first` function,
which returns the first result from `jsonb_path_query`.

#### builtins: add jsonb_path_match

This commit adds the `jsonb_path_match` function, which returns a
boolean that evaluates the predicate query, and returns null if the
query result isn't a predicate.

Informs: #22513
Release note (sql change): Add the `jsonb_path_match` function, which
returns the result of a predicate query.
