### PR TITLE
indexrec: make ReplaceIndex recommendations safer

### DIFF
--- a/pkg/sql/idxrecommendations/idx_recommendations_test.go
+++ b/pkg/sql/idxrecommendations/idx_recommendations_test.go
@@ -52,7 +52,12 @@ func TestIndexRecommendationsStats(t *testing.T) {
 			{
 				stmt:        "SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.k WHERE t1.i > 3 AND t2.i > 3",
 				fingerprint: "SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.k WHERE (t1.i > _) AND (t2.i > _)",
-				recommendations: "{\"replacement : CREATE UNIQUE INDEX ON idxrectest.public.t1 (i) STORING (k); DROP INDEX idxrectest.public.t1@existing_t1_i;\"," +
+				recommendations: "{\"replacement : " +
+					"CREATE UNIQUE INDEX ON idxrectest.public.t1 (i) STORING (k) " +
+					"/* After successfully creating the replacement index, manually run: " +
+					"`ALTER INDEX idxrectest.public.t1@existing_t1_i NOT VISIBLE` " +
+					"and then, after verifying workload performance, manually run: " +
+					"`DROP INDEX idxrectest.public.t1@existing_t1_i` */;\"," +
 					"\"creation : CREATE INDEX ON idxrectest.public.t2 (i) STORING (k);\"}",
 			},
 		}

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -1300,7 +1300,7 @@ vectorized: true
 ·
 index recommendations: 1
 1. type: index replacement
-   SQL commands: CREATE INDEX ON test.public.tt (x) STORING (y); DROP INDEX test.public.tt@a;
+   SQL commands: CREATE INDEX ON test.public.tt (x) STORING (y) /* After successfully creating the replacement index, manually run: `ALTER INDEX test.public.tt@a NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX test.public.tt@a` */;
 
 statement ok
 CREATE DATABASE another_db;

--- a/pkg/sql/opt/indexrec/rec.go
+++ b/pkg/sql/opt/indexrec/rec.go
@@ -285,11 +285,21 @@ func (ir *indexRecommendation) constructIndexRec(ctx context.Context) (Rec, erro
 			Unique: existingIndex.IsUnique(),
 			Type:   ir.index.Type(),
 		}
+		alterCmd := tree.AlterIndexVisible{
+			Index: tree.TableIndexName{
+				Table: tableName,
+				Index: tree.UnrestrictedName(existingIndex.Name()),
+			},
+			Invisibility: tree.IndexInvisibility{
+				Value: 1.0,
+			},
+		}
 		sb.WriteString(createCmd.String())
-		sb.WriteByte(';')
-		sb.WriteByte(' ')
+		sb.WriteString(" /* After successfully creating the replacement index, manually run: `")
+		sb.WriteString(alterCmd.String())
+		sb.WriteString("` and then, after verifying workload performance, manually run: `")
 		sb.WriteString(dropCmd.String())
-		sb.WriteByte(';')
+		sb.WriteString("` */;")
 		return Rec{sb.String(), TypeReplaceIndex}, nil
 	case TypeAlterIndex:
 		alterCmd := tree.AlterIndexVisible{

--- a/pkg/sql/opt/indexrec/testdata/index
+++ b/pkg/sql/opt/indexrec/testdata/index
@@ -76,7 +76,7 @@ scan t1@existing_t1_k
 index-recommendations
 SELECT i FROM t1 WHERE k >= 3
 ----
-replacement: CREATE INDEX ON t.public.t1 (k) STORING (i, s); DROP INDEX t.public.t1@existing_t1_k;
+replacement: CREATE INDEX ON t.public.t1 (k) STORING (i, s) /* After successfully creating the replacement index, manually run: `ALTER INDEX t.public.t1@existing_t1_k NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX t.public.t1@existing_t1_k` */;
 --
 optimal plan:
 project
@@ -94,7 +94,7 @@ project
 index-recommendations
 SELECT t1.k FROM t1 JOIN t2 ON t1.k = t2.k WHERE t1.i > 3 AND t2.i > 3
 ----
-replacement: CREATE UNIQUE INDEX ON t.public.t1 (i) STORING (k); DROP INDEX t.public.t1@existing_t1_i;
+replacement: CREATE UNIQUE INDEX ON t.public.t1 (i) STORING (k) /* After successfully creating the replacement index, manually run: `ALTER INDEX t.public.t1@existing_t1_i NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX t.public.t1@existing_t1_i` */;
 creation: CREATE INDEX ON t.public.t2 (i) STORING (k);
 --
 optimal plan:
@@ -2135,7 +2135,7 @@ CREATE INDEX idx_2 ON t5(v) STORING (i)
 index-recommendations
 SELECT i, j FROM t5 WHERE v > 1
 ----
-replacement: CREATE INDEX ON t.public.t5 (v) STORING (i, j); DROP INDEX t.public.t5@idx_2;
+replacement: CREATE INDEX ON t.public.t5 (v) STORING (i, j) /* After successfully creating the replacement index, manually run: `ALTER INDEX t.public.t5@idx_2 NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX t.public.t5@idx_2` */;
 --
 optimal plan:
 project
@@ -2159,7 +2159,7 @@ CREATE INDEX idx_3 ON t5(v, i)
 index-recommendations
 SELECT i, j FROM t5 WHERE v > 1
 ----
-replacement: CREATE INDEX ON t.public.t5 (v) STORING (i, j); DROP INDEX t.public.t5@idx_1;
+replacement: CREATE INDEX ON t.public.t5 (v) STORING (i, j) /* After successfully creating the replacement index, manually run: `ALTER INDEX t.public.t5@idx_1 NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX t.public.t5@idx_1` */;
 --
 optimal plan:
 project
@@ -2296,7 +2296,7 @@ scan t_notvisible@idx_p_visible
 index-recommendations
 SELECT i FROM t_notvisible WHERE v > 1
 ----
-replacement: CREATE INDEX ON t.public.t_notvisible (v) STORING (i); DROP INDEX t.public.t_notvisible@idx_v_visible;
+replacement: CREATE INDEX ON t.public.t_notvisible (v) STORING (i) /* After successfully creating the replacement index, manually run: `ALTER INDEX t.public.t_notvisible@idx_v_visible NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX t.public.t_notvisible@idx_v_visible` */;
 --
 optimal plan:
 project
@@ -2311,7 +2311,7 @@ project
 index-recommendations
 SELECT i FROM t_notvisible WHERE p > 1
 ----
-replacement: CREATE INDEX ON t.public.t_notvisible (p) STORING (i); DROP INDEX t.public.t_notvisible@idx_p_visible;
+replacement: CREATE INDEX ON t.public.t_notvisible (p) STORING (i) /* After successfully creating the replacement index, manually run: `ALTER INDEX t.public.t_notvisible@idx_p_visible NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX t.public.t_notvisible@idx_p_visible` */;
 --
 optimal plan:
 project

--- a/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/indexActionBtn.tsx
@@ -108,19 +108,23 @@ const IdxRecAction = (props: IdxRecProps): React.ReactElement => {
       );
       break;
     case "ReplaceIndex":
-      title = "replace the index";
-      btnLAbel = "Replace Index";
+      title = "create a replacement index";
+      btnLAbel = "Create Replacement Index";
       descriptionDocs = (
         <>
-          {" "}
+          {"a "}
           <Anchor href={createIndex} target="_blank">
             CREATE INDEX
+          </Anchor>
+          {" statement. The commented-out "}
+          <Anchor href={alterIndex} target="_blank">
+            ALTER INDEX
           </Anchor>
           {" and "}
           <Anchor href={dropIndex} target="_blank">
             DROP INDEX
           </Anchor>
-          {" statements"}
+          {" statements should be copied and run manually afterward"}
         </>
       );
       break;

--- a/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/utils.ts
@@ -158,7 +158,7 @@ export function insightType(type: InsightType): string {
     case "DropIndex":
       return "Drop Unused Index";
     case "ReplaceIndex":
-      return "Replace Index";
+      return "Create Replacement Index";
     case "AlterIndex":
       return "Alter Index";
     case "HighContention":


### PR DESCRIPTION
Change ReplaceIndex recommendations from a two-statement batched command
to a single-statement command with a comment containing additional
statements. For example, a recommendation to replace a secondary index
with a storing secondary index changes from:

```
CREATE INDEX ON defaultdb.public.foo (b) STORING (c); DROP INDEX defaultdb.public.foo@foo_b_idx;
```

to:

```
CREATE INDEX ON defaultdb.public.foo (b) STORING (c) /* After successfully creating the replacement index, manually run: `ALTER INDEX defaultdb.public.foo@foo_b_idx NOT VISIBLE` and then, after verifying workload performance, manually run: `DROP INDEX defaultdb.public.foo@foo_b_idx` */;
```

Fixes: https://github.com/cockroachdb/cockroach/issues/137841

Release note (ui change): Schema insights which recommend replacing an
index were previously a two-statement command consisting of a CREATE
INDEX and a DROP INDEX statement. When these two DDL statements were run
as a single batched command, it was possible for one statement to
succeed and one to fail. This is because DDL statements do not have the
same atomicity guarantees as other SQL statements in CockroachDB.

This commit changes index-replacement insights to be a single CREATE
INDEX statement followed by a comment with additional DDL statements to
be run manually. The first additional DDL statement is an ALTER INDEX
NOT VISIBLE statement, which makes the old index invisible to the
optimizer. The second additional DDL statement is a DROP INDEX statement
which should only be run after making the old index invisible and
verifying that workload performance is satisfactory.