### PR TITLE
opt: reduce execbuilder allocations

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -775,7 +775,7 @@ func init() {
 // to run. See the comments for the Phase enumeration for more details
 // on what each phase includes.
 func BenchmarkPhases(b *testing.B) {
-	for _, query := range queriesToTest(b) {
+	for _, query := range queriesToTest() {
 		h := newHarness(b, query, schemas)
 		b.Run(query.name, func(b *testing.B) {
 			b.Run("Simple", func(b *testing.B) {
@@ -1086,7 +1086,7 @@ func makeParameterizedQueryWithORs(size int) benchQuery {
 // in the testSizes array and test name suffix. The test names produced are:
 // ored-preds-100
 // ored-preds-using-params-100
-func makeOredPredsTests(b *testing.B) []benchQuery {
+func makeOredPredsTests() []benchQuery {
 	// Add more entries to this array to test with different numbers of ORed
 	// predicates.
 	testSizes := [...]int{100}
@@ -1100,8 +1100,8 @@ func makeOredPredsTests(b *testing.B) []benchQuery {
 	return benchQueries
 }
 
-func queriesToTest(b *testing.B) []benchQuery {
-	allQueries := append(queries[:], makeOredPredsTests(b)...)
+func queriesToTest() []benchQuery {
+	allQueries := append(queries[:], makeOredPredsTests()...)
 	return allQueries
 }
 
@@ -1146,7 +1146,7 @@ func BenchmarkEndToEnd(b *testing.B) {
 		sr.Exec(b, schema)
 	}
 
-	for _, query := range queriesToTest(b) {
+	for _, query := range queriesToTest() {
 		args := trimSingleQuotes(query.args)
 		b.Run(query.name, func(b *testing.B) {
 			for _, vectorize := range []string{"on", "off"} {
@@ -1743,7 +1743,7 @@ func BenchmarkExecBuild(b *testing.B) {
 	var testCases []testCase
 
 	// Add the basic queries.
-	for _, query := range queriesToTest(b) {
+	for _, query := range queriesToTest() {
 		testCases = append(testCases, testCase{query, schemas})
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2749,14 +2749,19 @@ func (b *Builder) buildLookupJoin(
 		lookupCols.Remove(join.ContinuationCol)
 	}
 
-	lookupOrdinals, lookupColMap := b.getColumns(lookupCols, join.Table)
-
+	numInputCols := inputCols.MaxOrd() + 1
+	var lookupOrdinals exec.TableColumnOrdinalSet
 	// leftAndRightCols are the columns used in expressions evaluated by this
 	// join.
-	leftAndRightCols := b.joinOutputMap(inputCols, lookupColMap)
-
-	// lookupColMap is no longer used, so it can be freed.
-	b.colOrdsAlloc.Free(lookupColMap)
+	leftAndRightCols := b.colOrdsAlloc.Copy(inputCols)
+	for i, rightOrd, n := 0, 0, md.Table(join.Table).ColumnCount(); i < n; i++ {
+		colID := join.Table.ColumnID(i)
+		if lookupCols.Contains(colID) {
+			lookupOrdinals.Add(i)
+			leftAndRightCols.Set(colID, rightOrd+numInputCols)
+			rightOrd++
+		}
+	}
 
 	// Create the output column mapping.
 	switch {


### PR DESCRIPTION
#### opt: use embedded array for colOrdMap free list

We now use any embedded array instead of a slice to store the list of of
`colOrdMap`s in `execbuilder`. This reduces allocations.

Previously the free list could contain an unbounded number of freed
maps. Now it can store up to 4. Our benchmarks show that this should be
enough in practice, i.e., this limitation won't incur additional
allocations due to allocating more than 4 freed maps.

Epic: None
Release note: None

#### opt: eliminate intermediate colOrdMap

A `colOrdMap` used temporarily while execbuild-ing look-up joins is no
longer allocated.

Release note: None

#### opt: remove unused parameters with benchmark helper functions

Release note: None
