### PR TITLE
release-25.2: logictest: raise TxnLivenessThreshold for multitenant configs

### DIFF
--- a/pkg/sql/logictest/BUILD.bazel
+++ b/pkg/sql/logictest/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/kv/kvclient/rangefeed",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/kvserverbase",
+        "//pkg/kv/kvserver/txnwait",
         "//pkg/multitenant/tenantcapabilities",
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/security/username",


### PR DESCRIPTION
Backport 1/1 commits from #144307 on behalf of @rafiss.

/cc @cockroachdb/release

----

Logic tests are flaky due to overload when running in multitenant mode. This patch increases the threshold for transaction heartbeat timeouts, which will make it less likely for foreground operations to be aborted by background jobs like the span config reconciler or the job registry loop to reclaim jobs from dead sessions.

This change was first added in a8ccd6b4174, but then was later reverted in 84079c9db23 since we fixed auto-retry behavior. I'm adding it back now since we are still seeing these flakes for statements/transactions that cannot be auto-retried.

fixes https://github.com/cockroachdb/cockroach/issues/143660
fixes https://github.com/cockroachdb/cockroach/issues/143946
Release note: None

----

Release justification: test only change