### PR TITLE
sql: disable buffered writes if ReturnRawMVCCValues needed

### DIFF
--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -238,6 +238,7 @@ func newCFetcherWrapper(
 		true,  /* singleUse */
 		collectStats,
 		alwaysReallocate,
+		nil, /* txn */
 	}
 
 	// This memory monitor is not connected to the memory accounting system

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -347,6 +347,7 @@ func NewColBatchScan(
 		true, /* singleUse */
 		shouldCollectStats,
 		false, /* alwaysReallocate */
+		flowCtx.Txn,
 	}
 	if err = fetcher.Init(fetcherAllocator, kvFetcher, tableArgs); err != nil {
 		fetcher.Release()

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -602,6 +602,7 @@ func NewColIndexJoin(
 		false, /* singleUse */
 		shouldCollectStats,
 		false, /* alwaysReallocate */
+		txn,
 	}
 	if err = fetcher.Init(
 		fetcherAllocator, kvFetcher, tableArgs,

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -252,9 +252,70 @@ SELECT * FROM t4
 2  200
 3  300
 
+subtest regression
+
 # Regression test for #144274.
 statement ok
 EXPLAIN CREATE DATABASE foo
 
 statement ok
 EXPLAIN ANALYZE CREATE DATABASE foo
+
+# Regression test for #144273.
+statement ok
+CREATE TABLE t144273 (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  INDEX (a),
+  INDEX (b),
+  FAMILY (k, a, b)
+)
+
+statement ok
+PREPARE p AS UPDATE t144273 t1 SET a = t2.a + 1, b = t2.b + 1 FROM t144273 t2 WHERE t1.k = t2.a AND t1.k = $1
+
+statement ok
+SET vectorize = on
+
+statement ok
+INSERT INTO t144273 VALUES (1, 1, 1);
+
+# The table IDs in the kv trace below are different with the legacy schema
+# changer, so disable that configuration.
+skipif config local-legacy-schema-changer
+query T kvtrace
+EXECUTE p(1)
+----
+Scan /Table/114/2/{1-2}
+Scan /Table/114/1/1/0
+Scan /Table/114/1/1/0
+Put (locking) /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/2
+Del /Table/114/2/1/1/0
+Put /Table/114/2/2/1/0 -> /BYTES/
+Del /Table/114/3/1/1/0
+Put /Table/114/3/2/1/0 -> /BYTES/
+
+statement ok
+SET vectorize = off
+
+statement ok
+INSERT INTO t144273 VALUES (2, 2, 2);
+
+# The table IDs in the kv trace below are different with the legacy schema
+# changer, so disable that configuration.
+skipif config local-legacy-schema-changer
+query T kvtrace
+EXECUTE p(2)
+----
+Scan /Table/114/2/{2-3}
+Scan /Table/114/1/1/0, /Table/114/1/2/0
+Scan /Table/114/1/2/0
+Put (locking) /Table/114/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/3
+Del /Table/114/2/2/2/0
+Put /Table/114/2/3/2/0 -> /BYTES/
+Del /Table/114/3/2/2/0
+Put /Table/114/3/3/2/0 -> /BYTES/
+
+statement ok
+RESET vectorize


### PR DESCRIPTION
Buffered writes don't yet support the `ReturnRawMVCCValues` option of Gets, Scans, and ReverseScans, which is needed to produce certain system columns. Therefore, this commit disables buffered writes if those system columns are requested when scanning data.

Fixes #144273

Release note: None