### PR TITLE
sqlproxyccl/acl: use newer btree

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -34,7 +34,7 @@ require (
 	github.com/golang/mock v1.6.0
 	github.com/golang/protobuf v1.5.4
 	github.com/golang/snappy v0.0.5-0.20231225225746-43d5d4cd4e0e
-	github.com/google/btree v1.1.3 // indirect
+	github.com/google/btree v1.1.3
 	github.com/google/pprof v0.0.0-20240227163752-401108e1b7e7
 	github.com/google/uuid v1.6.0 // indirect
 	google.golang.org/api v0.114.0

--- a/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
+++ b/pkg/ccl/sqlproxyccl/acl/BUILD.bazel
@@ -21,9 +21,9 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_google_btree//:btree",
         "@com_github_pires_go_proxyproto//:go-proxyproto",
         "@com_github_pires_go_proxyproto//tlvparse",
-        "@com_github_raduberinde_btree//:btree",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],
 )
@@ -50,7 +50,6 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_pires_go_proxyproto//:go-proxyproto",
         "@com_github_pires_go_proxyproto//tlvparse",
-        "@com_github_raduberinde_btree//:btree",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",
     ],

--- a/pkg/ccl/sqlproxyccl/acl/watcher_test.go
+++ b/pkg/ccl/sqlproxyccl/acl/watcher_test.go
@@ -11,7 +11,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/RaduBerinde/btree" // TODO(#144504): switch to the newer btree
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenant"
 	"github.com/cockroachdb/cockroach/pkg/ccl/sqlproxyccl/tenantdirsvr"
 	"github.com/cockroachdb/cockroach/pkg/ccl/testutilsccl"
@@ -403,8 +402,8 @@ func TestACLWatcher(t *testing.T) {
 		require.Nil(t, err)
 
 		var l *listener
-		watcher.listeners.Ascend(func(i btree.Item) bool {
-			l = i.(*listener)
+		watcher.listeners.Ascend(func(lst *listener) bool {
+			l = lst
 			return false
 		})
 		require.NotNil(t, l)


### PR DESCRIPTION
Use `BtreeG` in the acl watcher code.
Informs: #144504
Release note: None