### PR TITLE
release-25.1: ci: reduce concurrency of remote execution builds

### DIFF
--- a/build/github/acceptance-test.sh
+++ b/build/github/acceptance-test.sh
@@ -14,13 +14,13 @@ set -x
 
 bazel build --config crosslinux //pkg/cmd/cockroach-short \
     --bes_keywords integration-test-artifact-build \
-    --jobs 100 $(./build/github/engflow-args.sh)
+    --jobs 50 $(./build/github/engflow-args.sh)
 
 COCKROACH=$(bazel info bazel-bin --config=crosslinux)/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short
 
 bazel test //pkg/acceptance:acceptance_test \
   --config crosslinux \
-  --jobs 100 $(./build/github/engflow-args.sh) \
+  --jobs 50 $(./build/github/engflow-args.sh) \
   --remote_download_minimal \
   --test_arg=-b=$COCKROACH \
   --test_env=COCKROACH_DEV_LICENSE \

--- a/build/github/build.sh
+++ b/build/github/build.sh
@@ -41,7 +41,7 @@ fi
 
 bazel build \
     --config "$CONFIG" $EXTRA_ARGS \
-    --jobs 100 \
+    --jobs 50 \
     --build_event_binary_file=bes.bin \
     --bes_keywords ci-build \
     $(./build/github/engflow-args.sh) \

--- a/build/github/check-generated-code.sh
+++ b/build/github/check-generated-code.sh
@@ -45,7 +45,7 @@ if ! (./build/bazelutil/check.sh &> artifacts/check-out.log || (cat_output artif
 fi
 rm artifacts/check-out.log
 
-ENGFLOW_ARGS="--config crosslinux --jobs 100 $(./build/github/engflow-args.sh) --remote_download_minimal"
+ENGFLOW_ARGS="--config crosslinux --jobs 50 $(./build/github/engflow-args.sh) --remote_download_minimal"
 
 EXTRA_BAZEL_ARGS="$ENGFLOW_ARGS" \
     COCKROACH_BAZEL_FORCE_GENERATE=1 \

--- a/build/github/cockroach-microbench-ci.sh
+++ b/build/github/cockroach-microbench-ci.sh
@@ -30,7 +30,7 @@ if $SKIP_COMPARISON && ! $PUSH_STEP; then
 fi
 
 # Build binary with Bazel
-bazel build --config crosslinux $(./build/github/engflow-args.sh) --jobs 100 //pkg/cmd/roachprod-microbench
+bazel build --config crosslinux $(./build/github/engflow-args.sh) --jobs 50 //pkg/cmd/roachprod-microbench
 
 roachprod_microbench_dir="_bazel/bin/pkg/cmd/roachprod-microbench/roachprod-microbench_"
 
@@ -41,7 +41,7 @@ mkdir -p "$output_dir"
 bazel test //pkg/sql/tests:tests_test \
   --test_timeout=1800 \
   --strategy=TestRunner=sandboxed \
-  --jobs 100 \
+  --jobs 50 \
   --config=crosslinux \
   --remote_download_minimal \
   $(./build/github/engflow-args.sh) \

--- a/build/github/docker-image.sh
+++ b/build/github/docker-image.sh
@@ -27,7 +27,7 @@ esac
 
 build_arch=${1:-amd64}
 
-bazel build //pkg/cmd/cockroach //c-deps:libgeos --config $CROSSCONFIG --jobs 100 $(./build/github/engflow-args.sh)
+bazel build //pkg/cmd/cockroach //c-deps:libgeos --config $CROSSCONFIG --jobs 50 $(./build/github/engflow-args.sh)
 cp _bazel/bin/pkg/cmd/cockroach/cockroach_/cockroach build/deploy
 cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos.so build/deploy
 cp _bazel/cockroach/external/$ARCHIVEDIR/lib/libgeos_c.so build/deploy
@@ -59,4 +59,4 @@ bazel test \
   --config=crosslinux \
   --test_timeout=3000 \
   --remote_download_minimal \
-  --jobs 100 $(./build/github/engflow-args.sh) --build_event_binary_file=bes.bin
+  --jobs 50 $(./build/github/engflow-args.sh) --build_event_binary_file=bes.bin

--- a/build/github/examples-orms.sh
+++ b/build/github/examples-orms.sh
@@ -10,7 +10,7 @@ set -euxo pipefail
 
 pushd cockroach
 bazel build //pkg/cmd/cockroach-short \
-      --config crosslinux --jobs 100 \
+      --config crosslinux --jobs 50 \
       --bes_keywords integration-test-artifact-build \
       $(./build/github/engflow-args.sh)
 cp _bazel/bin/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short ../examples-orms/cockroach

--- a/build/github/lint.sh
+++ b/build/github/lint.sh
@@ -12,11 +12,11 @@ WORKSPACE=$(bazel info workspace)
 
 # GCAssert and unused need generated files in the workspace to work properly.
 bazel run //pkg/gen:code \
-    --config crosslinux --jobs 100 \
+    --config crosslinux --jobs 50 \
     --remote_download_minimal $(./build/github/engflow-args.sh)
 bazel run //pkg/cmd/generate-cgo:generate-cgo \
     --run_under="cd $WORKSPACE && " \
-    --config crosslinux --jobs 100 \
+    --config crosslinux --jobs 50 \
     --remote_download_minimal $(./build/github/engflow-args.sh)
 
 bazel test \
@@ -30,5 +30,5 @@ bazel test \
   --test_env=COCKROACH_WORKSPACE=$WORKSPACE \
   --test_timeout=1800 \
   --build_event_binary_file=bes.bin \
-  --jobs 100 \
+  --jobs 50 \
   --remote_download_minimal $(./build/github/engflow-args.sh)

--- a/build/github/local-roachtest.sh
+++ b/build/github/local-roachtest.sh
@@ -29,7 +29,7 @@ set -x
 
 bazel build --config=$CROSSCONFIG $(./build/github/engflow-args.sh) \
       --bes_keywords integration-test-artifact-build \
-      --jobs 100 \
+      --jobs 50 \
       //pkg/cmd/cockroach-short \
       //pkg/cmd/roachtest \
       //pkg/cmd/roachprod \

--- a/build/github/prepare-summarize-build.sh
+++ b/build/github/prepare-summarize-build.sh
@@ -10,4 +10,4 @@ set -euxo pipefail
 
 THIS_DIR=$(cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd)
 
-bazel build //pkg/cmd/bazci/bazel-github-helper --config crosslinux --jobs 100 $($THIS_DIR/engflow-args.sh) --bes_keywords helper-binary
+bazel build //pkg/cmd/bazci/bazel-github-helper --config crosslinux --jobs 50 $($THIS_DIR/engflow-args.sh) --bes_keywords helper-binary

--- a/build/github/unit-tests.sh
+++ b/build/github/unit-tests.sh
@@ -17,7 +17,7 @@ fi
 
 
 bazel test //pkg:all_tests //pkg/ui:lint //pkg/ui:test \
-    --config crosslinux --jobs 300 --remote_download_minimal \
+    --config crosslinux --jobs 200 --remote_download_minimal \
     --bes_keywords ci-unit-test --config=use_ci_timeouts \
     --build_event_binary_file=bes.bin $(./build/github/engflow-args.sh) \
     $EXTRA_PARAMS


### PR DESCRIPTION
Backport 1/1 commits from #144072.

/cc @cockroachdb/release

Release justification: Non-production code changes

---

... to limit load on the EngFlow cluster.

Epic: DEVINF-1424
Release note: None
