### PR TITLE
drt: add generic framework for SQL object creation and cleanup

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "register.go",
         "resize.go",
         "session_vars.go",
+        "sql_objects.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operations",
     visibility = ["//visibility:public"],

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -20,6 +20,7 @@ func RegisterOperations(r registry.Registry) {
 	registerDiskStall(r)
 	registerNodeKill(r)
 	registerClusterSettings(r)
+	registerCreateSQLOperations(r)
 	registerBackupRestore(r)
 	registerManualCompaction(r)
 	registerResize(r)

--- a/pkg/cmd/roachtest/operations/sql_objects.go
+++ b/pkg/cmd/roachtest/operations/sql_objects.go
@@ -1,0 +1,126 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// genericSQLCleanup is a generic cleanup struct that drops a SQL object
+// (e.g., ROLE, USER, TYPE, TABLE) using a simple DROP statement.
+// It assumes the object name was generated and is safe to drop unconditionally.
+type genericSQLCleanup struct {
+	objectType string
+	objectName string
+}
+
+func (cl *genericSQLCleanup) Cleanup(
+	ctx context.Context, o operation.Operation, c cluster.Cluster,
+) {
+	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	o.Status(fmt.Sprintf("dropping %s %s", cl.objectType, cl.objectName))
+	_, err := conn.ExecContext(ctx,
+		fmt.Sprintf("DROP %s %s", cl.objectType, cl.objectName))
+	if err != nil {
+		o.Fatal(err)
+	}
+}
+
+func runSQLOperation(
+	objectType string, namePrefix string, createSQL func(name string) string,
+) func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+		conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+		defer conn.Close()
+
+		rng, _ := randutil.NewPseudoRand()
+		name := fmt.Sprintf("%s_%d", namePrefix, rng.Uint32())
+
+		createStmt := createSQL(name)
+
+		o.Status(fmt.Sprintf("creating %s %s", objectType, name))
+		if _, err := conn.ExecContext(ctx, createStmt); err != nil {
+			o.Fatal(err)
+		}
+
+		o.Status(fmt.Sprintf("%s %s created", objectType, name))
+
+		return &genericSQLCleanup{
+			objectType: objectType,
+			objectName: name,
+		}
+	}
+}
+
+// registerCreateSQLOperations registers a group of SQL object creation operations
+// (e.g., create-role, create-user, create-type, create-table) under a shared
+// framework that handles execution and cleanup consistently.
+func registerCreateSQLOperations(r registry.Registry) {
+	objs := []struct {
+		name       string
+		objectType string
+		prefix     string
+		createSQL  func(name string) string
+	}{
+		{
+			name:       "create-role",
+			objectType: "ROLE",
+			prefix:     "roachtest_role",
+			createSQL: func(name string) string {
+				return fmt.Sprintf("CREATE ROLE %s", name)
+			},
+		},
+		{
+			name:       "create-user",
+			objectType: "USER",
+			prefix:     "roachtest_user",
+			createSQL: func(name string) string {
+				return fmt.Sprintf("CREATE USER %s", name)
+			},
+		},
+		{
+			name:       "create-type",
+			objectType: "TYPE",
+			prefix:     "roachtest_enum",
+			createSQL: func(name string) string {
+				enumVals := []string{"'one'", "'two'", "'three'"}
+				return fmt.Sprintf("CREATE TYPE %s AS ENUM (%s)", name, strings.Join(enumVals, ", "))
+			},
+		},
+		{
+			name:       "create-table",
+			objectType: "TABLE",
+			prefix:     "roachtest_table",
+			createSQL: func(name string) string {
+				return fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, val STRING)", name)
+			},
+		},
+	}
+
+	for _, obj := range objs {
+		r.AddOperation(registry.OperationSpec{
+			Name:               obj.name,
+			Owner:              registry.OwnerSQLFoundations,
+			Timeout:            time.Hour,
+			CompatibleClouds:   registry.AllClouds,
+			CanRunConcurrently: registry.OperationCanRunConcurrently,
+			Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase},
+			Run:                runSQLOperation(obj.objectType, obj.prefix, obj.createSQL),
+		})
+	}
+}


### PR DESCRIPTION
This patch introduces a unified framework that allows declarative registration of SQL object operations. Each operation specifies its object type, naming pattern, and creation statement, while cleanup is handled generically with a simple DROP statement. This framework supports `create-role`, `create-user`, `create-type`, and `create-table` operations out of the box.

Epic: none
Fixes: #138412, #138413, #138416, #138417, #138418, #138419
Release note: None