### PR TITLE
stmtdiagnostics: fix recently added migration

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_bundle
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_bundle
@@ -5,6 +5,20 @@
 # contents of the bundles (this is done elsewhere), so the check here is simply
 # that the bundle can be collected.
 
+# Insert a diagnostics request that won't be completed and never expires.
+statement ok
+INSERT INTO system.statement_diagnostics_requests(id, completed, statement_fingerprint, requested_at)
+    VALUES (1, false, 'SELECT _, _ FROM _', now());
+
+# Speed up the polling goroutine.
+#
+# In combination with the incomplete request this is used to ensure that the
+# polling goroutine gracefully handles the mixed-version state too. We'll also
+# sleep for 1s in each state to ensure the polling loop has at least one chance
+# to run on each node.
+statement ok
+SET CLUSTER SETTING sql.stmt_diagnostics.poll_interval = '100ms';
+
 statement ok
 CREATE TABLE t (k INT PRIMARY KEY);
 
@@ -23,14 +37,23 @@ EXPLAIN ANALYZE (DEBUG) SELECT * FROM t;
 upgrade 1
 
 statement ok
+SELECT pg_sleep(1);
+
+statement ok
 EXPLAIN ANALYZE (DEBUG) SELECT * FROM t;
 
 upgrade 0
 
 statement ok
+SELECT pg_sleep(1);
+
+statement ok
 EXPLAIN ANALYZE (DEBUG) SELECT * FROM t;
 
 upgrade 2
+
+statement ok
+SELECT pg_sleep(1);
 
 statement ok
 EXPLAIN ANALYZE (DEBUG) SELECT * FROM t;

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -768,8 +768,10 @@ func (r *Registry) pollRequests(ctx context.Context) error {
 		if b, ok := row[7].(*tree.DBool); ok {
 			redacted = bool(*b)
 		}
-		if u, ok := row[8].(*tree.DString); ok {
-			username = string(*u)
+		if isUsernameSet {
+			if u, ok := row[8].(*tree.DString); ok {
+				username = string(*u)
+			}
 		}
 		ids.Add(int(id))
 		r.addRequestInternalLocked(ctx, id, stmtFingerprint, planGist, antiPlanGist, samplingProbability, minExecutionLatency, expiresAt, redacted, username)


### PR DESCRIPTION
This commit fixes the bug that Michael noticed during the review of the backport. It also extends the mixed-version logic test a bit to exercise the polling goroutine.

Epic: None
Release note: None