### PR TITLE
sql,optbuilder: route descriptor lookups for triggers through cache

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -47,6 +47,7 @@ go_test(
         "orm_queries_bench_test.go",
         "rtt_analysis_test.go",
         "system_bench_test.go",
+        "trigger_resolution_test.go",
         "truncate_bench_test.go",
         "udf_resolution_test.go",
         "validate_benchmark_data_test.go",

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -119,7 +119,7 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_empty_database_Name
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 1,SystemDatabaseQueries/select_system.users_without_schema_Name
-3,TriggerResolution/insert_into_table_with_trigger
+1,TriggerResolution/insert_into_table_with_trigger
 15,Truncate/truncate_1_column_0_rows
 15,Truncate/truncate_1_column_1_row
 15,Truncate/truncate_1_column_2_rows

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -119,6 +119,7 @@ exp,benchmark
 1,SystemDatabaseQueries/select_system.users_with_empty_database_Name
 1,SystemDatabaseQueries/select_system.users_with_schema_Name
 1,SystemDatabaseQueries/select_system.users_without_schema_Name
+3,TriggerResolution/insert_into_table_with_trigger
 15,Truncate/truncate_1_column_0_rows
 15,Truncate/truncate_1_column_1_row
 15,Truncate/truncate_1_column_2_rows

--- a/pkg/bench/rttanalysis/trigger_resolution_test.go
+++ b/pkg/bench/rttanalysis/trigger_resolution_test.go
@@ -1,0 +1,24 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rttanalysis
+
+import "testing"
+
+func BenchmarkTriggerResolution(b *testing.B) {
+	reg.Run(b)
+}
+func init() {
+	reg.Register("TriggerResolution", []RoundTripBenchTestCase{
+		{
+			Name: "insert into table with trigger",
+			Setup: `
+        CREATE TABLE trigger_table (a INT);
+        CREATE FUNCTION trigger_fn() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
+        CREATE TRIGGER tr BEFORE INSERT ON trigger_table FOR EACH ROW EXECUTE FUNCTION trigger_fn();`,
+			Stmt: `INSERT INTO trigger_table VALUES (100);`,
+		},
+	})
+}

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4037,7 +4037,7 @@ statement ok
 CREATE OR REPLACE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEW; END $$;
 
 # ==============================================================================
-# Test that descriptor backreferences are cleaned up
+# Test that descriptor backreferences are cleaned up.
 # ==============================================================================
 
 subtest ensure_back_ref_cleanup
@@ -4085,6 +4085,100 @@ DROP FUNCTION update_listing_balance ;
 # Sanity to verify the dependency no longer exists.
 statement ok
 drop table listings_balance cascade;
+
+# ==============================================================================
+# Test trigger arguments.
+# ==============================================================================
+
+statement ok
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE 'NEW: %', NEW;
+    RAISE NOTICE 'OLD: %', OLD;
+    RAISE NOTICE 'TG_NAME: %', TG_NAME;
+    RAISE NOTICE 'TG_WHEN: %', TG_WHEN;
+    RAISE NOTICE 'TG_LEVEL: %', TG_LEVEL;
+    RAISE NOTICE 'TG_OP: %', TG_OP;
+    RAISE NOTICE 'TG_RELID: %', TG_RELID;
+    RAISE NOTICE 'TG_RELNAME: %', TG_RELNAME;
+    RAISE NOTICE 'TG_TABLE_NAME: %', TG_TABLE_NAME;
+    RAISE NOTICE 'TG_TABLE_SCHEMA: %', TG_TABLE_SCHEMA;
+    RAISE NOTICE 'TG_NARGS: %', TG_NARGS;
+    -- TODO(#135311): uncomment this when we support TG_ARGV.
+    --RAISE NOTICE 'TG_ARGV: %s', TG_ARGV;
+    RETURN NEW;
+  END
+$$;
+
+statement ok
+CREATE TRIGGER foo BEFORE INSERT OR UPDATE ON xy FOR EACH ROW WHEN ((NEW).x = 1) EXECUTE FUNCTION g();
+
+statement ok
+CREATE TRIGGER bar AFTER INSERT OR UPDATE ON xy FOR EACH ROW WHEN ((NEW).x = 1) EXECUTE FUNCTION g();
+
+query T noticetrace
+INSERT INTO xy VALUES (1, 2);
+----
+NOTICE: NEW: (1,2)
+NOTICE: OLD: <NULL>
+NOTICE: TG_NAME: foo
+NOTICE: TG_WHEN: BEFORE
+NOTICE: TG_LEVEL: ROW
+NOTICE: TG_OP: INSERT
+NOTICE: TG_RELID: 106
+NOTICE: TG_RELNAME: xy
+NOTICE: TG_TABLE_NAME: xy
+NOTICE: TG_TABLE_SCHEMA: public
+NOTICE: TG_NARGS: 0
+NOTICE: NEW: (1,2)
+NOTICE: OLD: <NULL>
+NOTICE: TG_NAME: bar
+NOTICE: TG_WHEN: AFTER
+NOTICE: TG_LEVEL: ROW
+NOTICE: TG_OP: INSERT
+NOTICE: TG_RELID: 106
+NOTICE: TG_RELNAME: xy
+NOTICE: TG_TABLE_NAME: xy
+NOTICE: TG_TABLE_SCHEMA: public
+NOTICE: TG_NARGS: 0
+
+query T noticetrace
+UPDATE xy SET y = 3 WHERE x = 1;
+----
+NOTICE: NEW: (1,3)
+NOTICE: OLD: (1,2)
+NOTICE: TG_NAME: foo
+NOTICE: TG_WHEN: BEFORE
+NOTICE: TG_LEVEL: ROW
+NOTICE: TG_OP: UPDATE
+NOTICE: TG_RELID: 106
+NOTICE: TG_RELNAME: xy
+NOTICE: TG_TABLE_NAME: xy
+NOTICE: TG_TABLE_SCHEMA: public
+NOTICE: TG_NARGS: 0
+NOTICE: NEW: (1,3)
+NOTICE: OLD: (1,2)
+NOTICE: TG_NAME: bar
+NOTICE: TG_WHEN: AFTER
+NOTICE: TG_LEVEL: ROW
+NOTICE: TG_OP: UPDATE
+NOTICE: TG_RELID: 106
+NOTICE: TG_RELNAME: xy
+NOTICE: TG_TABLE_NAME: xy
+NOTICE: TG_TABLE_SCHEMA: public
+NOTICE: TG_NARGS: 0
+
+statement ok
+DROP TRIGGER foo ON xy;
+
+statement ok
+DROP TRIGGER bar ON xy;
+
+statement ok
+DROP FUNCTION g;
+
+statement ok
+DELETE FROM xy WHERE true;
 
 # ==============================================================================
 # Regression tests.

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -153,6 +153,10 @@ type Catalog interface {
 	// be safely copied or used across goroutines.
 	ResolveSchema(ctx context.Context, flags Flags, name *SchemaName) (Schema, SchemaName, error)
 
+	// ResolveSchemaByID is similar to ResolveSchema, except that it locates a
+	// schema by its StableID. See the comment for StableID for more details.
+	ResolveSchemaByID(ctx context.Context, flags Flags, id StableID) (Schema, error)
+
 	// GetAllSchemaNamesForDB Gets all the SchemaNames for a database.
 	GetAllSchemaNamesForDB(ctx context.Context, dbName string) ([]SchemaName, error)
 

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -175,6 +175,10 @@ type Table interface {
 	// owning database could not be determined.
 	GetDatabaseID() descpb.ID
 
+	// GetSchemaID returns the owning schema id of the table, or zero, if the
+	// owning schema could not be determined.
+	GetSchemaID() descpb.ID
+
 	// IsHypothetical returns true if this is a hypothetical table (used when
 	// searching for index recommendations).
 	IsHypothetical() bool

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -650,6 +650,11 @@ func (u *unknownTable) GetDatabaseID() descpb.ID {
 	return 0
 }
 
+// GetSchemaID is part of the cat.Table interface.
+func (u *unknownTable) GetSchemaID() descpb.ID {
+	return 0
+}
+
 // IsHypothetical is part of the cat.Table interface.
 func (u *unknownTable) IsHypothetical() bool {
 	return false

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -240,7 +240,7 @@ func (mb *mutationBuilder) buildTriggerFunctionArgs(
 		f.ConstructConstVal(tgWhen, types.String),        // TG_WHEN
 		f.ConstructConstVal(tgLevel, types.String),       // TG_LEVEL
 		f.ConstructConstVal(tgOp, types.String),          // TG_OP
-		f.ConstructConstVal(tgRelID, types.Oid),          // TG_RELIID
+		f.ConstructConstVal(tgRelID, types.Oid),          // TG_RELID
 		f.ConstructConstVal(tgTableName, types.String),   // TG_RELNAME
 		f.ConstructConstVal(tgTableName, types.String),   // TG_TABLE_NAME
 		f.ConstructConstVal(tgTableSchema, types.String), // TG_TABLE_SCHEMA
@@ -703,7 +703,7 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 					f.ConstructConstVal(tgWhen, types.String),  // TG_WHEN
 					f.ConstructConstVal(tgLevel, types.String), // TG_LEVEL
 					tgOp,                                    // TG_OP
-					f.ConstructConstVal(tgRelID, types.Oid), // TG_RELIID
+					f.ConstructConstVal(tgRelID, types.Oid), // TG_RELID
 					f.ConstructConstVal(tgTableName, types.String),   // TG_RELNAME
 					f.ConstructConstVal(tgTableName, types.String),   // TG_TABLE_NAME
 					f.ConstructConstVal(tgTableSchema, types.String), // TG_TABLE_SCHEMA

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -220,11 +220,13 @@ func (mb *mutationBuilder) buildTriggerFunctionArgs(
 	tgOp := tree.NewDString(eventType.String())
 	tgRelID := tree.NewDOid(oid.Oid(mb.tab.ID()))
 	tgTableName := tree.NewDString(string(mb.tab.Name()))
-	fqName, err := mb.b.catalog.FullyQualifiedName(mb.b.ctx, mb.tab)
+	schema, err := mb.b.catalog.ResolveSchemaByID(
+		mb.b.ctx, cat.Flags{}, cat.StableID(mb.tab.GetSchemaID()),
+	)
 	if err != nil {
 		panic(err)
 	}
-	tgTableSchema := tree.NewDString(fqName.Schema())
+	tgTableSchema := tree.NewDString(schema.Name().Schema())
 	tgNumArgs := tree.NewDInt(tree.DInt(len(trigger.FuncArgs())))
 	tgArgV := tree.NewDArray(types.String)
 	for _, arg := range trigger.FuncArgs() {

--- a/pkg/sql/opt/testutils/testcat/create_table.go
+++ b/pkg/sql/opt/testutils/testcat/create_table.go
@@ -80,7 +80,7 @@ func (tc *Catalog) CreateTable(stmt *tree.CreateTable) *Table {
 		isRbr = stmt.Locality.LocalityLevel == tree.LocalityLevelRow
 		isRbt = stmt.Locality.LocalityLevel == tree.LocalityLevelTable
 	}
-	tab := &Table{TabID: tc.nextStableID(), TabName: stmt.Table, Catalog: tc}
+	tab := &Table{TabID: tc.nextStableID(), SchemaID: testSchemaID, TabName: stmt.Table, Catalog: tc}
 
 	if isRbt && stmt.Locality.TableRegion != "" {
 		tab.multiRegion = true
@@ -490,7 +490,13 @@ func (tc *Catalog) CreateTableAs(name tree.TableName, columns []cat.Column) *Tab
 	// Update the table name to include catalog and schema if not provided.
 	tc.qualifyTableName(&name)
 
-	tab := &Table{TabID: tc.nextStableID(), TabName: name, Catalog: tc, Columns: columns}
+	tab := &Table{
+		TabID:    tc.nextStableID(),
+		SchemaID: testSchemaID,
+		TabName:  name,
+		Catalog:  tc,
+		Columns:  columns,
+	}
 
 	var rowid cat.Column
 	ordinal := len(columns)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -741,8 +741,7 @@ func (p *planner) CheckPrivilegeForTableID(
 	return p.CheckPrivilegeForUser(ctx, desc, privilege, p.User())
 }
 
-// LookupTableByID looks up a table, by the given descriptor ID. Based on the
-// CommonLookupFlags, it could use or skip the Collection cache.
+// LookupTableByID looks up a table, by the given descriptor ID.
 func (p *planner) LookupTableByID(
 	ctx context.Context, tableID descpb.ID,
 ) (catalog.TableDescriptor, error) {
@@ -751,6 +750,28 @@ func (p *planner) LookupTableByID(
 		return nil, err
 	}
 	return table, nil
+}
+
+// LookupSchemaByID looks up a schema by the given descriptor ID.
+func (p *planner) LookupSchemaByID(
+	ctx context.Context, schemaID descpb.ID,
+) (catalog.SchemaDescriptor, error) {
+	schema, err := p.byIDGetterBuilder().WithoutNonPublic().Get().Schema(ctx, schemaID)
+	if err != nil {
+		return nil, err
+	}
+	return schema, nil
+}
+
+// LookupDatabaseByID looks up a database by the given descriptor ID.
+func (p *planner) LookupDatabaseByID(
+	ctx context.Context, databaseID descpb.ID,
+) (catalog.DatabaseDescriptor, error) {
+	database, err := p.byIDGetterBuilder().WithoutNonPublic().Get().Database(ctx, databaseID)
+	if err != nil {
+		return nil, err
+	}
+	return database, nil
 }
 
 // SessionData is part of the PlanHookState interface.


### PR DESCRIPTION
#### rttanalysis: add test case with a trigger

This commit adds an rttanalysis test case that creates a trigger on
a table and then inserts into the table. This will be useful in the
following commit, which seeks to ensure the schema lookup during
planning of a trigger goes through the cache.

Informs #144211

Release note: None

#### sql: add logic test for trigger arguments

This commit adds a test to ensure that trigger function arguments are
provided correctly.

Epic: None

Release note: None

#### sql,optbuilder: route descriptor lookups for triggers through cache

Triggers have a `TG_TABLE_SCHEMA` argument which provides the schema
name. Getting the schema name requires doing a descriptor lookup when
the trigger is planned, which previously avoided the cache and always
performed an expensive KV lookup. This commit plumbs `ResolveSchemaByID`,
which allows the lookup to hit the descriptor cache.

Fixes #144211

Release note (performance improvement): Triggers now perform the
descriptor lookup for `TG_TABLE_SCHEMA` against a cache. This can
significantly reduce trigger planning latency in multi-region databases.