### PR TITLE
schemachanger: when taking a vector index offline, notify client

### DIFF
--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -55,11 +55,11 @@ func (p *planner) AlterPrimaryKey(
 	alterPrimaryKeyLocalitySwap *alterPrimaryKeyLocalitySwap,
 ) error {
 	// Check if sql_safe_updates is enabled and the table has vector indexes
-	if p.EvalContext().SessionData().SafeUpdates {
-		for _, idx := range tableDesc.AllIndexes() {
-			if idx.GetType() == idxtype.VECTOR {
-				return pgerror.DangerousStatementf("ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt")
-			}
+	if len(tableDesc.VectorIndexes()) > 0 {
+		if p.EvalContext().SessionData().SafeUpdates {
+			return pgerror.DangerousStatementf("ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt")
+		} else {
+			p.BufferClientNotice(ctx, pgnotice.Newf("ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt"))
 		}
 	}
 

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -60,8 +60,12 @@ func (p *planner) CreateIndex(ctx context.Context, n *tree.CreateIndex) (planNod
 	}
 
 	// Check if sql_safe_updates is enabled and this is a vector index
-	if n.Type == idxtype.VECTOR && p.EvalContext().SessionData().SafeUpdates {
-		return nil, pgerror.DangerousStatementf("CREATE VECTOR INDEX will disable writes to the table while the index is being built")
+	if n.Type == idxtype.VECTOR {
+		if p.EvalContext().SessionData().SafeUpdates {
+			return nil, pgerror.DangerousStatementf("CREATE VECTOR INDEX will disable writes to the table while the index is being built")
+		} else {
+			p.BufferClientNotice(ctx, pgnotice.Newf("CREATE VECTOR INDEX will disable writes to the table while the index is being built"))
+		}
 	}
 
 	_, tableDesc, err := p.ResolveMutableTableDescriptor(

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -26,11 +26,14 @@ ALTER TABLE simple ALTER PRIMARY KEY USING COLUMNS (b)
 statement ok
 SET sql_safe_updates = false
 
-statement ok
+statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
 CREATE VECTOR INDEX ON simple (vec1)
 
+statement notice ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt
+ALTER TABLE simple ALTER PRIMARY KEY USING COLUMNS (b)
+
 # Alternate syntax.
-statement ok
+statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
 CREATE INDEX ON simple USING cspann (vec1 ASC);
 
 query TT
@@ -40,9 +43,10 @@ simple  CREATE TABLE public.simple (
           a INT8 NOT NULL,
           b INT8 NOT NULL,
           vec1 VECTOR(3) NULL,
-          CONSTRAINT simple_pkey PRIMARY KEY (a ASC),
+          CONSTRAINT simple_pkey PRIMARY KEY (b ASC),
           VECTOR INDEX simple_vec1_idx (vec1),
           VECTOR INDEX simple_vec1_idx1 (vec1),
+          UNIQUE INDEX simple_a_key (a ASC),
           VECTOR INDEX simple_vec1_idx2 (vec1),
           FAMILY fam_0_a_vec1_b (a, vec1, b)
         )
@@ -68,7 +72,7 @@ CREATE TABLE alt_syntax (
   FAMILY (a, vec1)
 )
 
-statement ok
+statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
 CREATE VECTOR INDEX another_index ON alt_syntax (vec1)
 
 query TT
@@ -403,7 +407,7 @@ INSERT INTO backfill_test VALUES
   (2, 'jill', 20, '[4.0, 5.0, 6.0]', '[6.0, 5.0, 4.0]'),
   (3, 'ash',  30, '[7.0, 8.0, 9.0]', '[9.0, 8.0, 7.0]');
 
-statement ok
+statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
 CREATE VECTOR INDEX ON backfill_test (enc)
 
 query ITITT
@@ -455,7 +459,7 @@ SELECT * FROM backfill_test@backfill_test_enc_idx ORDER BY enc <-> '[1.0, 2.0, 3
 3  ash   30  [7,8,9]    [9,8,7]
 6  ash   60  [7.5,8,9]  [9,8,7.5]
 
-statement ok
+statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
 CREATE VECTOR INDEX ON backfill_test (username, prefix_enc)
 
 query ITITT

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/paramparse"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
@@ -60,14 +61,19 @@ func alterPrimaryKey(
 	b BuildCtx, tn *tree.TableName, tbl *scpb.Table, stmt tree.Statement, t alterPrimaryKeySpec,
 ) {
 	// Check if sql_safe_updates is enabled and the table has a vector index
-	if b.EvalCtx().SessionData().SafeUpdates {
-		tableElts := b.QueryByID(tbl.TableID).Filter(notFilter(absentTargetFilter))
-		scpb.ForEachSecondaryIndex(tableElts, func(_ scpb.Status, _ scpb.TargetStatus, idx *scpb.SecondaryIndex) {
-			if idx.Type == idxtype.VECTOR {
+	tableElts := b.QueryByID(tbl.TableID).Filter(notFilter(absentTargetFilter))
+	noticeSent := false
+	scpb.ForEachSecondaryIndex(tableElts, func(_ scpb.Status, _ scpb.TargetStatus, idx *scpb.SecondaryIndex) {
+		if idx.Type == idxtype.VECTOR {
+			if b.EvalCtx().SessionData().SafeUpdates {
 				panic(pgerror.DangerousStatementf("ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt"))
+			} else if !noticeSent {
+				noticeSender := b.EvalCtx().ClientNoticeSender
+				noticeSender.BufferClientNotice(b, pgnotice.Newf("ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt"))
+				noticeSent = true
 			}
-		})
-	}
+		}
+	})
 
 	// Panic on certain forbidden `ALTER PRIMARY KEY` cases (e.g. one of
 	// the new primary key column is a virtual column). See the comments


### PR DESCRIPTION
A previous patch disabled mutations on vector indexes if sql_safe_updates was enabled. This patch send the associated error message as a notice even if sql_safe_updates is disabled, so there are no surprises.

Informs: #144443
Release note (sql change): CREATE VECTOR INDEX and ALTER PRIMARY KEY will now send a notice that vector indexes will be offline during the change operation when sql_safe_updates is disabled.