### PR TITLE
release-24.3: sql: avoid unnecessary version bumps for UDTs during ALTER TABLE

### DIFF
--- a/pkg/ccl/backupccl/restore_job.go
+++ b/pkg/ccl/backupccl/restore_job.go
@@ -1403,7 +1403,7 @@ func createImportingDescriptors(
 					if err != nil {
 						return err
 					}
-					typDesc.AddReferencingDescriptorID(table.GetID())
+					_ = typDesc.AddReferencingDescriptorID(table.GetID())
 					if err := descsCol.WriteDescToBatch(
 						ctx, kvTrace, typDesc, b,
 					); err != nil {
@@ -3131,7 +3131,7 @@ func (r *restoreResumer) removeExistingTypeBackReferences(
 				}
 				existing := desc.(*typedesc.Mutable)
 				existing.MaybeIncrementVersion()
-				existing.RemoveReferencingDescriptorID(tbl.ID)
+				_ = existing.RemoveReferencingDescriptorID(tbl.ID)
 			}
 		}
 	}

--- a/pkg/sql/alter_table_locality.go
+++ b/pkg/sql/alter_table_locality.go
@@ -665,9 +665,10 @@ func setNewLocalityConfig(
 		if err != nil {
 			return err
 		}
-		typ.RemoveReferencingDescriptorID(desc.GetID())
-		if err := descsCol.WriteDescToBatch(ctx, kvTrace, typ, b); err != nil {
-			return err
+		if typ.RemoveReferencingDescriptorID(desc.GetID()) {
+			if err := descsCol.WriteDescToBatch(ctx, kvTrace, typ, b); err != nil {
+				return err
+			}
 		}
 	}
 	desc.LocalityConfig = &config
@@ -677,9 +678,10 @@ func setNewLocalityConfig(
 		if err != nil {
 			return err
 		}
-		typ.AddReferencingDescriptorID(desc.GetID())
-		if err := descsCol.WriteDescToBatch(ctx, kvTrace, typ, b); err != nil {
-			return err
+		if typ.AddReferencingDescriptorID(desc.GetID()) {
+			if err := descsCol.WriteDescToBatch(ctx, kvTrace, typ, b); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/sql/catalog/typedesc/type_desc.go
+++ b/pkg/sql/catalog/typedesc/type_desc.go
@@ -409,25 +409,29 @@ func (desc *Mutable) AddEnumValue(node *tree.AlterTypeAddValue) error {
 }
 
 // AddReferencingDescriptorID adds a new referencing descriptor ID to the
-// TypeDescriptor. It ensures that duplicates are not added.
-func (desc *Mutable) AddReferencingDescriptorID(new descpb.ID) {
+// TypeDescriptor, ensuring no duplicates are added. Returns false if the ID
+// was already present and no changes were made.
+func (desc *Mutable) AddReferencingDescriptorID(new descpb.ID) bool {
 	for _, id := range desc.ReferencingDescriptorIDs {
 		if new == id {
-			return
+			return false
 		}
 	}
 	desc.ReferencingDescriptorIDs = append(desc.ReferencingDescriptorIDs, new)
+	return true
 }
 
 // RemoveReferencingDescriptorID removes the desired referencing descriptor ID
-// from the catalog.TypeDescriptor. It has no effect if the requested ID is not present.
-func (desc *Mutable) RemoveReferencingDescriptorID(remove descpb.ID) {
+// from the catalog.TypeDescriptor. If the ID is not present, the method has no
+// effect and returns false to indicate that no removal occurred.
+func (desc *Mutable) RemoveReferencingDescriptorID(remove descpb.ID) bool {
 	for i, id := range desc.ReferencingDescriptorIDs {
 		if id == remove {
 			desc.ReferencingDescriptorIDs = append(desc.ReferencingDescriptorIDs[:i], desc.ReferencingDescriptorIDs[i+1:]...)
-			return
+			return true
 		}
 	}
+	return false
 }
 
 // SetParentSchemaID sets the SchemaID of the type.

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -510,7 +510,7 @@ func (n *createTableNode) startExec(params runParams) error {
 			if err != nil {
 				return errors.Wrap(err, "error resolving multi-region enum")
 			}
-			typeDesc.AddReferencingDescriptorID(desc.ID)
+			_ = typeDesc.AddReferencingDescriptorID(desc.ID)
 			err = params.p.writeTypeSchemaChange(
 				params.ctx, typeDesc, "add REGIONAL BY TABLE back reference")
 			if err != nil {

--- a/pkg/sql/drop_type.go
+++ b/pkg/sql/drop_type.go
@@ -169,7 +169,9 @@ func (p *planner) addTypeBackReference(
 		return err
 	}
 
-	mutDesc.AddReferencingDescriptorID(ref)
+	if !mutDesc.AddReferencingDescriptorID(ref) {
+		return nil // no-op
+	}
 	return p.writeTypeSchemaChange(ctx, mutDesc, jobDesc)
 }
 
@@ -181,9 +183,10 @@ func (p *planner) removeTypeBackReferences(
 		if err != nil {
 			return err
 		}
-		mutDesc.RemoveReferencingDescriptorID(ref)
-		if err := p.writeTypeSchemaChange(ctx, mutDesc, jobDesc); err != nil {
-			return err
+		if mutDesc.RemoveReferencingDescriptorID(ref) {
+			if err := p.writeTypeSchemaChange(ctx, mutDesc, jobDesc); err != nil {
+				return err
+			}
 		}
 	}
 	return nil

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4053,9 +4053,6 @@ alter table roach add column serial_id2 SERIAL
 
 subtest end
 
-statement ok
-set use_declarative_schema_changer = on
-
 # Tests for #131948 where we incorrectly backfilled empty column
 # families for composite datums.
 subtest composite_type_131948
@@ -4206,5 +4203,93 @@ DROP TABLE t1_add
 
 statement ok
 SET use_declarative_schema_changer = $use_decl_sc;
+
+subtest end
+
+# This is a regression test for #144293 where we were bumping the UDT version of
+# all types unconditionally in the legacy schema changer.
+subtest conditional_bump_udt_version
+
+statement ok
+CREATE TABLE t_conditional_bump_udt_version (
+  id INT PRIMARY KEY
+);
+
+let $use_decl_sc
+SHOW use_declarative_schema_changer
+
+# Turning off DSC to allow creation of types.
+statement ok
+set use_declarative_schema_changer = 'off';
+
+statement ok
+CREATE TYPE e1 AS ENUM ('a', 'b', 'c');
+
+statement ok
+SET use_declarative_schema_changer = $use_decl_sc;
+
+let $e1_version
+SELECT crdb_internal.pb_to_json('descriptor', descriptor) -> 'type' ->> 'version'
+from system.descriptor
+where id = 'e1'::REGTYPE::INT - 100000;
+
+# Add a column using e1. We expect a version bump in the enum.
+statement ok
+ALTER TABLE t_conditional_bump_udt_version ADD COLUMN e1_col e1;
+
+query I
+SELECT 1
+FROM system.descriptor
+WHERE id = 'e1'::REGTYPE::INT - 100000 AND
+  (crdb_internal.pb_to_json('descriptor', descriptor) -> 'type' ->> 'version')::INT > $e1_version;
+----
+1
+
+let $e1_version
+SELECT crdb_internal.pb_to_json('descriptor', descriptor) -> 'type' ->> 'version'
+from system.descriptor
+where id = 'e1'::REGTYPE::INT - 100000;
+
+# Add a regular int column. That should not bump the version.
+statement ok
+ALTER TABLE t_conditional_bump_udt_version ADD COLUMN i_col INT;
+
+query I
+SELECT 1
+FROM system.descriptor
+WHERE id = 'e1'::REGTYPE::INT - 100000 AND
+  (crdb_internal.pb_to_json('descriptor', descriptor) -> 'type' ->> 'version')::INT = $e1_version;
+----
+1
+
+# No bump for drop column.
+statement ok
+ALTER TABLE t_conditional_bump_udt_version DROP COLUMN i_col;
+
+query I
+SELECT 1
+FROM system.descriptor
+WHERE id = 'e1'::REGTYPE::INT - 100000 AND
+  (crdb_internal.pb_to_json('descriptor', descriptor) -> 'type' ->> 'version')::INT = $e1_version;
+----
+1
+
+# Ensure version bump happens when we drop the column using the type.
+statement ok
+ALTER TABLE t_conditional_bump_udt_version DROP COLUMN e1_col;
+
+query I
+SELECT 1
+FROM system.descriptor
+WHERE id = 'e1'::REGTYPE::INT - 100000 AND
+  (crdb_internal.pb_to_json('descriptor', descriptor) -> 'type' ->> 'version')::INT > $e1_version;
+----
+1
+
+statement ok
+DROP TABLE t_conditional_bump_udt_version;
+
+statement ok
+DROP TYPE e1;
 
 subtest end

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1142,10 +1142,11 @@ func (sc *SchemaChanger) dropViewDeps(
 				log.Warningf(ctx, "error resolving type dependency %d", id)
 				continue
 			}
-			typeDesc.RemoveReferencingDescriptorID(viewDesc.GetID())
-			if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, typeDesc, b); err != nil {
-				log.Warningf(ctx, "error removing dependency from type ID %d", id)
-				return err
+			if typeDesc.RemoveReferencingDescriptorID(viewDesc.GetID()) {
+				if err := descsCol.WriteDescToBatch(ctx, false /* kvTrace*/, typeDesc, b); err != nil {
+					log.Warningf(ctx, "error removing dependency from type ID %d", id)
+					return err
+				}
 			}
 		}
 		for i := 0; i < col.NumUsesSequences(); i++ {
@@ -1860,9 +1861,9 @@ func (sc *SchemaChanger) done(ctx context.Context) error {
 					return err
 				}
 				if isAddition {
-					typ.AddReferencingDescriptorID(scTable.ID)
+					_ = typ.AddReferencingDescriptorID(scTable.ID)
 				} else {
-					typ.RemoveReferencingDescriptorID(scTable.ID)
+					_ = typ.RemoveReferencingDescriptorID(scTable.ID)
 				}
 				if err := txn.Descriptors().WriteDescToBatch(ctx, kvTrace, typ, b); err != nil {
 					return err


### PR DESCRIPTION
Backport 1/1 commits from #144297.

/cc @cockroachdb/release

---

Previously, in the legacy schema changer, we unconditionally updated backreferences from tables to user-defined types (UDTs) during ALTER TABLE operations. This happened even when the backreferences remained unchanged.

While this behavior was functionally harmless, it caused the version of the referenced types to be incremented unnecessarily.

This change avoids version bumps unless the backreference actually changes.

Fixes: #144293

Epic: none
Release note: none
Release justification: low risk fix that helps avoid a bug