### PR TITLE
kvpb: remove combine for AdminScatterResponse

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -615,23 +615,6 @@ func (er *ExportResponse) combine(_ context.Context, c combinable, _ *BatchReque
 
 var _ combinable = &ExportResponse{}
 
-// combine implements the combinable interface.
-func (r *AdminScatterResponse) combine(_ context.Context, c combinable, _ *BatchRequest) error {
-	if r != nil {
-		otherR := c.(*AdminScatterResponse)
-		if err := r.ResponseHeader.combine(otherR.Header()); err != nil {
-			return err
-		}
-
-		r.RangeInfos = append(r.RangeInfos, otherR.RangeInfos...)
-		r.MVCCStats.Add(otherR.MVCCStats)
-		r.ReplicasScatteredBytes += otherR.ReplicasScatteredBytes
-	}
-	return nil
-}
-
-var _ combinable = &AdminScatterResponse{}
-
 func (avptr *AdminVerifyProtectedTimestampResponse) combine(
 	_ context.Context, c combinable, _ *BatchRequest,
 ) error {

--- a/pkg/kv/kvpb/api_test.go
+++ b/pkg/kv/kvpb/api_test.go
@@ -234,51 +234,6 @@ func TestCombinable(t *testing.T) {
 		}, v1)
 
 	})
-
-	t.Run("AdminScatter", func(t *testing.T) {
-
-		// Test that AdminScatterResponse properly implement it.
-		ar1 := &AdminScatterResponse{
-			RangeInfos: []roachpb.RangeInfo{{Desc: roachpb.RangeDescriptor{
-				RangeID: 1,
-			}}},
-			MVCCStats: enginepb.MVCCStats{
-				LiveBytes: 1,
-				LiveCount: 1,
-				KeyCount:  1,
-			},
-			ReplicasScatteredBytes: 42,
-		}
-
-		if _, ok := interface{}(ar1).(combinable); !ok {
-			t.Fatalf("AdminScatterResponse does not implement combinable")
-		}
-
-		ar2 := &AdminScatterResponse{
-			RangeInfos: []roachpb.RangeInfo{{Desc: roachpb.RangeDescriptor{
-				RangeID: 2,
-			}}},
-			MVCCStats: enginepb.MVCCStats{
-				LiveBytes: 2,
-				LiveCount: 2,
-				KeyCount:  2,
-			},
-			ReplicasScatteredBytes: 42,
-		}
-
-		wantedAR := &AdminScatterResponse{
-			RangeInfos:             []roachpb.RangeInfo{{Desc: roachpb.RangeDescriptor{RangeID: 1}}, {Desc: roachpb.RangeDescriptor{RangeID: 2}}},
-			MVCCStats:              enginepb.MVCCStats{LiveBytes: 3, LiveCount: 3, KeyCount: 3},
-			ReplicasScatteredBytes: 84,
-		}
-
-		require.NoError(t, ar1.combine(context.Background(), ar2, nil))
-		require.NoError(t, ar1.combine(context.Background(), &AdminScatterResponse{}, nil))
-
-		if !reflect.DeepEqual(ar1, wantedAR) {
-			t.Errorf("wanted %v, got %v", wantedAR, ar1)
-		}
-	})
 }
 
 // TestMustSetInner makes sure that calls to MustSetInner correctly reset the


### PR DESCRIPTION
This commit removes combine for AdminScatterResponse since it does not seem to
make sense two combine two AdminScatterResponse. Client side (such as
https://github.com/cockroachdb/cockroach/blob/f06be00bcb6657371df4bc872f0a40f5c0d6595d/pkg/backup/generative_split_and_scatter_processor.go#L225-L232)
only looks at the first RangeInfo returned when finding the node destination.
So it does not seem to make sense to just concatenating two slices for RangeInfo
when combining.

Fixes: #144864
Release note: none
