### PR TITLE
gossip: parallelize callback handling

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -1562,6 +1562,66 @@ func (g *Gossip) findClient(match func(*client) bool) *client {
 	return nil
 }
 
+// TestingAddInfoProtoAndWaitForAllCallbacks adds an info proto, and waits for all
+// matching callbacks to get called before returning. It's only intended to be
+// used for tests that assert on the result of the gossip propagation.
+func (g *Gossip) TestingAddInfoProtoAndWaitForAllCallbacks(
+	key string, msg protoutil.Message, ttl time.Duration,
+) error {
+	// Take the lock to avoid races where a callback could be added while this
+	// method is waiting for matching callbacks to be called.
+	g.mu.Lock()
+	defer g.mu.Unlock()
+
+	wg := &sync.WaitGroup{}
+
+	// Increment the wait group once per matching callback. It will be decremented
+	// once the processing is complete.
+	for _, cb := range g.mu.is.callbacks {
+		if cb.matcher.MatchString(key) {
+			wg.Add(1)
+		}
+	}
+
+	// Add the target info to the infoStore. This will trigger the registered
+	// callbacks to be called.
+	bytes, err := protoutil.Marshal(msg)
+	if err != nil {
+		return err
+	}
+	if err := g.addInfoLocked(key, bytes, ttl); err != nil {
+		return err
+	}
+
+	// At this point, we know that the callbacks that will be called have been
+	// added to the work queues. Now, we can append an entry item at the end of
+	// the matching callback's work queue that will decrement the wait group that
+	// was incremented earlier. This ensures that ALL matching callbacks have
+	// been called.
+	for _, cb := range g.mu.is.callbacks {
+		if cb.matcher.MatchString(key) {
+			cb.cw.mu.Lock()
+			cb.cw.mu.workQueue = append(cb.cw.mu.workQueue, callbackWorkItem{
+				method: func(_ string, _ roachpb.Value) {
+					wg.Done()
+				},
+				schedulingTime: timeutil.Now(),
+			})
+			cb.cw.mu.Unlock()
+		}
+
+		// Make sure to notify the callback worker that there is work to do.
+		select {
+		case cb.cw.callbackCh <- struct{}{}:
+		default:
+		}
+	}
+
+	// Wait for all the callbacks to finish processing.
+	wg.Wait()
+	return nil
+}
+
 // A firstRangeMissingError indicates that the first range has not yet
 // been gossiped. This will be the case for a node which hasn't yet
 // joined the gossip network.

--- a/pkg/gossip/infostore_test.go
+++ b/pkg/gossip/infostore_test.go
@@ -688,8 +688,6 @@ func TestCallbacksCalledSequentially(t *testing.T) {
 // BenchmarkCallbackParallelism benchmarks the parallelism of the callback
 // worker. It registers multiple callbacks, and executes a fake workload
 // that sleeps for a short duration to simulate work done in the callback.
-// If we implement a parallel execution of the callback workers, we should
-// see a significant speedup.
 func BenchmarkCallbackParallelism(b *testing.B) {
 	ctx := context.Background()
 	is, stopper := newTestInfoStore()

--- a/pkg/testutils/gossiputil/BUILD.bazel
+++ b/pkg/testutils/gossiputil/BUILD.bazel
@@ -9,6 +9,5 @@ go_library(
     deps = [
         "//pkg/gossip",
         "//pkg/roachpb",
-        "//pkg/util/syncutil",
     ],
 )

--- a/pkg/testutils/gossiputil/store_gossiper.go
+++ b/pkg/testutils/gossiputil/store_gossiper.go
@@ -6,40 +6,25 @@
 package gossiputil
 
 import (
-	"sync"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
 // StoreGossiper allows tests to push storeDescriptors into gossip and
 // synchronize on their callbacks. There can only be one storeGossiper used per
 // gossip instance.
 type StoreGossiper struct {
-	g           *gossip.Gossip
-	mu          syncutil.Mutex
-	cond        *sync.Cond
-	storeKeyMap map[string]struct{}
+	g *gossip.Gossip
 }
 
 // NewStoreGossiper creates a store gossiper for use by tests. It adds the
 // callback to gossip.
 func NewStoreGossiper(g *gossip.Gossip) *StoreGossiper {
 	sg := &StoreGossiper{
-		g:           g,
-		storeKeyMap: make(map[string]struct{}),
+		g: g,
 	}
-	sg.cond = sync.NewCond(&sg.mu)
-	// Redundant callbacks are required by StoreGossiper. See GossipWithFunction
-	// which waits for all of the callbacks to be invoked.
-	g.RegisterCallback(gossip.MakePrefixPattern(gossip.KeyStoreDescPrefix), func(key string, _ roachpb.Value) {
-		sg.mu.Lock()
-		defer sg.mu.Unlock()
-		delete(sg.storeKeyMap, key)
-		sg.cond.Broadcast()
-	}, gossip.Redundant)
 	return sg
 }
 
@@ -50,30 +35,11 @@ func (sg *StoreGossiper) GossipStores(storeDescs []*roachpb.StoreDescriptor, t *
 	for i, store := range storeDescs {
 		storeIDs[i] = store.StoreID
 	}
-	sg.GossipWithFunction(storeIDs, func() {
-		for i, storeDesc := range storeDescs {
-			if err := sg.g.AddInfoProto(gossip.MakeStoreDescKey(storeIDs[i]), storeDesc, 0); err != nil {
-				t.Fatal(err)
-			}
+
+	for i, storeDesc := range storeDescs {
+		if err := sg.g.TestingAddInfoProtoAndWaitForAllCallbacks(gossip.MakeStoreDescKey(storeIDs[i]),
+			storeDesc, 0); err != nil {
+			t.Fatal(err)
 		}
-	})
-}
-
-// GossipWithFunction calls gossipFn and blocks until gossip callbacks have
-// fired on each of the stores specified by storeIDs.
-func (sg *StoreGossiper) GossipWithFunction(storeIDs []roachpb.StoreID, gossipFn func()) {
-	sg.mu.Lock()
-	defer sg.mu.Unlock()
-	sg.storeKeyMap = make(map[string]struct{})
-	for _, storeID := range storeIDs {
-		storeKey := gossip.MakeStoreDescKey(storeID)
-		sg.storeKeyMap[storeKey] = struct{}{}
-	}
-
-	gossipFn()
-
-	// Wait for gossip callbacks to be invoked on all the stores.
-	for len(sg.storeKeyMap) > 0 {
-		sg.cond.Wait()
 	}
 }


### PR DESCRIPTION
This PR introduces parallel callback handling in the gossip package by:

1. Moving callback work management from a single global queue to per-callback-registration work queues.
2. Launching a dedicated worker goroutine for each callback registration.
3. Maintaining the guarantee that callbacks for the same key are executed sequentially. This only applies per callback registration, and there are no ordering guarantees between different callback registrations.

The changes improve performance by allowing different callbacks to execute concurrently while preserving the ordering guarantees. Each registration now has its own worker goroutine, channel for signalling new work, and mutex-protected work queue.

Also, it changes the way the storeGossiper used to wait for gossip to propagate. The storeGossiper used to subscribe to store updates, and then it used to rely on the single threaded execution of gossip callbacks to wait for its callback to get called, which means that all other callbacks have been called since the storeGossiper subscribed later. However, with parallel callback execution across different subscriptions, we needed to introduce a more robust way to ensure the
propagation of the gossiped info. We do this by introducing a new gossip method that creates a WaitGroup, incrementing it for every callback match. the WaitGroup will get decremented at the end of callbacks execution, ensuring that our update has definitely been propagated.

Benchmark results before/after:

```
name                    old time/op    new time/op    delta
CallbackParallelism-12    5.69ms ± 0%    1.15ms ± 0%  -79.87%  (p=0.000 n=14+12)

name                    old alloc/op   new alloc/op   delta
CallbackParallelism-12      696B ±68%      897B ±12%  +28.83%  (p=0.020 n=15+15)

name                    old allocs/op  new allocs/op  delta
CallbackParallelism-12      10.0 ± 0%      13.0 ± 0%  +30.00%  (p=0.000 n=15+12)
```

Fixes: #144187

Release note: None