### PR TITLE
bulk: disable async flush code path

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -692,7 +692,17 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 	// the next one; if memory is not available we'll just block on the send
 	// and then move on to the next send after this SST is no longer being held
 	// in memory.
-	flushAsync := reason == rangeFlush
+	//
+	// TODO(jeffswenson): re-enable flush async after fixing performance and
+	// correctness issues.
+	//
+	// CORRECTNESS: Something has to surface the error from the async flush to
+	// the caller. Right now the error is logged by `Reset`.
+	// PERFORMANCE: The only caller that sets `rangeFlush` calls Reset immediatly
+	// after, which blocks on all in flight requests. So there is no performance
+	// benefit to the async flush.
+	//flushAsync := reason == rangeFlush
+	flushAsync := false
 
 	var reserved int64
 	if flushAsync {


### PR DESCRIPTION
This PR disables the async flush path in the SST batcher due to a correctness bug. When a flush crosses a range boundary, it triggers an async goroutine to handle the RPC. Previously, any error from this goroutine would propagate through the top-level Flush call. However, PR #110218 modified Reset to wait for all async tasks to complete. This change assumed Reset was only used in cleanup, but it is also called by flushIfNeeded after each doFlush. As a result, any error is consumed and silently dropped before Flush is invoked.

Disabling async flush won't impact performance because Reset already waits for the async flush, making every flush effectively synchronous.

Informs: #143690
Informs: #144650
Release note: Fix rare corruption bug that impacts import and
materialized views.