### PR TITLE
util/bitarray: clean up a couple error messages

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/bit.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/bit.diffs
@@ -480,7 +480,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/bit.out --label=/
  
  SELECT set_bit(B'0101011000100100', 16, 1);	-- fail
 -ERROR:  bit index 16 out of valid range (0..15)
-+ERROR:  set_bit(): SetBitAtIndex: bit index 16 out of valid range (0..15)
++ERROR:  set_bit(): bit index 16 out of valid range (0..15)
  -- Overlay
  SELECT overlay(B'0101011100' placing '001' from 2 for 3);
 -  overlay   

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2962,10 +2962,10 @@ SELECT get_bit('000000'::varbit, 5) UNION SELECT get_bit('1111111'::varbit, 5)
 1
 0
 
-query error get_bit\(\): GetBitAtIndex: bit index 10 out of valid range \(0..4\)
+query error get_bit\(\): bit index 10 out of valid range \(0..4\)
 SELECT get_bit(B'10110', 10)
 
-query error get_bit\(\): GetBitAtIndex: bit index 0 out of valid range \(0..-1\)
+query error get_bit\(\): bit index 0 out of valid range \(0..-1\)
 SELECT get_bit(B'', 0);
 
 query II
@@ -3020,13 +3020,13 @@ SELECT set_bit('000000'::varbit, 5, 1) UNION SELECT set_bit('111111'::varbit, 5,
 000001
 111110
 
-query error set_bit\(\): SetBitAtIndex: bit index 10 out of valid range \(0..6\)
+query error set_bit\(\): bit index 10 out of valid range \(0..6\)
 SELECT set_bit(B'1101010', 10, 1)
 
 query error set_bit\(\): new bit must be 0 or 1
 SELECT set_bit(B'1001010', 0, 2)
 
-query error set_bit\(\): SetBitAtIndex: bit index 0 out of valid range \(0..-1\)
+query error set_bit\(\): bit index 0 out of valid range \(0..-1\)
 SELECT set_bit(B'', 0, 1)
 
 query IT

--- a/pkg/util/bitarray/bitarray.go
+++ b/pkg/util/bitarray/bitarray.go
@@ -582,8 +582,7 @@ func Next(d BitArray) BitArray {
 func (d BitArray) GetBitAtIndex(index int) (int, error) {
 	// Check whether index asked is inside BitArray.
 	if index < 0 || uint(index) >= d.BitLen() {
-		err := fmt.Errorf("GetBitAtIndex: bit index %d out of valid range (0..%d)", index, int(d.BitLen())-1)
-		return 0, pgerror.WithCandidateCode(err, pgcode.ArraySubscript)
+		return 0, pgerror.Newf(pgcode.ArraySubscript, "bit index %d out of valid range (0..%d)", index, int(d.BitLen())-1)
 	}
 	// To extract bit at the given index, we have to determine the
 	// position within words array, i.e. index/numBitsPerWord after
@@ -599,8 +598,7 @@ func (d BitArray) SetBitAtIndex(index, toSet int) (BitArray, error) {
 	res := d.Clone()
 	// Check whether index asked is inside BitArray.
 	if index < 0 || uint(index) >= res.BitLen() {
-		err := fmt.Errorf("SetBitAtIndex: bit index %d out of valid range (0..%d)", index, int(res.BitLen())-1)
-		return BitArray{}, pgerror.WithCandidateCode(err, pgcode.ArraySubscript)
+		return BitArray{}, pgerror.Newf(pgcode.ArraySubscript, "bit index %d out of valid range (0..%d)", index, int(res.BitLen())-1)
 	}
 	// To update bit at the given index, we have to determine the
 	// position within words array, i.e. index/numBitsPerWord after

--- a/pkg/util/bitarray/bitarray_test.go
+++ b/pkg/util/bitarray/bitarray_test.go
@@ -726,9 +726,9 @@ func TestGetBitAtIndex(t *testing.T) {
 		{"111111111111110001010101000000", "", 20, 0},
 		{"111111111111110001011101000000", "", 20, 1},
 		{"11111111", "", 7, 1},
-		{"010110", "GetBitAtIndex: bit index -1 out of valid range (0..5)", -1, 0},
-		{"", "GetBitAtIndex: bit index 0 out of valid range (0..-1)", 0, 0},
-		{"10100110", "GetBitAtIndex: bit index 8 out of valid range (0..7)", 8, 0},
+		{"010110", "bit index -1 out of valid range (0..5)", -1, 0},
+		{"", "bit index 0 out of valid range (0..-1)", 0, 0},
+		{"10100110", "bit index 8 out of valid range (0..7)", 8, 0},
 	}
 	for _, test := range testData {
 		t.Run(fmt.Sprintf("{%v,%d}", test.bitString, test.index), func(t *testing.T) {
@@ -758,9 +758,9 @@ func TestSetBitAtIndex(t *testing.T) {
 		{"1010101011", "", "1010101011", 0, 1},
 		{"1010101011", "", "1010101011", 1, 0},
 		{"111111111111110001010101000000", "", "111111111111110001011101000000", 20, 1},
-		{"010110", "SetBitAtIndex: bit index -1 out of valid range (0..5)", "", -1, 0},
-		{"10100110", "SetBitAtIndex: bit index 8 out of valid range (0..7)", "", 8, 0},
-		{"", "SetBitAtIndex: bit index 0 out of valid range (0..-1)", "", 0, 0},
+		{"010110", "bit index -1 out of valid range (0..5)", "", -1, 0},
+		{"10100110", "bit index 8 out of valid range (0..7)", "", 8, 0},
+		{"", "bit index 0 out of valid range (0..-1)", "", 0, 0},
 	}
 	for _, test := range testData {
 		t.Run(fmt.Sprintf("{%v,%d,%d}", test.bitString, test.index, test.toSet), func(t *testing.T) {


### PR DESCRIPTION
This commit removes `GetBitAtIndex` and `SetBitAtIndex` from the errors returned by these functions. It brings them closer to what postgres returns.

Epic: None
Release note: None