### PR TITLE
sql: enable TestUpsertFastPath with buffered writes

### DIFF
--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -15,12 +15,15 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/bootstrap"
 	"github.com/cockroachdb/cockroach/pkg/sql/mutations"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
@@ -35,135 +38,153 @@ func TestUpsertFastPath(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	if mutations.MaxBatchSize(false /* forceProductionMaxBatchSize */) == 1 {
-		// The fast path requires that the max batch size is at least 2, so
-		// we'll skip the test.
-		skip.UnderMetamorphic(t)
-	}
+	testutils.RunTrueAndFalse(t, "buffered-writes-enabled", func(t *testing.T, bufferedWritesEnabled bool) {
+		st := cluster.MakeTestingClusterSettings()
+		kvcoord.BufferedWritesEnabled.Override(ctx, &st.SV, bufferedWritesEnabled)
 
-	// This filter increments scans and endTxn for every ScanRequest and
-	// EndTxnRequest that hits user table data.
-	var gets uint64
-	var scans uint64
-	var endTxn uint64
-	var codecValue atomic.Value
-	filter := func(filterArgs kvserverbase.FilterArgs) *kvpb.Error {
-		codec := codecValue.Load()
-		if codec == nil {
+		if mutations.MaxBatchSize(false /* forceProductionMaxBatchSize */) == 1 {
+			// The fast path requires that the max batch size is at least 2, so
+			// we'll skip the test.
+			skip.UnderMetamorphic(t)
+		}
+
+		// This filter increments scans and endTxn for every ScanRequest and
+		// EndTxnRequest that hits user table data.
+		var gets uint64
+		var scans uint64
+		var endTxn uint64
+		var codecValue atomic.Value
+		filter := func(filterArgs kvserverbase.FilterArgs) *kvpb.Error {
+			codec := codecValue.Load()
+			if codec == nil {
+				return nil
+			}
+			if bytes.Compare(filterArgs.Req.Header().Key, bootstrap.TestingUserTableDataMin(codec.(keys.SQLCodec))) >= 0 {
+				switch filterArgs.Req.Method() {
+				case kvpb.Scan:
+					atomic.AddUint64(&scans, 1)
+				case kvpb.Get:
+					atomic.AddUint64(&gets, 1)
+				case kvpb.EndTxn:
+					if filterArgs.Hdr.Txn.Status == roachpb.STAGING {
+						// Ignore async explicit commits.
+						return nil
+					}
+					atomic.AddUint64(&endTxn, 1)
+				}
+			}
 			return nil
 		}
-		if bytes.Compare(filterArgs.Req.Header().Key, bootstrap.TestingUserTableDataMin(codec.(keys.SQLCodec))) >= 0 {
-			switch filterArgs.Req.Method() {
-			case kvpb.Scan:
-				atomic.AddUint64(&scans, 1)
-			case kvpb.Get:
-				atomic.AddUint64(&gets, 1)
-			case kvpb.EndTxn:
-				if filterArgs.Hdr.Txn.Status == roachpb.STAGING {
-					// Ignore async explicit commits.
-					return nil
-				}
-				atomic.AddUint64(&endTxn, 1)
-			}
+
+		srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Settings: st,
+			Knobs: base.TestingKnobs{Store: &kvserver.StoreTestingKnobs{
+				EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
+					TestingEvalFilter: filter,
+				},
+			}},
+		})
+		defer srv.Stopper().Stop(context.Background())
+		codecValue.Store(srv.ApplicationLayer().Codec())
+		sqlDB := sqlutils.MakeSQLRunner(conn)
+		sqlDB.Exec(t, `CREATE DATABASE d`)
+		sqlDB.Exec(t, `CREATE TABLE d.kv (k INT PRIMARY KEY, v INT)`)
+
+		// This should hit the fast path.
+		atomic.StoreUint64(&gets, 0)
+		atomic.StoreUint64(&scans, 0)
+		atomic.StoreUint64(&endTxn, 0)
+		sqlDB.Exec(t, `UPSERT INTO d.kv VALUES (1, 1)`)
+		if s := atomic.LoadUint64(&scans); s != 0 {
+			t.Errorf("expected no scans (the upsert fast path) but got %d", s)
 		}
-		return nil
-	}
+		if s := atomic.LoadUint64(&endTxn); s != 0 {
+			t.Errorf("expected no end-txn (1PC) but got %d", s)
+		}
 
-	srv, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Knobs: base.TestingKnobs{Store: &kvserver.StoreTestingKnobs{
-			EvalKnobs: kvserverbase.BatchEvalTestingKnobs{
-				TestingEvalFilter: filter,
-			},
-		}},
+		// This could hit the fast path, but doesn't right now because of #14482.
+		atomic.StoreUint64(&gets, 0)
+		atomic.StoreUint64(&scans, 0)
+		atomic.StoreUint64(&endTxn, 0)
+		sqlDB.Exec(t, `INSERT INTO d.kv VALUES (1, 1) ON CONFLICT (k) DO UPDATE SET v=excluded.v`)
+		if s := atomic.LoadUint64(&gets); s != 1 {
+			t.Errorf("expected 1 get (no upsert fast path) but got %d", s)
+		}
+		if s := atomic.LoadUint64(&scans); s != 0 {
+			t.Errorf("expected 0 scans but got %d", s)
+		}
+		if s := atomic.LoadUint64(&endTxn); s != 0 {
+			t.Errorf("expected no end-txn (1PC) but got %d", s)
+		}
+
+		// This should not hit the fast path because it doesn't set every column.
+		atomic.StoreUint64(&gets, 0)
+		atomic.StoreUint64(&scans, 0)
+		atomic.StoreUint64(&endTxn, 0)
+		sqlDB.Exec(t, `UPSERT INTO d.kv (k) VALUES (1)`)
+		if s := atomic.LoadUint64(&gets); s != 1 {
+			t.Errorf("expected 1 get (no upsert fast path) but got %d", s)
+		}
+		if s := atomic.LoadUint64(&scans); s != 0 {
+			t.Errorf("expected 0 scans but got %d", s)
+		}
+		if s := atomic.LoadUint64(&endTxn); s != 0 {
+			t.Errorf("expected no end-txn (1PC) but got %d", s)
+		}
+
+		// This should hit the fast path. 1PC is contingent on the use of buffered
+		// writes because we're executing an explicit transaction.
+		atomic.StoreUint64(&gets, 0)
+		atomic.StoreUint64(&scans, 0)
+		atomic.StoreUint64(&endTxn, 0)
+		tx, err := conn.Begin()
+		if err != nil {
+			t.Fatal(err)
+		}
+		if _, err := tx.Exec(`UPSERT INTO d.kv VALUES (1, 1)`); err != nil {
+			t.Fatal(err)
+		}
+		if err := tx.Commit(); err != nil {
+			t.Fatal(err)
+		}
+
+		expGets := uint64(0)
+		expEndTxns := uint64(1)
+		if bufferedWritesEnabled {
+			// When buffered writes are enabled, the Put is decomposed into a locking
+			// Get and a buffered Put.
+			expGets = 1
+			// When buffered writes are enabled, we're able to hit 1PC even though
+			// we're executing an explicit transaction.
+			expEndTxns = 0
+		}
+
+		if s := atomic.LoadUint64(&gets); s != expGets {
+			t.Errorf("expected %d gets (the upsert fast path) but got %d", expGets, s)
+		}
+		if s := atomic.LoadUint64(&scans); s != 0 {
+			t.Errorf("expected no scans (the upsert fast path) but got %d", s)
+		}
+		if s := atomic.LoadUint64(&endTxn); s != expEndTxns {
+			t.Errorf("expected %d end-txn (no 1PC) but got %d", expEndTxns, s)
+		}
+
+		// This should not hit the fast path because kv has a secondary index.
+		sqlDB.Exec(t, `CREATE INDEX vidx ON d.kv (v)`)
+		atomic.StoreUint64(&gets, 0)
+		atomic.StoreUint64(&scans, 0)
+		atomic.StoreUint64(&endTxn, 0)
+		sqlDB.Exec(t, `UPSERT INTO d.kv VALUES (1, 1)`)
+		if s := atomic.LoadUint64(&gets); s != 1 {
+			t.Errorf("expected 1 get (no upsert fast path) but got %d", s)
+		}
+		if s := atomic.LoadUint64(&scans); s != 0 {
+			t.Errorf("expected 0 scans (no upsert fast path) but got %d", s)
+		}
+		if s := atomic.LoadUint64(&endTxn); s != 0 {
+			t.Errorf("expected no end-txn (1PC) but got %d", s)
+		}
 	})
-	defer srv.Stopper().Stop(context.Background())
-	codecValue.Store(srv.ApplicationLayer().Codec())
-	sqlDB := sqlutils.MakeSQLRunner(conn)
-	sqlDB.Exec(t, `CREATE DATABASE d`)
-	sqlDB.Exec(t, `CREATE TABLE d.kv (k INT PRIMARY KEY, v INT)`)
-
-	// This should hit the fast path.
-	atomic.StoreUint64(&gets, 0)
-	atomic.StoreUint64(&scans, 0)
-	atomic.StoreUint64(&endTxn, 0)
-	sqlDB.Exec(t, `UPSERT INTO d.kv VALUES (1, 1)`)
-	if s := atomic.LoadUint64(&scans); s != 0 {
-		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&endTxn); s != 0 {
-		t.Errorf("expected no end-txn (1PC) but got %d", s)
-	}
-
-	// This could hit the fast path, but doesn't right now because of #14482.
-	atomic.StoreUint64(&gets, 0)
-	atomic.StoreUint64(&scans, 0)
-	atomic.StoreUint64(&endTxn, 0)
-	sqlDB.Exec(t, `INSERT INTO d.kv VALUES (1, 1) ON CONFLICT (k) DO UPDATE SET v=excluded.v`)
-	if s := atomic.LoadUint64(&gets); s != 1 {
-		t.Errorf("expected 1 get (no upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&scans); s != 0 {
-		t.Errorf("expected 0 scans but got %d", s)
-	}
-	if s := atomic.LoadUint64(&endTxn); s != 0 {
-		t.Errorf("expected no end-txn (1PC) but got %d", s)
-	}
-
-	// This should not hit the fast path because it doesn't set every column.
-	atomic.StoreUint64(&gets, 0)
-	atomic.StoreUint64(&scans, 0)
-	atomic.StoreUint64(&endTxn, 0)
-	sqlDB.Exec(t, `UPSERT INTO d.kv (k) VALUES (1)`)
-	if s := atomic.LoadUint64(&gets); s != 1 {
-		t.Errorf("expected 1 get (no upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&scans); s != 0 {
-		t.Errorf("expected 0 scans but got %d", s)
-	}
-	if s := atomic.LoadUint64(&endTxn); s != 0 {
-		t.Errorf("expected no end-txn (1PC) but got %d", s)
-	}
-
-	// This should hit the fast path, but won't be a 1PC because of the explicit
-	// transaction.
-	atomic.StoreUint64(&gets, 0)
-	atomic.StoreUint64(&scans, 0)
-	atomic.StoreUint64(&endTxn, 0)
-	tx, err := conn.Begin()
-	if err != nil {
-		t.Fatal(err)
-	}
-	if _, err := tx.Exec(`UPSERT INTO d.kv VALUES (1, 1)`); err != nil {
-		t.Fatal(err)
-	}
-	if err := tx.Commit(); err != nil {
-		t.Fatal(err)
-	}
-	if s := atomic.LoadUint64(&gets); s != 0 {
-		t.Errorf("expected no gets (the upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&scans); s != 0 {
-		t.Errorf("expected no scans (the upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&endTxn); s != 1 {
-		t.Errorf("expected 1 end-txn (no 1PC) but got %d", s)
-	}
-
-	// This should not hit the fast path because kv has a secondary index.
-	sqlDB.Exec(t, `CREATE INDEX vidx ON d.kv (v)`)
-	atomic.StoreUint64(&gets, 0)
-	atomic.StoreUint64(&scans, 0)
-	atomic.StoreUint64(&endTxn, 0)
-	sqlDB.Exec(t, `UPSERT INTO d.kv VALUES (1, 1)`)
-	if s := atomic.LoadUint64(&gets); s != 1 {
-		t.Errorf("expected 1 get (no upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&scans); s != 0 {
-		t.Errorf("expected 0 scans (no upsert fast path) but got %d", s)
-	}
-	if s := atomic.LoadUint64(&endTxn); s != 0 {
-		t.Errorf("expected no end-txn (1PC) but got %d", s)
-	}
 }
 
 func TestConcurrentUpsert(t *testing.T) {


### PR DESCRIPTION
We're able to hit 1PC in more cases when buffered writes are enabled. Teach TestUpsertFastPath about it.

Epic: none

Release note: None