### PR TITLE
structlogging: conditionally log hot ranges if the node is burdened

### DIFF
--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3059,6 +3059,7 @@ func (s *systemStatusServer) localHotRanges(
 	slices.SortFunc(resp.Ranges, func(a, b *serverpb.HotRangesResponseV2_HotRange) int {
 		return cmp.Compare(a.CPUTimePerSecond, b.CPUTimePerSecond)
 	})
+
 	// truncate the response if localLimit is set
 	if localLimit != 0 && localLimit < len(resp.Ranges) {
 		resp.Ranges = resp.Ranges[:localLimit]

--- a/pkg/server/structlogging/BUILD.bazel
+++ b/pkg/server/structlogging/BUILD.bazel
@@ -41,9 +41,11 @@ go_test(
         "//pkg/base",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/plan",
+        "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
@@ -54,5 +56,6 @@ go_test(
         "//pkg/util/log/logpb",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -25,7 +25,16 @@ import (
 )
 
 // ReportTopHottestRanges limits the number of ranges to be reported per iteration
-const ReportTopHottestRanges = 5
+var ReportTopHottestRanges int32 = 5
+
+// CheckInterval is the interval at which the system checks
+// whether or not to log the hot ranges.
+var CheckInterval = time.Second
+
+// TestLoopChannel triggers the hot ranges logging loop to start again.
+// It's useful in the context of a test, where we don't want to wait
+// for whatever the last time the interval was.
+var TestLoopChannel = make(chan struct{}, 1)
 
 var TelemetryHotRangesStatsInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
@@ -48,18 +57,38 @@ var TelemetryHotRangesStatsLoggingDelay = settings.RegisterDurationSetting(
 	1*time.Second,
 )
 
+// TelemetryHotRangesStatsCPUThreshold defines the cpu duration
+// per second which needs to be exceeded for the system to automatically
+// log the hot ranges. It tracks the reasoning that the kv layer
+// uses to determine when to begin sampling reads for a given
+// range in the keyspace, more information found where the cluster
+// setting SplitByLoadCPUThreshold is defined.
+var TelemetryHotRangesStatsCPUThreshold = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"server.telemetry.hot_ranges_stats.cpu_threshold",
+	"the cpu time over which the system will automatically begin logging hot ranges",
+	time.Second/4,
+)
+
 // hotRangesLoggingScheduler is responsible for logging index usage stats
 // on a scheduled interval.
 type hotRangesLoggingScheduler struct {
-	ie          sql.InternalExecutor
 	sServer     serverpb.TenantStatusServer
 	st          *cluster.Settings
 	stopper     *stop.Stopper
 	job         *jobs.Job
 	multiTenant bool
+	lastLogged  time.Time
 }
 
-// StartHotRangesLoggingScheduler starts the capture index usage statistics logging scheduler.
+// StartHotRangesLoggingScheduler starts the hot range log task
+// or job.
+//
+// For system tenants, or single tenant deployments, it runs as
+// a task on each node, logging only the ranges on the node in
+// which it runs. For app tenants in a multi-tenant deployment,
+// it runs on a single node in the sql cluster, applying a fanout
+// to the kv layer to collect the hot ranges from all nodes.
 func StartHotRangesLoggingScheduler(
 	ctx context.Context,
 	stopper *stop.Stopper,
@@ -68,22 +97,24 @@ func StartHotRangesLoggingScheduler(
 	st *cluster.Settings,
 	ti *tenantcapabilities.Entry,
 ) error {
-	multiTenant := ti != nil && !ti.TenantID.IsSystem()
+	multiTenant := ti != nil && ti.TenantID.IsSet() && !ti.TenantID.IsSystem()
 	scheduler := hotRangesLoggingScheduler{
-		ie:          ie,
 		sServer:     sServer,
 		st:          st,
 		stopper:     stopper,
 		multiTenant: multiTenant,
+		lastLogged:  timeutil.Now(),
 	}
 
 	if multiTenant {
-		return scheduler.startJob(ctx, stopper)
+		return scheduler.startJob()
 	}
 
 	return scheduler.startTask(ctx, stopper)
 }
 
+// startTask is for usage in a system-tenant or non-multi-tenant
+// installation.
 func (s *hotRangesLoggingScheduler) startTask(ctx context.Context, stopper *stop.Stopper) error {
 	return stopper.RunAsyncTask(ctx, "hot-ranges-stats", func(ctx context.Context) {
 		err := s.start(ctx, stopper)
@@ -91,7 +122,7 @@ func (s *hotRangesLoggingScheduler) startTask(ctx context.Context, stopper *stop
 	})
 }
 
-func (s *hotRangesLoggingScheduler) startJob(ctx context.Context, stopper *stop.Stopper) error {
+func (s *hotRangesLoggingScheduler) startJob() error {
 	jobs.RegisterConstructor(
 		jobspb.TypeHotRangesLogger,
 		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
@@ -103,27 +134,20 @@ func (s *hotRangesLoggingScheduler) startJob(ctx context.Context, stopper *stop.
 }
 
 func (s *hotRangesLoggingScheduler) start(ctx context.Context, stopper *stop.Stopper) error {
-	intervalChangedChan := make(chan struct{})
-	// We have to register this callback first. Otherwise we may run into
-	// an unlikely but possible scenario where we've started the ticker,
-	// and the setting is changed before we register the callback and the
-	// ticker will not be reset to the new value.
-	TelemetryHotRangesStatsInterval.SetOnChange(&s.st.SV, func(ctx context.Context) {
-		intervalChangedChan <- struct{}{}
-	})
-
-	ticker := time.NewTicker(TelemetryHotRangesStatsInterval.Get(&s.st.SV))
-
 	for {
+		ci := CheckInterval
+		if s.multiTenant {
+			ci *= 5
+		}
 		select {
 		case <-stopper.ShouldQuiesce():
 			return nil
 		case <-ctx.Done():
 			return nil
-		case <-ticker.C:
+		case <-time.After(ci):
 			s.maybeLogHotRanges(ctx, stopper)
-		case <-intervalChangedChan:
-			ticker.Reset(TelemetryHotRangesStatsInterval.Get(&s.st.SV))
+		case <-TestLoopChannel:
+			continue
 		}
 	}
 }
@@ -131,29 +155,78 @@ func (s *hotRangesLoggingScheduler) start(ctx context.Context, stopper *stop.Sto
 // maybeLogHotRanges is a small helper function which couples the
 // functionality of checking whether to log and logging.
 func (s *hotRangesLoggingScheduler) maybeLogHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	if s.shouldLog() {
+	if s.shouldLog(ctx) {
 		s.logHotRanges(ctx, stopper)
+		s.lastLogged = timeutil.Now()
 	}
 }
 
-// shouldLog checks the below conditions to see whether it should emit logs.
-//   - Is the cluster setting server.telemetry.hot_ranges_stats.enabled true?
-func (s *hotRangesLoggingScheduler) shouldLog() bool {
-	return TelemetryHotRangesStatsEnabled.Get(&s.st.SV)
+// shouldLog checks the below conditions to see whether it
+// should emit logs.
+//
+//		To return true, we verify that both:
+//		 - The logging setting is enabled.
+//	   - One of the following conditions is met:
+//		   -- It's been greater than the log interval since we last logged.
+//		   -- One of the replicas see exceeds our cpu threshold.
+func (s *hotRangesLoggingScheduler) shouldLog(ctx context.Context) bool {
+	enabled := TelemetryHotRangesStatsEnabled.Get(&s.st.SV)
+	if !enabled {
+		return false
+	}
+
+	logInterval := TelemetryHotRangesStatsInterval.Get(&s.st.SV)
+	if timeutil.Since(s.lastLogged) > logInterval {
+		return true
+	}
+
+	// Getting the hot ranges with the statsOnly flag will
+	// ensure the call doesn't touch the keyspace. Therefore
+	// drastically lightening the overhead of fetching them.
+	resp, err := s.getHotRanges(context.Background(), true)
+	if err != nil {
+		log.Warningf(ctx, "failed to get hot ranges: %s", err)
+		return false
+	}
+	cpuThreshold := TelemetryHotRangesStatsCPUThreshold.Get(&s.st.SV)
+	return maxCPU(resp.Ranges) > cpuThreshold
 }
 
-// logHotRanges collects the hot ranges from this node's status server and
-// sends them to the TELEMETRY log channel.
-func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	req := &serverpb.HotRangesRequest{}
+func maxCPU(ranges []*serverpb.HotRangesResponseV2_HotRange) time.Duration {
+	maxSeen := float64(0)
+	for _, r := range ranges {
+		if r.CPUTimePerSecond > maxSeen {
+			maxSeen = r.CPUTimePerSecond
+		}
+	}
+	return time.Duration(maxSeen)
+}
+
+// getHotRanges is a simple utility function for making a hot ranges
+// request to the status server. It can be used to fetch only the
+// stats for ranges requested, or everything. It also determines
+// whether to limit the request to only the local node, or to
+// issue a fanout for multi-tenant apps.
+func (s *hotRangesLoggingScheduler) getHotRanges(
+	ctx context.Context, statsOnly bool,
+) (*serverpb.HotRangesResponseV2, error) {
+	req := &serverpb.HotRangesRequest{
+		PerNodeLimit: ReportTopHottestRanges,
+		StatsOnly:    statsOnly,
+	}
 
 	// if we are running in single tenant mode, only log the ranges on the status server.
 	if !s.multiTenant {
 		req.Nodes = []string{"local"}
-		req.PageSize = ReportTopHottestRanges
 	}
 
-	resp, err := s.sServer.HotRangesV2(ctx, req)
+	return s.sServer.HotRangesV2(ctx, req)
+}
+
+// logHotRanges collects the hot ranges from this node's status server and
+// sends them to the HEALTH log channel.
+func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
+	resp, err := s.getHotRanges(ctx, false)
 	if err != nil {
 		log.Warningf(ctx, "failed to get hot ranges: %s", err)
 		return

--- a/pkg/server/structlogging/hot_ranges_log_job.go
+++ b/pkg/server/structlogging/hot_ranges_log_job.go
@@ -13,6 +13,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// hot_ranges_log_job.go adds the required functions to satisfy
+// the jobs.Scheduler interface for the hot ranges logging job.
+// This is only required for app tenants in a multi-tenant deployment
+// as the app tenants have no notion of "local" ranges, and therefore
+// require a fanout to be performed to collect the hot ranges.
+// It's run as a job, as since fanout is required, only one node
+// needs to run it at any given time, as opposed to the every
+// node task behavior otherwise.
 func (s *hotRangesLoggingScheduler) Resume(ctx context.Context, execCtxI interface{}) error {
 	// This job is a forever running background job, and it is always safe to
 	// terminate the SQL pod whenever the job is running, so mark it as idle.

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -9,15 +9,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
-	"slices"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/plan"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/structlogging"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -26,13 +28,127 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
 )
+
+// setup an impossibly low cpu threshold, test clusters
+// do not seem to record cpu utilization per replica.
+const lowCPUThreshold = time.Duration(-1)
+const highCPUThreshold = time.Second
+const defaultTestWait = time.Second
+const lowDelay = 50 * time.Millisecond
+const highDelay = time.Minute
+
+// TestHotRangeLogger tests that hot ranges stats are logged per node.
+// It uses system ranges to verify behavior.
+func TestHotRangeLoggerSettings(t *testing.T) {
+	skip.UnderRace(t)
+	skip.UnderStress(t)
+	ctx := context.Background()
+
+	// We only want to run this once within the suite, as the
+	// subsystem we depend on takes on the order of whole seconds
+	// to warm.
+	s, spy, teardown := setupTestServer(t, ctx)
+	defer teardown()
+
+	for _, test := range []struct {
+		enabled            bool
+		tickerInterval     time.Duration
+		logSettingInterval time.Duration
+		waitFor            time.Duration
+		logCPUThreshold    time.Duration
+		hasLogs            bool
+	}{
+		// Tests the straightforward use case, where we expect no threshold,
+		// a minimal interval, minimal loop, and zero threshold should
+		// result in multiple logs.
+		{true, lowDelay, lowDelay, defaultTestWait, lowCPUThreshold, true},
+
+		// This test is the same as the default case, except the
+		// cluster setting which controls logging is off.
+		{false, lowDelay, lowDelay, defaultTestWait, lowCPUThreshold, false},
+
+		// This test validates that even when we check on a low cadance,
+		// if the threshold is not passed and the interval is long,
+		// no logs will appear.
+		{true, lowDelay, highDelay, defaultTestWait, highCPUThreshold, false},
+
+		// This test validates that even if the interval is long,
+		// if the cpu threshold is low, and its checked, the system
+		// will produce logs.
+		{true, lowDelay, highDelay, defaultTestWait, lowCPUThreshold, true},
+
+		// This test validates with a high check cadance, no logs
+		// will appear, even if the interval and thresholds are low.
+		{true, highDelay, lowDelay, defaultTestWait, lowCPUThreshold, false},
+
+		// This test checks that if there's a low logging interval
+		// if the cpuThreshold is high, logs will still appear.
+		{true, lowDelay, lowDelay, defaultTestWait, highCPUThreshold, true},
+	} {
+		t.Run(fmt.Sprintf("settings tests %v", test), func(t *testing.T) {
+			setupTest(ctx, s.ClusterSettings(), test.enabled, test.logSettingInterval, test.tickerInterval, test.logCPUThreshold, spy)
+			time.Sleep(test.waitFor)
+			require.Equal(t, test.hasLogs, hasNonZeroQPSRange(spy.Logs()))
+		})
+	}
+
+	t.Run("the per node restriction limits the number of unique logs", func(t *testing.T) {
+		countSeenRanges := func(logs []testLog) int {
+			counts := make(map[int64]int)
+			for _, l := range logs {
+				counts[l.Stats.RangeID]++
+			}
+			return len(counts)
+		}
+
+		// without a limit set, we should see many ranges.
+		setupTest(ctx, s.ClusterSettings(), true, lowDelay, lowDelay, lowCPUThreshold, spy)
+		time.Sleep(time.Second)
+		require.Greater(t, countSeenRanges(spy.Logs()), 1)
+
+		// with a limit, only one range should show up.
+		structlogging.ReportTopHottestRanges = 1
+		setupTest(ctx, s.ClusterSettings(), true, lowDelay, lowDelay, lowCPUThreshold, spy)
+		time.Sleep(time.Second)
+		require.Equal(t, countSeenRanges(spy.Logs()), 1)
+	})
+}
+
+// For multi-tenancy, we want to test the differing behavior.
+// Specifically, we want to test the following:
+//   - Logs are written separately for system and app tenants.
+//   - For app tenants, the interval at which logs are collected
+//     is longer.
+//   - For app tenants, a job is initialized for the hot ranges
+//     logger, whereas for the system tenant it runs as a task.
+func TestHotRangeLoggerMultitenant(t *testing.T) {
+	skip.UnderRace(t)
+	ctx := context.Background()
+	s, spy, teardown := setupTestServer(t, ctx)
+	tenantID := roachpb.MustMakeTenantID(2)
+	tt, err := s.TenantController().StartTenant(ctx, base.TestTenantArgs{
+		TenantID: tenantID,
+	})
+	spy.Logs()
+	require.NoError(t, err)
+	require.NotNil(t, tt)
+	// TODO (brian): the jobs system isn't registering this correctly,
+	// this will be fixed in a short follow pr.
+	defer teardown()
+}
+
+type testLog struct {
+	TenantID string
+	Stats    eventpb.HotRangesStats
+}
 
 type hotRangesLogSpy struct {
 	t  *testing.T
 	mu struct {
 		syncutil.RWMutex
-		logs []eventpb.HotRangesStats
+		logs []testLog
 	}
 }
 
@@ -54,13 +170,13 @@ func (spy *hotRangesLogSpy) Intercept(e []byte) {
 		spy.t.Fatal(err)
 	}
 
-	spy.mu.logs = append(spy.mu.logs, rangesLog)
+	spy.mu.logs = append(spy.mu.logs, testLog{entry.TenantID, rangesLog})
 }
 
-func (spy *hotRangesLogSpy) Logs() []eventpb.HotRangesStats {
+func (spy *hotRangesLogSpy) Logs() []testLog {
 	spy.mu.RLock()
 	defer spy.mu.RUnlock()
-	logs := make([]eventpb.HotRangesStats, len(spy.mu.logs))
+	logs := make([]testLog, len(spy.mu.logs))
 	copy(logs, spy.mu.logs)
 	return logs
 }
@@ -71,20 +187,27 @@ func (spy *hotRangesLogSpy) Reset() {
 	spy.mu.logs = nil
 }
 
-func setupHotRangesLogTest(
+// setupTestServer is a somewhat lengthy warmup process
+// to ensure that the hot ranges tests are ready to run.
+// It sets up a cluster, runs it until the hot range stats are
+// warm by dialing the knobs to noisy, and checking for output,
+// then redials the knobs back to quiet so the test can take over.
+func setupTestServer(
 	t *testing.T, ctx context.Context,
-) (serverutils.ApplicationLayerInterface, *hotRangesLogSpy, func()) {
+) (serverutils.TestServerInterface, *hotRangesLogSpy, func()) {
 	sc := log.ScopeWithoutShowLogs(t)
 	spy := &hotRangesLogSpy{t: t}
-	tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestControlsTenantsExplicitly,
-			Knobs: base.TestingKnobs{
-				Store: &kvserver.StoreTestingKnobs{
-					ReplicaPlannerKnobs: plan.ReplicaPlannerTestingKnobs{
-						DisableReplicaRebalancing: true,
-					},
+
+	// override internal settings.
+	structlogging.ReportTopHottestRanges = 1000
+	structlogging.CheckInterval = 100 * time.Millisecond
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				ReplicaPlannerKnobs: plan.ReplicaPlannerTestingKnobs{
+					DisableReplicaRebalancing: true,
 				},
 			},
 		},
@@ -92,7 +215,7 @@ func setupHotRangesLogTest(
 
 	leakChecker := leaktest.AfterTest(t)
 	logInterceptor := log.InterceptWith(ctx, spy)
-	stopper := tc.Stopper()
+	stopper := s.Stopper()
 	teardown := func() {
 		stopper.Stop(ctx)
 		sc.Close(t)
@@ -100,39 +223,57 @@ func setupHotRangesLogTest(
 		leakChecker()
 	}
 
-	ts := tc.ApplicationLayer(0)
-	return ts, spy, teardown
-}
+	ts := s.ApplicationLayer()
 
-// TestHotRangeLogger tests that hot ranges stats are logged per node.
-// The test will ensure each node contains 5 distinct range replicas for hot
-// ranges logging. Each node should thus log 5 distinct range ids.
-func TestHotRangeLogger(t *testing.T) {
-	skip.UnderRace(t)
-	ctx := context.Background()
-	ts, spy, teardown := setupHotRangesLogTest(t, ctx)
-	defer teardown()
-
+	// lower settings so that we can wait for the stats to warm.
 	structlogging.TelemetryHotRangesStatsEnabled.Override(ctx, &ts.ClusterSettings().SV, true)
 	structlogging.TelemetryHotRangesStatsInterval.Override(ctx, &ts.ClusterSettings().SV, time.Millisecond)
 	structlogging.TelemetryHotRangesStatsLoggingDelay.Override(ctx, &ts.ClusterSettings().SV, 0*time.Millisecond)
 
+	// simulate some queries.
+	for range 1000 {
+		_, err := ts.SQLConn(t).Exec("SELECT * FROM system.namespace")
+		require.NoError(t, err)
+	}
+
 	testutils.SucceedsSoon(t, func() error {
 		logs := spy.Logs()
 
-		// Look for a descriptor, which we always expect to exist in the system.
-		for _, l := range logs {
-			if !slices.Equal(l.Databases, []string{"‹system›"}) {
-				continue
-			}
-			if !slices.Equal(l.Tables, []string{"‹sqlliveness›"}) {
-				continue
-			}
-			if !slices.Equal(l.Indexes, []string{"‹primary›"}) {
-				continue
-			}
+		if hasNonZeroQPSRange(logs) {
 			return nil
 		}
 		return errors.New("waited too long for the synthetic data")
 	})
+
+	return s, spy, teardown
+}
+
+// Utility function which generally indicates that the hot ranges
+// are being logged.
+func hasNonZeroQPSRange(logs []testLog) bool {
+	for _, l := range logs {
+		if l.Stats.Qps == 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func setupTest(
+	ctx context.Context,
+	st *cluster.Settings,
+	enabled bool,
+	logInterval, tickerInterval time.Duration,
+	logCPUThreshold time.Duration,
+	spy *hotRangesLogSpy,
+) {
+	structlogging.TelemetryHotRangesStatsEnabled.Override(ctx, &st.SV, enabled)
+	structlogging.TelemetryHotRangesStatsInterval.Override(ctx, &st.SV, logInterval)
+	structlogging.TelemetryHotRangesStatsCPUThreshold.Override(ctx, &st.SV, logCPUThreshold)
+	structlogging.CheckInterval = tickerInterval
+	// wait for the activity from the previous test to drain.
+	time.Sleep(100 * time.Millisecond)
+	structlogging.TestLoopChannel <- struct{}{}
+	spy.Reset()
 }


### PR DESCRIPTION
structlogging: conditionally log hot ranges if the node is burdened

Prior to this change, if the system were enabled to, the hot ranges would log on a regular interval from each node in the system. This interval however was long (4h by default) and would leave a lot of gaps in the system, any hotspot which wasn't effectively continuous was likely to be missed from it.

So that partner teams have better historical visibility into the system, we here add a check every minute for whether the node is in a "burdened" state. Burdened here is defined as any given range using greater than 250ms cpu time per second. If it is, we log the hot ranges for that node.

Doing so allows for both better precision, if a range is hot, it's likely to be logged, due to the minute by minute check, without sacrificing recall, in that these decisions are made at a node local level.

For multi-tenant deployments, this check happens instead once every 5 minutes, and polls & logs the entire cluster.

Fixes: #138767
Epic: CRDB-43150

Release note (general): If the cluster setting
`server.telemetry.hot_ranges_stats.enabled` is enabled,