### PR TITLE
roachtest/allocbench: Add labels to the std-dev metric

### DIFF
--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -351,7 +351,20 @@ func runAllocationBench(
 	// worst/best case outcomes.
 	result, sampleStddev := findMinDistanceClusterStatRun(t, samples)
 	for tag, value := range sampleStddev {
-		result.Total[fmt.Sprintf("std_%s", tag)] = value
+		metricName := fmt.Sprintf("std_%s", tag)
+		result.Total[metricName] = value
+
+		// Populate BenchmarkMetrics with metadata if it's initialized
+		// (it will be initialized only when OpenMetrics is enabled)
+		if result.BenchmarkMetrics != nil {
+			result.BenchmarkMetrics[metricName] = roachtestutil.AggregatedMetric{
+				Name:             metricName,
+				Value:            roachtestutil.MetricPoint(value),
+				Unit:             "stddev",
+				IsHigherBetter:   false, // Lower standard deviation is better
+				AdditionalLabels: nil,
+			}
+		}
 	}
 	if result == nil {
 		t.L().PrintfCtx(ctx, "no samples found for allocation bench run, won't put any artifacts")

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -163,7 +163,7 @@ func getMaxWarehousesAboveEfficiency(
 	aggregatedMetrics = append(aggregatedMetrics, &roachtestutil.AggregatedMetric{
 		Name:           fmt.Sprintf("%s_max_warehouse", testName),
 		Value:          roachtestutil.MetricPoint(maxEfficientWarehouse),
-		Unit:           "",
+		Unit:           "warehouses",
 		IsHigherBetter: true,
 		// labels added here override any labels imported from the stats file.
 		// since we don't want to specify a warehouse label for this metric, we pass an empty label.


### PR DESCRIPTION
Adds unit and is_higher_better tags to std-dev metrics being emitted from allocbench tests.
Adds code for aggregate value generation in cdc/scan test.
Adds missing unit label for tpcc test.

Epic: none
Fixes: none