### PR TITLE
jsonpath: separate `silent` error and `strict` structural checks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1018,10 +1018,10 @@ SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[-1]');
 statement error pgcode 22033 pq: jsonpath array subscript is out of bounds
 SELECT jsonb_path_query('[1, 2, 3, 4, 5]', 'strict $[-1]');
 
-statement error pgcode 22038 pq: operand of unary jsonpath operator - is not a numeric value
+statement error pgcode 2203B pq: operand of unary jsonpath operator - is not a numeric value
 SELECT jsonb_path_query('[1, 2, 3, 4, "hello"]', '-$[*]');
 
-statement error pgcode 22038 pq: operand of unary jsonpath operator \+ is not a numeric value
+statement error pgcode 2203B pq: operand of unary jsonpath operator \+ is not a numeric value
 SELECT jsonb_path_query('null', '+$');
 
 query T
@@ -1191,3 +1191,187 @@ query T
 SELECT jsonb_path_query('[1,2,0,3]', '$[*] ? ((2 / @ > 0) is unknown)');
 ----
 0
+
+statement error pgcode 2203A pq: JSON object does not contain key "a"
+SELECT jsonb_path_query('{}', 'strict $.a', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', 'strict $.a', '{}', true);
+
+query empty
+SELECT jsonb_path_query('{}', '$.a', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', '$.a', '{}', true);
+
+query empty
+SELECT jsonb_path_query('{}', 'strict 0 / 0', '{}', true);
+
+statement error pgcode 22012 pq: division by zero
+SELECT jsonb_path_query('{}', 'strict 0 / 0', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', '0 / 0', '{}', true);
+
+statement error pgcode 22012 pq: division by zero
+SELECT jsonb_path_query('{}', '0 / 0', '{}', false);
+
+query T
+SELECT jsonb_path_query('{}', 'strict (0 / 0) < (0 / 0)', '{}', true);
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', 'strict (0 / 0) < (0 / 0)', '{}', false);
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', '(0 / 0) < (0 / 0)', '{}', true);
+----
+null
+
+query T
+SELECT jsonb_path_query('{}', '(0 / 0) < (0 / 0)', '{}', false);
+----
+null
+
+query empty
+SELECT jsonb_path_query('{}', 'strict $[*]', '{}', true);
+
+statement error pgcode 22039 pq: jsonpath wildcard array accessor can only be applied to an array
+SELECT jsonb_path_query('{}', 'strict $[*]', '{}', false);
+
+query T
+SELECT jsonb_path_query('{}', '$[*]', '{}', true);
+----
+{}
+
+query T
+SELECT jsonb_path_query('{}', '$[*]', '{}', false);
+----
+{}
+
+query empty
+SELECT jsonb_path_query('{"a": 1}', 'strict $[0]', '{}', true);
+
+statement error pgcode 22039 pq: jsonpath array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": 1}', 'strict $[0]', '{}', false);
+
+query T
+SELECT jsonb_path_query('{"a": 1}', '$[0]', '{}', true);
+----
+{"a": 1}
+
+query T
+SELECT jsonb_path_query('{"a": 1}', '$[0]', '{}', false);
+----
+{"a": 1}
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3]', 'strict $[3]', '{}', true);
+
+statement error pgcode 22033 pq: jsonpath array subscript is out of bounds
+SELECT jsonb_path_query('[1, 2, 3]', 'strict $[3]', '{}', false);
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3]', '$[3]', '{}', true);
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3]', '$[3]', '{}', false);
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3]', 'strict $["a"]', '{}', true);
+
+statement error pgcode 22033 pq: jsonpath array subscript is not a single numeric value
+SELECT jsonb_path_query('[1, 2, 3]', 'strict $["a"]', '{}', false);
+
+query empty
+SELECT jsonb_path_query('[1, 2, 3]', '$["a"]', '{}', true);
+
+statement error pgcode 22033 pq: jsonpath array subscript is not a single numeric value
+SELECT jsonb_path_query('[1, 2, 3]', '$["a"]', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{"a": "hello"}', 'strict $.a[1 to 3]', '{}', true);
+
+statement error pgcode 22039 pq: jsonpath array accessor can only be applied to an array
+SELECT jsonb_path_query('{"a": "hello"}', 'strict $.a[1 to 3]', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{"a": "hello"}', '$.a[1 to 3]', '{}', true);
+
+query empty
+SELECT jsonb_path_query('{"a": "hello"}', '$.a[1 to 3]', '{}', false);
+
+query empty
+SELECT jsonb_path_query('"abc"', 'strict $.a', '{}', true);
+
+statement error pgcode 2203A pq: jsonpath member accessor can only be applied to an object
+SELECT jsonb_path_query('"abc"', 'strict $.a', '{}', false);
+
+query empty
+SELECT jsonb_path_query('"abc"', '$.a', '{}', true);
+
+query empty
+SELECT jsonb_path_query('"abc"', '$.a', '{}', false);
+
+query empty
+SELECT jsonb_path_query('"abc"', 'strict $.*', '{}', true);
+
+statement error pgcode 2203C pq: jsonpath wildcard member accessor can only be applied to an object
+SELECT jsonb_path_query('"abc"', 'strict $.*', '{}', false);
+
+query empty
+SELECT jsonb_path_query('"abc"', '$.*', '{}', true);
+
+query empty
+SELECT jsonb_path_query('"abc"', '$.*', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', 'strict -$', '{}', true);
+
+statement error pgcode 2203B pq: operand of unary jsonpath operator - is not a numeric value
+SELECT jsonb_path_query('{}', 'strict -$', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', '-$', '{}', true);
+
+statement error pgcode 2203B pq: operand of unary jsonpath operator - is not a numeric value
+SELECT jsonb_path_query('{}', '-$', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', 'strict $ - 1', '{}', true);
+
+statement error pgcode 22038 pq: left operand of jsonpath operator - is not a single numeric value
+SELECT jsonb_path_query('{}', 'strict $ - 1', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', '$ - 1', '{}', true);
+
+statement error pgcode 22038 pq: left operand of jsonpath operator - is not a single numeric value
+SELECT jsonb_path_query('{}', '$ - 1', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', 'strict 1 - $', '{}', true);
+
+statement error pgcode 22038 pq: right operand of jsonpath operator - is not a single numeric value
+SELECT jsonb_path_query('{}', 'strict 1 - $', '{}', false);
+
+query empty
+SELECT jsonb_path_query('{}', '1 - $', '{}', true);
+
+statement error pgcode 22038 pq: right operand of jsonpath operator - is not a single numeric value
+SELECT jsonb_path_query('{}', '1 - $', '{}', false);
+
+statement error pgcode 42704 pq: could not find jsonpath variable "var"
+SELECT jsonb_path_query('{}', 'strict $var', '{}', true);
+
+statement error pgcode 42704 pq: could not find jsonpath variable "var"
+SELECT jsonb_path_query('{}', 'strict $var', '{}', false);
+
+statement error pgcode 42704 pq: could not find jsonpath variable "var"
+SELECT jsonb_path_query('{}', '$var', '{}', true);
+
+statement error pgcode 42704 pq: could not find jsonpath variable "var"
+SELECT jsonb_path_query('{}', '$var', '{}', false);

--- a/pkg/util/jsonpath/eval/array.go
+++ b/pkg/util/jsonpath/eval/array.go
@@ -13,22 +13,28 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var (
+	errWildcardOnNonArray     = pgerror.Newf(pgcode.SQLJSONArrayNotFound, "jsonpath wildcard array accessor can only be applied to an array")
+	errIndexOnNonArray        = pgerror.Newf(pgcode.SQLJSONArrayNotFound, "jsonpath array accessor can only be applied to an array")
+	errIndexOutOfBounds       = pgerror.Newf(pgcode.InvalidSQLJSONSubscript, "jsonpath array subscript is out of bounds")
+	errIndexNotSingleNumValue = pgerror.Newf(pgcode.InvalidSQLJSONSubscript, "jsonpath array subscript is not a single numeric value")
+)
+
 func (ctx *jsonpathCtx) evalArrayWildcard(jsonValue json.JSON) ([]json.JSON, error) {
 	if jsonValue.Type() == json.ArrayJSONType {
 		// Do not evaluate any paths, just unwrap the current target.
 		return ctx.unwrapCurrentTargetAndEval(nil /* jsonPath */, jsonValue, !ctx.strict /* unwrapNext */)
 	} else if !ctx.strict {
 		return []json.JSON{jsonValue}, nil
-	} else {
-		return nil, pgerror.Newf(pgcode.SQLJSONArrayNotFound, "jsonpath wildcard array accessor can only be applied to an array")
 	}
+	return nil, maybeThrowError(ctx, errWildcardOnNonArray)
 }
 
 func (ctx *jsonpathCtx) evalArrayList(
 	arrayList jsonpath.ArrayList, jsonValue json.JSON,
 ) ([]json.JSON, error) {
 	if ctx.strict && jsonValue.Type() != json.ArrayJSONType {
-		return nil, pgerror.Newf(pgcode.SQLJSONArrayNotFound, "jsonpath array accessor can only be applied to an array")
+		return nil, maybeThrowError(ctx, errIndexOnNonArray)
 	}
 
 	length := jsonValue.Len()
@@ -50,23 +56,22 @@ func (ctx *jsonpathCtx) evalArrayList(
 		if idxRange, ok := idxAccessor.(jsonpath.ArrayIndexRange); ok {
 			from, err = ctx.resolveArrayIndex(idxRange.Start, jsonValue)
 			if err != nil {
-				return nil, err
+				return nil, maybeThrowError(ctx, err)
 			}
 			to, err = ctx.resolveArrayIndex(idxRange.End, jsonValue)
 			if err != nil {
-				return nil, err
+				return nil, maybeThrowError(ctx, err)
 			}
 		} else {
 			from, err = ctx.resolveArrayIndex(idxAccessor, jsonValue)
 			if err != nil {
-				return nil, err
+				return nil, maybeThrowError(ctx, err)
 			}
 			to = from
 		}
 
 		if ctx.strict && (from < 0 || from > to || to >= length) {
-			return nil, pgerror.Newf(pgcode.InvalidSQLJSONSubscript,
-				"jsonpath array subscript is out of bounds")
+			return nil, maybeThrowError(ctx, errIndexOutOfBounds)
 		}
 		for i := max(from, 0); i <= min(to, length-1); i++ {
 			v, err := jsonArrayValueAtIndex(ctx, jsonValue, i)
@@ -84,14 +89,17 @@ func (ctx *jsonpathCtx) evalArrayList(
 
 func (ctx *jsonpathCtx) evalLast() ([]json.JSON, error) {
 	if ctx.innermostArrayLength == -1 {
-		// TODO(normanchenn): this check should be done during jsonpath parsing.
-		return nil, pgerror.Newf(pgcode.Syntax, "LAST is allowed only in array subscripts")
+		// This invariant is checked during jsonpath parsing.
+		return nil, errors.AssertionFailedf("LAST is allowed only in array subscripts")
 	}
 
 	lastIndex := ctx.innermostArrayLength - 1
 	return []json.JSON{json.FromInt(lastIndex)}, nil
 }
 
+// resolveArrayIndex resolves the index of the array. It returns the resolved index,
+// and an error for errors. resolveArrayIndex does not suppress errors even if
+// ctx.silent is set. The caller is responsible for suppressing errors if needed.
 func (ctx *jsonpathCtx) resolveArrayIndex(
 	jsonPath jsonpath.Path, jsonValue json.JSON,
 ) (int, error) {
@@ -100,11 +108,13 @@ func (ctx *jsonpathCtx) resolveArrayIndex(
 		return 0, err
 	}
 	if len(evalResults) != 1 || evalResults[0].Type() != json.NumberJSONType {
-		return -1, pgerror.Newf(pgcode.InvalidSQLJSONSubscript, "jsonpath array subscript is not a single numeric value")
+		return -1, errIndexNotSingleNumValue
 	}
+	// TODO(normanchenn): Postgres returns an error if the index is outside int32
+	// range. (ex. `select jsonb_path_query('[1]', 'lax $[10000000000000000]');
 	i, err := asInt(evalResults[0])
 	if err != nil {
-		return -1, pgerror.Newf(pgcode.InvalidSQLJSONSubscript, "jsonpath array subscript is not a single numeric value")
+		return -1, errIndexNotSingleNumValue
 	}
 	return i, nil
 }
@@ -123,7 +133,7 @@ func asInt(j json.JSON) (int, error) {
 
 func jsonArrayValueAtIndex(ctx *jsonpathCtx, jsonValue json.JSON, index int) (json.JSON, error) {
 	if ctx.strict && jsonValue.Type() != json.ArrayJSONType {
-		return nil, pgerror.Newf(pgcode.SQLJSONArrayNotFound, "jsonpath array accessor can only be applied to an array")
+		return nil, errors.AssertionFailedf("jsonpath array accessor can only be applied to an array")
 	} else if jsonValue.Type() != json.ArrayJSONType {
 		if index == 0 {
 			return jsonValue, nil
@@ -132,10 +142,9 @@ func jsonArrayValueAtIndex(ctx *jsonpathCtx, jsonValue json.JSON, index int) (js
 	}
 
 	if ctx.strict && index >= jsonValue.Len() {
-		return nil, pgerror.Newf(pgcode.InvalidSQLJSONSubscript, "jsonpath array subscript is out of bounds")
+		return nil, errors.AssertionFailedf("jsonpath array subscript is out of bounds")
 	}
 	if index < 0 {
-		// Shouldn't happen, would have been caught above.
 		return nil, errors.AssertionFailedf("negative array index")
 	}
 	return jsonValue.FetchValIdx(index)

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -22,13 +22,37 @@ var (
 type jsonpathCtx struct {
 	// Root of the given JSON object ($). We store this because we will need to
 	// support queries with multiple root elements (ex. $.a ? ($.b == "hello").
-	root   json.JSON
-	vars   json.JSON
+	root json.JSON
+	// vars is the JSON object that contains the variables that may be used in
+	// the JSONPath query. It is a JSON object that contains key-value pairs of
+	// variable names to their corresponding values.
+	vars json.JSON
+	// strict variable is used to determine how structural errors within the
+	// JSON objects are handled. If strict is true, the query will error out on
+	// structural errors (ex. key accessors on arrays, key accessors on invalid
+	// keys, etc.). Otherwise, the query will attempt to continue execution.
+	// This is controlled by the strict or lax keywords at the start of the
+	// JSONPath query.
 	strict bool
+	// silent variable is used to determine how errors should be thrown during
+	// evaluation. If silent is true, the query will not throw most errors. If
+	// silent is false, the query will throw errors such as key accessors in
+	// strict mode on invalid keys. However, if silent is true, the query will
+	// return nothing. This is controlled by the optional silent variable in
+	// jsonb_path_* builtin functions.
+	silent bool
 
 	// innermostArrayLength stores the length of the innermost array. If the current
 	// evaluation context is not evaluating on an array, this value is -1.
 	innermostArrayLength int
+}
+
+// maybeThrowError should only be called for suppresible errors via ctx.silent.
+func maybeThrowError(ctx *jsonpathCtx, err error) error {
+	if ctx.silent {
+		return nil
+	}
+	return err
 }
 
 func JsonpathQuery(
@@ -36,7 +60,7 @@ func JsonpathQuery(
 ) ([]tree.DJSON, error) {
 	parsedPath, err := parser.Parse(string(path))
 	if err != nil {
-		return []tree.DJSON{}, err
+		return nil, err
 	}
 	expr := parsedPath.AST
 
@@ -44,11 +68,8 @@ func JsonpathQuery(
 		root:                 target.JSON,
 		vars:                 vars.JSON,
 		strict:               expr.Strict,
+		silent:               bool(silent),
 		innermostArrayLength: -1,
-	}
-	// When silent is true, overwrite the strict mode.
-	if bool(silent) {
-		ctx.strict = false
 	}
 
 	j, err := ctx.eval(expr.Path, ctx.root, !ctx.strict /* unwrap */)
@@ -145,7 +166,7 @@ func (ctx *jsonpathCtx) executeAnyItem(
 	jsonPath jsonpath.Path, jsonValue json.JSON, unwrapNext bool,
 ) ([]json.JSON, error) {
 	if jsonValue.Len() == 0 {
-		return []json.JSON{}, nil
+		return nil, nil
 	}
 	var agg []json.JSON
 	processItem := func(item json.JSON) error {

--- a/pkg/util/jsonpath/eval/filter.go
+++ b/pkg/util/jsonpath/eval/filter.go
@@ -26,11 +26,11 @@ func (ctx *jsonpathCtx) evalFilter(
 	if err != nil {
 		// Postgres doesn't error when there's a structure error within filter
 		// conditions, and will return nothing instead.
-		return []json.JSON{}, nil //nolint:returnerrcheck
+		return nil, nil //nolint:returnerrcheck
 	}
 
 	if b == jsonpathBoolTrue {
 		return []json.JSON{jsonValue}, nil
 	}
-	return []json.JSON{}, nil
+	return nil, nil
 }


### PR DESCRIPTION
The `jsonb_path_*` functions include a `silent` argument, and JSONPath queries have a `strict` mode. Previously, the implementation combined these variables, treating `silent=true` as equivalent to forcing lax mode (`strict=false`).

However, `strict` mode primary handles errors related to structural issues, whereas `silent` controls whether runtime errors encountered during path evaluation should cause the query to fail or are suppressed.

This commit refactors the evaluation context (`jsonpathCtx`) to handle these distinctly.

Epic: None
Release note: None