### PR TITLE
roachtest: disable scheduled backups for benchmarks

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2166,6 +2166,9 @@ func (c *clusterImpl) StartE(
 	defer c.clearStatusForClusterOpt(startOpts.RoachtestOpts.Worker)
 
 	startOpts.RoachprodOpts.EncryptedStores = c.encAtRest
+	if c.t.Spec().(*registry.TestSpec).Benchmark {
+		startOpts.RoachprodOpts.ScheduleBackups = false
+	}
 
 	// Needed for backward-compat on crdb_internal.ranges{_no_leases}.
 	// Remove in v23.2.

--- a/pkg/cmd/roachtest/option/options.go
+++ b/pkg/cmd/roachtest/option/options.go
@@ -236,6 +236,9 @@ func StorageCluster(nodes NodeListOption) StartStopOption {
 
 // NoBackupSchedule can be used to generate StartOpts that skip the
 // creation of the default backup schedule.
+//
+// Note that tests marked as Benchmarks will be opted out of backup
+// schedules automatically, even if scheduled backups remain enabled.
 func NoBackupSchedule(opts interface{}) {
 	switch opts := opts.(type) {
 	case *StartOpts:


### PR DESCRIPTION
Got bitten by this again[^1], benchmarks should not have random stuff running in
the background.

If anyone ever wants scheduled backups in their benchmarks, it will be easy
enough to add an override. I suspect we'll never need it, so I did not add one.

Touches https://github.com/cockroachdb/cockroach/issues/143138#issuecomment-2801512001.

[^1]: https://github.com/cockroachdb/cockroach/issues/143138#issuecomment-2801512001

Epic: none

Release note: None
