### PR TITLE
release-24.1: ui: fix table page size option bug

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/indexDetailsPage/indexDetailsPage.tsx
@@ -203,9 +203,9 @@ export class IndexDetailsPage extends React.Component<
     });
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { stmtPagination } = this.state;
-    this.setState({ stmtPagination: { ...stmtPagination, current } });
+    this.setState({ stmtPagination: { ...stmtPagination, current, pageSize } });
   };
 
   resetPagination = (): void => {
@@ -657,6 +657,7 @@ export class IndexDetailsPage extends React.Component<
                       current={stmtPagination.current}
                       total={filteredStmts.length}
                       onChange={this.onChangePage}
+                      onShowSizeChange={this.onChangePage}
                     />
                   </Loading>
                 </SummaryCard>

--- a/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/schemaInsights/schemaInsightsView.tsx
@@ -6,7 +6,7 @@
 import React, { useContext } from "react";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
-import { ISortedTablePagination, SortSetting } from "../../sortedtable";
+import { SortSetting } from "../../sortedtable";
 import classNames from "classnames/bind";
 import { PageConfig, PageConfigItem } from "../../pageConfig";
 import { Loading } from "../../loading";
@@ -35,7 +35,7 @@ import { Pagination } from "../../pagination";
 import { EmptySchemaInsightsTablePlaceholder } from "./emptySchemaInsightsTablePlaceholder";
 import { CockroachCloudContext } from "../../contexts";
 import { InlineAlert } from "@cockroachlabs/ui-components";
-import { insights } from "src/util";
+import { insights, usePagination } from "src/util";
 import { Anchor } from "src/anchor";
 import insightTableStyles from "../../insightsTable/insightsTable.module.scss";
 const cx = classNames.bind(styles);
@@ -82,10 +82,7 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
   csIndexUnusedDuration,
 }: SchemaInsightsViewProps) => {
   const isCockroachCloud = useContext(CockroachCloudContext);
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, SCHEMA_INSIGHT_SEARCH_PARAM),
@@ -151,20 +148,6 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
     sortSetting.columnTitle,
     search,
   ]);
-
-  const onChangePage = (current: number): void => {
-    setPagination({
-      current: current,
-      pageSize: 10,
-    });
-  };
-
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: 10,
-    });
-  };
 
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
@@ -270,7 +253,8 @@ export const SchemaInsightsView: React.FC<SchemaInsightsViewProps> = ({
               pageSize={pagination.pageSize}
               current={pagination.current}
               total={filteredSchemaInsights?.length}
-              onChange={onChangePage}
+              onChange={updatePagination}
+              onShowSizeChange={updatePagination}
             />
             {maxSizeApiReached && (
               <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/statementInsights/statementInsightsView.tsx
@@ -6,10 +6,7 @@
 import React, { useEffect, useState, useCallback } from "react";
 import classNames from "classnames/bind";
 import { useHistory } from "react-router-dom";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
@@ -53,7 +50,7 @@ import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import { commonStyles } from "../../../common";
 import { useScheduleFunction } from "src/util/hooks";
 import { InlineAlert } from "@cockroachlabs/ui-components";
-import { insights } from "src/util";
+import { insights, usePagination } from "src/util";
 import { Anchor } from "src/anchor";
 
 const cx = classNames.bind(styles);
@@ -107,10 +104,7 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
   dropDownSelect,
   maxSizeApiReached,
 }: StatementInsightsViewProps) => {
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, INSIGHT_STMT_SEARCH_PARAM),
@@ -175,20 +169,6 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
     sortSetting.columnTitle,
     search,
   ]);
-
-  const onChangePage = (current: number): void => {
-    setPagination({
-      current: current,
-      pageSize: 10,
-    });
-  };
-
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: 10,
-    });
-  };
 
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
@@ -329,7 +309,8 @@ export const StatementInsightsView: React.FC<StatementInsightsViewProps> = ({
               pageSize={pagination.pageSize}
               current={pagination.current}
               total={filteredStatements?.length}
-              onChange={onChangePage}
+              onChange={updatePagination}
+              onShowSizeChange={updatePagination}
             />
             {maxSizeApiReached && (
               <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/workloadInsights/transactionInsights/transactionInsightsView.tsx
@@ -6,10 +6,7 @@
 import React, { useCallback, useEffect, useState } from "react";
 import classNames from "classnames/bind";
 import { useHistory } from "react-router-dom";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
@@ -46,7 +43,7 @@ import { TxnInsightsRequest } from "src/api";
 import styles from "src/statementsPage/statementsPage.module.scss";
 import sortableTableStyles from "src/sortedtable/sortedtable.module.scss";
 import { commonStyles } from "../../../common";
-import { useScheduleFunction } from "src/util/hooks";
+import { useScheduleFunction, usePagination } from "src/util/hooks";
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { insights } from "src/util";
 import { Anchor } from "src/anchor";
@@ -102,10 +99,7 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     maxSizeApiReached,
   } = props;
 
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: 10,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(1, 10);
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, INSIGHT_TXN_SEARCH_PARAM),
@@ -166,20 +160,6 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
     sortSetting.columnTitle,
     search,
   ]);
-
-  const onChangePage = (current: number): void => {
-    setPagination({
-      current: current,
-      pageSize: 10,
-    });
-  };
-
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: 10,
-    });
-  };
 
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
@@ -300,7 +280,8 @@ export const TransactionInsightsView: React.FC<TransactionInsightsViewProps> = (
               pageSize={pagination.pageSize}
               current={pagination.current}
               total={filteredTransactions?.length}
-              onChange={onChangePage}
+              onChange={updatePagination}
+              onShowSizeChange={updatePagination}
             />
             {maxSizeApiReached && (
               <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobsPage/jobsPage.tsx
@@ -172,9 +172,9 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
     clearTimeout(this.refreshDataInterval);
   }
 
-  onChangePage = (current: number): void => {
+  setPagination = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   resetPagination = (): void => {
@@ -366,9 +366,10 @@ export class JobsPage extends React.Component<JobsPageProps, PageState> {
               </section>
               <Pagination
                 pageSize={pagination.pageSize}
+                onShowSizeChange={this.setPagination}
                 current={pagination.current}
                 total={filteredJobs.length}
-                onChange={this.onChangePage}
+                onChange={this.setPagination}
               />
             </div>
           </Loading>

--- a/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.tsx
@@ -14,7 +14,7 @@ const cx = classNames.bind(styles);
 
 export type PaginationProps = Pick<
   AntPaginationProps,
-  "pageSize" | "current" | "total" | "onChange"
+  "pageSize" | "current" | "total" | "onChange" | "onShowSizeChange"
 >;
 
 export const Pagination: React.FC<PaginationProps> = props => {

--- a/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/schedules/schedulesPage/scheduleTable.tsx
@@ -210,9 +210,9 @@ export class ScheduleTable extends React.Component<
     this.setCurrentPageToOneIfSchedulesChanged(prevProps);
   }
 
-  onChangePage = (current: number) => {
+  onChangePage = (current: number, pageSize: number) => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   renderEmptyState = () => {
@@ -271,6 +271,7 @@ export class ScheduleTable extends React.Component<
           current={pagination.current}
           total={schedules.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </React.Fragment>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.tsx
@@ -227,9 +227,9 @@ export class SessionsPage extends React.Component<
     );
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
     if (this.props.onPageChanged) {
       this.props.onPageChanged(current);
     }
@@ -437,6 +437,7 @@ export class SessionsPage extends React.Component<
           current={pagination.current}
           total={sessionsToDisplay.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/activeStatementsView.tsx
@@ -7,10 +7,7 @@ import React, { useEffect, useState } from "react";
 import classNames from "classnames/bind";
 import moment, { Moment } from "moment-timezone";
 import { useHistory } from "react-router-dom";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
@@ -34,6 +31,7 @@ import {
 import { ActiveStatementsSection } from "../activeExecutions/activeStatementsSection";
 import { queryByName, syncHistory } from "src/util/query";
 import { getTableSortFromURL } from "../sortedtable/getTableSortFromURL";
+import { usePagination } from "../util";
 import { getActiveStatementFiltersFromURL } from "src/queryFilter/utils";
 import { Pagination } from "src/pagination";
 import { InlineAlert } from "@cockroachlabs/ui-components";
@@ -87,10 +85,10 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
   lastUpdated,
   onManualRefresh,
 }: ActiveStatementsViewProps) => {
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: PAGE_SIZE,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(
+    1,
+    PAGE_SIZE,
+  );
   const history = useHistory();
   const [search, setSearch] = useState<string>(
     queryByName(history.location, ACTIVE_STATEMENT_SEARCH_PARAM),
@@ -188,13 +186,6 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
     search,
   ]);
 
-  const resetPagination = () => {
-    setPagination({
-      pageSize: PAGE_SIZE,
-      current: 1,
-    });
-  };
-
   const onSortClick = (ss: SortSetting): void => {
     onSortChange(ss);
     resetPagination();
@@ -243,13 +234,6 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
-
-  const onChangePage = (page: number) => {
-    setPagination({
-      ...pagination,
-      current: page,
-    });
-  };
 
   return (
     <div className={cx("root")}>
@@ -322,7 +306,8 @@ export const ActiveStatementsView: React.FC<ActiveStatementsViewProps> = ({
             pageSize={pagination.pageSize}
             current={pagination.current}
             total={filteredStatements?.length}
-            onChange={onChangePage}
+            onChange={updatePagination}
+            onShowSizeChange={updatePagination}
           />
           {maxSizeApiReached && (
             <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsPage/statementsPage.tsx
@@ -402,11 +402,11 @@ export class StatementsPage extends React.Component<
     this.props.dismissAlertMessage();
   }
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
     this.setState(prevState => ({
       ...prevState,
-      pagination: { ...pagination, current },
+      pagination: { ...pagination, current, pageSize },
     }));
     if (this.props.onPageChanged) {
       this.props.onPageChanged(current);
@@ -700,6 +700,7 @@ export class StatementsPage extends React.Component<
           current={pagination.current}
           total={data.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionDetails/transactionDetails.tsx
@@ -280,9 +280,9 @@ export class TransactionDetails extends React.Component<
     });
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   backToTransactionsClick = (): void => {
@@ -594,6 +594,7 @@ export class TransactionDetails extends React.Component<
                   current={pagination.current}
                   total={aggregatedStatements.length}
                   onChange={this.onChangePage}
+                  onShowSizeChange={this.onChangePage}
                 />
               </React.Fragment>
             );

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/activeTransactionsView.tsx
@@ -6,10 +6,7 @@
 import React, { useEffect, useState } from "react";
 import classNames from "classnames/bind";
 import { useHistory } from "react-router-dom";
-import {
-  ISortedTablePagination,
-  SortSetting,
-} from "src/sortedtable/sortedtable";
+import { SortSetting } from "src/sortedtable/sortedtable";
 import { Loading } from "src/loading/loading";
 import { PageConfig, PageConfigItem } from "src/pageConfig/pageConfig";
 import { Search } from "src/search/search";
@@ -38,6 +35,7 @@ import { filterActiveTransactions } from "../activeExecutions/activeStatementUti
 import { InlineAlert } from "@cockroachlabs/ui-components";
 import { RefreshControl } from "src/activeExecutions/refreshControl";
 import moment, { Moment } from "moment-timezone";
+import { usePagination } from "../util";
 
 const cx = classNames.bind(styles);
 
@@ -87,10 +85,10 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
   lastUpdated,
   onManualRefresh,
 }: ActiveTransactionsViewProps) => {
-  const [pagination, setPagination] = useState<ISortedTablePagination>({
-    current: 1,
-    pageSize: PAGE_SIZE,
-  });
+  const [pagination, updatePagination, resetPagination] = usePagination(
+    1,
+    PAGE_SIZE,
+  );
 
   const history = useHistory();
   const [search, setSearch] = useState<string>(
@@ -187,13 +185,6 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
     search,
   ]);
 
-  const resetPagination = () => {
-    setPagination({
-      current: 1,
-      pageSize: PAGE_SIZE,
-    });
-  };
-
   const onChangeSortSetting = (ss: SortSetting): void => {
     onSortChange(ss);
     resetPagination();
@@ -240,13 +231,6 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
     internalAppNamePrefix,
     search,
   );
-
-  const onChangePage = (page: number) => {
-    setPagination({
-      ...pagination,
-      current: page,
-    });
-  };
 
   return (
     <div className={cx("root")}>
@@ -320,7 +304,8 @@ export const ActiveTransactionsView: React.FC<ActiveTransactionsViewProps> = ({
             pageSize={pagination.pageSize}
             current={pagination.current}
             total={filteredTransactions?.length}
-            onChange={onChangePage}
+            onChange={updatePagination}
+            onShowSizeChange={updatePagination}
           />
           {maxSizeApiReached && (
             <InlineAlert

--- a/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/transactionsPage/transactionsPage.tsx
@@ -291,9 +291,9 @@ export class TransactionsPage extends React.Component<
     );
   };
 
-  onChangePage = (current: number): void => {
+  onChangePage = (current: number, pageSize: number): void => {
     const { pagination } = this.state;
-    this.setState({ pagination: { ...pagination, current } });
+    this.setState({ pagination: { ...pagination, current, pageSize } });
   };
 
   resetPagination = (): void => {
@@ -648,6 +648,7 @@ export class TransactionsPage extends React.Component<
           current={current}
           total={transactionsToDisplay.length}
           onChange={this.onChangePage}
+          onShowSizeChange={this.onChangePage}
         />
       </>
     );

--- a/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/hooks.ts
@@ -3,8 +3,9 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import { useEffect, useCallback, useRef } from "react";
+import { useEffect, useCallback, useRef, useState } from "react";
 import moment from "moment/moment";
+import { ISortedTablePagination } from "../sortedtable";
 
 export const usePrevious = <T>(value: T): T | undefined => {
   const ref = useRef<T>();
@@ -93,4 +94,34 @@ export const useScheduleFunction = (
   }, [schedule, clearSchedule]);
 
   return [scheduleNow, clearSchedule];
+};
+
+/**
+ * usePagination creates a pagination state and provides functions to update and reset it. The update function
+ * is compatible with the Ant Design Table component.
+ * @param defaultPage the default page to be used for pagination
+ * @param defaultPageSize the default page size to be used for pagination
+ */
+export const usePagination = (
+  defaultPage: number,
+  defaultPageSize: number,
+): [
+  ISortedTablePagination,
+  (current: number, pageSize: number) => void,
+  () => void,
+] => {
+  const [pagination, setPagination] = useState<ISortedTablePagination>({
+    current: defaultPage,
+    pageSize: defaultPageSize,
+  });
+  const updatePagination = (current: number, pageSize: number) => {
+    setPagination({
+      current,
+      pageSize,
+    });
+  };
+  const resetPagination = () => {
+    updatePagination(defaultPage, defaultPageSize);
+  };
+  return [pagination, updatePagination, resetPagination];
 };

--- a/pkg/ui/workspaces/cluster-ui/src/util/index.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/util/index.ts
@@ -12,6 +12,7 @@ export * from "./docs";
 export * from "./fixLong";
 export * from "./format";
 export * from "./formatDate";
+export * from "./hooks";
 export * from "./logger";
 export * from "./requestError";
 export * from "./sql/summarize";

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesTable.tsx
@@ -3,7 +3,7 @@
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
 
-import React, { useState } from "react";
+import React from "react";
 import { Link } from "react-router-dom";
 import { Tooltip } from "antd";
 import "antd/lib/tooltip/style";
@@ -51,11 +51,7 @@ const HotRangesTable = ({
   sortSetting,
   onSortChange,
 }: HotRangesTableProps) => {
-  const [pagination, setPagination] = useState({
-    pageSize: PAGE_SIZE,
-    current: 1,
-  });
-
+  const [pagination, updatePagination] = util.usePagination(1, PAGE_SIZE);
   const columns: ColumnDescriptor<cockroach.server.serverpb.HotRangesResponseV2.IHotRange>[] =
     [
       {
@@ -326,15 +322,11 @@ const HotRangesTable = ({
         }
       />
       <Pagination
-        pageSize={PAGE_SIZE}
+        pageSize={pagination.pageSize}
         current={pagination.current}
         total={hotRangesList.length}
-        onChange={(page: number, pageSize?: number) =>
-          setPagination({
-            pageSize,
-            current: page,
-          })
-        }
+        onChange={updatePagination}
+        onShowSizeChange={updatePagination}
       />
     </div>
   );


### PR DESCRIPTION
Backport 1/1 commits from #144556.

/cc @cockroachdb/release

---

Previously, tables that showed a page size dropdown option didn't work properly. Selecting a different page size wouldn't do anything and would stay at
whatever the default configuration was.

Now, selecting a different page size option should update the table accordingly.

For functionaly components, the pagination logic
was refactored into a `usePagination` hook to
reduce repeated code

Fixes: CC-32064
Epic:CC-31904
Release note (bug fix): Fixed bug in the UI where
tables with page size dropdown options weren't
updating when a new page size option was chosen.
Now, tables update accordingly
