### PR TITLE
kv/bulk: stop ignoring errors from async flushes

### DIFF
--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -458,7 +458,7 @@ func (rd *restoreDataProcessor) runRestoreWorkers(
 
 func (rd *restoreDataProcessor) processRestoreSpanEntry(
 	ctx context.Context, kr *KeyRewriter, sst mergedSST,
-) (kvpb.BulkOpSummary, error) {
+) (_ kvpb.BulkOpSummary, retErr error) {
 	db := rd.FlowCtx.Cfg.DB
 	var summary kvpb.BulkOpSummary
 
@@ -519,7 +519,9 @@ func (rd *restoreDataProcessor) processRestoreSpanEntry(
 			return summary, err
 		}
 	}
-	defer batcher.Close(ctx)
+	defer func() {
+		retErr = errors.CombineErrors(retErr, batcher.Close(ctx))
+	}()
 
 	// Read log.V once first to avoid the vmodule mutex in the tight loop below.
 	verbose := log.V(5)
@@ -718,9 +720,9 @@ func reserveRestoreWorkerMemory(
 // implement a mock SSTBatcher used purely for job progress tracking.
 type SSTBatcherExecutor interface {
 	AddMVCCKey(ctx context.Context, key storage.MVCCKey, value []byte) error
-	Reset(ctx context.Context)
+	Reset(ctx context.Context) error
 	Flush(ctx context.Context) error
-	Close(ctx context.Context)
+	Close(ctx context.Context) error
 	GetSummary() kvpb.BulkOpSummary
 }
 
@@ -737,7 +739,7 @@ func (b *sstBatcherNoop) AddMVCCKey(ctx context.Context, key storage.MVCCKey, va
 }
 
 // Reset resets the counter
-func (b *sstBatcherNoop) Reset(ctx context.Context) {}
+func (b *sstBatcherNoop) Reset(ctx context.Context) error { return nil }
 
 // Flush noops.
 func (b *sstBatcherNoop) Flush(ctx context.Context) error {
@@ -745,8 +747,7 @@ func (b *sstBatcherNoop) Flush(ctx context.Context) error {
 }
 
 // Close noops.
-func (b *sstBatcherNoop) Close(ctx context.Context) {
-}
+func (b *sstBatcherNoop) Close(ctx context.Context) error { return nil }
 
 // GetSummary returns this batcher's total added rows/bytes/etc.
 func (b *sstBatcherNoop) GetSummary() kvpb.BulkOpSummary {

--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -377,7 +377,9 @@ func (o *offlineInitialScanProcessor) checkpoint(
 	if err := o.flushBatch(ctx); err != nil {
 		return errors.Wrap(err, "flushing batcher on checkpoint")
 	}
-	o.batcher.Reset(ctx)
+	if err := o.batcher.Reset(ctx); err != nil {
+		return errors.Wrap(err, "resetting batcher on checkpoint")
+	}
 
 	select {
 	case o.checkpointCh <- offlineCheckpoint{
@@ -409,7 +411,9 @@ func (o *offlineInitialScanProcessor) flushBatch(ctx context.Context) error {
 	if err := o.batcher.Flush(ctx); err != nil {
 		return err
 	}
-	o.batcher.Reset(ctx)
+	if err := o.batcher.Reset(ctx); err != nil {
+		return err
+	}
 	o.lastKeyAdded = roachpb.Key{}
 	return nil
 }

--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -313,11 +313,13 @@ func (o *offlineInitialScanProcessor) close() {
 	// worker group. The client close and stopCh close above should result
 	// in exit signals being sent to all relevant goroutines.
 	if err := o.workerGroup.Wait(); err != nil {
-		log.Errorf(o.Ctx(), "error on close(): %s", err)
+		log.Errorf(o.Ctx(), "error on close(): %v", err)
 	}
 
 	if o.batcher != nil {
-		o.batcher.Close(o.Ctx())
+		if err := o.batcher.Close(o.Ctx()); err != nil {
+			log.Errorf(o.Ctx(), "error on close(): %v", err)
+		}
 	}
 
 	o.InternalClose()

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -591,11 +591,13 @@ func (sip *streamIngestionProcessor) close() {
 		sip.subscriptionCancel()
 	}
 	if err := sip.subscriptionGroup.Wait(); err != nil {
-		log.Errorf(sip.Ctx(), "error on close(): %s", err)
+		log.Errorf(sip.Ctx(), "error on close(): %v", err)
 	}
 
 	if sip.batcher != nil {
-		sip.batcher.Close(sip.Ctx())
+		if err := sip.batcher.Close(sip.Ctx()); err != nil {
+			log.Errorf(sip.Ctx(), "error on close(): %v", err)
+		}
 	}
 	sip.maxFlushRateTimer.Stop()
 	sip.aggTimer.Stop()

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -1276,11 +1276,15 @@ type flushableBuffer struct {
 
 // flushBuffer flushes the given streamIngestionBuffer via the SST
 // batchers and returns the underlying streamIngestionBuffer to the pool.
-func (sip *streamIngestionProcessor) flushBuffer(b flushableBuffer) (*jobspb.ResolvedSpans, error) {
+func (sip *streamIngestionProcessor) flushBuffer(
+	b flushableBuffer,
+) (_ *jobspb.ResolvedSpans, retErr error) {
 	ctx, sp := tracing.ChildSpan(sip.Ctx(), "stream-ingestion-flush")
 	defer sp.Finish()
 	// Ensure the batcher is always reset, even on early error returns.
-	defer sip.batcher.Reset(ctx)
+	defer func() {
+		retErr = errors.CombineErrors(retErr, sip.batcher.Reset(ctx))
+	}()
 
 	// First process the point KVs.
 	//

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -162,7 +162,7 @@ func (b *BufferingAdder) SetOnFlush(fn func(summary kvpb.BulkOpSummary)) {
 }
 
 // Close closes the underlying SST builder.
-func (b *BufferingAdder) Close(ctx context.Context) {
+func (b *BufferingAdder) Close(ctx context.Context) error {
 	if log.V(1) {
 		b.sink.mu.Lock()
 		if b.sink.mu.totalStats.BufferFlushes > 0 {
@@ -176,9 +176,12 @@ func (b *BufferingAdder) Close(ctx context.Context) {
 		}
 		b.sink.mu.Unlock()
 	}
-	b.sink.Close(ctx)
+	if err := b.sink.Close(ctx); err != nil {
+		return err
+	}
 	b.memAcc.Close(ctx)
 	b.bulkMon.Stop(ctx)
+	return nil
 }
 
 // Add adds a key to the buffer and checks if it needs to flush.
@@ -268,7 +271,9 @@ func (b *BufferingAdder) doFlush(ctx context.Context, forSize bool) error {
 		b.curBufSummary.Reset()
 		return nil
 	}
-	b.sink.Reset(ctx)
+	if err := b.sink.Reset(ctx); err != nil {
+		return err
+	}
 	b.sink.currentStats.BufferFlushes++
 
 	var before *bulkpb.IngestionPerformanceStats

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -235,8 +235,8 @@ func MakeSSTBatcher(
 	}
 	b.mu.lastFlush = timeutil.Now()
 	b.mu.tracingSpan = tracing.SpanFromContext(ctx)
-	b.Reset(ctx)
-	return b, nil
+	err := b.Reset(ctx)
+	return b, err
 }
 
 // MakeStreamSSTBatcher creates a batcher configured to ingest duplicate keys
@@ -275,8 +275,8 @@ func MakeStreamSSTBatcher(
 	b.mu.lastFlush = timeutil.Now()
 	b.mu.tracingSpan = tracing.SpanFromContext(ctx)
 	b.SetOnFlush(onFlush)
-	b.Reset(ctx)
-	return b, nil
+	err := b.Reset(ctx)
+	return b, err
 }
 
 // MakeTestingSSTBatcher creates a batcher for testing, allowing setting options
@@ -299,8 +299,8 @@ func MakeTestingSSTBatcher(
 		limiter:        sendLimiter,
 		priority:       admissionpb.BulkNormalPri,
 	}
-	b.Reset(ctx)
-	return b, nil
+	err := b.Reset(ctx)
+	return b, err
 }
 
 func (b *SSTBatcher) updateMVCCStats(key storage.MVCCKey, value []byte) {
@@ -426,9 +426,9 @@ func (b *SSTBatcher) AddMVCCKey(ctx context.Context, key storage.MVCCKey, value 
 }
 
 // Reset clears all state in the batcher and prepares it for reuse.
-func (b *SSTBatcher) Reset(ctx context.Context) {
+func (b *SSTBatcher) Reset(ctx context.Context) error {
 	if err := b.asyncAddSSTs.Wait(); err != nil {
-		log.Warningf(ctx, "closing with flushes in-progress encountered an error: %v", err)
+		return errors.Wrapf(err, "closing with flushes in-progress encountered an error")
 	}
 	b.asyncAddSSTs = ctxgroup.Group{}
 
@@ -462,6 +462,7 @@ func (b *SSTBatcher) Reset(ctx context.Context) {
 	if b.mu.totalStats.SendWaitByStore == nil {
 		b.mu.totalStats.SendWaitByStore = make(map[roachpb.StoreID]time.Duration)
 	}
+	return nil
 }
 
 const (
@@ -496,8 +497,8 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 		if err := b.doFlush(ctx, rangeFlush); err != nil {
 			return err
 		}
-		b.Reset(ctx)
-		return nil
+		err := b.Reset(ctx)
+		return err
 	}
 
 	if b.sstWriter.DataSize >= ingestFileSize(b.settings) {
@@ -521,8 +522,8 @@ func (b *SSTBatcher) flushIfNeeded(ctx context.Context, nextKey roachpb.Key) err
 		if err := b.doFlush(ctx, sizeFlush); err != nil {
 			return err
 		}
-		b.Reset(ctx)
-		return nil
+		err := b.Reset(ctx)
+		return err
 	}
 	return nil
 }
@@ -768,12 +769,13 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 }
 
 // Close closes the underlying SST builder.
-func (b *SSTBatcher) Close(ctx context.Context) {
+func (b *SSTBatcher) Close(ctx context.Context) error {
 	b.sstWriter.Close()
 	if err := b.asyncAddSSTs.Wait(); err != nil {
-		log.Warningf(ctx, "closing with flushes in-progress encountered an error: %v", err)
+		return errors.Wrap(err, "closing with flushes in-progress encountered an error")
 	}
 	b.mem.Close(ctx)
+	return nil
 }
 
 // GetSummary returns this batcher's total added rows/bytes/etc.

--- a/pkg/kv/bulk/sst_batcher_test.go
+++ b/pkg/kv/bulk/sst_batcher_test.go
@@ -206,7 +206,7 @@ func TestDuplicateHandling(t *testing.T) {
 			b, err := bulk.MakeTestingSSTBatcher(ctx, kvDB, s.ClusterSettings(),
 				tc.skipDuplicates, tc.ingestAll, mem.MakeConcurrentBoundAccount(), reqs)
 			require.NoError(t, err)
-			defer b.Close(ctx)
+			defer func() { require.NoError(t, b.Close(ctx)) }()
 			k := func(i int, ts int64) storage.MVCCKey {
 				return storageutils.PointKey(fmt.Sprintf("bulk-test-%s-%04d", tc.name, i+1), int(ts))
 			}
@@ -318,7 +318,7 @@ func runTestImport(t *testing.T, batchSizeValue int64) {
 			)
 			require.NoError(t, err)
 
-			defer b.Close(ctx)
+			defer func() { require.NoError(t, b.Close(ctx)) }()
 
 			var expected []kv.KeyValue
 
@@ -384,8 +384,7 @@ func TestImportEpochIngestion(t *testing.T) {
 	b, err := bulk.MakeTestingSSTBatcher(ctx, kvDB, s.ClusterSettings(),
 		false, true, mem.MakeConcurrentBoundAccount(), reqs)
 	require.NoError(t, err)
-	defer b.Close(ctx)
-
+	defer func() { require.NoError(t, b.Close(ctx)) }()
 	startKey := storageutils.PointKey("a", 1)
 	endKey := storageutils.PointKey("b", 1)
 	value := storageutils.StringValueRaw("myHumbleValue")

--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -91,7 +91,7 @@ type BulkAdder interface {
 	// GetSummary returns a summary of rows/bytes/etc written by this batcher.
 	GetSummary() kvpb.BulkOpSummary
 	// Close closes the underlying buffers/writers.
-	Close(ctx context.Context)
+	Close(ctx context.Context) error
 	// SetOnFlush sets a callback function called after flushing the buffer.
 	SetOnFlush(func(summary kvpb.BulkOpSummary))
 }

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -352,7 +352,7 @@ func ingestKvs(
 	spec *execinfrapb.ReadImportDataSpec,
 	progCh chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
 	kvCh <-chan row.KVBatch,
-) (*kvpb.BulkOpSummary, error) {
+) (_ *kvpb.BulkOpSummary, retErr error) {
 	ctx, span := tracing.ChildSpan(ctx, "import-ingest-kvs")
 	defer span.Finish()
 
@@ -407,7 +407,9 @@ func ingestKvs(
 	if err != nil {
 		return nil, err
 	}
-	defer pkIndexAdder.Close(ctx)
+	defer func() {
+		retErr = errors.CombineErrors(retErr, pkIndexAdder.Close(ctx))
+	}()
 
 	minBufferSize, maxBufferSize = importBufferConfigSizes(flowCtx.Cfg.Settings,
 		false /* isPKAdder */)
@@ -424,7 +426,9 @@ func ingestKvs(
 	if err != nil {
 		return nil, err
 	}
-	defer indexAdder.Close(ctx)
+	defer func() {
+		retErr = errors.CombineErrors(retErr, indexAdder.Close(ctx))
+	}()
 
 	// Setup progress tracking:
 	//  - offsets maps source file IDs to offsets in the slices below.

--- a/pkg/sql/importer/import_processor_test.go
+++ b/pkg/sql/importer/import_processor_test.go
@@ -222,7 +222,7 @@ func (a *doNothingKeyAdder) Flush(_ context.Context) error {
 func (*doNothingKeyAdder) IsEmpty() bool                             { return true }
 func (*doNothingKeyAdder) CurrentBufferFill() float32                { return 0 }
 func (*doNothingKeyAdder) GetSummary() kvpb.BulkOpSummary            { return kvpb.BulkOpSummary{} }
-func (*doNothingKeyAdder) Close(_ context.Context)                   {}
+func (*doNothingKeyAdder) Close(_ context.Context) error             { return nil }
 func (a *doNothingKeyAdder) SetOnFlush(f func(_ kvpb.BulkOpSummary)) { a.onFlush = f }
 
 var eofOffset int64 = math.MaxInt64

--- a/pkg/sql/rowexec/indexbackfiller.go
+++ b/pkg/sql/rowexec/indexbackfiller.go
@@ -238,7 +238,7 @@ func (ib *indexBackfiller) ingestIndexEntries(
 	ctx context.Context,
 	indexEntryCh <-chan indexEntryBatch,
 	progCh chan execinfrapb.RemoteProducerMetadata_BulkProcessorProgress,
-) error {
+) (retErr error) {
 	ctx, span := tracing.ChildSpan(ctx, "ingestIndexEntries")
 	defer span.Finish()
 
@@ -257,7 +257,9 @@ func (ib *indexBackfiller) ingestIndexEntries(
 	if err != nil {
 		return err
 	}
-	defer adder.Close(ctx)
+	defer func() {
+		retErr = errors.CombineErrors(retErr, adder.Close(ctx))
+	}()
 
 	// Synchronizes read and write access on completedSpans which is updated on a
 	// BulkAdder flush, but is read when progress is being sent back to the


### PR DESCRIPTION
###  kv/bulk: stop ignoring errors from async flushes

The error handling for Reset appears to have been broken by 50d101612ff. The error handling for Close never appears to have been correct.

fixes #143690
Release note (bug fix): Operations that write data in bulk, like index backfills or RESTORE jobs, previously could report incorrect errors when disk capacity was too low. This is fixed now.


### crosscluster: handle errors from sstbatcher.Close

This patch adds logic to swallow the error and log it. We may want to
take this further and propagate the error further up the call stack, but
I'm starting here for now.