### PR TITLE
jsonpath: validate array indices are within int32 range

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1406,3 +1406,25 @@ query T
 SELECT jsonb_path_query('{"a": {"b": [{"c": 1}, {"c": 2}]}}', '($.a.b[1]).c');
 ----
 2
+
+statement error pgcode 22033 pq: jsonpath array subscript is out of integer range
+SELECT jsonb_path_query('[1]', 'lax $[10000000000000000]');
+
+statement error pgcode 22033 pq: jsonpath array subscript is out of integer range
+SELECT jsonb_path_query('[1]', 'lax $[-10000000000000000]');
+
+# MaxInt32
+query empty
+SELECT jsonb_path_query('[1]', '$[2147483647]');
+
+# MaxInt32 + 1
+statement error pgcode 22033 pq: jsonpath array subscript is out of integer range
+SELECT jsonb_path_query('[1]', '$[2147483648]');
+
+# MinInt32
+query empty
+SELECT jsonb_path_query('[1]', '$[-2147483648]');
+
+# MinInt32 - 1
+statement error pgcode 22033 pq: jsonpath array subscript is out of integer range
+SELECT jsonb_path_query('[1]', '$[-2147483649]');

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -18,7 +18,6 @@ import (
 
 var (
 	errUnimplemented         = unimplemented.NewWithIssue(22513, "unimplemented")
-	errInternal              = errors.New("internal error")
 	errSingleBooleanRequired = pgerror.Newf(pgcode.SingletonSQLJSONItemRequired, "single boolean result is expected")
 )
 


### PR DESCRIPTION
This commit adds validation to ensure JSONPath array indices are within
the int32 range, matching Postgres' behaviour. Now, we return an error
for indices outside the int32 range.

Epic: None
Release note: None