### PR TITLE
release-25.2: kvserver: skip TestLeaseQueueShedsOnIOOverload under duress

### DIFF
--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -544,6 +544,11 @@ func TestLeaseQueueRaceReplicateQueue(t *testing.T) {
 func TestLeaseQueueShedsOnIOOverload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// The SucceedsSoon has been observed to occasionally time out in both
+	// deadlock and race builds.
+	skip.UnderDuressWithIssue(t, 138903)
+
 	ctx := context.Background()
 
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})


### PR DESCRIPTION
Backport 1/1 commits from #144460 on behalf of @tbg.

/cc @cockroachdb/release

----

Closes #144379.
Closes #138903.

Epic: None
Release note: None

----

Release justification: skip under duress