### PR TITLE
kvserver: acquire token for admin scatter

### DIFF
--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4148,16 +4148,20 @@ func intersectTargets(
 	return intersection
 }
 
-// adminScatter moves replicas and leaseholders for a selection of ranges.
-func (r *Replica) adminScatter(
-	ctx context.Context, args kvpb.AdminScatterRequest,
-) (kvpb.AdminScatterResponse, error) {
-	rq := r.store.replicateQueue
-	retryOpts := retry.Options{
-		InitialBackoff: 50 * time.Millisecond,
-		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
-		MaxRetries:     5,
+// scatterRangeAndRandomizeLeases does two things: 1. attempts to move replicas
+// of a range using the replicate queue to perform changes upon a range until we
+// hit a terminating error or `maxAttempts`. 2. attempts to transfer lease to a
+// randomly chosen suitable replica. scatterRangeAndRandomizeLeases is
+// best-effort, randomized, and does not guarantee a uniform distribution.
+// Return number of replicas moved based on comparing the state before and after
+// the scatter operation.
+func (r *Replica) scatterRangeAndRandomizeLeases(ctx context.Context, randomizeLeases bool) int {
+	// Construct a mapping to store the replica IDs before we attempt to scatter
+	// them. This is used to below to check which replicas were actually moved by
+	// the replicate queue .
+	preScatterReplicaIDs := make(map[roachpb.ReplicaID]struct{})
+	for _, rd := range r.Desc().Replicas().Descriptors() {
+		preScatterReplicaIDs[rd.ReplicaID] = struct{}{}
 	}
 
 	// On every `processOneChange` call with the `scatter` option set, stores in
@@ -4172,18 +4176,12 @@ func (r *Replica) adminScatter(
 	maxAttempts := len(r.Desc().Replicas().Descriptors())
 	currentAttempt := 0
 
-	if args.MaxSize > 0 {
-		if existing, limit := r.GetMVCCStats().Total(), args.MaxSize; existing > limit {
-			return kvpb.AdminScatterResponse{}, errors.Errorf("existing range size %d exceeds specified limit %d", existing, limit)
-		}
-	}
-
-	// Construct a mapping to store the replica IDs before we attempt to scatter
-	// them. This is used to below to check which replicas were actually moved by
-	// the replicate queue .
-	preScatterReplicaIDs := make(map[roachpb.ReplicaID]struct{})
-	for _, rd := range r.Desc().Replicas().Descriptors() {
-		preScatterReplicaIDs[rd.ReplicaID] = struct{}{}
+	rq := r.store.replicateQueue
+	retryOpts := retry.Options{
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+		Multiplier:     2,
+		MaxRetries:     5,
 	}
 
 	// Loop until we hit an error or until we hit `maxAttempts` for the range.
@@ -4225,7 +4223,7 @@ func (r *Replica) adminScatter(
 	// queue would do on its own (#17341), do so after the replicate queue is
 	// done by transferring the lease to any of the given N replicas with
 	// probability 1/N of choosing each.
-	if args.RandomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
+	if randomizeLeases && r.OwnsValidLease(ctx, r.store.Clock().NowAsClockTimestamp()) {
 		desc, conf := r.DescAndSpanConfig()
 		potentialLeaseTargets := r.store.allocator.ValidLeaseTargets(
 			ctx, r.store.cfg.StorePool, desc, conf, desc.Replicas().VoterDescriptors(), r, allocator.TransferLeaseOptions{})
@@ -4256,6 +4254,23 @@ func (r *Replica) adminScatter(
 			numReplicasMoved++
 		}
 	}
+	return numReplicasMoved
+}
+
+// adminScatter moves replicas and leaseholders for a selection of ranges. It is
+// best-effort. Ranges that cannot be moved will just return early and not
+// return an error.
+func (r *Replica) adminScatter(
+	ctx context.Context, args kvpb.AdminScatterRequest,
+) (kvpb.AdminScatterResponse, error) {
+	if args.MaxSize > 0 {
+		if existing, limit := r.GetMVCCStats().Total(), args.MaxSize; existing > limit {
+			return kvpb.AdminScatterResponse{},
+				errors.Errorf("existing range size %d exceeds specified limit %d", existing, limit)
+		}
+	}
+
+	numReplicasMoved := r.scatterRangeAndRandomizeLeases(ctx, args.RandomizeLeases)
 
 	ri := r.GetRangeInfo(ctx)
 	stats := r.GetMVCCStats()

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4156,14 +4156,35 @@ func intersectTargets(
 // Return number of replicas moved based on comparing the state before and after
 // the scatter operation.
 func (r *Replica) scatterRangeAndRandomizeLeases(ctx context.Context, randomizeLeases bool) int {
-	// Acquire the allocator token explicitly, since rq.processOneChange bypasses
-	// replicateQueue.process, where the token is normally acquired. The allocator
-	// token is shared by the store rebalancer, replicate queue, and lease queue
-	// to coordinate replication changes on the same range.
-	if tokenErr := r.allocatorToken.TryAcquire(ctx, "admin scatter"); tokenErr != nil {
-		log.Warningf(ctx, "failed to scatter range: unable to acquire allocator token due to %v", tokenErr)
+	retryOpts := retry.Options{
+		InitialBackoff: 50 * time.Millisecond,
+		MaxBackoff:     1 * time.Second,
+		Multiplier:     2,
+		MaxRetries:     5,
+	}
+
+	var tokenErr error
+	// Acquire the allocator token explicitly to coordinate replication changes on
+	// the replica, since rq.processOneChange and r.AdminTransferLease bypasses
+	// replicateQueue.process and leaseQueue.process, where the token is normally
+	// acquired. The allocator token is shared by the store rebalancer, replicate
+	// queue, and lease queue to coordinate replication changes on the same range.
+	// Retry if token acquisition failed until the MaxRetries is hit.
+	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
+		tokenErr = r.allocatorToken.TryAcquire(ctx, "admin scatter")
+		if tokenErr == nil {
+			break
+		}
+	}
+
+	// Return early with number of replicas moved as 0.
+	if tokenErr != nil {
+		log.Warningf(ctx, "failed to scatter range: unable to acquire allocator "+
+			"due to %v after %d attempts", tokenErr, retryOpts.MaxRetries)
 		return 0
 	}
+
+	// Successfully acquired the token.
 	defer r.allocatorToken.Release(ctx)
 
 	// Construct a mapping to store the replica IDs before we attempt to scatter
@@ -4187,14 +4208,13 @@ func (r *Replica) scatterRangeAndRandomizeLeases(ctx context.Context, randomizeL
 	currentAttempt := 0
 
 	rq := r.store.replicateQueue
-	retryOpts := retry.Options{
-		InitialBackoff: 50 * time.Millisecond,
-		MaxBackoff:     1 * time.Second,
-		Multiplier:     2,
-		MaxRetries:     5,
-	}
 
-	// Loop until we hit an error or until we hit `maxAttempts` for the range.
+	// Loop until an error occurs or we reach maxAttempts for the range.
+	// maxAttempts is set to the replication factor to ensure we at least attempt
+	// rebalancing for each replica. Separately, MaxRetries (set to 5) controls
+	// the number of retries for retriable errors within each replica attempt
+	// (currentAttempt). Note that there's a backoff between retries for each
+	// currentAttempt, but no backoff between different attempts.
 	for re := retry.StartWithCtx(ctx, retryOpts); re.Next(); {
 		if currentAttempt == maxAttempts {
 			log.Eventf(ctx, "stopped scattering after hitting max %d attempts", maxAttempts)

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4156,6 +4156,16 @@ func intersectTargets(
 // Return number of replicas moved based on comparing the state before and after
 // the scatter operation.
 func (r *Replica) scatterRangeAndRandomizeLeases(ctx context.Context, randomizeLeases bool) int {
+	// Acquire the allocator token explicitly, since rq.processOneChange bypasses
+	// replicateQueue.process, where the token is normally acquired. The allocator
+	// token is shared by the store rebalancer, replicate queue, and lease queue
+	// to coordinate replication changes on the same range.
+	if tokenErr := r.allocatorToken.TryAcquire(ctx, "admin scatter"); tokenErr != nil {
+		log.Warningf(ctx, "failed to scatter range: unable to acquire allocator token due to %v", tokenErr)
+		return 0
+	}
+	defer r.allocatorToken.Release(ctx)
+
 	// Construct a mapping to store the replica IDs before we attempt to scatter
 	// them. This is used to below to check which replicas were actually moved by
 	// the replicate queue .
@@ -4231,15 +4241,10 @@ func (r *Replica) scatterRangeAndRandomizeLeases(ctx context.Context, randomizeL
 			newLeaseholderIdx := rand.Intn(len(potentialLeaseTargets))
 			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID
 			if targetStoreID != r.store.StoreID() {
-				if tokenErr := r.allocatorToken.TryAcquire(ctx, "scatter"); tokenErr != nil {
-					log.Warningf(ctx, "failed to scatter lease to s%d: %v", targetStoreID, tokenErr)
-				} else {
-					defer r.allocatorToken.Release(ctx)
-					log.VEventf(ctx, 2, "randomly transferring lease to s%d", targetStoreID)
-					if err := r.AdminTransferLease(ctx, targetStoreID, false /* bypassSafetyChecks */); err != nil {
-						log.Warningf(ctx, "scatter lease to s%d failed due to %v: candidates included %v",
-							targetStoreID, err, potentialLeaseTargets)
-					}
+				log.VEventf(ctx, 2, "randomly transferring lease to s%d", targetStoreID)
+				if err := r.AdminTransferLease(ctx, targetStoreID, false /* bypassSafetyChecks */); err != nil {
+					log.Warningf(ctx, "scatter lease to s%d failed due to %v: candidates included %v",
+						targetStoreID, err, potentialLeaseTargets)
 				}
 			}
 		}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4232,12 +4232,13 @@ func (r *Replica) scatterRangeAndRandomizeLeases(ctx context.Context, randomizeL
 			targetStoreID := potentialLeaseTargets[newLeaseholderIdx].StoreID
 			if targetStoreID != r.store.StoreID() {
 				if tokenErr := r.allocatorToken.TryAcquire(ctx, "scatter"); tokenErr != nil {
-					log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, tokenErr)
+					log.Warningf(ctx, "failed to scatter lease to s%d: %v", targetStoreID, tokenErr)
 				} else {
 					defer r.allocatorToken.Release(ctx)
 					log.VEventf(ctx, 2, "randomly transferring lease to s%d", targetStoreID)
 					if err := r.AdminTransferLease(ctx, targetStoreID, false /* bypassSafetyChecks */); err != nil {
-						log.Warningf(ctx, "failed to scatter lease to s%d: %+v", targetStoreID, err)
+						log.Warningf(ctx, "scatter lease to s%d failed due to %v: candidates included %v",
+							targetStoreID, err, potentialLeaseTargets)
 					}
 				}
 			}

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2377,6 +2377,40 @@ func TestReplicateQueueAllocatorToken(t *testing.T) {
 	require.ErrorAs(t, processErr, &allocationError)
 }
 
+// TestAdminScatterAllocatorToken verifies issue #144579 by demonstrating that
+// AdminScatter does not acquire the allocator token. AdminScatter should not
+// have scattered replicas while the token was explicitly held by the test. But
+// the test confirms otherwise.
+func TestAdminScatterAllocatorToken(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{
+		ReplicationMode: base.ReplicationManual,
+	})
+	defer tc.Stopper().Stop(ctx)
+
+	key := roachpb.Key("a")
+	_, _, err := tc.SplitRange(key)
+	require.NoError(t, err)
+	repl := tc.GetRaftLeader(t, roachpb.RKey(key))
+
+	require.NoError(t, repl.AllocatorToken().TryAcquire(ctx, "test"))
+	s := tc.Server(0)
+	db := s.DB()
+	require.NoError(t, db.Put(ctx, key, "abc"))
+	resp, err := db.AdminScatter(ctx, key, 0)
+	repl.AllocatorToken().Release(ctx)
+	require.NoError(t, err)
+	// A non-empty resp.ReplicasScatteredBytes indicates that the adminScatter did
+	// scatter the replica, even though it shouldn't have (because it didn't have
+	// the allocator token).
+	require.Greater(t, resp.ReplicasScatteredBytes, int64(0))
+	// We actually want resp.ReplicasScatteredBytes == 0.
+	//require.Equal(t, resp.ReplicasScatteredBytes, int64(0))
+}
+
 // TestReplicateQueueDecommissionScannerDisabled asserts that decommissioning
 // replicas are replaced by the replicate queue despite the scanner being
 // disabled, when EnqueueProblemRangeInReplicateQueueInterval is set to a

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2377,10 +2377,10 @@ func TestReplicateQueueAllocatorToken(t *testing.T) {
 	require.ErrorAs(t, processErr, &allocationError)
 }
 
-// TestAdminScatterAllocatorToken verifies issue #144579 by demonstrating that
-// AdminScatter does not acquire the allocator token. AdminScatter should not
-// have scattered replicas while the token was explicitly held by the test. But
-// the test confirms otherwise.
+// TestAdminScatterAllocatorToken verifies that AdminScatter does perform
+// allocator token acquisition. When the token is held, scatter should not move
+// any replicas. Once released, scatter should successfully rebalance replicas.
+// Regression test for #144579.
 func TestAdminScatterAllocatorToken(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2396,19 +2396,23 @@ func TestAdminScatterAllocatorToken(t *testing.T) {
 	require.NoError(t, err)
 	repl := tc.GetRaftLeader(t, roachpb.RKey(key))
 
+	// Hold allocator token and verify scatter is blocked
 	require.NoError(t, repl.AllocatorToken().TryAcquire(ctx, "test"))
 	s := tc.Server(0)
 	db := s.DB()
 	require.NoError(t, db.Put(ctx, key, "abc"))
-	resp, err := db.AdminScatter(ctx, key, 0)
+	scatterRespWithTokenHeld, err := db.AdminScatter(ctx, key, 0 /*maxSize*/)
+	require.NoError(t, err)
+	require.NotNil(t, scatterRespWithTokenHeld)
+	require.Equal(t, int64(0), scatterRespWithTokenHeld.ReplicasScatteredBytes)
+
+	// Release token and verify scatter succeeds.
 	repl.AllocatorToken().Release(ctx)
 	require.NoError(t, err)
-	// A non-empty resp.ReplicasScatteredBytes indicates that the adminScatter did
-	// scatter the replica, even though it shouldn't have (because it didn't have
-	// the allocator token).
-	require.Greater(t, resp.ReplicasScatteredBytes, int64(0))
-	// We actually want resp.ReplicasScatteredBytes == 0.
-	//require.Equal(t, resp.ReplicasScatteredBytes, int64(0))
+	scatterRespAfterRelease, err := db.AdminScatter(ctx, key, 0 /*maxSize*/)
+	require.NoError(t, err)
+	require.NotNil(t, scatterRespAfterRelease)
+	require.Greater(t, scatterRespAfterRelease.ReplicasScatteredBytes, int64(0))
 }
 
 // TestReplicateQueueDecommissionScannerDisabled asserts that decommissioning


### PR DESCRIPTION

**kvserver: AdminScatter does not obtain an allocator token**

This commit adds a test, `TestAdminScatterAllocatorToken`, demonstrating
that `AdminScatter` issues replica changes without obtaining an
allocator token. This can lead to the replicate queue and scatter
racing with each other (and failing due to descriptor-changed errors).

Informs: #144579
Release note: None

Co-authored-by: Mira Radeva mira@cockroachlabs.com

---

**kvserver: refactor scatter operation out in adminScatter**

This commit moves the scatter operation logic of adminScatter into a separate
helper function to enhance clarity and simplify future commits.

Epic: none
Release note: none

---

**kvserver: logs suitable candidates for lease transfer during adminScatter**

This commit adds logging for suitable lease transfer candidates during
adminScatter, providing more visibility into ideal candidates.

Epic: none
Release note: none

---

**kvserver: acquire token for admin scatter**

Previously, we have seen descriptor changed errors during scatter due to
concurrent range descriptor changes triggered by the replicate queue. The
replicate queue encountered similar errors, suggesting both it and scatter may
have conflicted when modifying the same range.

To prevent contention like this, we previously introduced the concept of an
allocator token, acquired per-range by the leaseholder to coordinate replication
changes. It's already used by the store rebalancer and replicate queue to
synchronize changes to the same range.

This patch updates AdminScatter to acquire the allocator token before calling
processOneChange, aligning its behavior with replicateQueue.process. Note that
AdminScatter currently does not retry if the token isn't available. A future
commit will introduce a server side retry.

Note that we are unclear whether this is the root cause of failed scatter
operations since descriptor changed should be treated as a retriable error.

Resolves: #144579
Release note: none

---

**kvserver: retry if token acquisition failed**

Previously, adminScatter did not retry on token acquisition failures for replica
changes, relying on the client to retry. This commit introduces server-side
retries, attempting up to 5 times before returning to client.

Part of: #144579
Release note: none
