### PR TITLE
release-25.1: ui: fix table page size option bug

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -208,9 +208,9 @@ export class IndexDetailsPage extends React.Component<
     });
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { stmtPagination } = this.state;
-    this.setState({ stmtPagination: { ...stmtPagination, current } });
+    this.setState({ stmtPagination: { ...stmtPagination, current, pageSize } });
   };
 
   resetPagination = (): void => {
@@ -654,6 +654,7 @@ export class IndexDetailsPage extends React.Component<
                       current={stmtPagination.current}
                       total={filteredStmts.length}
                       onChange={this.onChangePage}
+                      onShowSizeChange={this.onChangePage}
                     />
                   </Loading>
                 </SummaryCard>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -11,7 +11,7 @@ import { useHistory } from "react-router-dom";
 import { Anchor } from "src/anchor";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import styles from "src/statementsPage/statementsPage.module.scss";
-import { insights } from "src/util";
+import { insights, usePagination } from "src/util";
 
 import { CockroachCloudContext } from "../../contexts";
 import {
@@ -31,7 +31,7 @@ import {
 } from "../../queryFilter";
 import { getSchemaInsightEventFiltersFromURL } from "../../queryFilter/utils";
 import { Search } from "../../search";
-import { ISortedTablePagination, SortSetting } from "../../sortedtable";
+import { SortSetting } from "../../sortedtable";
 import { getTableSortFromURL } from "../../sortedtable/getTableSortFromURL";
 import { TableStatistics } from "../../tableStatistics";
 import { queryByName, syncHistory } from "../../util";
@@ -85,10 +85,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
   csIndexUnusedDuration,
 }: SchemaInsightsViewProps) => {
   const isCockroachCloud = useContext(CockroachCloudContext);
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, SCHEMA_INSIGHT_SEARCH_PARAM),
@@ -154,20 +151,6 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
     sortSetting.columnTitle,
     search,
   ]);
-
-  const onChangePage = (current: number): void => {
-    setPagination({
-      current: current,
-      pageSize: 10,
-    });
-  };
-
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: 10,
-    });
-  };
 
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
@@ -273,7 +256,8 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
               pageSize={pagination.pageSize}
               current={pagination.current}
               total={filteredSchemaInsights?.length}
-              onChange={onChangePage}
+              onChange={updatePagination}
+              onShowSizeChange={updatePagination}
             />
             {maxSizeApiReached && (
               <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -32,14 +32,11 @@ import {
 import { getWorkloadInsightEventFiltersFromURL } from "src/queryFilter/utils";
 import { Search } from "src/search/search";
 import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import { TableStatistics } from "src/tableStatistics";
-import { insights } from "src/util";
+import { insights, usePagination } from "src/util";
 import { useScheduleFunction } from "src/util/hooks";
 import { queryByName, syncHistory } from "src/util/query";
 
@@ -108,10 +105,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   dropDownSelect,
   maxSizeApiReached,
 }: StatementInsightsViewProps) => {
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, INSIGHT_STMT_SEARCH_PARAM),
@@ -176,20 +170,6 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
     sortSetting.columnTitle,
     search,
   ]);
-
-  const onChangePage = (current: number): void => {
-    setPagination({
-      current: current,
-      pageSize: 10,
-    });
-  };
-
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: 10,
-    });
-  };
 
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
@@ -330,7 +310,8 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
               pageSize={pagination.pageSize}
               current={pagination.current}
               total={filteredStatements?.length}
-              onChange={onChangePage}
+              onChange={updatePagination}
+              onShowSizeChange={updatePagination}
             />
             {maxSizeApiReached && (
               <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -29,10 +29,7 @@ import {
 import { getWorkloadInsightEventFiltersFromURL } from "src/queryFilter/utils";
 import { Search } from "src/search/search";
 import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import { TableStatistics } from "src/tableStatistics";
@@ -47,6 +44,7 @@ import {
   TimeScaleDropdown,
   timeScaleRangeToObj,
 } from "../../../timeScaleDropdown";
+import { usePagination } from "../../../util";
 import { InsightsError } from "../../insightsErrorComponent";
 import { EmptyInsightsTablePlaceholder } from "../util";
 
@@ -103,10 +101,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     maxSizeApiReached,
   } = props;
 
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, INSIGHT_TXN_SEARCH_PARAM),
@@ -167,20 +162,6 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     sortSetting.columnTitle,
     search,
   ]);
-
-  const onChangePage = (current: number): void => {
-    setPagination({
-      current: current,
-      pageSize: 10,
-    });
-  };
-
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: 10,
-    });
-  };
 
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
@@ -301,7 +282,8 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
               pageSize={pagination.pageSize}
               current={pagination.current}
               total={filteredTransactions?.length}
-              onChange={onChangePage}
+              onChange={updatePagination}
+              onShowSizeChange={updatePagination}
             />
             {maxSizeApiReached && (
               <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
@@ -174,9 +174,9 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
     clearTimeout(this.refreshDataInterval);
   }
 
-  onChangePage = (current: number): void => {
+  setPagination = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   resetPagination = (): void => {
@@ -368,9 +368,10 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
               </section>
               <Pagination
                 pageSize={pagination.pageSize}
+                onShowSizeChange={this.setPagination}
                 current={pagination.current}
                 total={filteredJobs.length}
-                onChange={this.onChangePage}
+                onChange={this.setPagination}
               />
             </div>
           </Loading>

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
@@ -212,9 +212,9 @@ export class ScheduleTable extends React.Component<
     this.setCurrentPageToOneIfSchedulesChanged(prevProps);
   }
 
-  onChangePage = (current: number) => {
+  onChangePage = (current: number, pageSize: number) => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   renderEmptyState = () => {
@@ -273,6 +273,7 @@ export class ScheduleTable extends React.Component<
           current={pagination.current}
           total={schedules.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </React.Fragment>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -226,9 +226,9 @@ export class SessionsPage extends React.Component<
     );
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
     if (this.props.onPageChanged) {
       this.props.onPageChanged(current);
     }
@@ -436,6 +436,7 @@ export class SessionsPage extends React.Component<
           current={pagination.current}
           total={sessionsToDisplay.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -21,10 +21,7 @@ import { Pagination } from "src/pagination";
 import { Filter } from "src/queryFilter";
 import { getActiveStatementFiltersFromURL } from "src/queryFilter/utils";
 import { Search } from "src/search/search";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import LoadingError from "src/sqlActivity/errorComponent";
 import { queryByName, syncHistory } from "src/util/query";
 
@@ -40,6 +37,7 @@ import {
   getFullFiltersAsStringRecord,
 } from "../queryFilter";
 import { getTableSortFromURL } from "../sortedtable/getTableSortFromURL";
+import { usePagination } from "../util";
 
 import styles from "./statementsPage.module.scss";
 
@@ -89,10 +87,10 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   lastUpdated,
   onManualRefresh,
 }: ActiveStatementsViewProps) => {
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: PAGE_SIZE,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(
+    1,
+    PAGE_SIZE,
+  );
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, ACTIVE_STATEMENT_SEARCH_PARAM),
@@ -190,13 +188,6 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
     search,
   ]);
 
-  const resetPagination = () => {
-    setPagination({
-      pageSize: PAGE_SIZE,
-      current: 1,
-    });
-  };
-
   const onSortClick = (ss: SortSetting): void => {
     onSortChange(ss);
     resetPagination();
@@ -245,13 +236,6 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
-
-  const onChangePage = (page: number) => {
-    setPagination({
-      ...pagination,
-      current: page,
-    });
-  };
 
   return (
     <div className={cx("root")}>
@@ -324,7 +308,8 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
             pageSize={pagination.pageSize}
             current={pagination.current}
             total={filteredStatements?.length}
-            onChange={onChangePage}
+            onChange={updatePagination}
+            onShowSizeChange={updatePagination}
           />
           {maxSizeApiReached && (
             <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -406,11 +406,11 @@ export class StatementsPage extends React.Component<
     this.props.dismissAlertMessage();
   }
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
     this.setState(prevState => ({
       ...prevState,
-      pagination: { ...pagination, current },
+      pagination: { ...pagination, current, pageSize },
     }));
     if (this.props.onPageChanged) {
       this.props.onPageChanged(current);
@@ -705,6 +705,7 @@ export class StatementsPage extends React.Component<
           current={pagination.current}
           total={data.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -282,9 +282,9 @@ export class TransactionDetails extends React.Component<
     });
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   backToTransactionsClick = (): void => {
@@ -596,6 +596,7 @@ export class TransactionDetails extends React.Component<
                   current={pagination.current}
                   total={aggregatedStatements.length}
                   onChange={this.onChangePage}
+                  onShowSizeChange={this.onChangePage}
                 />
               </React.Fragment>
             );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -23,10 +23,7 @@ import { Pagination } from "src/pagination";
 import { getActiveTransactionFiltersFromURL } from "src/queryFilter/utils";
 import { Search } from "src/search/search";
 import { getTableSortFromURL } from "src/sortedtable/getTableSortFromURL";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import LoadingError from "src/sqlActivity/errorComponent";
 import { queryByName, syncHistory } from "src/util/query";
 
@@ -41,6 +38,7 @@ import {
   inactiveFiltersState,
 } from "../queryFilter";
 import styles from "../statementsPage/statementsPage.module.scss";
+import { usePagination } from "../util";
 
 const cx = classNames.bind(styles);
 
@@ -90,10 +88,10 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   lastUpdated,
   onManualRefresh,
 }: ActiveTransactionsViewProps) => {
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: PAGE_SIZE,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(
+    1,
+    PAGE_SIZE,
+  );
 
   const history = useHistory();
   const [search, setSearch] = useState<string>(
@@ -190,13 +188,6 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
     search,
   ]);
 
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: PAGE_SIZE,
-    });
-  };
-
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
     resetPagination();
@@ -243,13 +234,6 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
-
-  const onChangePage = (page: number) => {
-    setPagination({
-      ...pagination,
-      current: page,
-    });
-  };
 
   return (
     <div className={cx("root")}>
@@ -323,7 +307,8 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
             pageSize={pagination.pageSize}
             current={pagination.current}
             total={filteredTransactions?.length}
-            onChange={onChangePage}
+            onChange={updatePagination}
+            onShowSizeChange={updatePagination}
           />
           {maxSizeApiReached && (
             <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -296,9 +296,9 @@ export class TransactionsPage extends React.Component<
     );
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   resetPagination = (): void => {
@@ -654,6 +654,7 @@ export class TransactionsPage extends React.Component<
           current={current}
           total={transactionsToDisplay.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
@@ -4,12 +4,13 @@
 // included in the /LICENSE file.
 
 import moment from "moment/moment";
-import { useEffect, useCallback, useRef, useContext } from "react";
+import { useEffect, useCallback, useRef, useContext, useState } from "react";
 import useSWR, { SWRConfiguration, SWRResponse } from "swr";
 import { Arguments, Fetcher } from "swr/_internal";
 import useSWRImmutable from "swr/immutable";
 
 import { ClusterDetailsContext } from "../contexts";
+import { ISortedTablePagination } from "../sortedtable";
 
 export const usePrevious = <T>(value: T): T | undefined => {
   const ref = useRef<T>();
@@ -168,4 +169,34 @@ export const useSwrImmutableWithClusterId = <
 ): SWRResponse<Data, Error, SWROptions> => {
   const keyWithClusterId = useSwrKeyWithClusterId(key) as SWRKey;
   return useSWRImmutable(keyWithClusterId, fetcher, config);
+};
+
+/**
+ * usePagination creates a pagination state and provides functions to update and reset it. The update function
+ * is compatible with the Ant Design Table component.
+ * @param defaultPage the default page to be used for pagination
+ * @param defaultPageSize the default page size to be used for pagination
+ */
+export const usePagination = (
+  defaultPage: number,
+  defaultPageSize: number,
+): [
+  ISortedTablePagination,
+  (current: number, pageSize: number) => void,
+  () => void,
+] => {
+  const [pagination, setPagination] = useState<ISortedTablePagination>({
+    current: defaultPage,
+    pageSize: defaultPageSize,
+  });
+  const updatePagination = (current: number, pageSize: number) => {
+    setPagination({
+      current,
+      pageSize,
+    });
+  };
+  const resetPagination = () => {
+    updatePagination(defaultPage, defaultPageSize);
+  };
+  return [pagination, updatePagination, resetPagination];
 };

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -16,7 +16,7 @@ import {
 import { Tooltip } from "antd";
 import classNames from "classnames/bind";
 import round from "lodash/round";
-import React, { useState } from "react";
+import React from "react";
 import { connect } from "react-redux";
 import { Link } from "react-router-dom";
 
@@ -52,11 +52,7 @@ const HotRangesTable = ({
   sortSetting,
   onSortChange,
 }: HotRangesTableProps) => {
-  const [pagination, setPagination] = useState({
-    pageSize: PAGE_SIZE,
-    current: 1,
-  });
-
+  const [pagination, updatePagination] = util.usePagination(1, PAGE_SIZE);
   const columns: ColumnDescriptor<cockroach.server.serverpb.HotRangesResponseV2.IHotRange>[] =
     [
       {
@@ -312,15 +308,11 @@ const HotRangesTable = ({
         }
       />
       <Pagination
-        pageSize={PAGE_SIZE}
+        pageSize={pagination.pageSize}
         current={pagination.current}
         total={hotRangesList.length}
-        onChange={(page: number, pageSize?: number) =>
-          setPagination({
-            pageSize,
-            current: page,
-          })
-        }
+        onChange={updatePagination}
+        onShowSizeChange={updatePagination}
       />
     </div>
   );


### PR DESCRIPTION
Backport 1/1 commits from #144556.

/cc @cockroachdb/release

---

Previously, tables that showed a page size dropdown option didn't work properly. Selecting a different page size wouldn't do anything and would stay at
whatever the default configuration was.

Now, selecting a different page size option should update the table accordingly.

For functionaly components, the pagination logic
was refactored into a `usePagination` hook to
reduce repeated code

Fixes: CC-32064
Epic:CC-31904
Release note (bug fix): Fixed bug in the UI where
tables with page size dropdown options weren't
updating when a new page size option was chosen.
Now, tables update accordingly
