### PR TITLE
jsonpath: optimize string lookups with arrays instead of maps

### DIFF
--- a/pkg/util/jsonpath/method.go
+++ b/pkg/util/jsonpath/method.go
@@ -15,7 +15,7 @@ const (
 	TypeMethod
 )
 
-var MethodTypeStrings = map[MethodType]string{
+var methodTypeStrings = [...]string{
 	SizeMethod: "size",
 	TypeMethod: "type",
 }
@@ -27,5 +27,8 @@ type Method struct {
 var _ Path = Method{}
 
 func (m Method) String() string {
-	return fmt.Sprintf(".%s()", MethodTypeStrings[m.Type])
+	if int(m.Type) < 0 || int(m.Type) >= len(methodTypeStrings) || m.Type == InvalidMethod {
+		panic(fmt.Sprintf("invalid method type: %d", m.Type))
+	}
+	return fmt.Sprintf(".%s()", methodTypeStrings[m.Type])
 }

--- a/pkg/util/jsonpath/operation.go
+++ b/pkg/util/jsonpath/operation.go
@@ -10,7 +10,8 @@ import "fmt"
 type OperationType int
 
 const (
-	OpCompEqual OperationType = iota
+	OpInvalid OperationType = iota
+	OpCompEqual
 	OpCompNotEqual
 	OpCompLess
 	OpCompLessEqual
@@ -32,7 +33,7 @@ const (
 	OpStartsWith
 )
 
-var OperationTypeStrings = map[OperationType]string{
+var OperationTypeStrings = [...]string{
 	OpCompEqual:        "==",
 	OpCompNotEqual:     "!=",
 	OpCompLess:         "<",
@@ -64,6 +65,9 @@ type Operation struct {
 var _ Path = Operation{}
 
 func (o Operation) String() string {
+	if int(o.Type) < 0 || int(o.Type) >= len(OperationTypeStrings) || o.Type == OpInvalid {
+		panic(fmt.Sprintf("invalid operation type: %d", o.Type))
+	}
 	// TODO(normanchenn): Fix recursive brackets. When there is a operation like
 	// 1 == 1 && 1 != 1, postgres will output (1 == 1 && 1 != 1), but we output
 	// ((1 == 1) && (1 != 1)).


### PR DESCRIPTION
This commit replaces MethodTypeStrings and OperationTypeStrings maps with arrays since the number of keys are small. The String() methods both now include bounds checking to handle invalid indices.

Epic: None
Release note: None