### PR TITLE
sql: more precise use of MakeSplitterForSideEffect

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -594,3 +594,40 @@ statement ok
 ROLLBACK;
 
 subtest end
+
+subtest regression_143138
+
+statement ok
+CREATE TABLE usertable (
+  ycsb_key VARCHAR(255) NOT NULL,
+  field0 STRING NOT NULL,
+  field1 STRING NOT NULL,
+  CONSTRAINT usertable_pkey PRIMARY KEY (ycsb_key ASC),
+  FAMILY fam_0_ycsb_key (ycsb_key),
+  FAMILY fam_1_field0 (field0),
+  FAMILY fam_2_field1 (field1)
+)
+
+statement ok
+SET plan_cache_mode = force_generic_plan
+
+statement ok
+PREPARE p AS UPDATE usertable SET field1 = $2:::STRING WHERE ycsb_key = $1:::STRING;
+
+query T kvtrace
+EXECUTE p ('foo', 'bar')
+----
+Scan /Table/119/1/"foo"/2/1 lock Exclusive (Block, Unreplicated)
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED;
+
+query T kvtrace
+EXECUTE p ('foo', 'bar')
+----
+Scan /Table/119/1/"foo"/2/1 lock Exclusive (Block, Unreplicated)
+
+statement ok
+ROLLBACK
+
+subtest end

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3363,7 +3363,15 @@ func (dsp *DistSQLPlanner) planIndexJoin(
 		return err
 	}
 
-	splitter := span.MakeSplitter(planInfo.fetch.desc, index, fetchOrdinals)
+	var splitter span.Splitter
+	// This logic matches opt.Locking.MustLockAllRequestedColumnFamilies.
+	if (joinReaderSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE &&
+		joinReaderSpec.LockingDurability == descpb.ScanLockingDurability_GUARANTEED) ||
+		joinReaderSpec.LockingWaitPolicy != descpb.ScanLockingWaitPolicy_BLOCK {
+		splitter = span.MakeSplitterForSideEffect(planInfo.fetch.desc, index, fetchOrdinals)
+	} else {
+		splitter = span.MakeSplitter(planInfo.fetch.desc, index, fetchOrdinals)
+	}
 	joinReaderSpec.SplitFamilyIDs = splitter.FamilyIDs()
 
 	p.PlanToStreamColMap = identityMap(p.PlanToStreamColMap, len(fetchColIDs))
@@ -3458,8 +3466,10 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 	}
 
 	var splitter span.Splitter
-	if joinReaderSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE &&
-		joinReaderSpec.LockingDurability == descpb.ScanLockingDurability_GUARANTEED {
+	// This logic matches opt.Locking.MustLockAllRequestedColumnFamilies.
+	if (joinReaderSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE &&
+		joinReaderSpec.LockingDurability == descpb.ScanLockingDurability_GUARANTEED) ||
+		joinReaderSpec.LockingWaitPolicy != descpb.ScanLockingWaitPolicy_BLOCK {
 		splitter = span.MakeSplitterForSideEffect(planInfo.fetch.desc, planInfo.fetch.index, fetchOrdinals)
 	} else {
 		splitter = span.MakeSplitter(planInfo.fetch.desc, planInfo.fetch.index, fetchOrdinals)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
 	"github.com/cockroachdb/cockroach/pkg/rpc/nodedialer"
@@ -3460,7 +3459,7 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 
 	var splitter span.Splitter
 	if joinReaderSpec.LockingStrength != descpb.ScanLockingStrength_FOR_NONE &&
-		planCtx.ExtendedEvalCtx.TxnIsoLevel != isolation.Serializable {
+		joinReaderSpec.LockingDurability == descpb.ScanLockingDurability_GUARANTEED {
 		splitter = span.MakeSplitterForSideEffect(planInfo.fetch.desc, planInfo.fetch.index, fetchOrdinals)
 	} else {
 		splitter = span.MakeSplitter(planInfo.fetch.desc, planInfo.fetch.index, fetchOrdinals)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -284,7 +284,12 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	if params.InvertedConstraint != nil {
 		spans, err = sb.SpansFromInvertedSpans(e.ctx, params.InvertedConstraint, params.IndexConstraint, nil /* scratch */)
 	} else {
-		splitter := span.MakeSplitter(tabDesc, idx, params.NeededCols)
+		var splitter span.Splitter
+		if params.Locking.MustLockAllRequestedColumnFamilies() {
+			splitter = span.MakeSplitterForSideEffect(tabDesc, idx, params.NeededCols)
+		} else {
+			splitter = span.MakeSplitter(tabDesc, idx, params.NeededCols)
+		}
 		spans, err = sb.SpansFromConstraint(params.IndexConstraint, splitter)
 	}
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -750,3 +750,82 @@ ROLLBACK
 
 statement ok
 RESET enable_durable_locking_for_serializable
+
+# Ensure that we lock all column families of a multi-family table when using
+# durable locking.
+
+statement ok
+CREATE TABLE abc (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  PRIMARY KEY (a),
+  INDEX (b),
+  FAMILY f0 (a),
+  FAMILY f1 (b),
+  FAMILY f2 (c)
+)
+
+statement ok
+INSERT INTO abc VALUES (6, 7, 8)
+
+statement ok
+SET optimizer_use_lock_op_for_serializable = on
+
+statement ok
+SET enable_durable_locking_for_serializable = on
+
+statement ok
+SET distsql = off
+
+# A scan where we normally skip reading family 0.
+query T kvtrace
+SELECT * FROM abc WHERE a = 6
+----
+Scan /Table/113/1/6/{1/1-2/2}
+
+# But with FOR UPDATE we must read all families.
+query T kvtrace
+SELECT * FROM abc WHERE a = 6 FOR UPDATE
+----
+Scan /Table/113/1/{6-7} lock Exclusive (Block, Replicated)
+
+# An index join where we normally skip reading family 0.
+query T kvtrace
+SELECT * FROM abc WHERE b = 7
+----
+Scan /Table/113/2/{7-8}
+Scan /Table/113/1/6/{1/1-2/2}
+
+# But with FOR UPDATE we must read all families.
+query T kvtrace
+SELECT * FROM abc WHERE b = 7 FOR UPDATE
+----
+Scan /Table/113/2/{7-8}
+Scan /Table/113/1/{6-7} lock Exclusive (Block, Replicated)
+
+statement ok
+INSERT INTO t129145 VALUES (6, 7)
+
+# A lookup join where we normally skip reading family 0.
+query T kvtrace
+SELECT * FROM t129145 INNER LOOKUP JOIN abc ON abc.a = t129145.a
+----
+Scan /Table/112/{1-2}
+Scan /Table/113/1/1/{1/1-2/2}, /Table/113/1/6/{1/1-2/2}
+
+# But with FOR UPDATE we must read all families.
+query T kvtrace
+SELECT * FROM t129145 INNER LOOKUP JOIN abc ON abc.a = t129145.a FOR UPDATE OF abc
+----
+Scan /Table/112/{1-2}
+Scan /Table/113/1/{1-2}, /Table/113/1/{6-7} lock Exclusive (Block, Replicated)
+
+statement ok
+RESET distsql
+
+statement ok
+RESET enable_durable_locking_for_serializable
+
+statement ok
+RESET optimizer_use_lock_op_for_serializable

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -2929,7 +2929,8 @@ vectorized: true
       table: t@t_pkey
       spans: /5/0
 
-# Table with multiple column families. Cannot push down locking.
+# Table with multiple column families. Test that we can push down locking in
+# some cases.
 statement ok
 CREATE TABLE xyz (
   x INT PRIMARY KEY,
@@ -2940,6 +2941,7 @@ CREATE TABLE xyz (
   FAMILY (z)
 )
 
+# We can't push down locking if the scan doesn't fetch all families.
 query T
 EXPLAIN (VERBOSE) SELECT y FROM xyz WHERE x = 1 FOR UPDATE
 ----
@@ -2963,40 +2965,85 @@ vectorized: true
           table: xyz@xyz_pkey
           spans: /1/0
 
+# We can push down locking if the scan fetches all families.
+query T
+EXPLAIN (VERBOSE) SELECT y, z FROM xyz WHERE x = 1 FOR UPDATE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (y, z)
+│
+└── • scan
+      columns: (x, y, z)
+      estimated row count: 1 (missing stats)
+      table: xyz@xyz_pkey
+      spans: /1-/2
+      locking strength: for update
+
+# We can't push down locking if the index join doesn't fetch all families.
+query T
+EXPLAIN (VERBOSE) SELECT y FROM xyz WHERE z = 2 FOR SHARE
+----
+distribution: local
+vectorized: true
+·
+• project
+│ columns: (y)
+│
+└── • lookup join (semi)
+    │ columns: (x, y)
+    │ estimated row count: 10 (missing stats)
+    │ table: xyz@xyz_pkey
+    │ equality: (x) = (x)
+    │ equality cols are key
+    │ locking strength: for share
+    │
+    └── • project
+        │ columns: (x, y)
+        │
+        └── • index join
+            │ columns: (x, y, z)
+            │ estimated row count: 10 (missing stats)
+            │ table: xyz@xyz_pkey
+            │ key columns: x
+            │
+            └── • scan
+                  columns: (x, z)
+                  estimated row count: 10 (missing stats)
+                  table: xyz@xyz_z_idx
+                  spans: /2-/3
+
+# We can push down locking if the index join fetches all families.
 query T
 EXPLAIN (VERBOSE) SELECT * FROM xyz WHERE z = 2 FOR SHARE
 ----
 distribution: local
 vectorized: true
 ·
-• lookup join (semi)
+• index join
 │ columns: (x, y, z)
 │ estimated row count: 10 (missing stats)
 │ table: xyz@xyz_pkey
-│ equality: (x) = (x)
-│ equality cols are key
+│ key columns: x
 │ locking strength: for share
 │
-└── • index join
-    │ columns: (x, y, z)
-    │ estimated row count: 10 (missing stats)
-    │ table: xyz@xyz_pkey
-    │ key columns: x
-    │
-    └── • scan
-          columns: (x, z)
-          estimated row count: 10 (missing stats)
-          table: xyz@xyz_z_idx
-          spans: /2-/3
+└── • scan
+      columns: (x, z)
+      estimated row count: 10 (missing stats)
+      table: xyz@xyz_z_idx
+      spans: /2-/3
 
+# We can't push down locking if the lookup join doesn't fetch all families.
 query T
-EXPLAIN (VERBOSE) SELECT * FROM t INNER LOOKUP JOIN xyz ON x = b WHERE a = 5 FOR UPDATE OF xyz
+EXPLAIN (VERBOSE) SELECT t.*, x FROM t INNER LOOKUP JOIN xyz ON x = b WHERE a = 5 FOR UPDATE OF xyz
 ----
 distribution: local
 vectorized: true
 ·
 • lookup join (semi)
-│ columns: (a, b, x, y, z)
+│ columns: (a, b, x)
 │ estimated row count: 1 (missing stats)
 │ table: xyz@xyz_pkey
 │ equality: (x) = (x)
@@ -3004,7 +3051,7 @@ vectorized: true
 │ locking strength: for update
 │
 └── • lookup join (inner)
-    │ columns: (a, b, x, y, z)
+    │ columns: (a, b, x)
     │ estimated row count: 1 (missing stats)
     │ table: xyz@xyz_pkey
     │ equality: (b) = (x)
@@ -3015,6 +3062,27 @@ vectorized: true
           estimated row count: 1 (missing stats)
           table: t@t_pkey
           spans: /5/0
+
+# We can push down locking if the lookup join fetches all families.
+query T
+EXPLAIN (VERBOSE) SELECT * FROM t INNER LOOKUP JOIN xyz ON x = b WHERE a = 5 FOR UPDATE OF xyz
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, x, y, z)
+│ estimated row count: 1 (missing stats)
+│ table: xyz@xyz_pkey
+│ equality: (b) = (x)
+│ equality cols are key
+│ locking strength: for update
+│
+└── • scan
+      columns: (a, b)
+      estimated row count: 1 (missing stats)
+      table: t@t_pkey
+      spans: /5/0
 
 statement ok
 RESET optimizer_use_lock_op_for_serializable

--- a/pkg/sql/opt/util.go
+++ b/pkg/sql/opt/util.go
@@ -160,3 +160,17 @@ func GetAllFKsAmongTables(
 	}
 	return addFKs
 }
+
+// FamiliesForCols returns the set of column families for the set of cols.
+func FamiliesForCols(tab cat.Table, tabID TableID, cols ColSet) (families intsets.Fast) {
+	for i, n := 0, tab.FamilyCount(); i < n; i++ {
+		family := tab.Family(i)
+		for j, m := 0, family.ColumnCount(); j < m; j++ {
+			if cols.Contains(tabID.ColumnID(family.Column(j).Ordinal)) {
+				families.Add(i)
+				break
+			}
+		}
+	}
+	return families
+}

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -183,7 +183,12 @@ func generateScanSpans(
 	if params.InvertedConstraint != nil {
 		return sb.SpansFromInvertedSpans(ctx, params.InvertedConstraint, params.IndexConstraint, nil /* scratch */)
 	}
-	splitter := span.MakeSplitter(tabDesc, index, params.NeededCols)
+	var splitter span.Splitter
+	if params.Locking.MustLockAllRequestedColumnFamilies() {
+		splitter = span.MakeSplitterForSideEffect(tabDesc, index, params.NeededCols)
+	} else {
+		splitter = span.MakeSplitter(tabDesc, index, params.NeededCols)
+	}
 	return sb.SpansFromConstraint(params.IndexConstraint, splitter)
 }
 


### PR DESCRIPTION
Make the usage of `span.MakeSplitterForSideEffect` more targeted, so that we use it when locking multi-column-family tables for SELECT FOR UPDATE statements but not for implicit for-update locking in mutation statements.

The first commit should fix the recent YCSB regression under Read Committed isolation. (See individual commits for details.)

Informs: #114566, #116838
Fixes: #143138

Release note: None