### PR TITLE
release-25.2: sql: update sql metric definition to support configurable labels 

### DIFF
--- a/pkg/server/telemetry/BUILD.bazel
+++ b/pkg/server/telemetry/BUILD.bazel
@@ -12,8 +12,10 @@ go_library(
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_prometheus_client_model//go",
     ],
 )
 

--- a/pkg/server/telemetry/features_test.go
+++ b/pkg/server/telemetry/features_test.go
@@ -92,11 +92,16 @@ func TestBucket(t *testing.T) {
 // for example, a report is created.
 func TestCounterWithMetric(t *testing.T) {
 	cm := telemetry.NewCounterWithMetric(metric.Metadata{Name: "test-metric"})
+	cag := telemetry.NewCounterWithAggMetric(metric.Metadata{Name: "test-agg-metric"})
+
 	cm.Inc()
+	cag.Inc("test-db", "test-app")
 
 	// Using GetFeatureCounts to read the telemetry value.
 	m1 := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly)
 	require.Equal(t, int32(1), m1["test-metric"])
+	require.Equal(t, int64(1), cm.Count())
+	require.Equal(t, int32(1), m1["test-agg-metric"])
 	require.Equal(t, int64(1), cm.Count())
 
 	// Reset the telemetry.
@@ -105,5 +110,7 @@ func TestCounterWithMetric(t *testing.T) {
 	// Verify only the telemetry is back to 0.
 	m2 := telemetry.GetFeatureCounts(telemetry.Raw, telemetry.ReadOnly)
 	require.Equal(t, int32(0), m2["test-metric"])
+	require.Equal(t, int64(1), cm.Count())
+	require.Equal(t, int32(0), m2["test-agg-metric"])
 	require.Equal(t, int64(1), cm.Count())
 }

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -579,6 +579,7 @@ go_library(
         "//pkg/util/memzipper",
         "//pkg/util/metamorphic",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/optional",
         "//pkg/util/pretty",

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -82,6 +82,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/sentryutil"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -571,27 +572,27 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 				Duration:     6 * metricsSampleInterval,
 				BucketConfig: metric.IOLatencyBuckets,
 			}),
-			SQLServiceLatency: metric.NewHistogram(metric.HistogramOptions{
+			SQLServiceLatency: aggmetric.NewSQLHistogram(metric.HistogramOptions{
 				Mode:         metric.HistogramModePreferHdrLatency,
 				Metadata:     getMetricMeta(MetaSQLServiceLatency, internal),
 				Duration:     6 * metricsSampleInterval,
 				BucketConfig: metric.IOLatencyBuckets,
 			}),
-			SQLTxnLatency: metric.NewHistogram(metric.HistogramOptions{
+			SQLTxnLatency: aggmetric.NewSQLHistogram(metric.HistogramOptions{
 				Mode:         metric.HistogramModePreferHdrLatency,
 				Metadata:     getMetricMeta(MetaSQLTxnLatency, internal),
 				Duration:     6 * metricsSampleInterval,
 				BucketConfig: metric.IOLatencyBuckets,
 			}),
-			SQLTxnsOpen:         metric.NewGauge(getMetricMeta(MetaSQLTxnsOpen, internal)),
-			SQLActiveStatements: metric.NewGauge(getMetricMeta(MetaSQLActiveQueries, internal)),
+			SQLTxnsOpen:         aggmetric.NewSQLGauge(getMetricMeta(MetaSQLTxnsOpen, internal)),
+			SQLActiveStatements: aggmetric.NewSQLGauge(getMetricMeta(MetaSQLActiveQueries, internal)),
 			SQLContendedTxns:    metric.NewCounter(getMetricMeta(MetaSQLTxnContended, internal)),
 
 			TxnAbortCount:                     metric.NewCounter(getMetricMeta(MetaTxnAbort, internal)),
-			FailureCount:                      metric.NewCounter(getMetricMeta(MetaFailure, internal)),
+			FailureCount:                      aggmetric.NewSQLCounter(getMetricMeta(MetaFailure, internal)),
 			StatementTimeoutCount:             metric.NewCounter(getMetricMeta(MetaStatementTimeout, internal)),
 			TransactionTimeoutCount:           metric.NewCounter(getMetricMeta(MetaTransactionTimeout, internal)),
-			FullTableOrIndexScanCount:         metric.NewCounter(getMetricMeta(MetaFullTableOrIndexScan, internal)),
+			FullTableOrIndexScanCount:         aggmetric.NewSQLCounter(getMetricMeta(MetaFullTableOrIndexScan, internal)),
 			FullTableOrIndexScanRejectedCount: metric.NewCounter(getMetricMeta(MetaFullTableOrIndexScanRejected, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
@@ -3011,12 +3012,14 @@ func (ex *connExecutor) execCopyOut(
 	ctx, cancelQuery = ctxlog.WithCancel(ctx)
 	queryID := ex.server.cfg.GenerateID()
 	ex.addActiveQuery(cmd.ParsedStmt, nil /* placeholders */, queryID, cancelQuery)
-	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
+	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1,
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
 
 	defer func() {
 		ex.removeActiveQuery(queryID, cmd.Stmt)
 		cancelQuery()
-		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
+		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1,
+			ex.sessionData().Database, ex.sessionData().ApplicationName)
 		if !payloadHasError(retPayload) {
 			ex.incrementExecutedStmtCounter(cmd.Stmt)
 		}
@@ -3223,12 +3226,14 @@ func (ex *connExecutor) execCopyIn(
 	ctx, cancelQuery = ctxlog.WithCancel(ctx)
 	queryID := ex.server.cfg.GenerateID()
 	ex.addActiveQuery(cmd.ParsedStmt, nil /* placeholders */, queryID, cancelQuery)
-	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
+	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1,
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
 
 	defer func() {
 		ex.removeActiveQuery(queryID, cmd.Stmt)
 		cancelQuery()
-		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
+		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1,
+			ex.sessionData().Database, ex.sessionData().ApplicationName)
 		if !payloadHasError(retPayload) {
 			ex.incrementExecutedStmtCounter(cmd.Stmt)
 		}
@@ -4588,17 +4593,17 @@ type StatementCounters struct {
 	QueryCount telemetry.CounterWithMetric
 
 	// Basic CRUD statements.
-	SelectCount telemetry.CounterWithMetric
-	UpdateCount telemetry.CounterWithMetric
-	InsertCount telemetry.CounterWithMetric
-	DeleteCount telemetry.CounterWithMetric
+	SelectCount telemetry.CounterWithAggMetric
+	UpdateCount telemetry.CounterWithAggMetric
+	InsertCount telemetry.CounterWithAggMetric
+	DeleteCount telemetry.CounterWithAggMetric
 	// CRUDQueryCount includes all 4 CRUD statements above.
-	CRUDQueryCount telemetry.CounterWithMetric
+	CRUDQueryCount telemetry.CounterWithAggMetric
 
 	// Transaction operations.
-	TxnBeginCount    telemetry.CounterWithMetric
-	TxnCommitCount   telemetry.CounterWithMetric
-	TxnRollbackCount telemetry.CounterWithMetric
+	TxnBeginCount    telemetry.CounterWithAggMetric
+	TxnCommitCount   telemetry.CounterWithAggMetric
+	TxnRollbackCount telemetry.CounterWithAggMetric
 	TxnUpgradedCount *metric.Counter
 
 	// Transaction XA two-phase commit operations.
@@ -4639,11 +4644,11 @@ type StatementCounters struct {
 
 func makeStartedStatementCounters(internal bool) StatementCounters {
 	return StatementCounters{
-		TxnBeginCount: telemetry.NewCounterWithMetric(
+		TxnBeginCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaTxnBeginStarted, internal)),
-		TxnCommitCount: telemetry.NewCounterWithMetric(
+		TxnCommitCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaTxnCommitStarted, internal)),
-		TxnRollbackCount: telemetry.NewCounterWithMetric(
+		TxnRollbackCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaTxnRollbackStarted, internal)),
 		TxnUpgradedCount: metric.NewCounter(
 			getMetricMeta(MetaTxnUpgradedFromWeakIsolation, internal)),
@@ -4665,15 +4670,15 @@ func makeStartedStatementCounters(internal bool) StatementCounters {
 			getMetricMeta(MetaReleaseSavepointStarted, internal)),
 		RollbackToSavepointCount: telemetry.NewCounterWithMetric(
 			getMetricMeta(MetaRollbackToSavepointStarted, internal)),
-		SelectCount: telemetry.NewCounterWithMetric(
+		SelectCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaSelectStarted, internal)),
-		UpdateCount: telemetry.NewCounterWithMetric(
+		UpdateCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaUpdateStarted, internal)),
-		InsertCount: telemetry.NewCounterWithMetric(
+		InsertCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaInsertStarted, internal)),
-		DeleteCount: telemetry.NewCounterWithMetric(
+		DeleteCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaDeleteStarted, internal)),
-		CRUDQueryCount: telemetry.NewCounterWithMetric(
+		CRUDQueryCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaCRUDStarted, internal)),
 		DdlCount: telemetry.NewCounterWithMetric(
 			getMetricMeta(MetaDdlStarted, internal)),
@@ -4692,11 +4697,11 @@ func makeStartedStatementCounters(internal bool) StatementCounters {
 
 func makeExecutedStatementCounters(internal bool) StatementCounters {
 	return StatementCounters{
-		TxnBeginCount: telemetry.NewCounterWithMetric(
+		TxnBeginCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaTxnBeginExecuted, internal)),
-		TxnCommitCount: telemetry.NewCounterWithMetric(
+		TxnCommitCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaTxnCommitExecuted, internal)),
-		TxnRollbackCount: telemetry.NewCounterWithMetric(
+		TxnRollbackCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaTxnRollbackExecuted, internal)),
 		TxnUpgradedCount: metric.NewCounter(
 			getMetricMeta(MetaTxnUpgradedFromWeakIsolation, internal)),
@@ -4718,15 +4723,15 @@ func makeExecutedStatementCounters(internal bool) StatementCounters {
 			getMetricMeta(MetaReleaseSavepointExecuted, internal)),
 		RollbackToSavepointCount: telemetry.NewCounterWithMetric(
 			getMetricMeta(MetaRollbackToSavepointExecuted, internal)),
-		SelectCount: telemetry.NewCounterWithMetric(
+		SelectCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaSelectExecuted, internal)),
-		UpdateCount: telemetry.NewCounterWithMetric(
+		UpdateCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaUpdateExecuted, internal)),
-		InsertCount: telemetry.NewCounterWithMetric(
+		InsertCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaInsertExecuted, internal)),
-		DeleteCount: telemetry.NewCounterWithMetric(
+		DeleteCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaDeleteExecuted, internal)),
-		CRUDQueryCount: telemetry.NewCounterWithMetric(
+		CRUDQueryCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaCRUDExecuted, internal)),
 		DdlCount: telemetry.NewCounterWithMetric(
 			getMetricMeta(MetaDdlExecuted, internal)),
@@ -4745,30 +4750,32 @@ func makeExecutedStatementCounters(internal bool) StatementCounters {
 
 func (sc *StatementCounters) incrementCount(ex *connExecutor, stmt tree.Statement) {
 	sc.QueryCount.Inc()
+	dbName := ex.sessionData().Database
+	appName := ex.sessionData().ApplicationName
 	switch t := stmt.(type) {
 	case *tree.BeginTransaction:
-		sc.TxnBeginCount.Inc()
+		sc.TxnBeginCount.Inc(dbName, appName)
 	case *tree.Select:
-		sc.SelectCount.Inc()
-		sc.CRUDQueryCount.Inc()
+		sc.SelectCount.Inc(dbName, appName)
+		sc.CRUDQueryCount.Inc(dbName, appName)
 	case *tree.Update:
-		sc.UpdateCount.Inc()
-		sc.CRUDQueryCount.Inc()
+		sc.UpdateCount.Inc(dbName, appName)
+		sc.CRUDQueryCount.Inc(dbName, appName)
 	case *tree.Insert:
-		sc.InsertCount.Inc()
-		sc.CRUDQueryCount.Inc()
+		sc.InsertCount.Inc(dbName, appName)
+		sc.CRUDQueryCount.Inc(dbName, appName)
 	case *tree.Delete:
-		sc.DeleteCount.Inc()
-		sc.CRUDQueryCount.Inc()
+		sc.DeleteCount.Inc(dbName, appName)
+		sc.CRUDQueryCount.Inc(dbName, appName)
 	case *tree.CommitTransaction:
-		sc.TxnCommitCount.Inc()
+		sc.TxnCommitCount.Inc(dbName, appName)
 	case *tree.RollbackTransaction:
 		// The CommitWait state means that the transaction has already committed
 		// after a specially handled `RELEASE SAVEPOINT cockroach_restart` command.
 		if ex.getTransactionState() == CommitWaitStateStr {
-			sc.TxnCommitCount.Inc()
+			sc.TxnCommitCount.Inc(dbName, appName)
 		} else {
-			sc.TxnRollbackCount.Inc()
+			sc.TxnRollbackCount.Inc(dbName, appName)
 		}
 	case *tree.PrepareTransaction:
 		sc.TxnPrepareCount.Inc()

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -261,7 +261,7 @@ func (ex *connExecutor) startIdleInSessionTimeout() {
 }
 
 func (ex *connExecutor) recordFailure(p eventNonRetriableErrPayload) {
-	ex.metrics.EngineMetrics.FailureCount.Inc(1)
+	ex.metrics.EngineMetrics.FailureCount.Inc(1, ex.sessionData().Database, ex.sessionData().ApplicationName)
 	switch {
 	case errors.Is(p.errorCause(), sqlerrors.QueryTimeoutError):
 		ex.metrics.EngineMetrics.StatementTimeoutCount.Inc(1)
@@ -414,7 +414,8 @@ func (ex *connExecutor) execStmtInOpenState(
 
 		// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 		// client connection, and is Server.InternalMetrics for internal executors.
-		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
+		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1,
+			ex.sessionData().Database, ex.sessionData().ApplicationName)
 	}()
 
 	// Special handling for SET TRANSACTION statements within a stored procedure
@@ -429,7 +430,8 @@ func (ex *connExecutor) execStmtInOpenState(
 
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.
-	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
+	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1,
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
 
 	p := &ex.planner
 	stmtTS := ex.server.cfg.Clock.PhysicalTime()
@@ -1369,7 +1371,8 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 		// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 		// client connection, and is Server.InternalMetrics for internal executors.
-		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1)
+		ex.metrics.EngineMetrics.SQLActiveStatements.Dec(1,
+			ex.sessionData().Database, ex.sessionData().ApplicationName)
 	}()
 
 	// Special handling for SET TRANSACTION statements within a stored procedure
@@ -1384,7 +1387,8 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.
-	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1)
+	ex.metrics.EngineMetrics.SQLActiveStatements.Inc(1,
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
 
 	// TODO(sql-sessions): persist the planner for a pausable portal, and reuse
 	// it for each re-execution.
@@ -3328,7 +3332,7 @@ func (ex *connExecutor) makeExecPlan(
 				)
 			}
 		}
-		ex.metrics.EngineMetrics.FullTableOrIndexScanCount.Inc(1)
+		ex.metrics.EngineMetrics.FullTableOrIndexScanCount.Inc(1, ex.sessionData().Database, ex.sessionData().ApplicationName)
 	}
 
 	// TODO(knz): Remove this accounting if/when savepoint rollbacks
@@ -4263,7 +4267,8 @@ func (ex *connExecutor) recordTransactionStart(txnID uuid.UUID) {
 
 	// Note ex.metrics is Server.Metrics for the connExecutor that serves the
 	// client connection, and is Server.InternalMetrics for internal executors.
-	ex.metrics.EngineMetrics.SQLTxnsOpen.Inc(1)
+	ex.metrics.EngineMetrics.SQLTxnsOpen.Inc(1,
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
 
 	ex.extraTxnState.shouldExecuteOnTxnFinish = true
 	ex.extraTxnState.txnFinishClosure.txnStartTime = txnStart
@@ -4308,8 +4313,10 @@ func (ex *connExecutor) recordTransactionFinish(
 	if contentionDuration := ex.extraTxnState.accumulatedStats.ContentionTime.Nanoseconds(); contentionDuration > 0 {
 		ex.metrics.EngineMetrics.SQLContendedTxns.Inc(1)
 	}
-	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1)
-	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(elapsedTime.Nanoseconds())
+	ex.metrics.EngineMetrics.SQLTxnsOpen.Dec(1,
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
+	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(elapsedTime.Nanoseconds(),
+		ex.sessionData().Database, ex.sessionData().ApplicationName)
 
 	ex.txnIDCacheWriter.Record(contentionpb.ResolvedTxnID{
 		TxnID:            ev.txnID,

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -67,6 +67,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/logcrash",
         "//pkg/util/metric",
+        "//pkg/util/metric/aggmetric",
         "//pkg/util/mon",
         "//pkg/util/optional",
         "//pkg/util/retry",

--- a/pkg/sql/execinfra/metrics.go
+++ b/pkg/sql/execinfra/metrics.go
@@ -9,6 +9,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 )
 
 // DistSQLMetrics contains pointers to the metrics for monitoring DistSQL
@@ -17,8 +18,8 @@ type DistSQLMetrics struct {
 	QueriesActive               *metric.Gauge
 	QueriesTotal                *metric.Counter
 	DistributedCount            *metric.Counter
-	ContendedQueriesCount       *metric.Counter
-	CumulativeContentionNanos   *metric.Counter
+	ContendedQueriesCount       *aggmetric.SQLCounter
+	CumulativeContentionNanos   *aggmetric.SQLCounter
 	FlowsActive                 *metric.Gauge
 	FlowsTotal                  *metric.Counter
 	MaxBytesHist                metric.IHistogram
@@ -153,8 +154,8 @@ func MakeDistSQLMetrics(histogramWindow time.Duration) DistSQLMetrics {
 		QueriesActive:             metric.NewGauge(metaQueriesActive),
 		QueriesTotal:              metric.NewCounter(metaQueriesTotal),
 		DistributedCount:          metric.NewCounter(metaDistributedCount),
-		ContendedQueriesCount:     metric.NewCounter(metaContendedQueriesCount),
-		CumulativeContentionNanos: metric.NewCounter(metaCumulativeContentionNanos),
+		ContendedQueriesCount:     aggmetric.NewSQLCounter(metaContendedQueriesCount),
+		CumulativeContentionNanos: aggmetric.NewSQLCounter(metaCumulativeContentionNanos),
 		FlowsActive:               metric.NewGauge(metaFlowsActive),
 		FlowsTotal:                metric.NewCounter(metaFlowsTotal),
 		MaxBytesHist: metric.NewHistogram(metric.HistogramOptions{

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlstats"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
+	"github.com/cockroachdb/cockroach/pkg/util/metric/aggmetric"
 )
 
 // EngineMetrics groups a set of SQL metrics.
@@ -34,10 +35,10 @@ type EngineMetrics struct {
 	DistSQLExecLatency    metric.IHistogram
 	SQLExecLatency        metric.IHistogram
 	DistSQLServiceLatency metric.IHistogram
-	SQLServiceLatency     metric.IHistogram
-	SQLTxnLatency         metric.IHistogram
-	SQLTxnsOpen           *metric.Gauge
-	SQLActiveStatements   *metric.Gauge
+	SQLServiceLatency     *aggmetric.SQLHistogram
+	SQLTxnLatency         *aggmetric.SQLHistogram
+	SQLTxnsOpen           *aggmetric.SQLGauge
+	SQLActiveStatements   *aggmetric.SQLGauge
 	SQLContendedTxns      *metric.Counter
 
 	// TxnAbortCount counts transactions that were aborted, either due
@@ -46,7 +47,7 @@ type EngineMetrics struct {
 	TxnAbortCount *metric.Counter
 
 	// FailureCount counts non-retriable errors in open transactions.
-	FailureCount *metric.Counter
+	FailureCount *aggmetric.SQLCounter
 
 	// StatementTimeoutCount tracks the number of statement failures due
 	// to exceeding the statement timeout.
@@ -57,7 +58,7 @@ type EngineMetrics struct {
 	TransactionTimeoutCount *metric.Counter
 
 	// FullTableOrIndexScanCount counts the number of full table or index scans.
-	FullTableOrIndexScanCount *metric.Counter
+	FullTableOrIndexScanCount *aggmetric.SQLCounter
 
 	// FullTableOrIndexScanRejectedCount counts the number of queries that were
 	// rejected because of the `disallow_full_table_scans` guardrail.
@@ -237,8 +238,10 @@ func (ex *connExecutor) recordStatementSummary(
 		}
 
 		if queryLevelStats.ContentionTime > 0 {
-			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.ContendedQueriesCount.Inc(1)
-			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.CumulativeContentionNanos.Inc(queryLevelStats.ContentionTime.Nanoseconds())
+			dbName := ex.sessionData().Database
+			appName := ex.sessionData().ApplicationName
+			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.ContendedQueriesCount.Inc(1, dbName, appName)
+			ex.planner.DistSQLPlanner().distSQLSrv.Metrics.CumulativeContentionNanos.Inc(queryLevelStats.ContentionTime.Nanoseconds(), dbName, appName)
 		}
 	}
 
@@ -319,7 +322,7 @@ func (ex *connExecutor) recordStatementLatencyMetrics(
 				m.SQLExecLatencyDetail.Observe(labels, float64(runLatRaw.Nanoseconds()))
 			}
 			m.SQLExecLatency.RecordValue(runLatRaw.Nanoseconds())
-			m.SQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds())
+			m.SQLServiceLatency.RecordValue(svcLatRaw.Nanoseconds(), ex.sessionData().Database, ex.sessionData().ApplicationName)
 		}
 	}
 }

--- a/pkg/sql/executor_statement_metrics_test.go
+++ b/pkg/sql/executor_statement_metrics_test.go
@@ -16,6 +16,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/stretchr/testify/require"
 )
@@ -186,6 +188,13 @@ func executorStub(detailEnabled bool) *connExecutor {
 			Settings: cluster.MakeTestingClusterSettings(),
 		},
 	}
+
+	ex.sessionDataStack = sessiondata.NewStack(&sessiondata.SessionData{
+		SessionData: sessiondatapb.SessionData{
+			Database:        "test-db",
+			ApplicationName: "test-app",
+		}},
+	)
 	metrics := makeMetrics(false, &ex.server.cfg.Settings.SV)
 	ex.metrics = &metrics
 

--- a/pkg/util/metric/aggmetric/counter.go
+++ b/pkg/util/metric/aggmetric/counter.go
@@ -313,6 +313,16 @@ func (c *SQLCounter) Inspect(f func(interface{})) {
 	f(c)
 }
 
+// Clear resets the counter to zero.
+func (c *SQLCounter) Clear() {
+	c.g.Clear()
+}
+
+// Count returns the aggregate count of all of its current and past children.
+func (c *SQLCounter) Count() int64 {
+	return c.g.Count()
+}
+
 // Inc increments the counter value by i for the given label values. If a
 // counter with the given label values doesn't exist yet, it creates a new
 // counter based on labelConfig and increments it. Inc increments parent metrics

--- a/pkg/util/metric/aggmetric/gauge.go
+++ b/pkg/util/metric/aggmetric/gauge.go
@@ -416,6 +416,11 @@ func (sg *SQLGauge) Inspect(f func(interface{})) {
 	f(sg)
 }
 
+// Value returns the aggregate sum of all of its current children.
+func (sg *SQLGauge) Value() int64 {
+	return sg.g.Value()
+}
+
 // Update sets the Gauge value to val for the given label values. If a
 // Gauge with the given label values doesn't exist yet, it creates a new
 // Gauge and updates it. Update increments parent metrics


### PR DESCRIPTION
Backport 1/1 commits from #144612.

/cc @cockroachdb/release

---

This patch updates sql metric declaration to support additional `database` and
`application_name` as labels. This is driven by cluster settings introduced as
part of https://github.com/cockroachdb/cockroach/pull/144610. The updated metrics will export additional labels based on
cluster settings `sql.metrics.application_name.enabled` and
`sql.metrics.database_name.enabled`. The SQLMetric will persist aggregate sum
of all its children, while children additionally exported to prometheus.

Epic: [CRDB-43153](https://cockroachlabs.atlassian.net/browse/CRDB-43153)
Part of: [CRDB-48251](https://cockroachlabs.atlassian.net/browse/CRDB-48251)
Release note: None

Updated metrics along with their `internal` counterpart (if exists):

- cr.node.sql.txns.open
- cr.node.sql.txn.latency
- cr.node.sql.txn.begin.count
- cr.node.sql.txn.commit.count
- cr.node.sql.txn.rollback.count
- cr.node.sql.statements.active
- cr.node.sql.update.count
- cr.node.sql.update.count
- cr.node.sql.insert.count
- cr.node.sql.delete.count
- cr.node.sql.crud.count
- cr.node.sql.service.latency
- cr.node.sql.distsql.contended_queries.count
- sql.distsql.cumulative_contention_nanos
- cr.node.sql.failure.count
- cr.node.sql.full.scan.count

---
Release justification: high priority customer feature request
