### PR TITLE
kvserver: metamorphically enable kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled

### DIFF
--- a/pkg/kv/kvserver/closedts/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/BUILD.bazel
@@ -13,6 +13,7 @@ go_library(
         "//pkg/kv/kvserver/closedts/ctpb",
         "//pkg/settings",
         "//pkg/util/hlc",
+        "//pkg/util/metamorphic",
     ],
 )
 

--- a/pkg/kv/kvserver/closedts/setting.go
+++ b/pkg/kv/kvserver/closedts/setting.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 )
 
 // NB: These settings are SystemVisible because they need to be read by e.g.
@@ -86,6 +87,6 @@ var LeadForGlobalReadsAutoTuneEnabled = settings.RegisterBoolSetting(
 		"furthest follower will be used to adjust closed timestamp policies for ranges"+
 		"ranges configured to serve global reads. "+
 		"kv.closed_timestamp.lead_for_global_reads_override takes precedence if set.",
-	false,
+	metamorphic.ConstantWithTestBool("kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled", false),
 	settings.WithPublic,
 )

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1339,7 +1339,7 @@ func (r *Replica) closedTimestampPolicyRLocked() ctpb.RangeClosedTimestampPolicy
 }
 
 // RefreshPolicy updates the replica's cached closed timestamp policy based on
-// span configurations and provided node latencies.
+// span configurations and provided node round-trip latencies.
 func (r *Replica) RefreshPolicy(latencies map[roachpb.NodeID]time.Duration) {
 	policy := func() ctpb.RangeClosedTimestampPolicy {
 		desc, conf := r.DescAndSpanConfig()


### PR DESCRIPTION
**kvserver: metamorphically enable kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled**

This commit metamorphically enables
kv.closed_timestamp.lead_for_global_reads_auto_tune.enabled.

Part of: #143888
Release note: none

---

**kvserver: clarify round-trip latency in policy refresher comments**

Previously, it might be unclear to readers unless they trace the behavior back
through rpccontext. This commit updates the comments in the policy refresher to
explicitly state that the latency being referred to is round-trip.

Epic: none
Release note: none
