### PR TITLE
roachtest: add operation to probe ranges

### DIFF
--- a/pkg/cmd/roachtest/operations/BUILD.bazel
+++ b/pkg/cmd/roachtest/operations/BUILD.bazel
@@ -20,6 +20,7 @@ go_library(
         "network_partition.go",
         "node_kill.go",
         "pause_job.go",
+        "probe_ranges.go",
         "register.go",
         "resize.go",
         "session_vars.go",

--- a/pkg/cmd/roachtest/operations/probe_ranges.go
+++ b/pkg/cmd/roachtest/operations/probe_ranges.go
@@ -1,0 +1,108 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package operations
+
+import (
+	"context"
+	"fmt"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/operation"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+)
+
+// runProbeRanges runs a read or write stmt against crdb_internal.probe_ranges which
+// tests for range availability which, if unhealthy, would result in serious failures
+// at higher levels of the DB.
+func runProbeRanges(
+	ctx context.Context, o operation.Operation, c cluster.Cluster, writeProbe bool,
+) registry.OperationCleanup {
+	rng, _ := randutil.NewPseudoRand()
+
+	nodes := c.All()
+	nid := nodes[rng.Intn(len(nodes))]
+
+	conn := c.Conn(ctx, o.L(), nid, option.VirtualClusterName(roachtestflags.VirtualCluster))
+	defer conn.Close()
+
+	probeType := "read"
+	if writeProbe {
+		probeType = "write"
+	}
+
+	o.Status(fmt.Sprintf("executing crdb_internal.probe-ranges %s statement against node %d", probeType, nid))
+
+	probeRangeStmt := fmt.Sprintf(`select count(error) as errors from crdb_internal.probe_ranges(INTERVAL '1s', '%s') where error != ''`, probeType)
+
+	range_errors, query_err := conn.QueryContext(ctx, probeRangeStmt)
+	if query_err != nil {
+		o.Fatal(query_err)
+	}
+
+	var errors int
+	if !range_errors.Next() {
+		o.Fatalf("Failed to scan value from crdb_internal.probe-ranges %s statement against node %d", probeType, nid)
+	}
+	if scanErr := range_errors.Scan(&errors); scanErr != nil {
+		o.Fatalf("Failed to scan value from crdb_internal.probe-ranges %s statement against node %d", probeType, nid)
+	} else {
+		// This would reflect an issue in KV layer, in which case we run another query to collect helpful information.
+		if errors > 0 {
+			o.Status(fmt.Sprintf("Found %d errors while executing crdb_internal.probe-ranges %s statement against node %d", errors, probeType, nid))
+			sampleErrorStmt := fmt.Sprintf(`select range_id, error from crdb_internal.probe_ranges(INTERVAL '1s', '%s') where error != '' LIMIT 5`, probeType)
+			sampleErrors, query_err := conn.QueryContext(ctx, sampleErrorStmt)
+			if query_err != nil {
+				o.Fatal(query_err)
+			}
+
+			// Log the specific errors, to assist debugging.
+			for sampleErrors.Next() {
+				var rangeId int
+				var rangeError string
+				if scanError := sampleErrors.Scan(&rangeId, &rangeError); scanError != nil {
+					o.Status(fmt.Sprintf("Failed to scan value from crdb_internal.probe-ranges %s statement against node %d", probeType, nid))
+					o.Fatal(scanError)
+				}
+				o.Status(fmt.Sprintf("Error on node %d on range %d: %s", nid, rangeId, rangeError))
+			}
+
+			o.Fatalf("Found range errors when probing via crdb_internal.probe-ranges %s statement against node %d", probeType, nid)
+		} else {
+			o.Status(fmt.Sprintf("Successfully executed crdb_internal.probe-ranges %s statement against node %d with no errors.", probeType, nid))
+		}
+	}
+
+	return nil
+}
+
+func registerProbeRanges(r registry.Registry) {
+	r.AddOperation(registry.OperationSpec{
+		Name:               "probe-ranges/read",
+		Owner:              registry.OwnerKV, // Contact SRE first, as they own the prober.
+		Timeout:            30 * time.Minute,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase, registry.OperationRequiresZeroUnavailableRanges},
+		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+			return runProbeRanges(ctx, o, c, false)
+		},
+	})
+	r.AddOperation(registry.OperationSpec{
+		Name:               "probe-ranges/write",
+		Owner:              registry.OwnerKV, // Contact SRE first, as they own the prober.
+		Timeout:            30 * time.Minute,
+		CompatibleClouds:   registry.AllClouds,
+		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase, registry.OperationRequiresZeroUnavailableRanges},
+		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
+			return runProbeRanges(ctx, o, c, true)
+		},
+	})
+}

--- a/pkg/cmd/roachtest/operations/register.go
+++ b/pkg/cmd/roachtest/operations/register.go
@@ -29,6 +29,7 @@ func RegisterOperations(r registry.Registry) {
 	registerResize(r)
 	registerPauseJob(r)
 	registerCancelJob(r)
+	registerProbeRanges(r)
 	registerLicenseThrottle(r)
 	registerSessionVariables(r)
 	registerDebugZip(r)


### PR DESCRIPTION
Since SRE uses crdb_internal.probe_ranges to test for prod cluster health, we would like to add this as a roach operation
to make the DRT cluster as realistic as possible, and test for potential issues with crdb_internal.probe_ranges, so we know ASAP if our alerting coverage drops.

**Background**
crdb_internal.probe_ranges is a virtual table that quickly probes the entire keyspace of the KV layer to return a table of schema (range_id | error | end_to_end_latency_ms). It has minimal dependencies, so it functions even when a cluster is quite broken. And since it probes the entire keyspace, it is useful when something has already gone wrong, in narrowing down an issue to specific ranges.

**What will this roach operation can catch?**
If this roach operation fails, there is either a bug in `crdb_internal.probe_ranges`, so SRE is short a critical tool, or there is a serious bug is present in KV layer, and KV team will need to know asap. Ideally SRE would be first to know if there is an issue, and can hand off to KV if necessary.

**Testing PR**
Tested that it works on roachtest cluster with
`roachtest run-operation noahthompsoncockroachlabscom-test probe-ranges`, and also was able to test that it successfully failed by forcing a range_error in DB, w/
```./bin/roachtest run-operation noahthompsoncockroachlabscom-test2 probe-ranges

Running operation probe-ranges on noahthompsoncockroachlabscom-test2.

2025/04/29 20:00:46 run_operation.go:145: [1] operation status: checking if operation probe-ranges/read dependencies are met
2025/04/29 20:00:47 run_operation.go:145: [1] operation status: running operation probe-ranges/read with run id 12821170976295052991
2025/04/29 20:00:47 probe_ranges.go:92: [1] operation status: executing crdb_internal.probe-ranges read statement against node 3
2025/04/29 20:00:47 probe_ranges.go:92: [1] operation status: found 1 errors while executing crdb_internal.probe-ranges read statement against node 3
2025/04/29 20:00:47 probe_ranges.go:92: [1] operation status: error on node 3 on range 4: test range error
2025/04/29 20:00:47 operation_impl.go:138: [1] operation failure #1: Found range errors when probing via crdb_internal.probe-ranges read statement against node 3
2025/04/29 20:00:47 run_operation.go:229: recovered from panic: o.Fatal() was called
```

**Future Work**
We would like to also enable KVProber cluster setting to test this from a different angle, this should be a very easy change.

Fixes: https://github.com/cockroachdb/cockroach/issues/102034
Release note: None
Epic: None