### PR TITLE
sql: adjust some tests to work with write buffering

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -899,6 +899,9 @@ func TestRetriableErrorDuringUpgradedTransaction(t *testing.T) {
 
 	var fooTableId uint32
 	testDB.Exec(t, "SET enable_implicit_transaction_for_batch_statements = true")
+	// The test injects a retry error after the interceptors, so we need to
+	// disable write buffers for the request to make it to the server.
+	testDB.Exec(t, "SET kv_transaction_buffered_writes_enabled = false")
 	testDB.Exec(t, "CREATE TABLE bar (a INT PRIMARY KEY)")
 	testDB.Exec(t, "CREATE TABLE foo (a INT PRIMARY KEY)")
 	testDB.QueryRow(t, "SELECT 'foo'::regclass::oid").Scan(&fooTableId)

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -133,6 +133,10 @@ SET TRANSACTION AS OF system time '-1s'
 statement ok
 ROLLBACK
 
+skipif config local-mixed-24.3 local-mixed-25.1
+statement ok
+SET kv_transaction_buffered_writes_enabled = false;
+
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE
 
@@ -144,6 +148,27 @@ SET TRANSACTION AS OF system time '-1s'
 
 statement ok
 ROLLBACK
+
+skipif config local-mixed-24.3 local-mixed-25.1
+statement ok
+SET kv_transaction_buffered_writes_enabled = true;
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+statement ok
+INSERT INTO t VALUES(1)
+
+skipif config local-mixed-24.3 local-mixed-25.1
+statement error cannot set fixed timestamp, .* already performed reads
+SET TRANSACTION AS OF system time '-1s'
+
+statement ok
+ROLLBACK
+
+skipif config local-mixed-24.3 local-mixed-25.1
+statement ok
+RESET kv_transaction_buffered_writes_enabled;
 
 # Verify that an expression that requires normalization does not result in an
 # internal error.

--- a/pkg/sql/metric_test.go
+++ b/pkg/sql/metric_test.go
@@ -216,6 +216,12 @@ func TestAbortCountConflictingWrites(t *testing.T) {
 
 		accum := initializeQueryCounter(s)
 
+		// The test injects a retry error after the interceptors, so we need to
+		// disable write buffers for the request to make it to the server.
+		if _, err := sqlDB.Exec("SET kv_transaction_buffered_writes_enabled = false"); err != nil {
+			t.Fatal(err)
+		}
+
 		if _, err := sqlDB.Exec("CREATE DATABASE db"); err != nil {
 			t.Fatal(err)
 		}


### PR DESCRIPTION
This commit adjusts the following tests so that they work with write buffering enabled by default:
- `as_of` logic test verifies a particular error message about "already performed writes" on an INSERT whereas with write buffering we get "already performed reads". It doesn't seem like a big deal, so we'll accept the deviation, and this commit makes it explicit.
- `TestRetriableErrorDuringUpgradedTransaction` and `TestAbortCountConflictingWrites` use the server filter testing knob which engages _after_ the interceptor stack, so we need to allow for the write to make it there and disable buffering.
- in `TestTxnContentionEventsTable` we expect the contention on non-unique secondary index, and since we changed the CPut to a Put there by default, we now tweak the session variable to use CPuts still.

Epic: None
Release note: None