### PR TITLE
logical: create table handler

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     srcs = [
         "create_logical_replication_stmt.go",
         "dead_letter_queue.go",
+        "event_decoder.go",
         "logical_replication_dist.go",
         "logical_replication_job.go",
         "logical_replication_writer_processor.go",
@@ -18,6 +19,7 @@ go_library(
         "replication_statements.go",
         "sql_row_reader.go",
         "sql_row_writer.go",
+        "table_batch_handler.go",
         "tombstone_updater.go",
         "udf_row_processor.go",
     ],
@@ -125,6 +127,7 @@ go_test(
         "replication_statements_test.go",
         "sql_row_reader_test.go",
         "sql_row_writer_test.go",
+        "table_batch_handler_test.go",
         "udf_row_processor_test.go",
     ],
     data = glob(["testdata/**"]) + [

--- a/pkg/crosscluster/logical/event_decoder.go
+++ b/pkg/crosscluster/logical/event_decoder.go
@@ -1,0 +1,39 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+)
+
+// decodedEvent is constructed from a replication stream event. The replication
+// stream event is encoded using the source table descriptor. The decoded must
+// contain datums that are compatible with the destination table descriptor.
+type decodedEvent struct {
+	// dstDescID is the descriptor ID for the table in the destination cluster.
+	dstDescID descpb.ID
+
+	// isDelete is true if the event is a delete. This implies values in the row
+	// may be NULL that are not allowed to be NULL in the source table's schema.
+	// Only the primary key columns are expected to have values.
+	isDelete bool
+
+	// originTimestamp is the mvcc timestamp of the row in the source cluster.
+	originTimestamp hlc.Timestamp
+
+	// row is the decoded row from the replication stream. The datums in row are
+	// in col id order for the destination table.
+	row tree.Datums
+
+	// prevRow is either the previous row from the replication stream or it is
+	// the local version of the row if there was a read refresh.
+	//
+	// The datums in prevRow are in col id order for the destination table. nil
+	// prevRow may still lose LWW if there is a recent tombstone.
+	prevRow tree.Datums
+}

--- a/pkg/crosscluster/logical/table_batch_handler.go
+++ b/pkg/crosscluster/logical/table_batch_handler.go
@@ -1,0 +1,240 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/errors"
+)
+
+// tableHandler applies batches of replication events that are destined for a
+// sinlgle table.
+type tableHandler struct {
+	sqlReader        *sqlRowReader
+	sqlWriter        *sqlRowWriter
+	db               descs.DB
+	tombstoneUpdater *tombstoneUpdater
+}
+
+type tableBatchStats struct {
+	// refreshedRows are the number of rows that were re-read from the local
+	// database.
+	refreshedRows int64
+	// inserts is the number of rows that were inserted.
+	inserts int64
+	// updates is the number of rows that were updated.
+	updates int64
+	// deletes is the number of rows that were deleted.
+	deletes int64
+	// tombstoneUpdates is the number of tombstones that were updated. This case
+	// only occurs if the event is a replicated delete and the row did not exist
+	// locally.
+	tombstoneUpdates int64
+	// refreshLwwLosers is the number of rows that were dropped as lww losers
+	// after reading them locally.
+	refreshLwwLosers int64
+	// kvLwwLosers is the number of rows that were dropped as lww losers after
+	// attempting to write to the KV layer. This case only occurs if there is a
+	// tombstone that is more recent than the replicated action.
+	kvLwwLosers int64
+}
+
+func (t *tableBatchStats) Add(o tableBatchStats) {
+	t.refreshedRows += o.refreshedRows
+	t.inserts += o.inserts
+	t.updates += o.updates
+	t.deletes += o.deletes
+	t.tombstoneUpdates += o.tombstoneUpdates
+	t.refreshLwwLosers += o.refreshLwwLosers
+	t.kvLwwLosers += o.kvLwwLosers
+}
+
+// newTableHandler creates a new tableHandler for the given table descriptor ID.
+// It internally constructs the sqlReader and sqlWriter components.
+func newTableHandler(
+	tableID descpb.ID,
+	db descs.DB,
+	codec keys.SQLCodec,
+	sd *sessiondata.SessionData,
+	leaseMgr *lease.Manager,
+	settings *cluster.Settings,
+) (*tableHandler, error) {
+	var table catalog.TableDescriptor
+
+	// NOTE: we don't hold a lease on the table descriptor, but validation
+	// prevents users from changing the set of columns or the primary key of an
+	// LDR replicated table.
+	err := db.DescsTxn(context.Background(), func(ctx context.Context, txn descs.Txn) error {
+		var err error
+		table, err = txn.Descriptors().GetLeasedImmutableTableByID(ctx, txn.KV(), tableID)
+		return err
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	reader, err := newSQLRowReader(table)
+	if err != nil {
+		return nil, err
+	}
+
+	writer, err := newSQLRowWriter(table)
+	if err != nil {
+		return nil, err
+	}
+
+	tombstoneUpdater := newTombstoneUpdater(codec, db.KV(), leaseMgr, tableID, sd, settings)
+
+	return &tableHandler{
+		sqlReader:        reader,
+		sqlWriter:        writer,
+		db:               db,
+		tombstoneUpdater: tombstoneUpdater,
+	}, nil
+}
+
+func (t *tableHandler) handleDecodedBatch(
+	ctx context.Context, batch []decodedEvent,
+) (tableBatchStats, error) {
+	stats, err := t.attemptBatch(ctx, batch)
+	if err == nil {
+		return stats, nil
+	}
+
+	refreshedBatch, refreshStats, err := t.refreshPrevRows(ctx, batch)
+	if err != nil {
+		return stats, err
+	}
+
+	stats, err = t.attemptBatch(ctx, refreshedBatch)
+	if err != nil {
+		return tableBatchStats{}, err
+	}
+
+	stats.Add(refreshStats)
+
+	return stats, nil
+}
+
+func (t *tableHandler) attemptBatch(
+	ctx context.Context, batch []decodedEvent,
+) (tableBatchStats, error) {
+	var stats tableBatchStats
+	err := t.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		for _, event := range batch {
+			switch {
+			case event.isDelete && len(event.prevRow) != 0:
+				stats.deletes++
+				err := t.sqlWriter.DeleteRow(ctx, txn, event.originTimestamp, event.prevRow)
+				if err != nil {
+					return err
+				}
+			case event.isDelete && len(event.prevRow) == 0:
+				stats.tombstoneUpdates++
+				tombstoneUpdateStats, err := t.tombstoneUpdater.updateTombstone(ctx, txn, event.originTimestamp, event.row)
+				if err != nil {
+					return err
+				}
+				stats.kvLwwLosers += tombstoneUpdateStats.kvWriteTooOld
+			case event.prevRow == nil:
+				stats.inserts++
+				err := t.sqlWriter.InsertRow(ctx, txn, event.originTimestamp, event.row)
+				if isLwwLoser(err) {
+					// Insert may observe a LWW failure if it attempts to write over a tombstone.
+					stats.kvLwwLosers++
+					continue
+				}
+				if err != nil {
+					return err
+				}
+			case event.prevRow != nil:
+				stats.updates++
+				err := t.sqlWriter.UpdateRow(ctx, txn, event.originTimestamp, event.prevRow, event.row)
+				if err != nil {
+					return err
+				}
+			default:
+				return errors.AssertionFailedf("unhandled event type: %v", event)
+			}
+		}
+		return nil
+	})
+	if err != nil {
+		return tableBatchStats{}, err
+	}
+	return stats, nil
+}
+
+// refreshPrevRows refreshes the prevRow field for each event in the batch. If
+// any event is known to be a lww loser based on the read, its dropped from the
+// batch.
+func (t *tableHandler) refreshPrevRows(
+	ctx context.Context, batch []decodedEvent,
+) ([]decodedEvent, tableBatchStats, error) {
+	var stats tableBatchStats
+	stats.refreshedRows = int64(len(batch))
+
+	rows := make([]tree.Datums, 0, len(batch))
+	for _, event := range batch {
+		rows = append(rows, event.row)
+	}
+
+	var refreshedRows map[int]priorRow
+	err := t.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+		var err error
+		// TODO(jeffswenson): should we apply the batch in the same transaction
+		// that we perform the read refresh? We could maybe even use locking reads.
+		refreshedRows, err = t.sqlReader.ReadRows(ctx, txn, rows)
+		return err
+	})
+	if err != nil {
+		return nil, tableBatchStats{}, err
+	}
+
+	refreshedBatch := make([]decodedEvent, 0, len(batch))
+	for i, event := range batch {
+		var prevRow tree.Datums
+		if refreshed, found := refreshedRows[i]; found {
+			if !refreshed.logicalTimestamp.Less(event.originTimestamp) {
+				// TODO(jeffswenson): update this logic when its time to handle
+				// ties.
+				// Skip the row because it is a lww loser. Note: we can only identify LWW
+				// losers during the read refresh if the row exists. If its a tombstone,
+				// the local value may win LWW, but we have to attempt the
+				// insert/tombstone update to find out. We even have to do this if the
+				// replicated event is a delete because the local tombstone may have an
+				// older logical timestamp.
+				stats.refreshLwwLosers++
+				continue
+			}
+			prevRow = refreshed.row
+		}
+		refreshedEvent := decodedEvent{
+			dstDescID:       event.dstDescID,
+			isDelete:        event.isDelete,
+			row:             event.row,
+			originTimestamp: event.originTimestamp,
+			prevRow:         prevRow,
+		}
+		refreshedBatch = append(refreshedBatch, refreshedEvent)
+	}
+
+	return refreshedBatch, stats, nil
+}
+
+func (t *tableHandler) ReleaseLeases(ctx context.Context) {
+	t.tombstoneUpdater.ReleaseLeases(ctx)
+}

--- a/pkg/crosscluster/logical/table_batch_handler_test.go
+++ b/pkg/crosscluster/logical/table_batch_handler_test.go
@@ -1,0 +1,387 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+type eventBuilder struct {
+	descID descpb.ID
+}
+
+func newEventBuilder(
+	t *testing.T, runner *sqlutils.SQLRunner, s serverutils.ApplicationLayerInterface,
+) *eventBuilder {
+	runner.Exec(t, `
+		CREATE TABLE test_table (
+			id STRING PRIMARY KEY,
+			value STRING
+		);
+	`)
+
+	// Get the actual table descriptor
+	desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", "test_table")
+
+	return &eventBuilder{
+		descID: desc.GetID(),
+	}
+}
+
+func (e *eventBuilder) makeInsert(id string, value string, timestamp hlc.Timestamp) decodedEvent {
+	return decodedEvent{
+		dstDescID:       e.descID,
+		isDelete:        false,
+		originTimestamp: timestamp,
+		row:             tree.Datums{tree.NewDString(id), tree.NewDString(value)},
+	}
+}
+
+func (e *eventBuilder) makeUpdate(
+	id string, old, new string, timestamp hlc.Timestamp,
+) decodedEvent {
+	return decodedEvent{
+		dstDescID:       e.descID,
+		isDelete:        false,
+		originTimestamp: timestamp,
+		row:             tree.Datums{tree.NewDString(id), tree.NewDString(new)},
+		prevRow:         tree.Datums{tree.NewDString(id), tree.NewDString(old)},
+	}
+}
+
+func (e *eventBuilder) makeDelete(id string, value string, timestamp hlc.Timestamp) decodedEvent {
+	return decodedEvent{
+		dstDescID:       e.descID,
+		isDelete:        true,
+		originTimestamp: timestamp,
+		row:             tree.Datums{tree.NewDString(id), tree.DNull},
+		prevRow:         tree.Datums{tree.NewDString(id), tree.NewDString(value)},
+	}
+}
+
+func newTestTableHandler(
+	t *testing.T, descID descpb.ID, s serverutils.ApplicationLayerInterface,
+) *tableHandler {
+	sd := sql.NewInternalSessionData(context.Background(), s.ClusterSettings(), "" /* opName */)
+	handler, err := newTableHandler(descID, s.InternalDB().(descs.DB), s.Codec(), sd, s.LeaseManager().(*lease.Manager), s.ClusterSettings())
+	require.NoError(t, err)
+	return handler
+}
+
+func TestTableHandlerFastPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+	eb := newEventBuilder(t, runner, s)
+	handler := newTestTableHandler(t, eb.descID, s)
+
+	// Apply a batch with inserts to popluate some data
+	stats, err := handler.handleDecodedBatch(ctx, []decodedEvent{
+		eb.makeInsert("1", "foo", s.Clock().Now()),
+		eb.makeInsert("2", "bar", s.Clock().Now()),
+	})
+	require.NoError(t, err)
+	require.Equal(t, tableBatchStats{inserts: 2}, stats)
+	runner.CheckQueryResults(t, `SELECT id, value FROM test_table`, [][]string{
+		{"1", "foo"},
+		{"2", "bar"},
+	})
+
+	// Apply a batch with updates and deletes for the previously written rows
+	stats, err = handler.handleDecodedBatch(ctx, []decodedEvent{
+		eb.makeUpdate("1", "foo", "foo-update", s.Clock().Now()),
+		eb.makeDelete("2", "bar", s.Clock().Now()),
+	})
+	require.NoError(t, err)
+	require.Equal(t, tableBatchStats{updates: 1, deletes: 1}, stats)
+	runner.CheckQueryResults(t, `SELECT id, value FROM test_table`, [][]string{
+		{"1", "foo-update"},
+	})
+
+}
+
+func TestTableHandlerSlowPath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	eb := newEventBuilder(t, runner, s)
+
+	handler := newTestTableHandler(t, eb.descID, s)
+
+	runner.Exec(t, `
+		INSERT INTO test_table (id, value) VALUES 
+		('a', 'alpha'), ('b', 'beta'), ('c', 'gamma');
+	`)
+
+	stats, err := handler.handleDecodedBatch(ctx, []decodedEvent{
+		eb.makeInsert("a", "alpha-update", s.Clock().Now()),
+		eb.makeUpdate("b", "wrong", "beta-update", s.Clock().Now()),
+		eb.makeDelete("c", "wrong", s.Clock().Now()),
+		// TODO(jeffswenson): add tombstone case
+		eb.makeDelete("d", "never-existed", s.Clock().Now()),
+		eb.makeUpdate("e", "never-existed", "omega-insert", s.Clock().Now()),
+	})
+	require.NoError(t, err)
+	require.Equal(t,
+		tableBatchStats{inserts: 1, updates: 2, deletes: 1, tombstoneUpdates: 1, refreshedRows: 5},
+		stats)
+
+	runner.CheckQueryResults(t, `SELECT id, value FROM test_table`, [][]string{
+		{"a", "alpha-update"}, // a was processed as an update
+		{"b", "beta-update"},  // b was processed as an update
+		// c is deleted, so it should not be in the result
+		// d has an update tombstone
+		{"e", "omega-insert"}, // e was processed as an insert
+	})
+}
+
+func TestTableHandlerDuplicateBatchEntries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	eb := newEventBuilder(t, runner, s)
+	handler := newTestTableHandler(t, eb.descID, s)
+
+	before := s.Clock().Now()
+	after := s.Clock().Now()
+
+	// TODO(jeffswenson): think about the different weird grouped batches that
+	// could exist. Is it sensitive to order? What happens when an update chain
+	// hits a refresh?
+	_, err := handler.handleDecodedBatch(ctx, []decodedEvent{
+		eb.makeUpdate("a", "wrong-value", "insert-followed-by-delete", before),
+		eb.makeDelete("a", "insert-followed-by-delete", after),
+	})
+	// The update causes a refresh and then after the refresh, the delete ends up
+	// taking the update tombstone path because there is no local row, but the
+	// cput fails because it observes the insert/delete.
+	require.ErrorContains(t, err, "unexpected value")
+}
+
+func TestTableHandlerExhaustive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// This test is an "exhaustive" test of the table handler. It tries to test
+	// cross product of every possible (replication event type, local value,
+	// previous value, lww win).
+	//
+	// Some things that aren't tested:
+	// 1. Batches containing multiple events of the same row.
+	// 2. The optimistic path. Since the batch is guaranteed to fail the first
+	//    apply attempt, it always takes the read refresh path.
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	eb := newEventBuilder(t, runner, s)
+
+	handler := newTestTableHandler(t, eb.descID, s)
+
+	type previousValue string
+	const (
+		previousValuePresent previousValue = "present"
+		previousValueAbsent  previousValue = "absent"
+	)
+	previousValues := []previousValue{
+		previousValuePresent,
+		previousValueAbsent,
+	}
+
+	type localValue string
+	const (
+		// The local value is the same as the previous value supplied by the
+		// event.
+		localValueMatch localValue = "previous-value"
+		// The local value is different from the previous value supplied by the
+		// event.
+		localValueMismatch localValue = "different-value"
+		// The local value never existed in the database.
+		localValueNull localValue = "null-value"
+		// The local value is a tombstone.
+		localValueTombstone localValue = "tombstone-value"
+	)
+	localValues := []localValue{
+		localValueMatch,
+		localValueMismatch,
+		localValueNull,
+		localValueTombstone,
+	}
+
+	type replicationType string
+	const (
+		replicationTypeUpdate replicationType = "update"
+		replicationTypeInsert replicationType = "insert"
+		replicationTypeDelete replicationType = "delete"
+	)
+	replicationTypes := []replicationType{
+		replicationTypeUpdate,
+		replicationTypeInsert,
+		replicationTypeDelete,
+	}
+
+	start := s.Clock().Now()
+
+	type testCase struct {
+		id              int
+		previousValue   previousValue
+		localValue      localValue
+		replicationType replicationType
+		winLww          bool
+	}
+	testCaseName := func(tc testCase) string {
+		return fmt.Sprintf("replication-type=%s:previous-value=%s:local-value=%s:win-lww=%t", tc.replicationType, tc.previousValue, tc.localValue, tc.winLww)
+	}
+	getPreviousValue := func(tc testCase) string {
+		if tc.previousValue == previousValuePresent {
+			return fmt.Sprintf("previous-value-%s", testCaseName(tc))
+		}
+		return ""
+	}
+	getNewValue := func(tc testCase) string {
+		return fmt.Sprintf("new-value-%s", testCaseName(tc))
+	}
+	getDecodedEvent := func(tc testCase) decodedEvent {
+		origin := start
+		if tc.winLww {
+			origin = s.Clock().Now()
+		}
+		switch tc.replicationType {
+		case replicationTypeUpdate:
+			return eb.makeUpdate(fmt.Sprintf("%d", tc.id), getPreviousValue(tc), getNewValue(tc), origin)
+		case replicationTypeInsert:
+			return eb.makeInsert(fmt.Sprintf("%d", tc.id), getNewValue(tc), origin)
+		case replicationTypeDelete:
+			return eb.makeDelete(fmt.Sprintf("%d", tc.id), getPreviousValue(tc), origin)
+		default:
+			panic(fmt.Sprintf("unknown replication type: %s", tc.replicationType))
+		}
+	}
+	getLocalValue := func(tc testCase) string {
+		switch tc.localValue {
+		case localValueMatch:
+			return getPreviousValue(tc)
+		case localValueMismatch:
+			return fmt.Sprintf("value-mismatch-%d", tc.id)
+		}
+		return ""
+	}
+
+	// Construct the Cartesian product of all the possible test cases.
+	var testCases []testCase
+	id := 1337 // Start at a non-zero value to avoid bugs that are papered over by ordered ids.
+	for _, previousValue := range previousValues {
+		for _, localValue := range localValues {
+			for _, replicationType := range replicationTypes {
+				for _, winLww := range []bool{true, false} {
+
+					if !winLww {
+						// If there is no tombstone or local row, then its
+						// impossible to lose lww. So skip the test case.
+						if localValue == localValueNull {
+							continue
+						}
+						if localValue == localValueMatch && previousValue == previousValueAbsent {
+							continue
+						}
+					}
+
+					testCases = append(testCases, testCase{
+						id:              id,
+						previousValue:   previousValue,
+						localValue:      localValue,
+						replicationType: replicationType,
+						winLww:          winLww,
+					})
+					id++
+				}
+			}
+		}
+	}
+
+	// Initialize the database with the specified local values.
+	for _, tc := range testCases {
+		switch tc.localValue {
+		case localValueMatch, localValueMismatch:
+			value := getLocalValue(tc)
+			if value == "" {
+				continue
+			}
+			runner.Exec(t, fmt.Sprintf(`INSERT INTO test_table (id, value) VALUES ('%d', '%s')`, tc.id, value))
+		case localValueNull:
+			// Do nothing
+		case localValueTombstone:
+			runner.Exec(t, fmt.Sprintf(`INSERT INTO test_table (id, value) VALUES ('%d', 'old-value-%d')`, tc.id, rand.Int()))
+			runner.Exec(t, fmt.Sprintf(`DELETE FROM test_table WHERE id = '%d'`, tc.id))
+		}
+	}
+
+	batch := make([]decodedEvent, 0, len(testCases))
+	for _, tc := range testCases {
+		batch = append(batch, getDecodedEvent(tc))
+	}
+	_, err := handler.handleDecodedBatch(ctx, batch)
+	require.NoError(t, err)
+
+	found := map[string]string{}
+	results := runner.QueryStr(t, `SELECT id, value FROM test_table`)
+	for _, row := range results {
+		found[row[0]] = row[1]
+	}
+
+	for _, tc := range testCases {
+		id := fmt.Sprintf("%d", tc.id)
+		var expected string
+		switch {
+		case tc.winLww && tc.replicationType != replicationTypeDelete:
+			expected = getNewValue(tc)
+		case !tc.winLww:
+			expected = getLocalValue(tc)
+		}
+		if expected == "" {
+			require.NotContains(t, found, id, "expected row %s to be deleted", id)
+		} else {
+			require.Equal(t, expected, found[id], "expected row %s to be %s", id, expected)
+		}
+	}
+}


### PR DESCRIPTION
The table handler is a `BatchHandler` that operates on rows from a
single table. Each batch is attempted twice. Once assuming the values
supplied are accurate and a second time with values read from the local
database.

Release note: none
Epic: [CRDB-48647](https://cockroachlabs.atlassian.net/browse/CRDB-48647)