### PR TITLE
kvserver: use WriteBatch instead of NewUnindexedBatch

### DIFF
--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -545,7 +545,7 @@ func (t *raftLogTruncator) tryEnactTruncations(
 	}
 	// Do the truncation of persistent raft entries, specified by enactIndex
 	// (this subsumes all the preceding queued truncations).
-	batch := t.store.getEngine().NewUnindexedBatch()
+	batch := t.store.getEngine().NewWriteBatch()
 	defer batch.Close()
 	if err := handleTruncatedStateBelowRaftPreApply(ctx, truncState,
 		pendingTruncs.mu.truncs[enactIndex].RaftTruncatedState,

--- a/pkg/kv/kvserver/raftstorebench/engine.go
+++ b/pkg/kv/kvserver/raftstorebench/engine.go
@@ -89,7 +89,7 @@ func growMemtable(t T, eng storage.Engine, target int64) {
 	// memtable size, and doubles with each flush. We'll have reached any
 	// reasonable memtable size in well under 20 iterations.
 	for memtableSize := int64(256 * 1024); memtableSize < target; memtableSize *= 2 {
-		b := eng.NewUnindexedBatch()
+		b := eng.NewWriteBatch()
 		require.NoError(t, b.PutUnversioned(roachpb.Key("zoo"), nil))
 		require.NoError(t, b.Commit(false)) // this works even when WAL is off
 
@@ -98,7 +98,7 @@ func growMemtable(t T, eng storage.Engine, target int64) {
 	}
 
 	// Delete the key.
-	b := eng.NewUnindexedBatch()
+	b := eng.NewWriteBatch()
 	require.NoError(t, b.ClearUnversioned(roachpb.Key("zoo"), storage.ClearOptions{}))
 	require.NoError(t, b.Commit(false))
 

--- a/pkg/kv/kvserver/raftstorebench/worker.go
+++ b/pkg/kv/kvserver/raftstorebench/worker.go
@@ -83,7 +83,7 @@ func (w *worker) doTruncForReplica(t T, r *replicaWriteState, truncIndex uint64)
 		logf(t, "r%d: truncIndex %d, nextIndex: %d", r.rangeID, truncIndex,
 			r.nextRaftLogIndex)
 	}
-	raftBatch := w.o.raftEng.NewUnindexedBatch()
+	raftBatch := w.o.raftEng.NewWriteBatch()
 	for i := r.truncatedLogIndex + 1; i <= truncIndex; i++ {
 		key := r.rangeIDPrefixBuf.RaftLogKey(kvpb.RaftIndex(i))
 		if w.o.cfg.SingleDel {

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -143,6 +143,9 @@ func (sm *replicaStateMachine) NewBatch() apply.Batch {
 	// make it safer.
 	b.r = r
 	b.applyStats = &sm.applyStats
+	// TODO(#144627): most commands do not need to read. Use NewWriteBatch because
+	// it is more efficient. If there are exceptions, sparingly use NewReader or
+	// NewBatch (if it needs to read its own writes, which is unlikely).
 	b.batch = r.store.TODOEngine().NewBatch()
 	r.mu.RLock()
 	b.state = r.shMu.state

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2983,9 +2983,9 @@ func handleTruncatedStateBelowRaftPreApply(
 	prev kvserverpb.RaftTruncatedState,
 	next kvserverpb.RaftTruncatedState,
 	loader logstore.StateLoader,
-	readWriter storage.ReadWriter,
+	writer storage.Writer,
 ) error {
-	return logstore.Compact(ctx, prev, next, loader, readWriter)
+	return logstore.Compact(ctx, prev, next, loader, writer)
 }
 
 // shouldCampaignAfterConfChange returns true if the current replica should


### PR DESCRIPTION
This PR replaces a few uses of `Engine.NewUnindexedBatch()` with `Engine.NewWriteBatch()`, in places where reading is not needed.

Epic: CRDB-46488