### PR TITLE
sql/importer: fix export parquet for NULL values

### DIFF
--- a/pkg/sql/importer/exportparquet.go
+++ b/pkg/sql/importer/exportparquet.go
@@ -170,10 +170,8 @@ func (sp *parquetWriterProcessor) Run(ctx context.Context, output execinfra.RowR
 					if err := memAcc.Grow(ctx, datumAllocSize); err != nil {
 						return err
 					}
-					if !ed.IsNull() {
-						if err := ed.EnsureDecoded(typs[i], alloc); err != nil {
-							return err
-						}
+					if err := ed.EnsureDecoded(typs[i], alloc); err != nil {
+						return err
 					}
 					// If we're encoding a DOidWrapper, then we want to cast
 					// the wrapped datum. Note that we don't use

--- a/pkg/sql/importer/exportparquet_test.go
+++ b/pkg/sql/importer/exportparquet_test.go
@@ -367,6 +367,15 @@ INDEX (y))`)
 			stmt: `EXPORT INTO PARQUET 'nodelocal://1/uncompress'
 							FROM SELECT * FROM foo `,
 		},
+		{
+			filePrefix: "null_vals_with_index",
+			prep: []string{
+				`CREATE TABLE null_vals_with_index (a STRING PRIMARY KEY, b STRING, INDEX b_idx (b ASC))`,
+				`INSERT INTO null_vals_with_index VALUES ('a', NULL)`,
+			},
+			stmt: `EXPORT INTO PARQUET 'nodelocal://1/null_vals_with_index'
+							FROM SELECT * FROM null_vals_with_index@b_idx`,
+		},
 	}
 
 	for _, test := range tests {


### PR DESCRIPTION
This patch fixes a bug where a NULL value could cause a parquet
export to fail because we weren't ensuring NULL values were
fully decoded being passing them to our parquet writer.

Fixes #144998

Release note (bug fix): A bug where a NULL value could cause a
parquet export to fail has been fixed.