### PR TITLE
storepool: lock individual storepool details instead of all details

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -480,59 +480,68 @@ func mockStorePool(
 	decommissionedStoreIDs []roachpb.StoreID,
 	suspectedStoreIDs []roachpb.StoreID,
 ) {
-	storePool.DetailsMu.Lock()
-	defer storePool.DetailsMu.Unlock()
-
 	liveNodeSet := map[roachpb.NodeID]livenesspb.NodeLivenessStatus{}
 	for _, storeID := range aliveStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range unavailableStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_UNAVAILABLE
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range deadStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_DEAD
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range decommissioningStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONING
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 	for _, storeID := range decommissionedStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_DECOMMISSIONED
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 
 	for _, storeID := range suspectedStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
-		detail := storePool.GetStoreDetailLocked(storeID)
+		detail := storePool.GetStoreDetail(storeID)
+		detail.Lock()
 		detail.LastUnavailable = storePool.Clock().Now()
 		detail.Desc = &roachpb.StoreDescriptor{
 			StoreID: storeID,
 			Node:    roachpb.NodeDescriptor{NodeID: roachpb.NodeID(storeID)},
 		}
+		detail.Unlock()
 	}
 
 	// Set the node liveness function using the set we constructed.
@@ -1379,16 +1388,20 @@ func TestAllocatorRebalanceDeadNodes(t *testing.T) {
 	}
 
 	// Initialize 8 stores: where store 6 is the target for rebalancing.
-	sp.DetailsMu.Lock()
-	sp.GetStoreDetailLocked(1).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(2).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(3).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(4).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(5).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(6).Desc.Capacity = ranges(0)
-	sp.GetStoreDetailLocked(7).Desc.Capacity = ranges(100)
-	sp.GetStoreDetailLocked(8).Desc.Capacity = ranges(100)
-	sp.DetailsMu.Unlock()
+	updateDescCapacity := func(storeID roachpb.StoreID, capacity roachpb.StoreCapacity) {
+		sd := sp.GetStoreDetail(storeID)
+		sd.Lock()
+		sd.Desc.Capacity = capacity
+		sd.Unlock()
+	}
+	updateDescCapacity(1, ranges(100))
+	updateDescCapacity(2, ranges(100))
+	updateDescCapacity(3, ranges(100))
+	updateDescCapacity(4, ranges(100))
+	updateDescCapacity(5, ranges(100))
+	updateDescCapacity(6, ranges(0))
+	updateDescCapacity(7, ranges(100))
+	updateDescCapacity(8, ranges(100))
 
 	// Each test case should describe a repair situation which has a lower
 	// priority than the previous test case.

--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_test.go
@@ -484,7 +484,6 @@ func mockStorePool(
 	defer storePool.DetailsMu.Unlock()
 
 	liveNodeSet := map[roachpb.NodeID]livenesspb.NodeLivenessStatus{}
-	storePool.DetailsMu.StoreDetails = map[roachpb.StoreID]*storepool.StoreDetail{}
 	for _, storeID := range aliveStoreIDs {
 		liveNodeSet[roachpb.NodeID(storeID)] = livenesspb.NodeLivenessStatus_LIVE
 		detail := storePool.GetStoreDetailLocked(storeID)

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -118,9 +118,10 @@ func (o *OverrideStorePool) GetStoreList(
 	defer o.sp.DetailsMu.Unlock()
 
 	var storeIDs roachpb.StoreIDSlice
-	for storeID := range o.sp.DetailsMu.StoreDetails {
+	o.sp.DetailsMu.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetail) bool {
 		storeIDs = append(storeIDs, storeID)
-	}
+		return true
+	})
 	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool.go
@@ -114,39 +114,31 @@ func (o *OverrideStorePool) DecommissioningReplicas(
 func (o *OverrideStorePool) GetStoreList(
 	filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	o.sp.DetailsMu.Lock()
-	defer o.sp.DetailsMu.Unlock()
-
 	var storeIDs roachpb.StoreIDSlice
-	o.sp.DetailsMu.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetail) bool {
+	o.sp.Details.StoreDetails.Range(func(storeID roachpb.StoreID, _ *StoreDetailMu) bool {
 		storeIDs = append(storeIDs, storeID)
 		return true
 	})
-	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
 // GetStoreListFromIDs implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) GetStoreListFromIDs(
 	storeIDs roachpb.StoreIDSlice, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	o.sp.DetailsMu.Lock()
-	defer o.sp.DetailsMu.Unlock()
-	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
 // GetStoreListForTargets implements the AllocatorStorePool interface.
 func (o *OverrideStorePool) GetStoreListForTargets(
 	candidates []roachpb.ReplicationTarget, filter StoreFilter,
 ) (StoreList, int, ThrottledStoreReasons) {
-	o.sp.DetailsMu.Lock()
-	defer o.sp.DetailsMu.Unlock()
-
 	storeIDs := make(roachpb.StoreIDSlice, 0, len(candidates))
 	for _, tgt := range candidates {
 		storeIDs = append(storeIDs, tgt.StoreID)
 	}
 
-	return o.sp.getStoreListFromIDsLocked(storeIDs, o.overrideNodeLivenessFn, filter)
+	return o.sp.getStoreListFromIDs(storeIDs, o.overrideNodeLivenessFn, filter)
 }
 
 // LiveAndDeadReplicas implements the AllocatorStorePool interface.

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -330,11 +330,11 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 	livenessOverrides[decommissioningStore.Node.NodeID] = livenesspb.NodeLivenessStatus_DECOMMISSIONING
 
 	// Set suspectedStore as suspected.
-	testStorePool.DetailsMu.Lock()
-	val, ok := testStorePool.DetailsMu.StoreDetails.Load(suspectedStore.StoreID)
+	val, ok := testStorePool.Details.StoreDetails.Load(suspectedStore.StoreID)
 	require.True(t, ok)
+	val.Lock()
 	val.LastUnavailable = testStorePool.clock.Now()
-	testStorePool.DetailsMu.Unlock()
+	val.Unlock()
 
 	// No filter or limited set of store IDs.
 	require.NoError(t, verifyStoreList(

--- a/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/override_store_pool_test.go
@@ -331,7 +331,9 @@ func TestOverrideStorePoolGetStoreList(t *testing.T) {
 
 	// Set suspectedStore as suspected.
 	testStorePool.DetailsMu.Lock()
-	testStorePool.DetailsMu.StoreDetails[suspectedStore.StoreID].LastUnavailable = testStorePool.clock.Now()
+	val, ok := testStorePool.DetailsMu.StoreDetails.Load(suspectedStore.StoreID)
+	require.True(t, ok)
+	val.LastUnavailable = testStorePool.clock.Now()
 	testStorePool.DetailsMu.Unlock()
 
 	// No filter or limited set of store IDs.

--- a/pkg/kv/kvserver/allocator/storepool/store_pool.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool.go
@@ -147,8 +147,7 @@ func (sd *StoreDetailMu) status(
 	nl NodeLivenessFunc,
 	suspectDuration time.Duration,
 ) storeStatus {
-	sd.Lock()
-	defer sd.Unlock()
+	sd.RLock() // all exist paths will RUnlock() the lock.
 	// During normal operation, we expect the state transitions for stores to look like the following:
 	//
 	//      +-----------------------+
@@ -170,19 +169,37 @@ func (sd *StoreDetailMu) status(
 	//                                        heartbeat
 	//
 
+	// updateLastUnavailableAndReturnStatusRLocked upgrades the read lock to a
+	// write lock, updates the LastUnavailable timestamp, returns the store
+	// status, and unlocks the write lock.
+	updateLastUnavailableAndReturnStatusRLocked := func(
+		lastUnavailable hlc.Timestamp, returnStatus storeStatus,
+	) storeStatus {
+		sd.RUnlock()
+		sd.Lock()
+		defer sd.Unlock()
+		sd.LastUnavailable = lastUnavailable
+		return returnStatus
+	}
+
+	// returnStatusRLocked unlocks the read lock and returns the store status.
+	returnStatusRLocked := func(returnStatus storeStatus) storeStatus {
+		defer sd.RUnlock()
+		return returnStatus
+	}
+
 	// The store is considered dead if it hasn't been updated via gossip
 	// within the liveness threshold. Note that LastUpdatedTime is set
 	// when the store detail is created and will have a non-zero value
 	// even before the first gossip arrives for a store.
 	deadAsOf := sd.LastUpdatedTime.AddDuration(deadThreshold)
 	if now.After(deadAsOf) {
-		sd.LastUnavailable = now
-		return storeStatusDead
+		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDead)
 	}
 	// If there's no descriptor (meaning no gossip ever arrived for this
 	// store), return unavailable.
 	if sd.Desc == nil {
-		return storeStatusUnknown
+		return returnStatusRLocked(storeStatusUnknown)
 	}
 
 	// Even if the store has been updated via gossip, we still rely on
@@ -192,34 +209,31 @@ func (sd *StoreDetailMu) status(
 	// dead -> decommissioning -> unknown -> draining -> suspect -> available.
 	switch nl(sd.Desc.Node.NodeID) {
 	case livenesspb.NodeLivenessStatus_DEAD, livenesspb.NodeLivenessStatus_DECOMMISSIONED:
-		sd.LastUnavailable = now
-		return storeStatusDead
+		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDead)
 	case livenesspb.NodeLivenessStatus_DECOMMISSIONING:
-		return storeStatusDecommissioning
+		return returnStatusRLocked(storeStatusDecommissioning)
 	case livenesspb.NodeLivenessStatus_UNAVAILABLE:
-		sd.LastUnavailable = now
-		return storeStatusUnknown
+		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusUnknown)
 	case livenesspb.NodeLivenessStatus_UNKNOWN:
-		return storeStatusUnknown
+		return returnStatusRLocked(storeStatusUnknown)
 	case livenesspb.NodeLivenessStatus_DRAINING:
-		sd.LastUnavailable = now
-		return storeStatusDraining
+		return updateLastUnavailableAndReturnStatusRLocked(now, storeStatusDraining)
 	}
 
 	// A store is throttled if it has missed receiving snapshots recently.
 	if sd.ThrottledUntil.After(now) {
-		return storeStatusThrottled
+		return returnStatusRLocked(storeStatusThrottled)
 	}
 
 	// Check whether the store is currently suspect. We measure that by
 	// looking at the time it was last unavailable making sure we have not seen any
 	// failures for a period of time defined by StoreSuspectDuration.
 	if sd.LastUnavailable.AddDuration(suspectDuration).After(now) {
-		return storeStatusSuspect
+		return returnStatusRLocked(storeStatusSuspect)
 	}
 
 	// Clear out the LastUnavailable once we return available status.
-	return storeStatusAvailable
+	return returnStatusRLocked(storeStatusAvailable)
 }
 
 // localityWithString maintains a string representation of each locality along

--- a/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
+++ b/pkg/kv/kvserver/allocator/storepool/store_pool_test.go
@@ -57,19 +57,15 @@ func TestStorePoolGossipUpdate(t *testing.T) {
 	defer stopper.Stop(ctx)
 	sg := gossiputil.NewStoreGossiper(g)
 
-	sp.DetailsMu.RLock()
-	if _, ok := sp.DetailsMu.StoreDetails.Load(2); ok {
+	if _, ok := sp.Details.StoreDetails.Load(2); ok {
 		t.Fatalf("store 2 is already in the pool's store list")
 	}
-	sp.DetailsMu.RUnlock()
 
 	sg.GossipStores(uniqueStore, t)
 
-	sp.DetailsMu.RLock()
-	if _, ok := sp.DetailsMu.StoreDetails.Load(2); !ok {
+	if _, ok := sp.Details.StoreDetails.Load(2); !ok {
 		t.Fatalf("store 2 isn't in the pool's store list")
 	}
-	sp.DetailsMu.RUnlock()
 }
 
 // verifyStoreList ensures that the returned list of stores is correct.
@@ -200,16 +196,18 @@ func TestStorePoolGetStoreList(t *testing.T) {
 
 	// Set deadStore as dead.
 	mnl.SetNodeStatus(deadStore.Node.NodeID, livenesspb.NodeLivenessStatus_DEAD)
-	sp.DetailsMu.Lock()
 	// Set declinedStore as throttled.
-	val, ok := sp.DetailsMu.StoreDetails.Load(declinedStore.StoreID)
+	val, ok := sp.Details.StoreDetails.Load(declinedStore.StoreID)
 	require.True(t, ok)
+	val.Lock()
 	(*val).ThrottledUntil = sp.clock.Now().AddDuration(time.Hour)
+	val.Unlock()
 	// Set suspectedStore as suspected.
-	val, ok = sp.DetailsMu.StoreDetails.Load(suspectedStore.StoreID)
+	val, ok = sp.Details.StoreDetails.Load(suspectedStore.StoreID)
 	require.True(t, ok)
+	val.Lock()
 	(*val).LastUnavailable = sp.clock.Now()
-	sp.DetailsMu.Unlock()
+	val.Unlock()
 
 	// No filter or limited set of store IDs.
 	if err := verifyStoreList(
@@ -428,12 +426,10 @@ func TestStorePoolGetStoreDetails(t *testing.T) {
 	sg := gossiputil.NewStoreGossiper(g)
 	sg.GossipStores(uniqueStore, t)
 
-	sp.DetailsMu.Lock()
-	defer sp.DetailsMu.Unlock()
-	if detail := sp.GetStoreDetailLocked(roachpb.StoreID(1)); detail.Desc != nil {
+	if detail := sp.GetStoreDetail(roachpb.StoreID(1)); detail.Desc != nil {
 		t.Errorf("unexpected fetched store ID 1: %+v", detail.Desc)
 	}
-	if detail := sp.GetStoreDetailLocked(roachpb.StoreID(2)); detail.Desc == nil {
+	if detail := sp.GetStoreDetail(roachpb.StoreID(2)); detail.Desc == nil {
 		t.Errorf("failed to fetch store ID 2")
 	}
 }
@@ -592,13 +588,13 @@ func TestStorePoolThrottle(t *testing.T) {
 	expected := sp.clock.Now().AddDuration(FailedReservationsTimeout.Get(&sp.st.SV))
 	sp.Throttle(ThrottleFailed, "", 1)
 
-	sp.DetailsMu.Lock()
-	detail := sp.GetStoreDetailLocked(1)
-	sp.DetailsMu.Unlock()
+	detail := sp.GetStoreDetail(1)
+	detail.RLock()
 	if detail.ThrottledUntil.WallTime != expected.WallTime {
 		t.Errorf("expected store to have been throttled to %v, found %v",
 			expected, detail.ThrottledUntil)
 	}
+	detail.RUnlock()
 }
 
 // See state transition diagram in storeDetail.status() for a visual
@@ -619,7 +615,7 @@ func TestStorePoolSuspected(t *testing.T) {
 	timeAfterNodeSuspect := liveness.TimeAfterNodeSuspect.Get(&sp.st.SV)
 
 	// Verify a store that we haven't seen yet is unknown status.
-	detail := sp.GetStoreDetailLocked(0)
+	detail := sp.GetStoreDetail(0)
 	s := detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusUnknown)
 	require.Equal(t, hlc.Timestamp{}, detail.LastUnavailable)
@@ -631,9 +627,7 @@ func TestStorePoolSuspected(t *testing.T) {
 
 	// Store starts in a live state if it hasn't been marked suspect yet.
 	mnl.SetNodeStatus(store.Node.NodeID, livenesspb.NodeLivenessStatus_LIVE)
-	sp.DetailsMu.Lock()
-	detail = sp.GetStoreDetailLocked(store.StoreID)
-	defer sp.DetailsMu.Unlock()
+	detail = sp.GetStoreDetail(store.StoreID)
 
 	s = detail.status(now, timeUntilNodeDead, sp.NodeLivenessFn, timeAfterNodeSuspect)
 	require.Equal(t, s, storeStatusAvailable)
@@ -903,10 +897,10 @@ func TestStorePoolString(t *testing.T) {
 	mnl.SetNodeStatus(7, livenesspb.NodeLivenessStatus_DRAINING)
 	mnl.SetNodeStatus(8, livenesspb.NodeLivenessStatus_LIVE)
 	mnl.SetNodeStatus(9, livenesspb.NodeLivenessStatus_LIVE)
-	val, ok := sp.DetailsMu.StoreDetails.Load(8)
+	val, ok := sp.Details.StoreDetails.Load(8)
 	require.True(t, ok)
 	(*val).LastUnavailable = sp.clock.Now()
-	val, ok = sp.DetailsMu.StoreDetails.Load(9)
+	val, ok = sp.Details.StoreDetails.Load(9)
 	require.True(t, ok)
 	(*val).ThrottledUntil = sp.clock.Now().AddDuration(time.Second)
 

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -406,13 +406,13 @@ func TestAllocatorThrottled(t *testing.T) {
 
 	// Finally, set that store to be throttled and ensure we don't send the
 	// replica to purgatory.
-	sp.DetailsMu.Lock()
-	storeDetail, ok := sp.DetailsMu.StoreDetails.Load(singleStore[0].StoreID)
+	storeDetail, ok := sp.Details.StoreDetails.Load(singleStore[0].StoreID)
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}
+	storeDetail.Lock()
 	storeDetail.ThrottledUntil = hlc.Timestamp{WallTime: timeutil.Now().Add(24 * time.Hour).UnixNano()}
-	sp.DetailsMu.Unlock()
+	storeDetail.Unlock()
 	_, _, err = a.AllocateVoter(ctx, sp, simpleSpanConfig, []roachpb.ReplicaDescriptor{}, nil, nil, allocatorimpl.Dead)
 	if _, ok := IsPurgatoryError(err); ok {
 		t.Fatalf("expected a non purgatory error, got: %+v", err)

--- a/pkg/kv/kvserver/allocator_impl_test.go
+++ b/pkg/kv/kvserver/allocator_impl_test.go
@@ -407,7 +407,7 @@ func TestAllocatorThrottled(t *testing.T) {
 	// Finally, set that store to be throttled and ensure we don't send the
 	// replica to purgatory.
 	sp.DetailsMu.Lock()
-	storeDetail, ok := sp.DetailsMu.StoreDetails[singleStore[0].StoreID]
+	storeDetail, ok := sp.DetailsMu.StoreDetails.Load(singleStore[0].StoreID)
 	if !ok {
 		t.Fatalf("store:%d was not found in the store pool", singleStore[0].StoreID)
 	}

--- a/pkg/kv/kvserver/asim/gossip/BUILD.bazel
+++ b/pkg/kv/kvserver/asim/gossip/BUILD.bazel
@@ -33,6 +33,7 @@ go_test(
         "//pkg/kv/kvserver/asim/config",
         "//pkg/kv/kvserver/asim/state",
         "//pkg/roachpb",
+        "//pkg/util/syncutil",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/kv/kvserver/asim/gossip/exchange.go
+++ b/pkg/kv/kvserver/asim/gossip/exchange.go
@@ -38,11 +38,11 @@ func (u *fixedDelayExchange) put(tick time.Time, descs ...roachpb.StoreDescripto
 
 // updates returns back exchanged infos, wrapped as store details that have
 // completed between the last tick update was called and the tick given.
-func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetail {
+func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetailMu {
 	slices.SortStableFunc(u.pending, func(a, b exchangeInfo) int {
 		return a.created.Compare(b.created)
 	})
-	var ready []*storepool.StoreDetail
+	var ready []*storepool.StoreDetailMu
 	i := 0
 	for ; i < len(u.pending) && !tick.Before(u.pending[i].created.Add(u.settings.StateExchangeDelay)); i++ {
 		ready = append(ready, makeStoreDetail(&u.pending[i].desc, u.pending[i].created))
@@ -51,10 +51,10 @@ func (u *fixedDelayExchange) updates(tick time.Time) []*storepool.StoreDetail {
 	return ready
 }
 
-// makeStoreDetail wraps a store descriptor into a storepool StoreDetail at the
+// makeStoreDetail wraps a store descriptor into a storepool StoreDetailMu at the
 // given tick.
-func makeStoreDetail(desc *roachpb.StoreDescriptor, tick time.Time) *storepool.StoreDetail {
-	return &storepool.StoreDetail{
+func makeStoreDetail(desc *roachpb.StoreDescriptor, tick time.Time) *storepool.StoreDetailMu {
+	return &storepool.StoreDetailMu{
 		Desc:            desc,
 		LastUpdatedTime: hlc.Timestamp{WallTime: tick.UnixNano()},
 	}

--- a/pkg/kv/kvserver/asim/gossip/gossip.go
+++ b/pkg/kv/kvserver/asim/gossip/gossip.go
@@ -204,7 +204,7 @@ func (g *gossip) maybeUpdateState(tick time.Time, s state.State) {
 		return
 	}
 
-	updateMap := map[roachpb.StoreID]*storepool.StoreDetail{}
+	updateMap := map[roachpb.StoreID]*storepool.StoreDetailMu{}
 	for _, update := range updates {
 		updateMap[update.Desc.StoreID] = update
 	}

--- a/pkg/kv/kvserver/asim/gossip/gossip_test.go
+++ b/pkg/kv/kvserver/asim/gossip/gossip_test.go
@@ -7,6 +7,7 @@ package gossip
 
 import (
 	"context"
+	"sort"
 	"testing"
 	"time"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/config"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/asim/state"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -26,7 +28,7 @@ func TestGossip(t *testing.T) {
 	for _, rng := range s.Ranges() {
 		s.TransferLease(rng.RangeID(), 1)
 	}
-	details := map[state.StoreID]*map[roachpb.StoreID]*storepool.StoreDetail{}
+	details := map[state.StoreID]*syncutil.Map[roachpb.StoreID, storepool.StoreDetail]{}
 
 	for _, store := range s.Stores() {
 		// Cast the storepool to a concrete storepool type in order to mutate
@@ -35,8 +37,8 @@ func TestGossip(t *testing.T) {
 		details[store.StoreID()] = &sp.DetailsMu.StoreDetails
 	}
 
-	assertStorePool := func(f func(prev, cur *map[roachpb.StoreID]*storepool.StoreDetail)) {
-		var prev *map[roachpb.StoreID]*storepool.StoreDetail
+	assertStorePool := func(f func(prev, cur *syncutil.Map[roachpb.StoreID, storepool.StoreDetail])) {
+		var prev *syncutil.Map[roachpb.StoreID, storepool.StoreDetail]
 		for _, cur := range details {
 			if prev != nil {
 				f(prev, cur)
@@ -45,13 +47,61 @@ func TestGossip(t *testing.T) {
 		}
 	}
 
-	assertEmptyFn := func(prev, cur *map[roachpb.StoreID]*storepool.StoreDetail) {
-		require.Len(t, *prev, 0)
-		require.Len(t, *cur, 0)
+	assertEmptyFn := func(prev, cur *syncutil.Map[roachpb.StoreID, storepool.StoreDetail]) {
+		prevCount, curCount := 0, 0
+		prev.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			prevCount++
+			return true
+		})
+		cur.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			curCount++
+			return true
+		})
+		require.Equal(t, 0, prevCount)
+		require.Equal(t, 0, curCount)
 	}
 
-	assertSameFn := func(prev, cur *map[roachpb.StoreID]*storepool.StoreDetail) {
-		require.Equal(t, *prev, *cur)
+	assertSameFn := func(prev, cur *syncutil.Map[roachpb.StoreID, storepool.StoreDetail]) {
+		var prevResults []struct {
+			StoreID roachpb.StoreID
+			Detail  *storepool.StoreDetail
+		}
+		var curResults []struct {
+			StoreID roachpb.StoreID
+			Detail  *storepool.StoreDetail
+		}
+
+		prev.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			prevResults = append(prevResults, struct {
+				StoreID roachpb.StoreID
+				Detail  *storepool.StoreDetail
+			}{
+				StoreID: key,
+				Detail:  value,
+			})
+			return true
+		})
+
+		cur.Range(func(key roachpb.StoreID, value *storepool.StoreDetail) bool {
+			curResults = append(curResults, struct {
+				StoreID roachpb.StoreID
+				Detail  *storepool.StoreDetail
+			}{
+				StoreID: key,
+				Detail:  value,
+			})
+			return true
+		})
+
+		// Sort the results by StoreID to ensure that the order is the same.
+		sort.Slice(prevResults, func(i, j int) bool {
+			return prevResults[i].StoreID < prevResults[j].StoreID
+		})
+		sort.Slice(curResults, func(i, j int) bool {
+			return curResults[i].StoreID < curResults[j].StoreID
+		})
+
+		require.Equal(t, prevResults, curResults)
 	}
 
 	gossip := NewGossip(s, settings)
@@ -109,11 +159,18 @@ func TestGossip(t *testing.T) {
 	assertStorePool(assertSameFn)
 	// Assert that the lease counts are as expected after transferring all of
 	// the leases to s2.
-	require.Equal(t, int32(0), (*details[1])[1].Desc.Capacity.LeaseCount)
+	val, ok := (*details[1]).Load(1)
+	require.True(t, ok)
+	require.Equal(t, int32(0), val.Desc.Capacity.LeaseCount)
 	// Depending on the capacity delta threshold, s2 may not have gossiped
 	// exactly when it reached 100 leases, as it earlier gossiped at 90+ leases,
 	// so 100 may be < lastGossip * capacityDeltaThreshold, not triggering
 	// gossip. Assert that the lease count gossiped is at least 90.
-	require.Greater(t, (*details[1])[2].Desc.Capacity.LeaseCount, int32(90))
-	require.Equal(t, int32(0), (*details[1])[3].Desc.Capacity.LeaseCount)
+	val, ok = (*details[1]).Load(2)
+	require.True(t, ok)
+	require.Greater(t, val.Desc.Capacity.LeaseCount, int32(90))
+
+	val, ok = (*details[1]).Load(3)
+	require.True(t, ok)
+	require.Equal(t, int32(0), val.Desc.Capacity.LeaseCount)
 }

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1079,10 +1079,8 @@ func (s *state) UpdateStorePool(
 	sort.Sort(storeIDs)
 	for _, gossipStoreID := range storeIDs {
 		detail := storeDescriptors[gossipStoreID]
-		copiedDetail := *detail
-		copiedDesc := *detail.Desc
-		copiedDetail.Desc = &copiedDesc
-		s.stores[storeID].storepool.DetailsMu.StoreDetails[gossipStoreID] = &copiedDetail
+		copiedDetail := detail.Copy()
+		s.stores[storeID].storepool.DetailsMu.StoreDetails.Store(gossipStoreID, copiedDetail)
 	}
 }
 

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -1070,7 +1070,7 @@ func (s *state) Clock() timeutil.TimeSource {
 // UpdateStorePool modifies the state of the StorePool for the Store with
 // ID StoreID.
 func (s *state) UpdateStorePool(
-	storeID StoreID, storeDescriptors map[roachpb.StoreID]*storepool.StoreDetail,
+	storeID StoreID, storeDescriptors map[roachpb.StoreID]*storepool.StoreDetailMu,
 ) {
 	var storeIDs roachpb.StoreIDSlice
 	for storeIDA := range storeDescriptors {
@@ -1080,7 +1080,7 @@ func (s *state) UpdateStorePool(
 	for _, gossipStoreID := range storeIDs {
 		detail := storeDescriptors[gossipStoreID]
 		copiedDetail := detail.Copy()
-		s.stores[storeID].storepool.DetailsMu.StoreDetails.Store(gossipStoreID, copiedDetail)
+		s.stores[storeID].storepool.Details.StoreDetails.Store(gossipStoreID, copiedDetail)
 	}
 }
 

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -154,7 +154,7 @@ type State interface {
 	Clock() timeutil.TimeSource
 	// UpdateStorePool modifies the state of the StorePool for the Store with
 	// ID StoreID.
-	UpdateStorePool(StoreID, map[roachpb.StoreID]*storepool.StoreDetail)
+	UpdateStorePool(StoreID, map[roachpb.StoreID]*storepool.StoreDetailMu)
 	// NextReplicasFn returns a function, that when called will return the current
 	// replicas that exist on the store.
 	NextReplicasFn(StoreID) func() []Replica

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -247,11 +247,11 @@ func BenchmarkStorePoolReadsWithConcurrentUpdates(b *testing.B) {
 					}
 					// Note that we have to lock the whole store pool just to update one
 					// store detail.
-					store.StorePool().DetailsMu.Lock()
-					detail := store.StorePool().GetStoreDetailLocked(roachpb.StoreID(i))
+					detail := store.StorePool().GetStoreDetail(roachpb.StoreID(i))
+					detail.Lock()
 					detail.LastUpdatedTime = detail.LastUpdatedTime.AddDuration(100 * time.Millisecond)
 					time.Sleep(100 * time.Millisecond)
-					store.StorePool().DetailsMu.Unlock()
+					detail.Unlock()
 				}
 			}
 		}

--- a/pkg/kv/kvserver/client_store_test.go
+++ b/pkg/kv/kvserver/client_store_test.go
@@ -211,3 +211,60 @@ func TestStoreLoadReplicaQuiescent(t *testing.T) {
 		}
 	})
 }
+
+// BenchmarkStorePoolReadsWithConcurrentUpdates checks the performance of
+// querying the store pool while there are concurrent updates to the store
+// details.
+func BenchmarkStorePoolReadsWithConcurrentUpdates(b *testing.B) {
+	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
+	ctx := context.Background()
+
+	// Create cluster with 3 nodes.
+	numNodes := 3
+	cluster := testcluster.StartTestCluster(b, numNodes, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer cluster.Stopper().Stop(ctx)
+
+	// Start a goroutine that continuously takes the write lock on storepool for
+	// updating the store details. This is to simulate the gossip callback that
+	// periodically updates the store details.
+	stopCh := make(chan struct{})
+	go func() {
+		store := cluster.GetFirstStoreFromServer(b, 0)
+		for {
+			select {
+			case <-stopCh:
+				return
+			default:
+				for i := range numNodes {
+					// Skip the updates to the store idx 1. This is to test the
+					// performance for updates to other stores while checking if the
+					// store is ready for routine replica transfer below.
+					if i == 1 {
+						continue
+					}
+					// Note that we have to lock the whole store pool just to update one
+					// store detail.
+					store.StorePool().DetailsMu.Lock()
+					detail := store.StorePool().GetStoreDetailLocked(roachpb.StoreID(i))
+					detail.LastUpdatedTime = detail.LastUpdatedTime.AddDuration(100 * time.Millisecond)
+					time.Sleep(100 * time.Millisecond)
+					store.StorePool().DetailsMu.Unlock()
+				}
+			}
+		}
+	}()
+
+	// Ensure the goroutine is stopped when the benchmark completes.
+	defer close(stopCh)
+
+	b.ResetTimer()
+	store := cluster.GetFirstStoreFromServer(b, 0)
+	for n := 0; n < b.N; n++ {
+		// Check if the store is ready for routine replica transfer. This function
+		// is periodically called from the replicate queue.
+		store.StorePool().IsStoreReadyForRoutineReplicaTransfer(ctx, roachpb.StoreID(1))
+	}
+}

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -59,6 +59,10 @@ func (s *Store) StoreLivenessTransport() *storeliveness.Transport {
 	return s.cfg.StoreLiveness.Transport
 }
 
+func (s *Store) StorePool() *storepool.StorePool {
+	return s.cfg.StorePool
+}
+
 func (s *Store) FindTargetAndTransferLease(
 	ctx context.Context, repl *Replica, desc *roachpb.RangeDescriptor, conf *roachpb.SpanConfig,
 ) (bool, error) {

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -468,7 +468,7 @@ func (s *Store) receiveSnapshot(
 	ctx context.Context, header *kvserverpb.SnapshotRequest_Header, stream incomingSnapshotStream,
 ) error {
 	// Draining nodes will generally not be rebalanced to (see the filtering that
-	// happens in getStoreListFromIDsLocked()), but in case they are, they should
+	// happens in getStoreListFromIDs()), but in case they are, they should
 	// reject the incoming rebalancing snapshots.
 	if s.IsDraining() {
 		switch t := header.SenderQueueName; t {

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3385,9 +3385,10 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 	desc.Capacity.Available = 1
 	desc.Capacity.Used = desc.Capacity.Capacity - desc.Capacity.Available
 
-	s.cfg.StorePool.DetailsMu.Lock()
-	s.cfg.StorePool.GetStoreDetailLocked(desc.StoreID).Desc = desc
-	s.cfg.StorePool.DetailsMu.Unlock()
+	sd := s.cfg.StorePool.GetStoreDetail(desc.StoreID)
+	sd.Lock()
+	sd.Desc = desc
+	sd.Unlock()
 
 	if n := s.ReservationCount(); n != 0 {
 		t.Fatalf("expected 0 reservations, but found %d", n)
@@ -3409,9 +3410,10 @@ func TestReserveSnapshotFullnessLimit(t *testing.T) {
 	// available disk space should be rejected.
 	desc.Capacity.Available = desc.Capacity.Capacity / 2
 	desc.Capacity.Used = desc.Capacity.Capacity - desc.Capacity.Available
-	s.cfg.StorePool.DetailsMu.Lock()
-	s.cfg.StorePool.GetStoreDetailLocked(desc.StoreID).Desc = desc
-	s.cfg.StorePool.DetailsMu.Unlock()
+	sd = s.cfg.StorePool.GetStoreDetail(desc.StoreID)
+	sd.Lock()
+	sd.Desc = desc
+	sd.Unlock()
 
 	if n := s.ReservationCount(); n != 0 {
 		t.Fatalf("expected 0 reservations, but found %d", n)


### PR DESCRIPTION
This commit takes mutex locks for individual storePool details instead of
the whole storePool map. This should reduce the mutex contention
especially at high store count clusters. Previously, every gossip store
update callback used to lock the whole StorePool.DetailsMu. This blocked
other accesses to any storepool.Detail.

Benchmark results:
```
name                                    old time/op    new time/op    delta
StorePoolReadsWithConcurrentUpdates-12    1.79ms ±40%    0.00ms ± 7%   -99.99%  (p=0.000 n=10+10)

name                                    old alloc/op   new alloc/op   delta
StorePoolReadsWithConcurrentUpdates-12    10.8kB ±57%     0.0kB ±33%   -99.99%  (p=0.000 n=10+10)

name                                    old allocs/op  new allocs/op  delta
StorePoolReadsWithConcurrentUpdates-12      44.2 ±22%       0.0       -100.00%  (p=0.000 n=9+10)
```

Note that the benchmark basically tests that updating a specific store detail
doesn't block accessing other store details.

References: #143145

Release note: None