### PR TITLE
release-23.2: ci: sign nightly and customized darwin builds

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release_on_linux.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release_on_linux.sh
@@ -5,8 +5,13 @@
 # Use of this software is governed by the CockroachDB Software License
 # included in the /LICENSE file.
 
-
 set -xeuo pipefail
+
+service_account=$(curl --header "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email" || echo "")
+if [[ $service_account != "signing-agent@crl-teamcity-agents.iam.gserviceaccount.com" ]]; then
+  echo "Not running on a signing agent, skipping signing"
+  exit 1
+fi
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
 source "$dir/teamcity-support.sh"  # For log_into_gcloud
@@ -20,6 +25,9 @@ remove_files_on_exit() {
 trap remove_files_on_exit EXIT
 
 mkdir -p .secrets
+# Explicitly set the account to the signing agent. This is helpful if one of the previous
+# commands failed and left the account set to something else.
+gcloud config set account "signing-agent@crl-teamcity-agents.iam.gserviceaccount.com"
 gcloud secrets versions access latest --secret=apple-signing-cert | base64 -d > "$curr_dir/.secrets/cert.p12"
 gcloud secrets versions access latest --secret=apple-signing-cert-password > "$curr_dir/.secrets/cert.pass"
 gcloud secrets versions access latest --secret=appstoreconnect-api-key > "$curr_dir/.secrets/api_key.json"

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-sign.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-sign.sh
@@ -1,0 +1,96 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euxo pipefail
+
+service_account=$(curl --header "Metadata-Flavor: Google" "http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/email" || echo "")
+
+if [[ $service_account != "signing-agent@crl-teamcity-agents.iam.gserviceaccount.com" ]]; then
+  echo "Not running on a signing agent, skipping signing"
+  exit 0
+fi
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+source "$dir/release/teamcity-support.sh"
+
+tc_start_block "Variable Setup"
+
+build_name=$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)
+
+# On no match, `grep -Eo` returns 1. `|| echo""` makes the script not error.
+release_branch="$(echo "$build_name" | grep -Eo "^v[0-9]+\.[0-9]+" || echo"")"
+is_customized_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
+is_release_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^((staging|release|rc)-(v)?[0-9][0-9]\.[0-9](\.0)?).*|master$" || echo "")"
+
+if [[ -z "${DRY_RUN}" ]] ; then
+  if [[ -z "${is_release_build}" ]] ; then
+    gcs_bucket="cockroach-customized-builds-artifacts-prod"
+    google_credentials="$GOOGLE_CREDENTIALS_CUSTOMIZED"
+  else
+    gcs_bucket="cockroach-builds-artifacts-prod"
+    google_credentials="$GCS_CREDENTIALS_PROD"
+  fi
+else
+  gcs_bucket="cockroach-builds-artifacts-dryrun"
+  build_name="${build_name}.dryrun"
+  google_credentials="$GCS_CREDENTIALS_DEV"
+fi
+
+cat << EOF
+
+  build_name:          $build_name
+  release_branch:      $release_branch
+  is_customized_build: $is_customized_build
+  gcs_bucket:          $gcs_bucket
+  is_release_build:    $is_release_build
+
+EOF
+tc_end_block "Variable Setup"
+
+secrets_dir="$(mktemp -d)"
+_on_exit() {
+  rm -rf "$secrets_dir"
+  gcloud config set account "signing-agent@crl-teamcity-agents.iam.gserviceaccount.com"
+}
+trap _on_exit EXIT
+
+
+# Explicitly set the account to the signing agent. This is helpful if one of the previous
+# commands failed and left the account set to something else.
+gcloud config set account "signing-agent@crl-teamcity-agents.iam.gserviceaccount.com"
+gcloud secrets versions access latest --secret=apple-signing-cert | base64 -d > "$secrets_dir/cert.p12"
+gcloud secrets versions access latest --secret=apple-signing-cert-password > "$secrets_dir/cert.pass"
+gcloud secrets versions access latest --secret=appstoreconnect-api-key > "$secrets_dir/api_key.json"
+
+google_credentials="$google_credentials" log_into_gcloud
+
+workdir="$(mktemp -d)"
+cd "$workdir"
+
+for product in cockroach cockroach-sql; do
+  # In case we want to sign darwin-10.9-amd64, we can add it here.
+  for platform in darwin-11.0-arm64; do
+    gsutil cp "gs://$gcs_bucket/$product-$build_name.$platform.unsigned.tgz" "$product-$build_name.$platform.unsigned.tgz"
+    tar -xzf "$product-$build_name.$platform.unsigned.tgz"
+    mv "$product-$build_name.$platform.unsigned" "$product-$build_name.$platform"
+    rcodesign sign \
+      --p12-file "$secrets_dir/cert.p12" --p12-password-file "$secrets_dir/cert.pass" \
+      --code-signature-flags runtime \
+      "$product-$build_name.$platform/$product"
+    zip -r crl.zip "$product-$build_name.$platform/$product"
+    rcodesign notary-submit --api-key-file "$secrets_dir/api_key.json" --wait crl.zip
+    tar -czf "$product-$build_name.$platform.tgz" "$product-$build_name.$platform"
+    shasum --algorithm 256 "$product-$build_name.$platform.tgz" > "$product-$build_name.$platform.tgz.sha256sum"
+    gsutil cp "$product-$build_name.$platform.tgz" "gs://$gcs_bucket/$product-$build_name.$platform.tgz"
+    gsutil cp "$product-$build_name.$platform.tgz.sha256sum" "gs://$gcs_bucket/$product-$build_name.$platform.tgz.sha256sum"
+    rm -rf "$product-$build_name.$platform" \
+      "$product-$build_name.$platform.tgz" \
+      "$product-$build_name.$platform.tgz.sha256sum" \
+      crl.zip
+  done
+done

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -146,6 +146,7 @@ The binaries will be available at:
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.linux-amd64.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.linux-amd64-fips.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.linux-arm64.tgz
+  https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.darwin-11.0-arm64.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.darwin-10.9-amd64.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.windows-6.2-amd64.zip
 

--- a/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-tagging.sh
@@ -92,6 +92,7 @@ Build ID: ${build_name}
 The binaries are available at:
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.linux-amd64.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.linux-arm64.tgz
+  https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.darwin-11.0-arm64.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.darwin-10.9-amd64.tgz
   https://storage.googleapis.com/$gcs_bucket/cockroach-$build_name.windows-6.2-amd64.zip
 

--- a/scripts/tag-custom-build.sh
+++ b/scripts/tag-custom-build.sh
@@ -86,6 +86,7 @@ The binaries will be available at:
   https://storage.googleapis.com/cockroach-customized-builds-artifacts-prod/cockroach-$ID.linux-amd64.tgz
   https://storage.googleapis.com/cockroach-customized-builds-artifacts-prod/cockroach-$ID.linux-amd64-fips.tgz
   https://storage.googleapis.com/cockroach-customized-builds-artifacts-prod/cockroach-$ID.linux-arm64.tgz
+  https://storage.googleapis.com/cockroach-customized-builds-artifacts-prod/cockroach-$ID.darwin-11.0-arm64.tgz
   https://storage.googleapis.com/cockroach-customized-builds-artifacts-prod/cockroach-$ID.darwin-10.9-amd64.tgz
   https://storage.googleapis.com/cockroach-customized-builds-artifacts-prod/cockroach-$ID.windows-6.2-amd64.zip
 


### PR DESCRIPTION
Backport 1/1 commits from #144345 on behalf of @rail.

/cc @cockroachdb/release

----

Previously, we didn't sign nightly and customized darwin builds. In some cases, it is easier to use dev machines to verify some functionality, but without signing, MacOS will not allow the app to run.

This commit adds a script to sign darwin binaries generated by the nightly and customized builds. Additionally, it adds sanity checks to ensure that the signing process is run on correct type of machines and correct service account is used.

Fixes: RE-794
Release note: none

----

Release justification: CI-only changes