### PR TITLE
release-25.2: sql: disable buffered writes for internal executor

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -965,6 +965,10 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	if o.BufferedWritesEnabled != nil {
 		sd.BufferedWritesEnabled = *o.BufferedWritesEnabled
 	}
+	// For 25.2, we're being conservative and explicitly disabling buffered
+	// writes for the internal executor.
+	// TODO(yuzefovich): remove this for 25.3.
+	sd.BufferedWritesEnabled = false
 
 	if o.MultiOverride != "" {
 		overrides := strings.Split(o.MultiOverride, ",")


### PR DESCRIPTION
Backport 1/1 commits from #144306 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

This is just another precaution for 25.2.

Epic: None
Release note: None

----

Release justification: new functionality.