### PR TITLE
storage: enable new format major version

### DIFF
--- a/pkg/cli/testdata/ear-list
+++ b/pkg/cli/testdata/ear-list
@@ -8,13 +8,13 @@ list
 000004.log:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: df 3a 47 28 5e fb 88 e3 9e b3 9b a3
-  counter: 1505393531
+  nonce: f9 35 f1 b1 73 c8 bc 8f bd f3 c0 1b
+  counter: 3210085521
 000005.sst:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: 0c 07 ac 42 50 0d 38 20 3c 91 cf c0
-  counter: 1731579598
+  nonce: 6e 34 f4 3c 11 43 1a f5 69 ce 33 f1
+  counter: 2398097086
 COCKROACHDB_DATA_KEYS_000001_monolith:
   env type: Store, AES128_CTR
   keyID: f594229216d81add7811c4360212eb7629b578ef4eab6e5d05679b3c5de48867
@@ -35,11 +35,11 @@ marker.datakeys.000001.COCKROACHDB_DATA_KEYS_000001_monolith:
   keyID: f594229216d81add7811c4360212eb7629b578ef4eab6e5d05679b3c5de48867
   nonce: 55 d7 d4 27 6c 97 9b dd f1 5d 40 c8
   counter: 467030050
-marker.format-version.000006.019:
+marker.format-version.000008.021:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef
-  nonce: e8 33 ee 2f ba ff 71 dd 29 20 97 62
-  counter: 953786306
+  nonce: 0c 07 ac 42 50 0d 38 20 3c 91 cf c0
+  counter: 1731579598
 marker.manifest.000001.MANIFEST-000001:
   env type: Data, AES128_CTR
   keyID: bbb65a9d114c2a18740f27b6933b74f61018bd5adf545c153b48ffe6473336ef

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2133,6 +2133,7 @@ func (p *Pebble) CreateCheckpoint(dir string, spans []roachpb.Span) error {
 // version associated with it, since they did so during the fence version.
 var pebbleFormatVersionMap = map[clusterversion.Key]pebble.FormatMajorVersion{
 	clusterversion.V24_3: pebble.FormatColumnarBlocks,
+	clusterversion.V25_2: pebble.FormatTableFormatV6,
 }
 
 // pebbleFormatVersionKeys contains the keys in the map above, in descending order.


### PR DESCRIPTION
With cluster version finalization, enable the latest format major version in Pebble.

Epic: none
Release note: none