### PR TITLE
release-25.2: schemachange: run test on `heavy` pool

### DIFF
--- a/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
+++ b/pkg/ccl/testccl/workload/schemachange/BUILD.bazel
@@ -10,7 +10,7 @@ go_test(
     data = [
         "//c-deps:libgeos",
     ],
-    exec_properties = {"test.Pool": "large"},
+    exec_properties = {"test.Pool": "heavy"},
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Backport 1/1 commits from #144501 on behalf of @rickystewart.

/cc @cockroachdb/release

----

fixes https://github.com/cockroachdb/cockroach/issues/144436
Epic: none
Release note: None

----

Release justification: test only change