### PR TITLE
raft: do not set self-match on becoming leader

### DIFF
--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -1071,9 +1071,6 @@ func (r *raft) reset(term uint64) {
 			Inflights:   tracker.NewInflights(r.maxInflight, r.maxInflightBytes),
 			IsLearner:   pr.IsLearner,
 		}
-		if id == r.id {
-			pr.Match = r.raftLog.lastIndex()
-		}
 	})
 
 	r.pendingConfIndex = 0

--- a/pkg/raft/testdata/campaign.txt
+++ b/pkg/raft/testdata/campaign.txt
@@ -133,3 +133,15 @@ stabilize
 > 1 receiving messages
   2->1 MsgAppResp Term:1 Log:0/3 Commit:3
   3->1 MsgAppResp Term:1 Log:0/3 Commit:3
+
+raft-state
+----
+1: StateLeader (Voter) Term:1 Lead:1 LeadEpoch:1
+2: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+3: StateFollower (Voter) Term:1 Lead:1 LeadEpoch:1
+
+status 1
+----
+1: StateReplicate match=3 next=4 sentCommit=2 matchCommit=2
+2: StateReplicate match=3 next=4 sentCommit=3 matchCommit=3
+3: StateReplicate match=3 next=4 sentCommit=3 matchCommit=3

--- a/pkg/raft/tracker/progress.go
+++ b/pkg/raft/tracker/progress.go
@@ -38,7 +38,7 @@ import (
 // TODO(pav-kv): consolidate all flow control state changes here. Much of the
 // transitions in raft.go logically belong here.
 type Progress struct {
-	// Match is the index up to which the follower's log is known to match the
+	// Match is the index up to which the peer's log is known to durably match the
 	// leader's.
 	Match uint64
 	// Next is the log index of the next entry to send to this follower. All


### PR DESCRIPTION
This fixes a "nearly" bug.

The contract of `Progress.Match` is that the index is durable. When becoming leader, there is no guarantee that `raftLog.lastIndex()` is durable locally. We could have got a quorum of votes, and yet the local storage hasn't voted/synced yet. We only know that a log index is durable when handling a self-`MsgAppResp` or a storage append ack.

This wasn't a real bug because `raftLog.lastIndex()` is an entry from previous terms, and the first entry at our leader's term comes after it. A leader can only commit entries from its own term (see `maybeCommit`), so this opportunistically set `Match` could not cause false-positive commits. But could be a bug if this `lastIndex` included the dummy entry, which is appended a few instructions down the line.

There is no value in setting `Match` for the leader this way, and it appears cleaner that `Match` is initialized empty and only updated by `MsgAppResp`, symmetrically for all peers including self. For the leader, it will be first updated when the dummy entry makes a durable roundtrip to local storage.

Epic: none
Release note: none