### PR TITLE
backup: set details.DownloadSpans in blocking OR job

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1775,7 +1775,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_do_download_files"); err != nil {
 			return err
 		}
-		return r.doDownloadFiles(ctx, p, details.DownloadSpans)
+		return r.doDownloadFiles(ctx, p)
 	}
 
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_load_descriptors_from_backup"); err != nil {
@@ -1820,6 +1820,21 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	preData, preValidateData, mainData, err := createImportingDescriptors(ctx, p, backupCodec, sqlDescs, r, latestBackupManifest)
 	if err != nil {
 		return err
+	}
+
+	if details.OnlineImpl() && len(details.DownloadSpans) == 0 {
+		// Persist the download spans before the link phase begins as OnFailOrCancel
+		// could use them if called.
+		downloadSpans, err := getDownloadSpans(p.ExecCfg().Codec, preData, mainData)
+		if err != nil {
+			return err
+		}
+		// Ensure we have the latest copy of the job details.
+		details = r.job.Details().(jobspb.RestoreDetails)
+		details.DownloadSpans = downloadSpans
+		if err := r.job.NoTxn().SetDetails(ctx, details); err != nil {
+			return errors.Wrap(err, "updating job details with download spans")
+		}
 	}
 
 	// Refresh the job details since they may have been updated when creating the
@@ -1977,11 +1992,13 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		return errors.Wrap(err, "inserting table statistics")
 	}
 	if details.ExperimentalCopy {
-		downloadSpans, err := getDownloadSpans(p.ExecCfg().Codec, preData, mainData)
-		if err != nil {
-			return err
+		if len(details.DownloadSpans) == 0 && !details.SchemaOnly {
+			return errors.AssertionFailedf("download spans should have been persisted to job details")
 		}
-		if err := r.doDownloadFiles(ctx, p, downloadSpans); err != nil {
+		// TODO(msbutler): ideally doDownloadFiles would not depend on job details
+		// and is instead passed an execCfg and the download spans and anything else
+		// it needs. If that occured, we would not need to update details above.
+		if err := r.doDownloadFiles(ctx, p); err != nil {
 			return err
 		}
 	}
@@ -2067,7 +2084,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 	}
 
 	r.restoreStats = resTotal
-	if err := r.maybeWriteDownloadJob(ctx, p.ExecCfg(), preData, mainData); err != nil {
+	if err := r.maybeWriteDownloadJob(ctx, p.ExecCfg()); err != nil {
 		return err
 	}
 

--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1860,7 +1860,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 			err.Error())
 	}
 
-	if len(details.TableDescs) == 0 && len(details.Tenants) == 0 && len(details.TypeDescs) == 0 {
+	if len(details.TableDescs) == 0 && len(details.Tenants) == 0 {
 		// We have no tables to restore (we are restoring an empty DB).
 		// Since we have already created any new databases that we needed,
 		// we can return without importing any data.

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -580,7 +580,10 @@ func getDownloadSpans(
 	if err != nil {
 		return nil, errors.Wrap(err, "creating key rewriter from rekeys")
 	}
-	downloadSpans := mainRestoreData.getSpans()
+	downloadSpans := make([]roachpb.Span, 0, len(mainRestoreData.getSpans())+len(preRestoreData.getSpans()))
+	for _, span := range mainRestoreData.getSpans() {
+		downloadSpans = append(downloadSpans, span.Clone())
+	}
 
 	// Intentionally download preRestoreData after the main data. During a cluster
 	// restore, preRestore data are linked to a temp system db that are then
@@ -588,10 +591,13 @@ func getDownloadSpans(
 	// should never be queried. We still want to download this data, however, to
 	// protect against external storage deletions of these linked in ssts, but at
 	// lower priority to the main data.
-	downloadSpans = append(downloadSpans, preRestoreData.getSpans()...)
+	for _, span := range preRestoreData.getSpans() {
+		downloadSpans = append(downloadSpans, span.Clone())
+	}
+
 	for i := range downloadSpans {
 		var err error
-		downloadSpans[i], err = rewriteSpan(kr, downloadSpans[i].Clone(), execinfrapb.ElidePrefix_None)
+		downloadSpans[i], err = rewriteSpan(kr, downloadSpans[i], execinfrapb.ElidePrefix_None)
 		if err != nil {
 			return nil, err
 		}
@@ -600,28 +606,24 @@ func getDownloadSpans(
 }
 
 func (r *restoreResumer) maybeWriteDownloadJob(
-	ctx context.Context,
-	execConfig *sql.ExecutorConfig,
-	preRestoreData restorationData,
-	mainRestoreData restorationData,
+	ctx context.Context, execConfig *sql.ExecutorConfig,
 ) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
 	if !details.ExperimentalOnline {
 		return nil
 	}
 
-	downloadSpans, err := getDownloadSpans(execConfig.Codec, preRestoreData, mainRestoreData)
-	if err != nil {
-		return errors.Wrap(err, "failed to get download spans")
+	if len(details.DownloadSpans) == 0 && !details.SchemaOnly {
+		return errors.AssertionFailedf("download spans should have been persisted to job details")
 	}
 
-	log.Infof(ctx, "creating job to track downloads in %d spans", len(downloadSpans))
+	log.Infof(ctx, "creating job to track downloads in %d spans", len(details.DownloadSpans))
 	downloadJobRecord := jobs.Record{
 		Description: fmt.Sprintf("Background Data Download for %s", r.job.Payload().Description),
 		Username:    r.job.Payload().UsernameProto.Decode(),
 		Details: jobspb.RestoreDetails{
 			DownloadJob:                        true,
-			DownloadSpans:                      downloadSpans,
+			DownloadSpans:                      details.DownloadSpans,
 			PostDownloadTableAutoStatsSettings: details.PostDownloadTableAutoStatsSettings},
 		Progress: jobspb.RestoreProgress{},
 	}
@@ -733,15 +735,13 @@ func getRemainingExternalFileBytes(
 	return remaining, nil
 }
 
-func (r *restoreResumer) doDownloadFiles(
-	ctx context.Context, execCtx sql.JobExecContext, downloadSpans roachpb.Spans,
-) error {
+func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExecContext) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
 
 	grp := ctxgroup.WithContext(ctx)
 	completionPoller := make(chan struct{})
 
-	grp.GoCtx(r.sendDownloadWorker(execCtx, downloadSpans, completionPoller))
+	grp.GoCtx(r.sendDownloadWorker(execCtx, details.DownloadSpans, completionPoller))
 	grp.GoCtx(func(ctx context.Context) error {
 		return r.waitForDownloadToComplete(ctx, execCtx, details, completionPoller)
 	})

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -568,7 +568,7 @@ func sendDownloadSpan(ctx context.Context, execCtx sql.JobExecContext, spans roa
 }
 
 func getDownloadSpans(
-	codec keys.SQLCodec, preRestoreData *restorationDataBase, mainRestoreData *mainRestorationData,
+	codec keys.SQLCodec, preRestoreData restorationData, mainRestoreData restorationData,
 ) (roachpb.Spans, error) {
 	rekey := mainRestoreData.getRekeys()
 	rekey = append(rekey, preRestoreData.getRekeys()...)
@@ -602,8 +602,8 @@ func getDownloadSpans(
 func (r *restoreResumer) maybeWriteDownloadJob(
 	ctx context.Context,
 	execConfig *sql.ExecutorConfig,
-	preRestoreData *restorationDataBase,
-	mainRestoreData *mainRestorationData,
+	preRestoreData restorationData,
+	mainRestoreData restorationData,
 ) error {
 	details := r.job.Details().(jobspb.RestoreDetails)
 	if !details.ExperimentalOnline {

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -633,8 +633,8 @@ message RestoreDetails {
 
   bool experimental_online = 31;
 
-  // DownloadSpans indicates this job is the download-step of a multi-step
-  // online restore.
+  // DownloadSpans indicates this job has run a link phase. These spans must be
+  // downloaded, else the OnFailOrCancel has to excice these spans.
   repeated roachpb.Span download_spans = 32 [(gogoproto.nullable) = false];
 
   // Removes regions.


### PR DESCRIPTION
As soon as the link phase starts, OR must be prepared to excise the restoring
key space in the event of a job failure or cancellation. This patch persists
DownloadSpans to the job record so the OnFailOrCancel routine can easily begin
recovery. This patch also slightly refactors the doDownloadSpans args to always
use details.DownloadSpans.

Epic: none

Release note: none