### PR TITLE
changefeedccl: add job tracing support to changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -128,6 +128,7 @@ go_library(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/bufalloc",
         "//pkg/util/buildutil",
+        "//pkg/util/bulk",
         "//pkg/util/cache",
         "//pkg/util/cancelchecker",
         "//pkg/util/cidr",

--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -349,6 +350,9 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 	// Once finalized, batches are sent to a parallelIO struct which handles
 	// performing multiple Flushes in parallel while maintaining Keys() ordering.
 	ioHandler := func(ctx context.Context, req IORequest) error {
+		ctx, sp := tracing.ChildSpan(ctx, "changefeed.batching_sink.io_handler")
+		defer sp.Finish()
+
 		batch, _ := req.(*sinkBatch)
 		defer s.metrics.recordSinkIOInflightChange(int64(-batch.numMessages))
 		s.metrics.recordSinkIOInflightChange(int64(batch.numMessages))
@@ -569,6 +573,9 @@ func makeBatchingSink(
 	}
 
 	sink.wg.GoCtx(func(ctx context.Context) error {
+		ctx, sp := tracing.ChildSpan(ctx, "changefeed.batching_sink.worker")
+		defer sp.Finish()
+
 		sink.runBatchingWorker(ctx)
 		return nil
 	})

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -82,6 +82,7 @@ func distChangefeedFlow(
 	description string,
 	localState *cachedState,
 	resultsCh chan<- tree.Datums,
+	onTracingEvent func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents),
 ) error {
 	opts := changefeedbase.MakeStatementOptions(details.Opts)
 	progress := localState.progress
@@ -135,7 +136,7 @@ func distChangefeedFlow(
 		}
 	}
 	return startDistChangefeed(
-		ctx, execCtx, jobID, schemaTS, details, description, initialHighWater, localState, resultsCh)
+		ctx, execCtx, jobID, schemaTS, details, description, initialHighWater, localState, resultsCh, onTracingEvent)
 }
 
 func fetchTableDescriptors(
@@ -234,6 +235,7 @@ func startDistChangefeed(
 	initialHighWater hlc.Timestamp,
 	localState *cachedState,
 	resultsCh chan<- tree.Datums,
+	onTracingEvent func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents),
 ) error {
 	execCfg := execCtx.ExecCfg()
 	tableDescs, err := fetchTableDescriptors(ctx, execCfg, AllTargets(details), schemaTS)
@@ -291,6 +293,9 @@ func startDistChangefeed(
 						localState.drainingNodes = append(localState.drainingNodes, meta.Changefeed.DrainInfo.NodeID)
 					}
 					localState.aggregatorFrontier = append(localState.aggregatorFrontier, meta.Changefeed.Checkpoint...)
+				}
+				if meta.AggregatorEvents != nil && onTracingEvent != nil {
+					onTracingEvent(ctx, meta.AggregatorEvents)
 				}
 				return nil
 			},

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exprutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -48,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -55,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -75,7 +78,9 @@ func init() {
 	jobs.RegisterConstructor(
 		jobspb.TypeChangefeed,
 		func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
-			return &changefeedResumer{job: job}
+			r := &changefeedResumer{job: job}
+			r.mu.perNodeAggregatorStats = make(bulk.ComponentAggregatorStats)
+			return r
 		},
 		jobs.UsesTenantCostControl,
 	)
@@ -417,7 +422,7 @@ func coreChangefeed(
 			knobs.BeforeDistChangefeed()
 		}
 
-		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh)
+		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh, nil)
 		if err == nil {
 			log.Infof(ctx, "core changefeed completed with no error")
 			return nil
@@ -1212,7 +1217,26 @@ func validateAndNormalizeChangefeedExpression(
 
 type changefeedResumer struct {
 	job *jobs.Job
+
+	mu struct {
+		syncutil.Mutex
+		// perNodeAggregatorStats is a per component running aggregate of trace
+		// driven AggregatorStats emitted by the processors.
+		perNodeAggregatorStats bulk.ComponentAggregatorStats
+	}
 }
+
+// DumpTraceAfterRun implements jobs.TraceableJob.
+func (b *changefeedResumer) DumpTraceAfterRun() bool {
+	return true
+}
+
+// ForceRealSpan implements jobs.TraceableJob.
+func (b *changefeedResumer) ForceRealSpan() bool {
+	return true
+}
+
+var _ jobs.TraceableJob = &changefeedResumer{}
 
 func (b *changefeedResumer) setJobStatusMessage(
 	ctx context.Context, lastUpdate time.Time, fmtOrMsg string, args ...interface{},
@@ -1406,6 +1430,17 @@ func (b *changefeedResumer) resumeWithRetries(
 		log.Warningf(ctx, "failed to resolve destination details for change monitoring: %v", err)
 	}
 
+	onTracingEvent := func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents) {
+		componentID := execinfrapb.ComponentID{
+			FlowID:        meta.FlowID,
+			SQLInstanceID: meta.SQLInstanceID,
+		}
+
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		b.mu.perNodeAggregatorStats[componentID] = *meta
+	}
+
 	for r := getRetry(ctx); r.Next(); {
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 
@@ -1423,7 +1458,7 @@ func (b *changefeedResumer) resumeWithRetries(
 			g := ctxgroup.WithContext(ctx)
 			g.GoCtx(func(ctx context.Context) error {
 				defer close(confPoller)
-				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh)
+				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh, onTracingEvent)
 			})
 			g.GoCtx(func(ctx context.Context) error {
 				t := time.NewTicker(15 * time.Second)
@@ -1655,8 +1690,17 @@ func (b *changefeedResumer) OnFailOrCancel(
 }
 
 // CollectProfile is part of the jobs.Resumer interface.
-func (b *changefeedResumer) CollectProfile(_ context.Context, _ interface{}) error {
-	return nil
+func (b *changefeedResumer) CollectProfile(ctx context.Context, execCtx interface{}) error {
+	p := execCtx.(sql.JobExecContext)
+	var aggStatsCopy bulk.ComponentAggregatorStats
+	func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		aggStatsCopy = b.mu.perNodeAggregatorStats.DeepCopy()
+	}()
+
+	return bulk.FlushTracingAggregatorStats(ctx, b.job.ID(),
+		p.ExecCfg().InternalDB, aggStatsCopy)
 }
 
 // Try to clean up a protected timestamp created by the changefeed.

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -685,6 +686,9 @@ func (c *parallelEventConsumer) startWorkers() error {
 		id := i
 		consumer := consumers[i]
 		workerClosure := func(ctx2 context.Context) error {
+			ctx2, sp := tracing.ChildSpan(ctx2, "changefeed.parallel_event_consumer.worker")
+			defer sp.Finish()
+
 			return c.workerLoop(ctx2, consumer, id)
 		}
 		c.g.GoCtx(workerClosure)


### PR DESCRIPTION
Adds support for job tracing to changefeeds. This
can be used as an additional debugging tool. The
data stored is summed span counts & times, per
job. The data can be accessed from the db console
like with other jobs.

Epic: none

Release note (ops change): Added job tracing support to changefeeds.
