### PR TITLE
kvserver: AdminScatter does not obtain an allocator token

### DIFF
--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2377,6 +2377,36 @@ func TestReplicateQueueAllocatorToken(t *testing.T) {
 	require.ErrorAs(t, processErr, &allocationError)
 }
 
+func TestAdminScatterAllocatorToken(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	key := roachpb.Key("a")
+	_, _, err := tc.SplitRange(key)
+	require.NoError(t, err)
+	repl := tc.GetRaftLeader(t, roachpb.RKey(key))
+
+	require.NoError(t, repl.AllocatorToken().TryAcquire(ctx, "test"))
+	s := tc.Server(0)
+	db := s.DB()
+	require.NoError(t, db.Put(ctx, key, "abc"))
+	resp, err := db.AdminScatter(ctx, key, 0)
+	repl.AllocatorToken().Release(ctx)
+	require.NoError(t, err)
+	// A non-empty resp.ReplicasScatteredBytes indicates that the adminScatter did
+	// scatter the replica, even though it shouldn't have (because it didn't have
+	// the allocator token).
+	require.Greater(t, resp.ReplicasScatteredBytes, int64(0))
+	// We actually want resp.ReplicasScatteredBytes == 0.
+	//require.Equal(t, resp.ReplicasScatteredBytes, int64(0))
+}
+
 // TestReplicateQueueDecommissionScannerDisabled asserts that decommissioning
 // replicas are replaced by the replicate queue despite the scanner being
 // disabled, when EnqueueProblemRangeInReplicateQueueInterval is set to a


### PR DESCRIPTION
This commit adds a test, `TestAdminScatterAllocatorToken`, demonstrating that `AadminScatter` issues replica changes without obtaining an allocator token. This can lead to the replicate queue and scatter racing with each other (and failing due to descriptor-changed errors).

Informs: #144579

Release note: None