### PR TITLE
tree: don't match variadic builtins when arg list is too short

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -2718,6 +2718,12 @@ Testing three, two, three
 query error pq: format\(\): error parsing format string: not enough arguments
 SELECT format(E'%2\x24s','foo');
 
+statement error pgcode 42883 pq: unknown signature: format\(\)
+SELECT format();
+
+statement error pgcode 42883 pq: unknown signature: format\(int\)
+SELECT format(42);
+
 subtest pg_is_in_recovery
 
 query B colnames


### PR DESCRIPTION
The new processing for variadic builtins is pretty permissive in what it allows because they underlying implementations are pretty permissive in what they accept. However, fixed arguments are still fixed arguments and must match.

Fixes: #144447
Release note: None