### PR TITLE
kvclient,sql: address a couple of TODOs for buffered writes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1167,12 +1167,15 @@ func (tc *TxnCoordSender) SetBufferedWritesEnabled(enabled bool) {
 	tc.mu.Lock()
 	defer tc.mu.Unlock()
 
-	if tc.mu.active && enabled && !tc.interceptorAlloc.txnWriteBuffer.enabled {
+	if enabled == tc.interceptorAlloc.txnWriteBuffer.enabled {
+		// No-op since we don't change whether write buffering is enabled.
+		return
+	}
+
+	if tc.mu.active && enabled {
 		panic("cannot enable buffered writes on a running transaction")
 	}
-	tc.interceptorAlloc.txnWriteBuffer.enabled = enabled
-	// TODO(yuzefovich): flush the buffer when going from "enabled" to
-	// "disabled".
+	tc.interceptorAlloc.txnWriteBuffer.setEnabled(enabled)
 }
 
 // BufferedWritesEnabled is part of the kv.TxnSender interface.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_pipeliner_test.go
@@ -35,19 +35,19 @@ import (
 // to SendLocked will return the default successful response.
 type mockLockedSender struct {
 	mockFn func(*kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error)
-	// numCalled is the number of times the mock function has been called.
+	// numCalled is the number of times SendLocked function has been called.
 	numCalled int
 }
 
 func (m *mockLockedSender) SendLocked(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, *kvpb.Error) {
+	m.numCalled++
 	if m.mockFn == nil {
 		br := ba.CreateReply()
 		br.Txn = ba.Txn
 		return br, nil
 	}
-	m.numCalled++
 	return m.mockFn(ba)
 }
 
@@ -58,7 +58,7 @@ func (m *mockLockedSender) MockSend(
 	m.mockFn = fn
 }
 
-// NumCalled returns the number of times the mock function has been called.
+// NumCalled returns the number of times the SendLocked function has been called.
 func (m *mockLockedSender) NumCalled() int {
 	return m.numCalled
 }

--- a/pkg/kv/sender.go
+++ b/pkg/kv/sender.go
@@ -131,7 +131,7 @@ type TxnSender interface {
 	// gateway node until the commit time. Only allowed on the RootTxn. Buffered
 	// writes cannot be enabled on a txn that performed any requests. When
 	// disabling buffered writes, if there are any writes in the buffer, they
-	// are flushed.
+	// are flushed with the next BatchRequest.
 	SetBufferedWritesEnabled(bool)
 
 	// BufferedWritesEnabled returns whether the buffered writes are enabled.

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -243,6 +243,11 @@ func (ts *txnState) resetForNewSQLTxn(
 			if err := ts.setIsolationLevelLocked(isoLevel); err != nil {
 				panic(err)
 			}
+			if isoLevel != isolation.Serializable {
+				// TODO(#143497): we currently only support buffered writes
+				// under serializable isolation.
+				bufferedWritesEnabled = false
+			}
 			if bufferedWritesEnabled {
 				ts.mu.txn.SetBufferedWritesEnabled(true /* enabled */)
 			}


### PR DESCRIPTION
**kvclient: improve mockLockedSender**

Previously, `NumCalled` would only keep track of the number of times the mock function of mockLockedSender has been called. In particular, this would mean that all `SendLocked` calls before the first `MockSend` in a test would not count towards the `NumCalled` number. I find this behavior confusing, so we now will track all `SendLocked` calls.

**kvclient,sql: address a couple of TODOs for buffered writes**

This commit addresses a couple of TODOs:
- we now actually flush the buffer when write buffering goes from "enabled" to "disabled" (which is done when we see the first DDL on the txn). In order to simplify the logic, the flush occurs on the next BatchRequest.
- we now only enable write buffering on the txn under serializable isolation. Read committed has a known issue, but snapshot _should_ be ok, yet we choose to be safe and disable for both.

Epic: None
Release note: None