### PR TITLE
release-25.1: pgwire: skip `TestAuthenticationAndHBARules`

### DIFF
--- a/pkg/sql/pgwire/auth_test.go
+++ b/pkg/sql/pgwire/auth_test.go
@@ -127,6 +127,7 @@ import (
 // alongside the "ok" or "ERROR" message.
 func TestAuthenticationAndHBARules(t *testing.T) {
 	defer leaktest.AfterTest(t)()
+	skip.WithIssue(t, 144782)
 	skip.UnderRace(t, "takes >1min under race")
 
 	testutils.RunTrueAndFalse(t, "insecure", func(t *testing.T, insecure bool) {


### PR DESCRIPTION
Backport 1/1 commits from #144783 on behalf of @rickystewart.

/cc @cockroachdb/release

----

See #144782

Epic: none
Release note: None

----

Release justification: test-only, unblocks CI