### PR TITLE
builder: downgrade `patchelf` to 0.17.2

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250418-212710
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250423-215642

--- a/build/bazelbuilder/Dockerfile
+++ b/build/bazelbuilder/Dockerfile
@@ -92,10 +92,10 @@ RUN case ${TARGETPLATFORM} in \
  rm -rf aws awscliv2.zip
 
 RUN case ${TARGETPLATFORM} in \
-    "linux/amd64") ARCH=x86_64; SHASUM=ce84f2447fb7a8679e58bc54a20dc2b01b37b5802e12c57eece772a6f14bf3f0 ;; \
-    "linux/arm64") ARCH=aarch64; SHASUM=ae13e2effe077e829be759182396b931d8f85cfb9cfe9d49385516ea367ef7b2 ;; \
+    "linux/amd64") ARCH=x86_64; SHASUM=a3fb9c1de3512bc91f27cc47297d6d6cf208adee9b64ed719130da59ac13e26b ;; \
+    "linux/arm64") ARCH=aarch64; SHASUM=e5165eb592a317e1f6da0ac7fcbccf60d7fb8e5ac1f0d7336a9be51c23308b06 ;; \
   esac && \
- curl -fsSL "https://github.com/NixOS/patchelf/releases/download/0.18.0/patchelf-0.18.0-$ARCH.tar.gz" -o "patchelf.tar.gz" && \
+ curl -fsSL "https://github.com/NixOS/patchelf/releases/download/0.17.2/patchelf-0.17.2-$ARCH.tar.gz" -o "patchelf.tar.gz" && \
  echo "$SHASUM patchelf.tar.gz" | sha256sum -c - && \
  tar --strip-components=1 -C /usr -xzf patchelf.tar.gz && \
  rm -rf patchelf.tar.gz

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -32,7 +32,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:97228ff5e3ccfed242b49b37fa427d03203bb69ee74c5129f29b6a6fa7662ad1",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:394483c5651c395cb4d72f4f3551a3c5027ba5c0c278d79c819f7793bdbc5096",
         "dockerReuse": "True",
         "Pool": "default",
     },
@@ -137,7 +137,7 @@ platform(
         "@platforms//cpu:arm64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:57c597624ed396b33be80548acfef221e5c340b09ed36a0d826c1798a414b10d",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:d855a27ab26c92c2a8cdc56bcc22f24cb2b50d6d9742af3c8eb61755f00bcccb",
         "dockerReuse": "True",
         "Pool": "default",
     },


### PR DESCRIPTION
Version 0.18 still has this issue: NixOS/patchelf#492

Epic: CRDB-21133
Release note: None