### PR TITLE
backup: prevent compactions on locality aware backups

### DIFF
--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -84,6 +84,8 @@ func maybeStartCompactionJob(
 		return 0, errors.New("custom incremental storage location not supported for compaction")
 	case len(triggerJob.SpecificTenantIds) != 0 || triggerJob.IncludeAllSecondaryTenants:
 		return 0, errors.New("backups of tenants not supported for compaction")
+	case len(triggerJob.URIsByLocalityKV) != 0:
+		return 0, errors.New("locality aware backups not supported for compaction")
 	}
 
 	env := scheduledjobs.ProdJobSchedulerEnv


### PR DESCRIPTION
While compactions *can* compact backups that have been partitioned by locality, the end product itself is not partitioned. Until that support is implemented, we should prevent compactions on locality aware backups.

Epic: None

Release note: Backup compactions does not yet support locality aware backups.