### PR TITLE
logical: have tombstone updater accept datums

### DIFF
--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -711,7 +711,7 @@ func (lww *lwwQuerier) DeleteRow(
 		// NOTE: at this point we don't know if we are updating a tombstone or if
 		// we are losing LWW. As long as it is a LWW loss or a tombstone update,
 		// updateTombstone will return okay.
-		return lww.tombstoneUpdaters[row.TableID].updateTombstone(ctx, txn, row)
+		return lww.tombstoneUpdaters[row.TableID].updateTombstoneAny(ctx, txn, row.MvccTimestamp, datums)
 	}
 	return batchStats{}, nil
 }


### PR DESCRIPTION
Previously, the tombstone deleter accepted a cdcevent.Row. Now, it accepts datums derived from the cdcevent.Row. This allows the tombstone updater to be used by the crud sql writer which internally expects datums.

This also removes an extra `isLwwLoser(err)` check that caused the tombstone updater to silently drop errors. This bug was caught by testing in #143988.

Release Note: none
Epic: CRDB-48647