### PR TITLE
drt: add create role operation

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "add_index.go",
         "backup_restore.go",
         "cluster_settings.go",
+        "create_role.go",
         "debug_zip.go",
         "disk_stall.go",
         "grant_revoke_all.go",

--- a/pkg/cmd/roachtest/operations/create_role.go
+++ b/pkg/cmd/roachtest/operations/create_role.go
@@ -1,0 +1,70 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+type cleanupCreatedRole struct {
+	role string
+}
+
+func (cl *cleanupCreatedRole) Cleanup(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	o.Status(fmt.Sprintf("dropping role %s", cl.role))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("DROP ROLE IF EXISTS %s", cl.role))
+	if err != nil {
+		o.Fatal(err)
+	}
+}
+
+func runCreateRole(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) registry.OperationCleanup {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	rng, _ := randutil.NewPseudoRand()
+	roleName := fmt.Sprintf("roachtest_role_%d", rng.Uint32())
+
+	o.Status(fmt.Sprintf("creating role %s", roleName))
+	_, err := conn.ExecContext(ctx, fmt.Sprintf("CREATE ROLE %s", roleName))
+	if err != nil {
+		o.Fatal(err)
+	}
+
+	o.Status(fmt.Sprintf("role %s created", roleName))
+
+	return &cleanupCreatedRole{
+		role: roleName,
+	}
+}
+
+func registerCreateRole(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:               "create-role",
+		Owner:              registry.OwnerSQLFoundations,
+		Timeout:            1 * time.Hour,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+		Run:                runCreateRole,
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -19,6 +19,7 @@ func RegisterOperations(r registry.Registry) {
 	registerNetworkPartition(r)
 	registerDiskStall(r)
 	registerNodeKill(r)
+	registerCreateRole(r)
 	registerClusterSettings(r)
 	registerBackupRestore(r)
 	registerManualCompaction(r)


### PR DESCRIPTION
This patch introduces a new operation that creates a SQL role with a randomized name and drops it during cleanup

Epic: none
Fixes: #138412
Release note: None