### PR TITLE
backup: compaction dist sql processor now handles errors correctly

### DIFF
--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -130,7 +130,7 @@ func runCompactionPlan(
 
 	evalCtxCopy := execCtx.ExtendedEvalContext().Copy()
 	dsp.Run(ctx, planCtx, nil /* txn */, plan, recv, evalCtxCopy, nil /* finishedSetupFn */)
-	return nil
+	return rowResultWriter.Err()
 }
 
 // createCompactionPlan creates an un-finalized physical plan that will


### PR DESCRIPTION
Previously, when one of the processor nodes in the backup compaction dist SQL plan ran into an error, the compaction job would continue on, blissfully unaware of the error. This would result in faulty job successes. This patch fixes the coordinator node so that errors from other nodes is properly handled and surfaced.

Epic: None

Release note: None