### PR TITLE
base: deprecate CheckEnterpriseEnabled

### DIFF
--- a/pkg/base/license.go
+++ b/pkg/base/license.go
@@ -12,18 +12,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"github.com/cockroachdb/errors"
 )
-
-var errEnterpriseNotEnabled = errors.New("OSS binaries do not include enterprise features")
 
 // CheckEnterpriseEnabled returns a non-nil error if the requested enterprise
 // feature is not enabled, including information or a link explaining how to
 // enable it.
 //
 // This function is overridden by an init hook in CCL builds.
+// Deprecated
 var CheckEnterpriseEnabled = func(_ *cluster.Settings, feature string) error {
-	return errEnterpriseNotEnabled // nb: this is squarely in the hot path on OSS builds
+	return nil
 }
 
 // CCLDistributionAndEnterpriseEnabled is a simpler version of


### PR DESCRIPTION
This change only affects tests. In all release builds, the `ccl` package is linked, which already was overriding this function to be a no-op.

However, test packages that did not import the `ccl` package were still getting the previous implementation, which returns a hard-coded error.

Epic: None
Release note: None