### PR TITLE
sql: honour RLS policies during query-based backfill

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -2594,6 +2594,133 @@ DROP TABLE multip;
 statement ok
 DROP USER multi_user;
 
+subtest ctas_and_mqt
+
+# Test that RLS is enforced, even when users create CTAS and materialized views
+
+statement ok
+CREATE ROLE alice LOGIN;
+
+statement ok
+CREATE ROLE bob LOGIN;
+
+statement ok
+CREATE TABLE documents (
+    id INT PRIMARY KEY,
+    owner TEXT NOT NULL,
+    content TEXT NOT NULL
+);
+
+statement ok
+INSERT INTO documents (id, owner, content) VALUES
+  (1, 'alice', 'Alice’s first document'),
+  (2, 'alice', 'Alice’s second document'),
+  (3, 'bob',   'Bob’s only document so far'),
+  (4, 'admin', 'Admin’s secret doc');
+
+statement ok
+GRANT ALL ON documents TO alice;
+
+statement ok
+GRANT ALL ON documents TO bob;
+
+statement ok
+GRANT CREATE ON SCHEMA public TO alice;
+
+statement ok
+GRANT CREATE ON SCHEMA public TO bob;
+
+statement ok
+ALTER TABLE documents ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY alice ON documents TO alice USING (owner = 'alice');
+
+statement ok
+CREATE POLICY bob ON documents TO bob USING (owner = 'bob');
+
+statement ok
+SET ROLE alice;
+
+query ITT
+SELECT * FROM documents ORDER BY ID;
+----
+1  alice  Alice’s first document
+2  alice  Alice’s second document
+
+statement ok
+CREATE TABLE ctas1 AS SELECT * FROM documents;
+
+query ITT
+SELECT * FROM ctas1 ORDER BY ID;
+----
+1  alice  Alice’s first document
+2  alice  Alice’s second document
+
+statement ok
+CREATE MATERIALIZED VIEW mqt_doc AS SELECT * FROM documents;
+
+query ITT
+SELECT * FROM mqt_doc ORDER BY ID;
+----
+1  alice  Alice’s first document
+2  alice  Alice’s second document
+
+statement ok
+GRANT ALL ON ctas1 TO bob;
+
+statement ok
+RESET ROLE;
+
+statement ok
+ALTER TABLE mqt_doc OWNER TO bob;
+
+statement ok
+SET ROLE bob;
+
+query ITT
+SELECT * FROM documents ORDER BY ID;
+----
+3  bob  Bob’s only document so far
+
+query ITT
+SELECT * FROM ctas1 ORDER BY ID;
+----
+1  alice  Alice’s first document
+2  alice  Alice’s second document
+
+query ITT
+SELECT * FROM mqt_doc ORDER BY ID;
+----
+1  alice  Alice’s first document
+2  alice  Alice’s second document
+
+statement ok
+REFRESH MATERIALIZED VIEW mqt_doc;
+
+query ITT
+SELECT * FROM mqt_doc ORDER BY ID;
+----
+3  bob  Bob’s only document so far
+
+statement ok
+RESET ROLE;
+
+statement ok
+DROP TABLE ctas1;
+
+statement ok
+DROP MATERIALIZED VIEW mqt_doc;
+
+statement ok
+DROP TABLE documents;
+
+statement ok
+REVOKE CREATE ON SCHEMA public FROM bob, alice;
+
+statement ok
+DROP ROLE alice, bob;
+
 subtest show_policies_edge_cases
 
 statement error pq: relation "nonexistent_table" does not exist

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -346,10 +346,14 @@ func (sc *SchemaChanger) backfillQueryIntoTable(
 		sd.SessionData = *sc.sessionData
 		// Create an internal planner as the planner used to serve the user query
 		// would have committed by this point.
+		//
+		// Note: the planner is created using the session’s user. This is important
+		// for row-level security (RLS), ensuring that the backfill query runs with
+		// the same visibility and access restrictions as the user who initiated it.
 		p, cleanup := NewInternalPlanner(
 			opName,
 			txn.KV(),
-			username.NodeUserName(),
+			sc.sessionData.User(),
 			&MemoryMetrics{},
 			sc.execCfg,
 			sd,


### PR DESCRIPTION
Previously, schema changes that performed backfill operations from a query—such as those for materialized views (MQTs) or CREATE TABLE ... AS (CTAS)—executed the query as the node user. This user has administrative privileges and bypasses all Row-Level Security (RLS) policies, unintentionally exposing rows the originator of the change should not have been able to access.

This change ensures that such query-based backfills run under the privileges of the user who initiated the schema change. As a result, RLS policies are correctly enforced, and only the rows visible to the initiating user are included in the result.

Fixes #144816
Fixes #144776

Epic: CRDB-11724
Release note: none
