### PR TITLE
jsonpath/eval: minor clean up around maybeThrowError

### DIFF
--- a/pkg/util/jsonpath/eval/array.go
+++ b/pkg/util/jsonpath/eval/array.go
@@ -27,14 +27,14 @@ func (ctx *jsonpathCtx) evalArrayWildcard(jsonValue json.JSON) ([]json.JSON, err
 	} else if !ctx.strict {
 		return []json.JSON{jsonValue}, nil
 	}
-	return nil, maybeThrowError(ctx, errWildcardOnNonArray)
+	return nil, errWildcardOnNonArray
 }
 
 func (ctx *jsonpathCtx) evalArrayList(
 	arrayList jsonpath.ArrayList, jsonValue json.JSON,
 ) ([]json.JSON, error) {
 	if ctx.strict && jsonValue.Type() != json.ArrayJSONType {
-		return nil, maybeThrowError(ctx, errIndexOnNonArray)
+		return nil, errIndexOnNonArray
 	}
 
 	length := jsonValue.Len()
@@ -71,7 +71,7 @@ func (ctx *jsonpathCtx) evalArrayList(
 		}
 
 		if ctx.strict && (from < 0 || from > to || to >= length) {
-			return nil, maybeThrowError(ctx, errIndexOutOfBounds)
+			return nil, errIndexOutOfBounds
 		}
 		for i := max(from, 0); i <= min(to, length-1); i++ {
 			v, err := jsonArrayValueAtIndex(ctx, jsonValue, i)

--- a/pkg/util/jsonpath/eval/key.go
+++ b/pkg/util/jsonpath/eval/key.go
@@ -26,19 +26,14 @@ func (ctx *jsonpathCtx) evalKey(
 			return nil, err
 		}
 		if val == nil {
-			if ctx.strict {
-				return nil, maybeThrowError(ctx,
-					pgerror.Newf(pgcode.SQLJSONMemberNotFound, "JSON object does not contain key %q", string(key)))
-			}
-			return nil, nil
+			return nil, maybeThrowError(ctx,
+				pgerror.Newf(pgcode.SQLJSONMemberNotFound, "JSON object does not contain key %q", string(key)))
 		}
 		return []json.JSON{val}, nil
 	} else if unwrap && jsonValue.Type() == json.ArrayJSONType {
 		return ctx.unwrapCurrentTargetAndEval(key, jsonValue, false /* unwrapNext */)
-	} else if ctx.strict {
-		return nil, maybeThrowError(ctx, errKeyAccessOnNonObject)
 	}
-	return nil, nil
+	return nil, maybeThrowError(ctx, errKeyAccessOnNonObject)
 }
 
 func (ctx *jsonpathCtx) evalAnyKey(
@@ -48,8 +43,6 @@ func (ctx *jsonpathCtx) evalAnyKey(
 		return ctx.executeAnyItem(nil /* jsonPath */, jsonValue, !ctx.strict /* unwrapNext */)
 	} else if unwrap && jsonValue.Type() == json.ArrayJSONType {
 		return ctx.unwrapCurrentTargetAndEval(anyKey, jsonValue, false /* unwrapNext */)
-	} else if ctx.strict {
-		return nil, maybeThrowError(ctx, errWildcardOnNonObject)
 	}
-	return nil, nil
+	return nil, maybeThrowError(ctx, errWildcardOnNonObject)
 }


### PR DESCRIPTION
I think we could remove some `ctx.strict` checks around error handling by using `maybeThrowError`. Relatedly, in a few spots we used the helper when we know that we're in the strict context, so we could just return error directly.

Epic: None
Release note: None