### PR TITLE
sql: add SwallowSettingOverrideErr session var

### DIFF
--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -970,6 +970,10 @@ func applyOverrides(o sessiondata.InternalExecutorOverride, sd *sessiondata.Sess
 	// TODO(yuzefovich): remove this for 25.3.
 	sd.BufferedWritesEnabled = false
 
+	if o.SwallowSettingOverrideErr {
+		sd.SwallowSettingOverrideErr = true
+	}
+
 	if o.MultiOverride != "" {
 		overrides := strings.Split(o.MultiOverride, ",")
 		for _, override := range overrides {

--- a/pkg/sql/sessiondata/internal.go
+++ b/pkg/sql/sessiondata/internal.go
@@ -87,6 +87,10 @@ type InternalExecutorOverride struct {
 	// BufferedWritesEnabled, if set, controls whether the buffered writes KV transaction
 	// protocol is used for user queries on the current session.
 	BufferedWritesEnabled *bool
+	// SwallowSettingOverrideErr, if set, indicates that when an app tenant
+	// attempts to set a cluster setting overrode by the system tenant, the query
+	// no-ops instead of errors.
+	SwallowSettingOverrideErr bool
 }
 
 // NoSessionDataOverride is the empty InternalExecutorOverride which does not
@@ -113,4 +117,9 @@ var NodeUserWithLowUserPrioritySessionDataOverride = InternalExecutorOverride{
 var NodeUserWithBulkLowPriSessionDataOverride = InternalExecutorOverride{
 	User:             username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
 	QualityOfService: &sessiondatapb.BulkLowQoS,
+}
+
+var NodeUserWithSwallowSettingOverride = InternalExecutorOverride{
+	User:                      username.MakeSQLUsernameFromPreNormalizedString(username.NodeUser),
+	SwallowSettingOverrideErr: true,
 }

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -653,6 +653,13 @@ message LocalOnlySessionData {
   // though it currently doesn't have Postgres-compatible 0-based indexing
   // behavior.
   bool allow_create_trigger_function_with_argv_references = 165;
+  
+  // SwallowSettingOverrideErr, if set, indicates that when an app tenant
+	// attempts to set a cluster setting overrode by the system tenant, the query
+	// no-ops instead of errors. 
+  bool swallow_setting_override_err = 166;
+
+  // NextID 167 
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -223,8 +223,10 @@ func (p *planner) SetClusterSetting(
 			}
 		}
 	}
-
 	if st.OverridesInformer != nil && st.OverridesInformer.IsOverridden(setting.InternalKey()) {
+		if p.SessionData().SwallowSettingOverrideErr {
+			return &zeroNode{}, nil
+		}
 		return nil, errors.Errorf("cluster setting '%s' is currently overridden by the operator", name)
 	}
 

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -165,8 +165,11 @@ func optInToDiagnosticsStatReporting(
 	if cluster.TelemetryOptOut {
 		return nil
 	}
-	_, err := deps.InternalExecutor.Exec(
-		ctx, "optInToDiagnosticsStatReporting", nil, /* txn */
+	_, err := deps.InternalExecutor.ExecEx(
+		ctx,
+		"optInToDiagnosticsStatReporting",
+		nil, /* txn */
+		sessiondata.NodeUserWithSwallowSettingOverride,
 		`SET CLUSTER SETTING diagnostics.reporting.enabled = true`)
 	return err
 }


### PR DESCRIPTION
When set, an app tenant that runs SET CLUSTER SETTING on a setting overrode by
the system tenant will noop instead of return an error.

Epic: none

Release note: none