### PR TITLE
backup: gracefully recover online restore failures and cancellations

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -2657,9 +2657,8 @@ func (r *restoreResumer) OnFailOrCancel(
 
 	details := r.job.Details().(jobspb.RestoreDetails)
 
-	// If this is a download-only job, there's no cleanup to do on cancel.
-	if len(details.DownloadSpans) > 0 {
-		return nil
+	if err := r.maybeCleanupFailedOnlineRestore(ctx, p, details); err != nil {
+		return err
 	}
 
 	// Emit to the event log that the job has started reverting.


### PR DESCRIPTION
This patch teaches online restore to cleanly excise restoring key space if the job fails or cancels after external ssts had been linked to the cluster. In other words, after a failed or canceled online restore, no external ssts should exist in the cluster. Here's how the recovery process works:

1. During the link phase, once the restoring key space has been split and scattered, but before linking begins, restore issues splits at the restoring table-index start and end keys with an infinite expiration. If OnFailOrCancel is called, we must excise whole ranges, so these sticky splits ensure that online restored keyspace is never collocated on a range that contains non OR-ed key space.

2. During OnFailOrCancel:
  - Flip the table descriptors offline if they are online
  - Excise the restored key space to remove all external ssts
  - remove the sticky bit on the restore sticky restore splits

3. During a successful download phase, unstick the sticky restore splits.

Epic: none

Release note: none