### PR TITLE
aggmetric: clean up ChildrenStorage interface

### DIFF
--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -46,8 +46,8 @@ func NewFunctionalGauge(
 		values := make([]int64, 0)
 		g.childSet.mu.Lock()
 		defer g.childSet.mu.Unlock()
-		g.childSet.mu.children.Do(func(e interface{}) {
-			cg := g.childSet.mu.children.GetChildMetric(e).(*Gauge)
+		g.childSet.mu.children.ForEach(func(metric ChildMetric) {
+			cg := metric.(*Gauge)
 			values = append(values, cg.Value())
 		})
 		return f(values)

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -247,8 +247,8 @@ func NewSQLHistogram(opts metric.HistogramOptions) *SQLHistogram {
 func (sh *SQLHistogram) apply(applyFn func(childMetric ChildMetric)) {
 	sh.mu.Lock()
 	defer sh.mu.Unlock()
-	sh.mu.children.Do(func(e interface{}) {
-		applyFn(sh.mu.children.GetChildMetric(e).(*SQLChildHistogram))
+	sh.mu.children.ForEach(func(metric ChildMetric) {
+		applyFn(metric.(*SQLChildHistogram))
 	})
 }
 


### PR DESCRIPTION
The interface has a `Do` function which passes an arbitrary
`interface{}` object to the function. The only thing the function can
do with that object is to pass it to `GetChildMetric`.

This dance is strange and unnecessary; we rename `Do` to `ForEach` and
change it to pass `ChildMetric` objects directly.

Informs: #144504
Epic: none
Release note: None