### PR TITLE
release-25.2: rowenc: handle encoding of NULL or missing vectors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -559,3 +559,25 @@ statement error vector_search_beam_size cannot be less than 1 or greater than 51
 SET vector_search_beam_size=513
 
 subtest end
+
+subtest test_144621
+
+statement ok
+CREATE TABLE test_144621 (a INT PRIMARY KEY, v VECTOR(3))
+
+statement ok
+CREATE VECTOR INDEX vec_idx ON test_144621 (v)
+
+statement ok
+INSERT INTO test_144621 VALUES (1, NULL)
+
+query I
+SELECT a FROM test_144621;
+----
+1
+
+query I
+SELECT a FROM test_144621@vec_idx ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
+----
+
+subtest end

--- a/pkg/sql/row/vector_index.go
+++ b/pkg/sql/row/vector_index.go
@@ -82,9 +82,7 @@ func (vm *VectorIndexUpdateHelper) initImpl(
 			if vm.PutPartitionKeys == nil {
 				vm.PutPartitionKeys = make(map[descpb.IndexID]tree.Datum)
 			}
-			if putPartitionKeys[valIdx] != tree.DNull {
-				vm.PutPartitionKeys[idx.GetID()] = putPartitionKeys[valIdx]
-			}
+			vm.PutPartitionKeys[idx.GetID()] = putPartitionKeys[valIdx]
 		}
 
 		// Retrieve the quantized vector, if it exists.
@@ -92,9 +90,7 @@ func (vm *VectorIndexUpdateHelper) initImpl(
 			if vm.PutQuantizedVecs == nil {
 				vm.PutQuantizedVecs = make(map[descpb.IndexID]tree.Datum)
 			}
-			if putQuantizedVecs[valIdx] != tree.DNull {
-				vm.PutQuantizedVecs[idx.GetID()] = putQuantizedVecs[valIdx]
-			}
+			vm.PutQuantizedVecs[idx.GetID()] = putQuantizedVecs[valIdx]
 		}
 
 		// Retrieve the partition key value for delete, if it exists.
@@ -102,9 +98,7 @@ func (vm *VectorIndexUpdateHelper) initImpl(
 			if vm.DelPartitionKeys == nil {
 				vm.DelPartitionKeys = make(map[descpb.IndexID]tree.Datum)
 			}
-			if delPartitionKeys[valIdx] != tree.DNull {
-				vm.DelPartitionKeys[idx.GetID()] = delPartitionKeys[valIdx]
-			}
+			vm.DelPartitionKeys[idx.GetID()] = delPartitionKeys[valIdx]
 		}
 
 		valIdx++

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1382,7 +1382,14 @@ func encodeSecondaryIndexKeyWithKeyPrefix(
 		secondaryIndexKey, err = encodeVectorIndexKey(
 			secondaryIndex, colMap, values, keyPrefix, vh,
 		)
-		secondaryKeys = [][]byte{secondaryIndexKey}
+		// This can happen if the search returns a NULL partition, which means the
+		// partition was not found in the DELETE case or the vector being inserted
+		// is NULL.
+		if secondaryIndexKey == nil {
+			secondaryKeys = [][]byte{}
+		} else {
+			secondaryKeys = [][]byte{secondaryIndexKey}
+		}
 	}
 	return secondaryKeys, containsNull, err
 }

--- a/pkg/sql/rowexec/vector_search.go
+++ b/pkg/sql/rowexec/vector_search.go
@@ -322,8 +322,13 @@ func (v *vectorMutationSearchProcessor) Next() (rowenc.EncDatumRow, *execinfrapb
 					break
 				}
 				// It is possible for the search not to find the target index entry, in
-				// which case the result is nil.
-				partitionKey = v.searcher.PartitionKey()
+				// which case the result is nil. In this case, we leave the partition key
+				// as NULL to signal to rowenc that we didn't find a partition key, but that
+				// it's okay since it's expected that this can happen due to fixups moving
+				// vector index entries around.
+				if v.searcher.PartitionKey() != nil {
+					partitionKey = v.searcher.PartitionKey()
+				}
 			}
 		}
 		row = append(row, rowenc.DatumToEncDatum(types.Int, partitionKey))

--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -52,6 +52,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/keys",
+        "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/security/username",
@@ -65,6 +66,7 @@ go_test(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/rowenc",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",


### PR DESCRIPTION
Backport 1/1 commits from #144712.

/cc @cockroachdb/release

---

Previously if the mutationSearch operator failed to find a partition for a vector because it was NULL or missing (e.g. being moved by fixup), rowenc would panic, causing the mutation to fail. This prevented the insertion of NULL vectors and would sometimes cause deletes to erroneously fail.

This patch allows mutationSearch to signal "partition not found, but it's okay" by sending a NULL partition instead of setting the partition value to nil. The 'nil' value now indicates a bad failure that should never happen whereas a NULL partition value means 'skip this row' ala a partial index.

Fixes: #144621
Release note (bug fix): NULL vectors can now be inserted into tables with vector indexes.

Release Justification: Low risk fix for a tech preview feature that doesn't touch outside code.