### PR TITLE
backfill: cleanup vector index backfill

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -470,7 +470,7 @@ type VectorIndexHelper struct {
 	vectorOrd int
 	// centroid is an all zeros centroid of the appropriate dimension for the vector
 	// column. It's used to encode the vector in the reader. The writer will
-	// re-encode the vector with the centroid for the parittionselected.
+	// re-encode the vector with the centroid for the partition selected.
 	centroid vector.T
 	// number of non-vector index key columns
 	numPrefixCols int
@@ -516,7 +516,7 @@ func (vih *VectorIndexHelper) ReEncodeVector(
 	key.Level = cspann.LeafLevel
 	quantizedVector, ok := tree.AsDBytes(searcher.EncodedVector())
 	if !ok {
-		panic("expected encoded vector to be of type DBytes")
+		return &rowenc.IndexEntry{}, errors.AssertionFailedf("expected encoded vector to be of type DBytes")
 	}
 
 	outputEntry.Key = append(outputEntry.Key[:0], vih.indexPrefix...)


### PR DESCRIPTION
Previously a patch to implement vector index backfill was committed and backported to 25.2 without consulting SQL Foundations. It turns out that they have some thoughts on the patch. This patch addresses their comments.

The changes here mostly address readability of the code, but there was at least one issue where progress reporting would not work correctly.

Epic: CRDB-42943
Release note: None