### PR TITLE
kvpb: add NoReplicasMoved to AdminScatterResponse

### DIFF
--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -212,11 +212,26 @@ func (s dbSplitAndScatterer) scatter(
 			// throughput.
 			log.Errorf(ctx, "failed to scatter span [%s,%s): %+v",
 				newScatterKey, newScatterKey.Next(), pErr.GoError())
+		} else {
+			// Log at INFO level when scatter request is rejected because the range is
+			// non-empty (range size exceeds req.MaxSize). This is expected during
+			// RESTORE resume.
+			log.Infof(ctx, "failed to scatter span [%s,%s): %+v",
+				newScatterKey, newScatterKey.Next(), pErr.GoError())
 		}
 		return 0, nil
 	}
 
-	return s.findDestination(res.(*kvpb.AdminScatterResponse)), nil
+	scatteredResp, ok := res.(*kvpb.AdminScatterResponse)
+	if !ok {
+		log.Fatalf(ctx, "expected AdminScatterResponse, got %T", res)
+	}
+	if scatteredResp.NoReplicasMoved {
+		// TODO(#144856): DR should consider retrying the scatter if no replicas
+		// were moved.
+		log.Warningf(ctx, "no replicas moved during scatter")
+	}
+	return s.findDestination(scatteredResp), nil
 }
 
 // findDestination returns the node ID of the node of the destination of the

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -626,6 +626,7 @@ func (r *AdminScatterResponse) combine(_ context.Context, c combinable, _ *Batch
 		r.RangeInfos = append(r.RangeInfos, otherR.RangeInfos...)
 		r.MVCCStats.Add(otherR.MVCCStats)
 		r.ReplicasScatteredBytes += otherR.ReplicasScatteredBytes
+		r.NoReplicasMoved = r.NoReplicasMoved && otherR.NoReplicasMoved
 	}
 	return nil
 }

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1974,6 +1974,13 @@ message AdminScatterResponse {
   // scattered
   int64 replicas_scattered_bytes = 5;
 
+  // NoReplicasMoved indicates whether no replicas were moved during the scatter
+  // operation. NB: this needs to be a separate field, since we can't reliably
+  // infer "no replica moved" from ReplicasScatteredBytes == 0. Empty ranges
+  // have stats.Total() == 0 and ReplicasScatteredBytes will be 0 regardless of
+  // whether any replicas were moved.
+  bool no_replicas_moved = 6;
+
   // NB: if you add a field here, don't forget to update combine().
 }
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1945,8 +1945,7 @@ message ExportResponse {
 
 // AdminScatterRequest is the argument to the AdminScatter() method, which moves
 // replicas and leaseholders for a selection of ranges. Scatter is best-effort;
-// ranges that cannot be moved will include an error detail in the response and
-// won't fail the request.
+// ranges that cannot be moved won't fail the request.
 message AdminScatterRequest {
   RequestHeader header = 1 [(gogoproto.nullable) = false, (gogoproto.embed) = true];
   bool randomize_leases = 2;

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4266,6 +4266,11 @@ func (r *Replica) adminScatter(
 		// that were moved so the value may not be entirely accurate, but it is
 		// adequate.
 		ReplicasScatteredBytes: stats.Total() * int64(numReplicasMoved),
+		// NB: this needs to be a separate field, since we can't reliably infer
+		// "no replica moved" from ReplicasScatteredBytes == 0. Empty ranges have
+		// stats.Total() == 0 and ReplicasScatteredBytes will be 0 regardless of
+		// whether any replicas were moved.
+		NoReplicasMoved: numReplicasMoved == 0,
 	}, nil
 }
 


### PR DESCRIPTION

**kvpb: remove outdated comment for AdminScatterRequest**

Previously, AdminScatterResponse included error details when range moves failed
(https://github.com/cockroachdb/cockroach/blob/225f782748bd13656a3a5ce99f3a5369be4a76a3/pkg/roachpb/api.proto#L849-L853).
These details were removed since
https://github.com/cockroachdb/cockroach/commit/dbd90cf0c331c1f109985a22f96937e75e46aa52.
This commit removes the now-outdated comment referring to them.

Epic: none
Release note: none

---

**kvpb: add NoReplicasMoved to AdminScatterResponse**

Previously, clients couldn't determine if the scatter operation from
AdminScatterRequest succeeded, as failures to move ranges would not result in a
client error being returned. Since AdminScatter is used in multiple places, we
chose to preserve the existing best-effort behavior and avoid surfacing these
errors to the client. But to improve visibility for clients, this commit
introduces a new no_replicas_moved field (defaulting to false for mixed-version
compatibility). This field indicates that no replicas were moved, based on
comparing the state before and after the scatter operation, suggesting the
operation may warrant further attention or a retry.

Note: the client side doesn't currently read this field, so this change doesn't
affect behavior yet.

Resolves: #144560
Resolves: #144548
Resolves: #144571
Release note: none

---

**backup: add warning when no replica moved from AdminScatter**

Previously, we introduced a new field NoReplicasMoved to
AdminScatterResponse. This is to provide more visibility into
the scatter operation to indicate whether AdminScatter actually
successfully moved replicas.

This commit just logs a warning if NoReplicasMoved is true
from the DR side. Note that retrying from the client side is
not implemented, so no behaviour changes exist yet. This remains
as an ongoing issue tracked in #144856.

Informs: #144856
Part of: #144560
Release note: none

