### PR TITLE
backup: add cluster setting for online restore layer limit

### DIFF
--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1814,7 +1814,7 @@ func doRestorePlan(
 	}
 
 	if restoreStmt.Options.OnlineImpl() {
-		if err := checkManifestsForOnlineCompat(ctx, mainBackupManifests); err != nil {
+		if err := checkManifestsForOnlineCompat(ctx, p.ExecCfg().Settings, mainBackupManifests); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
Previously, the layer limit for online restore was hardcoded at 3. This commit adds the cluster setting `backup.restore.online_layer_limit`, allowing us to dynamically adjust the layer limit. It is by default set to 10.

Epic: None

Release note: None