### PR TITLE
kvserver/closedts: add TestPolicyRefresherWithLatencies

### DIFF
--- a/pkg/kv/kvserver/closedts/policyrefresher/policy_refresher_test.go
+++ b/pkg/kv/kvserver/closedts/policyrefresher/policy_refresher_test.go
@@ -40,25 +40,37 @@ type mockSpanConfig struct {
 
 type mockReplica struct {
 	// Note that all fields below are protected by mu.
-	mu     syncutil.Mutex
-	conf   mockSpanConfig
-	policy ctpb.RangeClosedTimestampPolicy
+	mu             syncutil.Mutex
+	conf           mockSpanConfig
+	policy         ctpb.RangeClosedTimestampPolicy
+	furthestNodeID roachpb.NodeID
 }
 
-func (m *mockReplica) RefreshPolicy(_ map[roachpb.NodeID]time.Duration) {
+func (m *mockReplica) RefreshPolicy(latencies map[roachpb.NodeID]time.Duration) {
 	m.mu.Lock()
 	defer m.mu.Unlock()
-	if m.conf.isGlobalRead {
-		m.policy = ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO
-	} else {
+	if !m.conf.isGlobalRead {
 		m.policy = ctpb.LAG_BY_CLUSTER_SETTING
+		return
 	}
+	latency, ok := latencies[m.furthestNodeID]
+	if !ok {
+		m.policy = ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO
+		return
+	}
+	m.policy = closedts.FindBucketBasedOnNetworkRTT(latency)
 }
 
 func (m *mockReplica) GetPolicy() ctpb.RangeClosedTimestampPolicy {
 	m.mu.Lock()
 	defer m.mu.Unlock()
 	return m.policy
+}
+
+func (m *mockReplica) SetFurthestNodeID(nodeID roachpb.NodeID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.furthestNodeID = nodeID
 }
 
 func (m *mockReplica) BlockReplica() (unblock func()) {
@@ -242,4 +254,66 @@ func TestPolicyRefresherOnLatencyIntervalUpdate(t *testing.T) {
 		}
 		return errors.New("expected latency update")
 	})
+}
+
+// TestPolicyRefresherWithLatencies tests that the policy refresher correctly
+// updates policies based on latency information from different nodes.
+func TestPolicyRefresherWithLatencies(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	st := cluster.MakeTestingClusterSettings()
+	closedts.LeadForGlobalReadsAutoTuneEnabled.Override(ctx, &st.SV, true)
+
+	// Create a policy refresher with test latencies.
+	latencies := map[roachpb.NodeID]time.Duration{
+		1: 10 * time.Millisecond,
+		2: 50 * time.Millisecond,
+		3: 90 * time.Millisecond,
+	}
+
+	r := &mockReplica{}
+	// Configure replica to not use global reads span config initially.
+	r.SetSpanConfig(false)
+
+	getLeaseholders := func() []Replica { return []Replica{r} }
+	getLatencies := func() map[roachpb.NodeID]time.Duration { return latencies }
+
+	pr := NewPolicyRefresher(stopper, st, getLeaseholders, getLatencies, nil)
+	require.NotNil(t, pr)
+	require.Nil(t, pr.getCurrentLatencies())
+
+	// Initially, the policy should be LAG_BY_CLUSTER_SETTING.
+	require.Equal(t, r.GetPolicy(), ctpb.LAG_BY_CLUSTER_SETTING)
+
+	// Enable global reads and set furthest node to 1. We should get
+	// LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO policy before the cache update.
+	r.SetSpanConfig(true)
+	r.SetFurthestNodeID(1)
+	pr.refreshPolicies([]Replica{r})
+	require.Equal(t, r.GetPolicy(), ctpb.LEAD_FOR_GLOBAL_READS_WITH_NO_LATENCY_INFO)
+
+	// Update latency cache and verify we now get <20ms policy for node 1.
+	pr.updateLatencyCache()
+	require.NotNil(t, pr.getCurrentLatencies())
+	pr.refreshPolicies([]Replica{r})
+	require.Equal(t, r.GetPolicy(), ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_20MS)
+
+	// Set furthest node to 2 and verify we get <60ms policy.
+	r.SetFurthestNodeID(2)
+	pr.refreshPolicies([]Replica{r})
+	require.Equal(t, r.GetPolicy(), ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_60MS)
+
+	// Set furthest node to 3 and verify we get <100ms policy.
+	r.SetFurthestNodeID(3)
+	pr.refreshPolicies([]Replica{r})
+	require.Equal(t, r.GetPolicy(), ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_LESS_THAN_100MS)
+
+	// Update node 3's latency to 300ms and verify we get >=300ms policy.
+	latencies[3] = 300 * time.Millisecond
+	pr.updateLatencyCache()
+	pr.refreshPolicies([]Replica{r})
+	require.Equal(t, r.GetPolicy(), ctpb.LEAD_FOR_GLOBAL_READS_LATENCY_EQUAL_OR_GREATER_THAN_300MS)
 }


### PR DESCRIPTION
This commit adds a new test, TestPolicyRefresherWithLatencies, which verifies
that the policy refresher correctly updates latency information using mocked
latency map data.

Resolves: https://github.com/cockroachdb/cockroach/issues/143888
Release note: none