### PR TITLE
storage,kvserver: stop using NewUnindexedBatch

### DIFF
--- a/pkg/kv/kvserver/abortspan/abortspan.go
+++ b/pkg/kv/kvserver/abortspan/abortspan.go
@@ -69,9 +69,9 @@ func (sc *AbortSpan) max() roachpb.Key {
 	return MaxKey(sc.rangeID)
 }
 
-// ClearData removes all persisted items stored in the cache.
-func (sc *AbortSpan) ClearData(e storage.Engine) error {
-	b := e.NewUnindexedBatch()
+// clearData removes all persisted items stored in the cache. Only for testing.
+func (sc *AbortSpan) clearData(e storage.Engine) error {
+	b := e.NewBatch()
 	defer b.Close()
 	err := b.ClearMVCCIteratorRange(sc.min(), sc.max(), true /* pointKeys */, false /* rangeKeys */)
 	if err != nil {

--- a/pkg/kv/kvserver/abortspan/abortspan_test.go
+++ b/pkg/kv/kvserver/abortspan/abortspan_test.go
@@ -111,7 +111,7 @@ func TestAbortSpanPutGetClearData(t *testing.T) {
 	}
 
 	tryHit(true, entry)
-	if err := sc.ClearData(e); err != nil {
+	if err := sc.clearData(e); err != nil {
 		t.Error(err)
 	}
 	tryHit(false, roachpb.AbortSpanEntry{})

--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -152,6 +152,7 @@ type SyncCallback interface {
 func newStoreEntriesBatch(eng storage.Engine) storage.Batch {
 	// Use an unindexed batch because we don't need to read our writes, and
 	// it is more efficient.
+	// TODO(pav-kv): migrate off this method to NewWriteBatch + NewReader.
 	return eng.NewUnindexedBatch()
 }
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -986,6 +986,9 @@ type Engine interface {
 	//
 	// TODO(sumeer,jackson): Remove this method and force the caller to operate
 	// explicitly with a separate WriteBatch and Reader.
+	//
+	// There is exactly one remaining non-testing user of this method (log appends
+	// in raft storage) which should eventually migrate off. Do not add new uses.
 	NewUnindexedBatch() Batch
 	// NewWriteBatch returns a new write batch that will commit to the
 	// underlying Engine. The batch accumulates all mutations and applies them

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1400,9 +1400,8 @@ func (p *Pebble) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool
 // ClearMVCCRange implements the Engine interface.
 func (p *Pebble) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	// Write all the tombstones in one batch.
-	batch := p.NewUnindexedBatch()
+	batch := p.NewWriteBatch()
 	defer batch.Close()
-
 	if err := batch.ClearMVCCRange(start, end, pointKeys, rangeKeys); err != nil {
 		return err
 	}
@@ -1417,9 +1416,8 @@ func (p *Pebble) ClearMVCCVersions(start, end MVCCKey) error {
 // ClearMVCCIteratorRange implements the Engine interface.
 func (p *Pebble) ClearMVCCIteratorRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
 	// Write all the tombstones in one batch.
-	batch := p.NewUnindexedBatch()
+	batch := p.NewBatch()
 	defer batch.Close()
-
 	if err := batch.ClearMVCCIteratorRange(start, end, pointKeys, rangeKeys); err != nil {
 		return err
 	}


### PR DESCRIPTION
This PR removes most uses of `Engine.NewUnindexedBatch()`, and leaves only one. Raft storage writing still needs a `ReadWriter`, to use `MVCCPut` and similar methods, so it uses the unindexed batch for efficiency.

Epic: none
Release note: none