### PR TITLE
microbench-ci: noop test [dnm]

### DIFF
--- a/pkg/cmd/microbench-ci/config/pull-request-suite.yml
+++ b/pkg/cmd/microbench-ci/config/pull-request-suite.yml
@@ -10,7 +10,7 @@ benchmarks:
     retries: 3
     metrics:
       - name: "sec/op"
-        threshold: .6
+        threshold: .7
       - name: "allocs/op"
         threshold: .2
 


### PR DESCRIPTION
This is a noop test to check that the microbench-ci workflow is working.

Epic: None
Release note: None