### PR TITLE
opt: handle unsimplified groupby orderings

### DIFF
--- a/pkg/sql/opt/ordering/group_by.go
+++ b/pkg/sql/opt/ordering/group_by.go
@@ -23,9 +23,13 @@ func scalarGroupByBuildChildReqOrdering(
 
 func groupByCanProvideOrdering(expr memo.RelExpr, required *props.OrderingChoice) bool {
 	// GroupBy may require a certain ordering of its input, but can also pass
-	// through a stronger ordering on the grouping columns.
+	// through a stronger ordering on the grouping and pass-through columns.
+	//
+	// Note that an ordering on non-grouping columns is not actually useful, but
+	// we handle it anyway since ordering simplification rules can be disabled.
 	groupBy := expr.(*memo.GroupByExpr)
-	return required.CanProjectCols(groupBy.GroupingCols) && required.Intersects(&groupBy.Ordering)
+	return required.CanProjectCols(groupBy.Input.Relational().OutputCols) &&
+		required.Intersects(&groupBy.Ordering)
 }
 
 func groupByBuildChildReqOrdering(
@@ -36,9 +40,9 @@ func groupByBuildChildReqOrdering(
 	}
 	groupBy := parent.(*memo.GroupByExpr)
 	result := *required
-	if !result.SubsetOfCols(groupBy.GroupingCols) {
+	if !result.SubsetOfCols(groupBy.Input.Relational().OutputCols) {
 		result = result.Copy()
-		result.ProjectCols(groupBy.GroupingCols)
+		result.ProjectCols(groupBy.Input.Relational().OutputCols)
 	}
 
 	result = result.Intersection(&groupBy.Ordering)

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3280,3 +3280,49 @@ top-k
       ├── cardinality: [0 - 3]
       └── scan t106678
            └── columns: a:1 b:2
+
+# Regression test for #137508 - handle unsimplified group-by orderings.
+exec-ddl
+CREATE TABLE table_4 (
+  c_ol4_0 REGCLASS,
+  col4_1 BOOL NOT NULL,
+  col4_2 INT2 NOT NULL,
+  col4_3 REGCLASS NOT NULL,
+  col4_4 STRING NOT NULL AS (lower(CAST(col4_1 AS STRING))) STORED,
+  PRIMARY KEY (col4_3 DESC, col4_2 ASC)
+);
+----
+
+opt disable=(SimplifyWindowOrdering,SimplifyGroupByOrdering,PruneRootCols)
+SELECT concat_agg(col4_4 ORDER BY col4_4)
+FROM table_4 WHERE col4_1
+GROUP BY tableoid, col4_4
+ORDER BY tableoid, col4_4;
+----
+sort
+ ├── columns: concat_agg:8!null  [hidden: col4_4:5!null tableoid:7]
+ ├── key: (7)
+ ├── fd: ()-->(5), (7)-->(5,8)
+ ├── ordering: +7 opt(5) [actual: +7]
+ └── group-by (hash)
+      ├── columns: col4_4:5!null tableoid:7 concat_agg:8!null
+      ├── grouping columns: tableoid:7
+      ├── internal-ordering: +5
+      ├── key: (7)
+      ├── fd: ()-->(5), (7)-->(5,8)
+      ├── select
+      │    ├── columns: col4_1:2!null col4_4:5!null tableoid:7
+      │    ├── fd: ()-->(2,5)
+      │    ├── scan table_4
+      │    │    ├── columns: col4_1:2!null col4_4:5!null tableoid:7
+      │    │    ├── computed column expressions
+      │    │    │    └── col4_4:5
+      │    │    │         └── lower(col4_1:2::STRING)
+      │    │    └── fd: (2)-->(5)
+      │    └── filters
+      │         └── col4_1:2 [outer=(2), fd=()-->(2)]
+      └── aggregations
+           ├── concat-agg [as=concat_agg:8, outer=(5)]
+           │    └── col4_4:5
+           └── const-agg [as=col4_4:5, outer=(5)]
+                └── col4_4:5


### PR DESCRIPTION
This commit fixes a test-only assertion failure due to the GroupBy provided ordering logic relying on ordering simplification rules. The assertion errors happened because the provided ordering logic expected that a required ordering would only ever contain grouping columns. In reality, it is possible for the ordering to include `ConstAgg` and other "pass-through" columns. However, references to these columns are usually removed by rules like `SimplifyGroupByOrdering` because they are constant within a given group.

Since the failure only occurs with rules disabled and only in test builds, there is no release note.

Fixes #137508

Release note: None