### PR TITLE
workload: use multi region partitioner in auditor

### DIFF
--- a/pkg/workload/tpcc/new_order.go
+++ b/pkg/workload/tpcc/new_order.go
@@ -187,9 +187,17 @@ func (n *newOrder) run(ctx context.Context, wID int) (interface{}, time.Duration
 			allLocal = 0
 			// To avoid picking the local warehouse again, randomly choose among n-1
 			// warehouses and swap in the nth if necessary.
-			item.olSupplyWID = n.config.wPart.randActive(rng)
-			for item.olSupplyWID == wID {
+			if len(n.config.multiRegionCfg.regions) > 0 {
+				// For multi-region configurations, use the multi-region partitioner
+				item.olSupplyWID = n.config.wMRPart.randActive(rng)
+				for item.olSupplyWID == wID {
+					item.olSupplyWID = n.config.wMRPart.randActive(rng)
+				}
+			} else {
 				item.olSupplyWID = n.config.wPart.randActive(rng)
+				for item.olSupplyWID == wID {
+					item.olSupplyWID = n.config.wPart.randActive(rng)
+				}
 			}
 			n.config.auditor.Lock()
 			n.config.auditor.orderLineRemoteWarehouseFreq[item.olSupplyWID]++

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -484,9 +484,11 @@ func (w *tpcc) Hooks() workload.Hooks {
 				if err != nil {
 					return errors.Wrap(err, "error creating multi-region partitioner")
 				}
+				w.auditor = newAuditor(w.activeWarehouses, w.wMRPart, w.affinityPartitions)
+			} else {
+				w.auditor = newAuditor(w.activeWarehouses, w.wPart, w.affinityPartitions)
 			}
 
-			w.auditor = newAuditor(w.activeWarehouses, w.wPart, w.affinityPartitions)
 			return initializeMix(w)
 		},
 		PreCreate: func(db *gosql.DB) error {


### PR DESCRIPTION
Audtior should user multi region partitioner in multi region run of tpcc. Otherwise the audit checks fail for some warehouses.

Fixes: [CRDB-49260](https://cockroachlabs.atlassian.net/browse/CRDB-49260)
Epic: none