### PR TITLE
release-25.1: kvserver: skip TestLeasePreferencesDuringOutage under duress

### DIFF
--- a/pkg/kv/kvserver/client_lease_test.go
+++ b/pkg/kv/kvserver/client_lease_test.go
@@ -1056,7 +1056,7 @@ func TestLeasePreferencesDuringOutage(t *testing.T) {
 	skip.UnderShort(t)
 	// The test has 5 nodes. Its possible in stress-race for nodes to be starved
 	// out heartbeating their liveness.
-	skip.UnderRace(t)
+	skip.UnderDuressWithIssue(t, 144457)
 
 	stickyRegistry := fs.NewStickyRegistry()
 	ctx := context.Background()


### PR DESCRIPTION
Backport 1/1 commits from #144461 on behalf of @tbg.

/cc @cockroachdb/release

----

It was already skipped under race, I saw it fail under deadlock. Skip it there, too.

Closes #144457.

Epic: none

Release note: None

----

Release justification: test deflake