### PR TITLE
sql: optimize SHOW CREATE TABLE performance with many schema objects

### DIFF
--- a/pkg/ccl/benchccl/rttanalysisccl/testdata/benchmark_expectations
+++ b/pkg/ccl/benchccl/rttanalysisccl/testdata/benchmark_expectations
@@ -17,3 +17,6 @@ exp,benchmark
 10,AlterTableLocality/alter_from_rbr_to_regional_by_table
 13,AlterTableLocality/alter_from_regional_by_table_to_global
 18,AlterTableLocality/alter_from_regional_by_table_to_rbr
+10,VirtualTableQueries/select_from_crdb_internal.zones_(100_tables)
+10,VirtualTableQueries/select_from_crdb_internal.zones_(10_tables)
+10,VirtualTableQueries/select_from_crdb_internal.zones_(50_tables)


### PR DESCRIPTION
Previously, SHOW CREATE TABLE queried the crdb_internal.zones table to extract the zone configuration. This could be slow with a large number of objects because the subquery needed to scan the entirety of crdb_internal.zones, which would do one round-trip per zone config (to fetch descriptors). This patch optimizes crdb_internal.zones to fetch all required descriptors in a single request, instead of performing a round trip for each descriptor. Additionally, this patch adds a new BenchmarkORMQueries test in the rttanalysisccl package, configured for multi-region testing.

Fixes: #141827

Release note (bug fix): Improve slow SHOW CREATE TABLE on multi-region
databases with large number of objects