### PR TITLE
kvclient: enable savepoint rollbacks with buffered writes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -78,7 +78,7 @@ INSERT INTO t1 VALUES (1,1)
 statement ok
 COMMIT
 
-query II
+query II rowsort
 SELECT * FROM t1
 ----
 1 1
@@ -122,7 +122,7 @@ INSERT INTO t2 VALUES (1);
 statement ok
 COMMIT;
 
-query I
+query I rowsort
 SELECT * FROM t2
 ----
 1
@@ -151,7 +151,103 @@ DELETE FROM t3 WHERE k < 10 AND k > 0
 statement ok
 COMMIT
 
-query I
+query I rowsort
 SELECT count(*) from t3
 ----
 0
+
+# Test savepoints, and in particular savepoint rollbacks, with buffered writes. 
+# We test both intermediate selects after rollbacks and the final state
+# the transaction has been committed.
+subtest savepoint_rollbacks
+
+# First, create a new table with a secondary index on it. That way, the DELETE
+# statements below will not use DeleteRange requets which cause the buffer to
+# be flushed.
+statement ok
+CREATE TABLE t4 (k INT PRIMARY KEY, v INT)
+
+statement ok
+CREATE INDEX idx ON t4 (v)
+
+statement ok
+BEGIN;
+INSERT INTO t4 VALUES(1, 100), (2, 200), (3, 300);
+SAVEPOINT s1;
+INSERT INTO t4 VALUES(4, 400), (5, 500), (6, 600)
+
+query II rowsort
+SELECT * FROM t4
+----
+1  100
+2  200
+3  300
+4  400
+5  500
+6  600
+
+statement ok
+SAVEPOINT s2; 
+INSERT INTO t4 VALUES(7, 700), (8, 800), (9, 900)
+
+query II rowsort
+SELECT * FROM t4
+----
+1  100
+2  200
+3  300
+4  400
+5  500
+6  600
+7  700
+8  800
+9  900
+
+# Throw in some Deletes.
+statement ok
+DELETE FROM t4 WHERE k = 1;
+DELETE FROM t4 WHERE k = 2;
+DELETE FROM t4 WHERE k = 3;
+
+query II rowsort
+SELECT * FROM t4
+----
+4  400
+5  500
+6  600
+7  700
+8  800
+9  900
+
+statement ok
+ROLLBACK TO SAVEPOINT s2
+
+query II rowsort
+SELECT * FROM t4
+----
+1  100
+2  200
+3  300
+4  400
+5  500
+6  600
+
+statement ok
+ROLLBACK TO SAVEPOINT s1;
+
+query II rowsort
+SELECT * FROM t4
+----
+1  100
+2  200
+3  300
+
+statement ok
+COMMIT
+
+query II rowsort
+SELECT * FROM t4
+----
+1  100
+2  200
+3  300


### PR DESCRIPTION
First commit from https://github.com/cockroachdb/cockroach/pull/144058

----

This patch correctly handles savepoint rollbacks when buffered writes
are enabled. Whenever a savepoint is rolled back, any writes that belong
to the savepoint are removed from the buffer.

Closes https://github.com/cockroachdb/cockroach/issues/139059

Release note: None