### PR TITLE
ui: bump cluster-ui version to 25.2.0

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.2.0-prerelease.0",
+  "version": "25.2.0",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",


### PR DESCRIPTION
Epic: None
Release note: None