### PR TITLE
sql/schemachanger: fix RLS policy ordering when swapping elements

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -3141,3 +3141,42 @@ statement ok
 DROP USER bypassrls_user;
 
 subtest end
+
+
+subtest policy_with_schema_locked
+
+statement ok
+CREATE TABLE alter_policy_table_locked (c1 INT8 NOT NULL, c2 STRING NULL, CONSTRAINT alter_policy_table_pkey PRIMARY KEY (c1 ASC), FAMILY fam_0_c1_c2 (c1, c2)) WITH (schema_locked = true);
+
+statement ok
+CREATE POLICY p ON alter_policy_table_locked WITH CHECK (TRUE);
+
+statement ok
+ALTER POLICY p ON alter_policy_table_locked RENAME TO p_sel;
+
+query TT
+SHOW CREATE TABLE alter_policy_table_locked;
+----
+alter_policy_table_locked  CREATE TABLE public.alter_policy_table_locked (
+                             c1 INT8 NOT NULL,
+                             c2 STRING NULL,
+                             CONSTRAINT alter_policy_table_pkey PRIMARY KEY (c1 ASC),
+                             FAMILY fam_0_c1_c2 (c1, c2)
+                           ) WITH (schema_locked = true);
+                           CREATE POLICY p_sel ON public.alter_policy_table_locked AS PERMISSIVE FOR ALL TO public WITH CHECK (true)
+
+statement ok
+ALTER POLICY p_sel ON alter_policy_table_locked WITH CHECK (FALSE);
+
+query TT
+SHOW CREATE TABLE alter_policy_table_locked;
+----
+alter_policy_table_locked  CREATE TABLE public.alter_policy_table_locked (
+                             c1 INT8 NOT NULL,
+                             c2 STRING NULL,
+                             CONSTRAINT alter_policy_table_pkey PRIMARY KEY (c1 ASC),
+                             FAMILY fam_0_c1_c2 (c1, c2)
+                           ) WITH (schema_locked = true);
+                           CREATE POLICY p_sel ON public.alter_policy_table_locked AS PERMISSIVE FOR ALL TO public WITH CHECK (false)
+
+subtest end

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -4170,6 +4170,22 @@ deprules
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-Target, $partial-predicate-Node)
     - joinTargetNode($index, $index-Target, $index-Node)
+- name: policy dependents are swapped in order
+  from: drop-policy-dependent-Node
+  kind: Precedence
+  to: add-policy-dependent-Node
+  query:
+    - $drop-policy-dependent[Type] IN ['*scpb.PolicyDeps', '*scpb.PolicyName', '*scpb.PolicyRole', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr']
+    - $add-policy-dependent[Type] IN ['*scpb.PolicyDeps', '*scpb.PolicyName', '*scpb.PolicyRole', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr']
+    - $drop-policy-dependent[Type] = $sameType
+    - $add-policy-dependent[Type] = $sameType
+    - joinOnPolicyID($drop-policy-dependent, $add-policy-dependent, $table-id, $policy-id)
+    - $drop-policy-dependent-Target[TargetStatus] = ABSENT
+    - $drop-policy-dependent-Node[CurrentStatus] = ABSENT
+    - $add-policy-dependent-Target[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+    - $add-policy-dependent-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($drop-policy-dependent, $drop-policy-dependent-Target, $drop-policy-dependent-Node)
+    - joinTargetNode($add-policy-dependent, $add-policy-dependent-Target, $add-policy-dependent-Node)
 - name: primary index named right before index becomes public
   from: index-name-Node
   kind: SameStagePrecedence
@@ -9091,6 +9107,22 @@ deprules
     - $index-Node[CurrentStatus] = TRANSIENT_ABSENT
     - joinTargetNode($partial-predicate, $partial-predicate-Target, $partial-predicate-Node)
     - joinTargetNode($index, $index-Target, $index-Node)
+- name: policy dependents are swapped in order
+  from: drop-policy-dependent-Node
+  kind: Precedence
+  to: add-policy-dependent-Node
+  query:
+    - $drop-policy-dependent[Type] IN ['*scpb.PolicyDeps', '*scpb.PolicyName', '*scpb.PolicyRole', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr']
+    - $add-policy-dependent[Type] IN ['*scpb.PolicyDeps', '*scpb.PolicyName', '*scpb.PolicyRole', '*scpb.PolicyUsingExpr', '*scpb.PolicyWithCheckExpr']
+    - $drop-policy-dependent[Type] = $sameType
+    - $add-policy-dependent[Type] = $sameType
+    - joinOnPolicyID($drop-policy-dependent, $add-policy-dependent, $table-id, $policy-id)
+    - $drop-policy-dependent-Target[TargetStatus] = ABSENT
+    - $drop-policy-dependent-Node[CurrentStatus] = ABSENT
+    - $add-policy-dependent-Target[TargetStatus] IN [PUBLIC, TRANSIENT_ABSENT]
+    - $add-policy-dependent-Node[CurrentStatus] = PUBLIC
+    - joinTargetNode($drop-policy-dependent, $drop-policy-dependent-Target, $drop-policy-dependent-Node)
+    - joinTargetNode($add-policy-dependent, $add-policy-dependent-Target, $add-policy-dependent-Node)
 - name: primary index named right before index becomes public
   from: index-name-Node
   kind: SameStagePrecedence


### PR DESCRIPTION
Previously, the order of operations when swapping row-level security (RLS) policies was not explicitly enforced, depending instead on their addition order in the builder. New rules for automatically managing `schema_locked` highlighted a risk: without strict ordering, the swap sequence could be inadvertently reversed. This patch addresses this by enforcing that RLS policy drops always occur before the corresponding adds during a swap operation.

Fixes: #144767
Fixes: #144762

Release note: None