### PR TITLE
raft,kvserver: use RawNode for GetTerm

### DIFF
--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -127,7 +127,9 @@ func (r *Replica) raftTermLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) {
 func (r *Replica) GetTerm(i kvpb.RaftIndex) (kvpb.RaftTerm, error) {
 	r.mu.Lock()
 	defer r.mu.Unlock()
-	return r.raftTermLocked(i)
+	ls := r.mu.internalRaftGroup.LogStorage()
+	term, err := ls.Term(uint64(i))
+	return kvpb.RaftTerm(term), err
 }
 
 // LastIndex implements the raft.LogStorage interface.

--- a/pkg/raft/log.go
+++ b/pkg/raft/log.go
@@ -411,11 +411,11 @@ func (l *raftLog) lastEntryID() entryID {
 }
 
 func (l *raftLog) term(i uint64) (uint64, error) {
-	return l.snap(l.storage).term(i)
+	return l.snap(l.storage).Term(i)
 }
 
-// term returns the term of the log entry at the given index.
-func (l LogSnapshot) term(index uint64) (uint64, error) {
+// Term returns the term of the log entry at the given index.
+func (l LogSnapshot) Term(index uint64) (uint64, error) {
 	// Check the unstable log first, even before computing the valid index range,
 	// which may need to access the storage. If we find the entry's term in the
 	// unstable log, we know it was in the valid range.
@@ -544,7 +544,7 @@ func (l *raftLog) slice(lo, hi uint64, maxSize entryEncodingSize) ([]pb.Entry, e
 // Returns at least one entry if the interval contains any. The maxSize can only
 // be exceeded if the first entry (lo+1) is larger.
 func (l LogSnapshot) LeadSlice(lo, hi uint64, maxSize uint64) (LeadSlice, error) {
-	prevTerm, err := l.term(lo)
+	prevTerm, err := l.Term(lo)
 	if err != nil {
 		// The log is probably compacted at index > lo (err == ErrCompacted), or it
 		// can be a custom storage error.

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -198,6 +198,12 @@ func (rn *RawNode) LogSnapshot() LogSnapshot {
 	return rn.raft.raftLog.snap(rn.raft.raftLog.storage.LogSnapshot())
 }
 
+// LogStorage is the same as LogSnapshot, but the returned handle is only valid
+// while Replica.mu is held, and there are no steps to this RawNode.
+func (rn *RawNode) LogStorage() LogSnapshot {
+	return rn.raft.raftLog.snap(rn.raft.raftLog.storage)
+}
+
 // SendMsgApp conditionally sends a MsgApp message containing the given log
 // slice to the given peer. The message is returned to the caller, who is
 // responsible for actually sending it. The RawNode only updates the internal


### PR DESCRIPTION
The `RawNode` has the up-to-date log and a warmed up term cache.

Part of #143417
Epic: none
Release note: none