### PR TITLE
sql/schemachanger: gate CREATE POLICY in DSC prior to 25.2

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_row_level_security
@@ -1,0 +1,19 @@
+# LogicTest: local-mixed-25.1
+
+subtest create_drop_sanity
+
+statement ok
+CREATE TABLE sanity1();
+
+statement error pq: unimplemented: CREATE POLICY is not yet implemented
+CREATE POLICY p1 on sanity1 USING (true);
+
+# No block for DROP POLICY because policies shouldn't exist in versions prior to 25.2
+statement error pq: policy "nonexist1" for table "sanity1" does not exist
+DROP POLICY nonexist1 on sanity1;
+
+# Attempting to alter RLS returns this error because the declarative schema
+# changer fails with an unimplemented error, causing a fallback to the legacy
+# schema changer—which also doesn't support it.
+statement error pq: ALTER TABLE ... ROW LEVEL SECURITY is only implemented in the declarative schema changer
+ALTER TABLE sanity1 ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;

--- a/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
@@ -1186,6 +1186,13 @@ func TestLogic_merge_join(
 	runLogicTest(t, "merge_join")
 }
 
+func TestLogic_mixed_version_row_level_security(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_row_level_security")
+}
+
 func TestLogic_multi_statement(
 	t *testing.T,
 ) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
@@ -6,6 +6,7 @@
 package scbuildstmt
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -23,11 +24,15 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
 
 // CreatePolicy implements CREATE POLICY.
 func CreatePolicy(b BuildCtx, n *tree.CreatePolicy) {
+	if !b.EvalCtx().Settings.Version.ActiveVersion(b).IsActive(clusterversion.V25_2) {
+		panic(unimplemented.NewWithIssue(136696, "CREATE POLICY is not yet implemented"))
+	}
 	b.IncrementSchemaChangeCreateCounter("policy")
 
 	tableElems := b.ResolveTable(n.TableName, ResolveParams{


### PR DESCRIPTION
In v25.1, CREATE POLICY was partially implemented but guarded by a feature gate, which blocked usage of the DDL. That gate was removed for 25.2 since RLS is now GA.

However, CREATE POLICY still depends on DSC elements not present in 25.1. To prevent failures in mixed-version clusters, a version gate was added to the DSC logic to ensure CREATE POLICY cannot be planned unless the cluster has finalized to 25.2.

A new mixed-version test was added instead of modifying the existing `row_level_security` test, since the latter doesn't fully account for mixed-version behavior. This test is expected to be short-lived, relevant only while 25.1 remains supported.

Fixes #144625

Epic: CRDB-11724
Release note: none