### PR TITLE
*: audit all duration settings to ensure they have validation

### DIFF
--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -53,21 +53,18 @@ var (
 		"bulkio.backup.read_with_priority_after",
 		"amount of time since the read-as-of time above which a BACKUP should use priority when retrying reads",
 		time.Minute,
-		settings.NonNegativeDuration,
 		settings.WithPublic)
 	delayPerAttempt = settings.RegisterDurationSetting(
 		settings.ApplicationLevel,
 		"bulkio.backup.read_retry_delay",
 		"amount of time since the read-as-of time, per-prior attempt, to wait before making another attempt",
 		time.Second*5,
-		settings.NonNegativeDuration,
 	)
 	timeoutPerAttempt = settings.RegisterDurationSetting(
 		settings.ApplicationLevel,
 		"bulkio.backup.read_timeout",
 		"amount of time after which a read attempt is considered timed out, which causes the backup to fail",
 		time.Minute*5,
-		settings.NonNegativeDuration,
 		settings.WithPublic)
 
 	preSplitExports = settings.RegisterBoolSetting(

--- a/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
+++ b/pkg/ccl/changefeedccl/cdcevent/rowfetcher_cache.go
@@ -38,7 +38,6 @@ var traceKVLogFrequency = settings.RegisterDurationSetting(
 	"changefeed.cdcevent.trace_kv.log_frequency",
 	"controls how frequently KVs are logged when KV tracing is enabled",
 	500*time.Millisecond,
-	settings.NonNegativeDuration,
 )
 
 // rowFetcherCache maintains a cache of single table row.Fetchers. Given a key

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -694,7 +694,6 @@ var aggregatorHeartbeatFrequency = settings.RegisterDurationSetting(
 	"changefeed aggregator will emit a heartbeat message to the coordinator with this frequency; 0 disables. "+
 		"The setting value should be <=1/2 of server.shutdown.jobs.timeout period",
 	4*time.Second,
-	settings.NonNegativeDuration,
 )
 
 var aggregatorFlushJitter = settings.RegisterFloatSetting(

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -23,7 +23,6 @@ var TableDescriptorPollInterval = settings.RegisterDurationSetting(
 	"changefeed.experimental_poll_interval",
 	"polling interval for the table descriptors",
 	1*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // DefaultMinCheckpointFrequency is the default frequency to flush sink.
@@ -53,7 +52,6 @@ var SlowSpanLogThreshold = settings.RegisterDurationSetting(
 	"changefeed.slow_span_log_threshold",
 	"a changefeed will log spans with resolved timestamps this far behind the current wall-clock time; if 0, a default value is calculated based on other cluster settings",
 	0,
-	settings.NonNegativeDuration,
 )
 
 // IdleTimeout controls how long the changefeed will wait for a new KV being
@@ -63,7 +61,6 @@ var IdleTimeout = settings.RegisterDurationSetting(
 	"changefeed.idle_timeout",
 	"a changefeed will mark itself idle if no changes have been emitted for greater than this duration; if 0, the changefeed will never be marked idle",
 	10*time.Minute,
-	settings.NonNegativeDuration,
 	settings.WithName("changefeed.auto_idle.timeout"),
 )
 
@@ -75,7 +72,6 @@ var SpanCheckpointInterval = settings.RegisterDurationSetting(
 	"interval at which span-level checkpoints will be written; "+
 		"if 0, span-level checkpoints are disabled",
 	10*time.Minute,
-	settings.NonNegativeDuration,
 	settings.WithName("changefeed.span_checkpoint.interval"),
 )
 
@@ -90,7 +86,6 @@ var SpanCheckpointLagThreshold = settings.RegisterDurationSetting(
 		"to save leading span progress is written; if 0, span-level checkpoints "+
 		"due to lagging spans is disabled",
 	10*time.Minute,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 	settings.WithName("changefeed.span_checkpoint.lag_threshold"),
 )
@@ -185,7 +180,6 @@ var ResolvedTimestampMinUpdateInterval = settings.RegisterDurationSetting(
 		"updated again; default of 0 means no minimum interval is enforced but "+
 		"updating will still be limited by the average time it takes to checkpoint progress",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 	settings.WithName("changefeed.resolved_timestamp.min_update_interval"),
 )
@@ -227,7 +221,6 @@ var MaxProtectedTimestampAge = settings.RegisterDurationSetting(
 	"changefeed.protect_timestamp.max_age",
 	"fail the changefeed if the protected timestamp age exceeds this threshold; 0 disables expiration",
 	4*24*time.Hour,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // BatchReductionRetryEnabled enables the temporary reduction of batch sizes upon kafka message too large errors
@@ -354,5 +347,4 @@ var Quantize = settings.RegisterDurationSettingWithExplicitUnit(
 	"changefeed.resolved_timestamp.granularity",
 	"the granularity at which changefeed progress are quantized to make tracking more efficient",
 	0,
-	settings.NonNegativeDuration,
 )

--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -328,7 +328,7 @@ var UsageMetricsReportingInterval = settings.RegisterDurationSetting(
 	"changefeed.usage.reporting_interval",
 	"the interval at which the changefeed calculates and updates its usage metric",
 	5*time.Minute,
-	settings.PositiveDuration, settings.DurationInRange(2*time.Minute, 50*time.Minute),
+	settings.DurationInRange(2*time.Minute, 50*time.Minute),
 )
 
 // UsageMetricsReportingTimeoutPercent is the percent of

--- a/pkg/ccl/changefeedccl/telemetry.go
+++ b/pkg/ccl/changefeedccl/telemetry.go
@@ -181,5 +181,4 @@ var continuousTelemetryInterval = settings.RegisterDurationSetting(
 	"determines the interval at which each node emits continuous telemetry events"+
 		" during the lifespan of every changefeed; setting a zero value disables logging",
 	24*time.Hour,
-	settings.NonNegativeDuration,
 )

--- a/pkg/ccl/jwtauthccl/settings.go
+++ b/pkg/ccl/jwtauthccl/settings.go
@@ -142,7 +142,6 @@ var JWTAuthClientTimeout = settings.RegisterDurationSetting(
 	"sets the client timeout for external calls made during JWT authentication "+
 		"(e.g. fetching JWKS, etc.)",
 	15*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/followerreads.go
@@ -39,7 +39,6 @@ var ClosedTimestampPropagationSlack = settings.RegisterDurationSetting(
 		"propagate from a leaseholder to followers. This is taken into account by "+
 		"follower_read_timestamp().",
 	time.Second,
-	settings.NonNegativeDuration,
 )
 
 // getFollowerReadLag returns the (negative) offset duration from hlc.Now()

--- a/pkg/ccl/oidcccl/settings.go
+++ b/pkg/ccl/oidcccl/settings.go
@@ -81,7 +81,6 @@ var OIDCAuthClientTimeout = settings.RegisterDurationSetting(
 	"sets the client timeout for external calls made during OIDC authentication "+
 		"(e.g. authorization code flow, etc.)",
 	15*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -57,8 +57,7 @@ var (
 		settings.ApplicationLevel,
 		"logical_replication.consumer.job_checkpoint_frequency",
 		"controls the frequency with which the job updates their progress; if 0, disabled",
-		10*time.Second,
-		settings.NonNegativeDuration)
+		10*time.Second)
 
 	// heartbeatFrequency controls frequency the stream replication
 	// destination cluster sends heartbeat to the source cluster to keep
@@ -69,7 +68,6 @@ var (
 		"controls frequency the stream replication destination cluster sends heartbeat "+
 			"to the source cluster to keep the stream alive",
 		30*time.Second,
-		settings.NonNegativeDuration,
 	)
 )
 

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -88,7 +88,6 @@ var cutoverSignalPollInterval = settings.RegisterDurationSetting(
 	"bulkio.stream_ingestion.failover_signal_poll_interval",
 	"the interval at which the stream ingestion job checks if it has been signaled to cutover",
 	10*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithName("physical_replication.consumer.failover_signal_poll_interval"),
 )
 

--- a/pkg/crosscluster/settings.go
+++ b/pkg/crosscluster/settings.go
@@ -29,7 +29,6 @@ var StreamReplicationMinCheckpointFrequency = settings.RegisterDurationSetting(
 	"controls minimum frequency the stream replication source cluster sends checkpoints "+
 		"to the destination cluster",
 	10*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithName("physical_replication.producer.min_checkpoint_frequency"),
 )
 
@@ -41,7 +40,6 @@ var StreamReplicationConsumerHeartbeatFrequency = settings.RegisterDurationSetti
 	"controls frequency the stream replication destination cluster sends heartbeat "+
 		"to the source cluster to keep the stream alive",
 	30*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithName("physical_replication.consumer.heartbeat_frequency"),
 )
 
@@ -52,7 +50,6 @@ var JobCheckpointFrequency = settings.RegisterDurationSetting(
 	"stream_replication.job_checkpoint_frequency",
 	"controls the frequency with which partitions update their progress; if 0, disabled",
 	10*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithName("physical_replication.consumer.job_checkpoint_frequency"),
 )
 
@@ -88,7 +85,6 @@ var InterNodeLag = settings.RegisterDurationSetting(
 	"physical_replication.consumer.node_lag_replanning_threshold",
 	"the maximum difference in lag tolerated across two destination nodes; if 0, disabled",
 	5*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 // DumpFrontierEntries controls the frequency at which we persist the entries in
@@ -101,7 +97,6 @@ var DumpFrontierEntries = settings.RegisterDurationSetting(
 	"physical_replication.consumer.dump_frontier_entries_frequency",
 	"controls the frequency with which the frontier entries are persisted; if 0, disabled",
 	0,
-	settings.NonNegativeDuration,
 )
 
 // ReplicateSpanConfigsEnabled controls whether we replicate span

--- a/pkg/jobs/job_scheduler.go
+++ b/pkg/jobs/job_scheduler.go
@@ -446,6 +446,7 @@ var schedulerPaceSetting = settings.RegisterDurationSetting(
 	"jobs.scheduler.pace",
 	"how often to scan system.scheduled_jobs table",
 	time.Minute,
+	settings.PositiveDuration,
 )
 
 var schedulerMaxJobsPerIterationSetting = settings.RegisterIntSetting(

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -53,7 +53,6 @@ var (
 		"bulkio.ingest.flush_delay",
 		"amount of time to wait before sending a file to the KV/Storage layer to ingest",
 		0,
-		settings.NonNegativeDuration,
 	)
 
 	senderConcurrency = settings.RegisterIntSetting(

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker.go
@@ -113,14 +113,9 @@ var (
 			"(these can't retry internally, so should be long enough to allow quorum/lease recovery)",
 		10*time.Second,
 		settings.WithPublic,
-		settings.WithValidateDuration(func(t time.Duration) error {
-			// This prevents probes from exiting when idle, which can lead to buildup
-			// of probe goroutines, so cap it at 1 minute.
-			if t > time.Minute {
-				return errors.New("grace period can't be more than 1 minute")
-			}
-			return nil
-		}),
+		// This prevents probes from exiting when idle, which can lead to
+		// buildup of probe goroutines, so cap it at 1 minute.
+		settings.DurationInRange(0 /* minVal */, time.Minute),
 	)
 )
 

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -36,7 +36,6 @@ var FailedReservationsTimeout = settings.RegisterDurationSetting(
 	"server.failed_reservation_timeout",
 	"the amount of time to consider the store throttled for up-replication after a failed reservation call",
 	5*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithName("server.failed_reservation.timeout"),
 )
 

--- a/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
+++ b/pkg/kv/kvserver/batcheval/cmd_query_resolved_timestamp.go
@@ -30,7 +30,6 @@ var QueryResolvedTimestampIntentCleanupAge = settings.RegisterDurationSetting(
 	"kv.query_resolved_timestamp.intent_cleanup_age",
 	"minimum intent age that QueryResolvedTimestamp requests will consider for async intent cleanup",
 	10*time.Second,
-	settings.NonNegativeDuration,
 )
 
 func init() {

--- a/pkg/kv/kvserver/closedts/setting.go
+++ b/pkg/kv/kvserver/closedts/setting.go
@@ -23,7 +23,6 @@ var TargetDuration = settings.RegisterDurationSetting(
 	"kv.closed_timestamp.target_duration",
 	"if nonzero, attempt to provide closed timestamp notifications for timestamps trailing cluster time by approximately this duration",
 	3*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 
@@ -34,7 +33,6 @@ var SideTransportCloseInterval = settings.RegisterDurationSetting(
 	"the interval at which the closed timestamp side-transport attempts to "+
 		"advance each range's closed timestamp; set to 0 to disable the side-transport",
 	200*time.Millisecond,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 
@@ -47,7 +45,6 @@ var LeadForGlobalReadsOverride = settings.RegisterDurationSetting(
 	"kv.closed_timestamp.lead_for_global_reads_override",
 	"if nonzero, overrides the lead time that global_read ranges use to publish closed timestamps",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 
@@ -59,7 +56,6 @@ var RangeClosedTimestampPolicyRefreshInterval = settings.RegisterDurationSetting
 	"kv.closed_timestamp.policy_refresh_interval",
 	"interval at which the system refreshes closed timestamp policies for leaseholders",
 	5*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 // RangeClosedTimestampPolicyLatencyRefreshInterval determines how often the
@@ -71,7 +67,6 @@ var RangeClosedTimestampPolicyLatencyRefreshInterval = settings.RegisterDuration
 	"kv.closed_timestamp.policy_latency_refresh_interval",
 	"interval at which the system refreshes the latency cache based on observed latencies between nodes",
 	4*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 // LeadForGlobalReadsAutoTuneEnabled determines whether ranges configured to

--- a/pkg/kv/kvserver/consistency_queue.go
+++ b/pkg/kv/kvserver/consistency_queue.go
@@ -27,7 +27,6 @@ var consistencyCheckInterval = settings.RegisterDurationSetting(
 	"the time between range consistency checks; set to 0 to disable consistency checking."+
 		" Note that intervals that are too short can negatively impact performance.",
 	24*time.Hour,
-	settings.NonNegativeDuration,
 )
 
 var consistencyCheckRate = settings.RegisterByteSizeSetting(

--- a/pkg/kv/kvserver/gc/gc.go
+++ b/pkg/kv/kvserver/gc/gc.go
@@ -84,6 +84,8 @@ var TxnCleanupThreshold = settings.RegisterDurationSetting(
 	"the threshold after which a transaction is considered abandoned and "+
 		"fit for removal, as measured by the maximum of its last heartbeat and timestamp",
 	time.Hour,
+	// TODO(arul): consider increasing the floor.
+	settings.PositiveDuration,
 )
 
 // MaxLocksPerCleanupBatch is the maximum number of locks that GC will send

--- a/pkg/kv/kvserver/kvadmission/kvadmission.go
+++ b/pkg/kv/kvserver/kvadmission/kvadmission.go
@@ -111,7 +111,6 @@ var FlowTokenDropInterval = settings.RegisterDurationSetting(
 	"the interval at which the raft transport checks for pending flow token dispatches "+
 		"to nodes we're no longer connected to, in order to drop them; set to 0 to disable the mechanism",
 	30*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // FlowTokenDispatchInterval determines the frequency at which we check for
@@ -143,7 +142,6 @@ var ConnectedStoreExpiration = settings.RegisterDurationSetting(
 	"kvadmission.raft_transport.connected_store_expiration",
 	"the interval at which the raft transport prunes its set of connected stores; set to 0 to disable the mechanism",
 	5*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 // Controller provides admission control for the KV layer.

--- a/pkg/kv/kvserver/lease_queue.go
+++ b/pkg/kv/kvserver/lease_queue.go
@@ -46,7 +46,6 @@ var MinLeaseTransferInterval = settings.RegisterDurationSetting(
 		"It does not prevent transferring leases in order to allow a "+
 		"replica to be removed from a range.",
 	1*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // MinIOOverloadLeaseShedInterval controls how frequently a store may decide to
@@ -57,7 +56,6 @@ var MinIOOverloadLeaseShedInterval = settings.RegisterDurationSetting(
 	"controls how frequently all leases can be shed from a node "+
 		"due to the node becoming IO overloaded",
 	30*time.Second,
-	settings.NonNegativeDuration,
 )
 
 type leaseQueue struct {

--- a/pkg/kv/kvserver/merge_queue.go
+++ b/pkg/kv/kvserver/merge_queue.go
@@ -45,7 +45,6 @@ var MergeQueueInterval = settings.RegisterDurationSetting(
 	"kv.range_merge.queue_interval",
 	"how long the merge queue waits between processing replicas",
 	5*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // SkipMergeQueueForExternalBytes is a setting that controls whether

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -99,7 +99,6 @@ var mvccGCQueueInterval = settings.RegisterDurationSetting(
 	"kv.mvcc_gc.queue_interval",
 	"how long the mvcc gc queue waits between processing replicas",
 	mvccGCQueueDefaultTimerDuration,
-	settings.NonNegativeDuration,
 )
 
 // mvccGCQueueHighPriInterval
@@ -108,7 +107,6 @@ var mvccGCQueueHighPriInterval = settings.RegisterDurationSetting(
 	"kv.mvcc_gc.queue_high_priority_interval",
 	"how long the mvcc gc queue waits between processing high priority replicas (e.g. after table drops)",
 	mvccHiPriGCQueueDefaultTimerDuration,
-	settings.NonNegativeDuration,
 )
 
 // EnqueueInMvccGCQueueOnSpanConfigUpdateEnabled controls whether replicas

--- a/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
+++ b/pkg/kv/kvserver/protectedts/ptreconcile/reconciler.go
@@ -30,7 +30,6 @@ var ReconcileInterval = settings.RegisterDurationSetting(
 	"kv.protectedts.reconciliation.interval",
 	"the frequency for reconciling jobs with protected timestamp records",
 	5*time.Minute,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // StatusFunc is used to check on the status of a Record based on its Meta

--- a/pkg/kv/kvserver/protectedts/settings.go
+++ b/pkg/kv/kvserver/protectedts/settings.go
@@ -44,4 +44,5 @@ var PollInterval = settings.RegisterDurationSetting(
 	"kv.protectedts.poll_interval",
 	// TODO(ajwerner): better description.
 	"the interval at which the protectedts subsystem state is polled",
-	2*time.Minute, settings.NonNegativeDuration)
+	2*time.Minute,
+	settings.NonNegativeDuration)

--- a/pkg/kv/kvserver/protectedts/settings.go
+++ b/pkg/kv/kvserver/protectedts/settings.go
@@ -44,5 +44,4 @@ var PollInterval = settings.RegisterDurationSetting(
 	"kv.protectedts.poll_interval",
 	// TODO(ajwerner): better description.
 	"the interval at which the protectedts subsystem state is polled",
-	2*time.Minute,
-	settings.NonNegativeDuration)
+	2*time.Minute)

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -51,8 +51,7 @@ const (
 var queueGuaranteedProcessingTimeBudget = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"kv.queue.process.guaranteed_time_budget",
-	"the guaranteed duration before which the processing of a queue may "+
-		"time out",
+	"the guaranteed duration before which the processing of a queue may time out",
 	defaultProcessTimeout,
 	settings.WithVisibility(settings.Reserved),
 )

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -3234,7 +3234,8 @@ var traceSnapshotThreshold = settings.RegisterDurationSetting(
 	"kv.trace.snapshot.enable_threshold",
 	"enables tracing and gathers timing information on all snapshots;"+
 		"snapshots with a duration longer than this threshold will have their "+
-		"trace logged (set to 0 to disable);", 0,
+		"trace logged (set to 0 to disable);",
+	0,
 )
 
 var externalFileSnapshotting = settings.RegisterBoolSetting(

--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -55,7 +55,6 @@ var RangeFeedRefreshInterval = settings.RegisterDurationSetting(
 	"the interval at which closed-timestamp updates"+
 		"are delivered to rangefeeds; set to 0 to use kv.closed_timestamp.side_transport_interval",
 	3*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 
@@ -69,7 +68,6 @@ var RangeFeedSmearInterval = settings.RegisterDurationSetting(
 		"set to 0 to use kv.rangefeed.closed_timestamp_refresh_interval"+
 		"capped at kv.rangefeed.closed_timestamp_refresh_interval",
 	1*time.Millisecond,
-	settings.NonNegativeDuration,
 )
 
 // RangeFeedUseScheduler controls type of rangefeed processor is used to process

--- a/pkg/kv/kvserver/replicate_queue.go
+++ b/pkg/kv/kvserver/replicate_queue.go
@@ -97,7 +97,6 @@ var EnqueueProblemRangeInReplicateQueueInterval = settings.RegisterDurationSetti
 		"one which is underreplicated or has a replica on a decommissioning store, "+
 		"disabled when set to 0",
 	0,
-	settings.NonNegativeDuration,
 )
 
 var (

--- a/pkg/kv/kvserver/reports/reporter.go
+++ b/pkg/kv/kvserver/reports/reporter.go
@@ -47,7 +47,6 @@ var ReporterInterval = settings.RegisterDurationSetting(
 	"the frequency for generating the replication_constraint_stats, replication_stats_report and "+
 		"replication_critical_localities reports (set to 0 to disable)",
 	time.Minute,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // Reporter periodically produces a couple of reports on the cluster's data

--- a/pkg/kv/kvserver/spanlatch/settings.go
+++ b/pkg/kv/kvserver/spanlatch/settings.go
@@ -21,5 +21,4 @@ var LongLatchHoldThreshold = settings.RegisterDurationSetting(
 	"kv.concurrency.long_latch_hold_duration",
 	"the threshold for logging long latch holds",
 	3*time.Second,
-	settings.NonNegativeDuration,
 )

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -295,7 +295,6 @@ var LeaseTransferPerIterationTimeout = settings.RegisterDurationSetting(
 		"after changing this setting)",
 	5*time.Second,
 	settings.WithName("server.shutdown.lease_transfer_iteration.timeout"),
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 

--- a/pkg/security/tls_settings.go
+++ b/pkg/security/tls_settings.go
@@ -47,7 +47,6 @@ var ocspTimeout = settings.RegisterDurationSetting(
 	settings.ApplicationLevel, "security.ocsp.timeout",
 	"timeout before considering the OCSP server unreachable",
 	3*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 type clusterTLSSettings struct {

--- a/pkg/server/authserver/authentication.go
+++ b/pkg/server/authserver/authentication.go
@@ -111,7 +111,6 @@ var WebSessionTimeout = settings.RegisterDurationSetting(
 	"server.web_session_timeout",
 	"the duration that a newly created web session will be valid",
 	7*24*time.Hour,
-	settings.NonNegativeDuration,
 	settings.WithName("server.web_session.timeout"),
 	settings.WithPublic)
 

--- a/pkg/server/diagnostics/reporter.go
+++ b/pkg/server/diagnostics/reporter.go
@@ -67,7 +67,6 @@ var reportFrequency = settings.RegisterDurationSetting(
 	"diagnostics.reporting.interval",
 	"interval at which diagnostics data should be reported",
 	time.Hour,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // Reporter is a helper struct that phones home to report usage and diagnostics.

--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -37,7 +37,6 @@ var jemallocPurgePeriod = settings.RegisterDurationSettingWithExplicitUnit(
 	"server.jemalloc_purge_period",
 	"minimum amount of time that must pass between two jemalloc dirty page purges (0 disables purging)",
 	2*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 type sampleEnvironmentCfg struct {

--- a/pkg/server/hot_ranges.go
+++ b/pkg/server/hot_ranges.go
@@ -21,5 +21,4 @@ var HotRangesRequestNodeTimeout = settings.RegisterDurationSetting(
 	"server.hot_ranges_request.node.timeout",
 	"the duration allowed for a single node to return hot range data before the request is cancelled; if set to 0, there is no timeout",
 	time.Minute*5,
-	settings.NonNegativeDuration,
 	settings.WithPublic)

--- a/pkg/server/server_systemlog_gc.go
+++ b/pkg/server/server_systemlog_gc.go
@@ -29,7 +29,6 @@ var (
 		"server.log_gc.period",
 		"the period at which log-like system tables are checked for old entries",
 		time.Hour,
-		settings.NonNegativeDuration,
 		settings.WithPublic)
 
 	systemLogGCLimit = settings.RegisterIntSetting(

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -35,7 +35,6 @@ var SpanStatsNodeTimeout = settings.RegisterDurationSetting(
 	"the duration allowed for a single node to return span stats data before"+
 		" the request is cancelled; if set to 0, there is no timeout",
 	time.Minute,
-	settings.NonNegativeDuration,
 )
 
 const defaultRangeStatsBatchLimit = 100

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -32,7 +32,6 @@ var TelemetryHotRangesStatsInterval = settings.RegisterDurationSetting(
 	"server.telemetry.hot_ranges_stats.interval",
 	"the time interval to log hot ranges stats",
 	4*time.Hour,
-	settings.NonNegativeDuration,
 )
 
 var TelemetryHotRangesStatsEnabled = settings.RegisterBoolSetting(
@@ -47,7 +46,6 @@ var TelemetryHotRangesStatsLoggingDelay = settings.RegisterDurationSetting(
 	"server.telemetry.hot_ranges_stats.logging_delay",
 	"the time delay between emitting individual hot ranges stats logs",
 	1*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // hotRangesLoggingScheduler is responsible for logging index usage stats

--- a/pkg/settings/byte_size.go
+++ b/pkg/settings/byte_size.go
@@ -60,7 +60,7 @@ func RegisterByteSizeSetting(
 			}
 			hasExplicitValidationFn = true
 			if err := opt.validateInt64Fn(v); err != nil {
-				return errors.Wrapf(err, "invalid value for %s", key)
+				return err
 			}
 		}
 		if !hasExplicitValidationFn {

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -147,11 +147,14 @@ func (d *DurationSetting) setToDefault(ctx context.Context, sv *Values) {
 	}
 }
 
-// RegisterDurationSetting defines a new setting with type duration.
+// RegisterDurationSetting defines a new setting with type duration and any
+// supplied validation function(s). If no validation functions are given, then
+// the non-negative duration validation is performed.
 func RegisterDurationSetting(
 	class Class, key InternalKey, desc string, defaultValue time.Duration, opts ...SettingOption,
 ) *DurationSetting {
 	validateFn := func(val time.Duration) error {
+		hasExplicitValidationFn := false
 		for _, opt := range opts {
 			switch {
 			case opt.commonOpt != nil:
@@ -160,9 +163,14 @@ func RegisterDurationSetting(
 			default:
 				panic(errors.AssertionFailedf("wrong validator type"))
 			}
+			hasExplicitValidationFn = true
 			if err := opt.validateDurationFn(val); err != nil {
-				return errors.Wrapf(err, "invalid value for %s", key)
+				return err
 			}
+		}
+		if !hasExplicitValidationFn {
+			// Default validation.
+			return nonNegativeDurationInternal(val)
 		}
 		return nil
 	}
@@ -180,11 +188,13 @@ func RegisterDurationSetting(
 }
 
 // RegisterDurationSettingWithExplicitUnit defines a new setting with type
-// duration which requires an explicit unit when being set.
+// duration which requires an explicit unit when being set. If no validation
+// functions are given, then the non-negative duration validation is performed.
 func RegisterDurationSettingWithExplicitUnit(
 	class Class, key InternalKey, desc string, defaultValue time.Duration, opts ...SettingOption,
 ) *DurationSettingWithExplicitUnit {
 	validateFn := func(val time.Duration) error {
+		hasExplicitValidationFn := false
 		for _, opt := range opts {
 			switch {
 			case opt.commonOpt != nil:
@@ -193,9 +203,14 @@ func RegisterDurationSettingWithExplicitUnit(
 			default:
 				panic(errors.AssertionFailedf("wrong validator type"))
 			}
+			hasExplicitValidationFn = true
 			if err := opt.validateDurationFn(val); err != nil {
-				return errors.Wrapf(err, "invalid value for %s", key)
+				return err
 			}
+		}
+		if !hasExplicitValidationFn {
+			// Default validation.
+			return nonNegativeDurationInternal(val)
 		}
 		return nil
 	}
@@ -212,10 +227,6 @@ func RegisterDurationSettingWithExplicitUnit(
 	setting.apply(opts)
 	return setting
 }
-
-// NonNegativeDuration checks that the duration is greater or equal to
-// zero. It can be passed to RegisterDurationSetting.
-var NonNegativeDuration SettingOption = WithValidateDuration(nonNegativeDurationInternal)
 
 func nonNegativeDurationInternal(v time.Duration) error {
 	if v < 0 {

--- a/pkg/settings/duration.go
+++ b/pkg/settings/duration.go
@@ -179,9 +179,8 @@ func RegisterDurationSetting(
 	return setting
 }
 
-// RegisterPublicDurationSettingWithExplicitUnit defines a new
-// public setting with type duration which requires an explicit unit when being
-// set.
+// RegisterDurationSettingWithExplicitUnit defines a new setting with type
+// duration which requires an explicit unit when being set.
 func RegisterDurationSettingWithExplicitUnit(
 	class Class, key InternalKey, desc string, defaultValue time.Duration, opts ...SettingOption,
 ) *DurationSettingWithExplicitUnit {

--- a/pkg/settings/settings_test.go
+++ b/pkg/settings/settings_test.go
@@ -163,7 +163,7 @@ var i1A = settings.RegisterIntSetting(settings.ApplicationLevel, "i.1", "desc", 
 var i2A = settings.RegisterIntSetting(settings.ApplicationLevel, "i.2", "desc", 5)
 var fA = settings.RegisterFloatSetting(settings.SystemVisible, "f", "desc", 5.4)
 var dA = settings.RegisterDurationSetting(settings.ApplicationLevel, "d", "desc", time.Second)
-var duA = settings.RegisterDurationSettingWithExplicitUnit(settings.ApplicationLevel, "d_with_explicit_unit", "desc", time.Second, settings.NonNegativeDuration, settings.WithPublic)
+var duA = settings.RegisterDurationSettingWithExplicitUnit(settings.ApplicationLevel, "d_with_explicit_unit", "desc", time.Second, settings.WithPublic)
 var pA = settings.RegisterProtobufSetting(settings.ApplicationLevel, "p", "desc", &dummyVersion{msg1: "foo"})
 var _ = settings.RegisterDurationSetting(settings.ApplicationLevel, "d_with_maximum", "desc", time.Second, settings.NonNegativeDurationWithMaximum(time.Hour))
 var eA = settings.RegisterEnumSetting(settings.SystemOnly, "e", "desc", "foo", map[int64]string{1: "foo", 2: "bar", 3: "baz"})
@@ -188,7 +188,7 @@ var strVal = settings.RegisterStringSetting(settings.SystemOnly,
 		}
 		return nil
 	}))
-var dVal = settings.RegisterDurationSetting(settings.SystemOnly, "dVal", "desc", time.Second, settings.NonNegativeDuration)
+var dVal = settings.RegisterDurationSetting(settings.SystemOnly, "dVal", "desc", time.Second)
 var fVal = settings.RegisterFloatSetting(settings.SystemOnly, "fVal", "desc", 5.4, settings.NonNegativeFloat)
 var byteSizeVal = settings.RegisterByteSizeSetting(settings.SystemOnly, "byteSize.Val", "desc", mb)
 var iVal = settings.RegisterIntSetting(settings.SystemOnly,

--- a/pkg/spanconfig/spanconfigjob/job.go
+++ b/pkg/spanconfig/spanconfigjob/job.go
@@ -35,7 +35,6 @@ var ReconciliationJobCheckpointInterval = settings.RegisterDurationSetting(
 	"spanconfig.reconciliation_job.checkpoint_interval",
 	"the frequency at which the span config reconciliation job checkpoints itself",
 	5*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // Resume implements the jobs.Resumer interface.

--- a/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
+++ b/pkg/spanconfig/spanconfigkvsubscriber/kvsubscriber.go
@@ -58,7 +58,6 @@ var metricsPollerInterval = settings.RegisterDurationSetting(
 	"spanconfig.kvsubscriber.metrics_poller_interval",
 	"the interval at which the spanconfig.kvsubscriber.* metrics are kept up-to-date; set to 0 to disable the mechanism",
 	5*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // KVSubscriber is used to subscribe to global span configuration changes. It's

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -31,7 +31,6 @@ var checkReconciliationJobInterval = settings.RegisterDurationSetting(
 	"spanconfig.reconciliation_job.check_interval",
 	"the frequency at which to check if the span config reconciliation job exists (and to start it if not)",
 	10*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 // jobEnabledSetting gates the activation of the span config reconciliation job.

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -56,7 +56,6 @@ var IndexBackfillCheckpointInterval = settings.RegisterDurationSetting(
 	"bulkio.index_backfill.checkpoint_interval",
 	"the amount of time between index backfill checkpoint updates",
 	30*time.Second,
-	settings.NonNegativeDuration,
 )
 
 // MutationFilter is the type of a simple predicate on a mutation.

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -753,6 +753,12 @@ var statsAsOfTimeClusterMode = settings.RegisterDurationSetting(
 	"sql.crdb_internal.table_row_statistics.as_of_time",
 	"historical query time used to build the crdb_internal.table_row_statistics table",
 	-10*time.Second,
+	settings.WithValidateDuration(func(v time.Duration) error {
+		if v > 0 {
+			return errors.Errorf("cannot be set to a positive duration: %s", v)
+		}
+		return nil
+	}),
 )
 
 var crdbInternalTablesTableLastStats = virtualSchemaTable{

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -71,7 +71,7 @@ var maxTimestampAge = settings.RegisterDurationSetting(
 	"sql.stats.max_timestamp_age",
 	"maximum age of timestamp during table statistics collection",
 	5*time.Minute,
-	// TODO(yuzefovich): we should add non-negative duration validation.
+	settings.PositiveDuration,
 )
 
 // minAutoHistogramSamples and maxAutoHistogramSamples are the bounds used by

--- a/pkg/sql/exec_log.go
+++ b/pkg/sql/exec_log.go
@@ -55,7 +55,6 @@ var slowQueryLogThreshold = settings.RegisterDurationSettingWithExplicitUnit(
 	"when set to non-zero, log statements whose service latency exceeds "+
 		"the threshold to a secondary logger on each node",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -274,7 +274,8 @@ var traceTxnThreshold = settings.RegisterDurationSetting(
 		"note that enabling this may have a negative performance impact; "+
 		"this setting is coarser-grained than sql.trace.stmt.enable_threshold "+
 		"because it applies to all statements within a transaction as well as "+
-		"client communication (e.g. retries)", 0,
+		"client communication (e.g. retries)",
+	0,
 	settings.WithPublic)
 
 // TraceStmtThreshold is identical to traceTxnThreshold except it applies to

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -460,7 +460,6 @@ var clusterStatementTimeout = settings.RegisterDurationSetting(
 		"duration a query is permitted to run before it is canceled; if set to 0, "+
 		"there is no timeout",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 var clusterLockTimeout = settings.RegisterDurationSetting(
@@ -472,7 +471,6 @@ var clusterLockTimeout = settings.RegisterDurationSetting(
 		"a lock on a key or while blocking on an existing lock in order to "+
 		"perform a non-locking read on a key; if set to 0, there is no timeout",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 var clusterIdleInSessionTimeout = settings.RegisterDurationSetting(
@@ -483,7 +481,6 @@ var clusterIdleInSessionTimeout = settings.RegisterDurationSetting(
 		"duration a session is permitted to idle before the session is terminated; "+
 		"if set to 0, there is no timeout",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 var clusterIdleInTransactionSessionTimeout = settings.RegisterDurationSetting(
@@ -493,7 +490,6 @@ var clusterIdleInTransactionSessionTimeout = settings.RegisterDurationSetting(
 		"duration a session is permitted to idle in a transaction before the "+
 		"session is terminated; if set to 0, there is no timeout",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // TODO(rytaft): remove this once unique without index constraints are fully

--- a/pkg/sql/flowinfra/flow_registry.go
+++ b/pkg/sql/flowinfra/flow_registry.go
@@ -38,7 +38,6 @@ var SettingFlowStreamTimeout = settings.RegisterDurationSetting(
 	"sql.distsql.flow_stream_timeout",
 	"amount of time incoming streams wait for a flow to be set up before erroring out",
 	10*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithName("sql.distsql.flow_stream.timeout"),
 )
 

--- a/pkg/sql/gcjob/gc_job.go
+++ b/pkg/sql/gcjob/gc_job.go
@@ -426,7 +426,6 @@ var EmptySpanPollInterval = settings.RegisterDurationSetting(
 	"sql.gc_job.wait_for_gc.interval",
 	"interval at which the GC job should poll to see if the deleted data has been GC'd",
 	5*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 func waitForEmptyPrefix(

--- a/pkg/sql/idxusage/index_usage_stats_rec.go
+++ b/pkg/sql/idxusage/index_usage_stats_rec.go
@@ -42,7 +42,6 @@ var DropUnusedIndexDuration = settings.RegisterDurationSetting(
 	"sql.index_recommendation.drop_unused_duration",
 	"the index unused duration at which we begin to recommend dropping the index",
 	defaultUnusedIndexDuration,
-	settings.NonNegativeDuration,
 	settings.WithPublic,
 )
 

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -328,7 +328,6 @@ var inFlightTraceCollectorPollInterval = settings.RegisterDurationSetting(
 	"determines the interval between polling done by the in-flight trace "+
 		"collector for the statement bundle, set to zero to disable",
 	0,
-	settings.NonNegativeDuration,
 )
 
 var timeoutTraceCollectionEnabled = settings.RegisterBoolSetting(

--- a/pkg/sql/logictest/testdata/logic_test/cluster_settings
+++ b/pkg/sql/logictest/testdata/logic_test/cluster_settings
@@ -1,7 +1,7 @@
 statement ok
 SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '1ms'
 
-statement error pq: invalid value for sql.log.slow_query.latency_threshold: cannot be set to a negative duration
+statement error pq: cannot be set to a negative duration
 SET CLUSTER SETTING sql.log.slow_query.latency_threshold = '-1ms'
 
 statement error pq: invalid cluster setting argument type

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats.go
@@ -37,7 +37,6 @@ var telemetryCaptureIndexUsageStatsInterval = settings.RegisterDurationSetting(
 	"sql.telemetry.capture_index_usage_stats.interval",
 	"the scheduled interval time between capturing index usage statistics when capturing index usage statistics is enabled",
 	8*time.Hour,
-	settings.NonNegativeDuration,
 )
 
 var telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval = settings.RegisterDurationSetting(
@@ -45,7 +44,6 @@ var telemetryCaptureIndexUsageStatsStatusCheckEnabledInterval = settings.Registe
 	"sql.telemetry.capture_index_usage_stats.check_enabled_interval",
 	"the scheduled interval time between checks to see if index usage statistics has been enabled",
 	10*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 var telemetryCaptureIndexUsageStatsLoggingDelay = settings.RegisterDurationSetting(
@@ -54,7 +52,6 @@ var telemetryCaptureIndexUsageStatsLoggingDelay = settings.RegisterDurationSetti
 	"the time delay between emitting individual index usage stats logs, this is done to "+
 		"mitigate the log-line limit of 10 logs per second on the telemetry pipeline",
 	500*time.Millisecond,
-	settings.NonNegativeDuration,
 )
 
 // CaptureIndexUsageStatsTestingKnobs provides hooks and knobs for unit tests.

--- a/pkg/sql/sqlliveness/slbase/slbase.go
+++ b/pkg/sql/sqlliveness/slbase/slbase.go
@@ -18,7 +18,6 @@ var (
 		"server.sqlliveness.ttl",
 		"default sqlliveness session ttl",
 		40*time.Second,
-		settings.NonNegativeDuration,
 	)
 	// DefaultHeartBeat specifies the period between attempts to extend a session.
 	DefaultHeartBeat = settings.RegisterDurationSetting(
@@ -26,6 +25,5 @@ var (
 		"server.sqlliveness.heartbeat",
 		"duration heart beats to push session expiration further out in time",
 		5*time.Second,
-		settings.NonNegativeDuration,
 	)
 )

--- a/pkg/sql/sqlliveness/slstorage/slstorage.go
+++ b/pkg/sql/sqlliveness/slstorage/slstorage.go
@@ -43,7 +43,6 @@ var GCInterval = settings.RegisterDurationSetting(
 	"server.sqlliveness.gc_interval",
 	"duration between attempts to delete extant sessions that have expired",
 	time.Hour,
-	settings.NonNegativeDuration,
 )
 
 // GCJitter specifies the jitter fraction on the interval between attempts to

--- a/pkg/sql/sqlstats/insights/insights.go
+++ b/pkg/sql/sqlstats/insights/insights.go
@@ -56,7 +56,6 @@ var AnomalyDetectionLatencyThreshold = settings.RegisterDurationSetting(
 	"sql.insights.anomaly_detection.latency_threshold",
 	"statements must surpass this threshold to trigger anomaly detection and identification",
 	50*time.Millisecond,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // AnomalyDetectionMemoryLimit restricts the overall memory available for

--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -45,7 +45,6 @@ var MinimumInterval = settings.RegisterDurationSetting(
 		"flush operation starts within less than the minimum interval, the flush "+
 		"operation will be aborted",
 	0,
-	settings.NonNegativeDuration,
 )
 
 // DiscardInMemoryStatsWhenFlushDisabled is the cluster setting that allows the
@@ -150,5 +149,4 @@ var SQLStatsLimitTableCheckInterval = settings.RegisterDurationSetting(
 	"controls what interval the check is done if the statement and "+
 		"transaction statistics tables have grown past sql.stats.persisted_rows.max",
 	1*time.Hour,
-	settings.NonNegativeDuration,
 )

--- a/pkg/sql/sqlstats/ssmemstorage/ss_mem_counter.go
+++ b/pkg/sql/sqlstats/ssmemstorage/ss_mem_counter.go
@@ -63,7 +63,6 @@ var DiscardedStatsLogInterval = settings.RegisterDurationSetting(
 	"sql.metrics.discarded_stats_log.interval",
 	"interval between log emissions for discarded statistics due to SQL statistics memory limit",
 	1*time.Minute,
-	settings.NonNegativeDuration,
 	settings.WithVisibility(settings.Reserved))
 
 func NewSQLStatsAtomicCounters(

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -159,7 +159,6 @@ var statsGarbageCollectionInterval = settings.RegisterDurationSetting(
 	"sql.stats.garbage_collection_interval",
 	"interval between deleting stats for dropped tables, set to 0 to disable",
 	time.Hour,
-	settings.NonNegativeDuration,
 )
 
 // statsGarbageCollectionLimit controls the limit on the number of dropped

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -32,7 +32,6 @@ var pollingInterval = settings.RegisterDurationSetting(
 	"sql.stmt_diagnostics.poll_interval",
 	"rate at which the stmtdiagnostics.Registry polls for requests, set to zero to disable",
 	10*time.Second,
-	settings.NonNegativeDuration,
 )
 
 var bundleChunkSize = settings.RegisterByteSizeSetting(

--- a/pkg/sql/tablemetadatacache/cluster_settings.go
+++ b/pkg/sql/tablemetadatacache/cluster_settings.go
@@ -9,7 +9,6 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
-	"github.com/cockroachdb/errors"
 )
 
 const (
@@ -31,13 +30,8 @@ var DataValidDurationSetting = settings.RegisterDurationSetting(
 	"obs.tablemetadata.data_valid_duration",
 	"the duration for which the data in system.table_metadata is considered valid",
 	defaultDataValidDuration,
-	settings.WithValidateDuration(func(t time.Duration) error {
-		// This prevents the update loop from running too frequently.
-		if t < time.Minute {
-			return errors.New("validity period can't be less than 1 minute")
-		}
-		return nil
-	}),
+	// This prevents the update loop from running too frequently.
+	settings.DurationWithMinimum(time.Minute),
 	settings.WithPublic)
 
 var updateJobBatchSizeSetting = settings.RegisterIntSetting(

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -476,7 +476,6 @@ var userLoginTimeout = settings.RegisterDurationSetting(
 	"server.user_login.timeout",
 	"timeout after which client authentication times out if some system range is unavailable (0 = no timeout)",
 	10*time.Second,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // GetAllRoles returns a "set" (map) of Roles -> true.

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -154,7 +154,6 @@ var rangeSequencerGCThreshold = settings.RegisterDurationSetting(
 	"admission.replication_control.range_sequencer_gc_threshold",
 	"the inactive duration for a range sequencer after it's garbage collected",
 	5*time.Minute,
-	settings.NonNegativeDuration,
 )
 
 // WorkInfo provides information that is used to order work within an WorkQueue.

--- a/pkg/util/admission/work_queue.go
+++ b/pkg/util/admission/work_queue.go
@@ -130,36 +130,24 @@ var epochLIFOEpochDuration = settings.RegisterDurationSetting(
 	"admission.epoch_lifo.epoch_duration",
 	"the duration of an epoch, for epoch-LIFO admission control ordering",
 	epochLength,
-	settings.WithValidateDuration(func(v time.Duration) error {
-		if v < time.Millisecond {
-			return errors.Errorf("epoch-LIFO: epoch duration is too small")
-		}
-		return nil
-	}), settings.WithPublic)
+	settings.DurationWithMinimum(time.Millisecond),
+	settings.WithPublic)
 
 var epochLIFOEpochClosingDeltaDuration = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"admission.epoch_lifo.epoch_closing_delta_duration",
 	"the delta duration before closing an epoch, for epoch-LIFO admission control ordering",
 	epochClosingDelta,
-	settings.WithValidateDuration(func(v time.Duration) error {
-		if v < time.Millisecond {
-			return errors.Errorf("epoch-LIFO: epoch closing delta is too small")
-		}
-		return nil
-	}), settings.WithPublic)
+	settings.DurationWithMinimum(time.Millisecond),
+	settings.WithPublic)
 
 var epochLIFOQueueDelayThresholdToSwitchToLIFO = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
 	"admission.epoch_lifo.queue_delay_threshold_to_switch_to_lifo",
 	"the queue delay encountered by a (tenant,priority) for switching to epoch-LIFO ordering",
 	maxQueueDelayToSwitchToLifo,
-	settings.WithValidateDuration(func(v time.Duration) error {
-		if v < time.Millisecond {
-			return errors.Errorf("epoch-LIFO: queue delay threshold is too small")
-		}
-		return nil
-	}), settings.WithPublic)
+	settings.DurationWithMinimum(time.Millisecond),
+	settings.WithPublic)
 
 var rangeSequencerGCThreshold = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,

--- a/pkg/util/schedulerlatency/sampler.go
+++ b/pkg/util/schedulerlatency/sampler.go
@@ -33,12 +33,7 @@ var samplePeriod = settings.RegisterDurationSetting(
 	"scheduler_latency.sample_period",
 	"controls the duration between consecutive scheduler latency samples",
 	100*time.Millisecond,
-	settings.WithValidateDuration(func(period time.Duration) error {
-		if period < time.Millisecond {
-			return fmt.Errorf("minimum sample period is %s, got %s", time.Millisecond, period)
-		}
-		return nil
-	}),
+	settings.DurationWithMinimum(time.Millisecond),
 )
 
 var sampleDuration = settings.RegisterDurationSetting(
@@ -46,12 +41,7 @@ var sampleDuration = settings.RegisterDurationSetting(
 	"scheduler_latency.sample_duration",
 	"controls the duration over which each scheduler latency sample is a measurement over",
 	2500*time.Millisecond,
-	settings.WithValidateDuration(func(duration time.Duration) error {
-		if duration < 100*time.Millisecond {
-			return fmt.Errorf("minimum sample duration is %s, got %s", 100*time.Millisecond, duration)
-		}
-		return nil
-	}),
+	settings.DurationWithMinimum(100*time.Millisecond),
 )
 
 var schedulerLatency = metric.Metadata{

--- a/pkg/util/tracing/tracer.go
+++ b/pkg/util/tracing/tracer.go
@@ -187,7 +187,6 @@ var periodicSnapshotInterval = settings.RegisterDurationSetting(
 	"trace.snapshot.rate",
 	"if non-zero, interval at which background trace snapshots are captured",
 	0,
-	settings.NonNegativeDuration,
 	settings.WithPublic)
 
 // panicOnUseAfterFinish, if set, causes use of a span after Finish() to panic


### PR DESCRIPTION
This PR contains a couple of commits that audit all duration settings and ensure that they have validation functions. In most cases where there wasn't one, non-negative validation is added. The exceptions are:
- positive validation:
  - `kv.gc.txn_cleanup_threshold`
  - `jobs.scheduler.pace`
  - `sql.stats.max_timestamp_age`.
- non-positive validation:
  - `sql.crdb_internal.table_row_statistics.as_of_time`.

Non-negative validation is now assumed to be the default, so all its explicit usages are removed.

See each commit for details.

Epic: None
Release note: None