### PR TITLE
memo: release replacer closure during Memo.Detach

### DIFF
--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -628,6 +628,8 @@ func (m *Memo) NextRoutineResultBufferID() RoutineResultBufferID {
 // constructed in this memo.
 func (m *Memo) Detach() {
 	m.interner = interner{}
+	m.replacer = nil
+
 	// It is important to not hold on to the EvalCtx in the logicalPropsBuilder
 	// (#57059).
 	m.logPropsBuilder = logicalPropsBuilder{}


### PR DESCRIPTION
In #120875 we added a replacer closure to the memo, so that we could call back into `norm.Factory.Replace` from within
`statisticsBuilder.factorOutVirtualCols`, which only has access to the memo and not the factory. This closure, however, means that the memo could potentially prevent GC of, or have an invalid reference to the factory after detachment. We shouldn't need to run the statistics builder on this memo after detaching from the factory (we shouldn't be constructing any new expressions in it) so let's go ahead and release the reference.

Epic: None

Release note: None