### PR TITLE
jsonpath: add parenthesized expressions in jsonpath accessors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1375,3 +1375,34 @@ SELECT jsonb_path_query('{}', '$var', '{}', true);
 
 statement error pgcode 42704 pq: could not find jsonpath variable "var"
 SELECT jsonb_path_query('{}', '$var', '{}', false);
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '($[*] > 2) ? (@ == true)');
+----
+true
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '((($[*] > (2)))) ? ((@ == true))');
+----
+true
+
+query T
+SELECT jsonb_path_query('{"a": {"b": {"c": 1}}}', '($.a.b).c');
+----
+1
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": {"c": 1, "d": 2}}}', '($.a.b).*');
+----
+1
+2
+
+query T
+SELECT jsonb_path_query('{"a": [10, 20, 30]}', '($.a)[1]');
+----
+20
+
+query T
+SELECT jsonb_path_query('{"a": {"b": [{"c": 1}, {"c": 2}]}}', '($.a.b[1]).c');
+----
+2

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -304,6 +304,14 @@ accessor_expr:
   {
     $$.val = []jsonpath.Path{$1.path()}
   }
+| '(' expr ')' accessor_op
+  {
+    $$.val = []jsonpath.Path{$2.path(), $4.path()}
+  }
+| '(' predicate ')' accessor_op
+  {
+    $$.val = []jsonpath.Path{$2.path(), $4.path()}
+  }
 | accessor_expr accessor_op
   {
     $$.val = append($1.pathArr(), $2.path())

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -556,6 +556,34 @@ $.a starts with $var
 ----
 ($."a" starts with $"var") -- normalized!
 
+parse
+($.a).b
+----
+$."a"."b" -- normalized!
+
+parse
+(($.a.b).c.d).e.f
+----
+$."a"."b"."c"."d"."e"."f" -- normalized!
+
+parse
+(1 == 1).abc
+----
+(1 == 1)."abc" -- normalized!
+
+parse
+(((1 == 1).a.b == 2).c.d == 3).e.f
+----
+(((1 == 1)."a"."b" == 2)."c"."d" == 3)."e"."f" -- normalized!
+
+error
+($[*] > 2 ? (@ == true)
+----
+at or near "EOF": syntax error
+DETAIL: source SQL:
+($[*] > 2 ? (@ == true)
+                       ^
+
 # postgres allows floats as array indexes
 # parse
 # $.abc[1.0]


### PR DESCRIPTION
This commit adds support for parenthesized expressions in JSONPath
accessors.

Epic: None
Release note (sql change): Add support for parenthesized expressions in
JSONPath queries. For example, (`SELECT jsonb_path_query('3', '($ > 2) ? (@ == true)');`)