### PR TITLE
release-25.2: sql/vecindex: support operator class and index type syntax

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_index
@@ -206,11 +206,11 @@ SHOW CREATE TABLE vector
             b INT8 NULL,
             v VECTOR(3) NULL,
             CONSTRAINT vector_pkey PRIMARY KEY (a ASC),
-            VECTOR INDEX vector_b_v_idx (b ASC, v) PARTITION BY LIST (b) (
+            VECTOR INDEX vector_b_v_idx (b ASC, v vector_l2_ops) PARTITION BY LIST (b) (
               PARTITION p1 VALUES IN ((1)),
               PARTITION pu VALUES IN ((NULL))
             ),
-            VECTOR INDEX vector_idx (a ASC, b ASC, v) PARTITION BY LIST (a, b) (
+            VECTOR INDEX vector_idx (a ASC, b ASC, v vector_l2_ops) PARTITION BY LIST (a, b) (
               PARTITION p1 VALUES IN ((1, 1), (2, 2))
             )
           )

--- a/pkg/cmd/roachtest/testdata/pg_regress/btree_index.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/btree_index.diffs
@@ -86,13 +86,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/btree_index.out -
  -- "lost".
  --
  CREATE INDEX bt_i4_index ON bt_i4_heap USING btree (seqno int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX bt_name_index ON bt_name_heap USING btree (seqno name_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX bt_txt_index ON bt_txt_heap USING btree (seqno text_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX bt_f8_index ON bt_f8_heap USING btree (seqno float8_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  --
  -- test retrieval of min/max keys for each index
  --

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_index.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_index.diffs
@@ -10,10 +10,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  -- BTREE
  --
  CREATE INDEX onek_unique1 ON onek USING btree(unique1 int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX IF NOT EXISTS onek_unique1 ON onek USING btree(unique1 int4_ops);
 -NOTICE:  relation "onek_unique1" already exists, skipping
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX IF NOT EXISTS ON onek USING btree(unique1 int4_ops);
 -ERROR:  syntax error at or near "ON"
 -LINE 1: CREATE INDEX IF NOT EXISTS ON onek USING btree(unique1 int4_...
@@ -24,24 +24,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
 +                              ^
 +HINT:  try \h CREATE INDEX
  CREATE INDEX onek_unique2 ON onek USING btree(unique2 int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX onek_hundred ON onek USING btree(hundred int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX onek_stringu1 ON onek USING btree(stringu1 name_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX tenk1_unique1 ON tenk1 USING btree(unique1 int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX tenk1_unique2 ON tenk1 USING btree(unique2 int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX tenk1_hundred ON tenk1 USING btree(hundred int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX tenk1_thous_tenthous ON tenk1 (thousand, tenthous);
  CREATE INDEX tenk2_unique1 ON tenk2 USING btree(unique1 int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX tenk2_unique2 ON tenk2 USING btree(unique2 int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX tenk2_hundred ON tenk2 USING btree(hundred int4_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX rix ON road USING btree (name text_ops);
 +ERROR:  relation "road" does not exist
  CREATE INDEX iix ON ihighway USING btree (name text_ops);
@@ -61,13 +61,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  --
  CREATE INDEX onek2_u1_prtl ON onek2 USING btree(unique1 int4_ops)
  	where unique1 < 20 or unique1 > 980;
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX onek2_u2_prtl ON onek2 USING btree(unique2 int4_ops)
  	where stringu1 < 'B';
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  CREATE INDEX onek2_stu1_prtl ON onek2 USING btree(stringu1 name_ops)
  	where onek2.stringu1 >= 'J' and onek2.stringu1 < 'K';
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  --
  -- GiST (rtree-equivalent opclasses only)
  --
@@ -2086,7 +2086,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  DROP TABLE func_index_heap;
  CREATE TABLE func_index_heap (f1 text, f2 text);
  CREATE UNIQUE INDEX func_index_index on func_index_heap ((f1 || f2) text_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  INSERT INTO func_index_heap VALUES('ABC','DEF');
  INSERT INTO func_index_heap VALUES('AB','CDEFG');
  INSERT INTO func_index_heap VALUES('QWE','RTY');

--- a/pkg/cmd/roachtest/testdata/pg_regress/insert_conflict.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/insert_conflict.diffs
@@ -5,7 +5,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/insert_conflict.o
  -- named collations
  --
  create unique index op_index_key on insertconflicttest(key, fruit text_pattern_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create unique index collation_index_key on insertconflicttest(key, fruit collate "C");
 +ERROR:  at or near "collate": syntax error
 +DETAIL:  source SQL:

--- a/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
@@ -5,7 +5,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      comment	text
  );
  create unique index Room_rno on Room using btree (roomno bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table WSlot (
      slotname	char(20),
      roomno	char(8),
@@ -13,13 +13,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      backlink	char(20)
  );
  create unique index WSlot_name on WSlot using btree (slotname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table PField (
      name	text,
      comment	text
  );
  create unique index PField_name on PField using btree (name text_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table PSlot (
      slotname	char(20),
      pfname	text,
@@ -27,7 +27,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      backlink	char(20)
  );
  create unique index PSlot_name on PSlot using btree (slotname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table PLine (
      slotname	char(20),
      phonenumber	char(20),
@@ -35,14 +35,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      backlink	char(20)
  );
  create unique index PLine_name on PLine using btree (slotname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table Hub (
      name	char(14),
      comment	text,
      nslots	integer
  );
  create unique index Hub_name on Hub using btree (name bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table HSlot (
      slotname	char(20),
      hubname	char(14),
@@ -50,15 +50,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      slotlink	char(20)
  );
  create unique index HSlot_name on HSlot using btree (slotname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create index HSlot_hubname on HSlot using btree (hubname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table System (
      name	text,
      comment	text
  );
  create unique index System_name on System using btree (name text_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table IFace (
      slotname	char(20),
      sysname	text,
@@ -66,14 +66,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      slotlink	char(20)
  );
  create unique index IFace_name on IFace using btree (slotname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  create table PHone (
      slotname	char(20),
      comment	text,
      slotlink	char(20)
  );
  create unique index PHone_name on PHone using btree (slotname bpchar_ops);
-+ERROR:  operator classes are only allowed for the last column of an inverted index
++ERROR:  operator classes are only allowed for the last column of an inverted or vector index
  -- ************************************************************
  -- *
  -- * Trigger procedures and functions for the patchfield

--- a/pkg/sql/catalog/catformat/index.go
+++ b/pkg/sql/catalog/catformat/index.go
@@ -248,13 +248,19 @@ func FormatIndexElements(
 		} else {
 			f.FormatNameP(&index.KeyColumnNames[i])
 		}
-		// TODO(drewk): we might need to print something like "vector_l2_ops" for
-		// vector indexes.
-		if index.Type == idxtype.INVERTED &&
-			col.GetID() == index.InvertedColumnID() && len(index.InvertedColumnKinds) > 0 {
-			switch index.InvertedColumnKinds[0] {
-			case catpb.InvertedIndexColumnKind_TRIGRAM:
-				f.WriteString(" gin_trgm_ops")
+		switch index.Type {
+		case idxtype.INVERTED:
+			if col.GetID() == index.InvertedColumnID() && len(index.InvertedColumnKinds) > 0 {
+				switch index.InvertedColumnKinds[0] {
+				case catpb.InvertedIndexColumnKind_TRIGRAM:
+					f.WriteString(" gin_trgm_ops")
+				}
+			}
+		case idxtype.VECTOR:
+			// TODO(#144016): once more distance functions are supported, store the
+			// operator on the index and use it here.
+			if col.GetID() == index.VectorColumnID() {
+				f.WriteString(" vector_l2_ops")
 			}
 		}
 		// The last column of an inverted or vector index cannot have a DESC

--- a/pkg/sql/catalog/catformat/index_test.go
+++ b/pkg/sql/catalog/catformat/index_test.go
@@ -277,16 +277,16 @@ func TestIndexForDisplay(t *testing.T) {
 			tableName:   descpb.AnonymousTable,
 			partition:   "",
 			displayMode: IndexDisplayDefOnly,
-			expected:    "VECTOR INDEX baz (a)",
-			pgExpected:  "INDEX baz USING cspann (a)",
+			expected:    "VECTOR INDEX baz (a vector_l2_ops)",
+			pgExpected:  "INDEX baz USING cspann (a vector_l2_ops)",
 		},
 		{
 			index:       vectorIndex,
 			tableName:   tableName,
 			partition:   "",
 			displayMode: IndexDisplayShowCreate,
-			expected:    "CREATE VECTOR INDEX baz ON foo.public.bar (a)",
-			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING cspann (a)",
+			expected:    "CREATE VECTOR INDEX baz ON foo.public.bar (a vector_l2_ops)",
+			pgExpected:  "CREATE INDEX baz ON foo.public.bar USING cspann (a vector_l2_ops)",
 		},
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/create_index
+++ b/pkg/sql/logictest/testdata/logic_test/create_index
@@ -422,12 +422,12 @@ CREATE TABLE opclasses (a INT PRIMARY KEY, b TEXT, c JSON)
 
 # Make sure that we don't permit creating indexes with opclasses that aren't
 # inverted.
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 CREATE INDEX ON opclasses(b blah_ops)
 
 # Make sure that we don't permit creating indexes with opclasses that aren't
 # inverted, even if the type is invertible.
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 CREATE INDEX ON opclasses(c blah_ops)
 
 # Make sure that we don't permit creating indexes with opclasses that don't exist

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -219,7 +219,7 @@ like_indexes  CREATE TABLE public.like_indexes (
                 UNIQUE INDEX foo (b DESC, c ASC),
                 INDEX like_table_c_idx (c ASC) STORING (j),
                 INVERTED INDEX like_table_j_idx (j),
-                VECTOR INDEX like_table_v_idx (v)
+                VECTOR INDEX like_table_v_idx (v vector_l2_ops)
               )
 
 # INCLUDING GENERATED adds "generated columns", aka stored columns.
@@ -280,7 +280,7 @@ like_all  CREATE TABLE public.like_all (
             UNIQUE INDEX foo (b DESC, c ASC),
             INDEX like_table_c_idx (c ASC) STORING (j),
             INVERTED INDEX like_table_j_idx (j),
-            VECTOR INDEX like_table_v_idx (v),
+            VECTOR INDEX like_table_v_idx (v vector_l2_ops),
             CONSTRAINT check_a CHECK (a > 3:::INT8),
             CONSTRAINT unique_k UNIQUE WITHOUT INDEX (k),
             CONSTRAINT unique_h UNIQUE WITHOUT INDEX (h),
@@ -308,7 +308,7 @@ like_mixed  CREATE TABLE public.like_mixed (
               UNIQUE INDEX foo (b DESC, c ASC),
               INDEX like_table_c_idx (c ASC) STORING (j),
               INVERTED INDEX like_table_j_idx (j),
-              VECTOR INDEX like_table_v_idx (v)
+              VECTOR INDEX like_table_v_idx (v vector_l2_ops)
             )
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -29,7 +29,7 @@ CREATE TABLE public.t (
   INDEX t_a_plus_b_idx ((a + b) ASC),
   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
   INVERTED INDEX t_b_j_a_asc (b DESC, (j->'a':::STRING)),
-  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3))),
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3)) vector_l2_ops),
   FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 )
 
@@ -48,7 +48,7 @@ CREATE TABLE public.t (
   INDEX t_a_plus_b_idx ((a + b) ASC),
   INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
   INVERTED INDEX t_b_j_a_asc (b DESC, (j->‹×›:::STRING)),
-  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3))),
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3)) vector_l2_ops),
   FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 )
 
@@ -528,7 +528,7 @@ CREATE TABLE public.copy_indexes (
   INDEX named_idx ((a + 1:::INT8) ASC),
   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
   INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
-  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)))
+  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)) vector_l2_ops)
 )
 
 # Inaccessible expression index columns should be copied if the indexes are
@@ -557,7 +557,7 @@ CREATE TABLE public.copy_all (
   INDEX named_idx ((a + 1:::INT8) ASC),
   UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
   INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
-  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)))
+  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)) vector_l2_ops)
 )
 
 # Inaccessible expression index columns should be copied if the indexes are

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1383,7 +1383,7 @@ vec  CREATE TABLE public.vec (
        id INT8 NOT NULL,
        v VECTOR(3) NULL,
        CONSTRAINT vec_pkey PRIMARY KEY (id ASC),
-       VECTOR INDEX vec_id_v_idx (id ASC, v) WHERE (v <-> '[3,1,2]':::VECTOR) < 1.0:::FLOAT8,
+       VECTOR INDEX vec_id_v_idx (id ASC, v vector_l2_ops) WHERE (v <-> '[3,1,2]':::VECTOR) < 1.0:::FLOAT8,
        FAMILY fam_0_id_v (id, v)
      )
 

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -4132,8 +4132,8 @@ WHERE tablename = 'vector_table'
 ORDER BY indexname
 ----
 indexname          indexdef
-idxa               CREATE INDEX idxa ON test.public.vector_table USING cspann (a)
-idxb               CREATE INDEX idxb ON test.public.vector_table USING cspann (a)
+idxa               CREATE INDEX idxa ON test.public.vector_table USING cspann (a vector_l2_ops)
+idxb               CREATE INDEX idxb ON test.public.vector_table USING cspann (a vector_l2_ops)
 vector_table_pkey  CREATE UNIQUE INDEX vector_table_pkey ON test.public.vector_table USING btree (id ASC)
 
 subtest partial_index

--- a/pkg/sql/logictest/testdata/logic_test/trigram_indexes
+++ b/pkg/sql/logictest/testdata/logic_test/trigram_indexes
@@ -7,10 +7,10 @@ CREATE INVERTED INDEX ON a(t)
 statement error data type text has no default operator class for access method \"gin\"
 CREATE INDEX ON a USING GIN(t)
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 CREATE INDEX ON a (t gin_trgm_ops)
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 CREATE INVERTED INDEX ON a (a gin_trgm_ops, t gin_trgm_ops)
 
 statement error operator class \"blah_ops\" does not exist
@@ -244,19 +244,19 @@ foobar 367
 
 # Regression tests for #84512. Do not allow opclasses for non-inverted columns.
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 create table err (a int, index (a jsonb_ops));
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 create table err (a int, index (a gin_trgm_ops));
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 create table err (a int, index (a gist_trgm_ops));
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 create table err (a int, b int, index (a gin_trgm_ops, b));
 
-statement error pgcode 42804 operator classes are only allowed for the last column of an inverted index
+statement error pgcode 42804 operator classes are only allowed for the last column of an inverted or vector index
 create table err (a int, j json, inverted index (a gin_trgm_ops, j));
 
 # Regression test for #86614. Do not display opclasses for non-inverted columns

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -2,6 +2,8 @@
 # CREATE TABLE/INDEX tests.
 # ------------------------------------------------------------------------------
 
+subtest create_table_index
+
 # Test guardrail for vector index creation.
 # TODO(mw5h): remove these two statements once online modifications are supported.
 statement ok
@@ -44,10 +46,10 @@ simple  CREATE TABLE public.simple (
           b INT8 NOT NULL,
           vec1 VECTOR(3) NULL,
           CONSTRAINT simple_pkey PRIMARY KEY (b ASC),
-          VECTOR INDEX simple_vec1_idx (vec1),
-          VECTOR INDEX simple_vec1_idx1 (vec1),
+          VECTOR INDEX simple_vec1_idx (vec1 vector_l2_ops),
+          VECTOR INDEX simple_vec1_idx1 (vec1 vector_l2_ops),
           UNIQUE INDEX simple_a_key (a ASC),
-          VECTOR INDEX simple_vec1_idx2 (vec1),
+          VECTOR INDEX simple_vec1_idx2 (vec1 vector_l2_ops),
           FAMILY fam_0_a_vec1_b (a, vec1, b)
         )
 
@@ -82,8 +84,8 @@ alt_syntax  CREATE TABLE public.alt_syntax (
               a INT8 NOT NULL,
               vec1 VECTOR(3) NULL,
               CONSTRAINT alt_syntax_pkey PRIMARY KEY (a ASC),
-              VECTOR INDEX vec_idx (vec1),
-              VECTOR INDEX another_index (vec1),
+              VECTOR INDEX vec_idx (vec1 vector_l2_ops),
+              VECTOR INDEX another_index (vec1 vector_l2_ops),
               FAMILY fam_0_a_vec1 (a, vec1)
             )
 
@@ -109,8 +111,8 @@ multiple_indexes  CREATE TABLE public.multiple_indexes (
                     vec1 VECTOR(3) NULL,
                     vec2 VECTOR(1000) NULL,
                     CONSTRAINT multiple_indexes_pkey PRIMARY KEY (a ASC),
-                    VECTOR INDEX multiple_indexes_vec1_idx (vec1),
-                    VECTOR INDEX multiple_indexes_vec2_idx (vec2),
+                    VECTOR INDEX multiple_indexes_vec1_idx (vec1 vector_l2_ops),
+                    VECTOR INDEX multiple_indexes_vec2_idx (vec2 vector_l2_ops),
                     FAMILY fam_0_a_vec1_vec2 (a, vec1, vec2)
                   )
 
@@ -146,8 +148,8 @@ prefix_cols  CREATE TABLE public.prefix_cols (
                c INT8 NULL,
                vec1 VECTOR(3) NULL,
                CONSTRAINT prefix_cols_pkey PRIMARY KEY (a ASC),
-               VECTOR INDEX prefix_cols_c_b_vec1_idx (c DESC, b ASC, vec1),
-               VECTOR INDEX another_index (b ASC, c DESC, vec1),
+               VECTOR INDEX prefix_cols_c_b_vec1_idx (c DESC, b ASC, vec1 vector_l2_ops),
+               VECTOR INDEX another_index (b ASC, c DESC, vec1 vector_l2_ops),
                FAMILY fam_0_a_b_c_vec1 (a, b, c, vec1)
              )
 
@@ -187,15 +189,37 @@ storage_params  CREATE TABLE public.storage_params (
                   a INT8 NOT NULL,
                   v VECTOR(3) NULL,
                   CONSTRAINT storage_params_pkey PRIMARY KEY (a ASC),
-                  VECTOR INDEX storage_params_v_idx (v) WITH (build_beam_size=16),
-                  VECTOR INDEX storage_params_v_idx1 (v) WITH (min_partition_size=8, max_partition_size=64),
+                  VECTOR INDEX storage_params_v_idx (v vector_l2_ops) WITH (build_beam_size=16),
+                  VECTOR INDEX storage_params_v_idx1 (v vector_l2_ops) WITH (min_partition_size=8, max_partition_size=64),
                   FAMILY fam_0_a_v (a, v)
                 )
 
 statement ok
 DROP TABLE storage_params
 
+# It is possible to specify the default vector_l2_ops operator class.
+statement ok
+CREATE TABLE operator_class (
+  a INT PRIMARY KEY,
+  b INT,
+  vec1 VECTOR(3),
+  VECTOR INDEX (vec1 vector_l2_ops),
+  VECTOR INDEX (b, vec1 vector_l2_ops)
+)
+
+statement ok
+CREATE INDEX ON operator_class USING cspann (vec1 vector_l2_ops)
+
+statement ok
+CREATE INDEX ON operator_class USING cspann (b, vec1 vector_l2_ops)
+
+statement ok
+DROP TABLE operator_class
+
+subtest end
+
 # ----- CREATE TABLE errors -----
+subtest create_table_errors
 
 # Try to use vector in primary key.
 statement error column a has type vector, which is not indexable in a non-vector index\nHINT: you may want to create a vector index instead
@@ -243,7 +267,11 @@ CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), VECTOR INDEX (b, c DESC) 
 statement error pgcode 22023 max_partition_size \(7\) must be at least four times the value of min_partition_size \(2\)
 CREATE TABLE t (a INT PRIMARY KEY, b INT, c VECTOR(3), VECTOR INDEX (b, c DESC) WITH (min_partition_size = 2, max_partition_size = 7))
 
+subtest end
+
 # ----- CREATE INDEX errors -----
+subtest create_index_errors
+
 statement ok
 CREATE TABLE vec_errors (
   a INT PRIMARY KEY,
@@ -287,9 +315,15 @@ CREATE VECTOR INDEX on vec_errors (vec1) STORING (b);
 statement error at or near "hnsw": syntax error: unrecognized access method: hnsw
 CREATE INDEX ON vec_errors USING hnsw (vec1)
 
-# Operator classes are not (yet) supported.
-statement error operator classes are only allowed for the last column of an inverted index
-CREATE INDEX ON vec_errors USING cspann (vec1 vector_l2_ops)
+# Operator classes other than vector_l2_ops are not (yet) supported.
+statement error pgcode 0A000 pq: unimplemented: operator class vector_l1_ops is not supported
+CREATE INDEX ON vec_errors USING cspann (vec1 vector_l1_ops)
+
+statement error pgcode 0A000 pq: unimplemented: operator class vector_cosine_ops is not supported
+CREATE INDEX ON vec_errors USING cspann (vec1 vector_cosine_ops)
+
+statement error pgcode 42704 pq: operator class "nonexistent_op_type" does not exist
+CREATE INDEX ON vec_errors USING cspann (vec1 nonexistent_op_type)
 
 # Storage param error.
 statement error pgcode 22023 "build_beam_size" value must be between 1 and 512 inclusive
@@ -298,10 +332,14 @@ CREATE VECTOR INDEX ON vec_errors (vec1) WITH (build_beam_size = 0)
 statement ok
 DROP TABLE vec_errors
 
+subtest end
+
 # ------------------------------------------------------------------------------
 # ALTER TABLE tests.
 # TODO(andyk): Move these tests to alter_primary_key when insertion is possible.
 # ------------------------------------------------------------------------------
+
+subtest alter_table
 
 statement ok
 CREATE TABLE alter_test (
@@ -323,7 +361,7 @@ alter_test  CREATE TABLE public.alter_test (
               b INT8 NOT NULL,
               vec1 VECTOR(3) NULL,
               CONSTRAINT alter_test_pkey PRIMARY KEY (b ASC),
-              VECTOR INDEX alter_test_vec1_idx (vec1),
+              VECTOR INDEX alter_test_vec1_idx (vec1 vector_l2_ops),
               UNIQUE INDEX alter_test_a_key (a ASC),
               FAMILY fam_0_a_b_vec1 (a, b, vec1)
             )
@@ -331,10 +369,14 @@ alter_test  CREATE TABLE public.alter_test (
 statement ok
 DROP TABLE alter_test
 
+subtest end
+
 # ------------------------------------------------------------------------------
 # Execution tests.
 # ------------------------------------------------------------------------------
+subtest execution
 
+# Use small partition size so that index has more than one level.
 statement ok
 CREATE TABLE exec_test (
   a INT PRIMARY KEY,
@@ -388,6 +430,8 @@ SELECT a FROM exec_test WHERE b IS NULL ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 3;
 
 statement ok
 DROP TABLE exec_test
+
+subtest end
 
 #
 # Test backfill.

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -38,6 +38,10 @@ ALTER TABLE simple ALTER PRIMARY KEY USING COLUMNS (b)
 statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
 CREATE INDEX ON simple USING cspann (vec1 ASC);
 
+# We allow hnsw as an alias for cspann.
+statement ok
+CREATE INDEX ON simple USING hnsw (vec1);
+
 query TT
 SHOW CREATE TABLE simple
 ----
@@ -50,6 +54,7 @@ simple  CREATE TABLE public.simple (
           VECTOR INDEX simple_vec1_idx1 (vec1 vector_l2_ops),
           UNIQUE INDEX simple_a_key (a ASC),
           VECTOR INDEX simple_vec1_idx2 (vec1 vector_l2_ops),
+          VECTOR INDEX simple_vec1_idx3 (vec1 vector_l2_ops),
           FAMILY fam_0_a_vec1_b (a, vec1, b)
         )
 
@@ -312,8 +317,8 @@ statement error vector indexes don't support stored columns
 CREATE VECTOR INDEX on vec_errors (vec1) STORING (b);
 
 # Try to use unsupported vector index type.
-statement error at or near "hnsw": syntax error: unrecognized access method: hnsw
-CREATE INDEX ON vec_errors USING hnsw (vec1)
+statement error at or near "ivfflat": syntax error: unrecognized access method: ivfflat
+CREATE INDEX ON vec_errors USING ivfflat (vec1)
 
 # Operator classes other than vector_l2_ops are not (yet) supported.
 statement error pgcode 0A000 pq: unimplemented: operator class vector_l1_ops is not supported

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -1850,7 +1850,7 @@ func (oi *optIndex) InvertedColumn() cat.IndexColumn {
 // VectorColumn is part of the cat.Index interface.
 func (oi *optIndex) VectorColumn() cat.IndexColumn {
 	if oi.Type() != idxtype.VECTOR {
-		panic(errors.AssertionFailedf("non-vector indexes do not have inverted columns"))
+		panic(errors.AssertionFailedf("non-vector indexes do not have vector columns"))
 	}
 	ord := oi.idx.NumKeyColumns() - 1
 	return oi.Column(ord)

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -12353,7 +12353,7 @@ opt_index_access_method:
         val = idxtype.INVERTED
       case "btree":
         val = idxtype.FORWARD
-      case "cspann":
+      case "cspann", "hnsw":
         val = idxtype.VECTOR
       case "hash", "spgist", "brin":
         return unimplemented(sqllex, "index using " + $2)

--- a/pkg/sql/parser/testdata/create_index
+++ b/pkg/sql/parser/testdata/create_index
@@ -532,3 +532,11 @@ CREATE VECTOR INDEX a ON b (c) WITH ('build_beam_size' = 16, 'min_partition_size
 CREATE VECTOR INDEX a ON b (c) WITH ('build_beam_size' = (16), 'min_partition_size' = (8), 'max_partition_size' = (32)) -- fully parenthesized
 CREATE VECTOR INDEX a ON b (c) WITH ('build_beam_size' = _, 'min_partition_size' = _, 'max_partition_size' = _) -- literals removed
 CREATE VECTOR INDEX _ ON _ (_) WITH ('build_beam_size' = 16, 'min_partition_size' = 8, 'max_partition_size' = 32) -- identifiers removed
+
+parse
+CREATE INDEX a ON b USING HNSW (c)
+----
+CREATE VECTOR INDEX a ON b (c) -- normalized!
+CREATE VECTOR INDEX a ON b (c) -- fully parenthesized
+CREATE VECTOR INDEX a ON b (c) -- literals removed
+CREATE VECTOR INDEX _ ON _ (_) -- identifiers removed

--- a/pkg/sql/sem/idxtype/idxtype.go
+++ b/pkg/sql/sem/idxtype/idxtype.go
@@ -53,10 +53,11 @@ func (t T) SupportsStoring() bool {
 // SupportsOpClass is true if this index type allows columns to specify an
 // operator class, which defines an alternate set of operators used when sorting
 // and querying those columns.
-// NOTE: Currently, only inverted indexes support operator classes, and only on
-// the last column of the index.
+//
+// NOTE: Currently, only inverted and vector indexes support operator classes,
+// and only on the last column of the index.
 func (t T) SupportsOpClass() bool {
-	return t == INVERTED
+	return t == INVERTED || t == VECTOR
 }
 
 // ErrorText describes the type of the index using the phrase "an inverted


### PR DESCRIPTION
Backport 2/2 commits from #144533.

/cc @cockroachdb/release

---

#### sql/vecindex: ability to specify distance functions for index creation

This commit adds support for specifying the operator class for a vector
index (e.g. `vector_l2_ops`, `vector_cosine_ops` etc.). Currently, only
`vector_l2_ops` is supported. It is also the default option, which means
that users can omit the operator class in index definitions.

Fixes #143110

Release note (sql change): It is now possible to specify the operator
class for a vector index, although only `vector_l2_ops` is supported for
now. In addition, `vector_l2_ops` is the default, so it is possible to
omit the operator class from an index definition.

#### sql/vecindex: make hnsw alias for cspann for index creation

This commit adds `hnsw` to the accepted list of index types when a
vector index is defined using the `USING` syntax. However, we will
silently provide a `cspann` index instead. This change is made in
anticipation of third-party tools that want to use `cspann`.

Fixes #143109

Release note (sql change): When creating a vector index via the `USING`
syntax, is is now possible to specify `hnsw` as the index type, although
a `cspann` vector index will still be provided. The goal of this change
is to increase compatibility with third-party tools.

---

Release justification: pg-compatibility improvement for vector indexing preview