### PR TITLE
plpgsql: fix ordinal variable references and FOR loops

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_assign
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_assign
@@ -122,3 +122,62 @@ CREATE FUNCTION f(val xy) RETURNS xy AS $$
 $$ LANGUAGE PLpgSQL;
 
 subtest end
+
+# Ordinal parameter references should reflect updates made by variable
+# assignment.
+subtest regression_143887
+
+statement ok
+CREATE FUNCTION f(x INT) RETURNS INT AS $$
+  BEGIN
+    RAISE NOTICE '% = %', x, $1;
+    x := $1 + 1;
+    RAISE NOTICE '% = %', x, $1;
+    IF x IS NOT NULL THEN
+      x := $1 + 100;
+      RAISE NOTICE '% = %', x, $1;
+    END IF;
+    RAISE NOTICE '% = %', x, $1;
+    RETURN x + $1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f(0);
+----
+NOTICE: 0 = 0
+NOTICE: 1 = 1
+NOTICE: 101 = 101
+NOTICE: 101 = 101
+
+query I
+SELECT f(0);
+----
+202
+
+statement ok
+DROP FUNCTION f
+
+statement ok
+CREATE FUNCTION f(foo xy) RETURNS INT AS $$
+  BEGIN
+    foo := ROW(1, 2);
+    RAISE NOTICE '% = %', foo, $1;
+    RETURN (foo).x + ($1).x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f((100, 200));
+----
+NOTICE: (1,2) = (1,2)
+
+query I
+SELECT f((100, 200));
+----
+2
+
+statement ok
+DROP FUNCTION f(xy);
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_call
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_call
@@ -1,4 +1,7 @@
 statement ok
+CREATE TABLE xy (x INT, y INT);
+
+statement ok
 CREATE PROCEDURE p_nested() AS $$
   BEGIN
     RAISE NOTICE 'p_nested';
@@ -457,9 +460,6 @@ subtest end
 subtest regression_143171
 
 statement ok
-CREATE TABLE xy (x INT, y INT);
-
-statement ok
 CREATE PROCEDURE p_143171(OUT foo INT) LANGUAGE PLpgSQL AS $$
   BEGIN
     INSERT INTO xy VALUES (1, 2) RETURNING x INTO foo;
@@ -489,7 +489,83 @@ DROP PROCEDURE p2_143171;
 statement ok
 DROP PROCEDURE p_143171;
 
+subtest end
+
+# Ordinal parameter references should reflect updates made by
+# CALL statements.
+subtest regression_143887
+
 statement ok
-DROP TABLE xy;
+CREATE PROCEDURE p143887(INOUT x INT) LANGUAGE PLpgSQL AS $$
+  BEGIN
+    IF x = 0 THEN
+      x := 1;
+    ELSE
+      x := x + 100;
+    END IF;
+  END
+$$;
+
+statement ok
+CREATE FUNCTION f(x INT) RETURNS INT AS $$
+  BEGIN
+    RAISE NOTICE '% = %', x, $1;
+    CALL p143887(x);
+    RAISE NOTICE '% = %', x, $1;
+    IF x IS NOT NULL THEN
+      CALL p143887(x);
+      RAISE NOTICE '% = %', x, $1;
+    END IF;
+    RAISE NOTICE '% = %', x, $1;
+    RETURN x + $1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f(0);
+----
+NOTICE: 0 = 0
+NOTICE: 1 = 1
+NOTICE: 101 = 101
+NOTICE: 101 = 101
+
+query I
+SELECT f(0);
+----
+202
+
+statement ok
+DROP FUNCTION f(INT);
+DROP PROCEDURE p143887;
+
+statement ok
+CREATE PROCEDURE p143887(INOUT foo xy) LANGUAGE PLpgSQL AS $$
+  BEGIN
+    foo := ROW(1, 2);
+  END
+$$;
+
+statement ok
+CREATE FUNCTION f(foo xy) RETURNS INT AS $$
+  BEGIN
+    CALL p143887(foo);
+    RAISE NOTICE '% = %', foo, $1;
+    RETURN (foo).x + ($1).x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f((100, 200));
+----
+NOTICE: (1,2) = (1,2)
+
+query I
+SELECT f((100, 200));
+----
+2
+
+statement ok
+DROP FUNCTION f(xy);
+DROP PROCEDURE p143887;
 
 subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
@@ -2104,3 +2104,68 @@ subtest end
 
 statement ok
 RESET autocommit_before_ddl
+
+# Ordinal parameter references should reflect updates made by
+# FETCH statements.
+subtest regression_143887
+
+statement ok
+DROP FUNCTION f(INT);
+CREATE FUNCTION f(x INT) RETURNS INT AS $$
+  DECLARE foo REFCURSOR;
+  BEGIN
+    OPEN foo FOR SELECT bar FROM (VALUES (1), (100)) AS v(bar);
+    RAISE NOTICE '% = %', x, $1;
+    FETCH foo INTO x;
+    RAISE NOTICE '% = %', x, $1;
+    IF x IS NOT NULL THEN
+      FETCH foo INTO x;
+      RAISE NOTICE '% = %', x, $1;
+    END IF;
+    RAISE NOTICE '% = %', x, $1;
+    RETURN x + $1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f(0);
+----
+NOTICE: 0 = 0
+NOTICE: 1 = 1
+NOTICE: 100 = 100
+NOTICE: 100 = 100
+
+query I
+SELECT f(0);
+----
+200
+
+statement ok
+DROP FUNCTION f(INT);
+
+statement ok
+CREATE FUNCTION f(foo xy) RETURNS INT AS $$
+  DECLARE
+    bar REFCURSOR;
+  BEGIN
+    OPEN bar FOR SELECT 1, 2;
+    FETCH bar INTO foo;
+    RAISE NOTICE '% = %', foo, $1;
+    RETURN (foo).x + ($1).x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f((100, 200));
+----
+NOTICE: (1,2) = (1,2)
+
+query I
+SELECT f((100, 200));
+----
+2
+
+statement ok
+DROP FUNCTION f(xy);
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_into
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_into
@@ -523,3 +523,63 @@ statement ok
 RESET plpgsql_use_strict_into;
 
 subtest end
+
+# Ordinal parameter references should reflect updates made by
+# SELECT INTO statements.
+subtest regression_143887
+
+statement ok
+DROP FUNCTION f(INT);
+CREATE FUNCTION f(x INT) RETURNS INT AS $$
+  BEGIN
+    RAISE NOTICE '% = %', x, $1;
+    SELECT $1 + 1 INTO x;
+    RAISE NOTICE '% = %', x, $1;
+    IF x IS NOT NULL THEN
+      SELECT $1 + 100 INTO x;
+      RAISE NOTICE '% = %', x, $1;
+    END IF;
+    RAISE NOTICE '% = %', x, $1;
+    RETURN x + $1;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f(0);
+----
+NOTICE: 0 = 0
+NOTICE: 1 = 1
+NOTICE: 101 = 101
+NOTICE: 101 = 101
+
+query I
+SELECT f(0);
+----
+202
+
+statement ok
+DROP FUNCTION f(INT);
+
+statement ok
+CREATE FUNCTION f(foo xy) RETURNS INT AS $$
+  BEGIN
+    SELECT 1, 2 INTO foo;
+    RAISE NOTICE '% = %', foo, $1;
+    RETURN (foo).x + ($1).x;
+  END
+$$ LANGUAGE PLpgSQL;
+
+query T noticetrace
+SELECT f((100, 200));
+----
+NOTICE: (1,2) = (1,2)
+
+query I
+SELECT f((100, 200));
+----
+2
+
+statement ok
+DROP FUNCTION f(xy);
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -3294,3 +3294,82 @@ statement ok
 EXECUTE foo (100);
 
 subtest end
+
+# Make sure that only the original function parameters can be referenced by
+# ordinal syntax.
+subtest regression_143887
+
+# Case with SQL expression.
+statement error pgcode 42P02 pq: no value provided for placeholder: \$3
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN $3; END $$;
+
+# Case with SQL statement.
+statement error pgcode 42P02 pq: no value provided for placeholder: \$3
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$ BEGIN SELECT $3; RETURN 0; END $$;
+
+# Case with SQL expression.
+statement error pgcode 42P02 pq: no value provided for placeholder: \$3
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    z INT := x + y;
+  BEGIN
+    RETURN $3;
+  END
+$$;
+
+# Case with SQL statement.
+statement error pgcode 42P02 pq: no value provided for placeholder: \$3
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    z INT := x + y;
+  BEGIN
+    SELECT $3;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 42P02 pq: no value provided for placeholder: \$3
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    z INT := x + y;
+  BEGIN
+    z := z * 100 * x;
+    IF x > y THEN
+      RETURN $3;
+    END IF;
+    RETURN 0;
+  END
+$$;
+
+statement error pgcode 42P02 pq: no value provided for placeholder: \$3
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    z INT := x + y;
+  BEGIN
+    DECLARE
+      w INT := z + x + y;
+    BEGIN
+      z := z * 100 * x;
+      RETURN $3 + $4;
+    END;
+    RETURN 0;
+  END
+$$;
+
+# Make sure that function parameters can still be referenced via ordinal syntax.
+statement ok
+CREATE FUNCTION f143887(x INT, y INT) RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    z INT := x + y;
+  BEGIN
+    SELECT $1 + $2;
+    RETURN $1 + $2;
+  END
+$$;
+
+query I
+SELECT f143887(100, 200);
+----
+300
+
+subtest end

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -3373,3 +3373,39 @@ SELECT f143887(100, 200);
 300
 
 subtest end
+
+# Nested FOR loops should not interfere with one another.
+subtest regression_144321
+
+statement ok
+CREATE FUNCTION f144321() RETURNS INT LANGUAGE PLpgSQL AS $$
+  DECLARE
+    outer_counter INT := 0;
+    inner_counter INT := 0;
+  BEGIN
+    FOR i IN 1..4 LOOP
+      FOR j IN 1..2 LOOP
+        RAISE NOTICE 'i: % j: %', i, j;
+        inner_counter := inner_counter + 1;
+      END LOOP;
+      outer_counter := outer_counter + 1;
+    END LOOP;
+    RAISE NOTICE 'outer_counter: % inner_counter: %', outer_counter, inner_counter;
+    RETURN 0;
+  END
+$$;
+
+query T noticetrace
+SELECT f144321();
+----
+NOTICE: i: 1 j: 1
+NOTICE: i: 1 j: 2
+NOTICE: i: 2 j: 1
+NOTICE: i: 2 j: 2
+NOTICE: i: 3 j: 1
+NOTICE: i: 3 j: 2
+NOTICE: i: 4 j: 1
+NOTICE: i: 4 j: 2
+NOTICE: outer_counter: 4 inner_counter: 8
+
+subtest end

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -1546,7 +1546,7 @@ func (b *plpgsqlBuilder) buildCursorNameGen(nameCon *continuation, nameVar ast.V
 func (b *plpgsqlBuilder) addPLpgSQLAssign(
 	inScope *scope, ident ast.Variable, val ast.Expr, indirection tree.Name,
 ) *scope {
-	typ := b.resolveVariableForAssign(ident)
+	typ, ord := b.resolveVariableForAssign(ident)
 	assignScope := inScope.push()
 	for i := range inScope.cols {
 		col := &inScope.cols[i]
@@ -1569,7 +1569,8 @@ func (b *plpgsqlBuilder) addPLpgSQLAssign(
 		scalar = b.buildSQLExpr(val, typ, inScope)
 	}
 	b.addBarrierIfVolatile(inScope, scalar)
-	b.ob.synthesizeColumn(assignScope, colName, typ, nil, scalar)
+	col := b.ob.synthesizeColumn(assignScope, colName, typ, nil, scalar)
+	col.setParamOrd(ord)
 	b.ob.constructProjectForScope(inScope, assignScope)
 	b.addBarrierIfVolatile(assignScope, scalar)
 	return assignScope
@@ -1578,7 +1579,7 @@ func (b *plpgsqlBuilder) addPLpgSQLAssign(
 // assignToHiddenVariable is similar to addPLpgSQLAssign, but it assigns to a
 // hidden variable that is not visible to the user.
 func (b *plpgsqlBuilder) assignToHiddenVariable(inScope *scope, name string, val ast.Expr) *scope {
-	typ := b.resolveHiddenVariableForAssign(name)
+	typ, ord := b.resolveHiddenVariableForAssign(name)
 	assignScope := inScope.push()
 	for i := range inScope.cols {
 		col := &inScope.cols[i]
@@ -1593,7 +1594,8 @@ func (b *plpgsqlBuilder) assignToHiddenVariable(inScope *scope, name string, val
 	colName := scopeColName("").WithMetadataName(name)
 	scalar := b.buildSQLExpr(val, typ, inScope)
 	b.addBarrierIfVolatile(inScope, scalar)
-	b.ob.synthesizeColumn(assignScope, colName, typ, nil, scalar)
+	col := b.ob.synthesizeColumn(assignScope, colName, typ, nil, scalar)
+	col.setParamOrd(ord)
 	b.ob.constructProjectForScope(inScope, assignScope)
 	b.addBarrierIfVolatile(assignScope, scalar)
 	return assignScope
@@ -1660,15 +1662,22 @@ func (b *plpgsqlBuilder) handleIndirectionForAssign(
 func (b *plpgsqlBuilder) buildInto(stmtScope *scope, target []ast.Variable) *scope {
 	var targetTypes []*types.T
 	var targetNames []ast.Variable
-	if b.targetIsRecordVar(target) {
+	var targetOrds []int
+	targetIsRecordVar := b.targetIsRecordVar(target)
+	if targetIsRecordVar {
 		// For a single record-type variable, the SQL statement columns are assigned
 		// as elements of the variable, rather than the variable itself.
-		targetTypes = b.resolveVariableForAssign(target[0]).TupleContents()
+		//
+		// Note that we don't need to get the param ordinal here, since that's
+		// handled in projectRecordVar below.
+		typ, _ := b.resolveVariableForAssign(target[0])
+		targetTypes = typ.TupleContents()
 	} else {
 		targetNames = target
 		targetTypes = make([]*types.T, len(target))
+		targetOrds = make([]int, len(target))
 		for j := range target {
-			targetTypes[j] = b.resolveVariableForAssign(target[j])
+			targetTypes[j], targetOrds[j] = b.resolveVariableForAssign(target[j])
 		}
 	}
 
@@ -1692,10 +1701,14 @@ func (b *plpgsqlBuilder) buildInto(stmtScope *scope, target []ast.Variable) *sco
 			scalar = b.ob.factory.ConstructConstVal(tree.DNull, typ)
 		}
 		scalar = b.coerceType(scalar, typ)
-		b.ob.synthesizeColumn(intoScope, colName, typ, nil /* expr */, scalar)
+		col := b.ob.synthesizeColumn(intoScope, colName, typ, nil /* expr */, scalar)
+		if !targetIsRecordVar {
+			// Setting the param ordinal will be handled in projectRecordVar below.
+			col.setParamOrd(targetOrds[j])
+		}
 	}
 	b.ob.constructProjectForScope(stmtScope, intoScope)
-	if b.targetIsRecordVar(target) {
+	if targetIsRecordVar {
 		// Handle a single record-type variable (see projectRecordVar for details).
 		intoScope = b.projectRecordVar(intoScope, target[0])
 	}
@@ -2125,11 +2138,12 @@ func (b *plpgsqlBuilder) buildFetch(s *scope, fetch *ast.Fetch) *scope {
 			// If the target is a single record-type variable, the columns of the
 			// FETCH are assigned as its *elements*, rather than directly to the
 			// variable.
-			typs = b.resolveVariableForAssign(fetch.Target[0]).TupleContents()
+			typ, _ := b.resolveVariableForAssign(fetch.Target[0])
+			typs = typ.TupleContents()
 		} else {
 			typs = make([]*types.T, len(fetch.Target))
 			for i := range fetch.Target {
-				typ := b.resolveVariableForAssign(fetch.Target[i])
+				typ, _ := b.resolveVariableForAssign(fetch.Target[i])
 				typs[i] = typ
 			}
 		}
@@ -2171,7 +2185,11 @@ func (b *plpgsqlBuilder) buildFetch(s *scope, fetch *ast.Fetch) *scope {
 // targetIsSingleCompositeVar returns true if the given INTO target is a single
 // RECORD-type variable.
 func (b *plpgsqlBuilder) targetIsRecordVar(target []ast.Variable) bool {
-	return len(target) == 1 && b.resolveVariableForAssign(target[0]).Family() == types.TupleFamily
+	if len(target) != 1 {
+		return false
+	}
+	typ, _ := b.resolveVariableForAssign(target[0])
+	return typ.Family() == types.TupleFamily
 }
 
 // projectRecordVar handles the special case when a single RECORD-type variable
@@ -2179,7 +2197,7 @@ func (b *plpgsqlBuilder) targetIsRecordVar(target []ast.Variable) bool {
 // statement should be wrapped into a tuple, which is assigned to the
 // RECORD-type variable.
 func (b *plpgsqlBuilder) projectRecordVar(s *scope, name ast.Variable) *scope {
-	typ := b.resolveVariableForAssign(name)
+	typ, ord := b.resolveVariableForAssign(name)
 	recordScope := s.push()
 	elems := make(memo.ScalarListExpr, len(s.cols))
 	for j := range elems {
@@ -2187,6 +2205,7 @@ func (b *plpgsqlBuilder) projectRecordVar(s *scope, name ast.Variable) *scope {
 	}
 	tuple := b.ob.factory.ConstructTuple(elems, typ)
 	col := b.ob.synthesizeColumn(recordScope, scopeColName(name), typ, nil /* expr */, tuple)
+	col.setParamOrd(ord)
 	recordScope.expr = b.ob.constructProject(s.expr, []scopeColumn{*col})
 	return recordScope
 }
@@ -2197,13 +2216,13 @@ func (b *plpgsqlBuilder) projectRecordVar(s *scope, name ast.Variable) *scope {
 // continuations will have more parameters than those of its parent.
 func (b *plpgsqlBuilder) makeContinuation(conName string) continuation {
 	s := b.ob.allocScope()
-	params := make(opt.ColList, 0, b.variableCount()+b.hiddenVariableCount())
+	params := make(opt.ColList, 0, b.variableCount(len(b.blocks)))
 	addParam := func(name scopeColumnName, typ *types.T) {
 		col := b.ob.synthesizeColumn(s, name, typ, nil /* expr */, nil /* scalar */)
 		// TODO(mgartner): Lift the 100 parameter restriction for synthesized
 		// continuation UDFs.
 		paramOrd := len(params)
-		col.setParamOrd(len(params))
+		col.setParamOrd(paramOrd)
 		if b.ob.insideFuncDef && b.options.isTriggerFn && paramOrd == triggerArgvColIdx {
 			// Due to #135311, we disallow references to the TG_ARGV param for now.
 			if !b.ob.evalCtx.SessionData().AllowCreateTriggerFunctionWithArgvReferences {
@@ -2394,12 +2413,16 @@ func (b *plpgsqlBuilder) buildSQLExpr(expr ast.Expr, typ *types.T, s *scope) opt
 		return memo.NullSingleton
 	}
 	// Save any outer CTEs before building the expression, which may have
-	// subqueries with inner CTEs.
-	prevCTEs := b.ob.ctes
-	b.ob.ctes = nil
-	defer func() {
+	// subqueries with inner CTEs. Also set the maxParamOrd to the number of
+	// routine parameters.
+	defer func(prevCTEs cteSources, prevCheckMaxParamOrd bool, prevMaxParamOrd int) {
 		b.ob.ctes = prevCTEs
-	}()
+		s.checkMaxParamOrd = prevCheckMaxParamOrd
+		s.maxParamOrd = prevMaxParamOrd
+	}(b.ob.ctes, s.checkMaxParamOrd, s.maxParamOrd)
+	b.ob.ctes = nil
+	s.checkMaxParamOrd = true
+	s.maxParamOrd = len(b.rootBlock().vars)
 	expr, _ = tree.WalkExpr(s, expr)
 	typedExpr, err := expr.TypeCheck(b.ob.ctx, b.ob.semaCtx, typ)
 	if err != nil {
@@ -2433,6 +2456,13 @@ func (b *plpgsqlBuilder) buildSQLStatement(stmt tree.Statement, inScope *scope) 
 		outScope.expr = b.ob.factory.ConstructNoColsRow()
 		return outScope
 	}
+	// Set the maxParamOrd to the number of routine parameters.
+	defer func(prevCheckMaxParamOrd bool, prevMaxParamOrd int) {
+		inScope.checkMaxParamOrd = prevCheckMaxParamOrd
+		inScope.maxParamOrd = prevMaxParamOrd
+	}(inScope.checkMaxParamOrd, inScope.maxParamOrd)
+	inScope.checkMaxParamOrd = true
+	inScope.maxParamOrd = len(b.rootBlock().vars)
 	return b.ob.buildStmtAtRootWithScope(stmt, nil /* desiredTypes */, inScope)
 }
 
@@ -2463,8 +2493,10 @@ func (b *plpgsqlBuilder) coerceType(scalar opt.ScalarExpr, typ *types.T) opt.Sca
 }
 
 // resolveVariableForAssign attempts to retrieve the type of the variable with
-// the given name, throwing an error if no such variable exists.
-func (b *plpgsqlBuilder) resolveVariableForAssign(name ast.Variable) *types.T {
+// the given name, as well as its ordinal position within the set of all
+// variables in the current scope. It throws an error if no such variable
+// exists.
+func (b *plpgsqlBuilder) resolveVariableForAssign(name ast.Variable) (varTyp *types.T, varIdx int) {
 	// Search the blocks in reverse order to ensure that more recent declarations
 	// are encountered first.
 	for i := len(b.blocks) - 1; i >= 0; i-- {
@@ -2478,7 +2510,16 @@ func (b *plpgsqlBuilder) resolveVariableForAssign(name ast.Variable) *types.T {
 				panic(pgerror.Newf(pgcode.ErrorInAssignment, "variable \"%s\" is declared CONSTANT", name))
 			}
 		}
-		return typ
+		// Get the ordinal position of the variable within the set of variables in
+		// the current scope.
+		varIdx = b.variableCount(i)
+		for j := range block.vars {
+			if block.vars[j] == name {
+				varIdx += j
+				break
+			}
+		}
+		return typ, varIdx
 	}
 	panic(pgerror.Newf(pgcode.Syntax, "\"%s\" is not a known variable", name))
 }
@@ -2486,7 +2527,7 @@ func (b *plpgsqlBuilder) resolveVariableForAssign(name ast.Variable) *types.T {
 // resolveHiddenVariableForAssign is similar to resolveVariableForAssign, but
 // applies to hidden variables, which are identified only by their name in the
 // query's metadata. It panics if the hidden variable is not found.
-func (b *plpgsqlBuilder) resolveHiddenVariableForAssign(name string) *types.T {
+func (b *plpgsqlBuilder) resolveHiddenVariableForAssign(name string) (varTyp *types.T, varIdx int) {
 	// Search the blocks in reverse order to ensure that more recent declarations
 	// are encountered first.
 	for i := len(b.blocks) - 1; i >= 0; i-- {
@@ -2495,7 +2536,16 @@ func (b *plpgsqlBuilder) resolveHiddenVariableForAssign(name string) *types.T {
 		if !ok {
 			continue
 		}
-		return typ
+		// Get the ordinal position of the variable within the set of variables in
+		// the current scope.
+		varIdx = b.variableCount(i) + len(block.vars)
+		for j := range block.hiddenVars {
+			if block.hiddenVars[j] == name {
+				varIdx += j
+				break
+			}
+		}
+		return typ, varIdx
 	}
 	panic(errors.AssertionFailedf("hidden variable %s not found", name))
 }
@@ -2510,14 +2560,15 @@ func (b *plpgsqlBuilder) projectTupleAsIntoTarget(inScope *scope, target []ast.V
 	intoScope := inScope.push()
 	tupleCol := inScope.cols[0].id
 	for i := range target {
-		typ := b.resolveVariableForAssign(target[i])
+		typ, ord := b.resolveVariableForAssign(target[i])
 		colName := scopeColName(target[i])
 		scalar := b.ob.factory.ConstructColumnAccess(
 			b.ob.factory.ConstructVariable(tupleCol),
 			memo.TupleOrdinal(i),
 		)
 		scalar = b.coerceType(scalar, typ)
-		b.ob.synthesizeColumn(intoScope, colName, typ, nil /* expr */, scalar)
+		col := b.ob.synthesizeColumn(intoScope, colName, typ, nil /* expr */, scalar)
+		col.setParamOrd(ord)
 	}
 	b.ob.constructProjectForScope(inScope, intoScope)
 	return intoScope
@@ -2759,20 +2810,15 @@ func (b *plpgsqlBuilder) hasExceptionHandler() bool {
 }
 
 // variableCount returns the number of PL/pgSQL variables that are in scope for
-// the current block. Note that this count does not include hidden variables.
-func (b *plpgsqlBuilder) variableCount() int {
-	var count int
-	for i := range b.blocks {
-		count += len(b.blocks[i].vars)
+// the first numBlocks blocks. This count includes hidden variables.
+func (b *plpgsqlBuilder) variableCount(numBlocks int) int {
+	if numBlocks > len(b.blocks) {
+		panic(errors.AssertionFailedf(
+			"numBlocks %d exceeds number of blocks %d", numBlocks, len(b.blocks)))
 	}
-	return count
-}
-
-// variableCountWithHidden returns the number of hidden variables that are in
-// scope for the current block.
-func (b *plpgsqlBuilder) hiddenVariableCount() int {
 	var count int
-	for i := range b.blocks {
+	for i := range numBlocks {
+		count += len(b.blocks[i].vars)
 		count += len(b.blocks[i].hiddenVars)
 	}
 	return count

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -673,33 +673,19 @@ func (s *scope) findExistingCol(expr tree.TypedExpr, allowSideEffects bool) *sco
 }
 
 // findFuncArgCol returns the column that represents a function argument and has
-// an ordinal matching the given placeholder index. If such a column is not
-// found in the current scope, ancestor scopes are successively searched. If no
-// matching function argument column is found, nil is returned.
-func (s *scope) findFuncArgCol(idx tree.PlaceholderIdx) *scopeColumn {
+// an ordinal matching the given 0-based ordinal position. If such a column is
+// not found in the current scope, ancestor scopes are successively searched.
+// If no matching function argument column is found, nil is returned.
+func (s *scope) findFuncArgCol(ord int) *scopeColumn {
 	for ; s != nil; s = s.parent {
-		if s.checkMaxParamOrd && int(idx) > (s.maxParamOrd-1) {
+		if s.checkMaxParamOrd && ord > (s.maxParamOrd-1) {
 			// Referencing this function parameter by ordinal is not allowed. Subtract
 			// 1 from maxParamOrd to convert it to a 0-based ordinal.
 			return nil
 		}
 		for i := range s.cols {
 			col := &s.cols[i]
-			if col.funcParamReferencedBy(idx) {
-				return col
-			}
-		}
-	}
-	return nil
-}
-
-// findAnonymousColumnWithMetadataName returns the first anonymous column that
-// has the given name in the query metadata.
-func (s *scope) findAnonymousColumnWithMetadataName(metadataName string) *scopeColumn {
-	for ; s != nil; s = s.parent {
-		for i := range s.cols {
-			col := &s.cols[i]
-			if col.name.refName == "" && col.name.metadataName == metadataName {
+			if col.funcParamReferencedBy(ord) {
 				return col
 			}
 		}
@@ -1120,7 +1106,7 @@ func (s *scope) VisitPre(expr tree.Expr) (recurse bool, newExpr tree.Expr) {
 		// NOTE: This likely won't work if we want to allow PREPARE statements
 		// within user-defined function bodies. We'll need to avoid replacing
 		// placeholders that are prepared statement parameters.
-		if col := s.findFuncArgCol(t.Idx); col != nil {
+		if col := s.findFuncArgCol(int(t.Idx)); col != nil {
 			return false, col
 		}
 

--- a/pkg/sql/opt/optbuilder/scope_column.go
+++ b/pkg/sql/opt/optbuilder/scope_column.go
@@ -145,9 +145,9 @@ func (c *scopeColumn) getParamOrd() int {
 }
 
 // funcParamReferencedBy returns true if the scopeColumn is a function parameter
-// column that can be referenced by the given placeholder.
-func (c *scopeColumn) funcParamReferencedBy(idx tree.PlaceholderIdx) bool {
-	return c.paramOrd > 0 && tree.PlaceholderIdx(c.paramOrd-1) == idx
+// column that can be referenced by the given 0-based ordinal.
+func (c *scopeColumn) funcParamReferencedBy(ord int) bool {
+	return c.paramOrd > 0 && int(c.paramOrd-1) == ord
 }
 
 // clearName sets the empty table and column name. This is used to make the

--- a/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
+++ b/pkg/sql/opt/optbuilder/testdata/udf_plpgsql
@@ -5972,6 +5972,131 @@ project
                      │                                                                     └── const: 0 [as=stmt_return_4:10]
                      └── const: 1
 
+# Case with a FETCH into a composite-typed variable.
+exec-ddl
+CREATE OR REPLACE FUNCTION f() RETURNS xy LANGUAGE PLpgSQL AS $$
+  DECLARE
+    foo xy;
+    bar REFCURSOR;
+  BEGIN
+    OPEN bar FOR SELECT 1, 2;
+    FETCH bar INTO foo;
+    RETURN foo;
+  END;
+$$;
+----
+
+build format=(show-scalars,show-types)
+SELECT f();
+----
+project
+ ├── columns: f:21(tuple{int AS x, int AS y})
+ ├── values
+ │    └── tuple [type=tuple]
+ └── projections
+      └── udf: f [as=f:21, type=tuple{int AS x, int AS y}]
+           └── body
+                └── limit
+                     ├── columns: "_gen_cursor_name_6":20(tuple{int AS x, int AS y})
+                     ├── project
+                     │    ├── columns: "_gen_cursor_name_6":20(tuple{int AS x, int AS y})
+                     │    ├── barrier
+                     │    │    ├── columns: foo:1(tuple{int AS x, int AS y}) bar:2(refcursor)
+                     │    │    └── project
+                     │    │         ├── columns: bar:2(refcursor) foo:1(tuple{int AS x, int AS y})
+                     │    │         ├── project
+                     │    │         │    ├── columns: foo:1(tuple{int AS x, int AS y})
+                     │    │         │    ├── values
+                     │    │         │    │    └── tuple [type=tuple]
+                     │    │         │    └── projections
+                     │    │         │         └── cast: RECORD [as=foo:1, type=tuple{int AS x, int AS y}]
+                     │    │         │              └── null [type=unknown]
+                     │    │         └── projections
+                     │    │              └── cast: REFCURSOR [as=bar:2, type=refcursor]
+                     │    │                   └── null [type=unknown]
+                     │    └── projections
+                     │         └── udf: _gen_cursor_name_6 [as="_gen_cursor_name_6":20, type=tuple{int AS x, int AS y}]
+                     │              ├── args
+                     │              │    ├── variable: foo:1 [type=tuple{int AS x, int AS y}]
+                     │              │    └── variable: bar:2 [type=refcursor]
+                     │              ├── params: foo:16(tuple{int AS x, int AS y}) bar:17(refcursor)
+                     │              └── body
+                     │                   └── project
+                     │                        ├── columns: "_stmt_open_1":19(tuple{int AS x, int AS y})
+                     │                        ├── barrier
+                     │                        │    ├── columns: bar:18(refcursor)
+                     │                        │    └── project
+                     │                        │         ├── columns: bar:18(refcursor)
+                     │                        │         ├── values
+                     │                        │         │    └── tuple [type=tuple]
+                     │                        │         └── projections
+                     │                        │              └── function: crdb_internal.plpgsql_gen_cursor_name [as=bar:18, type=refcursor]
+                     │                        │                   └── variable: bar:17 [type=refcursor]
+                     │                        └── projections
+                     │                             └── udf: _stmt_open_1 [as="_stmt_open_1":19, type=tuple{int AS x, int AS y}]
+                     │                                  ├── tail-call
+                     │                                  ├── args
+                     │                                  │    ├── variable: foo:16 [type=tuple{int AS x, int AS y}]
+                     │                                  │    └── variable: bar:18 [type=refcursor]
+                     │                                  ├── params: foo:3(tuple{int AS x, int AS y}) bar:4(refcursor)
+                     │                                  └── body
+                     │                                       ├── open-cursor
+                     │                                       │    └── project
+                     │                                       │         ├── columns: "?column?":5(int!null) "?column?":6(int!null)
+                     │                                       │         ├── values
+                     │                                       │         │    └── tuple [type=tuple]
+                     │                                       │         └── projections
+                     │                                       │              ├── const: 1 [as="?column?":5, type=int]
+                     │                                       │              └── const: 2 [as="?column?":6, type=int]
+                     │                                       └── project
+                     │                                            ├── columns: "_stmt_fetch_2":15(tuple{int AS x, int AS y})
+                     │                                            ├── values
+                     │                                            │    └── tuple [type=tuple]
+                     │                                            └── projections
+                     │                                                 └── udf: _stmt_fetch_2 [as="_stmt_fetch_2":15, type=tuple{int AS x, int AS y}]
+                     │                                                      ├── tail-call
+                     │                                                      ├── args
+                     │                                                      │    ├── variable: foo:3 [type=tuple{int AS x, int AS y}]
+                     │                                                      │    └── variable: bar:4 [type=refcursor]
+                     │                                                      ├── params: foo:7(tuple{int AS x, int AS y}) bar:8(refcursor)
+                     │                                                      └── body
+                     │                                                           └── project
+                     │                                                                ├── columns: "_stmt_fetch_ret_4":14(tuple{int AS x, int AS y})
+                     │                                                                ├── barrier
+                     │                                                                │    ├── columns: stmt_fetch_3:9(tuple{int, int}) foo:10(tuple{int AS x, int AS y})
+                     │                                                                │    └── project
+                     │                                                                │         ├── columns: foo:10(tuple{int AS x, int AS y}) stmt_fetch_3:9(tuple{int, int})
+                     │                                                                │         ├── project
+                     │                                                                │         │    ├── columns: stmt_fetch_3:9(tuple{int, int})
+                     │                                                                │         │    ├── values
+                     │                                                                │         │    │    └── tuple [type=tuple]
+                     │                                                                │         │    └── projections
+                     │                                                                │         │         └── function: crdb_internal.plpgsql_fetch [as=stmt_fetch_3:9, type=tuple{int, int}]
+                     │                                                                │         │              ├── variable: bar:8 [type=refcursor]
+                     │                                                                │         │              ├── const: 0 [type=int]
+                     │                                                                │         │              ├── const: 1 [type=int]
+                     │                                                                │         │              └── tuple [type=tuple{int, int}]
+                     │                                                                │         │                   ├── null [type=int]
+                     │                                                                │         │                   └── null [type=int]
+                     │                                                                │         └── projections
+                     │                                                                │              └── cast: RECORD [as=foo:10, type=tuple{int AS x, int AS y}]
+                     │                                                                │                   └── variable: stmt_fetch_3:9 [type=tuple{int, int}]
+                     │                                                                └── projections
+                     │                                                                     └── udf: _stmt_fetch_ret_4 [as="_stmt_fetch_ret_4":14, type=tuple{int AS x, int AS y}]
+                     │                                                                          ├── tail-call
+                     │                                                                          ├── args
+                     │                                                                          │    ├── variable: foo:10 [type=tuple{int AS x, int AS y}]
+                     │                                                                          │    └── variable: bar:8 [type=refcursor]
+                     │                                                                          ├── params: foo:11(tuple{int AS x, int AS y}) bar:12(refcursor)
+                     │                                                                          └── body
+                     │                                                                               └── project
+                     │                                                                                    ├── columns: stmt_return_5:13(tuple{int AS x, int AS y})
+                     │                                                                                    ├── values
+                     │                                                                                    │    └── tuple [type=tuple]
+                     │                                                                                    └── projections
+                     │                                                                                         └── variable: foo:11 [as=stmt_return_5:13, type=tuple{int AS x, int AS y}]
+                     └── const: 1 [type=int]
+
 # Correctly display the OTHERS branch.
 exec-ddl
 CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$


### PR DESCRIPTION
#### plpgsql: avoid redundant tuple when fetching into tuple var

Previously, a FETCH statement redundantly called `projectRecordVar`
when assigning a cursor result into a single composite-typed variable.
The resulting nested tuple was then unwrapped and assigned into the
variable.

This commit removes the extra step, and just directly assigns the FETCH
tuple into the composite-typed variable. This also fixes a bug with no
known visible effects, where we were incorrectly using the type of the
variable for the column projecting the nested tuple (it should have
been a tuple with a single element of the variable's type).

Epic: None

Release note: None

#### plpgsql: fix parameter ordinal references

Previously, variable assignment in PL/pgSQL routines did not update
the `paramOrd` field. As a result, referencing a variable via the
`$1` ordinal syntax did not always reflect updates to the variable.
In addition, it was possible to reference variables declared in blocks
within the routine body, rather than just the original routine parameters.

This commit fixes both issues by always setting `paramOrd` and setting
a `maxParamOrd` while building SQL expressions and statements, which
prevents the user from referencing block variables via ordinal syntax.
We use a `maxParamOrd` instead of simply not setting `paramOrd` for
block variables to allow the builder to internally reference any
variable with ordinal syntax.

Fixes #143887

Release note (bug fix): Fixed a bug existing since v24.1 that prevented
variable references using ordinal syntax (like `$1`) from reflecting
updates to the variable. Referencing variables declared in PL/pgSQL
blocks (instead of parameters) via ordinal syntax is now disallowed.

#### plpgsql: reference hidden variables only by ordinal

Hidden variables cannot be referenced by the user, and are used internally
to implement FOR LOOP bounds and counters. Previously, hidden variables
were referenced via metadata name. This was fragile, and in fact had
a bug because different loops used the same hidden variables names,
leading to incorrect results for nested loops.

This commit fixes the bug by tracking hidden variables by their ordinal
position among all variables in the current scope. The name of a hidden
variable is now only used for display. This ensures that a hidden variable
can always be uniquely identified, even within nested PL/pgSQL constructs.

Fixes #144321

Release note (bug fix): Fixed a bug existing since v24.3 that could cause
PL/pgSQL FOR loops to terminate early or show incorrect values for the
counter variable. The bug occurred when two or more FOR loops were nested
within one another.