### PR TITLE
release-24.3: sqlstatsutil: add sqlType to statement stats json fields

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -108,7 +108,8 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
            "p90": {{.Float}},
            "p99": {{.Float}}
          },
-         "lastErrorCode": "{{.String}}"
+         "lastErrorCode": "{{.String}}",
+				 "sqlType": "{{.String}}" 
        },
        "execution_statistics": {
          "cnt": {{.Int64}},

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -344,6 +344,7 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 		{"latencyInfo", (*latencyInfo)(&s.LatencyInfo)},
 		{"lastErrorCode", (*jsonString)(&s.LastErrorCode)},
 		{"failureCount", (*jsonInt)(&s.FailureCount)},
+		{"sqlType", (*jsonString)(&s.SQLType)},
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #144517.

/cc @cockroachdb/release

---

The jsonFields receiver on innerStmtStats didn't include the sqlType field, so the sql activity apis always returned an empty string for this field. This field is expected in db console and used to filter sql activity fingerprints by sql type.

Now, this field is properly set and can be used to filter fingerprints in sql activity

Fixes: CC-31238
Epic: CC-30965
Release note (bug fix): Fixes a bug in the sql activity page where filtering on "Statement Type" resulted in 0 results returned. This filter should now work.
