### PR TITLE
release-25.2: jsonpath: complete grammar and add unimplemented feature errors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -195,6 +195,27 @@ SELECT '$.number()'::JSONPATH;
 statement error unimplemented
 SELECT '$.string()'::JSONPATH;
 
+statement error unimplemented
+SELECT '$.**'::JSONPATH;
+
+statement error unimplemented
+SELECT '$.decimal()'::JSONPATH;
+
+statement error unimplemented
+SELECT '$.datetime()'::JSONPATH;
+
+statement error unimplemented
+SELECT '$.time()'::JSONPATH;
+
+statement error unimplemented
+SELECT '$.time_tz()'::JSONPATH;
+
+statement error unimplemented
+SELECT '$.timestamp()'::JSONPATH;
+
+statement error unimplemented
+SELECT '$.timestamp_tz()'::JSONPATH;
+
 query T
 SELECT '$.*'::JSONPATH
 ----
@@ -224,10 +245,3 @@ $.*
 
 # statement error unsupported comparison operator
 # SELECT * FROM a WHERE j = '$.a'
-
-## Unsupported Jsonpath
-
-# query T
-# SELECT '$.a.type()'::JSONPATH
-# ----
-# $.a.type()

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -108,6 +108,13 @@ func (s *JSONPathScanner) Scan(lval ScanSymType) {
 	case '@':
 		lval.SetID(lexbase.CURRENT)
 		return
+	case '*':
+		if s.peek() == '*' { // **
+			s.pos++
+			lval.SetID(lexbase.ANY)
+			return
+		}
+		return
 	default:
 		if sqllexbase.IsDigit(ch) {
 			s.scanNumber(lval, ch)

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -159,60 +159,20 @@ func regexBinaryOp(left jsonpath.Path, regex string) (jsonpath.Operation, error)
 %token <str> LESS_EQUALS GREATER_EQUALS NOT_EQUALS
 %token <str> ERROR
 
-%token <str> STRICT
-%token <str> LAX
-
-%token <str> VARIABLE
-%token <str> TO
-
-%token <str> TRUE
-%token <str> FALSE
-
-%token <str> EQUAL
-%token <str> NOT_EQUAL
-%token <str> LESS
-%token <str> LESS_EQUAL
-%token <str> GREATER
-%token <str> GREATER_EQUAL
-
-%token <str> ROOT
-
-%token <str> AND
-%token <str> OR
-%token <str> NOT
-
-%token <str> CURRENT
-
-%token <str> STR
-%token <str> NULL
-
-%token <str> LIKE_REGEX
-%token <str> FLAG
-
-%token <str> LAST
-%token <str> EXISTS
-%token <str> IS
-%token <str> UNKNOWN
-%token <str> STARTS
-%token <str> WITH
-
-%token <str> SIZE
-
-%token <str> TYPE
-
-%token <str> KEYVALUE
-
-%token <str> ABS
-%token <str> CEILING
-%token <str> FLOOR
-
-%token <str> BIGINT
-%token <str> BOOLEAN
-%token <str> DATE
-%token <str> DOUBLE
-%token <str> INTEGER
-%token <str> NUMBER
-%token <str> STRING
+%token <str> STRICT LAX
+%token <str> ROOT CURRENT
+%token <str> VARIABLE STR NULL
+%token <str> TRUE FALSE
+%token <str> EQUAL NOT_EQUAL LESS LESS_EQUAL GREATER GREATER_EQUAL
+%token <str> AND OR NOT
+%token <str> LIKE_REGEX FLAG
+%token <str> TO LAST
+%token <str> EXISTS IS UNKNOWN STARTS WITH
+%token <str> ANY
+%token <str> SIZE TYPE KEYVALUE
+%token <str> ABS CEILING FLOOR
+%token <str> BIGINT BOOLEAN DATE DOUBLE INTEGER NUMBER STRING
+%token <str> DECIMAL DATETIME TIME TIME_TZ TIMESTAMP TIMESTAMP_TZ
 
 %type <jsonpath.Jsonpath> jsonpath
 %type <jsonpath.Path> expr_or_predicate
@@ -376,6 +336,34 @@ accessor_op:
 | '.' method '(' ')'
   {
     $$.val = $2.path()
+  }
+| '.' any_path
+  {
+    return unimplemented(jsonpathlex, ".**")
+  }
+| '.' DECIMAL '(' opt_csv_list ')'
+  {
+    return unimplemented(jsonpathlex, ".decimal()")
+  }
+| '.' DATETIME '(' opt_datetime_template ')'
+  {
+    return unimplemented(jsonpathlex, ".datetime()")
+  }
+| '.' TIME '(' opt_datetime_precision ')'
+  {
+    return unimplemented(jsonpathlex, ".time()")
+  }
+| '.' TIME_TZ '(' opt_datetime_precision ')'
+  {
+    return unimplemented(jsonpathlex, ".time_tz()")
+  }
+| '.' TIMESTAMP '(' opt_datetime_precision ')'
+  {
+    return unimplemented(jsonpathlex, ".timestamp()")
+  }
+| '.' TIMESTAMP_TZ '(' opt_datetime_precision ')'
+  {
+    return unimplemented(jsonpathlex, ".timestamp_tz()")
   }
 ;
 
@@ -577,6 +565,105 @@ method:
   }
 ;
 
+any_path:
+  ANY
+  {
+    // Unimplemented from .**.
+  }
+| ANY '{' any_level '}'
+  {
+    // Unimplemented from .**.
+  }
+| ANY '{' any_level TO any_level '}'
+  {
+    // Unimplemented from .**.
+  }
+;
+
+any_level:
+  ICONST
+  {
+    // Unimplemented from .**.
+  }
+| LAST
+  {
+    // Unimplemented from .**.
+  }
+;
+
+opt_csv_list:
+  csv_list
+  {
+    // Unimplemented from .decimal().
+  }
+| /* empty */
+  {
+    // Unimplemented from .decimal().
+  }
+;
+
+csv_list:
+  csv_elem
+  {
+    // Unimplemented from .decimal().
+  }
+| csv_list ',' csv_elem
+  {
+    // Unimplemented from .decimal().
+  }
+;
+
+csv_elem:
+  ICONST
+  {
+    // Unimplemented from .decimal().
+  }
+| '+' ICONST %prec UMINUS
+  {
+    // Unimplemented from .decimal().
+  }
+| '-' ICONST %prec UMINUS
+  {
+    // Unimplemented from .decimal().
+  }
+;
+
+opt_datetime_template:
+  datetime_template
+  {
+    // Unimplemented from .datetime().
+  }
+| /* empty */
+  {
+    // Unimplemented from .datetime().
+  }
+;
+
+datetime_template:
+  STR
+  {
+    // Unimplemented from .datetime().
+  }
+;
+
+opt_datetime_precision:
+  datetime_precision
+  {
+    // Unimplemented from .time(), time_tz(), .timestamp(), .timestamp_tz().
+  }
+| /* empty */
+  {
+    // Unimplemented from .time(), time_tz(), .timestamp(), .timestamp_tz().
+  }
+;
+
+datetime_precision:
+  ICONST
+  {
+    // Unimplemented from .time(), time_tz(), .timestamp(), .timestamp_tz().
+  }
+;
+
 scalar_value:
   VARIABLE
   {
@@ -632,6 +719,8 @@ unreserved_keyword:
 | BOOLEAN
 | CEILING
 | DATE
+| DATETIME
+| DECIMAL
 | DOUBLE
 | EXISTS
 | FALSE
@@ -649,6 +738,10 @@ unreserved_keyword:
 | STARTS
 | STRICT
 | STRING
+| TIME
+| TIMESTAMP
+| TIMESTAMP_TZ
+| TIME_TZ
 | TO
 | TRUE
 | TYPE

--- a/pkg/util/jsonpath/parser/lexer.go
+++ b/pkg/util/jsonpath/parser/lexer.go
@@ -98,7 +98,8 @@ func (l *lexer) setErr(err error) {
 }
 
 func (l *lexer) Unimplemented(feature string) {
-	l.lastError = unimp.New(feature, "this syntax")
+	// Link to meta-issue for unimplemented JSONPath features.
+	l.lastError = unimp.NewWithIssuef(22513, "this syntax: %s", feature)
 	lastTok := l.lastToken()
 	l.lastError = parser.PopulateErrorDetails(lastTok.id, lastTok.str, lastTok.pos, l.lastError, l.in)
 	l.lastError = &tree.UnsupportedError{


### PR DESCRIPTION
Backport 1/1 commits from #144389.

/cc @cockroachdb/release

---

This commit completes the JSONPath grammar through implementing the grammar rules for all Postgres-compatible JSONPath features. Features that are not yet implemented are marked with unimplemented errors and linked to the JSONPath meta-issue #22513.

Epic: None
Release note: None

Release justification: Point unimplemented JSONPath features to the correct meta-issue.