### PR TITLE
roachtest: fix follower-reads/survival=region

### DIFF
--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -56,7 +56,7 @@ func registerFollowerReads(r registry.Registry) {
 				6, /* nodeCount */
 				spec.CPU(4),
 				spec.Geo(),
-				spec.GCEZones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,us-west1-b,europe-west2-b"),
+				spec.GCEZones("us-east1-b,us-east1-b,us-east1-b,us-west1-b,europe-west2-b,europe-west2-b"),
 			),
 			CompatibleClouds: registry.OnlyGCE,
 			Suites:           registry.Suites(registry.Nightly),


### PR DESCRIPTION
Previously, this test allocated 6 nodes: 3 in us-east1, 2 in us-west1, and 1 in europe-west2. When using survival regions, we would have 5 replicas and 2 would be allowed to be virtually anywhere without constraints. However, this proved problematic in serverless environments, as the additional regions could fall outside the user's configured regions. We later modified this logic to use the same constraints as super regions, which now forces one region to have more replicas. This patch adjusts the test so that the Europe region has one more replica to account for this logic.

Fixes: #143333
Fixes: #143199

Release note: None