### PR TITLE
sqlstats,ui: collect and display count of generic query plans

### DIFF
--- a/pkg/sql/appstatspb/app_stats.go
+++ b/pkg/sql/appstatspb/app_stats.go
@@ -213,6 +213,7 @@ func (s *StatementStatistics) Add(other *StatementStatistics) {
 
 	s.Count += other.Count
 	s.FailureCount += other.FailureCount
+	s.GenericCount += other.GenericCount
 }
 
 // AlmostEqual compares two StatementStatistics and their contained NumericStats

--- a/pkg/sql/appstatspb/app_stats.proto
+++ b/pkg/sql/appstatspb/app_stats.proto
@@ -135,6 +135,9 @@ message StatementStatistics {
   // follower replicas.
   optional bool used_follower_read = 35 [(gogoproto.nullable) = false];
 
+  // generic_count is the count of executions that used a generic query plan.
+  optional int64 generic_count = 36 [(gogoproto.nullable) = false];
+
   // Note: be sure to update `sql/app_stats.go` when adding/removing fields here!
 
   reserved 13, 14, 17, 18, 19, 20;

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -182,6 +182,7 @@ func (ex *connExecutor) recordStatementSummary(
 	recordedStmtStats := &sqlstats.RecordedStmtStats{
 		FingerprintID:        stmtFingerprintID,
 		QuerySummary:         stmt.StmtSummary,
+		Generic:              flags.IsSet(planFlagGeneric),
 		DistSQL:              flags.ShouldBeDistributed(),
 		Vec:                  flags.IsSet(planFlagVectorized),
 		ImplicitTxn:          implicitTxn,

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -53,6 +53,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
          "cnt": {{.Int64}},
          "firstAttemptCnt": {{.Int64}},
          "failureCount":    {{.Int64}},
+         "genericCount":    {{.Int64}},
          "maxRetries":      {{.Int64}},
          "lastExecAt":      "{{stringifyTime .Time}}",
          "numRows": {

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -344,6 +344,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"latencyInfo", (*latencyInfo)(&s.LatencyInfo)},
 		{"lastErrorCode", (*jsonString)(&s.LastErrorCode)},
 		{"failureCount", (*jsonInt)(&s.FailureCount)},
+		{"genericCount", (*jsonInt)(&s.GenericCount)},
 	}
 }
 

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer.go
@@ -77,6 +77,9 @@ func (s *Container) RecordStatement(ctx context.Context, value *sqlstats.Recorde
 		}
 		stats.mu.data.FailureCount++
 	}
+	if value.Generic {
+		stats.mu.data.GenericCount++
+	}
 	if value.AutoRetryCount == 0 {
 		stats.mu.data.FirstAttemptCount++
 	} else if int64(value.AutoRetryCount) > stats.mu.data.MaxRetries {

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_writer_test.go
@@ -118,6 +118,7 @@ func TestContainer_Add(t *testing.T) {
 			RowsRead:           20,
 			RowsWritten:        5,
 			Failed:             true,
+			Generic:            true,
 			StatementError:     errors.New("test error"),
 		}
 		require.NoError(t, src.RecordStatement(ctx, stmtStats))
@@ -159,6 +160,7 @@ func TestContainer_Add(t *testing.T) {
 			RowsRead:           70,
 			RowsWritten:        80,
 			Failed:             true,
+			Generic:            true,
 			StatementError:     errors.New("test error"),
 		}
 		reducedTxnFingerprintID := appstatspb.TransactionFingerprintID(321)
@@ -205,6 +207,7 @@ func verifyStmtStatsMultiple(
 	require.NotNil(t, destStmtStats)
 	require.Equal(t, destStmtStats.mu.data.Count, int64(count))
 	require.Equal(t, destStmtStats.mu.data.FailureCount, int64(count))
+	require.Equal(t, destStmtStats.mu.data.GenericCount, int64(count))
 	require.InEpsilon(t, float64(stmtStats.RowsAffected), destStmtStats.mu.data.NumRows.Mean, epsilon)
 	require.InEpsilon(t, float64(stmtStats.RowsAffected), destStmtStats.mu.data.NumRows.Mean, epsilon)
 	require.InEpsilon(t, stmtStats.IdleLatencySec, destStmtStats.mu.data.IdleLat.Mean, epsilon)

--- a/pkg/sql/sqlstats/ssprovider.go
+++ b/pkg/sql/sqlstats/ssprovider.go
@@ -70,6 +70,7 @@ type RecordedStmtStats struct {
 	TransactionID            uuid.UUID
 	AutoRetryCount           int
 	Failed                   bool
+	Generic                  bool
 	AutoRetryReason          error
 	RowsAffected             int
 	IdleLatencySec           float64

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/planDetails.tsx
@@ -190,6 +190,10 @@ function ExplainPlan({
               )}
             />
             <SummaryCardItem
+              label="Generic Query Plan"
+              value={RenderCount(plan.stats.generic_count, plan.stats.count)}
+            />
+            <SummaryCardItem
               label="Distributed"
               value={RenderCount(
                 plan.metadata.dist_sql_count,

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/planDetails/plansTable.tsx
@@ -38,6 +38,7 @@ const cx = classNames.bind(styles);
 const planDetailsColumnLabels = {
   avgExecTime: "Average Execution Time",
   avgRowsRead: "Average Rows Read",
+  generic: "Generic Query Plan",
   distSQL: "Distributed",
   execCount: "Execution Count",
   fullScan: "Full Scan",
@@ -154,6 +155,17 @@ export const planDetailsTableTitles: PlanDetailsTableTitleType = {
         content={"If the Explain Plan executed a full scan."}
       >
         {planDetailsColumnLabels.fullScan}
+      </Tooltip>
+    );
+  },
+  generic: () => {
+    return (
+      <Tooltip
+        style="tableTitle"
+        placement="bottom"
+        content={"If the Explain Plan was generic."}
+      >
+        {planDetailsColumnLabels.generic}
       </Tooltip>
     );
   },
@@ -366,6 +378,14 @@ export function makeExplainPlanColumns(
       cell: (item: PlanHashStats) =>
         formatNumberForDisplay(item.stats.latency_info.max, duration),
       sort: (item: PlanHashStats) => item.stats.latency_info.max,
+    },
+    {
+      name: "generic",
+      title: planDetailsTableTitles.generic(),
+      cell: (item: PlanHashStats) =>
+        RenderCount(item.stats.generic_count, item.stats.count),
+      sort: (item: PlanHashStats) =>
+        RenderCount(item.stats.generic_count, item.stats.count),
     },
     {
       name: "distSQL",

--- a/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/statementDetails/statementDetails.fixture.ts
@@ -30,6 +30,7 @@ const statementDetailsNoData: StatementDetailsResponse = {
     stats: {
       count: new Long(0),
       failure_count: new Long(0),
+      generic_count: new Long(0),
       first_attempt_count: new Long(0),
       max_retries: new Long(0),
       legacy_last_err: "",
@@ -86,6 +87,7 @@ const statementDetailsData: StatementDetailsResponse = {
     stats: {
       count: new Long(5),
       failure_count: new Long(2),
+      generic_count: new Long(1),
       first_attempt_count: new Long(5),
       max_retries: new Long(0),
       legacy_last_err: "",

--- a/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/appStats/appStats.ts
@@ -202,6 +202,7 @@ export function addStatementStats(
   return {
     count: a.count.add(b.count),
     failure_count: a.failure_count.add(b.failure_count),
+    generic_count: a.generic_count.add(b.generic_count),
     first_attempt_count: a.first_attempt_count.add(b.first_attempt_count),
     max_retries: a.max_retries.greaterThan(b.max_retries)
       ? a.max_retries

--- a/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/statements/statements.spec.tsx
@@ -295,6 +295,7 @@ function makeStats(): Required<StatementStatistics> {
     },
     last_error_code: "",
     failure_count: Long.fromNumber(0),
+    generic_count: Long.fromNumber(0),
   };
 }
 


### PR DESCRIPTION
The UI now displays the number of times a plan was executed as a generic
query plan. This is visible in both the "Explain Plans" table and the
plan details page.

Fixes #144585

Release note (ui): The "Explain Plans" table of the statement details
page and the plan details page now indicate whether or not the plan was
a generic query plan.
