### PR TITLE
release-25.2: sql: disable buffered writes for EXPLAIN of a DDL statement

### DIFF
--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -87,6 +87,12 @@ func (ex *connExecutor) maybeAdjustTxnForDDL(ctx context.Context, stmt Statement
 				return txnSchemaChangeErr
 			}
 		}
+	}
+	// For buffered writes, we need to check for DDL statements as well as EXPLAIN
+	// with DDL statements to avoid errors with the declarative schema changer
+	// (see #144274).
+	ast := tree.UnwrapExplain(stmt.AST)
+	if tree.CanModifySchema(ast) {
 		if ex.state.mu.txn.BufferedWritesEnabled() {
 			ex.state.mu.txn.SetBufferedWritesEnabled(false /* enabled */)
 			p.BufferClientNotice(ctx, pgnotice.Newf("disabling buffered writes on the current txn due to schema change"))

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -251,3 +251,10 @@ SELECT * FROM t4
 1  100
 2  200
 3  300
+
+# Regression test for #144274.
+statement ok
+EXPLAIN CREATE DATABASE foo
+
+statement ok
+EXPLAIN ANALYZE CREATE DATABASE foo

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -209,6 +209,18 @@ func ReturnsAtMostOneRow(stmt Statement) bool {
 
 }
 
+// UnwrapExplain returns the inner statement if the outer statement is an EXPLAIN
+// or EXPLAIN ANALYZE statement. Otherwise, it just returns the original statemnt.
+func UnwrapExplain(stmt Statement) Statement {
+	switch t := stmt.(type) {
+	case *Explain:
+		return t.Statement
+	case *ExplainAnalyze:
+		return t.Statement
+	}
+	return stmt
+}
+
 // HiddenFromShowQueries is a pseudo-interface to be implemented
 // by statements that should not show up in SHOW QUERIES (and are hence
 // not cancellable using CANCEL QUERIES either). Usually implemented by


### PR DESCRIPTION
Backport 1/1 commits from #144561 on behalf of @rytaft.

/cc @cockroachdb/release

----

This commit disables buffered writes if `EXPLAIN` is called with a DDL statement to avoid errors with the declarative schema changer.

Fixes #144274

Release note: None

----

Release justification: disabling a new feature under specific circumstance to avoid error