### PR TITLE
release-23.2: schemachange/mixed-versions-compat: disable 23.1 corpus

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_decl_schemachange_compat.go
@@ -138,6 +138,8 @@ func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c 
 
 	// Test definitions which indicates which version of the corpus to fetch,
 	// and the binary to validate against.
+	// Note: Testing against 23.1 corpus files has been removed since we no longer
+	// run nightlies on that branch because that version is end of life.
 	compatTests := []struct {
 		testName               string
 		binaryVersion          *clusterupgrade.Version
@@ -149,11 +151,6 @@ func runDeclSchemaChangeCompatMixedVersions(ctx context.Context, t test.Test, c 
 			binaryVersion:          predecessorVersion,
 			corpusVersion:          fmt.Sprintf("mixed-release-%s", releaseSeries(currentVersion)),
 			alternateCorpusVersion: "mixed-master",
-		},
-		{
-			testName:      "forwards compatibility",
-			binaryVersion: currentVersion,
-			corpusVersion: fmt.Sprintf("release-%s", releaseSeries(predecessorVersion)),
 		},
 		{
 			testName:      "same version",


### PR DESCRIPTION
Previously, logic tests were run on the 23.1 branch to generate a corpus file used to verify that schema change plans remained stable across versions. Since the 23.1 branch is now end-of-life and no longer produces this corpus, running these compatibility tests leads to failures.

This change disables the backwards compatibility test for 23.1 to avoid such test failures due to the missing corpus.

Fixes #143956
Release note: none
Release justification: Test-only change to disable outdated compatibility tests.