### PR TITLE
kvserver: skip TestLeasePreferencesDuringOutage under duress

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1058,7 +1058,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 	skip.UnderShort(t)
 	// The test has 5 nodes. Its possible in stress-race for nodes to be starved
 	// out heartbeating their liveness.
-	skip.UnderRace(t)
+	skip.UnderDuressWithIssue(t, 144457)
 
 	stickyRegistry := fs.NewStickyRegistry()
 	ctx := context.Background()


### PR DESCRIPTION
It was already skipped under race, I saw it fail under deadlock. Skip it there, too.

Closes #144457.

Epic: none

Release note: None