### PR TITLE
drt: fix issue with add-index

### DIFF
--- a/pkg/cmd/roachtest/operations/add_index.go
+++ b/pkg/cmd/roachtest/operations/add_index.go
@@ -54,6 +54,10 @@ func runAddIndex(
 	rng, _ := randutil.NewPseudoRand()
 	dbName := helpers.PickRandomDB(ctx, o, conn, helpers.SystemDBs)
 	tableName := helpers.PickRandomTable(ctx, o, conn, dbName)
+	if _, err := conn.ExecContext(ctx, fmt.Sprintf("USE %s", dbName)); err != nil {
+		o.Fatal(err)
+	}
+
 	rows, err := conn.QueryContext(ctx, fmt.Sprintf(
 		`
 SELECT


### PR DESCRIPTION
add-index operation fails today when a table is passed as an argument. The issue was because the select from pg_catalog.pg_attribute requires you to set the database by "USE DB_NAME". In case a table is not specified, the same gets executed in "PickRandomTable" function.

Epic: None
Release: None