### PR TITLE
kvserver: create a new PebbleCorruptionError

### DIFF
--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -45,6 +45,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//extgrpc",
+        "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//proto",

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	_ "github.com/cockroachdb/errors/extgrpc" // register EncodeError support for gRPC Status
+	"github.com/cockroachdb/pebble"
 	"github.com/cockroachdb/redact"
 	"github.com/gogo/protobuf/proto"
 )
@@ -347,6 +348,7 @@ func init() {
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.RefreshFailedError", &RefreshFailedError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.MVCCHistoryMutationError", &MVCCHistoryMutationError{})
 	errors.RegisterTypeMigration(roachpbPath, "*roachpb.InsufficientSpaceError", &InsufficientSpaceError{})
+	errors.RegisterTypeMigration(roachpbPath, "*roachpb.PebbleCorruptionError", &PebbleCorruptionError{})
 }
 
 // GoError returns a Go error converted from Error. If the error is a transaction
@@ -1621,6 +1623,35 @@ func (e *InsufficientSpaceError) Format(s fmt.State, verb rune) {
 func (e *InsufficientSpaceError) SafeFormatError(p errors.Printer) (next error) {
 	p.Printf("store %d has insufficient remaining capacity to %s (remaining: %s / %.1f%%, min required: %.1f%%)",
 		e.StoreID, redact.SafeString(e.Op), humanizeutil.IBytes(e.Available), float64(e.Available)/float64(e.Capacity)*100, e.Required*100)
+	return nil
+}
+
+// NewPebbleCorruptionError creates a new PebbleCorruptionError.
+func NewPebbleCorruptionError(
+	storeID roachpb.StoreID, info *pebble.DataCorruptionInfo,
+) *PebbleCorruptionError {
+	err := &PebbleCorruptionError{
+		StoreID:  storeID,
+		Path:     info.Path,
+		IsRemote: info.IsRemote,
+		ExtraMsg: info.Details.Error(),
+	}
+	return err
+}
+
+func (e *PebbleCorruptionError) Error() string {
+	return fmt.Sprint(e)
+}
+
+// Format implements fmt.Formatter.
+func (e *PebbleCorruptionError) Format(s fmt.State, verb rune) {
+	errors.FormatError(e, s, verb)
+}
+
+// SafeFormatError implements errors.SafeFormatter.
+func (e *PebbleCorruptionError) SafeFormatError(p errors.Printer) (next error) {
+	p.Printf("pebble corruption error on store id:%d, path:%s, remote:%t, extra message: %s",
+		e.StoreID, e.Path, e.IsRemote, e.ExtraMsg)
 	return nil
 }
 

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -791,3 +791,16 @@ message InsufficientSpaceError {
    // RequiredFraction is the required remaining capacity fraction.
    optional double required = 5 [(gogoproto.nullable) = false];
 }
+
+
+// PebbleCorruptionError indicates that pebble thinks that there is a data                                                                                                                                                                                  
+// corruption.                                                                                                                                                                                                                                                
+message PebbleCorruptionError {
+  optional int64 store_id = 1 [(gogoproto.nullable) = false,
+    (gogoproto.customname) = "StoreID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.StoreID"];
+  optional string path = 2 [(gogoproto.nullable) = false];
+  optional bool is_remote = 3 [(gogoproto.nullable) = false];
+  optional string extra_msg = 4 [(gogoproto.nullable) = false];
+}
+   

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/pebble"
 	"github.com/kr/pretty"
 )
 
@@ -559,6 +560,15 @@ func evaluateCommand(
 		}
 		log.VEventf(ctx, 2, "evaluated %s command %s, txn=%v : resp=%s, err=%v",
 			args.Method(), trunc(args.String()), h.Txn, resp, err)
+	}
+
+	// If there is a pebble data corruption error, we want to serialize it by
+	// returning the KV error PebbleCorruptionError. This way, the error can be
+	// extracted by KV clients.
+	if err != nil {
+		if info := pebble.ExtractDataCorruptionInfo(err); info != nil {
+			err = kvpb.NewPebbleCorruptionError(rec.StoreID(), info)
+		}
 	}
 	return pd, err
 }


### PR DESCRIPTION
This commit introduces a new KV error called PebbleCorruptionError. This error is set when pebble returns DataCorruptionError, indicating that there is a data corruption (a file that an SSTable is pointing to got deleted for example).

References: #143135

Release note: None