### PR TITLE
sql: fix infinite loop in prepare/execute of PL/pgSQL loop

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -3271,3 +3271,26 @@ CREATE FUNCTION create_secret_role() RETURNS VOID SECURITY DEFINER AS $$
 $$ LANGUAGE plpgsql;
 
 subtest end
+
+subtest regression_144020
+
+statement ok
+CREATE FUNCTION f144020() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    i INT := 0;
+  BEGIN
+    WHILE i < 3 LOOP
+      RAISE NOTICE 'foo';
+      i := i + 1;
+    END LOOP;
+    RETURN i;
+  END
+$$;
+
+statement ok
+PREPARE foo AS SELECT $1::INT, f144020();
+
+statement ok
+EXECUTE foo (100);
+
+subtest end


### PR DESCRIPTION
We recently added unconditional copying for the body of a routine during placeholder assignment in #141596. However, we missed that a routine can recursively invoke itself, leading to an infinite loop during the copy. This commit fixes the bug by keeping track of which recursive routine definitions have been seen so far during the copying of the expression tree, and short-circuiting if one has already been seen.

Fixes #144020

Release note (bug fix): Fixed a bug that could cause a stack overflow during execution of a prepared statement that invoked  a PL/pgSQL routine with a loop. The bug existed in versions v23.2.22, v24.1.15, v24.3.9, v25.1.2, v25.1.3, and pre-release versions of 25.2 prior to v25.2.0-alpha.3.