### PR TITLE
roachprod: suppress metamorphic constants when checking binary version

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -386,7 +386,7 @@ func (c *SyncedCluster) fetchVersion(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts,
 ) (*version.Version, error) {
 	node := c.Nodes[0]
-	runVersionCmd := cockroachNodeBinary(c, node) + " version --build-tag"
+	runVersionCmd := SuppressMetamorphicConstantsEnvVar() + " " + cockroachNodeBinary(c, node) + " version --build-tag"
 
 	result, err := c.runCmdOnSingleNode(ctx, l, node, runVersionCmd, defaultCmdOpts("run-cockroach-version"))
 	if err != nil {


### PR DESCRIPTION
Metamorphic constants are irrelevant for checking the version and break the parsing. This also caused roachtests to log a long warning message with all the metamorphic constants, which is confusing and pollutes the logs.

Fixes: none
Release note: none
Epic: none