### PR TITLE
backup: skip TestBackupCompaction

### DIFF
--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -39,6 +39,7 @@ import (
 func TestBackupCompaction(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.WithIssue(t, 144110, "flaky test")
 
 	ctx := context.Background()
 	tempDir, tempDirCleanup := testutils.TempDir(t)


### PR DESCRIPTION
This commit skips TestBackupCompaction since it is flaky.

Related: #144110
Release note: none