### PR TITLE
vecindex: update vector index key and value encodings

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -489,7 +489,7 @@ type VectorIndexHelper struct {
 func (vih *VectorIndexHelper) ReEncodeVector(
 	ctx context.Context, txn *kv.Txn, keyBytes []byte, entry *rowenc.IndexEntry,
 ) (*rowenc.IndexEntry, error) {
-	key, err := vecencoding.DecodeKey(keyBytes, vih.numPrefixCols)
+	key, err := vecencoding.DecodeVectorKey(keyBytes, vih.numPrefixCols)
 	if err != nil {
 		return &rowenc.IndexEntry{}, err
 	}
@@ -520,9 +520,9 @@ func (vih *VectorIndexHelper) ReEncodeVector(
 	entry.Key = entry.Key[:0]
 	entry.Key = append(entry.Key, vih.indexPrefix...)
 	entry.Key = key.Encode(entry.Key)
-	entryValueLen := vecencoding.EncodedVectorIndexValueLen(quantizedVector.UnsafeBytes(), suffix)
+	entryValueLen := vecencoding.EncodedVectorValueLen(quantizedVector.UnsafeBytes(), suffix)
 	buf := entry.Value.AllocBytes(entryValueLen)[:0]
-	vecencoding.EncodeVectorIndexValue(buf, quantizedVector.UnsafeBytes(), suffix)
+	vecencoding.EncodeVectorValue(buf, quantizedVector.UnsafeBytes(), suffix)
 
 	// entry.Family is left unchanged from the entry we received, originally encoded by rowenc.EncodeSecondaryIndexes()
 

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -1316,7 +1316,7 @@ func TestVectorEncoding(t *testing.T) {
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "defaultdb", "prefix_cols")
 
 	testVector := vector.T{1, 2, 4}
-	encodedVector, err := vecencoding.EncodeUnquantizedVector([]byte{}, 0, testVector)
+	encodedVector, err := vecencoding.EncodeUnquantizerVector([]byte{}, 0, testVector)
 	require.NoError(t, err)
 
 	vh := VectorIndexEncodingHelper{
@@ -1405,7 +1405,7 @@ func TestVectorCompositeEncoding(t *testing.T) {
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "defaultdb", "prefix_cols")
 
 	testVector := vector.T{1, 2, 4}
-	encodedVector, err := vecencoding.EncodeUnquantizedVector([]byte{}, 0, testVector)
+	encodedVector, err := vecencoding.EncodeUnquantizerVector([]byte{}, 0, testVector)
 	require.NoError(t, err)
 
 	vh := VectorIndexEncodingHelper{

--- a/pkg/sql/vecindex/cspann/partition_metadata.go
+++ b/pkg/sql/vecindex/cspann/partition_metadata.go
@@ -147,6 +147,9 @@ type PartitionStateDetails struct {
 	//   be merged into the root partition.
 	Source PartitionKey
 	// Timestamp is the time of the last state transition for the partition.
+	// NOTE: We use NowNoMono to get the current time because the monotonic clock
+	// reading is not round-tripped through the encoding/decoding functions, since
+	// it's not useful to store.
 	Timestamp time.Time
 }
 

--- a/pkg/sql/vecindex/cspann/partition_metadata.go
+++ b/pkg/sql/vecindex/cspann/partition_metadata.go
@@ -154,7 +154,7 @@ type PartitionStateDetails struct {
 func MakeReadyDetails() PartitionStateDetails {
 	return PartitionStateDetails{
 		State:     ReadyState,
-		Timestamp: timeutil.Now(),
+		Timestamp: timeutil.NowNoMono(),
 	}
 }
 
@@ -165,7 +165,7 @@ func MakeSplittingDetails(target1, target2 PartitionKey) PartitionStateDetails {
 		State:     SplittingState,
 		Target1:   target1,
 		Target2:   target2,
-		Timestamp: timeutil.Now(),
+		Timestamp: timeutil.NowNoMono(),
 	}
 }
 
@@ -176,7 +176,7 @@ func MakeDrainingForSplitDetails(target1, target2 PartitionKey) PartitionStateDe
 		State:     DrainingForSplitState,
 		Target1:   target1,
 		Target2:   target2,
-		Timestamp: timeutil.Now(),
+		Timestamp: timeutil.NowNoMono(),
 	}
 }
 
@@ -186,7 +186,7 @@ func MakeDrainingForMergeDetails(target PartitionKey) PartitionStateDetails {
 	return PartitionStateDetails{
 		State:     DrainingForMergeState,
 		Target1:   target,
-		Timestamp: timeutil.Now(),
+		Timestamp: timeutil.NowNoMono(),
 	}
 }
 
@@ -196,7 +196,7 @@ func MakeUpdatingDetails(source PartitionKey) PartitionStateDetails {
 	return PartitionStateDetails{
 		State:     UpdatingState,
 		Source:    source,
-		Timestamp: timeutil.Now(),
+		Timestamp: timeutil.NowNoMono(),
 	}
 }
 
@@ -208,7 +208,7 @@ func MakeAddingLevelDetails(target1, target2 PartitionKey) PartitionStateDetails
 		State:     AddingLevelState,
 		Target1:   target1,
 		Target2:   target2,
-		Timestamp: timeutil.Now(),
+		Timestamp: timeutil.NowNoMono(),
 	}
 }
 

--- a/pkg/sql/vecindex/vecencoding/BUILD.bazel
+++ b/pkg/sql/vecindex/vecencoding/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecencoding",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
+        "//pkg/roachpb",
         "//pkg/sql/vecindex/cspann",
         "//pkg/sql/vecindex/cspann/quantize",
         "//pkg/util/encoding",
@@ -18,6 +20,7 @@ go_test(
     srcs = ["encoding_test.go"],
     deps = [
         ":vecencoding",
+        "//pkg/roachpb",
         "//pkg/sql/randgen",
         "//pkg/sql/sem/tree",
         "//pkg/sql/types",

--- a/pkg/sql/vecindex/vecencoding/encoding.go
+++ b/pkg/sql/vecindex/vecencoding/encoding.go
@@ -6,8 +6,11 @@
 package vecencoding
 
 import (
+	"encoding/binary"
 	"slices"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
@@ -16,36 +19,94 @@ import (
 
 /* Vector indexes are encoded as follows:
 
-Interior (non-leaf) partition KV key:
-  ┌────────────┬──────────────┬───────────┬─────┬─────────────────┐
-  │Index Prefix│Prefix Columns│PartitionID│Level│Child PartitionID│
-  └────────────┴──────────────┴───────────┴─────┴─────────────────┘
-Leaf partition KV key:
-  ┌────────────┬──────────────┬───────────┬─────┬───────────┬────────────────────┐
-  │Index Prefix│Prefix Columns│PartitionID│Level│Primary Key│Sentinel Family ID 0│
-  └────────────┴──────────────┴───────────┴─────┴───────────┴────────────────────┘
-Value:
+Metadata KV key:
+  Metadata keys always sort before vector keys, since Family ID 0 always
+  sorts before Level, which is >= 1.
+  ┌────────────┬──────────────┬────────────┬───────────┐
+  │Index Prefix│Prefix Columns│PartitionKey│Family ID 0│
+  └────────────┴──────────────┴────────────┴───────────┘
+Metadata KV Value:
+  ┌─────┬─────┬───────┬───────┬──────┬─────────┬────────┐
+  │Level│State│Target1│Target2│Source|Timestamp│Centroid|
+  └─────┴─────┴───────┴───────┴──────┴─────────┴────────┘
+Vector KV key (interior, non-leaf partition):
+  ┌────────────┬──────────────┬────────────┬─────┬──────────────────┬───────────┐
+  │Index Prefix│Prefix Columns│PartitionKey│Level│Child PartitionKey│Family ID 0│
+  └────────────┴──────────────┴────────────┴─────┴──────────────────┴───────────┘
+Vector KV key (leaf partition):
+  ┌────────────┬──────────────┬────────────┬─────┬──────────┬───────────┐
+  │Index Prefix│Prefix Columns│PartitionKey│Level│PrimaryKey│Family ID 0│
+  └────────────┴──────────────┴────────────┴─────┴──────────┴───────────┘
+Vector KV Value:
   ┌────────────────────────┬────────────────────────┐
   │Quantized+Encoded Vector│Composite+Stored Columns│
   └────────────────────────┴────────────────────────┘
 */
 
-// VectorIndexKey is a deconstructed key value, as described above, minus the
+// EncodeMetadataKey constructs the KV key for the metadata record in a
+// partition. All vector keys in the partition sort after it.
+func EncodeMetadataKey(
+	indexPrefix []byte, encodedPrefixCols []byte, partitionKey cspann.PartitionKey,
+) roachpb.Key {
+	capacity := len(indexPrefix) + len(encodedPrefixCols) + EncodedPartitionKeyLen(partitionKey) + 1
+	keyBuffer := make([]byte, 0, capacity)
+	keyBuffer = append(keyBuffer, indexPrefix...)
+	keyBuffer = append(keyBuffer, encodedPrefixCols...)
+	keyBuffer = EncodePartitionKey(keyBuffer, partitionKey)
+	return keys.MakeFamilyKey(keyBuffer, 0)
+}
+
+// EncodeStartVectorKey constructs the KV key that precedes all the KV keys for
+// vector data records in the partition.
+func EncodeStartVectorKey(metadataKey roachpb.Key) roachpb.Key {
+	// The last byte of the metadata key is the Family ID field (always 0). Vector
+	// keys have a Level field instead. Since level values are always > 0,
+	// increment the last byte to get the starting value.
+	keyBuffer := slices.Clone(metadataKey)
+	keyBuffer[len(keyBuffer)-1]++
+	return keyBuffer
+}
+
+// EncodeEndVectorKey constructs the KV key that succeeds all the KV keys for
+// vector data records in the partition.
+func EncodeEndVectorKey(metadataKey roachpb.Key) roachpb.Key {
+	// Chop the last byte, which is the family ID.
+	n := len(metadataKey) - 1
+	return metadataKey[:n:n].PrefixEnd()
+}
+
+// EncodePrefixVectorKey constructs the prefix that is shared by all KV keys for
+// vector data records in the partition.
+func EncodePrefixVectorKey(metadataKey roachpb.Key, level cspann.Level) roachpb.Key {
+	// Chop the last byte, which is the family ID.
+	n := len(metadataKey) - 1
+	return EncodePartitionLevel(metadataKey[:n:n], level)
+}
+
+// EncodedPrefixVectorKeyLen returns the number of bytes needed to encode the
+// prefix for vector data records in the partition.
+func EncodedPrefixVectorKeyLen(metadataKey roachpb.Key, level cspann.Level) int {
+	return len(metadataKey) - 1 + EncodedPartitionLevelLen(level)
+}
+
+// DecodedVectorKey is a deconstructed key value, as described above, minus the
 // index prefix. Any suffix bytes (child partition, primary key) are left in the
 // Suffix value.
-type VectorIndexKey struct {
-	Prefix       cspann.TreeKey
+type DecodedVectorKey struct {
+	Prefix       []byte
 	PartitionKey cspann.PartitionKey
 	Level        cspann.Level
 	Suffix       []byte
 }
 
-// DecodeKey takes an encoded key value, minus the /Tenant/Table/Index prefix,
+// DecodeVectorKey takes an encoded key value, minus the /Tenant/Table/Index prefix,
 // and extracts the vector index specific portions of it in an VectorIndexKey
 // struct.
-func DecodeKey(keyBytes []byte, numPrefixColumns int) (vecIndexKey VectorIndexKey, err error) {
+func DecodeVectorKey(
+	keyBytes []byte, numPrefixColumns int,
+) (vecIndexKey DecodedVectorKey, err error) {
 	prefixLen := 0
-	for i := 0; i < numPrefixColumns; i++ {
+	for range numPrefixColumns {
 		columnWidth, err := encoding.PeekLength(keyBytes[prefixLen:])
 		if err != nil {
 			return vecIndexKey, err
@@ -76,40 +137,55 @@ func DecodeKey(keyBytes []byte, numPrefixColumns int) (vecIndexKey VectorIndexKe
 	return vecIndexKey, nil
 }
 
-// Encode takes a VectorIndexKey and turns it back into encoded bytes that can be
+// Encode takes a VectorKey and turns it back into encoded bytes that can be
 // appended to the index's prefix to form a key value.
-func (vik *VectorIndexKey) Encode(appendTo []byte) []byte {
+func (vik *DecodedVectorKey) Encode(appendTo []byte) []byte {
 	appendTo = append(appendTo, vik.Prefix...)
 	appendTo = EncodePartitionKey(appendTo, vik.PartitionKey)
 	appendTo = EncodePartitionLevel(appendTo, vik.Level)
 	return append(appendTo, vik.Suffix...)
 }
 
-// EncodedVectorIndexValueLen returns the number of bytes needed to encode the
-// value side of a vector index entry.
-func EncodedVectorIndexValueLen(vectorData []byte, compositeData []byte) int {
-	return len(vectorData) + len(compositeData)
-}
-
-// EncodeVectorIndexValue takes a quantized vector entry and any composite key
-// data and returns the byte slice encoding the value side of the vector index
-// entry. This value will still need to be further encoded as Bytes in the
+// EncodeVectorValue takes a quantized vector entry and any composite key data
+// and returns the byte slice encoding the value side of the vector index entry.
+// This value will still need to be further encoded as Bytes in the
 // valueside.Value
-func EncodeVectorIndexValue(appendTo []byte, vectorData []byte, compositeData []byte) []byte {
+func EncodeVectorValue(appendTo []byte, vectorData []byte, compositeData []byte) []byte {
 	// The value side is encoded as a concatenation of the vector data and the
 	// composite data.
 	appendTo = append(appendTo, vectorData...)
 	return append(appendTo, compositeData...)
 }
 
-// EncodePartitionMetadata encodes the metadata for a partition.
-func EncodePartitionMetadata(level cspann.Level, centroid vector.T) ([]byte, error) {
-	// The encoding consists of 8 bytes for the level, and a 4-byte length,
-	// followed by 4 bytes for each dimension in the vector.
-	encMetadataSize := 8 + (4 * (len(centroid) + 1))
+// EncodedVectorValueLen returns the number of bytes needed to encode the value
+// side of a vector index entry.
+func EncodedVectorValueLen(vectorData []byte, compositeData []byte) int {
+	return len(vectorData) + len(compositeData)
+}
+
+// EncodeMetadataValue encodes the metadata KV value for a partition.
+func EncodeMetadataValue(metadata cspann.PartitionMetadata) []byte {
+	// The encoding consists of:
+	// - 4 bytes for the level
+	// - 4 bytes for the state
+	// - 8 bytes for first target partition key (0 if InvalidKey)
+	// - 8 bytes for second target partition key (0 if InvalidKey)
+	// - 8 bytes for source partition key (0 if InvalidKey)
+	// - 0-20 bytes for timestamp (variable encoding)
+	// - 4 bytes count of dimensions
+	// - 4 bytes for each dimension in the vector
+	encMetadataSize := 4 + 8 + 8 + 8 + binary.MaxVarintLen64*2 + 4 + 4*len(metadata.Centroid)
 	buf := make([]byte, 0, encMetadataSize)
-	buf = encoding.EncodeUint32Ascending(buf, uint32(level))
-	return vector.Encode(buf, centroid)
+	buf = encoding.EncodeUint32Ascending(buf, uint32(metadata.Level))
+	buf = encoding.EncodeUint32Ascending(buf, uint32(metadata.StateDetails.State))
+	buf = encoding.EncodeUint64Ascending(buf, uint64(metadata.StateDetails.Target1))
+	buf = encoding.EncodeUint64Ascending(buf, uint64(metadata.StateDetails.Target2))
+	buf = encoding.EncodeUint64Ascending(buf, uint64(metadata.StateDetails.Source))
+	buf = encoding.EncodeUntaggedTimeValue(buf, metadata.StateDetails.Timestamp)
+
+	// vector.Encode never returns a non-nil error, so suppress return value.
+	buf, _ = vector.Encode(buf, metadata.Centroid)
+	return buf
 }
 
 // EncodeRaBitQVector encodes a RaBitQ vector into the given byte slice.
@@ -125,8 +201,9 @@ func EncodeRaBitQVector(
 	return appendTo
 }
 
-// EncodeUnquantizedVector encodes a full vector into the given byte slice.
-func EncodeUnquantizedVector(
+// EncodeUnquantizerVector encodes an Unquantizer vector and centroid distance
+// into the given byte slice.
+func EncodeUnquantizerVector(
 	appendTo []byte, centroidDistance float32, v vector.T,
 ) ([]byte, error) {
 	appendTo = encoding.EncodeUntaggedFloat32Value(appendTo, centroidDistance)
@@ -167,19 +244,47 @@ func EncodeChildKey(appendTo []byte, key cspann.ChildKey) []byte {
 	return EncodePartitionKey(appendTo, key.PartitionKey)
 }
 
-// DecodePartitionMetadata decodes the metadata for a partition.
-func DecodePartitionMetadata(
-	encMetadata []byte,
-) (level cspann.Level, centroid vector.T, err error) {
+// DecodeMetadataValue decodes the metadata KV value for a partition.
+func DecodeMetadataValue(encMetadata []byte) (metadata cspann.PartitionMetadata, err error) {
 	encMetadata, decodedLevel, err := encoding.DecodeUint32Ascending(encMetadata)
 	if err != nil {
-		return 0, nil, err
+		return cspann.PartitionMetadata{}, err
 	}
-	_, centroid, err = vector.Decode(encMetadata)
+	encMetadata, decodedState, err := encoding.DecodeUint32Ascending(encMetadata)
 	if err != nil {
-		return 0, nil, err
+		return cspann.PartitionMetadata{}, err
 	}
-	return cspann.Level(decodedLevel), centroid, nil
+	encMetadata, decodedTarget1, err := encoding.DecodeUint64Ascending(encMetadata)
+	if err != nil {
+		return cspann.PartitionMetadata{}, err
+	}
+	encMetadata, decodedTarget2, err := encoding.DecodeUint64Ascending(encMetadata)
+	if err != nil {
+		return cspann.PartitionMetadata{}, err
+	}
+	encMetadata, decodedSource, err := encoding.DecodeUint64Ascending(encMetadata)
+	if err != nil {
+		return cspann.PartitionMetadata{}, err
+	}
+	encMetadata, decodedTime, err := encoding.DecodeUntaggedTimeValue(encMetadata)
+	if err != nil {
+		return cspann.PartitionMetadata{}, err
+	}
+	_, centroid, err := vector.Decode(encMetadata)
+	if err != nil {
+		return cspann.PartitionMetadata{}, err
+	}
+	return cspann.PartitionMetadata{
+		Level:    cspann.Level(decodedLevel),
+		Centroid: centroid,
+		StateDetails: cspann.PartitionStateDetails{
+			State:     cspann.PartitionState(decodedState),
+			Target1:   cspann.PartitionKey(decodedTarget1),
+			Target2:   cspann.PartitionKey(decodedTarget2),
+			Source:    cspann.PartitionKey(decodedSource),
+			Timestamp: decodedTime,
+		},
+	}, nil
 }
 
 // DecodeRaBitQVectorToSet decodes a RaBitQ vector entry into the given
@@ -204,7 +309,7 @@ func DecodeRaBitQVectorToSet(
 	vectorSet.CentroidDistances = append(vectorSet.CentroidDistances, centroidDistance)
 	vectorSet.DotProducts = append(vectorSet.DotProducts, dotProduct)
 	vectorSet.Codes.Data = slices.Grow(vectorSet.Codes.Data, vectorSet.Codes.Width)
-	for i := 0; i < vectorSet.Codes.Width; i++ {
+	for range vectorSet.Codes.Width {
 		var codeWord uint64
 		encVector, codeWord, err = encoding.DecodeUint64Ascending(encVector)
 		if err != nil {
@@ -216,9 +321,10 @@ func DecodeRaBitQVectorToSet(
 	return encVector, nil
 }
 
-// DecodeUnquantizedVectorToSet decodes a full vector entry into the given
-// UnQuantizedVectorSet. The vector set must have been initialized with the
-// correct number of dimensions. It returns the remainder of the input buffer.
+// DecodeUnquantizedVectorToSet decodes an Unquantizer vector entry into the
+// given UnQuantizedVectorSet. The vector set must have been initialized with
+// the correct number of dimensions. It returns the remainder of the input
+// buffer.
 func DecodeUnquantizedVectorToSet(
 	encVector []byte, vectorSet *quantize.UnQuantizedVectorSet,
 ) ([]byte, error) {

--- a/pkg/sql/vecindex/vecstore/store_test.go
+++ b/pkg/sql/vecindex/vecstore/store_test.go
@@ -179,9 +179,6 @@ func TestStore(t *testing.T) {
 				return
 			}
 
-			// Step so that we can see the new root partition.
-			require.NoError(t, tx.(*Txn).kv.Step(ctx, true /* allowReadTimestampStep */))
-
 			// Run GetPartitionMetadata again, to ensure that it succeeds, as a
 			// way of simulating multiple vectors being inserted in the same
 			// SQL statement.

--- a/pkg/sql/vecindex/vecstore/store_test.go
+++ b/pkg/sql/vecindex/vecstore/store_test.go
@@ -179,6 +179,9 @@ func TestStore(t *testing.T) {
 				return
 			}
 
+			// Step so that we can see the new root partition.
+			require.NoError(t, tx.(*Txn).kv.Step(ctx, true /* allowReadTimestampStep */))
+
 			// Run GetPartitionMetadata again, to ensure that it succeeds, as a
 			// way of simulating multiple vectors being inserted in the same
 			// SQL statement.

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -107,7 +107,7 @@ func (sc *storeCodec) encodeVector(w *workspace.T, v vector.T, centroid vector.T
 func (sc *storeCodec) encodeVectorFromSet(vs quantize.QuantizedVectorSet, idx int) ([]byte, error) {
 	switch t := vs.(type) {
 	case *quantize.UnQuantizedVectorSet:
-		return vecencoding.EncodeUnquantizedVector(
+		return vecencoding.EncodeUnquantizerVector(
 			[]byte{}, t.CentroidDistances[idx], t.Vectors.At(idx))
 	case *quantize.RaBitQuantizedVectorSet:
 		return vecencoding.EncodeRaBitQVector(
@@ -185,11 +185,11 @@ func (tx *Txn) decodePartition(
 	}
 	tx.tmpValueBytes = tx.tmpValueBytes[:len(vectorEntries)]
 
-	// Vector entries add the encoded partition level to the metadata key.
-	metaKeyLen := calculateMetaKeyLen(tx.store, treeKey, partitionKey)
-	metaKeyLen += vecencoding.EncodedPartitionLevelLen(metadata.Level)
+	// Determine the length of the prefix of vector data records.
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
+	prefixLen := vecencoding.EncodedPrefixVectorKeyLen(metadataKey, metadata.Level)
 	for i, entry := range vectorEntries {
-		childKey, err := vecencoding.DecodeChildKey(entry.Key[metaKeyLen:], metadata.Level)
+		childKey, err := vecencoding.DecodeChildKey(entry.Key[prefixLen:], metadata.Level)
 		if err != nil {
 			return nil, err
 		}
@@ -215,10 +215,11 @@ func (tx *Txn) GetPartition(
 
 	// GetPartition is used by fixup to split and merge partitions, so we want to
 	// block concurrent writes.
-	metadataKey := tx.store.encodePartitionKey(treeKey, partitionKey)
-	metadataKey = slices.Clip(metadataKey)
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
+	startKey := vecencoding.EncodeStartVectorKey(metadataKey)
+	endKey := vecencoding.EncodeEndVectorKey(metadataKey)
 	b.GetForUpdate(metadataKey, tx.lockDurability)
-	b.Scan(metadataKey.Next(), metadataKey.PrefixEnd())
+	b.Scan(startKey, endKey)
 	err := tx.kv.Run(ctx, b)
 	if err != nil {
 		return nil, err
@@ -244,23 +245,19 @@ func (tx *Txn) insertPartition(
 ) error {
 	b := tx.kv.NewBatch()
 
-	metadataKey := tx.store.encodePartitionKey(treeKey, partitionKey)
-	metadataKey = slices.Clip(metadataKey)
-	meta, err := vecencoding.EncodePartitionMetadata(partition.Level(), partition.QuantizedSet().GetCentroid())
-	if err != nil {
-		return err
-	}
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
+	meta := vecencoding.EncodeMetadataValue(*partition.Metadata())
 	b.Put(metadataKey, meta)
 
-	// Cap the key so that any append allocates a new slice.
-	key := vecencoding.EncodePartitionLevel(metadataKey, partition.Level())
-	key = slices.Clip(key)
+	// Cap the key so that appends allocate a new slice.
+	vectorKey := vecencoding.EncodePrefixVectorKey(metadataKey, partition.Level())
+	vectorKey = slices.Clip(vectorKey)
 	codec := tx.getCodecForPartitionKey(partitionKey)
 	childKeys := partition.ChildKeys()
 	valueBytes := partition.ValueBytes()
 	for i := 0; i < partition.QuantizedSet().GetCount(); i++ {
 		// The child key gets appended to 'key' here.
-		k := vecencoding.EncodeChildKey(key, childKeys[i])
+		k := vecencoding.EncodeChildKey(vectorKey, childKeys[i])
 		encodedValue, err := codec.encodeVectorFromSet(partition.QuantizedSet(), i)
 		if err != nil {
 			return err
@@ -296,10 +293,10 @@ func (tx *Txn) DeletePartition(
 ) error {
 	b := tx.kv.NewBatch()
 
-	startKey := tx.store.encodePartitionKey(treeKey, partitionKey)
-	endKey := startKey.PrefixEnd()
-
-	b.DelRange(startKey, endKey, false /* returnKeys */)
+	// Delete the metadata record and all vector records in the partition.
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
+	endKey := vecencoding.EncodeEndVectorKey(metadataKey)
+	b.DelRange(metadataKey, endKey, false /* returnKeys */)
 	return tx.kv.Run(ctx, b)
 }
 
@@ -310,10 +307,7 @@ func (tx *Txn) GetPartitionMetadata(
 	// TODO(mw5h): Add to an existing batch instead of starting a new one.
 	b := tx.kv.NewBatch()
 
-	// Cap the metadata key so that any append allocates a new slice.
-	metadataKey := tx.store.encodePartitionKey(treeKey, partitionKey)
-	metadataKey = slices.Clip(metadataKey)
-
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
 	if forUpdate {
 		// By acquiring a shared lock on metadata key, we prevent splits/merges of
 		// this partition from conflicting with the add operation.
@@ -350,11 +344,8 @@ func (tx *Txn) AddToPartition(
 	// TODO(mw5h): Add to an existing batch instead of starting a new one.
 	b := tx.kv.NewBatch()
 
-	// Cap the metadata key so that any append allocates a new slice.
-	metadataKey := tx.store.encodePartitionKey(treeKey, partitionKey)
-	metadataKey = slices.Clip(metadataKey)
-
 	// Get partition metadata, needed to quantize the vector.
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
 	b.Get(metadataKey)
 	err := tx.kv.Run(ctx, b)
 	if err != nil {
@@ -365,7 +356,7 @@ func (tx *Txn) AddToPartition(
 		return err
 	}
 
-	entryKey := vecencoding.EncodePartitionLevel(metadataKey, level)
+	entryKey := vecencoding.EncodePrefixVectorKey(metadataKey, level)
 	entryKey = vecencoding.EncodeChildKey(entryKey, childKey)
 
 	// Quantize the vector and add it to the partition with a Put command.
@@ -395,11 +386,8 @@ func (tx *Txn) RemoveFromPartition(
 ) error {
 	b := tx.kv.NewBatch()
 
-	// Cap the metadata key so that the append allocates a new slice for the child
-	// key.
-	metadataKey := tx.store.encodePartitionKey(treeKey, partitionKey)
-	metadataKey = slices.Clip(metadataKey)
-	entryKey := vecencoding.EncodePartitionLevel(metadataKey, level)
+	metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, partitionKey)
+	entryKey := vecencoding.EncodePrefixVectorKey(metadataKey, level)
 	entryKey = vecencoding.EncodeChildKey(entryKey, childKey)
 	b.Del(entryKey)
 	if err := tx.kv.Run(ctx, b); err != nil {
@@ -421,16 +409,17 @@ func (tx *Txn) SearchPartitions(
 	b := tx.kv.NewBatch()
 
 	for i := range toSearch {
-		// Cap the metadata key so that any append allocates a new slice.
-		metadataKey := tx.store.encodePartitionKey(treeKey, toSearch[i].Key)
-		metadataKey = slices.Clip(metadataKey)
+		metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, toSearch[i].Key)
 		b.Get(metadataKey)
 		if toSearch[i].ExcludeLeafVectors {
 			// Skip past vectors at the leaf level.
-			startKey := vecencoding.EncodePartitionLevel(metadataKey, cspann.SecondLevel)
-			b.Scan(startKey, metadataKey.PrefixEnd())
+			startKey := vecencoding.EncodePrefixVectorKey(metadataKey, cspann.SecondLevel)
+			endKey := vecencoding.EncodeEndVectorKey(metadataKey)
+			b.Scan(startKey, endKey)
 		} else {
-			b.Scan(metadataKey.Next(), metadataKey.PrefixEnd())
+			startKey := vecencoding.EncodeStartVectorKey(metadataKey)
+			endKey := vecencoding.EncodeEndVectorKey(metadataKey)
+			b.Scan(startKey, endKey)
 		}
 	}
 
@@ -546,7 +535,7 @@ func (tx *Txn) getFullVectorsFromPartitionMetadata(
 			numPKLookups++
 			continue
 		}
-		metadataKey := tx.store.encodePartitionKey(treeKey, ref.Key.PartitionKey)
+		metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, ref.Key.PartitionKey)
 		if b == nil {
 			b = tx.kv.NewBatch()
 		}
@@ -576,10 +565,11 @@ func (tx *Txn) getFullVectorsFromPartitionMetadata(
 			refs[idx].Vector = tx.store.emptyVec
 		} else {
 			// Get the centroid from the partition metadata.
-			_, refs[idx].Vector, err = vecencoding.DecodePartitionMetadata(result.Rows[0].ValueBytes())
+			metadata, err := vecencoding.DecodeMetadataValue(result.Rows[0].ValueBytes())
 			if err != nil {
 				return 0, err
 			}
+			refs[idx].Vector = metadata.Centroid
 		}
 		idx++
 	}
@@ -614,10 +604,7 @@ func (tx *Txn) createRootPartition(
 		Centroid:     tx.store.emptyVec,
 		StateDetails: cspann.MakeReadyDetails(),
 	}
-	encoded, err := vecencoding.EncodePartitionMetadata(metadata.Level, metadata.Centroid)
-	if err != nil {
-		return cspann.PartitionMetadata{}, err
-	}
+	encoded := vecencoding.EncodeMetadataValue(metadata)
 
 	// Use CPutAllowingIfNotExists in order to handle the case where the same
 	// transaction inserts multiple vectors (e.g. multiple VALUES rows). In that
@@ -678,22 +665,5 @@ func (tx *Txn) getMetadataFromKVResult(
 		return metadata, nil
 	}
 
-	level, centroid, err := vecencoding.DecodePartitionMetadata(value)
-	if err != nil {
-		return cspann.PartitionMetadata{}, err
-	}
-
-	// Return the metadata.
-	return cspann.PartitionMetadata{
-		Level:        level,
-		Centroid:     centroid,
-		StateDetails: cspann.MakeReadyDetails(),
-	}, nil
-}
-
-// calculateMetaKeyLen returns the length of the metadata partition key.
-func calculateMetaKeyLen(
-	store *Store, treeKey cspann.TreeKey, partitionKey cspann.PartitionKey,
-) int {
-	return len(store.prefix) + len(treeKey) + vecencoding.EncodedPartitionKeyLen(partitionKey)
+	return vecencoding.DecodeMetadataValue(value)
 }


### PR DESCRIPTION
First commit:
When multiple workers are racing to create the root partition, it's possible to trigger an error when the root partition already exists and is in a state other than Ready (e.g. Splitting). Fix this by creating the root metadata record only if doesn't already exist. If it does exist, just return the current metadata.

Second commit:
Make two updates to how KV keys and values are encoded for vector indexes:

1. Add Family ID to the end of the metadata KV key encoding. This is required by the KV split code, which checks the family ID to ensure that splits don't split column families for the same row across ranges.

2. Encode the partition state fields in the metadata KV value. This is needed for the new non-transactional background split code.

Epic: CRDB-42943

Release note: None