### PR TITLE
kvserver: add TestObsoleteCode

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -324,6 +324,7 @@ go_test(
         "metrics_test.go",
         "mvcc_gc_queue_test.go",
         "node_liveness_test.go",
+        "obsolete_code_test.go",
         "queue_concurrency_test.go",
         "queue_test.go",
         "raft_log_queue_test.go",

--- a/pkg/kv/kvserver/obsolete_code_test.go
+++ b/pkg/kv/kvserver/obsolete_code_test.go
@@ -1,0 +1,42 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+)
+
+// TestObsoleteCode contains nudges for cleanups that may be possible in the
+// future. When this test fails (which is necessarily a result of bumping the
+// MinSupportedVersion), please carry out the cleanups that are now possible or
+// file issues against the KV team asking them to do so (at which point you may
+// comment out the failing check).
+func TestObsoleteCode(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	msv := clusterversion.RemoveDevOffset(clusterversion.MinSupported.Version())
+	t.Logf("MinSupported: %v", msv)
+
+	v25dot2 := clusterversion.RemoveDevOffset(clusterversion.V25_2.Version())
+
+	// v25.2 is the last version to interpret RangeKeysInOrder. 25.3+ ignores
+	// the field on incoming snapshots but continues to set it on outgoing
+	// snapshots for compatibility reasons. This can be removed when the below
+	// check fires.
+	//
+	// See https://github.com/cockroachdb/cockroach/pull/144613.
+	//
+	// NB: the below comparison intentionally minimizes the number of assumptions
+	// on what release follows 25.2.
+	if !msv.LessEq(v25dot2) {
+		_ = kvserverpb.SnapshotRequest_Header{}.RangeKeysInOrder
+		t.Fatalf("SnapshotRequest_Header.RangeKeysInOrder can be removed")
+	}
+}


### PR DESCRIPTION
We often make changes that will allow follow-up cleanup to occur at some future
point in time, once enough "water has passed under the bridge".

One example of this is https://github.com/cockroachdb/cockroach/pull/144613, which partially migrated out of a boolean
snapshot RPC parameter but had to retain the flag on the RPC for a few more
releases.

We aim to be more proactive about this cleanup once it becomes possible, but
there isn't a great way to remind ourselves. Additionally, the moment the
cleanup becomes possible is usually a bump of the MinSupportedVersion, which is
carried out by a release team member who may be uncomfortable making various
cleanups in teams' code they don't fully understand.

This PR attempts a low-touch approach to this: TestObsoleteCode fails
when a MinVersionBump makes additional cleanups possible. The test
instructs the PR author to file issues/reach out to the team and to
then disable the check.

The hope is that this will encourage the team to perform the cleanup
as soon as possible.

Epic: none
Release note: None