### PR TITLE
release-25.2: kvclient: fix handling of ResumeSpans in txnWriteBuffer

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -439,3 +439,43 @@ query I
 SELECT count(*) FROM uvw
 ----
 64
+
+# Create some large blobs that will require the scans to be paginated (in 10MiB
+# chunks).
+statement ok
+CREATE TABLE large (k PRIMARY KEY, blob) AS SELECT i * 100, repeat('a', 11 * 1024 * 1024) FROM generate_series(1, 4) AS g(i);
+
+statement ok
+BEGIN;
+
+statement ok
+INSERT INTO large SELECT 11 + i * 100, 'b' FROM generate_series(1, 4) AS g(i);
+
+# Forward scan.
+query I
+SELECT k FROM large ORDER BY k;
+----
+100
+111
+200
+211
+300
+311
+400
+411
+
+# Reverse scan.
+query I
+SELECT k FROM large ORDER BY k DESC;
+----
+411
+400
+311
+300
+211
+200
+111
+100
+
+statement ok
+COMMIT;


### PR DESCRIPTION
Backport 1/1 commits from #144839 on behalf of @yuzefovich.

/cc @cockroachdb/release

----

Previously, we incorrectly handled Scans and ReverseScans when they had ResumeSpan set. In particular, we would include buffered writes that overlapped with the key span until the "full end", ignoring where the ResumeSpan started. This meant that we could include the same buffered write multiple times into the merged response. This is now fixed by overlapping the btree only with the key span that was scanned on the current "page".

Addresses: #144277.
Epic: None

Release note: None

----

Release justification: bw is disabled by default.