### PR TITLE
metric: add `useStaticLabels` to GetName()

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -636,19 +636,19 @@ func (ts *testState) metrics(*testing.T, *datadriven.TestData, cmdArgs) string {
 			typ.Inspect(func(v interface{}) {
 				switch it := v.(type) {
 				case *metric.Gauge:
-					state[typ.GetName()] = it.Value()
+					state[typ.GetName(false /* useStaticLabels */)] = it.Value()
 				case *metric.Counter:
-					state[typ.GetName()] = it.Count()
+					state[typ.GetName(false /* useStaticLabels */)] = it.Count()
 				case *metric.CounterFloat64:
-					state[typ.GetName()] = fmt.Sprintf("%.2f", it.Count())
+					state[typ.GetName(false /* useStaticLabels */)] = fmt.Sprintf("%.2f", it.Count())
 				case *aggmetric.AggCounter:
-					state[typ.GetName()] = it.Count()
+					state[typ.GetName(false /* useStaticLabels */)] = it.Count()
 					promIter, ok := v.(metric.PrometheusIterable)
 					if !ok {
 						return
 					}
 					promIter.Each(it.GetLabels(false /* useStaticLabels */), func(m *prometheusgo.Metric) {
-						childMetrics += fmt.Sprintf("%s{", typ.GetName())
+						childMetrics += fmt.Sprintf("%s{", typ.GetName(false /* useStaticLabels */))
 						for i, l := range m.Label {
 							if i > 0 {
 								childMetrics += ","

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -244,7 +244,7 @@ func TestClientGossipMetrics(t *testing.T) {
 					s.nodeMetrics.BytesReceived,
 				} {
 					if count := counter.Count(); count <= 0 {
-						return errors.Errorf("%d: expected metrics counter %q > 0; = %d", i, counter.GetName(), count)
+						return errors.Errorf("%d: expected metrics counter %q > 0; = %d", i, counter.GetName(false /* useStaticLabels */), count)
 					}
 				}
 			}

--- a/pkg/kv/kvserver/client_metrics_test.go
+++ b/pkg/kv/kvserver/client_metrics_test.go
@@ -36,14 +36,14 @@ import (
 )
 
 type gaugeValuer interface {
-	GetName() string
+	GetName(useStaticLabels bool) string
 	Value() int64
 }
 
 func checkGauge(t *testing.T, id string, g gaugeValuer, e int64) {
 	t.Helper()
 	if a := g.Value(); a != e {
-		t.Error(errors.Errorf("%s for store %s: gauge %d != computed %d", g.GetName(), id, a, e))
+		t.Error(errors.Errorf("%s for store %s: gauge %d != computed %d", g.GetName(false /* useStaticLabels */), id, a, e))
 	}
 }
 
@@ -368,7 +368,7 @@ func TestStoreMetrics(t *testing.T) {
 			{m.RdbTableReadersMemEstimate, 50},
 		} {
 			if a := tc.gauge.Value(); a < tc.min {
-				t.Errorf("gauge %s = %d < min %d", tc.gauge.GetName(), a, tc.min)
+				t.Errorf("gauge %s = %d < min %d", tc.gauge.GetName(false /* useStaticLabels */), a, tc.min)
 			}
 		}
 		for _, tc := range []struct {
@@ -382,7 +382,7 @@ func TestStoreMetrics(t *testing.T) {
 			{m.RdbCompactions, 0},
 		} {
 			if a := tc.counter.Count(); a < tc.min {
-				t.Errorf("counter %s = %d < min %d", tc.counter.GetName(), a, tc.min)
+				t.Errorf("counter %s = %d < min %d", tc.counter.GetName(false /* useStaticLabels */), a, tc.min)
 			}
 		}
 	}

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/range_controller_test.go
@@ -1522,20 +1522,20 @@ func TestRangeController(t *testing.T) {
 						admissionpb.RegularWorkClass,
 						admissionpb.ElasticWorkClass,
 					} {
-						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Waiting[wc].GetName(), evalMetrics.Waiting[wc].Value())
-						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Admitted[wc].GetName(), evalMetrics.Admitted[wc].Count())
-						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Errored[wc].GetName(), evalMetrics.Errored[wc].Count())
-						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Bypassed[wc].GetName(), evalMetrics.Bypassed[wc].Count())
+						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Waiting[wc].GetName(false /* useStaticLabels */), evalMetrics.Waiting[wc].Value())
+						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Admitted[wc].GetName(false /* useStaticLabels */), evalMetrics.Admitted[wc].Count())
+						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Errored[wc].GetName(false /* useStaticLabels */), evalMetrics.Errored[wc].Count())
+						fmt.Fprintf(&buf, "%-50v: %v\n", evalMetrics.Bypassed[wc].GetName(false /* useStaticLabels */), evalMetrics.Bypassed[wc].Count())
 						// We only print the number of recorded durations, instead of any
 						// percentiles or cumulative wait times as these are
 						// non-deterministic in the test.
 						fmt.Fprintf(&buf, "%-50v: %v\n",
-							fmt.Sprintf("%v.count", evalMetrics.Duration[wc].GetName()),
+							fmt.Sprintf("%v.count", evalMetrics.Duration[wc].GetName(false /* useStaticLabels */)),
 							testingFirst(evalMetrics.Duration[wc].CumulativeSnapshot().Total()))
 					}
 				case "range_controller":
 					rcMetrics := state.rcMetrics
-					fmt.Fprintf(&buf, "%v: %v\n", rcMetrics.Count.GetName(), rcMetrics.Count.Value())
+					fmt.Fprintf(&buf, "%v: %v\n", rcMetrics.Count.GetName(false /* useStaticLabels */), rcMetrics.Count.Value())
 				case "send_queue":
 					sendQueueMetrics := state.rcMetrics.SendQueue
 					sendQueueTokenMetrics := state.ssTokenCounter.tokenMetrics.CounterMetrics[SendToken].SendQueue[0]
@@ -1556,17 +1556,17 @@ func TestRangeController(t *testing.T) {
 					}
 					sendQueueMetrics.SizeBytes.Update(sizeBytes)
 					sendQueueMetrics.SizeCount.Update(sizeCount)
-					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.SizeCount.GetName(), sendQueueMetrics.SizeCount.Value())
-					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.SizeBytes.GetName(), sendQueueMetrics.SizeBytes.Value())
-					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.ForceFlushedScheduledCount.GetName(), sendQueueMetrics.ForceFlushedScheduledCount.Value())
-					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.DeductedForSchedulerBytes.GetName(), sendQueueMetrics.DeductedForSchedulerBytes.Value())
-					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.PreventionCount.GetName(), sendQueueMetrics.PreventionCount.Count())
-					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueTokenMetrics.ForceFlushDeducted.GetName(), sendQueueTokenMetrics.ForceFlushDeducted.Count())
+					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.SizeCount.GetName(false /* useStaticLabels */), sendQueueMetrics.SizeCount.Value())
+					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.SizeBytes.GetName(false /* useStaticLabels */), sendQueueMetrics.SizeBytes.Value())
+					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.ForceFlushedScheduledCount.GetName(false /* useStaticLabels */), sendQueueMetrics.ForceFlushedScheduledCount.Value())
+					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.DeductedForSchedulerBytes.GetName(false /* useStaticLabels */), sendQueueMetrics.DeductedForSchedulerBytes.Value())
+					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueMetrics.PreventionCount.GetName(false /* useStaticLabels */), sendQueueMetrics.PreventionCount.Count())
+					fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueTokenMetrics.ForceFlushDeducted.GetName(false /* useStaticLabels */), sendQueueTokenMetrics.ForceFlushDeducted.Count())
 					for _, wc := range []admissionpb.WorkClass{
 						admissionpb.RegularWorkClass,
 						admissionpb.ElasticWorkClass,
 					} {
-						fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueTokenMetrics.PreventionDeducted[wc].GetName(), sendQueueTokenMetrics.PreventionDeducted[wc].Count())
+						fmt.Fprintf(&buf, "%-66v: %v\n", sendQueueTokenMetrics.PreventionDeducted[wc].GetName(false /* useStaticLabels */), sendQueueTokenMetrics.PreventionDeducted[wc].Count())
 					}
 
 				default:

--- a/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/rac2/token_counter_test.go
@@ -66,23 +66,23 @@ func TestTokenAdjustment(t *testing.T) {
 				admissionpb.ElasticWorkClass,
 			} {
 				fmt.Fprintf(buf, "  %-7v\n", wc)
-				fmt.Fprintf(buf, "    %-66v: %v\n", streamMetrics.Count[wc].GetName(), streamMetrics.Count[wc].Value())
-				fmt.Fprintf(buf, "    %-66v: %v\n", streamMetrics.BlockedCount[wc].GetName(), streamMetrics.BlockedCount[wc].Value())
-				fmt.Fprintf(buf, "    %-66v: %v\n", streamMetrics.TokensAvailable[wc].GetName(), ft(streamMetrics.TokensAvailable[wc].Value()))
-				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Deducted[wc].GetName(), ft(counterMetrics.Deducted[wc].Count()))
-				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Disconnected[wc].GetName(), ft(counterMetrics.Disconnected[wc].Count()))
-				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Returned[wc].GetName(), ft(counterMetrics.Returned[wc].Count()))
-				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Unaccounted[wc].GetName(), ft(counterMetrics.Unaccounted[wc].Count()))
+				fmt.Fprintf(buf, "    %-66v: %v\n", streamMetrics.Count[wc].GetName(false /* useStaticLabels */), streamMetrics.Count[wc].Value())
+				fmt.Fprintf(buf, "    %-66v: %v\n", streamMetrics.BlockedCount[wc].GetName(false /* useStaticLabels */), streamMetrics.BlockedCount[wc].Value())
+				fmt.Fprintf(buf, "    %-66v: %v\n", streamMetrics.TokensAvailable[wc].GetName(false /* useStaticLabels */), ft(streamMetrics.TokensAvailable[wc].Value()))
+				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Deducted[wc].GetName(false /* useStaticLabels */), ft(counterMetrics.Deducted[wc].Count()))
+				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Disconnected[wc].GetName(false /* useStaticLabels */), ft(counterMetrics.Disconnected[wc].Count()))
+				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Returned[wc].GetName(false /* useStaticLabels */), ft(counterMetrics.Returned[wc].Count()))
+				fmt.Fprintf(buf, "    %-66v: %v\n", counterMetrics.Unaccounted[wc].GetName(false /* useStaticLabels */), ft(counterMetrics.Unaccounted[wc].Count()))
 			}
 			if t == SendToken {
 				sendQueueMetrics := counterMetrics.SendQueue[0]
 				fmt.Fprintf(buf, "  send queue token metrics\n")
-				fmt.Fprintf(buf, "    %-66v: %v\n", sendQueueMetrics.ForceFlushDeducted.GetName(), ft(sendQueueMetrics.ForceFlushDeducted.Count()))
+				fmt.Fprintf(buf, "    %-66v: %v\n", sendQueueMetrics.ForceFlushDeducted.GetName(false /* useStaticLabels */), ft(sendQueueMetrics.ForceFlushDeducted.Count()))
 				for _, wc := range []admissionpb.WorkClass{
 					admissionpb.RegularWorkClass,
 					admissionpb.ElasticWorkClass,
 				} {
-					fmt.Fprintf(buf, "    %-66v: %v\n", sendQueueMetrics.PreventionDeducted[wc].GetName(), ft(sendQueueMetrics.PreventionDeducted[wc].Count()))
+					fmt.Fprintf(buf, "    %-66v: %v\n", sendQueueMetrics.PreventionDeducted[wc].GetName(false /* useStaticLabels */), ft(sendQueueMetrics.PreventionDeducted[wc].Count()))
 				}
 			}
 		}

--- a/pkg/server/status/recorder.go
+++ b/pkg/server/status/recorder.go
@@ -831,7 +831,7 @@ func (rr registryRecorder) recordChild(
 				return
 			}
 			*dest = append(*dest, tspb.TimeSeriesData{
-				Name:   fmt.Sprintf(rr.format, prom.GetName()),
+				Name:   fmt.Sprintf(rr.format, prom.GetName(false /* useStaticLabels */)),
 				Source: rr.source,
 				Datapoints: []tspb.TimeSeriesDatapoint{
 					{

--- a/pkg/server/status/recorder_test.go
+++ b/pkg/server/status/recorder_test.go
@@ -757,7 +757,7 @@ func BenchmarkExtractValueAllocs(b *testing.B) {
 
 	// Run a benchmark and report allocations.
 	for n := 0; n < b.N; n++ {
-		if err := extractValue(h.GetName(), h, func(string, float64) {}); err != nil {
+		if err := extractValue(h.GetName(false /* useStaticLabels */), h, func(string, float64) {}); err != nil {
 			b.Error(err)
 		}
 	}

--- a/pkg/server/telemetry/features.go
+++ b/pkg/server/telemetry/features.go
@@ -135,8 +135,8 @@ func (c CounterWithMetric) Count() int64 {
 // different.
 
 // GetName implements metric.Iterable
-func (c CounterWithMetric) GetName() string {
-	return c.metric.GetName()
+func (c CounterWithMetric) GetName(useStaticLabels bool) string {
+	return c.metric.GetName(useStaticLabels)
 }
 
 // GetHelp implements metric.Iterable

--- a/pkg/util/asciitsdb/asciitsdb.go
+++ b/pkg/util/asciitsdb/asciitsdb.go
@@ -225,7 +225,7 @@ func (t *TSDB) registerIterable(metric metric.Iterable) {
 	if t.mu.scraped {
 		t.t.Fatalf("register all metrics upfront before Scrape()")
 	}
-	t.mu.points[metric.GetName()] = []float64{}
+	t.mu.points[metric.GetName(false /* useStaticLabels */)] = []float64{}
 }
 
 // Option represents a configuration setting.

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -35,10 +35,7 @@ func NewCounter(metadata metric.Metadata, childLabels ...string) *AggCounter {
 }
 
 // GetName is part of the metric.Iterable interface.
-func (c *AggCounter) GetName() string { return c.g.GetName() }
-
-// GetLabeledName is part of the metric.Iterable interface.
-func (c *AggCounter) GetLabeledName() string { return c.g.GetLabeledName() }
+func (c *AggCounter) GetName(useStaticLabels bool) string { return c.g.GetName(useStaticLabels) }
 
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounter) GetHelp() string { return c.g.GetHelp() }
@@ -177,10 +174,7 @@ func NewCounterFloat64(metadata metric.Metadata, childLabels ...string) *AggCoun
 }
 
 // GetName is part of the metric.Iterable interface.
-func (c *AggCounterFloat64) GetName() string { return c.g.GetName() }
-
-// GetLabeledName is part of the metric.Iterable interface.
-func (c *AggCounterFloat64) GetLabeledName() string { return c.g.GetLabeledName() }
+func (c *AggCounterFloat64) GetName(useStaticLabels bool) string { return c.g.GetName(useStaticLabels) }
 
 // GetHelp is part of the metric.Iterable interface.
 func (c *AggCounterFloat64) GetHelp() string { return c.g.GetHelp() }

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -58,10 +58,7 @@ func NewFunctionalGauge(
 }
 
 // GetName is part of the metric.Iterable interface.
-func (g *AggGauge) GetName() string { return g.g.GetName() }
-
-// GetLabeledName is part of the metric.Iterable interface.
-func (g *AggGauge) GetLabeledName() string { return g.g.GetLabeledName() }
+func (g *AggGauge) GetName(useStaticLabels bool) string { return g.g.GetName(useStaticLabels) }
 
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGauge) GetHelp() string { return g.g.GetHelp() }
@@ -263,10 +260,7 @@ func NewGaugeFloat64(metadata metric.Metadata, childLabels ...string) *AggGaugeF
 }
 
 // GetName is part of the metric.Iterable interface.
-func (g *AggGaugeFloat64) GetName() string { return g.g.GetName() }
-
-// GetLabeledName is part of the metric.Iterable interface.
-func (g *AggGaugeFloat64) GetLabeledName() string { return g.g.GetLabeledName() }
+func (g *AggGaugeFloat64) GetName(useStaticLabels bool) string { return g.g.GetName(useStaticLabels) }
 
 // GetHelp is part of the metric.Iterable interface.
 func (g *AggGaugeFloat64) GetHelp() string { return g.g.GetHelp() }

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -92,10 +92,7 @@ func NewHistogram(opts metric.HistogramOptions, childLabels ...string) *AggHisto
 }
 
 // GetName is part of the metric.Iterable interface.
-func (a *AggHistogram) GetName() string { return a.h.GetName() }
-
-// GetLabeledName is part of the metric.Iterable interface.
-func (a *AggHistogram) GetLabeledName() string { return a.h.GetLabeledName() }
+func (a *AggHistogram) GetName(useStaticLabels bool) string { return a.h.GetName(useStaticLabels) }
 
 // GetHelp is part of the metric.Iterable interface.
 func (a *AggHistogram) GetHelp() string { return a.h.GetHelp() }

--- a/pkg/util/metric/metric.go
+++ b/pkg/util/metric/metric.go
@@ -42,7 +42,7 @@ const (
 // Iterable provides a method for synchronized access to interior objects.
 type Iterable interface {
 	// GetName returns the fully-qualified name of the metric.
-	GetName() string
+	GetName(useStaticLabels bool) string
 	// GetHelp returns the help text for the metric.
 	GetHelp() string
 	// GetMeasurement returns the label for the metric, which describes the entity
@@ -59,9 +59,7 @@ type Iterable interface {
 
 type PrometheusCompatible interface {
 	// GetName is a method on Metadata
-	GetName() string
-	// GetLabeledName is a method on Metadata
-	GetLabeledName() string
+	GetName(useStaticLabels bool) string
 	// GetHelp is a method on Metadata
 	GetHelp() string
 	// GetType returns the prometheus type enum for this metric.
@@ -138,20 +136,14 @@ type CumulativeHistogram interface {
 	CumulativeSnapshot() HistogramSnapshot
 }
 
-// GetName returns the metric's name.
-func (m *Metadata) GetName() string {
-	return m.Name
-}
-
-// GetLabeledName returns the metric's labeled name. This name is expected to be
-// repeated with different static label sets. Those labels can be accessed via
-// `GetLabels(true)`. If the metric does not have a labeled name, the metric's
-// name is returned.
-func (m *Metadata) GetLabeledName() string {
-	if m.LabeledName == "" {
-		return m.Name
+// GetName returns the metric's name. When `useStaticLabels` is true, it returns
+// the metric's labeled name if it's non-empty. Otherwise, it returns the metric's
+// name.
+func (m *Metadata) GetName(useStaticLabels bool) string {
+	if useStaticLabels && m.LabeledName != "" {
+		return m.LabeledName
 	}
-	return m.LabeledName
+	return m.Name
 }
 
 // GetHelp returns the metric's help string.

--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -52,6 +52,9 @@ enum Unit {
 message Metadata {
   // name is the name of the metric as if it was unlabeled. Set this to ensure
   // it gets recorded in TSDB.
+  // Note: this name value is used by the metric registry to uniquely identify
+  // the metric. Please ensure that it is unique across the codebase even if a
+  // labeled_name is provided.
   required string name = 1 [(gogoproto.nullable) = false];
   required string help = 2 [(gogoproto.nullable) = false];
   required string measurement = 3 [(gogoproto.nullable) = false];

--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -56,12 +56,7 @@ func MakePrometheusExporterForSelectedMetrics(selection map[string]struct{}) Pro
 func (pm *PrometheusExporter) findOrCreateFamily(
 	prom PrometheusCompatible, options *scrapeOptions,
 ) *prometheusgo.MetricFamily {
-	var familyName string
-	if options.useStaticLabels {
-		familyName = exportedName(prom.GetLabeledName())
-	} else {
-		familyName = exportedName(prom.GetName())
-	}
+	familyName := exportedName(prom.GetName(options.useStaticLabels))
 	if family, ok := pm.families[familyName]; ok {
 		return family
 	}

--- a/pkg/util/metric/registry.go
+++ b/pkg/util/metric/registry.go
@@ -78,9 +78,9 @@ func (r *Registry) GetLabels() []*prometheusgo.LabelPair {
 func (r *Registry) AddMetric(metric Iterable) {
 	r.Lock()
 	defer r.Unlock()
-	r.tracked[metric.GetName()] = metric
+	r.tracked[metric.GetName(false /* useStaticLabels */)] = metric
 	if log.V(2) {
-		log.Infof(context.TODO(), "added metric: %s (%T)", metric.GetName(), metric)
+		log.Infof(context.TODO(), "added metric: %s (%T)", metric.GetName(false /* useStaticLabels */), metric)
 	}
 }
 
@@ -103,9 +103,9 @@ func (r *Registry) Contains(name string) bool {
 func (r *Registry) RemoveMetric(metric Iterable) {
 	r.Lock()
 	defer r.Unlock()
-	delete(r.tracked, metric.GetName())
+	delete(r.tracked, metric.GetName(false /* useStaticLabels */))
 	if log.V(2) {
-		log.Infof(context.TODO(), "removed metric: %s (%T)", metric.GetName(), metric)
+		log.Infof(context.TODO(), "removed metric: %s (%T)", metric.GetName(false /* useStaticLabels */), metric)
 	}
 }
 
@@ -184,7 +184,7 @@ func (r *Registry) WriteMetricsMetadata(dest map[string]Metadata) {
 	r.Lock()
 	defer r.Unlock()
 	for _, v := range r.tracked {
-		dest[v.GetName()] = v.GetMetadata()
+		dest[v.GetName(false /* useStaticLabels */)] = v.GetMetadata()
 	}
 }
 
@@ -194,7 +194,7 @@ func (r *Registry) Each(f func(name string, val interface{})) {
 	defer r.Unlock()
 	for _, metric := range r.tracked {
 		metric.Inspect(func(v interface{}) {
-			f(metric.GetName(), v)
+			f(metric.GetName(false /* useStaticLabels */), v)
 		})
 	}
 }
@@ -220,7 +220,7 @@ func (r *Registry) MarshalJSON() ([]byte, error) {
 	m := make(map[string]interface{})
 	for _, metric := range r.tracked {
 		metric.Inspect(func(v interface{}) {
-			m[metric.GetName()] = v
+			m[metric.GetName(false /* useStaticLabels */)] = v
 		})
 	}
 	return json.Marshal(m)

--- a/pkg/util/metric/registry_test.go
+++ b/pkg/util/metric/registry_test.go
@@ -19,7 +19,7 @@ func (r *Registry) findMetricByName(name string) Iterable {
 	r.Lock()
 	defer r.Unlock()
 	for _, metric := range r.tracked {
-		if metric.GetName() == name {
+		if metric.GetName(false /* useStaticLabels */) == name {
 			return metric
 		}
 	}


### PR DESCRIPTION
Remove the `GetLabeledName()` API and change all call-sites.

Release note: None