### PR TITLE
sql/schemachanger: avoid falling back when adding multiple pks

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1540,3 +1540,23 @@ statement ok
 EXPLAIN (DDL) CREATE SCHEMA sc1
 
 subtest end
+
+
+subtest multiple_primary_key
+
+statement ok
+CREATE TABLE multiple_pk_attempt(n INT PRIMARY KEY, j INT)
+
+let $use_decl_sc
+SHOW use_declarative_schema_changer
+
+statement ok
+SET use_declarative_schema_changer = 'unsafe_always'
+
+statement error pgcode 42611 multiple primary keys for table \"multiple_pk_attempt\" are not allowed
+ALTER TABLE multiple_pk_attempt ADD PRIMARY KEY (j);
+
+statement ok
+SET use_declarative_schema_changer = $use_decl_sc
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -85,7 +85,12 @@ func alterTableAddPrimaryKey(
 	if getPrimaryIndexDefaultRowIDColumn(
 		b, tbl.TableID, oldPrimaryIndex.IndexID,
 	) == nil {
-		panic(scerrors.NotImplementedError(t))
+		// If the constraint already exists then nothing to do here.
+		if oldPrimaryIndex != nil && d.IfNotExists {
+			return
+		}
+		panic(pgerror.Newf(pgcode.InvalidColumnDefinition,
+			"multiple primary keys for table %q are not allowed", tn.Object()))
 	}
 	alterPrimaryKey(b, tn, tbl, stmt, alterPrimaryKeySpec{
 		n:             t,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -447,12 +447,18 @@ func fallBackIfRegionalByRowTable(b BuildCtx, t tree.NodeFormatter, tableID cati
 	}
 }
 
+// mustRetrieveCurrentPrimaryIndexElement retrieves the current primary index,
+// which must be public.
 func mustRetrieveCurrentPrimaryIndexElement(
 	b BuildCtx, tableID catid.DescID,
 ) (res *scpb.PrimaryIndex) {
 	scpb.ForEachPrimaryIndex(b.QueryByID(tableID), func(
 		current scpb.Status, target scpb.TargetStatus, e *scpb.PrimaryIndex,
 	) {
+		// TODO(fqazi): We don't support DROP CONSTRAINT PRIMARY KEY, so there is no
+		// risk of ever seeing a non-public PrimaryIndex element. In the future when
+		// we do support DROP CONSTRAINT PRIMARY KEY, we should adapt callers of
+		// this function to handle the absent primary index case.
 		if current == scpb.Status_PUBLIC {
 			res = e
 		}

--- a/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
+++ b/pkg/sql/schemachanger/scbuild/testdata/unimplemented_alter_table
@@ -33,10 +33,6 @@ ALTER TABLE defaultdb.foo EXPERIMENTAL_AUDIT SET READ WRITE
 ----
 
 unimplemented
-ALTER TABLE defaultdb.foo ADD PRIMARY KEY (l);
-----
-
-unimplemented
 ALTER TABLE defaultdb.foo PARTITION BY NOTHING
 ----
 

--- a/pkg/sql/schemachanger/scbuild/testdata/zone_cfg
+++ b/pkg/sql/schemachanger/scbuild/testdata/zone_cfg
@@ -46,10 +46,6 @@ ALTER TABLE defaultdb.foo_index_zone_cfg ADD COLUMN j INT
 - [[IndexColumn:{DescID: 105, ColumnID: 7, IndexID: 1}, PUBLIC], ABSENT]
   {columnId: 7, indexId: 1, kind: STORED, ordinalInKind: 5, tableId: 105}
 
-unimplemented
-ALTER TABLE defaultdb.foo_index_zone_cfg ADD PRIMARY KEY (i, n)
-----
-
 build
 ALTER TABLE defaultdb.foo_index_zone_cfg DROP COLUMN k
 ----


### PR DESCRIPTION
Previously, the declarative schema changer would incorrectly fallback if the user was attempting to add multiple primary keys. This was a gap in the logic for automatically cleaning up default pks, which return a not implemented error if the rowid column was not found. To address this, this patch will always generates the correct error.

Fixes: #144235

Release note: None