### PR TITLE
sql: update sql metric definition to support configurable labels 

### DIFF
--- a/pkg/server/telemetry/BUILD.bazel
+++ b/pkg/server/telemetry/BUILD.bazel
@@ -12,8 +12,10 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_prometheus_client_model//go",
     ],
 )
 

--- a/pkg/server/telemetry/features_test.go
+++ b/pkg/server/telemetry/features_test.go
@@ -92,11 +92,16 @@ func TestBucket(t *testing.T) {
 // for example, a report is created.
 func TestCounterWithMetric(t *testing.T) {
 	cm := telemetry.NewCounterWithMetric(metric.Metadata{Name: "test-metric"})
+	cag := telemetry.NewCounterWithAggMetric(metric.Metadata{Name: "test-agg-metric"})
+
 	cm.Inc()
+	cag.Inc("test-db", "test-app")
 
 	// Using GetFeatureCounts to read the telemetry value.
 	m1 := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly)
 	require.Equal(t, int32(1), m1["test-metric"])
+	require.Equal(t, int64(1), cm.Count())
+	require.Equal(t, int32(1), m1["test-agg-metric"])
 	require.Equal(t, int64(1), cm.Count())
 
 	// Reset the telemetry.
@@ -105,5 +110,7 @@ func TestCounterWithMetric(t *testing.T) {
 	// Verify only the telemetry is back to 0.
 	m2 := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly)
 	require.Equal(t, int32(0), m2["test-metric"])
+	require.Equal(t, int64(1), cm.Count())
+	require.Equal(t, int32(0), m2["test-agg-metric"])
 	require.Equal(t, int64(1), cm.Count())
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -582,6 +582,7 @@ go_library(
         "//pkg/util/memzipper",
         "//pkg/util/metamorphic",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/optional",
         "//pkg/util/pretty",

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/optional",
         "//pkg/util/retry",

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 )
 
 // DistSQLMetrics contains pointers to the metrics for monitoring DistSQL
@@ -17,8 +18,8 @@ type DistSQLMetrics struct {
 	QueriesActive               *metric.Gauge
 	QueriesTotal                *metric.Counter
 	DistributedCount            *metric.Counter
-	ContendedQueriesCount       *metric.Counter
-	CumulativeContentionNanos   *metric.Counter
+	ContendedQueriesCount       *aggmetric.SQLCounter
+	CumulativeContentionNanos   *aggmetric.SQLCounter
 	FlowsActive                 *metric.Gauge
 	FlowsTotal                  *metric.Counter
 	MaxBytesHist                metric.IHistogram
@@ -153,8 +154,8 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		QueriesActive:             metric.NewGauge(metaQueriesActive),
 		QueriesTotal:              metric.NewCounter(metaQueriesTotal),
 		DistributedCount:          metric.NewCounter(metaDistributedCount),
-		ContendedQueriesCount:     metric.NewCounter(metaContendedQueriesCount),
-		CumulativeContentionNanos: metric.NewCounter(metaCumulativeContentionNanos),
+		ContendedQueriesCount:     aggmetric.NewSQLCounter(metaContendedQueriesCount),
+		CumulativeContentionNanos: aggmetric.NewSQLCounter(metaCumulativeContentionNanos),
 		FlowsActive:               metric.NewGauge(metaFlowsActive),
 		FlowsTotal:                metric.NewCounter(metaFlowsTotal),
 		MaxBytesHist: metric.NewHistogram(metric.HistogramOptions{

--- a/pkg/sql/executor_statement_metrics_test.go
+++ b/pkg/sql/executor_statement_metrics_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -186,6 +188,13 @@ func executorStub(detailEnabled bool) *connExecutor {
 			Settings: cluster.MakeTestingClusterSettings(),
 		},
 	}
+
+	ex.sessionDataStack = sessiondata.NewStack(&sessiondata.SessionData{
+		SessionData: sessiondatapb.SessionData{
+			Database:        "test-db",
+			ApplicationName: "test-app",
+		}},
+	)
 	metrics := makeMetrics(false, &ex.server.cfg.Settings.SV)
 	ex.metrics = &metrics
 

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -313,6 +313,16 @@ func (c *SQLCounter) Inspect(f func(interface{})) {
 	f(c)
 }
 
+// Clear resets the counter to zero.
+func (c *SQLCounter) Clear() {
+	c.g.Clear()
+}
+
+// Count returns the aggregate count of all of its current and past children.
+func (c *SQLCounter) Count() int64 {
+	return c.g.Count()
+}
+
 // Inc increments the counter value by i for the given label values. If a
 // counter with the given label values doesn't exist yet, it creates a new
 // counter based on labelConfig and increments it. Inc increments parent metrics

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -427,6 +427,11 @@ func (sg *SQLGauge) Inspect(f func(interface{})) {
 	f(sg)
 }
 
+// Value returns the aggregate sum of all of its current children.
+func (sg *SQLGauge) Value() int64 {
+	return sg.g.Value()
+}
+
 // Update updates the Gauge value by i for the given label values. If a
 // Gauge with the given label values doesn't exist yet, it creates a new
 // Gauge and updates it. Update increments parent metrics


### PR DESCRIPTION
This patch updates sql metric declaration to support additional `database` and
`application_name` as labels. This is driven by cluster settings introduced as
part of https://github.com/cockroachdb/cockroach/pull/144610. The updated metrics will export additional labels based on
cluster settings `sql.metrics.application_name.enabled` and
`sql.metrics.database_name.enabled`. The SQLMetric will persist aggregate sum
of all its children, while children additionally exported to prometheus.

Epic: [CRDB-43153](https://cockroachlabs.atlassian.net/browse/CRDB-43153)
Part of: [CRDB-48251](https://cockroachlabs.atlassian.net/browse/CRDB-48251)
Release note: None

Updated metrics along with their `internal` counterpart (if exists):

- cr.node.sql.txns.open
- cr.node.sql.txn.latency
- cr.node.sql.txn.begin.count
- cr.node.sql.txn.commit.count
- cr.node.sql.txn.rollback.count
- cr.node.sql.statements.active
- cr.node.sql.update.count
- cr.node.sql.update.count
- cr.node.sql.insert.count
- cr.node.sql.delete.count
- cr.node.sql.crud.count
- cr.node.sql.service.latency
- cr.node.sql.distsql.contended_queries.count
- sql.distsql.cumulative_contention_nanos
- cr.node.sql.failure.count
- cr.node.sql.full.scan.count