### PR TITLE
crosscluster/logical: validate schema on resume

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_dist.go
+++ b/pkg/crosscluster/logical/logical_replication_dist.go
@@ -36,6 +36,7 @@ func constructLogicalReplicationWriterSpecs(
 	discard jobspb.LogicalReplicationDetails_Discard,
 	mode jobspb.LogicalReplicationDetails_ApplyMode,
 	metricsLabel string,
+	writer writerType,
 ) (map[base.SQLInstanceID][]execinfrapb.LogicalReplicationWriterSpec, error) {
 	spanGroup := roachpb.SpanGroup{}
 	baseSpec := execinfrapb.LogicalReplicationWriterSpec{
@@ -50,6 +51,7 @@ func constructLogicalReplicationWriterSpecs(
 		Mode:                        mode,
 		MetricsLabel:                metricsLabel,
 		TypeDescriptors:             srcTypes,
+		WriterType:                  string(writer),
 	}
 
 	writerSpecs := make(map[base.SQLInstanceID][]execinfrapb.LogicalReplicationWriterSpec, len(destSQLInstances))

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -510,7 +510,10 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 	if defaultFnID := payload.DefaultConflictResolution.FunctionId; defaultFnID != 0 {
 		defaultFnOID = catid.FuncIDToOID(catid.DescID(defaultFnID))
 	}
-
+	writer, err := getWriterType(ctx, payload.Mode, execCfg.Settings)
+	if err != nil {
+		return nil, nil, info, err
+	}
 	crossClusterResolver := crosscluster.MakeCrossClusterTypeResolver(plan.SourceTypes)
 	tableMetadataByDestID := make(map[int32]execinfrapb.TableReplicationMetadata)
 	if err := sql.DescsTxn(ctx, execCfg, func(ctx context.Context, txn isql.Txn, descriptors *descs.Collection) error {
@@ -534,6 +537,10 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 			scDesc, err := descriptors.ByIDWithoutLeased(txn.KV()).WithoutNonPublic().Get().Schema(ctx, dstTableDesc.GetParentSchemaID())
 			if err != nil {
 				return errors.Wrapf(err, "failed to look up schema descriptor for table %d", pair.DstDescriptorID)
+			}
+
+			if err := tabledesc.CheckLogicalReplicationCompatibility(&srcTableDesc, dstTableDesc.TableDesc(), payload.SkipSchemaCheck || payload.CreateTable, writer == writerTypeLegacyKV); err != nil {
+				return err
 			}
 
 			var fnOID oid.Oid

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -597,6 +597,7 @@ func (p *logicalReplicationPlanner) generatePlanImpl(
 		payload.Discard,
 		payload.Mode,
 		payload.MetricsLabel,
+		writer,
 	)
 	if err != nil {
 		return nil, nil, info, err

--- a/pkg/crosscluster/logical/logical_replication_job_test.go
+++ b/pkg/crosscluster/logical/logical_replication_job_test.go
@@ -2428,7 +2428,17 @@ func TestMismatchColIDs(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc, s, sqlA, sqlB := setupLogicalTestServer(t, ctx, testClusterBaseClusterArgs, 1)
+
+	streamingKnobs := &sql.StreamingTestingKnobs{
+		DistSQLRetryPolicy: &retry.Options{
+			InitialBackoff: time.Microsecond,
+			MaxBackoff:     2 * time.Microsecond,
+			MaxRetries:     1,
+		},
+	}
+	args := testClusterBaseClusterArgs
+	args.ServerArgs.Knobs.Streaming = streamingKnobs
+	tc, s, sqlA, sqlB := setupLogicalTestServer(t, ctx, args, 1)
 	defer tc.Stopper().Stop(ctx)
 
 	dbBURL := replicationtestutils.GetExternalConnectionURI(t, s, s, serverutils.DBName("b"))
@@ -2449,17 +2459,29 @@ func TestMismatchColIDs(t *testing.T) {
 	sqlB.Exec(t, "ALTER TABLE foo DROP COLUMN bar")
 	sqlB.Exec(t, "INSERT INTO foo VALUES (4, 'world')")
 
-	// LDR immediate mode creation should fail because of mismatched column IDs.
+	// When using the kv writer, LDR immediate mode creation should fail because of mismatched column IDs.
+	sqlA.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.immediate_mode_writer = 'legacy-kv'")
 	sqlA.ExpectErr(t,
 		"destination table foo column baz has ID 3, but the source table foo has ID 4",
 		"CREATE LOGICAL REPLICATION STREAM FROM TABLE foo ON $1 INTO TABLE foo WITH MODE = 'immediate'", dbBURL.String())
 
-	// LDR validated mode creation should succeed because the SQL writer supports mismatched column IDs.
 	var jobID jobspb.JobID
 	sqlA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE foo ON $1 INTO TABLE foo WITH MODE = 'validated'", dbBURL.String()).Scan(&jobID)
-
 	now := s.Clock().Now()
 	WaitUntilReplicatedTime(t, now, sqlA, jobID)
+
+	sqlA.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.immediate_mode_writer = 'sql'")
+	sqlA.QueryRow(t, "CREATE LOGICAL REPLICATION STREAM FROM TABLE foo ON $1 INTO TABLE foo WITH MODE = 'immediate'", dbBURL.String()).Scan(&jobID)
+	now = s.Clock().Now()
+	WaitUntilReplicatedTime(t, now, sqlA, jobID)
+
+	// Ensure the validation works on resumption as well.
+	sqlA.Exec(t, "PAUSE JOB $1", jobID)
+	jobutils.WaitForJobToPause(t, sqlA, jobID)
+
+	sqlA.Exec(t, "SET CLUSTER SETTING logical_replication.consumer.immediate_mode_writer = 'legacy-kv'")
+	sqlA.Exec(t, "RESUME JOB $1", jobID)
+	jobutils.WaitForJobToPause(t, sqlA, jobID)
 }
 
 // TestLogicalReplicationCreationChecks verifies that we check that the table

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -292,6 +292,8 @@ message LogicalReplicationDetails {
 
   string command = 16;
 
+  bool skip_schema_check = 17;
+
   // Next ID: 17.
 }
 

--- a/pkg/sql/catalog/tabledesc/logical_replication_helpers.go
+++ b/pkg/sql/catalog/tabledesc/logical_replication_helpers.go
@@ -218,7 +218,7 @@ func checkSrcDstColsMatch(
 		}
 
 		if requireKvWriterCompatible && srcCol.ID != dstCol.ID {
-			return errors.Newf("destination table %s column %s has ID %d, but the source table %s has ID %d",
+			return errors.Newf("destination table %s column %s has ID %d, but the source table %s has ID %d. To circumvent this check, unset logical_replication.consumer.immediate_mode_writer from 'legacy-kv'",
 				dst.Name, dstCol.Name, dstCol.ID, src.Name, srcCol.ID,
 			)
 		}

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -536,7 +536,10 @@ message LogicalReplicationWriterSpec {
     optional string metrics_label = 11 [(gogoproto.nullable) = false];
 
     repeated cockroach.sql.sqlbase.TypeDescriptor type_descriptors = 13;
-    // Next ID: 14.
+
+    optional string writer_type = 14 [(gogoproto.nullable) = false];
+
+    // Next ID: 15.
 }
 
 message LogicalReplicationOfflineScanSpec {


### PR DESCRIPTION
Because the user can toggle the use of the kv writer via a cluster setting, we
need to validate that their replicating tables comply with their writer mode
whenever we spin up the LDR distsql flow.

This patch also slightly refactors the input to the validation checker during
planning to read from the writer type cluster setting. This means immediate
mode using the the sql writer can replicate even if the column ids in the
tables don't match.

Epic: none

Release note: none