### PR TITLE
sql: Fix flaky TestInternalAppNamePrefix

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -2457,11 +2457,11 @@ func TestInternalAppNamePrefix(t *testing.T) {
 		initialInternalMetrics := sqlServer.InternalMetrics.ExecutedStatementCounters.InsertCount.Count()
 		initialUserMetrics := sqlServer.Metrics.ExecutedStatementCounters.InsertCount.Count()
 		runner.Exec(t, "INSERT into test values (1, 1)")
-		// Confirm only internal metrics increased.
+		// Confirm user metrics did not increase.
 		finalInternalMetrics := sqlServer.InternalMetrics.ExecutedStatementCounters.InsertCount.Count()
 		finalUserMetrics := sqlServer.Metrics.ExecutedStatementCounters.InsertCount.Count()
 		require.Equal(t, initialUserMetrics, finalUserMetrics)
-		require.Equal(t, initialInternalMetrics+1, finalInternalMetrics)
+		require.Greater(t, finalInternalMetrics, initialInternalMetrics)
 	})
 
 	t.Run("app name set in session", func(t *testing.T) {
@@ -2486,20 +2486,18 @@ func TestInternalAppNamePrefix(t *testing.T) {
 		runner.Exec(t, fmt.Sprintf("set application_name='%v'", catconstants.InternalAppNamePrefix+"mytest"))
 		runner.Exec(t, "INSERT into test values (2, 1)")
 
-		// Confirm only internal metrics increased.
+		// Confirm user metrics did not increase.
 		finalInternalMetrics := sqlServer.InternalMetrics.ExecutedStatementCounters.InsertCount.Count()
 		finalUserMetrics := sqlServer.Metrics.ExecutedStatementCounters.InsertCount.Count()
 		require.Equal(t, initialUserMetrics, finalUserMetrics)
-		require.Equal(t, initialInternalMetrics+1, finalInternalMetrics)
+		require.Greater(t, finalInternalMetrics, initialInternalMetrics)
 
 		// Reset app name.
 		runner.Exec(t, "set application_name='mytest'")
 		runner.Exec(t, "INSERT into test values (3, 1)")
 
-		// Confirm only user metrics increased.
-		finalInternalMetrics = sqlServer.InternalMetrics.ExecutedStatementCounters.InsertCount.Count()
+		// Confirm user metrics increased.
 		finalUserMetrics = sqlServer.Metrics.ExecutedStatementCounters.InsertCount.Count()
-		require.Equal(t, initialUserMetrics+1, finalUserMetrics)
-		require.Equal(t, initialInternalMetrics+1, finalInternalMetrics)
+		require.Greater(t, finalUserMetrics, initialUserMetrics)
 	})
 }


### PR DESCRIPTION
Previously the test would assert that the internal metrics and user metrics increased or stayed the same based on the app name.

However, for the internal metrics this was flaky, so instead of looking for the metric count to increase by 1, we just require that it increased, and most importantly that the user metrics don't increase when internal app name is set.

Release note: None
Fixes: #144094