### PR TITLE
builder: install a more recent version of `patchelf`

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250409-061148
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250418-212710

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -24,7 +24,6 @@ RUN apt-get update \
     netbase \
     openjdk-8-jre \
     openssh-client \
-    patchelf \
     python-is-python3 \
     python3 \
     python3.8-venv \
@@ -91,6 +90,15 @@ RUN case ${TARGETPLATFORM} in \
  unzip awscliv2.zip && \
  ./aws/install && \
  rm -rf aws awscliv2.zip
+
+RUN case ${TARGETPLATFORM} in \
+    "linux/amd64") ARCH=x86_64; SHASUM=ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0 ;; \
+    "linux/arm64") ARCH=aarch64; SHASUM=ae13e2effe077e829be759182396b931d8f85cfb9cfe9d49385516ea367ef7b2 ;; \
+  esac && \
+ curl -fsSL "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-$ARCH.tar.gz" -o "patchelf.tar.gz" && \
+ echo "$SHASUM patchelf.tar.gz" | sha256sum -c - && \
+ tar --strip-components=1 -C /usr -xzf patchelf.tar.gz && \
+ rm -rf patchelf.tar.gz
 
 # Install Bazelisk as Bazel.
 # NOTE: you should keep this in sync with build/packer/teamcity-agent.sh and

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -32,7 +32,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:dd13f3b97a0baac1dc311cc1d81c39b97071907efb3c6669fa659667a4df5d9b",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:97228ff5e3ccfed242b49b37fa427d03203bb69ee74c5129f29b6a6fa7662ad1",
         "dockerReuse": "True",
         "Pool": "default",
     },
@@ -137,7 +137,7 @@ platform(
         "@platforms//cpu:arm64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:3c43c89d875fe1d1c05ce40313fad76a928b8dd29af1554e9cb765e9aaaab054",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:57c597624ed396b33be80548acfef221e5c340b09ed36a0d826c1798a414b10d",
         "dockerReuse": "True",
         "Pool": "default",
     },


### PR DESCRIPTION
The version previously in use produces buggy results on s390x.

Epic: CRDB-21133
Release note: None