### PR TITLE
changefeedccl: improve test coverage of ALTER CHANGEFEED

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/testfeed.go
+++ b/pkg/ccl/changefeedccl/cdctest/testfeed.go
@@ -107,6 +107,6 @@ type EnterpriseTestFeed interface {
 	Progress() (*jobspb.ChangefeedProgress, error)
 	// HighWaterMark returns feed highwatermark.
 	HighWaterMark() (hlc.Timestamp, error)
-	// TickHighWaterMark waits until job highwatermark progresses beyond specified threshold.
-	TickHighWaterMark(minHWM hlc.Timestamp) error
+	// WaitForHighWaterMark waits until job highwatermark progresses beyond specified threshold.
+	WaitForHighWaterMark(minHWM hlc.Timestamp) error
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -7976,7 +7976,7 @@ func TestChangefeedHandlesRollingRestart(t *testing.T) {
 
 		// Even though checkpointing was disabled, when we drain, an attempt is
 		// made to persist up-to-date checkpoint.
-		require.NoError(t, jf.TickHighWaterMark(beforeInsert))
+		require.NoError(t, jf.WaitForHighWaterMark(beforeInsert))
 
 		// Let the retry proceed.
 		ctx, cancel = context.WithTimeout(context.Background(), time.Second*60)

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -282,6 +282,10 @@ func assertPayloadsBaseErr(
 	sourceAssertion func(map[string]any),
 	envelopeType changefeedbase.EnvelopeType,
 ) error {
+	if log.V(1) {
+		log.Infof(ctx, "expected messages: \n%s", strings.Join(expected, "\n"))
+	}
+
 	actual, err := readNextMessages(ctx, f, len(expected))
 	if err != nil {
 		return err

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -548,8 +548,8 @@ func (f *jobFeed) HighWaterMark() (hlc.Timestamp, error) {
 	return hwm, nil
 }
 
-// TickHighWaterMark implements the TestFeed interface.
-func (f *jobFeed) TickHighWaterMark(minHWM hlc.Timestamp) error {
+// WaitForHighWaterMark implements the TestFeed interface.
+func (f *jobFeed) WaitForHighWaterMark(minHWM hlc.Timestamp) error {
 	return testutils.SucceedsWithinError(func() error {
 		current, err := f.HighWaterMark()
 		if err != nil {
@@ -559,7 +559,7 @@ func (f *jobFeed) TickHighWaterMark(minHWM hlc.Timestamp) error {
 			return nil
 		}
 		return errors.Newf("waiting to tick: current=%s min=%s", current, minHWM)
-	}, 10*time.Second)
+	}, timeout())
 }
 
 // FetchTerminalJobErr retrieves the error message from changefeed job.


### PR DESCRIPTION
This patch adds the following unit tests:
* TestAlterChangefeedAddDropSameTarget
* TestAlterChangefeedDropTargetDuringInitialScan
* TestAlterChangefeedRandomizedTargetChanges

Fixes #143154

Release note: None