### PR TITLE
release-25.2: sqlstatsutil: add sqlType to statement stats json fields

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -106,7 +106,8 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "min": {{.Float}},
            "max": {{.Float}}
          },
-         "lastErrorCode": "{{.String}}"
+         "lastErrorCode": "{{.String}}",
+				 "sqlType": "{{.String}}" 
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -345,6 +345,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"lastErrorCode", (*jsonString)(&s.LastErrorCode)},
 		{"failureCount", (*jsonInt)(&s.FailureCount)},
 		{"genericCount", (*jsonInt)(&s.GenericCount)},
+		{"sqlType", (*jsonString)(&s.SQLType)},
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #144517.

/cc @cockroachdb/release

---

The jsonFields receiver on innerStmtStats didn't include the sqlType field, so the sql activity apis always returned an empty string for this field. This field is expected in db console and used to filter sql activity fingerprints by sql type.

Now, this field is properly set and can be used to filter fingerprints in sql activity

Fixes: CC-31238
Epic: CC-30965
Release note (bug fix): Fixes a bug in the sql activity page where filtering on "Statement Type" resulted in 0 results returned. This filter should now work.
