### PR TITLE
sql: store JSONPath AST in Datum

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1515,9 +1515,10 @@ SELECT jsonb_path_query('null', '"123".type()');
 ----
 "string"
 
-# TODO(#144258): should be "number", but the scanner doesn't scan this properly.
-statement error pgcode 42601 pq: at or near \"trailing junk after numeric literal
+query T
 SELECT jsonb_path_query('null', '(123).type()');
+----
+"number"
 
 query T
 SELECT jsonb_path_query('null', 'true.type()');

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -372,7 +372,8 @@ func (h *hasher) HashDatum(val tree.Datum) {
 		h.HashString(t.Locale)
 		h.HashString(t.Contents)
 	case *tree.DJsonpath:
-		h.HashString(string(*t))
+		// TODO(#22513): Workaround until we allow jsonpath encoding.
+		h.HashString(t.String())
 	default:
 		h.bytes, h.bytes3 = encodeDatum(h.bytes[:0], val, h.bytes3[:0])
 		h.HashBytes(h.bytes)
@@ -912,7 +913,7 @@ func (h *hasher) IsDatumEqual(l, r tree.Datum) bool {
 	case *tree.DJsonpath:
 		// TODO(#22513): Workaround until we allow jsonpath encoding.
 		rt := r.(*tree.DJsonpath)
-		return h.IsStringEqual(string(*lt), string(*rt))
+		return h.IsStringEqual(lt.String(), rt.String())
 	default:
 		h.bytes, h.bytes3 = encodeDatum(h.bytes[:0], l, h.bytes3[:0])
 		h.bytes2, h.bytes3 = encodeDatum(h.bytes2[:0], r, h.bytes3[:0])

--- a/pkg/sql/parser/statements/statement.go
+++ b/pkg/sql/parser/statements/statement.go
@@ -98,7 +98,8 @@ func (stmt JsonpathStatement) String() string {
 // StringWithFlags returns the AST formatted as a string (with the given flags).
 func (stmt JsonpathStatement) StringWithFlags(flags tree.FmtFlags) string {
 	ctx := tree.NewFmtCtx(flags)
-	stmt.AST.Format(ctx)
+	// TODO(#22513): Create a specific Format method for jsonpath that redacts constants.
+	ctx.FormatStringConstant(stmt.AST.String())
 	return ctx.CloseAndGetString()
 }
 

--- a/pkg/sql/pgwire/pgwirebase/BUILD.bazel
+++ b/pkg/sql/pgwire/pgwirebase/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/ipaddr",
         "//pkg/util/json",
+        "//pkg/util/jsonpath/parser",
         "//pkg/util/timeofday",
         "//pkg/util/timetz",
         "//pkg/util/timeutil/pgdate",

--- a/pkg/sql/pgwire/pgwirebase/encoding.go
+++ b/pkg/sql/pgwire/pgwirebase/encoding.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	jsonpathparser "github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timetz"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
@@ -474,7 +475,11 @@ func DecodeDatum(
 			}
 			return da.NewDJSON(tree.DJSON{JSON: v}), nil
 		case oidext.T_jsonpath:
-			return da.NewDJsonpath(tree.DJsonpath(bs)), nil
+			jp, err := jsonpathparser.Parse(bs)
+			if err != nil {
+				return nil, tree.MakeParseError(bs, typ, err)
+			}
+			return da.NewDJsonpath(tree.DJsonpath{Jsonpath: *jp.AST}), nil
 		case oid.T_tsquery:
 			ret, err := tsearch.ParseTSQuery(bs)
 			if err != nil {
@@ -760,7 +765,11 @@ func DecodeDatum(
 			}
 			return da.NewDJSON(tree.DJSON{JSON: v}), nil
 		case oidext.T_jsonpath:
-			return da.NewDJsonpath(tree.DJsonpath(bs)), nil
+			jp, err := jsonpathparser.Parse(bs)
+			if err != nil {
+				return nil, tree.MakeParseError(bs, typ, err)
+			}
+			return da.NewDJsonpath(tree.DJsonpath{Jsonpath: *jp.AST}), nil
 		case oid.T_varbit, oid.T_bit:
 			if len(b) < 4 {
 				return nil, NewProtocolViolationErrorf("insufficient data: %d", len(b))

--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -27,9 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/ipaddr"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
-	// TODO(normanchenn): temporarily import the parser here to ensure that
-	// init() is called.
-	_ "github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
+	jsonpathparser "github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
@@ -233,8 +231,11 @@ func RandDatumWithNullChance(
 		}
 		return &tree.DJSON{JSON: j}
 	case types.JsonpathFamily:
-		jsonpath := randJsonpath(rng)
-		return tree.NewDJsonpath(jsonpath)
+		jp, err := jsonpathparser.Parse(randJsonpath(rng))
+		if err != nil {
+			return nil
+		}
+		return tree.NewDJsonpath(*jp.AST)
 	case types.TupleFamily:
 		tuple := tree.DTuple{D: make(tree.Datums, len(typ.TupleContents()))}
 		if nullChance == 0 {

--- a/pkg/sql/sem/eval/cast.go
+++ b/pkg/sql/sem/eval/cast.go
@@ -495,7 +495,7 @@ func performCastWithoutPrecisionTruncation(
 		case *tree.DJSON:
 			s = t.JSON.String()
 		case *tree.DJsonpath:
-			s = string(*t)
+			s = t.Jsonpath.String()
 		case *tree.DTSQuery:
 			s = t.TSQuery.String()
 		case *tree.DTSVector:

--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -166,6 +166,7 @@ go_library(
         "//pkg/util/ipaddr",
         "//pkg/util/iterutil",
         "//pkg/util/json",
+        "//pkg/util/jsonpath",
         "//pkg/util/pretty",
         "//pkg/util/stringencoding",
         "//pkg/util/syncutil",

--- a/pkg/sql/sem/tree/datum_alloc.go
+++ b/pkg/sql/sem/tree/datum_alloc.go
@@ -46,6 +46,7 @@ type DatumAlloc struct {
 	duuidAlloc        []DUuid
 	dipnetAlloc       []DIPAddr
 	djsonAlloc        []DJSON
+	djsonpathAlloc    []DJsonpath
 	dtupleAlloc       []DTuple
 	doidAlloc         []DOid
 	dvoidAlloc        []DVoid
@@ -692,8 +693,17 @@ func (a *DatumAlloc) NewDJsonpath(v DJsonpath) *DJsonpath {
 		*r = v
 		return r
 	}
-	r := (*DJsonpath)(a.newString())
+	buf := &a.djsonpathAlloc
+	if len(*buf) == 0 {
+		allocSize := defaultDatumAllocSize
+		if a.DefaultAllocSize != 0 {
+			allocSize = a.DefaultAllocSize
+		}
+		*buf = make([]DJsonpath, allocSize)
+	}
+	r := &(*buf)[0]
 	*r = v
+	*buf = (*buf)[1:]
 	return r
 }
 

--- a/pkg/util/jsonpath/BUILD.bazel
+++ b/pkg/util/jsonpath/BUILD.bazel
@@ -10,8 +10,5 @@ go_library(
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/jsonpath",
     visibility = ["//visibility:public"],
-    deps = [
-        "//pkg/sql/sem/tree",
-        "//pkg/util/json",
-    ],
+    deps = ["//pkg/util/json"],
 )

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
-	"github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser"
 	"github.com/cockroachdb/errors"
 )
 
@@ -134,12 +133,7 @@ func JsonpathMatch(
 func jsonpathQuery(
 	target tree.DJSON, path tree.DJsonpath, vars tree.DJSON, silent tree.DBool,
 ) ([]json.JSON, error) {
-	parsedPath, err := parser.Parse(string(path))
-	if err != nil {
-		return []json.JSON{}, err
-	}
-	expr := parsedPath.AST
-
+	expr := path.Jsonpath
 	ctx := &jsonpathCtx{
 		root:                 target.JSON,
 		vars:                 vars.JSON,
@@ -147,7 +141,6 @@ func jsonpathQuery(
 		silent:               bool(silent),
 		innermostArrayLength: -1,
 	}
-
 	return ctx.eval(expr.Path, ctx.root, !ctx.strict /* unwrap */)
 }
 

--- a/pkg/util/jsonpath/expr.go
+++ b/pkg/util/jsonpath/expr.go
@@ -8,8 +8,6 @@ package jsonpath
 import (
 	"fmt"
 	"strings"
-
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 type Jsonpath struct {
@@ -23,10 +21,6 @@ func (j Jsonpath) String() string {
 		mode = "strict "
 	}
 	return mode + j.Path.String()
-}
-
-func (j Jsonpath) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString(j.String())
 }
 
 type Path interface {
@@ -130,8 +124,7 @@ func (r Regex) String() string {
 	return fmt.Sprintf("%q flag %q", r.Regex, r.Flags)
 }
 
-var _ tree.RegexpCacheKey = Regex{}
-
+// Pattern implements the tree.RegexpCacheKey interface.
 func (r Regex) Pattern() (string, error) {
 	return r.Regex, nil
 }

--- a/pkg/util/jsonpath/parser/parse.go
+++ b/pkg/util/jsonpath/parser/parse.go
@@ -16,12 +16,12 @@ import (
 )
 
 func init() {
-	tree.ValidateJSONPath = func(jsonpath string) (string, error) {
+	tree.ValidateJSONPath = func(jsonpath string) (*jsonpath.Jsonpath, error) {
 		jp, err := Parse(jsonpath)
 		if err != nil {
-			return "", err
+			return nil, err
 		}
-		return jp.AST.String(), nil
+		return jp.AST, nil
 	}
 }
 

--- a/pkg/util/jsonpath/parser/parser_test.go
+++ b/pkg/util/jsonpath/parser/parser_test.go
@@ -57,7 +57,7 @@ func VerifyParse(t *testing.T, input, pos string) string {
 		t.Fatalf("%s\nunexpected parse error: %v", pos, err)
 	}
 
-	ref := jsonpath.String()
+	ref := jsonpath.AST.String()
 	note := ""
 	if ref != input {
 		note = " -- normalized!"


### PR DESCRIPTION
This commits modifies the JSONPath implementation to store the parsed
AST directly in the DJsonpath Datum instead of storing it as a string.

This change will improve JSONPath query execution times significantly
since we do not need to parse the JSONPath query string for each row we
evaluate the query on.

Closes: #144099
Release note: None