### PR TITLE
changefeedccl: max changefeed.resolved_timestamp.granularity to 10s

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -346,5 +346,5 @@ var Quantize = settings.RegisterDurationSettingWithExplicitUnit(
 	settings.ApplicationLevel,
 	"changefeed.resolved_timestamp.granularity",
 	"the granularity at which changefeed progress is quantized to make tracking more efficient",
-	time.Duration(metamorphic.ConstantWithTestRange("changefeed.resolved_timestamp.granularity", 0, 0, 20))*time.Second,
+	time.Duration(metamorphic.ConstantWithTestRange("changefeed.resolved_timestamp.granularity", 0, 0, 10))*time.Second,
 )


### PR DESCRIPTION
changefeed.resolved_timestamp.granularity was recently made metamorphic, but is causing test flakiness due to timeouts when it is >10s. This PR reduces the max to 10s.

Epic: none
Fixes: #144956
Fixes: #144948
Fixes: #144934

Release note: none