### PR TITLE
release-24.1: jobs: add jobs.avoid_full_scans_in_find_running_jobs.enabled

### DIFF
--- a/pkg/jobs/BUILD.bazel
+++ b/pkg/jobs/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/json",
         "//pkg/util/log",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/pprofutil",
         "//pkg/util/protoutil",

--- a/pkg/spanconfig/spanconfigmanager/manager.go
+++ b/pkg/spanconfig/spanconfigmanager/manager.go
@@ -128,7 +128,7 @@ func (m *Manager) run(ctx context.Context) {
 			return
 		}
 
-		started, err := m.createAndStartJobIfNoneExists(ctx)
+		started, err := m.createAndStartJobIfNoneExists(ctx, m.settings)
 		if err != nil {
 			log.Errorf(ctx, "error starting auto span config reconciliation job: %v", err)
 		}
@@ -162,7 +162,9 @@ func (m *Manager) run(ctx context.Context) {
 // createAndStartJobIfNoneExists creates span config reconciliation job iff it
 // hasn't been created already and notifies the jobs registry to adopt it.
 // Returns a boolean indicating if the job was created.
-func (m *Manager) createAndStartJobIfNoneExists(ctx context.Context) (bool, error) {
+func (m *Manager) createAndStartJobIfNoneExists(
+	ctx context.Context, cs *cluster.Settings,
+) (bool, error) {
 	if m.knobs.ManagerDisableJobCreation {
 		return false, nil
 	}
@@ -177,8 +179,9 @@ func (m *Manager) createAndStartJobIfNoneExists(ctx context.Context) (bool, erro
 
 	var job *jobs.Job
 	if err := m.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		exists, err := jobs.RunningJobExists(ctx, jobspb.InvalidJobID, txn,
-			jobspb.TypeAutoSpanConfigReconciliation)
+		exists, err := jobs.RunningJobExists(
+			ctx, cs, jobspb.InvalidJobID, txn, jobspb.TypeAutoSpanConfigReconciliation,
+		)
 		if err != nil {
 			return err
 		}

--- a/pkg/spanconfig/spanconfigmanager/manager_test.go
+++ b/pkg/spanconfig/spanconfigmanager/manager_test.go
@@ -104,7 +104,7 @@ func TestManagerConcurrentJobCreation(t *testing.T) {
 
 	var g errgroup.Group
 	g.Go(func() error {
-		started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx)
+		started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx, ts.ClusterSettings())
 		if err != nil {
 			return err
 		}
@@ -117,7 +117,7 @@ func TestManagerConcurrentJobCreation(t *testing.T) {
 		// Only try to start the job if the first goroutine has reached the testing
 		// knob and is blocked.
 		<-isBlocked
-		started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx)
+		started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx, ts.ClusterSettings())
 		if err != nil {
 			return err
 		}
@@ -183,7 +183,7 @@ func TestManagerStartsJobIfFailed(t *testing.T) {
 	)
 	require.NoError(t, err)
 
-	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx)
+	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx, ts.ClusterSettings())
 	require.NoError(t, err)
 	require.True(t, started)
 }
@@ -331,7 +331,7 @@ func TestReconciliationJobErrorAndRecovery(t *testing.T) {
 		},
 	)
 
-	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx)
+	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx, ts.ClusterSettings())
 	require.NoError(t, err)
 	require.True(t, started)
 
@@ -354,7 +354,7 @@ func TestReconciliationJobErrorAndRecovery(t *testing.T) {
 	mu.err = nil
 	mu.Unlock()
 
-	started, err = manager.TestingCreateAndStartJobIfNoneExists(ctx)
+	started, err = manager.TestingCreateAndStartJobIfNoneExists(ctx, ts.ClusterSettings())
 	require.NoError(t, err)
 	require.True(t, started)
 
@@ -421,7 +421,7 @@ func TestReconciliationUsesRightCheckpoint(t *testing.T) {
 		nil,
 	)
 
-	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx)
+	started, err := manager.TestingCreateAndStartJobIfNoneExists(ctx, ts.ClusterSettings())
 	require.NoError(t, err)
 	require.True(t, started)
 

--- a/pkg/spanconfig/spanconfigmanager/test_helpers.go
+++ b/pkg/spanconfig/spanconfigmanager/test_helpers.go
@@ -5,10 +5,16 @@
 
 package spanconfigmanager
 
-import "context"
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+)
 
 // TestingCreateAndStartJobIfNoneExists is a wrapper around
 // createAndStartJobIfNoneExists for testing it.
-func (m *Manager) TestingCreateAndStartJobIfNoneExists(ctx context.Context) (bool, error) {
-	return m.createAndStartJobIfNoneExists(ctx)
+func (m *Manager) TestingCreateAndStartJobIfNoneExists(
+	ctx context.Context, cs *cluster.Settings,
+) (bool, error) {
+	return m.createAndStartJobIfNoneExists(ctx, cs)
 }


### PR DESCRIPTION
Backport 1/2 commits from #144309.

/cc @cockroachdb/release

---

#### jobs: add jobs.avoid_full_scans_in_find_running_jobs.enabled

The `jobs.avoid_full_scans_in_find_running_jobs.enabled` cluster setting
has been added which adds `AVOID_FULL_SCAN` hints to two internal,
jobs-related queries: `find-running-jobs-of-type` and
`find-all-running-jobs-of-type`. This hint prevents the optimizer from
choosing bad query plans with full table scans.

Epic: None
Release note: None

---

Release justification: Change gated behind cluster setting.


