### PR TITLE
roachtest: provision admission-control/database-drop with 800GiB/node

### DIFF
--- a/pkg/cmd/roachtest/tests/admission_control_database_drop.go
+++ b/pkg/cmd/roachtest/tests/admission_control_database_drop.go
@@ -29,7 +29,12 @@ func registerDatabaseDrop(r registry.Registry) {
 		spec.CPU(8),
 		spec.WorkloadNode(),
 		spec.WorkloadNodeCPU(8),
-		spec.VolumeSize(500),
+		// The dataset uses above 4TiB of data, and if we have to create the dataset
+		// via IMPORT we need some buffer. 500GiB per node (4.5TiB total) has been
+		// found to fail regularly in the past since the IMPORT job fails when any
+		// node falls below 5% available capacity. 800GiB (7.2TiB) ought to be more
+		// than enough.
+		spec.VolumeSize(800),
 		spec.GCEVolumeType("pd-ssd"),
 		spec.GCEMachineType("n2-standard-8"),
 		spec.GCEZones("us-east1-b"),


### PR DESCRIPTION
This gives the cluster >7TiB of available capacity, which should be more than enough to import the ~4.1TiB dataset.

Informs https://github.com/cockroachdb/cockroach/issues/143690#issuecomment-2800865856.
^-- does not fix, since we also saw unique constraint violations.

Epic: none
Release note: None