### PR TITLE
dr: alias streaming replication to PCR

### DIFF
--- a/docs/RFCS/20201119_streaming_cluster_to_cluster.md
+++ b/docs/RFCS/20201119_streaming_cluster_to_cluster.md
@@ -5,7 +5,7 @@
 - RFC PR: 56932
 - Cockroach Issue: #57433
 
-# Streaming Replication Between Clusters
+# Streaming Replication Between Clusters (aka Physical Cluster Replication - PCR)
 
 ## Summary
 


### PR DESCRIPTION
Add an alias in the original Streaming Replication Between Clusters RFC to PCR, for easier discovery.

I can see an argument for not merging this, as the original RFC might not bare resemblance to what was built in the end, but the RFC is basically undiscoverable today due to its antiquated naming.

Epic: none
Release note: None