### PR TITLE
backup: fail compaction jobs upon encountering range keys 

### DIFF
--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -534,7 +534,7 @@ func (c compactionChain) createCompactionManifest(
 	// range keys.
 	lastBackup := c.lastBackup()
 	if len(lastBackup.Tenants) != 0 {
-		return nil, errors.New("backup compactions does not yet support range keys")
+		return nil, errors.New("backup compactions does not support range keys")
 	}
 	if err := checkCoverage(ctx, c.lastBackup().Spans, c.backupChain); err != nil {
 		return nil, err

--- a/pkg/backup/compaction_processor.go
+++ b/pkg/backup/compaction_processor.go
@@ -367,6 +367,11 @@ func openSSTs(
 	storeFiles := make([]storageccl.StoreFile, 0, len(entry.Files))
 	for idx := range entry.Files {
 		file := entry.Files[idx]
+		if file.HasRangeKeys {
+			// TODO (kev-cao): Come back and update this to range keys when
+			// SSTSinkKeyWriter has been updated to support range keys.
+			return mergedSST{}, errors.New("backup compactions does not support range keys")
+		}
 		dir, err := execCfg.DistSQLSrv.ExternalStorage(ctx, file.Dir)
 		if err != nil {
 			return mergedSST{}, err
@@ -375,8 +380,6 @@ func openSSTs(
 		storeFiles = append(storeFiles, storageccl.StoreFile{Store: dir, FilePath: file.Path})
 	}
 	iterOpts := storage.IterOptions{
-		// TODO (kev-cao): Come back and update this to range keys when
-		// SSTSinkKeyWriter has been updated to support range keys.
 		KeyTypes:   storage.IterKeyTypePointsOnly,
 		LowerBound: keys.LocalMax,
 		UpperBound: keys.MaxKey,

--- a/pkg/backup/testdata/backup-restore/rangekeys
+++ b/pkg/backup/testdata/backup-restore/rangekeys
@@ -29,8 +29,11 @@ exec-sql
 INSERT INTO foo VALUES (3,'z');
 ----
 
-exec-sql
-BACKUP INTO 'nodelocal://1/test-root/';
+save-cluster-ts tag=start
+----
+
+backup aost=start
+BACKUP INTO 'nodelocal://1/test-root/' AS OF SYSTEM TIME start;
 ----
 
 exec-sql
@@ -61,6 +64,15 @@ exec-sql
 INSERT INTO foo VALUES (4,'a'),(5,'b');
 ----
 
+# Create two incremental backups to test compaction
+exec-sql
+BACKUP INTO LATEST IN 'nodelocal://1/test-root/';
+----
+
+exec-sql
+INSERT INTO foo VALUES (6,'a'),(7,'b');
+----
+
 kv request=DeleteRange target=baz
 ----
 
@@ -68,8 +80,11 @@ exec-sql
 INSERT INTO baz VALUES (33,'zz');
 ----
 
-exec-sql
-BACKUP INTO LATEST IN 'nodelocal://1/test-root/';
+save-cluster-ts tag=end
+----
+
+backup aost=end
+BACKUP INTO LATEST IN 'nodelocal://1/test-root/' AS OF SYSTEM TIME end;
 ----
 
 exec-sql
@@ -84,9 +99,25 @@ regex matches error
 query-sql
 SELECT count(*) from orig1.foo
 ----
-3
+5
 
 query-sql
 SELECT count(*) from orig1.baz
 ----
 1
+
+let $backup_path
+SHOW BACKUPS IN 'nodelocal://1/test-root/';
+----
+
+compact start=start end=end tag=comp_job
+SELECT crdb_internal.backup_compaction('BACKUP INTO LATEST IN ''nodelocal://1/test-root/''', '$backup_path', start, end);
+----
+
+job tag=comp_job wait-for-state=failed
+----
+
+query-sql regex=(compactions does not support range keys)
+SELECT error FROM [SHOW JOBS] WHERE job_type = 'BACKUP' AND status = 'failed' ORDER BY created DESC LIMIT 1;
+----
+true


### PR DESCRIPTION
Previously if a compaction job encountered a range key, it would erroneously continue the job and succeed. As the current implementation of the backup compaction iterator skips range keys, if the compaction job encounters an SST file that contains range keys, it should fail the job.

Epic: None

Release note: Compaction jobs now properly fail upon encountering range keys.