### PR TITLE
kvcoord: support stateful txn retries in txnWriteBuffer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1817,3 +1817,37 @@ func TestTxnWriteBufferFlushesAfterDisabling(t *testing.T) {
 	require.Len(t, br.Responses, 1)
 	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
 }
+
+// TestTxnWriteBufferClearsBufferOnEpochBump tests that the txnWriteBuffer
+// clears its buffer whenever the epoch is bumped.
+func TestTxnWriteBufferClearsBufferOnEpochBump(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+
+	txn := makeTxnProto()
+	txn.Sequence = 1
+
+	keyA, keyB, keyC := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c")
+
+	// Blindly write to some keys that should all be buffered.
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putA := putArgs(keyA, "valA", txn.Sequence)
+	putB := putArgs(keyB, "valB", txn.Sequence)
+	delC := delArgs(keyC, txn.Sequence)
+	ba.Add(putA, putB, delC)
+
+	numCalled := mockSender.NumCalled()
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+	require.Equal(t, numCalled, mockSender.NumCalled())
+
+	// The buffer should be cleared after epoch bump.
+	twb.epochBumpedLocked()
+	require.Equal(t, 0, len(twb.testingBufferedWritesAsSlice()))
+	require.Equal(t, 0, int(twb.bufferSize))
+	require.Equal(t, numCalled, mockSender.NumCalled())
+}


### PR DESCRIPTION
Previously, a stateful transaction retry would result in:

1) errors when calling SetBufferedWritesEnabled, and 2) erroneous writes from the previous epoch being flushed

Here, (1) is fixed by separately tracking the flushed state from the enabled state, allowing SetBufferedWritesEnabled to be called even after we've disabled future flushing.

(2) is solved by clearing the buffer when the epoch is bumped.

We've decided to keep write buffering disabled after an epoch bump to maintain the current invariant that once we've stopped buffering writes, we won't resume buffering.

Fixes #139057

Release note: None