### PR TITLE
kvserver: deflake TestMultiSSTWriterInitSST

### DIFF
--- a/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/replica_sst_snapshot_storage_test.go
@@ -284,8 +284,13 @@ func TestMultiSSTWriterInitSST(t *testing.T) {
 	localSpans := keySpans[:len(keySpans)-1]
 	mvccSpan := keySpans[len(keySpans)-1]
 
+	st := cluster.MakeTestingClusterSettings()
+
+	// Disabling columnar blocks causes stats changes.
+	storage.ColumnarBlocksEnabled.Override(context.Background(), &st.SV, true)
+
 	msstw, err := newMultiSSTWriter(
-		ctx, cluster.MakeTestingClusterSettings(), scratch, localSpans, mvccSpan, 0,
+		ctx, st, scratch, localSpans, mvccSpan, 0,
 		false /* skipRangeDelForMVCCSpan */, false, /* rangeKeysInOrder */
 	)
 	require.NoError(t, err)


### PR DESCRIPTION
Need to disable a metamorphic variable.

```
./dev test --stress --filter TestMultiSSTWriterInitSST ./pkg/kv/kvserver/
```

Now passes. Previously it'd fail ~immediately.

Fixes #144294.

Epic: none
Release note: None
