### PR TITLE
release-25.2: schemachangerccl: increase polling duration for TestSubzonesRemovedByGCAfterIndexSwap

### DIFF
--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -233,7 +233,7 @@ CREATE TABLE person (
 	})
 
 	// Keep retrying until the old index and temporary index are removed by the GC job.
-	runner.SucceedsSoonDuration = 12 * time.Second
+	runner.SucceedsSoonDuration = 30 * time.Second
 	runner.CheckQueryResultsRetry(t, subzonesQuery, [][]string{
 		{"3", "north_america", "4", `/3/"CA"`, "NULL"},
 		{"3", "north_america", "4", `/3/"US"`, "NULL"},


### PR DESCRIPTION
Backport 1/1 commits from #144698 on behalf of @rafiss.

/cc @cockroachdb/release

----

fixes https://github.com/cockroachdb/cockroach/issues/144697
Release note: None

----

Release justification: test only change