### PR TITLE
changefeedccl: fix panic when setting min_checkpoint_frequency < 10ns

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -711,10 +711,11 @@ func nextFlushWithJitter(s timeutil.TimeSource, d time.Duration, j float64) (tim
 	if j < 0 || d < 0 {
 		return s.Now(), errors.AssertionFailedf("invalid jitter value: %f, duration: %s", j, d)
 	}
-	if j == 0 || d == 0 {
+	maxJitter := int64(j * float64(d))
+	if maxJitter == 0 {
 		return s.Now().Add(d), nil
 	}
-	nextFlush := d + time.Duration(rand.Int63n(int64(j*float64(d))))
+	nextFlush := d + time.Duration(rand.Int63n(maxJitter))
 	return s.Now().Add(nextFlush), nil
 }
 

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -8911,6 +8911,20 @@ func TestFlushJitter(t *testing.T) {
 			expectedFlushDuration: 100 * time.Millisecond,
 			expectedErr:           false,
 		},
+		// Expect actual jitter to be 0 since flushFrequency * jitter < 1.
+		{
+			flushFrequency:        1,
+			jitter:                0.1,
+			expectedFlushDuration: 1,
+			expectedErr:           false,
+		},
+		// Expect actual jitter to be 0 since flushFrequency * jitter < 1.
+		{
+			flushFrequency:        10,
+			jitter:                0.01,
+			expectedFlushDuration: 10,
+			expectedErr:           false,
+		},
 	} {
 		t.Run(fmt.Sprintf("flushfrequency=%sjitter=%f", tc.flushFrequency, tc.jitter), func(t *testing.T) {
 			for i := 0; i < numIters; i++ {


### PR DESCRIPTION
Previously when min_checkpoint_frequency is set to
be less than 10ns, it would cause a panic if
we're using the default
changefeed.aggregator.flush_jitter value of 0.1.

This fix would also prevent panics from happening
if min_checkpoint_frequency > 10ns but
flush_jitter is set too low.

Release note (bug fix): Fixed a bug where using
values changefeed.aggregator.flush_jitter,
min_checkpoint_frequency such that
changefeed.aggregator.flush_jitter *
min_checkpoint_frequency < 1 would cause a panic.
Jitter will now be disabled in this case.

Fixes: https://github.com/cockroachdb/cockroach/issues/143436