### PR TITLE
release: add --version-bump-only flag to update_versions

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/update_versions.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions.sh
@@ -14,6 +14,6 @@ source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
 tc_start_block "Run Update Versions Release Phase"
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e RELEASED_VERSION -e NEXT_VERSION -e SMTP_PASSWORD -e GH_TOKEN" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e DRY_RUN -e RELEASED_VERSION -e NEXT_VERSION -e SMTP_PASSWORD -e GH_TOKEN -e VERSION_BUMP_ONLY" \
   run_bazel build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
 tc_end_block "Run Update Versions Release Phase"

--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -10,11 +10,16 @@ set -xeuo pipefail
 
 to=dev-inf+release-dev@cockroachlabs.com
 dry_run=true
+version_bump_only=false
 # override dev defaults with production values
 if [[ -z "${DRY_RUN}" ]] ; then
   echo "Setting production values"
   to=release-engineering-team@cockroachlabs.com
   dry_run=false
+fi
+
+if [[ -n "${VERSION_BUMP_ONLY}" ]] ; then
+  version_bump_only=true
 fi
 
 # run git fetch in order to get all remote branches
@@ -31,6 +36,7 @@ bazel build --config=crosslinux //pkg/cmd/release
 $(bazel info --config=crosslinux bazel-bin)/pkg/cmd/release/release_/release \
   update-versions \
   --dry-run=$dry_run \
+  --version-bump-only=$version_bump_only \
   --released-version=$RELEASED_VERSION \
   --next-version=$NEXT_VERSION \
   --template-dir=pkg/cmd/release/templates \

--- a/pkg/cmd/release/update_versions.go
+++ b/pkg/cmd/release/update_versions.go
@@ -35,6 +35,7 @@ Release justification: non-production (release infra) change.
 const (
 	releasedVersionFlag = "released-version"
 	nextVersionFlag     = "next-version"
+	versionBumpOnly     = "version-bump-only"
 )
 
 var updateVersionsFlags = struct {
@@ -46,6 +47,7 @@ var updateVersionsFlags = struct {
 	smtpHost           string
 	smtpPort           int
 	emailAddresses     []string
+	versionBumpOnly    bool
 }{}
 
 var updateVersionsCmd = &cobra.Command{
@@ -57,6 +59,7 @@ var updateVersionsCmd = &cobra.Command{
 
 func init() {
 	updateVersionsCmd.Flags().BoolVar(&updateVersionsFlags.dryRun, dryRun, false, "print diff and emails without any side effects")
+	updateVersionsCmd.Flags().BoolVar(&updateVersionsFlags.versionBumpOnly, versionBumpOnly, false, "only bump the version, do not create any other PRs")
 	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.releasedVersionStr, releasedVersionFlag, "", "released cockroachdb version")
 	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.nextVersionStr, nextVersionFlag, "", "next cockroachdb version")
 	updateVersionsCmd.Flags().StringVar(&updateVersionsFlags.templatesDir, templatesDir, "", "templates directory")
@@ -489,6 +492,10 @@ func generateRepoList(
 			},
 		}
 		reposToWorkOn = append(reposToWorkOn, repo)
+	}
+	if updateVersionsFlags.versionBumpOnly {
+		log.Println("Version bump only, skipping other PRs")
+		return reposToWorkOn, nil
 	}
 
 	// 2. Brew. Update for all stable releases


### PR DESCRIPTION
Previously, the update_versions command would always generate PRs for all repos. In some cases we want to generate version bumps without affecting other repos. This commit adds a --version-bump-only flag.

Release note: none
Epic: none