### PR TITLE
sql: disallow set-returning PL/pgSQL functions in mixed version state

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
@@ -1,3 +1,5 @@
+# LogicTest: !local-mixed-24.3 !local-mixed-25.1
+
 statement ok
 CREATE TABLE xy (x INT, y INT);
 INSERT INTO xy VALUES (1, 2), (3, 4), (5, 6);

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.3/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.3/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 32,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-24.3/generated_test.go
@@ -173,13 +173,6 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
-func TestCCLLogic_plpgsql_srf(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runCCLLogicTest(t, "plpgsql_srf")
-}
-
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.1/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.1/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 32,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.1/generated_test.go
@@ -173,13 +173,6 @@ func TestCCLLogic_plpgsql_record(
 	runCCLLogicTest(t, "plpgsql_record")
 }
 
-func TestCCLLogic_plpgsql_srf(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runCCLLogicTest(t, "plpgsql_srf")
-}
-
 func TestCCLLogic_plpgsql_txn(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_plpgsql_srf
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_plpgsql_srf
@@ -1,0 +1,24 @@
+# LogicTest: cockroach-go-testserver-configs
+
+statement error pgcode 0A000 pq: unimplemented: set-returning PL/pgSQL functions are not yet supported
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 1; END $$;
+
+upgrade 0
+
+statement error pgcode 0A000 pq: unimplemented: PL/pgSQL set-returning functions are only supported in v25.2 and later
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 1; END $$;
+
+upgrade 1
+
+upgrade 2
+
+statement ok
+SET CLUSTER SETTING version = crdb_internal.node_executable_version();
+
+query B retry
+SELECT crdb_internal.is_at_least_version('25.1-02')
+----
+true
+
+statement ok
+CREATE FUNCTION f() RETURNS SETOF INT LANGUAGE PLpgSQL AS $$ BEGIN RETURN NEXT 1; END $$;

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 9,
+    shard_count = 10,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/generated_test.go
@@ -108,6 +108,13 @@ func TestLogic_mixed_version_jsonpath(
 	runLogicTest(t, "mixed_version_jsonpath")
 }
 
+func TestLogic_mixed_version_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_plpgsql_srf")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.1/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.1/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 9,
+    shard_count = 10,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-25.1/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-25.1/generated_test.go
@@ -108,6 +108,13 @@ func TestLogic_mixed_version_jsonpath(
 	runLogicTest(t, "mixed_version_jsonpath")
 }
 
+func TestLogic_mixed_version_plpgsql_srf(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "mixed_version_plpgsql_srf")
+}
+
 func TestLogic_mixed_version_stats(
 	t *testing.T,
 ) {


### PR DESCRIPTION
This commit adds a version check during routine creation for set-returning PL/pgSQL function.

Fixes #144914

Release note (bug fix): Fixed a bug in alpha and beta versions of 25.2 that allowed a set-returning PL/pgSQL function to be created before the version change was finalized.