### PR TITLE
release-24.1: ci: prioritize `staging-*` builds higher

### DIFF
--- a/build/github/engflow-args.sh
+++ b/build/github/engflow-args.sh
@@ -10,6 +10,14 @@
 
 ARGS='--config engflowpublic --tls_client_certificate=/home/agent/engflow.crt --tls_client_key=/home/agent/engflow.key --experimental_build_event_upload_retry_minimum_delay 3s --experimental_build_event_upload_max_retries 8'
 
+if [[ "$GITHUB_ACTIONS_BRANCH" == staging-* ]]
+then
+    ARGS="$ARGS --remote_execution_priority=8"
+elif [ "$GITHUB_ACTIONS_BRANCH" == "staging" ]
+then
+    ARGS="$ARGS --remote_execution_priority=6"
+fi
+
 if [ ! -z "$GITHUB_ACTIONS_BRANCH" ]
 then
     ARGS="$ARGS --bes_keywords branch=$GITHUB_ACTIONS_BRANCH"


### PR DESCRIPTION
Backport 1/1 commits from #144088.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

These builds are high-priority backports and we want them to get through the queue as quickly as possible.

Epic: DEVINF-1449
Release note: None
