### PR TITLE
changefeedccl: fix notice display for sinks with topics

### DIFF
--- a/pkg/ccl/changefeedccl/topic.go
+++ b/pkg/ccl/changefeedccl/topic.go
@@ -185,7 +185,7 @@ func (tn *TopicNamer) makeName(s changefeedbase.Target, td TopicDescriptor) (str
 		return tn.nameFromComponents(s.StatementTimeName, s.FamilyName), nil
 	case jobspb.ChangefeedTargetSpecification_EACH_FAMILY:
 		if td == nil {
-			return tn.nameFromComponents(s.StatementTimeName, familyPlaceholder), nil
+			return tn.nameFromComponents(s.StatementTimeName) + string(tn.join) + familyPlaceholder, nil
 		}
 		name, components := td.GetNameComponents()
 		return tn.nameFromComponents(name, components...), nil


### PR DESCRIPTION
Whenever a changefeed is created into a sink that
has topics and with the split_column_families
option, we show a notice message with the
name format of the topics that will be emitted to. 
Assuming that there is no topic_prefix and
topic_name provided, and the table is named t, 
the expected format would be t.{family}. The 
expected notice message would be

NOTICE: changefeed will emit to topic t.{family}

But instead, we were showing

NOTICE: changefeed will emit to topic t._u007b_family_u007d_

Release note(bug fix): Fix confusing notice display when creating a changefeed with split_column_families

Fixes: #128973
Epic: CRDB-41784