### PR TITLE
ui: fix duplicate drop unused index tags

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/databases/tableIndexesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/databases/tableIndexesApi.ts
@@ -88,7 +88,11 @@ export const useTableIndexStats = ({
           stat?.statistics?.stats?.total_rows_read?.toNumber() ?? 0,
         indexRecs:
           data?.index_recommendations
-            ?.filter(rec => rec?.type != null)
+            ?.filter(
+              rec =>
+                rec?.type != null &&
+                rec.index_id === stat.statistics?.key?.index_id,
+            )
             .map(formatIndexRecsProto) ?? [],
       };
     });


### PR DESCRIPTION
"Drop unused index" tags were being duplicated in the table index details page for every drop index recommendation that existed for said table.

Now, only 1 tag is shown per row

Epic: CC-30965
Fixes: CC-31183
Release note (bug fix): Fixed ui bug where "Drop unused index" tag was being shown more than once in the table index details page