### PR TITLE
release-25.2: tree: add a session variable to get pre-25.2 variadic function typing

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4128,6 +4128,10 @@ func (m *sessionDataMutator) SetAllowCreateTriggerFunctionWithArgvReferences(val
 	m.data.AllowCreateTriggerFunctionWithArgvReferences = val
 }
 
+func (m *sessionDataMutator) SetUsePre_25_2VariadicBuiltins(val bool) {
+	m.data.UsePre_25_2VariadicBuiltins = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -211,6 +211,21 @@ EXECUTE concat_stmt(':')
 ----
 1:
 
+statement ok
+SET use_pre_25_2_variadic_builtins = true
+
+statement ok
+PREPARE concat_stmt2 AS SELECT concat("foo"."a", $1) FROM foo
+
+statement error pgcode 22P02 pq: could not parse \":\" as type int: strconv.ParseInt: parsing \":\": invalid syntax
+EXECUTE concat_stmt2(':')
+
+statement ok
+RESET use_pre_25_2_variadic_builtins
+
+statement ok
+PREPARE concat_stmt3 AS SELECT concat("foo"."a", $1) FROM foo
+
 query T
 SELECT substr('RoacH', 2, 3)
 ----
@@ -3112,6 +3127,35 @@ EXECUTE nn_stmt('foo')
 1  1  1  1  3  3  3  3
 1  1  1  1  3  3  3  3
 2  2  2  2  2  2  2  2
+
+statement ok
+SET use_pre_25_2_variadic_builtins = true
+
+statement error pgcode 42883 pq: unknown signature: num_nulls\(int, anyelement, int, string\)
+PREPARE nn_stmt2 AS SELECT num_nulls(42, $1, a, b) FROM nulls_test
+
+# This should work without the cast to ::INT, but there's a bug in the pre-25.2
+# typechecking where we fail to make the type inference and panic. This has
+# existed since at least 24.2.
+statement ok
+PREPARE nn_stmt3 AS SELECT num_nulls(42, $1::INT, a) FROM nulls_test
+
+query I rowsort
+EXECUTE nn_stmt3(42)
+----
+0
+0
+1
+1
+
+statement error pgcode 22P02 pq: could not parse \"foo\" as type int: strconv.ParseInt: parsing \"foo\": invalid syntax
+EXECUTE nn_stmt3('foo')
+
+statement ok
+RESET use_pre_25_2_variadic_builtins
+
+statement error pgcode 42P18 pq: num_nulls\(\): error type checking resolved expression:: could not determine data type of placeholder \$1
+PREPARE nn_stmt4 AS SELECT num_nulls(42, $1, a) FROM nulls_test
 
 subtest pb_to_json
 

--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -223,7 +223,7 @@ EXECUTE concat_stmt2(':')
 statement ok
 RESET use_pre_25_2_variadic_builtins
 
-statement ok
+statement error pgcode 42P18 pq: concat\(\): error type checking resolved expression:: could not determine data type of placeholder \$1
 PREPARE concat_stmt3 AS SELECT concat("foo"."a", $1) FROM foo
 
 query T

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4102,6 +4102,7 @@ unbounded_parallel_scans                                   off
 unconstrained_non_covering_index_scan_enabled              off
 unsafe_allow_triggers_modifying_cascades                   off
 use_cputs_on_non_unique_indexes                            off
+use_pre_25_2_variadic_builtins                             off
 variable_inequality_lookup_join_enabled                    on
 xmloption                                                  content
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3113,6 +3113,7 @@ unconstrained_non_covering_index_scan_enabled              off                 N
 unsafe_allow_triggers_modifying_cascades                   off                 NULL      NULL        NULL        string
 use_cputs_on_non_unique_indexes                            off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                             on                  NULL      NULL        NULL        string
+use_pre_25_2_variadic_builtins                             off                 NULL      NULL        NULL        string
 variable_inequality_lookup_join_enabled                    on                  NULL      NULL        NULL        string
 vectorize                                                  on                  NULL      NULL        NULL        string
 xmloption                                                  content             NULL      NULL        NULL        string
@@ -3330,6 +3331,7 @@ unconstrained_non_covering_index_scan_enabled              off                 N
 unsafe_allow_triggers_modifying_cascades                   off                 NULL  user     NULL      off                 off
 use_cputs_on_non_unique_indexes                            off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                             on                  NULL  user     NULL      on                  on
+use_pre_25_2_variadic_builtins                             off                 NULL  user     NULL      off                 off
 variable_inequality_lookup_join_enabled                    on                  NULL  user     NULL      on                  on
 vectorize                                                  on                  NULL  user     NULL      on                  on
 xmloption                                                  content             NULL  user     NULL      content             content
@@ -3547,6 +3549,7 @@ unconstrained_non_covering_index_scan_enabled              NULL    NULL     NULL
 unsafe_allow_triggers_modifying_cascades                   NULL    NULL     NULL     NULL        NULL
 use_cputs_on_non_unique_indexes                            NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                             NULL    NULL     NULL     NULL        NULL
+use_pre_25_2_variadic_builtins                             NULL    NULL     NULL     NULL        NULL
 variable_inequality_lookup_join_enabled                    NULL    NULL     NULL     NULL        NULL
 vectorize                                                  NULL    NULL     NULL     NULL        NULL
 xmloption                                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -229,6 +229,7 @@ unconstrained_non_covering_index_scan_enabled              off
 unsafe_allow_triggers_modifying_cascades                   off
 use_cputs_on_non_unique_indexes                            off
 use_declarative_schema_changer                             on
+use_pre_25_2_variadic_builtins                             off
 variable_inequality_lookup_join_enabled                    on
 vectorize                                                  on
 xmloption                                                  content

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -205,6 +205,7 @@ type Memo struct {
 	planLookupJoinsWithReverseScans            bool
 	useInsertFastPath                          bool
 	internal                                   bool
+	usePre_25_2VariadicBuiltins                bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -307,6 +308,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		planLookupJoinsWithReverseScans:            evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans,
 		useInsertFastPath:                          evalCtx.SessionData().InsertFastPath,
 		internal:                                   evalCtx.SessionData().Internal,
+		usePre_25_2VariadicBuiltins:                evalCtx.SessionData().UsePre_25_2VariadicBuiltins,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -482,6 +484,7 @@ func (m *Memo) IsStale(
 		m.planLookupJoinsWithReverseScans != evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans ||
 		m.useInsertFastPath != evalCtx.SessionData().InsertFastPath ||
 		m.internal != evalCtx.SessionData().Internal ||
+		m.usePre_25_2VariadicBuiltins != evalCtx.SessionData().UsePre_25_2VariadicBuiltins ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -569,6 +569,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().Internal = false
 	notStale()
 
+	evalCtx.SessionData().UsePre_25_2VariadicBuiltins = true
+	stale()
+	evalCtx.SessionData().UsePre_25_2VariadicBuiltins = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -918,6 +918,7 @@ func (p *planner) resetPlanner(
 	p.semaCtx.DateStyle = sd.GetDateStyle()
 	p.semaCtx.IntervalStyle = sd.GetIntervalStyle()
 	p.semaCtx.UnsupportedTypeChecker = eval.NewUnsupportedTypeChecker(p.execCfg.Settings.Version)
+	p.semaCtx.UsePre_25_2VariadicBuiltins = sd.UsePre_25_2VariadicBuiltins
 
 	p.autoCommit = false
 

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -919,6 +919,10 @@ func (s *overloadTypeChecker) typeCheckOverloadedExprs(
 	// assumes AnyElement behavior for untyped parameters.
 	for i := range s.params {
 		if vt, ok := s.params[i].(VariadicType); ok && vt.VarType == types.Any {
+			if semaCtx.UsePre_25_2VariadicBuiltins {
+				vt.VarType = types.AnyElement
+				continue
+			}
 			if numOverloads > 1 {
 				return errors.AssertionFailedf(
 					"only one overload can have VariadicType {types.Any} parameters")

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -75,7 +75,7 @@ type SemaContext struct {
 	// supported by the current cluster version. It may be unset.
 	UnsupportedTypeChecker UnsupportedTypeChecker
 
-	// UsePre25_2VariadicBuiltins is set to true when we should use the pre-25.2
+	// UsePre_25_2VariadicBuiltins is set to true when we should use the pre-25.2
 	// variadic builtins behavior.
 	UsePre_25_2VariadicBuiltins bool
 }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -74,6 +74,10 @@ type SemaContext struct {
 	// UnsupportedTypeChecker is used to determine whether a builtin data type is
 	// supported by the current cluster version. It may be unset.
 	UnsupportedTypeChecker UnsupportedTypeChecker
+
+	// UsePre25_2VariadicBuiltins is set to true when we should use the pre-25.2
+	// variadic builtins behavior.
+	UsePre_25_2VariadicBuiltins bool
 }
 
 // SemaProperties is a holder for required and derived properties

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -654,6 +654,13 @@ message LocalOnlySessionData {
   // behavior.
   bool allow_create_trigger_function_with_argv_references = 165;
 
+  // Not backported (yet)
+  // bool create_table_with_schema_locked = 166;
+
+  // UsePre_25_2VariadicBuiltins, when true, will treat variadic builtins with a
+  // types.Any variadic argument as types.AnyElement (the pre-25.2 behavior)
+  bool use_pre_25_2_variadic_builtins = 167;
+  
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -3941,6 +3941,22 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalFalse,
 	},
+	// CockroachDB extension.
+	`use_pre_25_2_variadic_builtins`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`use_pre_25_2_variadic_builtins`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("use_pre_25_2_variadic_builtins", s)
+			if err != nil {
+				return err
+			}
+			m.SetUsePre_25_2VariadicBuiltins(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UsePre_25_2VariadicBuiltins), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Backport 1/1 commits from #144522.

/cc @cockroachdb/release

---

In 25.2 we're changing the handling of variadic builtin functions to be more like Postgres. Instead of the AnyElement behavior that CRDB has had prior to this release, variadic builtins will accept variable elements of type Any. Any differs from AnyElement in that Any is truly unconstrained, where all AnyElement parameters to a function must have the same type.

While the Any behavior is more flexible than AnyElement, it also means that the type checker can't infer argument types in some circumstances, which could lead to existing workloads to stop working properly. This patch introduces the 'use_pre_25_2_variadic_builtins' session variable and the 'sql.defaults.use_pre_25_2_variadic_builtins' cluster setting to get the old behavior back.

Fixes: #143359

Release justification: This is a low risk safety valve to turn off a feature already in 25.2.
