### PR TITLE
jsonpath: add support for non-integer array indices

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -264,22 +264,25 @@ SELECT jsonb_path_query('[1, 2, 3, 4, 5]', '$[1]');
 ----
 2
 
-# TODO(normanchenn): this will be changed after floats are supported.
-statement error pq: jsonpath array subscript is not a single numeric value
-SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[0.99]')
+query T
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[0.99]');
+----
+10
 
-# TODO(normanchenn): this will be changed after floats are supported.
-statement error pq: jsonpath array subscript is not a single numeric value
-SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[1.01]')
+query T
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[1.01]');
+----
+9
 
 query T
 SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varInt]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
 ----
 9
 
-# TODO(normanchenn): this will be changed after floats are supported.
-statement error pgcode 22033 jsonpath array subscript is not a single numeric value
-SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varFloat]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
+query T
+SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varFloat]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}');
+----
+8
 
 statement error pgcode 22033 jsonpath array subscript is not a single numeric value
 SELECT jsonb_path_query('{"a": [10, 9, 8, 7]}', '$.a[$varString]', '{"varInt": 1, "varFloat": 2.3, "varString": "a", "varBool": true, "varNull": null}')
@@ -1552,3 +1555,48 @@ query T
 SELECT jsonb_path_query('[1,2,3]', '$[last ? (@.type() == "number")]');
 ----
 3
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[1.1]');
+----
+2
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[1.5]');
+----
+2
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[1.99999999]');
+----
+2
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[2.1]');
+----
+3
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[2.5]');
+----
+3
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[2.99999999]');
+----
+3
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[-0.1]');
+----
+1
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[-0.5]');
+----
+1
+
+query T
+SELECT jsonb_path_query('[1, 2, 3]', '$[-0.99999999]');
+----
+1

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -195,6 +195,11 @@ SELECT '$.number()'::JSONPATH;
 statement error unimplemented
 SELECT '$.string()'::JSONPATH;
 
+query T
+SELECT '$.*'::JSONPATH
+----
+$.*
+
 ## When we allow table creation
 
 # statement ok
@@ -221,11 +226,6 @@ SELECT '$.string()'::JSONPATH;
 # SELECT * FROM a WHERE j = '$.a'
 
 ## Unsupported Jsonpath
-
-# query T
-# SELECT '$.*'::JSONPATH
-# ----
-# $.*
 
 # query T
 # SELECT '$.a.type()'::JSONPATH

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -599,14 +599,16 @@ $.a.type()
 ----
 $."a".type() -- normalized!
 
-# postgres allows floats as array indexes
-# parse
-# $.abc[1.0]
-# ----
+# Postgres outputs $."abc"[1.0]. This might be a limitation of the apd library.
+parse
+$.abc[1.0]
+----
+$."abc"[1] -- normalized!
 
-# parse
-# $.abc[1.1]
-# ----
+parse
+$.abc[1.1]
+----
+$."abc"[1.1] -- normalized!
 
 # Postgres outputs $."abc"[1000000000].
 parse
@@ -614,9 +616,11 @@ $.abc[1e9]
 ----
 $."abc"[1E+9] -- normalized!
 
-# parse
-# $.abc[0.0]
-# ----
+# Postgres outputs $."abc"[0.0].
+parse
+$.abc[0.0]
+----
+$."abc"[0] -- normalized!
 
 # TODO(normanchenn): Related to the TODOs in pkg/util/jsonpath/operation.go.
 parse
@@ -624,13 +628,15 @@ $.abc[-0]
 ----
 $."abc"[(-0)] -- normalized!
 
-# parse
-# $.abc[-1.99]
-# ----
+parse
+$.abc[-1.99]
+----
+$."abc"[(-1.99)] -- normalized!
 
-# parse
-# $[1.999999999999999]
-# ----
+parse
+$[1.999999999999999]
+----
+$[1.999999999999999]
 
 parse
 $[null]

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -608,19 +608,21 @@ $."a".type() -- normalized!
 # $.abc[1.1]
 # ----
 
-# in postgres this becomes $."a"[1000000000]
-# parse
-# $.abc[1e9]
-# ----
+# Postgres outputs $."abc"[1000000000].
+parse
+$.abc[1e9]
+----
+$."abc"[1E+9] -- normalized!
 
 # parse
 # $.abc[0.0]
 # ----
 
-# postgres allows negatives as array indexes
-# parse
-# $.abc[-0]
-# ----
+# TODO(normanchenn): Related to the TODOs in pkg/util/jsonpath/operation.go.
+parse
+$.abc[-0]
+----
+$."abc"[(-0)] -- normalized!
 
 # parse
 # $.abc[-1.99]
@@ -630,10 +632,11 @@ $."a".type() -- normalized!
 # $[1.999999999999999]
 # ----
 
-# parse
-# $.1a
-# ----
+parse
+$[null]
+----
+$[null]
 
 # parse
-# $[null]
+# $.1a
 # ----


### PR DESCRIPTION
#### jsonpath: enable disabled parser and logic tests

This commit uncomments previously disabled parser and logic tests that
were left behind in their respective commits that added the
functionality to perform the parsing or evaluation.

Release note: None

#### jsonpath: add support for non-integer array indices

This commit adds support for non-integer array indices, which adds
Postgres compatibility in the JSONPath feature set. Non-integer array
indices are rounded towards zero before being used as array indices
(floor for positive numbers, ceil for negative numbers).

Epic: None
Release note (sql change): Add support for non-integer array indices in
JSONPath queries (ex. `SELECT jsonb_path_query('[1, 2, 3]', '$[2.5]');`).
Indices are rounded towards 0.