### PR TITLE
catalog/lease: fix race condition releasing old versions

### DIFF
--- a/pkg/sql/catalog/lease/descriptor_state.go
+++ b/pkg/sql/catalog/lease/descriptor_state.go
@@ -203,10 +203,15 @@ func (t *descriptorState) removeInactiveVersions() []*storedLease {
 	for _, desc := range append([]*descriptorVersionState(nil), t.mu.active.data...) {
 		if desc.refcount.Load() == 0 {
 			t.mu.active.remove(desc)
-			if l := desc.mu.lease; l != nil {
-				desc.mu.lease = nil
-				leases = append(leases, l)
-			}
+			func() {
+				desc.mu.Lock()
+				defer desc.mu.Unlock()
+				if l := desc.mu.lease; l != nil {
+					desc.mu.lease = nil
+					leases = append(leases, l)
+
+				}
+			}()
 		}
 	}
 	return leases


### PR DESCRIPTION
Previously, a race condition existed between the name cache and the logic used to clean up old versions of leased descriptors. This issue was introduced when atomic operations were used to manipulate the descriptor version states. Specifically, after ensuring the reference count is zero, it's necessary to acquire a lock before releasing the stored lease. This patch adds logic to acquire and release a mutex when cleaning up old versions.

Fixes: #143815

Release note: None