### PR TITLE
spanconfigbounds: treat nil constraints as conforming

### DIFF
--- a/pkg/spanconfig/spanconfigbounds/constraints_field.go
+++ b/pkg/spanconfig/spanconfigbounds/constraints_field.go
@@ -119,6 +119,12 @@ func (c *constraintsConjunctionBounds) SafeFormat(s redact.SafePrinter, verb run
 func (c *constraintsConjunctionBounds) conforms(t *roachpb.SpanConfig, f Field) (conforms bool) {
 	s := sortedConstraints(c.Allowed)
 	constraints := f.(field[[]roachpb.ConstraintsConjunction]).fieldValue(t)
+
+	// If the field is not set, treat it as conforming. This allows unset
+	// constraints to conform without triggering fallback behavior.
+	if *constraints == nil {
+		return true
+	}
 	for i := range *constraints {
 		if !s.conjunctionConforms((*constraints)[i].Constraints) {
 			return false

--- a/pkg/spanconfig/spanconfigbounds/testdata/empty_and_missing
+++ b/pkg/spanconfig/spanconfigbounds/testdata/empty_and_missing
@@ -1,0 +1,102 @@
+### Define config bounds that allow two regions and hava a fallback.
+
+bounds name=foo
+constraint_bounds: <
+    allowed: <key: "region" value: "gcp-us-west2">
+    allowed: <key: "region" value: "gcp-europe-west1">
+    fallback: <constraints: <key: "region" value: "gcp-europe-west1">>
+>
+----
+
+bounds-fields bounds=foo
+----
+range_min_bytes: *
+range_max_bytes: *
+global_reads: *
+num_voters: *
+num_replicas: *
+gc.ttlseconds: *
+constraints: {allowed: [{+region=gcp-europe-west1}, {+region=gcp-us-west2}], fallback: [[{+region=gcp-europe-west1}]]}
+voter_constraints: {allowed: [{+region=gcp-europe-west1}, {+region=gcp-us-west2}], fallback: [[{+region=gcp-europe-west1}]]}
+lease_preferences: {allowed: [{+region=gcp-europe-west1}, {+region=gcp-us-west2}], fallback: [[{+region=gcp-europe-west1}]]}
+
+
+### Define a config with empty voter constraints and replica constraints in the
+### two allowed regions. It satisfies the config bounds above.
+
+config name=empty-voter-constraints
+num_voters: 5
+num_replicas: 5
+constraints: <
+  num_replicas: 3
+  constraints: <key: "region" value: "gcp-europe-west1">
+>
+constraints: <
+  num_replicas: 2
+  constraints: <key: "region" value: "gcp-us-west2">
+>
+voter_constraints: <>
+----
+
+conforms bounds=foo config=empty-voter-constraints
+----
+true
+
+### Define a config with missing voter constraints and replica constraints in
+### the two allowed regions. It should satisfy the config bounds, same as
+### empty voter constraints does.
+### See https://github.com/cockroachdb/cockroach/issues/143524.
+
+config name=missing-voter-constraints
+num_voters: 5
+num_replicas: 5
+constraints: <
+  num_replicas: 3
+  constraints: <key: "region" value: "gcp-europe-west1">
+>
+constraints: <
+  num_replicas: 2
+  constraints: <key: "region" value: "gcp-us-west2">
+>
+----
+
+conforms bounds=foo config=missing-voter-constraints
+----
+true
+
+### Test the same behavior for constraints field.
+
+config name=empty-constraints
+num_voters: 5
+num_replicas: 5
+voter_constraints: <
+  num_replicas: 3
+  constraints: <key: "region" value: "gcp-europe-west1">
+>
+voter_constraints: <
+  num_replicas: 2
+  constraints: <key: "region" value: "gcp-us-west2">
+>
+constraints: <>
+----
+
+conforms bounds=foo config=empty-constraints
+----
+true
+
+config name=missing-constraints
+num_voters: 5
+num_replicas: 5
+voter_constraints: <
+  num_replicas: 3
+  constraints: <key: "region" value: "gcp-europe-west1">
+>
+voter_constraints: <
+  num_replicas: 2
+  constraints: <key: "region" value: "gcp-us-west2">
+>
+----
+
+conforms bounds=foo config=missing-constraints
+----
+true

--- a/pkg/spanconfig/spanconfigbounds/testdata/regions
+++ b/pkg/spanconfig/spanconfigbounds/testdata/regions
@@ -105,8 +105,8 @@ span config bounds violated for fields: voter_constraints
 Error types: (1) *spanconfigbounds.ViolationError
 
 # Note that this case is interesting because we won't touch the out-of-bounds
-# num_replicas in the voter_constraints. It's invalid but it's okay because we
-# are clamping the outer num_replicas.
+# num_replicas in the voter_constraints. It's invalid but it's okay because the
+# outer num_replicas limits the number of replicas.
 clamp bounds=bound_to_three_regions
 gc_policy: <ttl_seconds: 127>
 range_min_bytes: 100
@@ -118,36 +118,6 @@ voter_constraints: <
     constraints: <type: REQUIRED key: "region" value: "us-central1">
 >
 ----
-@@ -4,8 +4,29 @@
-   ttl_seconds: 127
- >
- num_replicas: 3
- num_voters: 3
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-east1"
-+  >
-+>
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-central1"
-+  >
-+>
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-west1"
-+  >
-+>
- voter_constraints: <
-   num_replicas: 4
-   constraints: <
-     key: "region"
 
 
 # Show that when the user has requested all the voters to be in a
@@ -164,32 +134,8 @@ voter_constraints: <
 >
 ----
 ----
-@@ -4,11 +4,32 @@
-   ttl_seconds: 127
- >
- num_replicas: 3
+@@ -7,8 +7,8 @@
  num_voters: 3
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-east1"
-+  >
-+>
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-central1"
-+  >
-+>
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-west1"
-+  >
-+>
  voter_constraints: <
    constraints: <
      key: "region"
@@ -203,7 +149,7 @@ voter_constraints: <
 
 # This is dealing with the weird situation where there was more than one
 # voter_constraints, and at least one of them did not conform. In this
-# case, we choose to spread the replicas over all the fallback regions.
+# case, we choose to spread the voters over all the fallback regions.
 
 clamp bounds=bound_to_three_regions
 gc_policy: <ttl_seconds: 127>
@@ -219,34 +165,13 @@ voter_constraints: <
 >
 ----
 ----
-@@ -2,19 +2,49 @@
+@@ -2,19 +2,28 @@
  range_max_bytes: 10
  gc_policy: <
    ttl_seconds: 127
  >
 +num_replicas: 3
 +num_voters: 3
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-east1"
-+  >
-+>
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-central1"
-+  >
-+>
-+constraints: <
-+  num_replicas: 1
-+  constraints: <
-+    key: "region"
-+    value: "us-west1"
-+  >
-+>
  voter_constraints: <
 -  num_replicas: 4
 +  num_replicas: 1


### PR DESCRIPTION
Previously, when voter_constraints or constraints fields were
not set in a spanconfig, the conformance check would fail. This was
not consistent with how empty constraints were handled, since those
would always pass conformance checks. The reason for the difference is
related to how protobufs represent empty lists.

This inconsistency caused unnecessary fallback behavior for tables
that didn't explicitly set these constraint fields.

This change modifies the conformance check to treat nil constraint
fields as conforming, matching the behavior of empty constraint
lists. This allows zone configurations without explicit constraints
to satisfy bounds without triggering fallback behavior.

No release note since this only affects Serverless.

Fixes cockroachdb#143524

Release note: None

