### PR TITLE
roachtest: add TPC-C 1000 WH nowait test

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -741,6 +741,25 @@ func registerTPCC(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
+		Name:                      "tpcc-nowait/w=1000/nodes=5/cpu=16",
+		Owner:                     registry.OwnerTestEng,
+		Benchmark:                 true,
+		Cluster:                   r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+		CompatibleClouds:          registry.AllExceptAzure,
+		Suites:                    registry.Suites(registry.Nightly),
+		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCC(ctx, t, t.L(), c, tpccOptions{
+				Warehouses:                    1000,
+				Duration:                      10 * time.Minute,
+				ExtraRunArgs:                  "--wait=false --tolerate-errors --workers=200",
+				SetupType:                     usingImport,
+				DisableDefaultScheduledBackup: true,
+			})
+		},
+	})
+
+	r.Add(registry.TestSpec{
 		Name:              "tpcc-nowait/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
 		Benchmark:         true,


### PR DESCRIPTION
We currently have a TPC-C nowait test in roachperf, but it's a one warehouse test, which isn't very realistic. This commit adds a more realistic test where we won't be contending on a single warehouse.

Epic: none
Release note: none