### PR TITLE
kvserver: export CachedClosedTimestampPolicy

### DIFF
--- a/pkg/kv/kvserver/closedts/policy.go
+++ b/pkg/kv/kvserver/closedts/policy.go
@@ -13,7 +13,7 @@ import (
 )
 
 const (
-	defaultMaxNetworkRTT = 150 * time.Millisecond
+	DefaultMaxNetworkRTT = 150 * time.Millisecond
 )
 
 // computeLeadTimeForGlobalReads calculates how far ahead of the current time a
@@ -118,7 +118,7 @@ func TargetForPolicy(
 			targetOffsetTime = leadTargetOverride
 			break
 		}
-		targetOffsetTime = computeLeadTimeForGlobalReads(defaultMaxNetworkRTT,
+		targetOffsetTime = computeLeadTimeForGlobalReads(DefaultMaxNetworkRTT,
 			maxClockOffset, sideTransportCloseInterval)
 	default:
 		panic("unexpected RangeClosedTimestampPolicy")

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -2737,6 +2737,21 @@ func (r *Replica) GetMutexForTesting() *ReplicaMutex {
 	return &r.mu.ReplicaMutex
 }
 
+// TODO(wenyihu6): rename the *ForTesting functions to be Testing* (see
+// #144119 for more details).
+
+// SetCachedClosedTimestampPolicyForTesting sets the closed timestamp policy on r
+// to be the given policy. It is a test-only helper method.
+func (r *Replica) SetCachedClosedTimestampPolicyForTesting(policy ctpb.RangeClosedTimestampPolicy) {
+	r.cachedClosedTimestampPolicy.Store(int32(policy))
+}
+
+// GetCachedClosedTimestampPolicyForTesting returns the closed timestamp policy on r.
+// It is a test-only helper method.
+func (r *Replica) GetCachedClosedTimestampPolicyForTesting() ctpb.RangeClosedTimestampPolicy {
+	return ctpb.RangeClosedTimestampPolicy(r.cachedClosedTimestampPolicy.Load())
+}
+
 // maybeEnqueueProblemRange will enqueue the replica for processing into the
 // replicate queue iff:
 //

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -16,7 +16,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -30,12 +29,6 @@ import (
 	"github.com/stretchr/testify/require"
 	"golang.org/x/sync/errgroup"
 )
-
-// TestingSetCachedClosedTimestampPolicy sets the closed timestamp policy on r
-// to be the given policy. It is a test-only helper method.
-func (r *Replica) TestingSetCachedClosedTimestampPolicy(policy ctpb.RangeClosedTimestampPolicy) {
-	r.cachedClosedTimestampPolicy.Store(int32(policy))
-}
 
 func TestSideTransportClosed(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -1095,7 +1095,7 @@ func TestClosedTimestampPolicyRefreshIntervalOnLeaseTransfers(t *testing.T) {
 	})
 
 	// Force repl2 policy to be LAG_BY_CLUSTER_SETTING.
-	repl2.TestingSetCachedClosedTimestampPolicy(ctpb.LAG_BY_CLUSTER_SETTING)
+	repl2.SetCachedClosedTimestampPolicyForTesting(ctpb.LAG_BY_CLUSTER_SETTING)
 	require.Equal(t, roachpb.LAG_BY_CLUSTER_SETTING, repl2.GetRangeInfo(ctx).ClosedTimestampPolicy)
 
 	// Ensure that transferring the lease to repl2 does trigger a lease refresh.


### PR DESCRIPTION
**kvserver: export CachedClosedTimestampPolicy in get, set**

This commit adds two exported method to get and set the
private field replica.CachedClosedTimestampPolicy, which
will be accessed directly outside of the package for testing
purposes.

Release note: none
Epic: none

---

**kvserver/closedts: export DefaultMaxNetworkRTT**

This commit exports closedts.defaultMaxNetworkRTT, which will be used as the
fallback latency value when peer replica latency is unavailable.

Release note: none
Epic: none
