### PR TITLE
release-25.2: sql/opt/optbuilder: apply RLS filters after virtual column projection

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -2176,6 +2176,202 @@ SET ROLE root
 statement ok
 DROP ROLE rls_cache_user;
 
+subtest computed_virtual_cols
+
+statement ok
+CREATE ROLE alice LOGIN;
+
+statement ok
+CREATE TABLE t (
+      k INT PRIMARY KEY,
+      a INT,
+      b INT,
+      c INT,
+      v INT AS (c + 1) VIRTUAL
+);
+
+statement ok
+INSERT INTO t VALUES (1,1,1,1),(-1,-1,-1,-1);
+
+statement ok
+GRANT SELECT, INSERT, UPDATE, DELETE ON t TO alice;
+
+statement ok
+ALTER TABLE t ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY select_policy
+ON t
+FOR SELECT
+TO alice
+USING (v > 0);
+
+statement ok
+CREATE POLICY insert_policy
+ON t
+FOR INSERT
+TO alice
+WITH CHECK (v > 1);
+
+statement ok
+CREATE POLICY update_policy
+ON t
+FOR UPDATE
+TO alice
+USING (v > 2);
+
+statement ok
+CREATE POLICY delete_policy
+ON t
+FOR DELETE
+TO alice
+USING (v > 3);
+
+statement ok
+SET ROLE alice;
+
+query IIIII
+SELECT * FROM t;
+----
+1  1  1  1  2
+
+query II
+SELECT k,a FROM t WHERE b IS NOT NULL;;
+----
+1  1
+
+statement ok
+INSERT INTO t VALUES (2,2,2,2);
+
+statement error pq: new row violates row-level security policy for table "t"
+INSERT INTO t VALUES (3,0,0,0);
+
+query IIIII
+UPDATE t SET c = 4 WHERE k = 2 RETURNING *;
+----
+2  2  2  4  5
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET c = 0 WHERE k = 2 RETURNING *;
+
+query I
+DELETE FROM t RETURNING v;
+----
+5
+
+statement ok
+SET ROLE root;
+
+query IIIII
+SELECT * FROM t ORDER BY k;
+----
+-1  -1  -1  -1  0
+1   1   1   1   2
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP USER ALICE;
+
+subtest computed_stored_cols
+
+statement ok
+CREATE ROLE pat LOGIN;
+
+statement ok
+CREATE TABLE t (
+      k INT PRIMARY KEY,
+      a INT,
+      b INT,
+      c INT,
+      v INT AS (c + 1) STORED
+);
+
+statement ok
+INSERT INTO t VALUES (1,1,1,1),(-1,-1,-1,-1);
+
+statement ok
+GRANT SELECT, INSERT, UPDATE, DELETE ON t TO pat;
+
+statement ok
+ALTER TABLE t ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY select_policy
+ON t
+FOR SELECT
+TO pat
+USING (v > 0);
+
+statement ok
+CREATE POLICY insert_policy
+ON t
+FOR INSERT
+TO pat
+WITH CHECK (v > 1);
+
+statement ok
+CREATE POLICY update_policy
+ON t
+FOR UPDATE
+TO pat
+USING (v > 2);
+
+statement ok
+CREATE POLICY delete_policy
+ON t
+FOR DELETE
+TO pat
+USING (v > 3);
+
+statement ok
+SET ROLE pat;
+
+query IIIII
+SELECT * FROM t;
+----
+1  1  1  1  2
+
+query II
+SELECT k,a FROM t WHERE b IS NOT NULL;;
+----
+1  1
+
+statement ok
+INSERT INTO t VALUES (2,2,2,2);
+
+statement error pq: new row violates row-level security policy for table "t"
+INSERT INTO t VALUES (3,0,0,0);
+
+query IIIII
+UPDATE t SET c = 4 WHERE k = 2 RETURNING *;
+----
+2  2  2  4  5
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET c = 0 WHERE k = 2 RETURNING *;
+
+query I
+DELETE FROM t RETURNING v;
+----
+5
+
+statement ok
+SET ROLE root;
+
+query IIIII
+SELECT * FROM t ORDER BY k;
+----
+-1  -1  -1  -1  0
+1   1   1   1   2
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP USER PAT;
+
 subtest block_invalid_expressions
 
 statement ok

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -753,7 +753,6 @@ func (b *Builder) buildScan(
 	// Add the partial indexes after constructing the scan so we can use the
 	// logical properties of the scan to fully normalize the index predicates.
 	b.addPartialIndexPredicatesForTable(tabMeta, outScope.expr)
-	b.addRowLevelSecurityFilter(tabMeta, outScope, policyCommandScope)
 
 	if !virtualColIDs.Empty() {
 		// Project the expressions for the virtual columns (and pass through all
@@ -770,6 +769,10 @@ func (b *Builder) buildScan(
 		})
 		outScope.expr = b.factory.ConstructProject(outScope.expr, proj, scanColIDs)
 	}
+
+	// Apply any filters required to enforce RLS policies. This must be done
+	// after projecting out virtual columns, in case any policies reference them.
+	b.addRowLevelSecurityFilter(tabMeta, outScope, policyCommandScope)
 
 	if b.trackSchemaDeps {
 		dep := opt.SchemaDep{DataSource: tab}

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -851,3 +851,291 @@ insert t1
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
            └── c3_default:9 >= '2025-01-01' [as=rls:11]
+
+# Tests for when stored virtual column is used in an RLS expression
+
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  v INT AS (c + 1) VIRTUAL
+);
+----
+
+exec-ddl
+ALTER TABLE t ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY select_policy
+ON t
+FOR SELECT
+TO fred
+USING (v > 0);
+----
+
+exec-ddl
+CREATE POLICY insert_policy
+ON t
+FOR INSERT
+TO fred
+USING (v > 1);
+----
+
+exec-ddl
+CREATE POLICY update_policy
+ON t
+FOR UPDATE
+TO fred
+USING (v > 5);
+----
+
+build
+SELECT * FROM t
+----
+project
+ ├── columns: k:1!null a:2 b:3 c:4 v:5!null
+ └── select
+      ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      ├── project
+      │    ├── columns: v:5 k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    ├── scan t
+      │    │    ├── columns: k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    │    └── computed column expressions
+      │    │         └── v:5
+      │    │              └── c:4 + 1
+      │    └── projections
+      │         └── c:4 + 1 [as=v:5]
+      └── filters
+           └── v:5 > 0
+
+# Do a SELECT that doesn't reference the virtual column.
+build
+SELECT k, c FROM t WHERE a IS NULL;
+----
+project
+ ├── columns: k:1!null c:4
+ └── select
+      ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      ├── select
+      │    ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    ├── project
+      │    │    ├── columns: v:5 k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    │    ├── scan t
+      │    │    │    ├── columns: k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    │    │    └── computed column expressions
+      │    │    │         └── v:5
+      │    │    │              └── c:4 + 1
+      │    │    └── projections
+      │    │         └── c:4 + 1 [as=v:5]
+      │    └── filters
+      │         └── v:5 > 0
+      └── filters
+           └── a:2 IS NULL
+
+build
+INSERT INTO t VALUES (1,2,3,4);
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => k:1
+ │    ├── column2:9 => a:2
+ │    ├── column3:10 => b:3
+ │    ├── column4:11 => c:4
+ │    └── v_comp:12 => v:5
+ ├── check columns: rls:13
+ └── project
+      ├── columns: rls:13!null column1:8!null column2:9!null column3:10!null column4:11!null v_comp:12!null
+      ├── project
+      │    ├── columns: v_comp:12!null column1:8!null column2:9!null column3:10!null column4:11!null
+      │    ├── values
+      │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null
+      │    │    └── (1, 2, 3, 4)
+      │    └── projections
+      │         └── column4:11 + 1 [as=v_comp:12]
+      └── projections
+           └── v_comp:12 > 1 [as=rls:13]
+
+build
+UPDATE t SET c = -10 WHERE k = 1;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: k:8 a:9 b:10 c:11 v:12
+ ├── update-mapping:
+ │    ├── c_new:15 => c:4
+ │    └── v_comp:16 => v:5
+ ├── check columns: rls:17
+ └── project
+      ├── columns: rls:17!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14 c_new:15!null v_comp:16!null
+      ├── project
+      │    ├── columns: v_comp:16!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14 c_new:15!null
+      │    ├── project
+      │    │    ├── columns: c_new:15!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── select
+      │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: v:12 k:8!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    │    ├── scan t
+      │    │    │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    │    └── v:12
+      │    │    │    │    │    │    │         └── c:11 + 1
+      │    │    │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         └── c:11 + 1 [as=v:12]
+      │    │    │    │    └── filters
+      │    │    │    │         └── (v:12 > 0) AND (v:12 > 5)
+      │    │    │    └── filters
+      │    │    │         └── k:8 = 1
+      │    │    └── projections
+      │    │         └── -10 [as=c_new:15]
+      │    └── projections
+      │         └── c_new:15 + 1 [as=v_comp:16]
+      └── projections
+           └── (v_comp:16 > 0) AND (v_comp:16 > 5) [as=rls:17]
+
+# Tests for when computed stored column is used in an RLS expression
+
+exec-ddl
+DROP TABLE t
+----
+
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  v INT AS (c + 1) STORED
+);
+----
+
+exec-ddl
+ALTER TABLE t ENABLE ROW LEVEL SECURITY, FORCE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY select_policy
+ON t
+FOR SELECT
+TO fred
+USING (v > 0);
+----
+
+exec-ddl
+CREATE POLICY insert_policy
+ON t
+FOR INSERT
+TO fred
+USING (v > 1);
+----
+
+exec-ddl
+CREATE POLICY update_policy
+ON t
+FOR UPDATE
+TO fred
+USING (v > 5);
+----
+
+build
+SELECT * FROM t
+----
+project
+ ├── columns: k:1!null a:2 b:3 c:4 v:5!null
+ └── select
+      ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      ├── scan t
+      │    ├── columns: k:1!null a:2 b:3 c:4 v:5 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    └── computed column expressions
+      │         └── v:5
+      │              └── c:4 + 1
+      └── filters
+           └── v:5 > 0
+
+# Do a SELECT that doesn't reference the stored column.
+build
+SELECT k, c FROM t WHERE a IS NULL;
+----
+project
+ ├── columns: k:1!null c:4
+ └── select
+      ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      ├── select
+      │    ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    ├── scan t
+      │    │    ├── columns: k:1!null a:2 b:3 c:4 v:5 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │    │    └── computed column expressions
+      │    │         └── v:5
+      │    │              └── c:4 + 1
+      │    └── filters
+      │         └── v:5 > 0
+      └── filters
+           └── a:2 IS NULL
+
+build
+INSERT INTO t VALUES (1,2,3,4);
+----
+insert t
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => k:1
+ │    ├── column2:9 => a:2
+ │    ├── column3:10 => b:3
+ │    ├── column4:11 => c:4
+ │    └── v_comp:12 => v:5
+ ├── check columns: rls:13
+ └── project
+      ├── columns: rls:13!null column1:8!null column2:9!null column3:10!null column4:11!null v_comp:12!null
+      ├── project
+      │    ├── columns: v_comp:12!null column1:8!null column2:9!null column3:10!null column4:11!null
+      │    ├── values
+      │    │    ├── columns: column1:8!null column2:9!null column3:10!null column4:11!null
+      │    │    └── (1, 2, 3, 4)
+      │    └── projections
+      │         └── column4:11 + 1 [as=v_comp:12]
+      └── projections
+           └── v_comp:12 > 1 [as=rls:13]
+
+build
+UPDATE t SET c = -10 WHERE k = 1;
+----
+update t
+ ├── columns: <none>
+ ├── fetch columns: k:8 a:9 b:10 c:11 v:12
+ ├── update-mapping:
+ │    ├── c_new:15 => c:4
+ │    └── v_comp:16 => v:5
+ ├── check columns: rls:17
+ └── project
+      ├── columns: rls:17!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14 c_new:15!null v_comp:16!null
+      ├── project
+      │    ├── columns: v_comp:16!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14 c_new:15!null
+      │    ├── project
+      │    │    ├── columns: c_new:15!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    ├── select
+      │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    ├── scan t
+      │    │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    └── v:12
+      │    │    │    │    │    │         └── c:11 + 1
+      │    │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    └── filters
+      │    │    │    │         └── (v:12 > 0) AND (v:12 > 5)
+      │    │    │    └── filters
+      │    │    │         └── k:8 = 1
+      │    │    └── projections
+      │    │         └── -10 [as=c_new:15]
+      │    └── projections
+      │         └── c_new:15 + 1 [as=v_comp:16]
+      └── projections
+           └── (v_comp:16 > 0) AND (v_comp:16 > 5) [as=rls:17]


### PR DESCRIPTION
Backport 1/1 commits from #144841 on behalf of @spilchen.

/cc @cockroachdb/release

----

Previously, row-level security (RLS) filters were applied before virtual columns were projected from their computed expressions. This caused issues when filters referenced virtual columns, since the projection had not yet occurred—leading to outer column references that violated optimizer invariants.

A simple SELECT query with a virtual column and an RLS filter would produce a plan like:

```
project
 ├── columns: k:1!null a:2 b:3 c:4 v:5
 └── project
      ├── ...
      ├── select
      │    ├── ...
      │    └── filters
      │         └── v:5 > 0  # ← RLS filter, but v:5 not yet projected
      └── projections
           └── c:4 + 1 [as=v:5]  # ← project virtual column v:5 
```

This change moves the RLS filter construction to after the projection of virtual columns, ensuring filters reference valid columns. The revised plan correctly applies the RLS filter post-projection:

```
project
 ├── ...
 └── select
      ├── ...
      ├── project
      │    ├── ...
      │    └── projections
      │         └── c:4 + 1 [as=v:5]
      └── filters
           └── v:5 > 0
```

Fixes #144771

Epic: CRDB-11724
Release note: none

----

Release justification: important fix for new 25.2 feature