### PR TITLE
workload: add Row Level Security operations to Random Schema Changer

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -101,6 +101,7 @@ const (
 	alterTableDropConstraint          // ALTER TABLE <table> DROP CONSTRAINT <constraint>
 	alterTableDropNotNull             // ALTER TABLE <table> ALTER [COLUMN] <column> DROP NOT NULL
 	alterTableDropStored              // ALTER TABLE <table> ALTER [COLUMN] <column> DROP STORED
+	alterTableRLS                     // ALTER TABLE <table> [ENABLE|DISABLE|FORCE|NO FORCE] ROW LEVEL SECURITY
 	alterTableLocality                // ALTER TABLE <table> LOCALITY <locality>
 	alterTableRenameColumn            // ALTER TABLE <table> RENAME [COLUMN] <column> TO <column>
 	alterTableSetColumnDefault        // ALTER TABLE <table> ALTER [COLUMN] <column> SET DEFAULT <expr>
@@ -224,6 +225,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	alterTableDropConstraint:          (*operationGenerator).dropConstraint,
 	alterTableDropNotNull:             (*operationGenerator).dropColumnNotNull,
 	alterTableDropStored:              (*operationGenerator).dropColumnStored,
+	alterTableRLS:                     (*operationGenerator).alterTableRLS,
 	alterTableLocality:                (*operationGenerator).alterTableLocality,
 	alterTableRenameColumn:            (*operationGenerator).renameColumn,
 	alterTableSetColumnDefault:        (*operationGenerator).setColumnDefault,
@@ -275,6 +277,7 @@ var opWeights = []int{
 	alterTableDropConstraint:          1,
 	alterTableDropNotNull:             1,
 	alterTableDropStored:              1,
+	alterTableRLS:                     1,
 	alterTableLocality:                1,
 	alterTableRenameColumn:            1,
 	alterTableSetColumnDefault:        1,
@@ -318,6 +321,7 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	alterTableDropColumn:              clusterversion.MinSupported,
 	alterTableDropConstraint:          clusterversion.MinSupported,
 	alterTableDropNotNull:             clusterversion.MinSupported,
+	alterTableRLS:                     clusterversion.V25_2,
 	alterTypeDropValue:                clusterversion.MinSupported,
 	commentOn:                         clusterversion.MinSupported,
 	createIndex:                       clusterversion.MinSupported,

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -38,27 +38,28 @@ func _() {
 	_ = x[alterTableDropConstraint-22]
 	_ = x[alterTableDropNotNull-23]
 	_ = x[alterTableDropStored-24]
-	_ = x[alterTableLocality-25]
-	_ = x[alterTableRenameColumn-26]
-	_ = x[alterTableSetColumnDefault-27]
-	_ = x[alterTableSetColumnNotNull-28]
-	_ = x[alterTypeDropValue-29]
-	_ = x[createTypeEnum-30]
-	_ = x[createTypeComposite-31]
-	_ = x[createIndex-32]
-	_ = x[createSchema-33]
-	_ = x[createSequence-34]
-	_ = x[createTable-35]
-	_ = x[createTableAs-36]
-	_ = x[createView-37]
-	_ = x[createFunction-38]
-	_ = x[commentOn-39]
-	_ = x[dropFunction-40]
-	_ = x[dropIndex-41]
-	_ = x[dropSchema-42]
-	_ = x[dropSequence-43]
-	_ = x[dropTable-44]
-	_ = x[dropView-45]
+	_ = x[alterTableRLS-25]
+	_ = x[alterTableLocality-26]
+	_ = x[alterTableRenameColumn-27]
+	_ = x[alterTableSetColumnDefault-28]
+	_ = x[alterTableSetColumnNotNull-29]
+	_ = x[alterTypeDropValue-30]
+	_ = x[createTypeEnum-31]
+	_ = x[createTypeComposite-32]
+	_ = x[createIndex-33]
+	_ = x[createSchema-34]
+	_ = x[createSequence-35]
+	_ = x[createTable-36]
+	_ = x[createTableAs-37]
+	_ = x[createView-38]
+	_ = x[createFunction-39]
+	_ = x[commentOn-40]
+	_ = x[dropFunction-41]
+	_ = x[dropIndex-42]
+	_ = x[dropSchema-43]
+	_ = x[dropSequence-44]
+	_ = x[dropTable-45]
+	_ = x[dropView-46]
 }
 
 func (i opType) String() string {
@@ -113,6 +114,8 @@ func (i opType) String() string {
 		return "alterTableDropNotNull"
 	case alterTableDropStored:
 		return "alterTableDropStored"
+	case alterTableRLS:
+		return "alterTableRLS"
 	case alterTableLocality:
 		return "alterTableLocality"
 	case alterTableRenameColumn:


### PR DESCRIPTION
Added four new operations to the Random Schema Changer workload to test ROW LEVEL SECURITY commands:
```
ALTER TABLE <table> ENABLE ROW LEVEL SECURITY
ALTER TABLE <table> DISABLE ROW LEVEL SECURITY
ALTER TABLE <table> FORCE ROW LEVEL SECURITY
ALTER TABLE <table> NO FORCE ROW LEVEL SECURITY
```
These operations are available in the declarative schema changer for cluster version 25.2 and above.

Informs: #137120
Epic: CRDB-11724
Release note: none