### PR TITLE
sql, opt: add UpdateSwap and DeleteSwap to exec factory 

### DIFF
--- a/pkg/sql/delete_swap.go
+++ b/pkg/sql/delete_swap.go
@@ -142,3 +142,7 @@ func (d *deleteSwapNode) Close(ctx context.Context) {
 func (d *deleteSwapNode) rowsWritten() int64 {
 	return d.run.td.rowsWritten
 }
+
+func (d *deleteSwapNode) enableAutoCommit() {
+	d.run.td.enableAutoCommit()
+}

--- a/pkg/sql/delete_swap.go
+++ b/pkg/sql/delete_swap.go
@@ -133,6 +133,7 @@ func (d *deleteSwapNode) BatchedValues(rowIdx int) tree.Datums {
 }
 
 func (d *deleteSwapNode) Close(ctx context.Context) {
+	d.input.Close(ctx)
 	d.run.td.close(ctx)
 	*d = deleteSwapNode{}
 	deleteSwapNodePool.Put(d)

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1418,6 +1418,21 @@ func (e *distSQLSpecExecFactory) ConstructUpdate(
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: update")
 }
 
+func (e *distSQLSpecExecFactory) ConstructUpdateSwap(
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.TableColumnOrdinalSet,
+	updateCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
+	autoCommit bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(
+		47473, "experimental opt-driven distsql planning: update swap",
+	)
+}
+
 func (e *distSQLSpecExecFactory) ConstructUpsert(
 	input exec.Node,
 	table cat.Table,
@@ -1446,6 +1461,20 @@ func (e *distSQLSpecExecFactory) ConstructDelete(
 	autoCommit bool,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: delete")
+}
+
+func (e *distSQLSpecExecFactory) ConstructDeleteSwap(
+	input exec.Node,
+	table cat.Table,
+	fetchCols exec.TableColumnOrdinalSet,
+	returnCols exec.TableColumnOrdinalSet,
+	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
+	autoCommit bool,
+) (exec.Node, error) {
+	return nil, unimplemented.NewWithIssue(
+		47473, "experimental opt-driven distsql planning: delete swap",
+	)
 }
 
 func (e *distSQLSpecExecFactory) ConstructDeleteRange(

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -35,7 +35,7 @@ import (
 )
 
 func init() {
-	if numOperators != 65 {
+	if numOperators != 67 {
 		// This error occurs when an operator has been added or removed in
 		// pkg/sql/opt/exec/explain/factory.opt. If an operator is added at the
 		// end of factory.opt, simply adjust the hardcoded value above. If an

--- a/pkg/sql/opt/exec/explain/result_columns.go
+++ b/pkg/sql/opt/exec/explain/result_columns.go
@@ -189,12 +189,26 @@ func getResultColumns(
 			a.Passthrough...,
 		), nil
 
+	case updateSwapOp:
+		a := args.(*updateSwapArgs)
+		return appendColumns(
+			tableColumns(a.Table, a.ReturnCols),
+			a.Passthrough...,
+		), nil
+
 	case upsertOp:
 		a := args.(*upsertArgs)
 		return tableColumns(a.Table, a.ReturnCols), nil
 
 	case deleteOp:
 		a := args.(*deleteArgs)
+		return appendColumns(
+			tableColumns(a.Table, a.ReturnCols),
+			a.Passthrough...,
+		), nil
+
+	case deleteSwapOp:
+		a := args.(*deleteSwapArgs)
 		return appendColumns(
 			tableColumns(a.Table, a.ReturnCols),
 			a.Passthrough...,

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -652,6 +652,9 @@ define Delete {
 #  - the input to the delete is a scan (without limits);
 #  - there are no inbound FKs to the table.
 #
+# If both DeleteSwap and DeleteRange could be used for a DELETE statement,
+# DeleteSwap takes precedence.
+#
 # See the comment for ConstructScan for descriptions of the needed and
 # indexConstraint parameters, since DeleteRange combines Delete + Scan into a
 # single operator.
@@ -887,4 +890,112 @@ define VectorMutationSearch {
     # Indicates whether the search operation is for an index put or del. If set,
     # the search must return the quantized vector.
     IsIndexPut bool
+}
+
+# UpdateSwap performs an UPDATE statement as a compare-and-swap operation, which
+# only succeeds if the existing row matches what was expected. This
+# compare-and-swap allows the statement to skip the initial fetch from the
+# target table, which changes some simple UPDATE statements from 2 round trips
+# to 1 round trip.
+#
+# This fast path is only possible when certain conditions hold true:
+# - all columns in the primary index are constrained to a single exact value
+#   by the WHERE clause;
+# - only a single row is modified;
+# - there are no FK checks or cascades;
+# - there are no uniqueness checks;
+# - there are no check constraints;
+# - there are no after triggers.
+#
+# Multiple indexes and complex projections are supported.
+#
+# For example, the following statement would be able to use UpdateSwap, as it
+# only updates a single row and all columns are constrained to a single exact
+# value by the WHERE clause.
+#
+#   CREATE TABLE abcd (
+#     a INT PRIMARY KEY,
+#     b INT,
+#     c INT,
+#     d INT AS (b + c) VIRTUAL,
+#     INDEX (b)
+#   );
+#
+#   UPDATE abcd SET a = b + 1, c = 3
+#     WHERE a = 1
+#     AND b IS NOT DISTINCT FROM 2
+#     AND c IS NOT DISTINCT FROM NULL
+#     RETURNING c, d;
+#
+# The parameters are mostly the same as for Update.
+define UpdateSwap {
+    Input exec.Node
+    Table cat.Table
+    FetchCols exec.TableColumnOrdinalSet
+    UpdateCols exec.TableColumnOrdinalSet
+    ReturnCols exec.TableColumnOrdinalSet
+    Passthrough colinfo.ResultColumns
+
+    # If set, the input has already acquired the locks during the initial scan
+    # of the Update (i.e. on the "old" KVs within these indexes).
+    LockedIndexes cat.IndexOrdinals
+
+    # If set, the operator will commit the transaction as part of its execution.
+    AutoCommit bool
+}
+
+# DeleteSwap performs a DELETE statement as a compare-and-swap operation, which
+# only succeeds if the existing row matches what was expected. This
+# compare-and-swap allows the statement to skip the initial fetch from the
+# target table, which changes some simple DELETE statements from 2 round trips
+# to 1 round trip.
+#
+# This fast path is only possible when certain conditions hold true:
+# - all columns in the primary index are constrained to a single exact value
+#   by the WHERE clause;
+# - only a single row is deleted;
+# - there are no FK checks or cascades;
+# - there are no uniqueness checks;
+# - there are no after triggers.
+#
+# Multiple indexes and complex projections are supported.
+#
+# For example, the following statement would be able to use DeleteSwap, as it
+# only deletes a single row and all columns are constrained to a single exact
+# value by the WHERE clause.
+#
+#   CREATE TABLE abcd (
+#     a INT PRIMARY KEY,
+#     b INT,
+#     c INT,
+#     d INT AS (b + c) VIRTUAL,
+#     INDEX (b)
+#   );
+#
+#   DELETE FROM abcd
+#     WHERE a = 1
+#     AND b IS NOT DISTINCT FROM 2
+#     AND c IS NOT DISTINCT FROM NULL
+#     RETURNING *;
+#
+# If both DeleteSwap and DeleteRange could be used for a DELETE statement,
+# DeleteSwap takes precedence.
+#
+# The parameters are the same as for Delete.
+define DeleteSwap {
+    Input exec.Node
+    Table cat.Table
+    FetchCols exec.TableColumnOrdinalSet
+    ReturnCols exec.TableColumnOrdinalSet
+    Passthrough colinfo.ResultColumns
+
+    # If set, the input has already acquired the locks on the specified indexes
+    # on all keys that might be deleted from that index.
+    LockedIndexes cat.IndexOrdinals
+
+    # If set, the operator will commit the transaction as part of its execution.
+    # This is false when executing inside an explicit transaction, or there are
+    # multiple mutations in a statement, or the output of the mutation is
+    # processed through side-effecting expressions.
+    AutoCommit bool
 }

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1630,6 +1630,81 @@ func (ef *execFactory) ConstructUpdate(
 	return &rowCountNode{source: upd}, nil
 }
 
+func (ef *execFactory) ConstructUpdateSwap(
+	input exec.Node,
+	table cat.Table,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	updateColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
+	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
+	autoCommit bool,
+) (exec.Node, error) {
+	// TODO(radu): the execution code has an annoying limitation that the fetch
+	// columns must be a superset of the update columns, even when the "old" value
+	// of a column is not necessary. The optimizer code for pruning columns is
+	// aware of this limitation.
+	if !updateColOrdSet.SubsetOf(fetchColOrdSet) {
+		return nil, errors.AssertionFailedf("execution requires all update columns have a fetch column")
+	}
+
+	// For update swap, fetch columns need to include at least every column that
+	// could appear in the primary index.
+	primaryIndex := table.Index(cat.PrimaryIndex)
+	for i := 0; i < primaryIndex.ColumnCount(); i++ {
+		col := primaryIndex.Column(i)
+		if col.Kind() == cat.System {
+			continue
+		}
+		if !fetchColOrdSet.Contains(col.Ordinal()) {
+			return nil, errors.AssertionFailedf("fetch columns missing col %v", col.ColName())
+		}
+	}
+
+	rowsNeeded := !returnColOrdSet.Empty()
+	tabDesc := table.(*optTable).desc
+
+	upd := updateSwapNodePool.Get().(*updateSwapNode)
+	*upd = updateSwapNode{
+		singleInputPlanNode: singleInputPlanNode{input.(planNode)},
+	}
+
+	// If rows are not needed, no columns are returned.
+	var returnCols []catalog.Column
+	if rowsNeeded {
+		returnCols = makeColList(table, returnColOrdSet)
+		upd.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
+		// Add the passthrough columns to the returning columns.
+		upd.columns = append(upd.columns, passthrough...)
+	}
+
+	// Create the table updater, which does the bulk of the work.
+	if err := ef.constructUpdateRun(
+		&upd.run, table, fetchColOrdSet, updateColOrdSet, returnColOrdSet, rowsNeeded,
+		returnCols, exec.CheckOrdinalSet{} /* checks */, passthrough,
+		nil /* uniqueWithTombstoneIndexes */, lockedIndexes,
+	); err != nil {
+		return nil, err
+	}
+
+	if autoCommit {
+		upd.enableAutoCommit()
+	}
+
+	// Serialize the data-modifying plan to ensure that no data is observed that
+	// hasn't been validated first. See the comments on BatchedNext() in
+	// plan_batch.go.
+	if rowsNeeded {
+		return &spoolNode{
+			singleInputPlanNode: singleInputPlanNode{&serializeNode{source: upd}},
+		}, nil
+	}
+
+	// We could use serializeNode here, but using rowCountNode is an
+	// optimization that saves on calls to Next() by the caller.
+	return &rowCountNode{source: upd}, nil
+}
+
 func (ef *execFactory) constructUpdateRun(
 	run *updateRun,
 	table cat.Table,
@@ -1802,6 +1877,71 @@ func (ef *execFactory) ConstructDelete(
 	// Now make a delete node. We use a pool.
 	del := deleteNodePool.Get().(*deleteNode)
 	*del = deleteNode{
+		singleInputPlanNode: singleInputPlanNode{input.(planNode)},
+	}
+
+	// If rows are not needed, no columns are returned.
+	var returnCols []catalog.Column
+	if rowsNeeded {
+		returnCols = makeColList(table, returnColOrdSet)
+		// Delete returns the non-mutation columns specified, in the same
+		// order they are defined in the table.
+		del.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
+		// Add the passthrough columns to the returning columns.
+		del.columns = append(del.columns, passthrough...)
+	}
+
+	// Create the table deleter, which does the bulk of the work.
+	ef.constructDeleteRun(
+		&del.run, table, fetchColOrdSet, rowsNeeded, returnCols, passthrough, lockedIndexes,
+	)
+
+	if autoCommit {
+		del.enableAutoCommit()
+	}
+
+	// Serialize the data-modifying plan to ensure that no data is observed that
+	// hasn't been validated first. See the comments on BatchedNext() in
+	// plan_batch.go.
+	if rowsNeeded {
+		return &spoolNode{
+			singleInputPlanNode: singleInputPlanNode{&serializeNode{source: del}},
+		}, nil
+	}
+
+	// We could use serializeNode here, but using rowCountNode is an
+	// optimization that saves on calls to Next() by the caller.
+	return &rowCountNode{source: del}, nil
+}
+
+func (ef *execFactory) ConstructDeleteSwap(
+	input exec.Node,
+	table cat.Table,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
+	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
+	autoCommit bool,
+) (exec.Node, error) {
+	// For delete swap, fetch columns need to include at least every column that
+	// could appear in the primary index.
+	primaryIndex := table.Index(cat.PrimaryIndex)
+	for i := 0; i < primaryIndex.ColumnCount(); i++ {
+		col := primaryIndex.Column(i)
+		if col.Kind() == cat.System {
+			continue
+		}
+		if !fetchColOrdSet.Contains(col.Ordinal()) {
+			return nil, errors.AssertionFailedf("fetch columns missing col %v", col.ColName())
+		}
+	}
+
+	rowsNeeded := !returnColOrdSet.Empty()
+	tabDesc := table.(*optTable).desc
+
+	// Now make a delete node. We use a pool.
+	del := deleteSwapNodePool.Get().(*deleteSwapNode)
+	*del = deleteSwapNode{
 		singleInputPlanNode: singleInputPlanNode{input.(planNode)},
 	}
 

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1587,59 +1587,29 @@ func (ef *execFactory) ConstructUpdate(
 		return nil, errors.AssertionFailedf("execution requires all update columns have a fetch column")
 	}
 
-	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	fetchCols := makeColList(table, fetchColOrdSet)
-	updateCols := makeColList(table, updateColOrdSet)
-
-	// Create the table updater, which does the bulk of the work.
-	ru, err := row.MakeUpdater(
-		ef.planner.ExecCfg().Codec,
-		tabDesc,
-		ordinalsToIndexes(table, uniqueWithTombstoneIndexes),
-		ordinalsToIndexes(table, lockedIndexes),
-		updateCols,
-		fetchCols,
-		row.UpdaterDefault,
-		ef.planner.SessionData(),
-		&ef.planner.ExecCfg().Settings.SV,
-		ef.planner.ExecCfg().GetRowMetrics(ef.planner.SessionData().Internal),
-	)
-	if err != nil {
-		return nil, err
-	}
 
 	upd := updateNodePool.Get().(*updateNode)
 	*upd = updateNode{
 		singleInputPlanNode: singleInputPlanNode{input.(planNode)},
-		run: updateRun{
-			tu:             tableUpdater{ru: ru},
-			checkOrds:      checks,
-			numPassthrough: len(passthrough),
-		},
 	}
 
-	upd.run.regionLocalInfo.setupEnforceHomeRegion(ef.planner, table, ru.UpdateCols,
-		upd.run.tu.ru.UpdateColIDtoRowIndex)
-
 	// If rows are not needed, no columns are returned.
+	var returnCols []catalog.Column
 	if rowsNeeded {
-		returnCols := makeColList(table, returnColOrdSet)
-
+		returnCols = makeColList(table, returnColOrdSet)
 		upd.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
 		// Add the passthrough columns to the returning columns.
 		upd.columns = append(upd.columns, passthrough...)
+	}
 
-		// Set the rowIdxToRetIdx for the mutation. Update returns the non-mutation
-		// columns specified, in the same order they are defined in the table.
-		//
-		// The Updater derives/stores the fetch columns of the mutation and
-		// since the return columns are always a subset of the fetch columns,
-		// we can use use the fetch columns to generate the mapping for the
-		// returned rows.
-		upd.run.rowIdxToRetIdx = row.ColMapping(ru.FetchCols, returnCols)
-		upd.run.rowsNeeded = true
+	// Create the table updater, which does the bulk of the work.
+	if err := ef.constructUpdateRun(
+		&upd.run, table, fetchColOrdSet, updateColOrdSet, returnColOrdSet, rowsNeeded, returnCols,
+		checks, passthrough, uniqueWithTombstoneIndexes, lockedIndexes,
+	); err != nil {
+		return nil, err
 	}
 
 	if autoCommit {
@@ -1658,6 +1628,62 @@ func (ef *execFactory) ConstructUpdate(
 	// We could use serializeNode here, but using rowCountNode is an
 	// optimization that saves on calls to Next() by the caller.
 	return &rowCountNode{source: upd}, nil
+}
+
+func (ef *execFactory) constructUpdateRun(
+	run *updateRun,
+	table cat.Table,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	updateColOrdSet exec.TableColumnOrdinalSet,
+	returnColOrdSet exec.TableColumnOrdinalSet,
+	rowsNeeded bool,
+	returnCols []catalog.Column,
+	checks exec.CheckOrdinalSet,
+	passthrough colinfo.ResultColumns,
+	uniqueWithTombstoneIndexes cat.IndexOrdinals,
+	lockedIndexes cat.IndexOrdinals,
+) error {
+	tabDesc := table.(*optTable).desc
+	fetchCols := makeColList(table, fetchColOrdSet)
+	updateCols := makeColList(table, updateColOrdSet)
+
+	// Create the table updater.
+	ru, err := row.MakeUpdater(
+		ef.planner.ExecCfg().Codec,
+		tabDesc,
+		ordinalsToIndexes(table, uniqueWithTombstoneIndexes),
+		ordinalsToIndexes(table, lockedIndexes),
+		updateCols,
+		fetchCols,
+		row.UpdaterDefault,
+		ef.planner.SessionData(),
+		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg().GetRowMetrics(ef.planner.SessionData().Internal),
+	)
+	if err != nil {
+		return err
+	}
+
+	run.tu = tableUpdater{ru: ru}
+	run.checkOrds = checks
+	run.numPassthrough = len(passthrough)
+
+	run.regionLocalInfo.setupEnforceHomeRegion(ef.planner, table, ru.UpdateCols,
+		run.tu.ru.UpdateColIDtoRowIndex)
+
+	if rowsNeeded {
+		// Set the rowIdxToRetIdx for the mutation. Update returns the non-mutation
+		// columns specified, in the same order they are defined in the table.
+		//
+		// The Updater derives/stores the fetch columns of the mutation and
+		// since the return columns are always a subset of the fetch columns,
+		// we can use use the fetch columns to generate the mapping for the
+		// returned rows.
+		run.rowIdxToRetIdx = row.ColMapping(ru.FetchCols, returnCols)
+		run.rowsNeeded = true
+	}
+
+	return nil
 }
 
 func (ef *execFactory) ConstructUpsert(
@@ -1770,45 +1796,30 @@ func (ef *execFactory) ConstructDelete(
 	lockedIndexes cat.IndexOrdinals,
 	autoCommit bool,
 ) (exec.Node, error) {
-	// Derive table and column descriptors.
 	rowsNeeded := !returnColOrdSet.Empty()
 	tabDesc := table.(*optTable).desc
-	fetchCols := makeColList(table, fetchColOrdSet)
-
-	// Create the table deleter, which does the bulk of the work.
-	rd := row.MakeDeleter(
-		ef.planner.ExecCfg().Codec,
-		tabDesc,
-		ordinalsToIndexes(table, lockedIndexes),
-		fetchCols,
-		ef.planner.SessionData(),
-		&ef.planner.ExecCfg().Settings.SV,
-		ef.planner.ExecCfg().GetRowMetrics(ef.planner.SessionData().Internal),
-	)
 
 	// Now make a delete node. We use a pool.
 	del := deleteNodePool.Get().(*deleteNode)
 	*del = deleteNode{
 		singleInputPlanNode: singleInputPlanNode{input.(planNode)},
-		run: deleteRun{
-			td:             tableDeleter{rd: rd},
-			numPassthrough: len(passthrough),
-		},
 	}
 
 	// If rows are not needed, no columns are returned.
+	var returnCols []catalog.Column
 	if rowsNeeded {
-		returnCols := makeColList(table, returnColOrdSet)
+		returnCols = makeColList(table, returnColOrdSet)
 		// Delete returns the non-mutation columns specified, in the same
 		// order they are defined in the table.
 		del.columns = colinfo.ResultColumnsFromColumns(tabDesc.GetID(), returnCols)
-
 		// Add the passthrough columns to the returning columns.
 		del.columns = append(del.columns, passthrough...)
-
-		del.run.rowIdxToRetIdx = row.ColMapping(rd.FetchCols, returnCols)
-		del.run.rowsNeeded = true
 	}
+
+	// Create the table deleter, which does the bulk of the work.
+	ef.constructDeleteRun(
+		&del.run, table, fetchColOrdSet, rowsNeeded, returnCols, passthrough, lockedIndexes,
+	)
 
 	if autoCommit {
 		del.enableAutoCommit()
@@ -1826,6 +1837,38 @@ func (ef *execFactory) ConstructDelete(
 	// We could use serializeNode here, but using rowCountNode is an
 	// optimization that saves on calls to Next() by the caller.
 	return &rowCountNode{source: del}, nil
+}
+
+func (ef *execFactory) constructDeleteRun(
+	run *deleteRun,
+	table cat.Table,
+	fetchColOrdSet exec.TableColumnOrdinalSet,
+	rowsNeeded bool,
+	returnCols []catalog.Column,
+	passthrough colinfo.ResultColumns,
+	lockedIndexes cat.IndexOrdinals,
+) {
+	tabDesc := table.(*optTable).desc
+	fetchCols := makeColList(table, fetchColOrdSet)
+
+	// Create the table deleter.
+	rd := row.MakeDeleter(
+		ef.planner.ExecCfg().Codec,
+		tabDesc,
+		ordinalsToIndexes(table, lockedIndexes),
+		fetchCols,
+		ef.planner.SessionData(),
+		&ef.planner.ExecCfg().Settings.SV,
+		ef.planner.ExecCfg().GetRowMetrics(ef.planner.SessionData().Internal),
+	)
+
+	run.td = tableDeleter{rd: rd}
+	run.numPassthrough = len(passthrough)
+
+	if rowsNeeded {
+		run.rowIdxToRetIdx = row.ColMapping(rd.FetchCols, returnCols)
+		run.rowsNeeded = true
+	}
 }
 
 func (ef *execFactory) ConstructDeleteRange(

--- a/pkg/sql/update_swap.go
+++ b/pkg/sql/update_swap.go
@@ -142,3 +142,7 @@ func (u *updateSwapNode) Close(ctx context.Context) {
 func (u *updateSwapNode) rowsWritten() int64 {
 	return u.run.tu.rowsWritten
 }
+
+func (u *updateSwapNode) enableAutoCommit() {
+	u.run.tu.enableAutoCommit()
+}

--- a/pkg/sql/update_swap.go
+++ b/pkg/sql/update_swap.go
@@ -133,6 +133,7 @@ func (u *updateSwapNode) BatchedValues(rowIdx int) tree.Datums {
 }
 
 func (u *updateSwapNode) Close(ctx context.Context) {
+	u.input.Close(ctx)
 	u.run.tu.close(ctx)
 	*u = updateSwapNode{}
 	updateSwapNodePool.Put(u)


### PR DESCRIPTION
This set of commits adds UpdateSwap and DeleteSwap constructors to the exec factory. The next PR will actually call these constructor functions during execbuild.

See individual commits for details.

Informs: #144503

Release note: None