### PR TITLE
kvserver: deflake TestRefreshPolicyWithVariousLatencies

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1366,7 +1366,7 @@ func (r *Replica) RefreshPolicy(latencies map[roachpb.NodeID]time.Duration) {
 		// policy bucket. This then controls how far in the future timestamps will
 		// be closed for the range.
 		maxLatency := time.Duration(-1)
-		for _, peer := range r.shMu.state.Desc.InternalReplicas {
+		for _, peer := range desc.InternalReplicas {
 			peerLatency := closedts.DefaultMaxNetworkRTT
 			if latency, ok := latencies[peer.NodeID]; ok {
 				peerLatency = latency


### PR DESCRIPTION
**kvserver: deflake TestRefreshPolicyWithVariousLatencies**

TestRefreshPolicyWithVariousLatencies verifies RefreshPolicy logic using a test
latencies map.

It was previously flaky due to: 1. not waiting for SetSpanConfig to take effect
before invoking RefreshPolicy, which could trigger the background policy
refresher during the test, and 2. background RefreshPolicy calls on leaseholder
replicas interfering with the test.

This commit resolves both issues by: 1. using SucceedsSoon to wait for
SetSpanConfig to take effect, and 2. invoking RefreshPolicy on a non-leaseholder
replica instead.

Epic: none
Release note: none

---

**kvserver: fix data race in RefreshPolicy**

Previously, replica.RefreshPolicy accessed r.shMu.state.Desc directly without
holding r.raftMu or r.mu. This commit fixes that by using the descriptor
obtained earlier from r.DescAndSpanConfig().

Epic: none
Release note: none
