### PR TITLE
release-25.1: changefeedccl: fix premature shutdown due to schema change bug

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -857,7 +857,7 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (retu
 		return nil
 	}
 
-	advanced, err := ca.frontier.ForwardResolvedSpan(ca.Ctx(), resolved)
+	advanced, err := ca.frontier.ForwardResolvedSpan(resolved)
 	if err != nil {
 		return err
 	}
@@ -1618,7 +1618,7 @@ func (cf *changeFrontier) noteAggregatorProgress(d rowenc.EncDatum) error {
 }
 
 func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
-	frontierChanged, err := cf.frontier.ForwardResolvedSpan(cf.Ctx(), resolved)
+	frontierChanged, err := cf.frontier.ForwardResolvedSpan(resolved)
 	if err != nil {
 		return err
 	}

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -846,6 +846,10 @@ func (ca *changeAggregator) flushBufferedEvents() error {
 // changeAggregator node to the changeFrontier node to allow the changeFrontier
 // to persist the overall changefeed's progress
 func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (returnErr error) {
+	if log.V(2) {
+		log.Infof(ca.Ctx(), "resolved span from kv feed: %#v", resolved)
+	}
+
 	if resolved.Timestamp.IsEmpty() {
 		// @0.0 resolved timestamps could come in from rangefeed checkpoint.
 		// When rangefeed starts running, it emits @0.0 resolved timestamp.
@@ -934,6 +938,9 @@ func (ca *changeAggregator) emitResolved(batch jobspb.ResolvedSpans) error {
 		Stats: jobspb.ResolvedSpans_Stats{
 			RecentKvCount: ca.recentKVCount,
 		},
+	}
+	if log.V(2) {
+		log.Infof(ca.Ctx(), "progress update to be sent to change frontier: %#v", progressUpdate)
 	}
 	updateBytes, err := protoutil.Marshal(&progressUpdate)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/resolvedspan/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/util/hlc",
-        "//pkg/util/log",
         "//pkg/util/span",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/ccl/changefeedccl/resolvedspan/frontier_test.go
+++ b/pkg/ccl/changefeedccl/resolvedspan/frontier_test.go
@@ -6,7 +6,6 @@
 package resolvedspan_test
 
 import (
-	"context"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/resolvedspan"
@@ -24,8 +23,6 @@ func TestAggregatorFrontier(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	ctx := context.Background()
-
 	// Create a fresh frontier with no progress.
 	statementTime := makeTS(10)
 	var initialHighwater hlc.Timestamp
@@ -38,32 +35,37 @@ func TestAggregatorFrontier(t *testing.T) {
 	require.Equal(t, initialHighwater, f.Frontier())
 
 	// Forward spans representing initial scan.
-	testBackfillSpan(t, ctx, f, "a", "b", statementTime, initialHighwater)
-	testBackfillSpan(t, ctx, f, "b", "f", statementTime, statementTime)
+	testBackfillSpan(t, f, "a", "b", statementTime, initialHighwater)
+	testBackfillSpan(t, f, "b", "f", statementTime, statementTime)
 
 	// Forward spans signalling a backfill is required.
 	backfillTS := makeTS(20)
-	testBoundarySpan(t, ctx, f, "a", "b", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
-	testBoundarySpan(t, ctx, f, "b", "c", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
-	testBoundarySpan(t, ctx, f, "c", "d", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
-	testBoundarySpan(t, ctx, f, "d", "e", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
-	testBoundarySpan(t, ctx, f, "e", "f", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, backfillTS.Prev())
+	testBoundarySpan(t, f, "a", "b", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBoundarySpan(t, f, "b", "c", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBoundarySpan(t, f, "c", "d", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBoundarySpan(t, f, "d", "e", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBoundarySpan(t, f, "e", "f", backfillTS.Prev(), jobspb.ResolvedSpan_BACKFILL, backfillTS.Prev())
 
-	// Confirm that attempting to signal an earlier boundary causes an assertion error.
+	// Verify that attempting to signal an earlier boundary causes an assertion error.
 	illegalBoundaryTS := makeTS(15)
-	testIllegalBoundarySpan(t, ctx, f, "a", "f", illegalBoundaryTS, jobspb.ResolvedSpan_BACKFILL)
-	testIllegalBoundarySpan(t, ctx, f, "a", "f", illegalBoundaryTS, jobspb.ResolvedSpan_RESTART)
-	testIllegalBoundarySpan(t, ctx, f, "a", "f", illegalBoundaryTS, jobspb.ResolvedSpan_EXIT)
+	testIllegalBoundarySpan(t, f, "a", "f", illegalBoundaryTS, jobspb.ResolvedSpan_BACKFILL)
+	testIllegalBoundarySpan(t, f, "a", "f", illegalBoundaryTS, jobspb.ResolvedSpan_RESTART)
+	testIllegalBoundarySpan(t, f, "a", "f", illegalBoundaryTS, jobspb.ResolvedSpan_EXIT)
+
+	// Verify that attempting to signal a boundary at the latest boundary time with a different
+	// boundary type causes an assertion error.
+	testIllegalBoundarySpan(t, f, "a", "f", backfillTS.Prev(), jobspb.ResolvedSpan_RESTART)
+	testIllegalBoundarySpan(t, f, "a", "f", backfillTS.Prev(), jobspb.ResolvedSpan_EXIT)
 
 	// Forward spans representing actual backfill.
-	testBackfillSpan(t, ctx, f, "d", "e", backfillTS, backfillTS.Prev())
-	testBackfillSpan(t, ctx, f, "e", "f", backfillTS, backfillTS.Prev())
-	testBackfillSpan(t, ctx, f, "a", "d", backfillTS, backfillTS)
+	testBackfillSpan(t, f, "d", "e", backfillTS, backfillTS.Prev())
+	testBackfillSpan(t, f, "e", "f", backfillTS, backfillTS.Prev())
+	testBackfillSpan(t, f, "a", "d", backfillTS, backfillTS)
 
 	// Forward spans signalling a restart is required.
 	restartTS := makeTS(30)
-	testBoundarySpan(t, ctx, f, "a", "b", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, backfillTS)
-	testBoundarySpan(t, ctx, f, "b", "f", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, restartTS.Prev())
+	testBoundarySpan(t, f, "a", "b", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, backfillTS)
+	testBoundarySpan(t, f, "b", "f", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, restartTS.Prev())
 
 	// Simulate restarting by creating a new frontier with the initial highwater
 	// set to the previous frontier timestamp.
@@ -76,20 +78,18 @@ func TestAggregatorFrontier(t *testing.T) {
 	require.NoError(t, err)
 
 	// Forward spans representing post-restart backfill.
-	testBackfillSpan(t, ctx, f, "a", "b", restartTS, initialHighwater)
-	testBackfillSpan(t, ctx, f, "e", "f", restartTS, initialHighwater)
-	testBackfillSpan(t, ctx, f, "b", "e", restartTS, restartTS)
+	testBackfillSpan(t, f, "a", "b", restartTS, initialHighwater)
+	testBackfillSpan(t, f, "e", "f", restartTS, initialHighwater)
+	testBackfillSpan(t, f, "b", "e", restartTS, restartTS)
 
 	// Forward spans signalling an exit is required.
 	exitTS := makeTS(40)
-	testBoundarySpan(t, ctx, f, "a", "f", exitTS.Prev(), jobspb.ResolvedSpan_EXIT, exitTS.Prev())
+	testBoundarySpan(t, f, "a", "f", exitTS.Prev(), jobspb.ResolvedSpan_EXIT, exitTS.Prev())
 }
 
 func TestCoordinatorFrontier(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
 
 	// Create a fresh frontier with no progress.
 	statementTime := makeTS(10)
@@ -103,35 +103,40 @@ func TestCoordinatorFrontier(t *testing.T) {
 	require.Equal(t, initialHighwater, f.Frontier())
 
 	// Forward spans representing initial scan.
-	testBackfillSpan(t, ctx, f, "a", "b", statementTime, initialHighwater)
-	testBackfillSpan(t, ctx, f, "b", "f", statementTime, statementTime)
+	testBackfillSpan(t, f, "a", "b", statementTime, initialHighwater)
+	testBackfillSpan(t, f, "b", "f", statementTime, statementTime)
 
 	// Forward span signalling a backfill is required.
 	backfillTS1 := makeTS(15)
-	testBoundarySpan(t, ctx, f, "a", "b", backfillTS1.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBoundarySpan(t, f, "a", "b", backfillTS1.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
 
 	// Forward span signalling another backfill is required (simulates multiple
 	// aggregators progressing at different speeds).
 	backfillTS2 := makeTS(20)
-	testBackfillSpan(t, ctx, f, "a", "b", backfillTS1, statementTime)
-	testBoundarySpan(t, ctx, f, "a", "b", backfillTS2.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBackfillSpan(t, f, "a", "b", backfillTS1, statementTime)
+	testBoundarySpan(t, f, "a", "b", backfillTS2.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
 
 	// Verify that spans signalling backfills at earlier timestamp are allowed.
-	testBoundarySpan(t, ctx, f, "b", "c", backfillTS1.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
+	testBoundarySpan(t, f, "b", "c", backfillTS1.Prev(), jobspb.ResolvedSpan_BACKFILL, statementTime)
 
 	// Verify that no other boundary spans at earlier timestamp are allowed.
-	testIllegalBoundarySpan(t, ctx, f, "a", "f", backfillTS1.Prev(), jobspb.ResolvedSpan_RESTART)
-	testIllegalBoundarySpan(t, ctx, f, "a", "f", backfillTS1.Prev(), jobspb.ResolvedSpan_EXIT)
+	testIllegalBoundarySpan(t, f, "a", "f", backfillTS1.Prev(), jobspb.ResolvedSpan_RESTART)
+	testIllegalBoundarySpan(t, f, "a", "f", backfillTS1.Prev(), jobspb.ResolvedSpan_EXIT)
+
+	// Verify that attempting to signal a boundary at the latest boundary time with a different
+	// boundary type causes an assertion error.
+	testIllegalBoundarySpan(t, f, "a", "f", backfillTS2.Prev(), jobspb.ResolvedSpan_RESTART)
+	testIllegalBoundarySpan(t, f, "a", "f", backfillTS2.Prev(), jobspb.ResolvedSpan_EXIT)
 
 	// Forward spans completing first backfill and signalling and completing second backfill.
-	testBackfillSpan(t, ctx, f, "b", "f", backfillTS1, backfillTS1)
-	testBoundarySpan(t, ctx, f, "b", "f", backfillTS2.Prev(), jobspb.ResolvedSpan_BACKFILL, backfillTS2.Prev())
-	testBackfillSpan(t, ctx, f, "a", "f", backfillTS2, backfillTS2)
+	testBackfillSpan(t, f, "b", "f", backfillTS1, backfillTS1)
+	testBoundarySpan(t, f, "b", "f", backfillTS2.Prev(), jobspb.ResolvedSpan_BACKFILL, backfillTS2.Prev())
+	testBackfillSpan(t, f, "a", "f", backfillTS2, backfillTS2)
 
 	// Forward spans signalling a restart is required.
 	restartTS := makeTS(30)
-	testBoundarySpan(t, ctx, f, "a", "b", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, backfillTS2)
-	testBoundarySpan(t, ctx, f, "b", "f", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, restartTS.Prev())
+	testBoundarySpan(t, f, "a", "b", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, backfillTS2)
+	testBoundarySpan(t, f, "b", "f", restartTS.Prev(), jobspb.ResolvedSpan_RESTART, restartTS.Prev())
 
 	// Simulate restarting by creating a new frontier with the initial highwater
 	// set to the previous frontier timestamp.
@@ -144,13 +149,13 @@ func TestCoordinatorFrontier(t *testing.T) {
 	require.NoError(t, err)
 
 	// Forward spans representing post-restart backfill.
-	testBackfillSpan(t, ctx, f, "a", "b", restartTS, initialHighwater)
-	testBackfillSpan(t, ctx, f, "e", "f", restartTS, initialHighwater)
-	testBackfillSpan(t, ctx, f, "b", "e", restartTS, restartTS)
+	testBackfillSpan(t, f, "a", "b", restartTS, initialHighwater)
+	testBackfillSpan(t, f, "e", "f", restartTS, initialHighwater)
+	testBackfillSpan(t, f, "b", "e", restartTS, restartTS)
 
 	// Forward spans signalling an exit is required.
 	exitTS := makeTS(40)
-	testBoundarySpan(t, ctx, f, "a", "f", exitTS.Prev(), jobspb.ResolvedSpan_EXIT, exitTS.Prev())
+	testBoundarySpan(t, f, "a", "f", exitTS.Prev(), jobspb.ResolvedSpan_EXIT, exitTS.Prev())
 }
 
 type frontier interface {
@@ -161,12 +166,7 @@ type frontier interface {
 }
 
 func testBackfillSpan(
-	t *testing.T,
-	ctx context.Context,
-	f frontier,
-	start, end string,
-	ts hlc.Timestamp,
-	frontierAfterSpan hlc.Timestamp,
+	t *testing.T, f frontier, start, end string, ts hlc.Timestamp, frontierAfterSpan hlc.Timestamp,
 ) {
 	backfillSpan := makeResolvedSpan(start, end, ts, jobspb.ResolvedSpan_NONE)
 	require.True(t, f.InBackfill(backfillSpan))
@@ -177,7 +177,6 @@ func testBackfillSpan(
 
 func testBoundarySpan(
 	t *testing.T,
-	ctx context.Context,
 	f frontier,
 	start, end string,
 	boundaryTS hlc.Timestamp,
@@ -222,7 +221,6 @@ func testBoundarySpan(
 
 func testIllegalBoundarySpan(
 	t *testing.T,
-	ctx context.Context,
 	f frontier,
 	start, end string,
 	boundaryTS hlc.Timestamp,


### PR DESCRIPTION
Backport 3/3 commits from #144004.

/cc @cockroachdb/release

---

Fixes #144108

Test failures on master:
Fixes #143976
Fixes #144045
Fixes #144219

Test failures on release branches (won't be fixed until PR is backported):
Informs #144287
Informs #144291
Informs #144352

---

**changefeedccl: add more verbose logging around schema changes**

This patch adds more verbose logging to the change aggregator around
receiving and emitting resolved spans to help debug recurring changefeed
schema change test flakes.

Release note: None

---

**changefeedccl: fix premature shutdown due to schema change bug**

This patch fixes a bug that could potentially cause a changefeed
to erroneously complete when one of its watched tables encounters a
schema change has been fixed.

The root cause for the bug was that if we happened to get a rangefeed
checkpoint at precisely `ts.Prev()` for some schema change timestamp
`ts`, the kv feed would deliver a resolved span with `ts` and a NONE
boundary to the change aggregator, which would advance its frontier;
then when the resolved span with `ts` and a RESTART boundary was
sent to the change aggregator, the frontier would not be advanced and
so would not be flushed to the change frontier. The change frontier
would then read a nil row from the change aggregator and shut the
changefeed down as if it had completed successfully.

This bug has been fixed by modifying the resolved span frontier
forwarding logic to consider forwarding to the current timestamp
but with a non-NONE boundary type to be advancing the frontier.

Two alternative solutions that were ruled out were:
1. Unconditionally flushing the frontier when we get a non-NONE boundary
   instead of only flushing when the frontier is advanced.
     - Problem: We would flush the frontier O(spans) number of times.
2. Making the kv feed not emit resolved events for rangefeed checkpoints
   that are at a schema change boundary.
     - Problem: We wouldn't be able to save the per-span progress at the
       schema change boundary.

Release note (bug fix): A bug that could potentially cause a changefeed
to erroneously complete when one of its watched tables encounters a
schema change has been fixed.

---

**changefeedccl/resolvedspan: update assertion for forwarding boundary** 

This patch adds an assertion that the frontier will not forward the
boundary to a different type at the same time. This assertion is
important because if it's violated, the changefeed processors will not
shut down correctly during a schema change. One potential way this
could be violated in the future is a change to how boundary types are
determined on aggregators causing different boundaries to be sent from
aggregators in a mixed-version cluster for the same schema change.

Release note: None

---

Release justification: low-risk, high-priority bug fix
