### PR TITLE
workload/tpcc: temporarily add back golang.org/x/exp/rand

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -282,7 +282,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`roachmart`:  0xda5e73423dbdb2d9,
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
-		`tpcc`:       0x3f37ea71beae16fb,
+		`tpcc`:       0xcccced25deea244e,
 		`tpch`:       0xcd2abbd021ed895d,
 		`ycsb`:       0x0e6012ee6491a0fb,
 	}

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2090,6 +2090,8 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`pkg/cmd/mirror/go/mirror.go`),
 			// As above, the bazel build tag has an impact here.
 			stream.GrepNot(`pkg/testutils/docker/single_node_docker_test.go`),
+			// TODO(#143870): remove uses of this package.
+			stream.GrepNot(`"golang.org/x/exp/rand" is deprecated`),
 		}
 		for analyzerName, config := range nogoConfig {
 			if !staticcheckCheckNameRe.MatchString(analyzerName) {

--- a/pkg/workload/tpcc/BUILD.bazel
+++ b/pkg/workload/tpcc/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_spf13_pflag//:pflag",
+        "@org_golang_x_exp//rand",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/pflag"
+	randold "golang.org/x/exp/rand"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -661,6 +662,9 @@ func (w *tpcc) Tables() []workload.Table {
 	aCharsInit := workloadimpl.PrecomputedRandInit(rand.NewPCG(seed, 0), precomputedLength, aCharsAlphabet)
 	lettersInit := workloadimpl.PrecomputedRandInit(rand.NewPCG(seed, 0), precomputedLength, lettersAlphabet)
 	numbersInit := workloadimpl.PrecomputedRandInit(rand.NewPCG(seed, 0), precomputedLength, numbersAlphabet)
+	aCharsInitOld := workloadimpl.PrecomputedRandInit(randold.New(randold.NewSource(seed)), precomputedLength, aCharsAlphabet)
+	lettersInitOld := workloadimpl.PrecomputedRandInit(randold.New(randold.NewSource(seed)), precomputedLength, lettersAlphabet)
+	numbersInitOld := workloadimpl.PrecomputedRandInit(randold.New(randold.NewSource(seed)), precomputedLength, numbersAlphabet)
 	if w.localsPool == nil {
 		w.localsPool = &sync.Pool{
 			New: func() interface{} {
@@ -673,6 +677,15 @@ func (w *tpcc) Tables() []workload.Table {
 						aChars:  aCharsInit(),
 						letters: lettersInit(),
 						numbers: numbersInit(),
+					},
+					rngOld: tpccRandOld{
+						Rand: randold.New(randold.NewSource(uint64(timeutil.Now().UnixNano()))),
+						// Intentionally wait until here to initialize the precomputed rands
+						// so a caller of Tables that only wants schema doesn't compute
+						// them.
+						aChars:  aCharsInitOld(),
+						letters: lettersInitOld(),
+						numbers: numbersInitOld(),
 					},
 				}
 			},


### PR DESCRIPTION
This commit is partial revert of 84dd73a7fecef8360194f8f72ab818d2c307dd8b which removed the usages of golang.org/x/exp/rand from the code base. In particular, this commit brings back the usage into Order and OrderLine generation of TPCC fixtures since the mentioned commit broke the mixed-version import. It's not immediately clear what's wrong there, but the imported tables in the mixed-version 25.1-master state don't pass 3.3.2.4 check.

I've been using COCKROACH_RANDOM_SEED=-1621471749504012229 with `import/mixed-versions` for (relatively) fast reproduction.

Informs: #143870.
Epic: None
Release note: None