### PR TITLE
ci: prioritize `staging-*` builds higher

### DIFF
--- a/build/github/engflow-args.sh
+++ b/build/github/engflow-args.sh
@@ -10,7 +10,10 @@
 
 ARGS='--config engflowpublic --tls_client_certificate=/home/agent/engflow.crt --tls_client_key=/home/agent/engflow.key --experimental_build_event_upload_retry_minimum_delay 3s --experimental_build_event_upload_max_retries 8'
 
-if [ "$GITHUB_ACTIONS_BRANCH" == "staging" ]
+if [[ "$GITHUB_ACTIONS_BRANCH" == staging-* ]]
+then
+    ARGS="$ARGS --remote_execution_priority=8"
+elif [ "$GITHUB_ACTIONS_BRANCH" == "staging" ]
 then
     ARGS="$ARGS --remote_execution_priority=6"
 fi


### PR DESCRIPTION
These builds are high-priority backports and we want them to get through the queue as quickly as possible.

Epic: DEVINF-1449
Release note: None