### PR TITLE
jsonpath: add support for .** operator

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1640,3 +1640,235 @@ query T
 SELECT jsonb_path_query('{"a": 10}', '$ ? ((@.a < 12) || (@.a < $value))');
 ----
 {"a": 10}
+
+query T
+SELECT jsonb_path_query('null', '$.**');
+----
+null
+
+query T
+SELECT jsonb_path_query('true', '$.**');
+----
+true
+
+query T
+SELECT jsonb_path_query('false', '$.**');
+----
+false
+
+query T
+SELECT jsonb_path_query('1', '$.**');
+----
+1
+
+query T
+SELECT jsonb_path_query('"hello"', '$.**');
+----
+"hello"
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3]', '$.**');
+----
+[1, 2, 3]
+1
+2
+3
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3, [4, 5, 6]]', '$.**');
+----
+[1, 2, 3, [4, 5, 6]]
+1
+2
+3
+[4, 5, 6]
+4
+5
+6
+
+query T rowsort
+SELECT jsonb_path_query('[1, 2, 3, [4, 5, 6, [true, null, "hello"]]]', '$.**');
+----
+[1, 2, 3, [4, 5, 6, [true, null, "hello"]]]
+1
+2
+3
+[4, 5, 6, [true, null, "hello"]]
+4
+5
+6
+[true, null, "hello"]
+true
+null
+"hello"
+
+query T rowsort
+SELECT jsonb_path_query('{"a": 1, "b": true, "c": null}', '$.**');
+----
+{"a": 1, "b": true, "c": null}
+1
+true
+null
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": {"c": {"d": [1, 2, 3, [4, 5, 6, [true, null, "e"]]]}}}, "f": false}', '$.**');
+----
+{"a": {"b": {"c": {"d": [1, 2, 3, [4, 5, 6, [true, null, "e"]]]}}}, "f": false}
+{"b": {"c": {"d": [1, 2, 3, [4, 5, 6, [true, null, "e"]]]}}}
+{"c": {"d": [1, 2, 3, [4, 5, 6, [true, null, "e"]]]}}
+{"d": [1, 2, 3, [4, 5, 6, [true, null, "e"]]]}
+[1, 2, 3, [4, 5, 6, [true, null, "e"]]]
+1
+2
+3
+[4, 5, 6, [true, null, "e"]]
+4
+5
+6
+[true, null, "e"]
+true
+null
+"e"
+false
+
+
+query T rowsort
+SELECT jsonb_path_query('{"a": [1, [true]], "b": null}', '$.**.**');
+----
+{"a": [1, [true]], "b": null}
+[1, [true]]
+1
+[true]
+true
+null
+[1, [true]]
+1
+[true]
+true
+1
+[true]
+true
+true
+null
+
+query T
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{0}');
+----
+{"a": {"b": true}, "c": [1, 2]}
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{1}');
+----
+{"b": true}
+[1, 2]
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{2}');
+----
+true
+1
+2
+
+query empty
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{3}');
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{last}');
+----
+true
+1
+2
+
+query T
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{0 to 0}');
+----
+{"a": {"b": true}, "c": [1, 2]}
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{0 to 1}');
+----
+{"a": {"b": true}, "c": [1, 2]}
+{"b": true}
+[1, 2]
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{1 to last}');
+----
+{"b": true}
+true
+[1, 2]
+1
+2
+
+query empty
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**{2 to 1}');
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', 'strict $.**', '{}', true);
+----
+{"a": {"b": true}, "c": [1, 2]}
+{"b": true}
+true
+[1, 2]
+1
+2
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', 'strict $.**', '{}', false);
+----
+{"a": {"b": true}, "c": [1, 2]}
+{"b": true}
+true
+[1, 2]
+1
+2
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**', '{}', true);
+----
+{"a": {"b": true}, "c": [1, 2]}
+{"b": true}
+true
+[1, 2]
+1
+2
+
+query T rowsort
+SELECT jsonb_path_query('{"a": {"b": true}, "c": [1, 2]}', '$.**', '{}', false);
+----
+{"a": {"b": true}, "c": [1, 2]}
+{"b": true}
+true
+[1, 2]
+1
+2
+
+# Test cases called out from the Postgres docs.
+query T rowsort
+SELECT jsonb_path_query('{"track": {"segments": [{"location":   [ 47.763, 13.4034 ], "start time": "2018-10-14 10:05:14", "HR": 73}, {"location":   [ 47.706, 13.2635 ], "start time": "2018-10-14 10:39:21", "HR": 135}]}}', 'lax $.**.HR');
+----
+73
+135
+73
+135
+
+# query T rowsort
+# SELECT jsonb_path_query('{"track": {"segments": [{"location":   [ 47.763, 13.4034 ], "start time": "2018-10-14 10:05:14", "HR": 73}, {"location":   [ 47.706, 13.2635 ], "start time": "2018-10-14 10:39:21", "HR": 135}]}}', 'strict $.**.HR');
+# ----
+# 73
+# 135
+
+query T rowsort
+SELECT jsonb_path_query('{"track": {"segments": [{"location":   [ 47.763, 13.4034 ], "start time": "2018-10-14 10:05:14", "HR": 73}, {"location":   [ 47.706, 13.2635 ], "start time": "2018-10-14 10:39:21", "HR": 135}]}}', 'lax $.track.segments[*].location ?(@[*] > 15)');
+----
+47.763
+47.706
+
+query T rowsort
+SELECT jsonb_path_query('{"track": {"segments": [{"location":   [ 47.763, 13.4034 ], "start time": "2018-10-14 10:05:14", "HR": 73}, {"location":   [ 47.706, 13.2635 ], "start time": "2018-10-14 10:39:21", "HR": 135}]}}', 'strict $.track.segments[*].location ?(@[*] > 15)');
+----
+[47.763, 13.4034]
+[47.706, 13.2635]
+
+query empty
+SELECT jsonb_path_query('{}', 'strict $.size()', '{}', true);

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -196,9 +196,6 @@ statement error unimplemented
 SELECT '$.string()'::JSONPATH;
 
 statement error unimplemented
-SELECT '$.**'::JSONPATH;
-
-statement error unimplemented
 SELECT '$.decimal()'::JSONPATH;
 
 statement error unimplemented

--- a/pkg/util/jsonpath/eval/method.go
+++ b/pkg/util/jsonpath/eval/method.go
@@ -25,6 +25,9 @@ func (ctx *jsonpathCtx) evalMethod(
 		if err != nil {
 			return nil, err
 		}
+		if size == -1 {
+			return nil, nil
+		}
 		return []json.JSON{json.FromInt(size)}, nil
 	case jsonpath.TypeMethod:
 		t := ctx.evalType(jsonValue)
@@ -37,7 +40,7 @@ func (ctx *jsonpathCtx) evalMethod(
 func (ctx *jsonpathCtx) evalSize(jsonValue json.JSON) (int, error) {
 	if jsonValue.Type() != json.ArrayJSONType {
 		if ctx.strict {
-			return -1, errEvalSizeNotArray
+			return -1, maybeThrowError(ctx, errEvalSizeNotArray)
 		}
 		return 1, nil
 	}

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -682,6 +682,69 @@ parse
 ----
 (1 + 123).type() -- normalized!
 
+parse
+$.**
+----
+$.**
+
+parse
+$.**.**
+----
+$.**.**
+
+parse
+$.**{0}
+----
+$.**{0}
+
+parse
+$.**{1}
+----
+$.**{1}
+
+parse
+$.**{last}
+----
+$.**{last}
+
+error
+$.**{-1}
+----
+at or near "-": syntax error
+DETAIL: source SQL:
+$.**{-1}
+     ^
+
+parse
+$.**{0 to 0}
+----
+$.**{0} -- normalized!
+
+parse
+$.**{0 to 1}
+----
+$.**{0 to 1}
+
+parse
+$.**{0 to last}
+----
+$.** -- normalized!
+
+parse
+$.**{last to last}
+----
+$.**{last} -- normalized!
+
+parse
+$.**{1 to last}
+----
+$.**{1 to last}
+
+parse
+$.**{2 to 1}
+----
+$.**{2 to 1}
+
 # parse
 # $.1a
 # ----

--- a/pkg/util/jsonpath/path.go
+++ b/pkg/util/jsonpath/path.go
@@ -7,6 +7,7 @@ package jsonpath
 
 import (
 	"fmt"
+	"math"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -215,5 +216,37 @@ func (a AnyKey) ToString(sb *strings.Builder, inKey, _ bool) {
 }
 
 func (a AnyKey) Validate(nestingLevel int, insideArraySubscript bool) error {
+	return nil
+}
+
+type Any struct {
+	Start int
+	End   int
+}
+
+var _ Path = Any{}
+
+func (a Any) ToString(sb *strings.Builder, inKey, printBrackets bool) {
+	if inKey {
+		sb.WriteString(".")
+	}
+	if a.Start == 0 && a.End == math.MaxInt {
+		sb.WriteString("**")
+	} else if a.Start == a.End {
+		if a.Start == math.MaxInt {
+			sb.WriteString("**{last}")
+		} else {
+			sb.WriteString(fmt.Sprintf("**{%d}", a.Start))
+		}
+	} else if a.Start == math.MaxInt {
+		sb.WriteString(fmt.Sprintf("**{last to %d}", a.End))
+	} else if a.End == math.MaxInt {
+		sb.WriteString(fmt.Sprintf("**{%d to last}", a.Start))
+	} else {
+		sb.WriteString(fmt.Sprintf("**{%d to %d}", a.Start, a.End))
+	}
+}
+
+func (a Any) Validate(nestingLevel int, insideArraySubscript bool) error {
 	return nil
 }


### PR DESCRIPTION
This commit adds support for the all paths operator `.**` for JSONPath
queries, which recursively matches all elements in a JSON document. This
implementation includes several variants:
- Basic `.**` operator which recursively matches all elements
- Level-specific matching with `.**{n}` syntax
- Range matching with `.**{n to m}` syntax

Epic: None
Release note (sql change): Add support for the JSONPath recursive
operator `.**`, `.**{n}`, `.**{n to m}`. For example, `SELECT
jsonb_path_query('{"a": [1, 2, 3]}', '$.**');`.