### PR TITLE
drt: generalize pause job to support backup, restore and LDR

### DIFF
--- a/pkg/cmd/roachtest/operations/pause_job.go
+++ b/pkg/cmd/roachtest/operations/pause_job.go
@@ -18,14 +18,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
-type resumePausedJob struct {
+// resumeJob implements OperationCleanup and resumes a paused job by job ID.
+type resumeJob struct {
 	jobId string
 }
 
-func (r *resumePausedJob) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
+func (r *resumeJob) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
 	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
 	defer conn.Close()
 
+	o.Status(fmt.Sprintf("resuming job %s", r.jobId))
 	resumeJobStmt := fmt.Sprintf("RESUME JOB %s", r.jobId)
 	_, err := conn.ExecContext(ctx, resumeJobStmt)
 	if err != nil {
@@ -33,51 +35,92 @@ func (r *resumePausedJob) Cleanup(ctx context.Context, o operation.Operation, c 
 	}
 }
 
-func pauseLDRJob(
-	ctx context.Context, o operation.Operation, c cluster.Cluster,
-) registry.OperationCleanup {
-	conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
-	defer conn.Close()
+// runPauseJob returns a registry.OperationCleanup function that pauses a running job of the given type.
+func runPauseJob(
+	jobType string,
+) func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+		conn := c.Conn(ctx, o.L(), 1, option.VirtualClusterName(roachtestflags.VirtualCluster))
+		defer conn.Close()
 
-	//fetch running ldr jobs
-	jobs, err := conn.QueryContext(ctx, "(WITH x AS (SHOW JOBS) SELECT job_id FROM x WHERE job_type = 'LOGICAL REPLICATION' AND status = 'running')")
-	if err != nil {
-		o.Fatal(err)
-	}
-
-	var jobIds []string
-	for jobs.Next() {
-		var jobId string
-		if err := jobs.Scan(&jobId); err != nil {
+		// Query for running jobs of the specified type
+		query := `
+			WITH jobs AS (SHOW JOBS)
+			SELECT job_id FROM jobs
+			WHERE job_type = $1 AND status = 'running'
+		`
+		rows, err := conn.QueryContext(ctx, query, jobType)
+		if err != nil {
 			o.Fatal(err)
 		}
-		jobIds = append(jobIds, jobId)
-	}
 
-	//pick a random ldr job
-	rng, _ := randutil.NewPseudoRand()
-	jobId := jobIds[rng.Intn(len(jobIds))]
+		var jobIds []string
+		for rows.Next() {
+			var jobId string
+			if err := rows.Scan(&jobId); err != nil {
+				o.Fatal(err)
+			}
+			jobIds = append(jobIds, jobId)
+		}
 
-	o.Status(fmt.Sprintf("pausing LDR job %s", jobId))
-	pauseJobStmt := fmt.Sprintf("PAUSE JOB %s WITH REASON = 'roachtest operation'", jobId)
-	_, err = conn.ExecContext(ctx, pauseJobStmt)
-	if err != nil {
-		o.Fatal(err)
-	}
+		if len(jobIds) == 0 {
+			o.Fatal(fmt.Sprintf("no running %s jobs found", jobType))
+		}
 
-	o.Status(fmt.Sprintf("paused LDR job %s", jobId))
-	return &resumePausedJob{
-		jobId: jobId,
+		// Randomly pick a job to pause
+		rng, _ := randutil.NewPseudoRand()
+		jobId := jobIds[rng.Intn(len(jobIds))]
+
+		o.Status(fmt.Sprintf("pausing %s job %s", jobType, jobId))
+		pauseStmt := fmt.Sprintf("PAUSE JOB %s WITH REASON = 'roachtest operation'", jobId)
+		if _, err := conn.ExecContext(ctx, pauseStmt); err != nil {
+			o.Fatal(err)
+		}
+
+		o.Status(fmt.Sprintf("paused %s job %s", jobType, jobId))
+
+		return &resumeJob{jobId: jobId}
 	}
 }
 
-func registerPauseLDRJob(r registry.Registry) {
-	r.AddOperation(registry.OperationSpec{
-		Name:             "pause-ldr",
-		Owner:            registry.OwnerDisasterRecovery,
-		Timeout:          15 * time.Minute,
-		CompatibleClouds: registry.AllClouds,
-		Dependencies:     []registry.OperationDependency{registry.OperationRequiresLDRJobRunning},
-		Run:              pauseLDRJob,
-	})
+// registerPauseJob registers pause-job operations for various job types (e.g., BACKUP, RESTORE, LOGICAL REPLICATION).
+func registerPauseJob(r registry.Registry) {
+	jobTypes := []struct {
+		JobType     string
+		OpName      string
+		Dependency  registry.OperationDependency
+		Owner       registry.Owner
+		Description string
+	}{
+		{
+			JobType:    "LOGICAL REPLICATION",
+			OpName:     "pause-job/logical-replication",
+			Dependency: registry.OperationRequiresLDRJobRunning,
+			Owner:      registry.OwnerDisasterRecovery,
+		},
+		{
+			JobType:    "BACKUP",
+			OpName:     "pause-job/backup",
+			Dependency: registry.OperationRequiresRunningBackupJob,
+			Owner:      registry.OwnerDisasterRecovery,
+		},
+		{
+			JobType:    "RESTORE",
+			OpName:     "pause-job/restore",
+			Dependency: registry.OperationRequiresRunningRestoreJob,
+			Owner:      registry.OwnerDisasterRecovery,
+		},
+	}
+
+	for _, jt := range jobTypes {
+		r.AddOperation(registry.OperationSpec{
+			Name:               jt.OpName,
+			Owner:              jt.Owner,
+			Timeout:            15 * time.Minute,
+			CompatibleClouds:   registry.AllClouds,
+			Dependencies:       []registry.OperationDependency{jt.Dependency},
+			Run:                runPauseJob(jt.JobType),
+			CanRunConcurrently: registry.OperationCanRunConcurrently,
+		})
+	}
 }

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -24,7 +24,7 @@ func RegisterOperations(r registry.Registry) {
 	registerBackupRestore(r)
 	registerManualCompaction(r)
 	registerResize(r)
-	registerPauseLDRJob(r)
+	registerPauseJob(r)
 	registerLicenseThrottle(r)
 	registerSessionVariables(r)
 	registerDebugZip(r)

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -27,6 +27,8 @@ const (
 	OperationRequiresZeroUnavailableRanges
 	OperationRequiresZeroUnderreplicatedRanges
 	OperationRequiresLDRJobRunning
+	OperationRequiresRunningBackupJob
+	OperationRequiresRunningRestoreJob
 )
 
 // OperationIsolation specifies to what extent the operation runner will try


### PR DESCRIPTION
Previously, the `pause-job` operation was hardcoded to target only `LOGICAL REPLICATION` jobs.
This was inadequate because it prevented the reuse of logic for other long-running jobs like BACKUP and RESTORE. This patch generalizes the `pause-job` operation into a parameterized function supporting `LOGICAL REPLICATION`, `BACKUP`, and `RESTORE`.

Epic: none
Fixes: #138503 #138504 #138507 #138508
Release note: None