### PR TITLE
jsonpath: add support for numeric JSONPath methods

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1640,3 +1640,164 @@ query T
 SELECT jsonb_path_query('{"a": 10}', '$ ? ((@.a < 12) || (@.a < $value))');
 ----
 {"a": 10}
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('{}', '$.abs()');
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('"a"', '$.abs()');
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('true', '$.abs()');
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('null', '$.abs()');
+
+query T
+SELECT jsonb_path_query('{}', '(1).abs()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(-1).abs()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(0.5).abs()');
+----
+0.5
+
+query T
+SELECT jsonb_path_query('{}', '(-0.5).abs()');
+----
+0.5
+
+query T rowsort
+SELECT jsonb_path_query('[1, -1, 0.5, -0.5]', '$.abs()');
+----
+1
+1
+0.5
+0.5
+
+query T
+SELECT jsonb_path_query('{}', '(1).ceiling()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(-1).ceiling()');
+----
+-1
+
+query T
+SELECT jsonb_path_query('{}', '(0.5).ceiling()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(-0.5).ceiling()');
+----
+0
+
+query T
+SELECT jsonb_path_query('{}', '(0.1).ceiling()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(-0.1).ceiling()');
+----
+0
+
+query T
+SELECT jsonb_path_query('{}', '(0.9).ceiling()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(-0.9).ceiling()');
+----
+0
+
+query T rowsort
+SELECT jsonb_path_query('[1, -1, 0.5, -0.5, 0.1, -0.1, 0.9, -0.9]', '$.ceiling()');
+----
+1
+-1
+1
+0
+1
+0
+1
+0
+
+query T
+SELECT jsonb_path_query('{}', '(1).floor()');
+----
+1
+
+query T
+SELECT jsonb_path_query('{}', '(-1).floor()');
+----
+-1
+
+query T
+SELECT jsonb_path_query('{}', '(0.5).floor()');
+----
+0
+
+query T
+SELECT jsonb_path_query('{}', '(-0.5).floor()');
+----
+-1
+
+query T
+SELECT jsonb_path_query('{}', '(0.1).floor()');
+----
+0
+
+query T
+SELECT jsonb_path_query('{}', '(-0.1).floor()');
+----
+-1
+
+query T
+SELECT jsonb_path_query('{}', '(0.9).floor()');
+----
+0
+
+query T
+SELECT jsonb_path_query('{}', '(-0.9).floor()');
+----
+-1
+
+query T rowsort
+SELECT jsonb_path_query('[1, -1, 0.5, -0.5, 0.1, -0.1, 0.9, -0.9]', '$.floor()');
+----
+1
+-1
+0
+-1
+0
+-1
+0
+-1
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('[[1, 2]]', '$.abs()');
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('[1, 2, [3, 4]]', '$.abs()');
+
+query T
+SELECT jsonb_path_query('{"a": -0.5}', '$.a.abs()')
+----
+0.5
+
+statement error pgcode 22036 pq: jsonpath item method .abs\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('"1"', '$.abs()');
+
+statement error pgcode 22036 pq: jsonpath item method .floor\(\) can only be applied to a numeric value
+SELECT jsonb_path_query('{}', '(null).floor()');

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -166,15 +166,6 @@ statement error unimplemented
 SELECT '$.keyvalue()'::JSONPATH;
 
 statement error unimplemented
-SELECT '$.abs()'::JSONPATH;
-
-statement error unimplemented
-SELECT '$.ceiling()'::JSONPATH;
-
-statement error unimplemented
-SELECT '$.floor()'::JSONPATH;
-
-statement error unimplemented
 SELECT '$.bigint()'::JSONPATH;
 
 statement error unimplemented

--- a/pkg/util/jsonpath/eval/eval.go
+++ b/pkg/util/jsonpath/eval/eval.go
@@ -183,7 +183,7 @@ func (ctx *jsonpathCtx) eval(
 	case jsonpath.Last:
 		return ctx.evalLast()
 	case jsonpath.Method:
-		return ctx.evalMethod(path, jsonValue)
+		return ctx.evalMethod(path, jsonValue, unwrap)
 	default:
 		return nil, errUnimplemented
 	}

--- a/pkg/util/jsonpath/eval/method.go
+++ b/pkg/util/jsonpath/eval/method.go
@@ -8,8 +8,10 @@ package eval
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/jsonpath"
+	"github.com/cockroachdb/errors"
 )
 
 var (
@@ -17,7 +19,7 @@ var (
 )
 
 func (ctx *jsonpathCtx) evalMethod(
-	method jsonpath.Method, jsonValue json.JSON,
+	method jsonpath.Method, jsonValue json.JSON, unwrap bool,
 ) ([]json.JSON, error) {
 	switch method.Type {
 	case jsonpath.SizeMethod:
@@ -29,6 +31,8 @@ func (ctx *jsonpathCtx) evalMethod(
 	case jsonpath.TypeMethod:
 		t := ctx.evalType(jsonValue)
 		return []json.JSON{json.FromString(t)}, nil
+	case jsonpath.AbsMethod, jsonpath.FloorMethod, jsonpath.CeilingMethod:
+		return ctx.evalNumericMethod(method, jsonValue, unwrap)
 	default:
 		return nil, errUnimplemented
 	}
@@ -51,4 +55,38 @@ func (ctx *jsonpathCtx) evalType(jsonValue json.JSON) string {
 		return "number"
 	}
 	return jsonValue.Type().String()
+}
+
+func (ctx *jsonpathCtx) evalNumericMethod(
+	jsonPath jsonpath.Path, jsonValue json.JSON, unwrap bool,
+) ([]json.JSON, error) {
+	if unwrap && jsonValue.Type() == json.ArrayJSONType {
+		return ctx.unwrapCurrentTargetAndEval(jsonPath, jsonValue, false /* unwrap */)
+	}
+	method, _ := jsonPath.(jsonpath.Method)
+	// AsDecimal allocates a new Decimal object, so we can modify it below.
+	dec, ok := jsonValue.AsDecimal()
+	if !ok {
+		return nil, maybeThrowError(ctx, pgerror.Newf(pgcode.NonNumericSQLJSONItem,
+			"jsonpath item method .%s() can only be applied to a numeric value",
+			jsonpath.MethodTypeStrings[method.Type]))
+	}
+	var err error
+	switch method.Type {
+	case jsonpath.AbsMethod:
+		dec = dec.Abs(dec)
+	case jsonpath.FloorMethod:
+		_, err = tree.ExactCtx.Floor(dec, dec)
+	case jsonpath.CeilingMethod:
+		_, err = tree.ExactCtx.Ceil(dec, dec)
+		if dec.IsZero() {
+			dec.Negative = false
+		}
+	default:
+		panic(errors.Newf("unimplemented method: %s", method.Type))
+	}
+	if err != nil {
+		return nil, err
+	}
+	return []json.JSON{json.FromDecimal(*dec)}, nil
 }

--- a/pkg/util/jsonpath/method.go
+++ b/pkg/util/jsonpath/method.go
@@ -18,11 +18,17 @@ const (
 	InvalidMethod MethodType = iota
 	SizeMethod
 	TypeMethod
+	AbsMethod
+	FloorMethod
+	CeilingMethod
 )
 
-var methodTypeStrings = [...]string{
-	SizeMethod: "size",
-	TypeMethod: "type",
+var MethodTypeStrings = [...]string{
+	SizeMethod:    "size",
+	TypeMethod:    "type",
+	AbsMethod:     "abs",
+	FloorMethod:   "floor",
+	CeilingMethod: "ceiling",
 }
 
 type Method struct {
@@ -33,8 +39,8 @@ var _ Path = Method{}
 
 func (m Method) ToString(sb *strings.Builder, _, _ bool) {
 	switch m.Type {
-	case SizeMethod, TypeMethod:
-		sb.WriteString(fmt.Sprintf(".%s()", methodTypeStrings[m.Type]))
+	case SizeMethod, TypeMethod, AbsMethod, FloorMethod, CeilingMethod:
+		sb.WriteString(fmt.Sprintf(".%s()", MethodTypeStrings[m.Type]))
 	default:
 		panic(errors.AssertionFailedf("unhandled method type: %d", m.Type))
 	}

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -569,15 +569,15 @@ method:
   }
 | ABS
   {
-    return unimplemented(jsonpathlex, ".abs()")
+    $$.val = jsonpath.Method{Type: jsonpath.AbsMethod}
   }
 | CEILING
   {
-    return unimplemented(jsonpathlex, ".ceiling()")
+    $$.val = jsonpath.Method{Type: jsonpath.CeilingMethod}
   }
 | FLOOR
   {
-    return unimplemented(jsonpathlex, ".floor()")
+    $$.val = jsonpath.Method{Type: jsonpath.FloorMethod}
   }
 | BIGINT
   {

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -682,6 +682,21 @@ parse
 ----
 (1 + 123).type() -- normalized!
 
+parse
+$.a.abs()
+----
+$."a".abs() -- normalized!
+
+parse
+$.a.floor()
+----
+$."a".floor() -- normalized!
+
+parse
+$.a.ceiling()
+----
+$."a".ceiling() -- normalized!
+
 # parse
 # $.1a
 # ----


### PR DESCRIPTION
This commit adds support for the following JSONPath numeric methods:
- `.abs()`
- `.floor()`
- `.ceiling()`
These methods can be applied to numeric values in JSONPath expressions.

Epic: None
Release note (sql change): Add support for numeric JSONPath methods
`.abs()`, `.floor()`, `.ceiling()`. For example, `SELECT
jsonb_path_query('-0.5', '$.abs()');`.