### PR TITLE
vecindex: remove search_beam_size cluster setting

### DIFF
--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -271,8 +271,13 @@ var retiredSettings = map[InternalKey]struct{}{
 
 // grandfatheredDefaultSettings is the list of "grandfathered" existing sql.defaults
 // cluster settings. In 22.2 and later, new session settings do not need an
-// associated sql.defaults cluster setting. Instead they can have their default
-// changed with ALTER ROLE ... SET.
+// associated sql.defaults cluster setting (see the `vector_search_beam_size`
+// setting in vars.go for an example). A session setting can have its default
+// changed with ALTER ROLE ... SET, similar to this (the example assumes that
+// all roles should use the new default):
+//
+//	ALTER ROLE ALL SET vector_search_beam_size=128;
+//
 // Caveat: in some cases, we may still add new sql.defaults cluster settings,
 // but the new ones *must* be marked as non-public. Undocumented settings are
 // excluded from the check that prevents new sql.defaults settings. The

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -40,7 +40,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
-	"github.com/cockroachdb/cockroach/pkg/sql/vecindex"
 	"github.com/cockroachdb/cockroach/pkg/util/duration"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -3998,7 +3997,7 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(int64(evalCtx.SessionData().VectorSearchBeamSize), 10), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return strconv.FormatInt(vecindex.SearchBeamSizeSetting.Get(sv), 10)
+			return "32"
 		},
 	},
 }

--- a/pkg/sql/vecindex/settings.go
+++ b/pkg/sql/vecindex/settings.go
@@ -44,19 +44,6 @@ var StalledOpTimeoutSetting = settings.RegisterDurationSetting(
 	settings.WithPublic,
 )
 
-// SearchBeamSizeSetting controls the number of candidates examined during
-// vector index searches. It represents the number of vector partitions that are
-// are considered at each level of the search tree. Higher values increase
-// search accuracy but require more processing resources.
-var SearchBeamSizeSetting = settings.RegisterIntSetting(
-	settings.ApplicationLevel,
-	"sql.vecindex.search_beam_size",
-	"number of vector partitions searched at each level of the search tree "+
-		"(higher values increase accuracy but require more processing)",
-	32,
-	settings.IntInRange(1, 512),
-)
-
 // VectorIndexEnabled is used to enable and disable vector indexes.
 var VectorIndexEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,


### PR DESCRIPTION
The `sql.vecindex.search_beam_size` cluster setting only exists to specify the default value for the vector_search_beam_size session setting. However, this is not necessary; session settings can specify a default value on their own. This commit removes the cluster setting and sets the global default to be "32" for the session setting.

Epic: CRDB-42943
Release note: None