### PR TITLE
jsonpath: refactor string representation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -101,54 +101,54 @@ SELECT bpchar('$.   abc    [*]':::JSONPATH::JSONPATH)::BPCHAR FROM t ORDER BY 1 
 $."abc"[*]
 
 query T
-SELECT '$.a[*] ? (@.b == 1 && @.c != 1)'::JSONPATH
+SELECT '$.a[*] ? (@.b == 1 && @.c != 1)'::JSONPATH;
 ----
-$."a"[*]?(((@."b" == 1) && (@."c" != 1)))
+$."a"[*]?(@."b" == 1 && @."c" != 1)
 
 query T
-SELECT '$.a[*] ? (@.b != 1)'::JSONPATH
+SELECT '$.a[*] ? (@.b != 1)'::JSONPATH;
 ----
-$."a"[*]?((@."b" != 1))
+$."a"[*]?(@."b" != 1)
 
 query T
-SELECT '$.a[*] ? (@.b < 1)'::JSONPATH
+SELECT '$.a[*] ? (@.b < 1)'::JSONPATH;
 ----
-$."a"[*]?((@."b" < 1))
+$."a"[*]?(@."b" < 1)
 
 query T
-SELECT '$.a[*] ? (@.b <= 1)'::JSONPATH
+SELECT '$.a[*] ? (@.b <= 1)'::JSONPATH;
 ----
-$."a"[*]?((@."b" <= 1))
+$."a"[*]?(@."b" <= 1)
 
 query T
-SELECT '$.a[*] ? (@.b > 1)'::JSONPATH
+SELECT '$.a[*] ? (@.b > 1)'::JSONPATH;
 ----
-$."a"[*]?((@."b" > 1))
+$."a"[*]?(@."b" > 1)
 
 query T
-SELECT '$.a[*] ? (@.b >= 1)'::JSONPATH
+SELECT '$.a[*] ? (@.b >= 1)'::JSONPATH;
 ----
-$."a"[*]?((@."b" >= 1))
+$."a"[*]?(@."b" >= 1)
 
 query T
-SELECT '$.a ? ($.b == 1)'::JSONPATH
+SELECT '$.a ? ($.b == 1)'::JSONPATH;
 ----
-$."a"?(($."b" == 1))
+$."a"?($."b" == 1)
 
 query T
-SELECT '$.a ? (@.b == 1).c ? (@.d == 2)'::JSONPATH
+SELECT '$.a ? (@.b == 1).c ? (@.d == 2)'::JSONPATH;
 ----
-$."a"?((@."b" == 1))."c"?((@."d" == 2))
+$."a"?(@."b" == 1)."c"?(@."d" == 2)
 
 query T
-SELECT '$.a?(@.b==1).c?(@.d==2)'::JSONPATH
+SELECT '$.a?(@.b==1).c?(@.d==2)'::JSONPATH;
 ----
-$."a"?((@."b" == 1))."c"?((@."d" == 2))
+$."a"?(@."b" == 1)."c"?(@."d" == 2)
 
 query T
-SELECT '$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  '::JSONPATH
+SELECT '$  .  a  ?  (  @  .  b  ==  1  )  .  c  ?  (  @  .  d  ==  2  )  '::JSONPATH;
 ----
-$."a"?((@."b" == 1))."c"?((@."d" == 2))
+$."a"?(@."b" == 1)."c"?(@."d" == 2)
 
 statement error pgcode 2201B pq: could not parse .* invalid regular expression: error parsing regexp: missing closing \)
 SELECT '$ ? (@ like_regex "(invalid pattern")'::JSONPATH

--- a/pkg/util/jsonpath/BUILD.bazel
+++ b/pkg/util/jsonpath/BUILD.bazel
@@ -15,5 +15,6 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/json",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/util/jsonpath/jsonpath.go
+++ b/pkg/util/jsonpath/jsonpath.go
@@ -5,17 +5,20 @@
 
 package jsonpath
 
+import "strings"
+
 type Jsonpath struct {
 	Strict bool
 	Path   Path
 }
 
 func (j Jsonpath) String() string {
-	var mode string
+	var sb strings.Builder
 	if j.Strict {
-		mode = "strict "
+		sb.WriteString("strict ")
 	}
-	return mode + j.Path.String()
+	j.Path.ToString(&sb, false /* inKey */, true /* printBrackets */)
+	return sb.String()
 }
 
 // Validate walks the Jsonpath AST. It returns an error if the AST is invalid

--- a/pkg/util/jsonpath/method.go
+++ b/pkg/util/jsonpath/method.go
@@ -5,7 +5,12 @@
 
 package jsonpath
 
-import "fmt"
+import (
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/errors"
+)
 
 type MethodType int
 
@@ -26,11 +31,13 @@ type Method struct {
 
 var _ Path = Method{}
 
-func (m Method) String() string {
-	if int(m.Type) < 0 || int(m.Type) >= len(methodTypeStrings) || m.Type == InvalidMethod {
-		panic(fmt.Sprintf("invalid method type: %d", m.Type))
+func (m Method) ToString(sb *strings.Builder, _, _ bool) {
+	switch m.Type {
+	case SizeMethod, TypeMethod:
+		sb.WriteString(fmt.Sprintf(".%s()", methodTypeStrings[m.Type]))
+	default:
+		panic(errors.AssertionFailedf("unhandled method type: %d", m.Type))
 	}
-	return fmt.Sprintf(".%s()", methodTypeStrings[m.Type])
 }
 
 func (m Method) Validate(nestingLevel int, insideArraySubscript bool) error {

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -335,17 +335,17 @@ $ == $
 parse
 1 == 1 && 1 != 1
 ----
-((1 == 1) && (1 != 1)) -- normalized!
+(1 == 1 && 1 != 1) -- normalized!
 
 parse
 1 == 1 || 1 != 1
 ----
-((1 == 1) || (1 != 1)) -- normalized!
+(1 == 1 || 1 != 1) -- normalized!
 
 parse
 $.abc ? ($.a[1] > 2)
 ----
-$."abc"?(($."a"[1] > 2)) -- normalized!
+$."abc"?($."a"[1] > 2) -- normalized!
 
 error
 @
@@ -355,12 +355,12 @@ error
 parse
 $.a[*] ? (@.b > 100)
 ----
-$."a"[*]?((@."b" > 100)) -- normalized!
+$."a"[*]?(@."b" > 100) -- normalized!
 
 parse
 $.a[*] ? (@.b > 100 || (@.c < 100))
 ----
-$."a"[*]?(((@."b" > 100) || (@."c" < 100))) -- normalized!
+$."a"[*]?(@."b" > 100 || @."c" < 100) -- normalized!
 
 parse
 1 + 1
@@ -370,12 +370,12 @@ parse
 parse
 1 + 1 * 2
 ----
-(1 + (1 * 2)) -- normalized!
+(1 + 1 * 2) -- normalized!
 
 parse
 1 + 2 - 3 * 4 / 5 % 6
 ----
-((1 + 2) - (((3 * 4) / 5) % 6)) -- normalized!
+((1 + 2) - ((3 * 4) / 5) % 6) -- normalized!
 
 parse
 (1 + 2) * (3 - 4) / 5
@@ -385,22 +385,22 @@ parse
 parse
 1 * 2 + 3 * 4
 ----
-((1 * 2) + (3 * 4)) -- normalized!
+(1 * 2 + 3 * 4) -- normalized!
 
 parse
 1 + 2 * (3 - 4) / (5 + 6) - 7 % 8
 ----
-((1 + ((2 * (3 - 4)) / (5 + 6))) - (7 % 8)) -- normalized!
+((1 + (2 * (3 - 4)) / (5 + 6)) - 7 % 8) -- normalized!
 
 parse
 1 * (2 + 3) - 4 / (5 - 6) % 7
 ----
-((1 * (2 + 3)) - ((4 / (5 - 6)) % 7)) -- normalized!
+(1 * (2 + 3) - (4 / (5 - 6)) % 7) -- normalized!
 
 parse
 ((1 + 2) * 3) - (4 % 5) * 6
 ----
-(((1 + 2) * 3) - ((4 % 5) * 6)) -- normalized!
+((1 + 2) * 3 - (4 % 5) * 6) -- normalized!
 
 parse
 1 + 2 - 3 + 4 - 5
@@ -410,12 +410,12 @@ parse
 parse
 $.c[$.b - $.a]
 ----
-$."c"[($."b" - $."a")] -- normalized!
+$."c"[$."b" - $."a"] -- normalized!
 
 parse
 $.c[$.b - $.a to $.d - $.b]
 ----
-$."c"[($."b" - $."a") to ($."d" - $."b")] -- normalized!
+$."c"[$."b" - $."a" to $."d" - $."b"] -- normalized!
 
 parse
 "hello" == "hello"
@@ -425,7 +425,7 @@ parse
 parse
 $.a ? (@.b == "string")
 ----
-$."a"?((@."b" == "string")) -- normalized!
+$."a"?(@."b" == "string") -- normalized!
 
 error
 "a" && "b"
@@ -456,7 +456,7 @@ DETAIL: source SQL:
 parse
 $.a ? (@.b like_regex "^[aeiou]")
 ----
-$."a"?((@."b" like_regex "^[aeiou]")) -- normalized!
+$."a"?(@."b" like_regex "^[aeiou]") -- normalized!
 
 parse
 $.*
@@ -491,7 +491,7 @@ parse
 parse
 1 + 2 * -4
 ----
-(1 + (2 * -4)) -- normalized!
+(1 + 2 * -4) -- normalized!
 
 error
 $ ? (@ like_regex "(invalid pattern")
@@ -524,22 +524,22 @@ exists ($."a") -- normalized!
 parse
 $.a ? (exists(@.b) && !exists(@.c))
 ----
-$."a"?((exists (@."b") && !(exists (@."c")))) -- normalized!
+$."a"?(exists (@."b") && !(exists (@."c"))) -- normalized!
 
 parse
 (1 + 2 == 3) is unknown
 ----
-(((1 + 2) == 3)) is unknown -- normalized!
+(1 + 2 == 3) is unknown
 
 parse
 ($ < 1) is unknown
 ----
-(($ < 1)) is unknown -- normalized!
+($ < 1) is unknown
 
 parse
 (null like_regex "^he.*$") is unknown
 ----
-((null like_regex "^he.*$")) is unknown -- normalized!
+(null like_regex "^he.*$") is unknown
 
 parse
 $ starts with "abc"
@@ -549,7 +549,7 @@ $ starts with "abc"
 parse
 $.a ? (@.b starts with "def")
 ----
-$."a"?((@."b" starts with "def")) -- normalized!
+$."a"?(@."b" starts with "def") -- normalized!
 
 parse
 $.a starts with $var

--- a/pkg/util/jsonpath/scalar.go
+++ b/pkg/util/jsonpath/scalar.go
@@ -7,8 +7,10 @@ package jsonpath
 
 import (
 	"fmt"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/json"
+	"github.com/cockroachdb/errors"
 )
 
 type ScalarType int
@@ -30,11 +32,17 @@ type Scalar struct {
 
 var _ Path = Scalar{}
 
-func (s Scalar) String() string {
-	if s.Type == ScalarVariable {
-		return fmt.Sprintf("$%q", s.Variable)
+func (s Scalar) ToString(sb *strings.Builder, _, _ bool) {
+	switch s.Type {
+	case ScalarInt, ScalarFloat, ScalarString, ScalarBool, ScalarNull:
+		sb.WriteString(s.Value.String())
+		return
+	case ScalarVariable:
+		sb.WriteString(fmt.Sprintf("$%q", s.Variable))
+		return
+	default:
+		panic(errors.AssertionFailedf("unhandled scalar type: %d", s.Type))
 	}
-	return s.Value.String()
 }
 
 func (s Scalar) Validate(nestingLevel int, insideArraySubscript bool) error {


### PR DESCRIPTION
This commit refactors the JSONPath string representation logic to more
closely match Postgres' output format. This new implementation notably
removes unnecessary parentheses around operations based on operation
precedence.

Epic: None
Release note: None