### PR TITLE
ui: bump cluster-ui version to 25.1.1

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.1.0-prerelease.1",
+  "version": "25.1.1",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Epic: None
Release note: None