### PR TITLE
opt/norm: add UseSwapMutation normalization rule

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4289,6 +4289,7 @@ use_improved_routine_dependency_tracking                         on
 use_pre_25_2_variadic_builtins                                   off
 use_proc_txn_control_extended_protocol_fix                       on
 use_soft_limit_for_distribute_scan                               on
+use_swap_mutations                                               off
 variable_inequality_lookup_join_enabled                          on
 vector_search_beam_size                                          32
 vector_search_rerank_multiplier                                  50

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3243,6 +3243,7 @@ use_improved_routine_dependency_tracking                         on             
 use_pre_25_2_variadic_builtins                                   off                 NULL      NULL        NULL        string
 use_proc_txn_control_extended_protocol_fix                       on                  NULL      NULL        NULL        string
 use_soft_limit_for_distribute_scan                               on                  NULL      NULL        NULL        string
+use_swap_mutations                                               off                 NULL      NULL        NULL        string
 variable_inequality_lookup_join_enabled                          on                  NULL      NULL        NULL        string
 vector_search_beam_size                                          32                  NULL      NULL        NULL        string
 vector_search_rerank_multiplier                                  50                  NULL      NULL        NULL        string
@@ -3492,6 +3493,7 @@ use_improved_routine_dependency_tracking                         on             
 use_pre_25_2_variadic_builtins                                   off                 NULL  user     NULL      off                 off
 use_proc_txn_control_extended_protocol_fix                       on                  NULL  user     NULL      on                  on
 use_soft_limit_for_distribute_scan                               on                  NULL  user     NULL      on                  on
+use_swap_mutations                                               off                 NULL  user     NULL      off                 off
 variable_inequality_lookup_join_enabled                          on                  NULL  user     NULL      on                  on
 vector_search_beam_size                                          32                  NULL  user     NULL      32                  32
 vector_search_rerank_multiplier                                  50                  NULL  user     NULL      50                  50
@@ -3733,6 +3735,7 @@ use_improved_routine_dependency_tracking                         NULL    NULL   
 use_pre_25_2_variadic_builtins                                   NULL    NULL     NULL     NULL        NULL
 use_proc_txn_control_extended_protocol_fix                       NULL    NULL     NULL     NULL        NULL
 use_soft_limit_for_distribute_scan                               NULL    NULL     NULL     NULL        NULL
+use_swap_mutations                                               NULL    NULL     NULL     NULL        NULL
 variable_inequality_lookup_join_enabled                          NULL    NULL     NULL     NULL        NULL
 vector_search_beam_size                                          NULL    NULL     NULL     NULL        NULL
 vector_search_rerank_multiplier                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -260,6 +260,7 @@ use_improved_routine_dependency_tracking                         on
 use_pre_25_2_variadic_builtins                                   off
 use_proc_txn_control_extended_protocol_fix                       on
 use_soft_limit_for_distribute_scan                               on
+use_swap_mutations                                               off
 variable_inequality_lookup_join_enabled                          on
 vector_search_beam_size                                          32
 vector_search_rerank_multiplier                                  50

--- a/pkg/sql/logictest/testdata/logic_test/swap_mutation
+++ b/pkg/sql/logictest/testdata/logic_test/swap_mutation
@@ -1,0 +1,127 @@
+# LogicTest: local
+
+# Test that unique indexes work correctly with swap mutations.
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  UNIQUE INDEX (y),
+  FAMILY (x, y, z)
+)
+
+statement ok
+INSERT INTO xyz VALUES (1, 1, 1), (2, 2, 2)
+
+# This statement should fail with a dupe key error.
+
+statement error duplicate key value violates unique constraint "xyz_y_key"
+UPDATE xyz SET y = 1 WHERE x = 2 AND y = 2 AND z = 2
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  1
+2  2  2
+
+# This statement should succeed and modify 0 rows, because no rows have z = 3.
+
+statement ok
+UPDATE xyz SET y = 1 WHERE x = 2 AND y = 2 AND z = 3
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  1
+2  2  2
+
+# Test rollback of swap mutations.
+
+statement ok
+BEGIN
+
+statement ok
+UPDATE xyz SET z = 11 WHERE x = 1 AND y = 1 AND z = 1
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  11
+2  2  2
+
+statement ok
+SAVEPOINT a
+
+statement ok
+UPDATE xyz SET z = 12 WHERE x = 2 AND y = 2 AND z = 2
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  11
+2  2  12
+
+statement ok
+ROLLBACK TO a
+
+statement ok
+UPDATE xyz SET z = 21 WHERE x = 1 AND y = 1 AND z = 11
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  21
+2  2  2
+
+statement ok
+SAVEPOINT b
+
+# This should do nothing.
+
+statement ok
+UPDATE xyz SET z = 31 WHERE x = 1 AND y = 1 AND z = 11
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  21
+2  2  2
+
+statement ok
+ROLLBACK TO b
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  21
+2  2  2
+
+statement ok
+ROLLBACK TO a
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  11
+2  2  2
+
+# This should do nothing.
+
+statement ok
+UPDATE xyz SET z = 31 WHERE x = 1 AND y = 1 AND z = 21
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  11
+2  2  2
+
+statement ok
+COMMIT
+
+query III
+SELECT * FROM xyz ORDER BY x
+----
+1  1  11
+2  2  2

--- a/pkg/sql/logictest/testdata/logic_test/swap_mutation
+++ b/pkg/sql/logictest/testdata/logic_test/swap_mutation
@@ -125,3 +125,58 @@ SELECT * FROM xyz ORDER BY x
 ----
 1  1  11
 2  2  2
+
+statement ok
+CREATE TABLE mno (m INT PRIMARY KEY, n INT, o INT NOT NULL, UNIQUE INDEX (o), INDEX (n), FAMILY (m, n, o))
+
+statement ok
+INSERT INTO mno VALUES (3, 3, 3), (4, 4, 4)
+
+statement error pq: duplicate key value violates unique constraint "mno_o_key"\nDETAIL: Key \(o\)=\(4\) already exists\.
+UPDATE mno SET o = 4 WHERE m = 3 AND n IS NOT DISTINCT FROM 3 AND o IS NOT DISTINCT FROM 3
+
+query III
+SELECT * FROM mno ORDER BY m
+----
+3  3  3
+4  4  4
+
+# The failure of the CPut of the primary index should trump the failure of the
+# CPut of the secondary index, meaning the end result should be 0 rows updated
+# instead of a dupe key error.
+statement ok
+UPDATE mno SET o = 4 WHERE m = 3 AND n IS NOT DISTINCT FROM 4 AND o IS NOT DISTINCT FROM 3
+
+query III
+SELECT * FROM mno ORDER BY m
+----
+3  3  3
+4  4  4
+
+statement ok
+ALTER TABLE mno ADD COLUMN p INT
+
+statement ok
+ALTER TABLE mno DROP COLUMN p
+
+statement error pq: duplicate key value violates unique constraint "mno_o_key"\nDETAIL: Key \(o\)=\(4\) already exists\.
+UPDATE mno SET o = 4 WHERE m = 3 AND n IS NOT DISTINCT FROM 3 AND o IS NOT DISTINCT FROM 3
+
+query III
+SELECT * FROM mno ORDER BY m
+----
+3  3  3
+4  4  4
+
+# Like above, even with the primary index ordered after the unique secondary
+# index, the failure of the CPut of the primary index should trump the failure
+# of the CPut of the secondary index, so the end result should be 0 rows updated
+# instead of a dupe key error.
+statement ok
+UPDATE mno SET o = 4 WHERE m = 3 AND n IS NOT DISTINCT FROM 4 AND o IS NOT DISTINCT FROM 3
+
+query III
+SELECT * FROM mno ORDER BY m
+----
+3  3  3
+4  4  4

--- a/pkg/sql/logictest/testdata/logic_test/swap_mutation
+++ b/pkg/sql/logictest/testdata/logic_test/swap_mutation
@@ -1,5 +1,8 @@
 # LogicTest: local
 
+statement ok
+SET use_swap_mutations = on
+
 # Test that unique indexes work correctly with swap mutations.
 
 statement ok
@@ -180,3 +183,6 @@ SELECT * FROM mno ORDER BY m
 ----
 3  3  3
 4  4  4
+
+statement ok
+RESET use_swap_mutations

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2418,6 +2418,13 @@ func TestLogic_subquery_correlated(
 	runLogicTest(t, "subquery_correlated")
 }
 
+func TestLogic_swap_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "swap_mutation")
+}
+
 func TestLogic_synthetic_privileges(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/column_meta.go
+++ b/pkg/sql/opt/column_meta.go
@@ -163,6 +163,25 @@ func (ocl OptionalColList) ToSet() ColSet {
 	return r
 }
 
+// CopyAndMaybeRemapColumns copies this OptionalColList, remapping any columns
+// present in the provided ColMap.
+func (ocl OptionalColList) CopyAndMaybeRemapColumns(m ColMap) (res OptionalColList) {
+	if len(ocl) == 0 {
+		return nil
+	}
+	res = make(OptionalColList, len(ocl))
+	for i, col := range ocl {
+		if col != 0 {
+			if val, ok := m.Get(int(col)); ok {
+				res[i] = ColumnID(val)
+			} else {
+				res[i] = col
+			}
+		}
+	}
+	return res
+}
+
 // ColumnMeta stores information about one of the columns stored in the
 // metadata.
 type ColumnMeta struct {

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -221,7 +221,7 @@ vectorized: true
 
 # Tracing tests for fast delete.
 statement ok
-CREATE TABLE a (a INT PRIMARY KEY)
+CREATE TABLE a (a DECIMAL PRIMARY KEY)
 
 # Delete range operates in chunks of 600 (defined by row.TableTruncateChunkSize).
 statement ok
@@ -427,28 +427,28 @@ distribution: local
 vectorized: true
 ·
 • render
-│ columns: (a int, b int, "?column?" unknown)
+│ columns: (a decimal, b int, "?column?" unknown)
 │ render ?column?: (NULL)[unknown]
-│ render a: (a)[int]
+│ render a: (a)[decimal]
 │ render b: (b)[int]
 │
 └── • delete
-    │ columns: (a int, b int)
+    │ columns: (a decimal, b int)
     │ estimated row count: 1,000 (missing stats)
     │ from: a
     │ auto commit
     │
     └── • distinct
-        │ columns: (a int, b int)
+        │ columns: (a decimal, b int)
         │ estimated row count: 1,000 (missing stats)
         │ distinct on: a
         │
         └── • cross join (inner)
-            │ columns: (a int, b int)
+            │ columns: (a decimal, b int)
             │ estimated row count: 333,333 (missing stats)
             │
             ├── • scan
-            │     columns: (a int)
+            │     columns: (a decimal)
             │     estimated row count: 1,000 (missing stats)
             │     table: a@a_pkey
             │     spans: FULL SCAN

--- a/pkg/sql/opt/exec/execbuilder/testdata/swap_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/swap_mutation
@@ -1,0 +1,732 @@
+# LogicTest: local
+
+# Test that update swap and delete swap work correctly and use a single batch.
+
+# Test swap mutations with only primary key columns.
+
+statement ok
+CREATE TABLE k (
+  k INT PRIMARY KEY
+)
+
+statement ok
+INSERT INTO k VALUES (1)
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE k SET k = 2 WHERE k = 1
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: k
+│ set: k
+│ auto commit
+│
+└── • values
+      size: 2 columns, 1 row
+
+query T kvtrace
+UPDATE k SET k = 2 WHERE k = 1
+----
+CPut /Table/106/1/1/0 -> nil (delete)
+CPut /Table/106/1/2/0 -> /TUPLE/
+
+query I
+SELECT * FROM k
+----
+2
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM k WHERE k = 2
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: k
+│ auto commit
+│
+└── • values
+      size: 1 column, 1 row
+
+query T kvtrace
+DELETE FROM k WHERE k = 2
+----
+CPut /Table/106/1/2/0 -> nil (delete)
+
+query I
+SELECT * FROM k
+----
+
+# Test swap mutations with only a primary index.
+
+statement ok
+CREATE TABLE kabc (
+  k INT PRIMARY KEY,
+  a STRING,
+  b TIMESTAMPTZ,
+  c BOOLEAN,
+  FAMILY (k, a, b, c)
+)
+
+statement ok
+INSERT INTO kabc VALUES (1, NULL, '1999-12-31 23:59:59', NULL)
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE kabc SET b = '2000-01-01 00:00:00' WHERE k = 1 AND a IS NULL AND b = '1999-12-31 23:59:59' AND c IS NULL
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: kabc
+│ set: b
+│ auto commit
+│
+└── • values
+      size: 5 columns, 1 row
+
+query T kvtrace
+UPDATE kabc SET b = '2000-01-01 00:00:00' WHERE k = 1 AND a IS NULL AND b = '1999-12-31 23:59:59' AND c IS NULL
+----
+CPut /Table/107/1/1/0 -> /TUPLE/3:3:Time/2000-01-01T00:00:00Z (swap)
+
+query ITTB
+SELECT * FROM kabc
+----
+1  NULL  2000-01-01 00:00:00 +0000 UTC  NULL
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM kabc WHERE k = 1 AND a IS NULL AND b = '2000-01-01 00:00:00' AND c IS NULL
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: kabc
+│ auto commit
+│
+└── • values
+      size: 4 columns, 1 row
+
+query T kvtrace
+DELETE FROM kabc WHERE k = 1 AND a IS NULL AND b = '2000-01-01 00:00:00' AND c IS NULL
+----
+CPut /Table/107/1/1/0 -> nil (delete)
+
+query ITTB
+SELECT * FROM kabc
+----
+
+# Test swap mutations with computed columns.
+
+statement ok
+CREATE TABLE abcde (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL AS (a + b) VIRTUAL,
+  d INT NOT NULL AS (a - b) VIRTUAL,
+  e INT NOT NULL AS (a * b) STORED,
+  PRIMARY KEY (a, e),
+  INDEX (c),
+  FAMILY (a, b, e)
+)
+
+statement ok
+INSERT INTO abcde (a, b) VALUES (1, 1)
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE abcde SET b = 0 WHERE a = 1 AND b = 1 AND e = 1
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: abcde
+│ set: b, c, d, e
+│ auto commit
+│
+└── • values
+      size: 9 columns, 1 row
+
+query T kvtrace
+UPDATE abcde SET b = 0 WHERE a = 1 AND b = 1 AND e = 1
+----
+CPut /Table/108/1/1/1/0 -> nil (delete)
+Del /Table/108/2/2/1/1/0
+CPut /Table/108/1/1/0/0 -> /TUPLE/2:2:Int/0
+Put /Table/108/2/1/1/0/0 -> /BYTES/
+
+query IIIII
+SELECT * FROM abcde
+----
+1  0  1  1  0
+
+# Test a delete swap where we don't actually delete a row.
+
+query T
+EXPLAIN DELETE FROM abcde WHERE a = 1 AND b = 1 AND e = 1
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: abcde
+│ auto commit
+│
+└── • values
+      size: 4 columns, 1 row
+
+query T kvtrace
+DELETE FROM abcde WHERE a = 1 AND b = 1 AND e = 1
+----
+CPut /Table/108/1/1/1/0 -> nil (delete)
+Del /Table/108/2/2/1/1/0
+
+query IIIII
+SELECT * FROM abcde@abcde_c_idx
+----
+1  0  1  1  0
+
+# Test swap mutations with a unique secondary index.
+
+statement ok
+CREATE TABLE xyz (
+  x INT PRIMARY KEY,
+  y INT,
+  z INT,
+  INDEX (y),
+  UNIQUE INDEX (z),
+  FAMILY (x, y, z)
+)
+
+statement ok
+INSERT INTO xyz VALUES (1, 2, 3), (4, 5, 6)
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE xyz SET x = 4, y = 7, z = 8 WHERE x = 4 AND y IS NOT DISTINCT FROM 5 AND z IS NOT DISTINCT FROM 6
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: xyz
+│ set: x, y, z
+│ auto commit
+│
+└── • values
+      size: 6 columns, 1 row
+
+query T kvtrace
+UPDATE xyz SET x = 4, y = 7, z = 8 WHERE x = 4 AND y IS NOT DISTINCT FROM 5 AND z IS NOT DISTINCT FROM 6
+----
+CPut /Table/109/1/4/0 -> /TUPLE/2:2:Int/7/1:3:Int/8 (swap)
+Del /Table/109/2/5/4/0
+Put /Table/109/2/7/4/0 -> /BYTES/
+Del (locking) /Table/109/3/6/0
+CPut /Table/109/3/8/0 -> /BYTES/0x8c
+
+query III
+SELECT * FROM xyz WHERE x = 4
+----
+4  7  8
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM xyz WHERE x = 1 AND y = 2 AND z = 3
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: xyz
+│ auto commit
+│
+└── • values
+      size: 3 columns, 1 row
+
+query T kvtrace
+DELETE FROM xyz WHERE x = 1 AND y = 2 AND z = 3
+----
+CPut /Table/109/1/1/0 -> nil (delete)
+Del /Table/109/2/2/1/0
+Del (locking) /Table/109/3/3/0
+
+query III
+SELECT * FROM xyz WHERE x = 1
+----
+
+# Test swap mutations with expression indexes.
+
+statement ok
+CREATE TABLE pq (
+  p INT PRIMARY KEY,
+  q INT,
+  INDEX ((p + q)),
+  FAMILY (p, q)
+)
+
+statement ok
+INSERT INTO pq VALUES (0, 1)
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE pq SET q = NULL WHERE p IS NOT DISTINCT FROM 0 AND q IS NOT DISTINCT FROM 1
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: pq
+│ set: q, crdb_internal_idx_expr
+│ auto commit
+│
+└── • values
+      size: 5 columns, 1 row
+
+query T kvtrace
+UPDATE pq SET q = NULL WHERE p IS NOT DISTINCT FROM 0 AND q IS NOT DISTINCT FROM 1
+----
+CPut /Table/110/1/0/0 -> /TUPLE/ (swap)
+Del /Table/110/2/1/0/0
+Put /Table/110/2/NULL/0/0 -> /BYTES/
+
+query II
+SELECT * FROM pq
+----
+0  NULL
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM pq WHERE p IS NOT DISTINCT FROM 0 AND q IS NOT DISTINCT FROM NULL
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: pq
+│ auto commit
+│
+└── • values
+      size: 3 columns, 1 row
+
+query T kvtrace
+DELETE FROM pq WHERE p IS NOT DISTINCT FROM 0 AND q IS NOT DISTINCT FROM NULL
+----
+CPut /Table/110/1/0/0 -> nil (delete)
+Del /Table/110/2/NULL/0/0
+
+query II
+SELECT * FROM pq
+----
+
+# Test swap mutations with partial indexes.
+
+statement ok
+CREATE TABLE mno (
+  m STRING NOT NULL,
+  n STRING NOT NULL,
+  o STRING,
+  PRIMARY KEY (n),
+  INDEX (m) WHERE o LIKE 'o%',
+  FAMILY (m, n, o)
+)
+
+statement ok
+INSERT INTO mno VALUES ('m1', 'n1', 'o'), ('m2', 'n2', NULL), ('m3', 'n3', '')
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE mno SET o = 'o' || o WHERE m = 'm1' AND n = 'n1' AND o = 'o'
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: mno
+│ set: o
+│ auto commit
+│
+└── • values
+      size: 6 columns, 1 row
+
+query T kvtrace
+UPDATE mno SET o = 'o' || o WHERE m = 'm1' AND n = 'n1' AND o = 'o'
+----
+CPut /Table/111/1/"n1"/0 -> /TUPLE/1:1:Bytes/m1/2:3:Bytes/oo (swap)
+
+query T kvtrace
+UPDATE mno SET o = 'o' || o WHERE m = 'm2' AND n = 'n2' AND o IS NULL
+----
+CPut /Table/111/1/"n2"/0 -> /TUPLE/1:1:Bytes/m2 (swap)
+
+query T kvtrace
+UPDATE mno SET o = 'o' || o WHERE m = 'm3' AND n = 'n3' AND o = ''
+----
+CPut /Table/111/1/"n3"/0 -> /TUPLE/1:1:Bytes/m3/2:3:Bytes/o (swap)
+Put /Table/111/2/"m3"/"n3"/0 -> /BYTES/
+
+query TTT
+SELECT * FROM mno ORDER BY n
+----
+m1  n1  oo
+m2  n2  NULL
+m3  n3  o
+
+query T
+SELECT m FROM mno@mno_m_idx WHERE o LIKE 'o%' ORDER BY m
+----
+m1
+m3
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM mno WHERE m = 'm1' AND n = 'n1' AND o = 'oo'
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: mno
+│ auto commit
+│
+└── • values
+      size: 4 columns, 1 row
+
+query T kvtrace
+DELETE FROM mno WHERE m = 'm1' AND n = 'n1' AND o = 'oo'
+----
+CPut /Table/111/1/"n1"/0 -> nil (delete)
+Del /Table/111/2/"m1"/"n1"/0
+
+query T kvtrace
+DELETE FROM mno WHERE m = 'm2' AND n = 'n2' AND o IS NULL
+----
+CPut /Table/111/1/"n2"/0 -> nil (delete)
+
+query T kvtrace
+DELETE FROM mno WHERE m = 'm3' AND n = 'n3' AND o = 'o'
+----
+CPut /Table/111/1/"n3"/0 -> nil (delete)
+Del /Table/111/2/"m3"/"n3"/0
+
+query TTT
+SELECT * FROM mno
+----
+
+# Test swap mutations with inverted indexes.
+
+statement ok
+CREATE TABLE uvw (
+  u UUID NOT NULL DEFAULT gen_random_uuid(),
+  v TEXT,
+  w INT[],
+  PRIMARY KEY (u),
+  INVERTED INDEX (v gin_trgm_ops),
+  INVERTED INDEX (w),
+  FAMILY (u, v, w)
+)
+
+statement ok
+INSERT INTO uvw VALUES ('a8ebe7c3-7fd9-4a75-a56a-242a1088d295', 'abcde', '{1, 2, 3}')
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE uvw SET v = v || 'f', w = w || 4 WHERE u = 'a8ebe7c3-7fd9-4a75-a56a-242a1088d295' AND v = 'abcde' AND w = '{1, 2, 3}'
+----
+distribution: local
+vectorized: true
+·
+• update swap
+│ table: uvw
+│ set: v, w
+│ auto commit
+│
+└── • values
+      size: 5 columns, 1 row
+
+query T kvtrace
+UPDATE uvw SET v = v || 'f', w = w || 4 WHERE u = 'a8ebe7c3-7fd9-4a75-a56a-242a1088d295' AND v = 'abcde' AND w = '{1, 2, 3}'
+----
+CPut /Table/112/1/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0 -> /TUPLE/2:2:Bytes/abcdef/1:3:Array/ARRAY[1,2,3,4] (swap)
+Del /Table/112/2/"de "/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Put /Table/112/2/"def"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0 -> /BYTES/
+Put /Table/112/2/"ef "/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0 -> /BYTES/
+Put /Table/112/3/4/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0 -> /BYTES/
+
+query TTT
+SELECT * FROM uvw
+----
+a8ebe7c3-7fd9-4a75-a56a-242a1088d295  abcdef  {1,2,3,4}
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM uvw WHERE u = 'a8ebe7c3-7fd9-4a75-a56a-242a1088d295' AND v = 'abcdef' AND w = '{1, 2, 3, 4}'
+----
+distribution: local
+vectorized: true
+·
+• delete swap
+│ from: uvw
+│ auto commit
+│
+└── • values
+      size: 3 columns, 1 row
+
+query T kvtrace
+DELETE FROM uvw WHERE u = 'a8ebe7c3-7fd9-4a75-a56a-242a1088d295' AND v = 'abcdef' AND w = '{1, 2, 3, 4}'
+----
+CPut /Table/112/1/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0 -> nil (delete)
+Del /Table/112/2/"  a"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/2/" ab"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/2/"abc"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/2/"bcd"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/2/"cde"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/2/"def"/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/2/"ef "/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/3/1/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/3/2/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/3/3/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+Del /Table/112/3/4/"\xa8\xeb\xe7\xc3\x7f\xd9Ju\xa5j$*\x10\x88ҕ"/0
+
+query III
+SELECT * FROM uvw
+----
+
+# Test swap mutations with multiple column families.
+
+# TODO: update swap and delete swap do not yet support multiple column families.
+
+statement ok
+CREATE TABLE rstuv (
+  r INT NOT NULL,
+  s INT NOT NULL,
+  t INT,
+  u INT,
+  v INT,
+  PRIMARY KEY (r, s),
+  INDEX (t) STORING (u, v),
+  INDEX (u) STORING (t, v),
+  FAMILY (r, s),
+  FAMILY (t),
+  FAMILY (u, v)
+)
+
+statement ok
+INSERT INTO rstuv VALUES (5, 6, 7, 8, NULL), (15, 16, NULL, 18, 19)
+
+# Test update swap.
+
+query T
+EXPLAIN UPDATE rstuv SET t = 27, u = 28, v = 29 WHERE r = 5 AND s = 6 AND t = 7 AND u = 8 AND v IS NULL
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: rstuv
+│ set: t, u, v
+│ auto commit
+│
+└── • render
+    │
+    └── • filter
+        │ filter: (u = 8) AND (v IS NULL)
+        │
+        └── • scan
+              missing stats
+              table: rstuv@rstuv_t_idx
+              spans: [/7/5/6 - /7/5/6]
+
+query T kvtrace
+UPDATE rstuv SET t = 27, u = 28, v = 29 WHERE r = 5 AND s = 6 AND t = 7 AND u = 8 AND v IS NULL
+----
+Scan /Table/113/2/7/5/{6-7}
+Put (locking) /Table/113/1/5/6/1/1 -> /INT/27
+Put (locking) /Table/113/1/5/6/2/1 -> /TUPLE/4:4:Int/28/1:5:Int/29
+Del /Table/113/2/7/5/6/0
+Put /Table/113/2/27/5/6/0 -> /BYTES/
+Del /Table/113/2/7/5/6/2/1
+Put /Table/113/2/27/5/6/2/1 -> /TUPLE/4:4:Int/28/1:5:Int/29
+Del /Table/113/3/8/5/6/0
+Put /Table/113/3/28/5/6/0 -> /BYTES/
+Del /Table/113/3/8/5/6/1/1
+Put /Table/113/3/28/5/6/1/1 -> /TUPLE/3:3:Int/27
+Put /Table/113/3/28/5/6/2/1 -> /TUPLE/5:5:Int/29
+
+query T kvtrace
+UPDATE rstuv SET t = 37, u = 38, v = 39 WHERE r = 15 AND s = 16 AND t IS NULL AND u = 18 AND v = 19
+----
+Scan /Table/113/2/NULL/15/1{6-7}
+Put (locking) /Table/113/1/15/16/1/1 -> /INT/37
+Put (locking) /Table/113/1/15/16/2/1 -> /TUPLE/4:4:Int/38/1:5:Int/39
+Del /Table/113/2/NULL/15/16/0
+Put /Table/113/2/37/15/16/0 -> /BYTES/
+Del /Table/113/2/NULL/15/16/2/1
+Put /Table/113/2/37/15/16/2/1 -> /TUPLE/4:4:Int/38/1:5:Int/39
+Del /Table/113/3/18/15/16/0
+Put /Table/113/3/38/15/16/0 -> /BYTES/
+Put /Table/113/3/38/15/16/1/1 -> /TUPLE/3:3:Int/37
+Del /Table/113/3/18/15/16/2/1
+Put /Table/113/3/38/15/16/2/1 -> /TUPLE/5:5:Int/39
+
+query IIIII
+SELECT * FROM rstuv ORDER BY r, s
+----
+5   6   27  28  29
+15  16  37  38  39
+
+# Test delete swap.
+
+query T
+EXPLAIN DELETE FROM rstuv WHERE r = 5 AND s = 6 AND t = 27 AND u = 28 AND v = 29
+----
+distribution: local
+vectorized: true
+·
+• delete
+│ from: rstuv
+│ auto commit
+│
+└── • filter
+    │ filter: (u = 28) AND (v = 29)
+    │
+    └── • scan
+          missing stats
+          table: rstuv@rstuv_t_idx
+          spans: [/27/5/6 - /27/5/6]
+
+query T kvtrace
+DELETE FROM rstuv WHERE r = 5 AND s = 6 AND t = 27 AND u = 28 AND v = 29
+----
+Scan /Table/113/2/27/5/{6-7}
+Del (locking) /Table/113/1/5/6/0
+Del (locking) /Table/113/1/5/6/1/1
+Del (locking) /Table/113/1/5/6/2/1
+Del /Table/113/2/27/5/6/0
+Del /Table/113/2/27/5/6/2/1
+Del /Table/113/3/28/5/6/0
+Del /Table/113/3/28/5/6/1/1
+Del /Table/113/3/28/5/6/2/1
+
+query T kvtrace
+DELETE FROM rstuv WHERE r = 15 AND s = 16 AND t = 37 AND u = 38 AND v = 39
+----
+Scan /Table/113/2/37/15/1{6-7}
+Del (locking) /Table/113/1/15/16/0
+Del (locking) /Table/113/1/15/16/1/1
+Del (locking) /Table/113/1/15/16/2/1
+Del /Table/113/2/37/15/16/0
+Del /Table/113/2/37/15/16/2/1
+Del /Table/113/3/38/15/16/0
+Del /Table/113/3/38/15/16/1/1
+Del /Table/113/3/38/15/16/2/1
+
+query IIIII
+SELECT * FROM rstuv
+----
+
+# Test swap mutations with a single column family.
+
+# TODO: support multiple column families.
+
+statement ok
+INSERT INTO rstuv VALUES (5, 6, 7, 8, NULL), (15, 16, NULL, 18, 19)
+
+# Test update swap.
+
+# TODO: If we're only modifying a single column family we shouldn't need to
+# constrain columns in other families to get a swap mutation.
+
+query T
+EXPLAIN UPDATE rstuv SET t = 27 WHERE r = 5 AND s = 6 AND t = 7
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: rstuv
+│ set: t
+│ auto commit
+│
+└── • render
+    │
+    └── • scan
+          missing stats
+          table: rstuv@rstuv_t_idx
+          spans: [/7/5/6 - /7/5/6]
+          locking strength: for update
+
+query T
+EXPLAIN UPDATE rstuv SET t = 27 WHERE r = 5 AND s = 6 AND t = 7 AND u = 8 AND v IS NULL
+----
+distribution: local
+vectorized: true
+·
+• update
+│ table: rstuv
+│ set: t
+│ auto commit
+│
+└── • render
+    │
+    └── • filter
+        │ filter: (u = 8) AND (v IS NULL)
+        │
+        └── • scan
+              missing stats
+              table: rstuv@rstuv_t_idx
+              spans: [/7/5/6 - /7/5/6]
+
+query T kvtrace
+UPDATE rstuv SET t = 27 WHERE r = 5 AND s = 6 AND t = 7 AND u = 8 AND v IS NULL
+----
+Scan /Table/113/2/7/5/{6-7}
+Put (locking) /Table/113/1/5/6/1/1 -> /INT/27
+Del /Table/113/2/7/5/6/0
+Put /Table/113/2/27/5/6/0 -> /BYTES/
+Del /Table/113/2/7/5/6/2/1
+Put /Table/113/2/27/5/6/2/1 -> /TUPLE/4:4:Int/8
+Put /Table/113/3/8/5/6/1/1 -> /TUPLE/3:3:Int/27
+
+query T kvtrace
+UPDATE rstuv SET t = NULL WHERE r = 5 AND s = 6 AND t = 27 AND u = 8 AND v IS NULL
+----
+Scan /Table/113/2/27/5/{6-7}
+Del (locking) /Table/113/1/5/6/1/1
+Del /Table/113/2/27/5/6/0
+Put /Table/113/2/NULL/5/6/0 -> /BYTES/
+Del /Table/113/2/27/5/6/2/1
+Put /Table/113/2/NULL/5/6/2/1 -> /TUPLE/4:4:Int/8
+Del /Table/113/3/8/5/6/1/1
+
+# This shouldn't update anything because t is not 100.
+
+statement ok
+UPDATE rstuv SET u = 28, v = 29 WHERE r = 5 AND s = 6 AND t = 100 AND u = 8 AND v IS NULL
+
+query IIIII
+SELECT * FROM rstuv ORDER BY r, s
+----
+5   6   NULL  8   NULL
+15  16  NULL  18  19

--- a/pkg/sql/opt/exec/execbuilder/testdata/swap_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/swap_mutation
@@ -1,5 +1,8 @@
 # LogicTest: local
 
+statement ok
+SET use_swap_mutations = on
+
 # Test that update swap and delete swap work correctly and use a single batch.
 
 # Test swap mutations with only primary key columns.
@@ -730,3 +733,6 @@ SELECT * FROM rstuv ORDER BY r, s
 ----
 5   6   NULL  8   NULL
 15  16  NULL  18  19
+
+statement ok
+RESET use_swap_mutations

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -638,6 +638,13 @@ func TestExecBuild_subquery_correlated(
 	runExecBuildLogicTest(t, "subquery_correlated")
 }
 
+func TestExecBuild_swap_mutation(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "swap_mutation")
+}
+
 func TestExecBuild_system(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -910,7 +910,13 @@ define VectorMutationSearch {
 # - there are no FK checks or cascades;
 # - there are no uniqueness checks;
 # - there are no check constraints;
-# - there are no after triggers.
+# - there are no vector indexes modified;
+# - there are no passthrough columns to RETURNING;
+# - there are no triggers;
+# - the table only uses a single column family;
+# - there are no mutation columns;
+# - there are no mutation indexes;
+# - there are no columns using composite encoding.
 #
 # Multiple indexes and complex projections are supported.
 #
@@ -958,10 +964,17 @@ define UpdateSwap {
 # This fast path is only possible when certain conditions hold true:
 # - all columns in the primary index are constrained to a single exact value
 #   by the WHERE clause;
-# - only a single row is deleted;
+# - only a single row is modified;
 # - there are no FK checks or cascades;
 # - there are no uniqueness checks;
-# - there are no after triggers.
+# - there are no check constraints;
+# - there are no vector indexes modified;
+# - there are no passthrough columns to RETURNING;
+# - there are no triggers;
+# - the table only uses a single column family;
+# - there are no mutation columns;
+# - there are no mutation indexes;
+# - there are no columns using composite encoding.
 #
 # Multiple indexes and complex projections are supported.
 #

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1918,6 +1918,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 		fmt.Fprintf(f.Buffer, " %s", seq.Name())
 
 	case *MutationPrivate:
+		if t.Swap {
+			fmt.Fprint(f.Buffer, " (swap)")
+		}
 		f.formatIndex(t.Table, cat.PrimaryIndex, false /* reverse */)
 
 	case *LockPrivate:

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -1610,6 +1610,10 @@ func (b *logicalPropsBuilder) buildMutationProps(mutation RelExpr, rel *props.Re
 	// -----------
 	// Inherit cardinality from input.
 	rel.Cardinality = inputProps.Cardinality
+	if private.Swap {
+		// Swap mutations can return zero rows.
+		rel.Cardinality = rel.Cardinality.AsLowAs(0)
+	}
 
 	// Statistics
 	// ----------

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -216,6 +216,7 @@ type Memo struct {
 	clampInequalitySelectivity                 bool
 	useMaxFrequencySelectivity                 bool
 	usingHintInjection                         bool
+	useSwapMutations                           bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -332,6 +333,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		clampInequalitySelectivity:                 evalCtx.SessionData().OptimizerClampInequalitySelectivity,
 		useMaxFrequencySelectivity:                 evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity,
 		usingHintInjection:                         evalCtx.Planner != nil && evalCtx.Planner.UsingHintInjection(),
+		useSwapMutations:                           evalCtx.SessionData().UseSwapMutations,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -512,6 +514,7 @@ func (m *Memo) IsStale(
 		m.clampInequalitySelectivity != evalCtx.SessionData().OptimizerClampInequalitySelectivity ||
 		m.useMaxFrequencySelectivity != evalCtx.SessionData().OptimizerUseMaxFrequencySelectivity ||
 		m.usingHintInjection != (evalCtx.Planner != nil && evalCtx.Planner.UsingHintInjection()) ||
+		m.useSwapMutations != evalCtx.SessionData().UseSwapMutations ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/norm/mutation_funcs.go
+++ b/pkg/sql/opt/norm/mutation_funcs.go
@@ -226,6 +226,10 @@ func (c *CustomFuncs) SimplifyPartialIndexProjections(
 // CanUseSwapMutation checks whether an Update or Delete can become an
 // UpdateSwap or DeleteSwap, respectively.
 func (c *CustomFuncs) CanUseSwapMutation(op opt.Operator, private *memo.MutationPrivate) bool {
+	if !c.f.evalCtx.SessionData().UseSwapMutations {
+		return false
+	}
+
 	// Checks are not currently handled by UpdateSwap or DeleteSwap.
 	if !private.CheckCols.IsEmpty() {
 		return false

--- a/pkg/sql/opt/norm/mutation_funcs.go
+++ b/pkg/sql/opt/norm/mutation_funcs.go
@@ -9,7 +9,9 @@ import (
 	"fmt"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 )
 
@@ -219,4 +221,211 @@ func (c *CustomFuncs) SimplifyPartialIndexProjections(
 	}
 
 	return simplified, &simplifiedPrivate
+}
+
+// CanUseSwapMutation checks whether an Update or Delete can become an
+// UpdateSwap or DeleteSwap, respectively.
+func (c *CustomFuncs) CanUseSwapMutation(op opt.Operator, private *memo.MutationPrivate) bool {
+	// Checks are not currently handled by UpdateSwap or DeleteSwap.
+	if !private.CheckCols.IsEmpty() {
+		return false
+	}
+
+	// Unique checks are not currently handled by UpdateSwap or DeleteSwap.
+	if len(private.UniqueWithTombstoneIndexes) != 0 {
+		return false
+	}
+
+	// Vector indexes are not currently handled by UpdateSwap or DeleteSwap.
+	if len(private.VectorIndexDelPartitionCols) != 0 ||
+		len(private.VectorIndexPutPartitionCols) != 0 ||
+		len(private.VectorIndexPutQuantizedVecCols) != 0 {
+		return false
+	}
+
+	// Passthrough columns are not currently remapped correctly by UseSwapMutation
+	// after BuildSwapMutationInput generates new column IDs.
+	if len(private.PassthroughCols) != 0 {
+		return false
+	}
+
+	// FK cascades are not currently handled by UpdateSwap or DeleteSwap.
+	if len(private.FKCascades) != 0 {
+		return false
+	}
+
+	md := c.mem.Metadata()
+	table := md.Table(private.Table)
+
+	// Triggers are not currently handled by UpdateSwap or DeleteSwap.
+	var eventsToMatch tree.TriggerEventTypeSet
+	if op == opt.UpdateOp {
+		eventsToMatch.Add(tree.TriggerEventUpdate)
+	} else if op == opt.DeleteOp {
+		eventsToMatch.Add(tree.TriggerEventDelete)
+	}
+	beforeTriggers := cat.GetRowLevelTriggers(table, tree.TriggerActionTimeBefore, eventsToMatch)
+	if len(beforeTriggers) != 0 {
+		return false
+	}
+	afterTriggers := cat.GetRowLevelTriggers(table, tree.TriggerActionTimeAfter, eventsToMatch)
+	if len(afterTriggers) != 0 {
+		return false
+	}
+	insteadOfTriggers := cat.GetRowLevelTriggers(table, tree.TriggerActionTimeInsteadOf, eventsToMatch)
+	if len(insteadOfTriggers) != 0 {
+		return false
+	}
+
+	// UpdateSwap currently has a bug with all-NULL column families where it will
+	// not issue a no-op CPut to validate an all-NULL column family's nonexistence
+	// in a case like:
+	//
+	//   CREATE TABLE abc (a INT PRIMARY KEY, b INT, c INT, FAMILY (a, b), FAMILY (c));
+	//   INSERT INTO abc VALUES (1, 2, NULL);
+	//   UPDATE abc SET b = b + 1 WHERE a = 1 AND b = 2 AND c IS NULL;
+	//
+	// Until this is fixed, and multi-column-family tables are better tested, we
+	// disallow UpdateSwap and DeleteSwap on multi-column-family tables.
+	// TODO(michae2): lift this restriction.
+	if table.FamilyCount() > 1 {
+		return false
+	}
+
+	// UpdateSwap and DeleteSwap require fetch columns to contain every column in
+	// the primary index, in order to build the expected value for the row.
+	// TODO(michae2): When it comes time to support multi-column-family tables, we
+	// might want to lift this restriction for updates that touch a single column
+	// family.
+	//
+	// UpdateSwap and DeleteSwap also do not currently handle mutation columns.
+	primaryIndex := table.Index(cat.PrimaryIndex)
+	for i := 0; i < primaryIndex.ColumnCount(); i++ {
+		col := primaryIndex.Column(i)
+		switch col.Kind() {
+		case cat.System:
+			continue
+		case cat.WriteOnly, cat.DeleteOnly:
+			return false
+		default:
+			if private.FetchCols[col.Ordinal()] == 0 {
+				return false
+			}
+		}
+	}
+
+	// UpdateSwap and DeleteSwap do not currently handle mutation indexes.
+	return table.DeletableIndexCount() == table.IndexCount()
+}
+
+// BuildSwapMutationInput tries to replace the initial scan of a mutation
+// statement with a ValuesExpr containing a single row. If it can successfully
+// rewrite the mutation input then the mutation can become a swap mutation.
+func (c *CustomFuncs) BuildSwapMutationInput(
+	input memo.RelExpr, private *memo.MutationPrivate,
+) (memo.RelExpr, opt.ColMap, bool) {
+	switch t := input.(type) {
+	case *memo.ProjectExpr:
+		if newInput, colMap, ok := c.BuildSwapMutationInput(t.Input, private); ok {
+			remappedProjections := c.f.RemapCols(&t.Projections, colMap).(*memo.ProjectionsExpr)
+			remappedPassthrough := t.Passthrough.CopyAndMaybeRemap(colMap)
+			return c.f.ConstructProject(newInput, *remappedProjections, remappedPassthrough), colMap, true
+		}
+	case *memo.SelectExpr:
+		if scan, ok := t.Input.(*memo.ScanExpr); ok {
+			// This must be a canonical scan to safely assume that the select
+			// filters contain all predicates from the query.
+			if scan.IsCanonical() && scan.Cols.SubsetOf(private.FetchCols.ToSet()) {
+				return c.buildSwapMutationValues(t.Filters, &scan.ScanPrivate)
+			}
+		}
+		// TODO(michae2): also match on joins here in order to support UPDATE FROM
+		// and DELETE FROM.
+		// TODO(michae2): also match on barriers.
+	}
+	return nil, opt.ColMap{}, false
+}
+
+// buildSwapMutationValues tries to construct a ValuesExpr containing the only
+// possible row that could satisfy the given filters on the given canonical
+// scan. UpdateSwap and DeleteSwap use this ValuesExpr in lieu of a ScanExpr.
+func (c *CustomFuncs) buildSwapMutationValues(
+	filters memo.FiltersExpr, scan *memo.ScanPrivate,
+) (memo.RelExpr, opt.ColMap, bool) {
+	md := c.mem.Metadata()
+
+	colExprs, remainingFilters, ok := memo.ExtractExactScalarExprsForColumns(
+		scan.Cols, filters, c.f.evalCtx, md, c.constructIsNotNull, c.f.ConstructFiltersItem,
+	)
+	if !ok {
+		return nil, opt.ColMap{}, false
+	}
+
+	newRow := make(memo.ScalarListExpr, 0, scan.Cols.Len())
+	newTypes := make([]*types.T, 0, scan.Cols.Len())
+	newCols := make(opt.ColList, 0, scan.Cols.Len())
+	var colMap opt.ColMap
+
+	scan.Cols.ForEach(func(col opt.ColumnID) {
+		if colExpr, ok := colExprs[col]; ok {
+			colMeta := md.ColumnMeta(col)
+			newCol := md.AddColumn(colMeta.Alias, colMeta.Type)
+			newRow = append(newRow, colExpr)
+			newTypes = append(newTypes, colMeta.Type)
+			newCols = append(newCols, newCol)
+			colMap.Set(int(col), int(newCol))
+		} else {
+			return
+		}
+	})
+	if len(newRow) < scan.Cols.Len() {
+		// We couldn't constrain every scan column to a single value.
+		// TODO(michae2): If any stored computed columns are still unconstrained, we
+		// could add a projection that computes them based on other column values.
+		return nil, opt.ColMap{}, false
+	}
+
+	tupleTyp := types.MakeTuple(newTypes)
+	tuple := c.f.ConstructTuple(newRow, tupleTyp)
+
+	expr := c.f.ConstructValues(
+		memo.ScalarListExpr{tuple},
+		&memo.ValuesPrivate{
+			Cols: newCols,
+			ID:   c.mem.Metadata().NextUniqueID(),
+		},
+	)
+
+	if len(remainingFilters) != 0 {
+		remappedRemainingFilters := c.f.RemapCols(&remainingFilters, colMap).(*memo.FiltersExpr)
+		expr = c.f.ConstructSelect(expr, *remappedRemainingFilters)
+	}
+
+	return expr, colMap, true
+}
+
+func (c *CustomFuncs) constructIsNotNull(colID opt.ColumnID) memo.FiltersItem {
+	return c.f.ConstructFiltersItem(
+		c.f.ConstructIsNot(
+			c.f.ConstructVariable(colID), memo.NullSingleton,
+		),
+	)
+}
+
+// UseSwapMutation builds a copy of the given MutationPrivate with Swap = true.
+func (c *CustomFuncs) UseSwapMutation(
+	private *memo.MutationPrivate, colMap opt.ColMap,
+) *memo.MutationPrivate {
+	swapPrivate := *private
+	swapPrivate.FetchCols = swapPrivate.FetchCols.CopyAndMaybeRemapColumns(colMap)
+	swapPrivate.UpdateCols = swapPrivate.UpdateCols.CopyAndMaybeRemapColumns(colMap)
+	swapPrivate.PartialIndexPutCols = swapPrivate.PartialIndexPutCols.CopyAndMaybeRemapColumns(colMap)
+	swapPrivate.PartialIndexDelCols = swapPrivate.PartialIndexDelCols.CopyAndMaybeRemapColumns(colMap)
+	swapPrivate.ReturnCols = swapPrivate.ReturnCols.CopyAndMaybeRemapColumns(colMap)
+	// If any of the PassthroughCols require remapping, then we will probably need
+	// a remapping Project on top of the mutation to map back to the original
+	// column ID. For now we disallow mutations with passthrough columns in
+	// CanUseSwapMutation to avoid this problem.
+	swapPrivate.Swap = true
+	return &swapPrivate
 }

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -126,6 +126,19 @@ func (c *CustomFuncs) NeededMutationFetchCols(
 		}
 	}
 
+	// For swap mutations, include all columns in the primary index.
+	if private.Swap {
+		primaryIndex := tabMeta.Table.Index(cat.PrimaryIndex)
+		for i := 0; i < primaryIndex.ColumnCount(); i++ {
+			col := primaryIndex.Column(i)
+			if col.Kind() == cat.System {
+				continue
+			}
+			ord := col.Ordinal()
+			cols.Add(tabMeta.MetaID.ColumnID(ord))
+		}
+	}
+
 	// Retain any FetchCols that are needed for ReturnCols. If a RETURN column
 	// is needed, then:
 	//   1. For Delete, the corresponding FETCH column is always needed, since

--- a/pkg/sql/opt/norm/rules/mutation.opt
+++ b/pkg/sql/opt/norm/rules/mutation.opt
@@ -50,3 +50,49 @@
 (Lock $rows:* & (HasZeroRows $rows))
 =>
 $rows
+
+# UseSwapMutation converts an Update or a Delete to an UpdateSwap or a
+# DeleteSwap, respectively. It also replaces the input Scan with Values,
+# possibly wrapped in a Select.
+#
+# UpdateSwap and DeleteSwap are optimistic compare-and-swap operations that are
+# possible when:
+#
+# - all columns in the primary index are constrained to a single exact value
+#   by the WHERE clause;
+# - only a single row is modified;
+# - there are no FK checks or cascades;
+# - there are no uniqueness checks;
+# - there are no check constraints;
+# - there are no vector indexes modified;
+# - there are no passthrough columns to RETURNING;
+# - there are no triggers;
+# - the table only uses a single column family;
+# - there are no mutation columns;
+# - there are no mutation indexes;
+# - there are no columns using composite encoding.
+#
+# This rule needs to run after PruneMutationInputCols and before
+# GenerateParameterizedJoin.
+[UseSwapMutation, Normalize]
+(Update | Delete
+    $input:* & (HasZeroOrOneRow $input)
+    []
+    []
+    $mutationPrivate:* &
+        (CanUseSwapMutation (OpName) $mutationPrivate) &
+        (Let
+            ($newInput $colMap $ok):(BuildSwapMutationInput
+                $input
+                $mutationPrivate
+            )
+            $ok
+        )
+)
+=>
+((OpName)
+    $newInput
+    []
+    []
+    (UseSwapMutation $mutationPrivate $colMap)
+)

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -451,8 +451,10 @@
 )
 
 # PruneMutationInputCols discards input columns that are never used by the
-# mutation operator.
-[PruneMutationInputCols, Normalize]
+# mutation operator. This is high priority so that it runs before
+# UseSwapMutation, UseSwapMutationWithProjection, and
+# UseSwapMutationWithProjectionProjection.
+[PruneMutationInputCols, Normalize, HighPriority]
 (Update | Upsert | Delete
     $input:*
     $uniqueChecks:*

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -390,3 +390,1780 @@ lock t
       │    └── fd: (1)-->(2)
       └── filters
            └── a:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+
+# --------------------------------------------------
+# UseSwapMutation
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE abc (
+  a INT NOT NULL,
+  b INT,
+  c BOOLEAN,
+  PRIMARY KEY (a),
+  FAMILY (a, b, c)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b IS NOT DISTINCT FROM 2 AND c
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:11!null b:12!null c:13!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      └── (1, 2, true)
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND (b = 2 AND c = FALSE)
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:11!null b:12!null c:13!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      └── (1, 2, false)
+
+# Test that we do not use swap mutations with unconstrained columns.
+
+norm expect-not=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b > 2
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b:7 => a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── select
+      ├── columns: a:6!null b:7!null c:8
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── scan abc
+      │    ├── columns: a:6!null b:7 c:8
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8)
+      └── filters
+           ├── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+           └── b:7 > 2 [outer=(7), constraints=(/7: [/3 - ]; tight)]
+
+# TODO: we cannot yet constrain this to a single row.
+
+norm
+UPDATE abc SET a = b WHERE a >= 1 AND a < 2 AND b = 2 AND c
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b:7 => a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── select
+      ├── columns: a:6!null b:7!null c:8!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── scan abc
+      │    ├── columns: a:6!null b:7 c:8
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8)
+      └── filters
+           ├── (a:6 >= 1) AND (a:6 < 2) [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+           ├── b:7 = 2 [outer=(7), constraints=(/7: [/2 - /2]; tight), fd=()-->(7)]
+           └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b IS NULL AND c IS NULL
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:11!null b:12 c:13
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      └── (1, NULL, NULL)
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b IS NOT DISTINCT FROM NULL AND c IS NOT DISTINCT FROM NULL
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:11!null b:12 c:13
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      └── (1, NULL, NULL)
+
+norm expect-not=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b IS DISTINCT FROM NULL AND c
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b:7 => a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── select
+      ├── columns: a:6!null b:7!null c:8!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── scan abc
+      │    ├── columns: a:6!null b:7 c:8
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8)
+      └── filters
+           ├── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+           ├── b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
+           └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b = 2 AND NOT c AND (a > b) = c
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:11!null b:12!null c:13!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      └── (1, 2, false)
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = $1 AND b IS NOT DISTINCT FROM $2 AND c IS NOT DISTINCT FROM $3
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── select
+      ├── columns: a:11!null b:12 c:13
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      ├── values
+      │    ├── columns: a:11 b:12 c:13
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(11-13)
+      │    └── ($1, $2, $3)
+      └── filters
+           └── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
+
+norm expect-not=UseSwapMutation
+UPDATE abc SET a = b WHERE a = $1 AND b = $2
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b:7 => a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── select
+      ├── columns: a:6!null b:7!null c:8
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── scan abc
+      │    ├── columns: a:6!null b:7 c:8
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8)
+      └── filters
+           ├── a:6 = $1 [outer=(6), constraints=(/6: (/NULL - ]), fd=()-->(6)]
+           └── b:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = $1 AND b = $2 AND c = $3
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── select
+      ├── columns: a:11!null b:12!null c:13!null
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      ├── values
+      │    ├── columns: a:11 b:12 c:13
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(11-13)
+      │    └── ($1, $2, $3)
+      └── filters
+           ├── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
+           ├── b:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
+           └── c:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
+
+# Additional predicates should become extra filters before the swap.
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = $1 AND b = $2 AND c AND c = $3 AND a < b
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── select
+      ├── columns: a:11!null b:12!null c:13!null
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      ├── values
+      │    ├── columns: a:11 b:12 c:13!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(11-13)
+      │    └── ($1, $2, true)
+      └── filters
+           ├── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
+           ├── b:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
+           ├── $3
+           └── a:11 < b:12 [outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ])]
+
+# Test that we do use swap mutations with RETURNING.
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = $1 AND b = $2 AND c AND a < b RETURNING a
+----
+update (swap) abc
+ ├── columns: a:1!null
+ ├── fetch columns: a:11 b:12 c:13
+ ├── update-mapping:
+ │    └── b:12 => abc.a:1
+ ├── return-mapping:
+ │    └── b:12 => abc.a:1
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── select
+      ├── columns: a:11!null b:12!null c:13!null
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      ├── values
+      │    ├── columns: a:11 b:12 c:13!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(11-13)
+      │    └── ($1, $2, true)
+      └── filters
+           ├── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
+           ├── b:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
+           └── a:11 < b:12 [outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ])]
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = b WHERE a = $1 AND b = $2 + 1 AND c RETURNING a + b
+----
+project
+ ├── columns: "?column?":11!null
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(11)
+ ├── update (swap) abc
+ │    ├── columns: abc.a:1!null abc.b:2!null
+ │    ├── fetch columns: a:12 b:13 c:14
+ │    ├── update-mapping:
+ │    │    └── b:13 => abc.a:1
+ │    ├── return-mapping:
+ │    │    ├── b:13 => abc.a:1
+ │    │    └── b:13 => abc.b:2
+ │    ├── cardinality: [0 - 1]
+ │    ├── volatile, mutations, has-placeholder
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+ │    └── select
+ │         ├── columns: a:12!null b:13!null c:14!null
+ │         ├── cardinality: [0 - 1]
+ │         ├── immutable, has-placeholder
+ │         ├── key: ()
+ │         ├── fd: ()-->(12-14)
+ │         ├── values
+ │         │    ├── columns: a:12 b:13 c:14!null
+ │         │    ├── cardinality: [1 - 1]
+ │         │    ├── immutable, has-placeholder
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(12-14)
+ │         │    └── ($1, $2 + 1, true)
+ │         └── filters
+ │              ├── a:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
+ │              └── b:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
+ └── projections
+      └── abc.a:1 + abc.b:2 [as="?column?":11, outer=(1,2), immutable]
+
+# Test delete swap for a few of the cases above.
+
+norm expect=UseSwapMutation
+DELETE FROM abc WHERE a = 1 AND b IS NOT DISTINCT FROM 1 AND c IS NOT DISTINCT FROM NULL
+----
+delete (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:11 b:12 c:13
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:11!null b:12!null c:13
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-13)
+      └── (1, 1, NULL)
+
+norm expect=UseSwapMutation
+DELETE FROM abc WHERE a = $1 AND b IS NOT DISTINCT FROM $2 AND c IS NOT DISTINCT FROM $3 RETURNING $4:::int
+----
+project
+ ├── columns: int8:14
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(14)
+ ├── delete (swap) abc
+ │    ├── columns: abc.a:1!null
+ │    ├── fetch columns: a:11 b:12 c:13
+ │    ├── return-mapping:
+ │    │    └── a:11 => abc.a:1
+ │    ├── cardinality: [0 - 1]
+ │    ├── volatile, mutations, has-placeholder
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── select
+ │         ├── columns: a:11!null b:12 c:13
+ │         ├── cardinality: [0 - 1]
+ │         ├── has-placeholder
+ │         ├── key: ()
+ │         ├── fd: ()-->(11-13)
+ │         ├── values
+ │         │    ├── columns: a:11 b:12 c:13
+ │         │    ├── cardinality: [1 - 1]
+ │         │    ├── has-placeholder
+ │         │    ├── key: ()
+ │         │    ├── fd: ()-->(11-13)
+ │         │    └── ($1, $2, $3)
+ │         └── filters
+ │              └── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
+ └── projections
+      └── $4 [as=int8:14]
+
+# Test that we do not use swap mutations when there is a column with a composite
+# key encoding (such as DECIMAL).
+
+exec-ddl
+CREATE TABLE xy (
+  x INT NOT NULL,
+  y DECIMAL,
+  PRIMARY KEY (x),
+  FAMILY (x, y)
+)
+----
+
+norm expect-not=UseSwapMutation
+UPDATE xy SET x = x WHERE x = 1 AND y = 2
+----
+update xy
+ ├── columns: <none>
+ ├── fetch columns: x:5 y:6
+ ├── update-mapping:
+ │    └── x:5 => x:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── select
+      ├── columns: x:5!null y:6!null
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(5,6)
+      ├── scan xy
+      │    ├── columns: x:5!null y:6
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      └── filters
+           ├── x:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+           └── y:6 = 2 [outer=(6), immutable, constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+
+norm expect-not=UseSwapMutation
+DELETE FROM xy WHERE x = 1 AND y = 2
+----
+delete xy
+ ├── columns: <none>
+ ├── fetch columns: x:5
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── select
+      ├── columns: x:5!null y:6!null
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(5,6)
+      ├── scan xy
+      │    ├── columns: x:5!null y:6
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      └── filters
+           ├── x:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+           └── y:6 = 2 [outer=(6), immutable, constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = 2 WHERE a = 1 AND b IS NOT DISTINCT FROM 1 AND c
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:12 b:13 c:14
+ ├── update-mapping:
+ │    └── a_new:11 => abc.a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:12!null b:13!null c:14!null a_new:11!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-14)
+      └── (1, 1, true, 2)
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = 1, b = 2, c = TRUE WHERE a = 4 AND b IS NOT DISTINCT FROM 5 AND c
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:14 b:15 c:16
+ ├── update-mapping:
+ │    ├── a_new:11 => abc.a:1
+ │    ├── b_new:12 => abc.b:2
+ │    └── c_new:13 => abc.c:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:14!null b:15!null c:16!null a_new:11!null b_new:12!null c_new:13!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-16)
+      └── (4, 5, true, 1, 2, true)
+
+norm expect=UseSwapMutation
+UPDATE abc SET a = $1, b = $2, c = $3 WHERE a = $4 AND b IS NOT DISTINCT FROM $5 AND c IS NOT DISTINCT FROM $6
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:14 b:15 c:16
+ ├── update-mapping:
+ │    ├── a_new:11 => abc.a:1
+ │    ├── b_new:12 => abc.b:2
+ │    └── c_new:13 => abc.c:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── project
+      ├── columns: a_new:11 b_new:12 c_new:13 a:14!null b:15 c:16
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(11-16)
+      ├── select
+      │    ├── columns: a:14!null b:15 c:16
+      │    ├── cardinality: [0 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(14-16)
+      │    ├── values
+      │    │    ├── columns: a:14 b:15 c:16
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(14-16)
+      │    │    └── ($4, $5, $6)
+      │    └── filters
+      │         └── a:14 IS NOT NULL [outer=(14), constraints=(/14: (/NULL - ]; tight)]
+      └── projections
+           ├── $1 [as=a_new:11]
+           ├── $2 [as=b_new:12]
+           └── $3 [as=c_new:13]
+
+exec-ddl
+CREATE TABLE mnop (
+  m INT NOT NULL,
+  n INT,
+  o INT AS (m + n) VIRTUAL,
+  p BOOLEAN AS (m < n) VIRTUAL,
+  PRIMARY KEY (m),
+  UNIQUE INDEX (n),
+  INDEX (o),
+  FAMILY (m, n, o, p)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE mnop SET m = 1, n = 2 WHERE m = 3 AND n IS NOT DISTINCT FROM 4
+----
+update (swap) mnop
+ ├── columns: <none>
+ ├── fetch columns: m:17 n:18 o:9 p:10
+ ├── update-mapping:
+ │    ├── m_new:13 => mnop.m:1
+ │    ├── n_new:14 => mnop.n:2
+ │    ├── o_comp:15 => o:3
+ │    └── p_comp:16 => p:4
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: m:17!null n:18!null o_comp:15!null p_comp:16!null m_new:13!null n_new:14!null o:9!null p:10!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(9,10,13-18)
+      └── (3, 4, 3, true, 1, 2, 7, true)
+
+norm expect=UseSwapMutation
+DELETE FROM mnop WHERE m = $1 AND n IS NOT DISTINCT FROM $2
+----
+delete (swap) mnop
+ ├── columns: <none>
+ ├── fetch columns: m:13 n:14 o:9
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── project
+      ├── columns: o:9 m:13!null n:14
+      ├── cardinality: [0 - 1]
+      ├── immutable, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(9,13,14)
+      ├── select
+      │    ├── columns: m:13!null n:14
+      │    ├── cardinality: [0 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(13,14)
+      │    ├── values
+      │    │    ├── columns: m:13 n:14
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(13,14)
+      │    │    └── ($1, $2)
+      │    └── filters
+      │         └── m:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
+      └── projections
+           └── m:13 + n:14 [as=o:9, outer=(13,14), immutable]
+
+norm expect=UseSwapMutation
+UPDATE mnop SET m = $1, n = $2 WHERE m = $3 AND n = $4 RETURNING o, p
+----
+project
+ ├── columns: o:3 p:4
+ ├── cardinality: [0 - 1]
+ ├── volatile, mutations, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(3,4)
+ └── update (swap) mnop
+      ├── columns: mnop.m:1!null o:3 p:4
+      ├── fetch columns: m:17 n:18 o:9 p:10
+      ├── update-mapping:
+      │    ├── m_new:13 => mnop.m:1
+      │    ├── n_new:14 => mnop.n:2
+      │    ├── o_comp:15 => o:3
+      │    └── p_comp:16 => p:4
+      ├── return-mapping:
+      │    ├── m_new:13 => mnop.m:1
+      │    ├── o_comp:15 => o:3
+      │    └── p_comp:16 => p:4
+      ├── cardinality: [0 - 1]
+      ├── volatile, mutations, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1,3,4)
+      └── project
+           ├── columns: o_comp:15 p_comp:16 o:9!null p:10!null m_new:13 n_new:14 m:17!null n:18!null
+           ├── cardinality: [0 - 1]
+           ├── immutable, has-placeholder
+           ├── key: ()
+           ├── fd: ()-->(9,10,13-18)
+           ├── project
+           │    ├── columns: m_new:13 n_new:14 o:9!null p:10!null m:17!null n:18!null
+           │    ├── cardinality: [0 - 1]
+           │    ├── immutable, has-placeholder
+           │    ├── key: ()
+           │    ├── fd: ()-->(9,10,13,14,17,18)
+           │    ├── select
+           │    │    ├── columns: m:17!null n:18!null
+           │    │    ├── cardinality: [0 - 1]
+           │    │    ├── has-placeholder
+           │    │    ├── key: ()
+           │    │    ├── fd: ()-->(17,18)
+           │    │    ├── values
+           │    │    │    ├── columns: m:17 n:18
+           │    │    │    ├── cardinality: [1 - 1]
+           │    │    │    ├── has-placeholder
+           │    │    │    ├── key: ()
+           │    │    │    ├── fd: ()-->(17,18)
+           │    │    │    └── ($3, $4)
+           │    │    └── filters
+           │    │         ├── m:17 IS NOT NULL [outer=(17), constraints=(/17: (/NULL - ]; tight)]
+           │    │         └── n:18 IS NOT NULL [outer=(18), constraints=(/18: (/NULL - ]; tight)]
+           │    └── projections
+           │         ├── $1 [as=m_new:13]
+           │         ├── $2 [as=n_new:14]
+           │         ├── m:17 + n:18 [as=o:9, outer=(17,18), immutable]
+           │         └── m:17 < n:18 [as=p:10, outer=(17,18)]
+           └── projections
+                ├── m_new:13 + n_new:14 [as=o_comp:15, outer=(13,14), immutable]
+                └── m_new:13 < n_new:14 [as=p_comp:16, outer=(13,14)]
+
+norm expect=UseSwapMutation
+UPDATE mnop SET m = $1, n = n + $2 WHERE m = $3 AND n IS NOT DISTINCT FROM $4 AND o = $5 AND NOT p
+----
+update (swap) mnop
+ ├── columns: <none>
+ ├── fetch columns: m:17 n:18 o:9 p:10
+ ├── update-mapping:
+ │    ├── m_new:13 => mnop.m:1
+ │    ├── n_new:14 => mnop.n:2
+ │    ├── o_comp:15 => o:3
+ │    └── p_comp:16 => p:4
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── project
+      ├── columns: o_comp:15 p_comp:16 o:9!null p:10!null m_new:13 n_new:14 m:17!null n:18!null
+      ├── cardinality: [0 - 1]
+      ├── immutable, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(9,10,13-18)
+      ├── project
+      │    ├── columns: m_new:13 n_new:14 o:9!null p:10!null m:17!null n:18!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable, has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(9,10,13,14,17,18)
+      │    ├── select
+      │    │    ├── columns: m:17!null n:18!null
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable, has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(17,18)
+      │    │    ├── values
+      │    │    │    ├── columns: m:17 n:18
+      │    │    │    ├── cardinality: [1 - 1]
+      │    │    │    ├── has-placeholder
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(17,18)
+      │    │    │    └── ($3, $4)
+      │    │    └── filters
+      │    │         ├── (m:17 + n:18) = $5 [outer=(17,18), immutable]
+      │    │         ├── m:17 >= n:18 [outer=(17,18), constraints=(/17: (/NULL - ]; /18: (/NULL - ])]
+      │    │         └── m:17 IS NOT NULL [outer=(17), constraints=(/17: (/NULL - ]; tight)]
+      │    └── projections
+      │         ├── $1 [as=m_new:13]
+      │         ├── n:18 + $2 [as=n_new:14, outer=(18), immutable]
+      │         ├── m:17 + n:18 [as=o:9, outer=(17,18), immutable]
+      │         └── m:17 < n:18 [as=p:10, outer=(17,18)]
+      └── projections
+           ├── m_new:13 + n_new:14 [as=o_comp:15, outer=(13,14), immutable]
+           └── m_new:13 < n_new:14 [as=p_comp:16, outer=(13,14)]
+
+# Test that we do use swap mutations with a subquery in the projection.
+
+norm expect=UseSwapMutation
+UPDATE abc SET b = (SELECT sum(m) FROM mnop) WHERE a = 1 AND b = 2 AND c
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:20 b:21 c:22
+ ├── update-mapping:
+ │    └── b_cast:19 => abc.b:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:20!null b:21!null c:22!null b_cast:19
+      ├── cardinality: [1 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(19-22)
+      └── tuple
+           ├── 1
+           ├── 2
+           ├── true
+           └── assignment-cast: INT8
+                └── subquery
+                     └── scalar-group-by
+                          ├── columns: sum:17
+                          ├── cardinality: [1 - 1]
+                          ├── key: ()
+                          ├── fd: ()-->(17)
+                          ├── scan mnop
+                          │    ├── columns: m:11!null
+                          │    ├── computed column expressions
+                          │    │    ├── o:13
+                          │    │    │    └── m:11 + n:12
+                          │    │    └── p:14
+                          │    │         └── m:11 < n:12
+                          │    └── key: (11)
+                          └── aggregations
+                               └── sum [as=sum:17, outer=(11)]
+                                    └── m:11
+
+# TODO: we do not yet use swap mutations with a subquery in a predicate, due to
+# the rule not matching the join.
+
+norm
+UPDATE abc SET b = 2 WHERE a = 1 AND b = (SELECT 1 FROM mnop LIMIT 1) AND c
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b_new:18 => b:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: b_new:18!null a:6!null b:7!null c:8!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8,18)
+      ├── inner-join (cross)
+      │    ├── columns: a:6!null b:7!null c:8!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8)
+      │    ├── select
+      │    │    ├── columns: a:6!null b:7!null c:8!null
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(6-8)
+      │    │    ├── scan abc
+      │    │    │    ├── columns: a:6!null b:7 c:8
+      │    │    │    ├── flags: avoid-full-scan
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(7,8)
+      │    │    └── filters
+      │    │         ├── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      │    │         ├── b:7 = 1 [outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      │    │         └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+      │    ├── limit
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── scan mnop
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── o:13
+      │    │    │    │    │    └── m:11 + n:12
+      │    │    │    │    └── p:14
+      │    │    │    │         └── m:11 < n:12
+      │    │    │    └── limit hint: 1.00
+      │    │    └── 1
+      │    └── filters (true)
+      └── projections
+           └── 2 [as=b_new:18]
+
+# TODO: we do not yet use swap mutations with CTEs due to the join.
+
+norm
+WITH w AS (SELECT sum(m) AS s FROM mnop) UPDATE abc SET b = 1 FROM w WHERE a = s AND b = 2 AND c
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:13 b:14 c:15
+ ├── passthrough columns: s:18
+ ├── update-mapping:
+ │    └── b_new:19 => b:9
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: b_new:19!null s:18!null a:13!null b:14!null c:15!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(13-15,18,19), (13)==(18), (18)==(13)
+      ├── inner-join (cross)
+      │    ├── columns: sum:7!null a:13!null b:14!null c:15!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │    ├── key: ()
+      │    ├── fd: ()-->(7,13-15), (7)==(13), (13)==(7)
+      │    ├── select
+      │    │    ├── columns: a:13!null b:14!null c:15!null
+      │    │    ├── key: (13)
+      │    │    ├── fd: ()-->(14,15)
+      │    │    ├── scan abc
+      │    │    │    ├── columns: a:13!null b:14 c:15
+      │    │    │    ├── flags: avoid-full-scan
+      │    │    │    ├── key: (13)
+      │    │    │    └── fd: (13)-->(14,15)
+      │    │    └── filters
+      │    │         ├── b:14 = 2 [outer=(14), constraints=(/14: [/2 - /2]; tight), fd=()-->(14)]
+      │    │         └── c:15 [outer=(15), constraints=(/15: [/true - /true]; tight), fd=()-->(15)]
+      │    ├── scalar-group-by
+      │    │    ├── columns: sum:7
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(7)
+      │    │    ├── scan mnop
+      │    │    │    ├── columns: m:1!null
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── o:3
+      │    │    │    │    │    └── m:1 + n:2
+      │    │    │    │    └── p:4
+      │    │    │    │         └── m:1 < n:2
+      │    │    │    └── key: (1)
+      │    │    └── aggregations
+      │    │         └── sum [as=sum:7, outer=(1)]
+      │    │              └── m:1
+      │    └── filters
+      │         └── a:13 = sum:7 [outer=(7,13), constraints=(/7: (/NULL - ]; /13: (/NULL - ]), fd=(7)==(13), (13)==(7)]
+      └── projections
+           ├── 1 [as=b_new:19]
+           └── sum:7 [as=s:18, outer=(7)]
+
+norm expect=UseSwapMutation
+WITH w AS (SELECT sum(m) AS s FROM mnop) UPDATE abc SET b = (SELECT s FROM w) WHERE a = 1 AND b = 2 AND c
+----
+update (swap) abc
+ ├── columns: <none>
+ ├── fetch columns: a:21 b:22 c:23
+ ├── update-mapping:
+ │    └── b_cast:20 => abc.b:9
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: a:21!null b:22!null c:23!null b_cast:20
+      ├── cardinality: [1 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(20-23)
+      └── tuple
+           ├── 1
+           ├── 2
+           ├── true
+           └── assignment-cast: INT8
+                └── subquery
+                     └── project
+                          ├── columns: s:18
+                          ├── cardinality: [1 - 1]
+                          ├── key: ()
+                          ├── fd: ()-->(18)
+                          ├── scalar-group-by
+                          │    ├── columns: sum:7
+                          │    ├── cardinality: [1 - 1]
+                          │    ├── key: ()
+                          │    ├── fd: ()-->(7)
+                          │    ├── scan mnop
+                          │    │    ├── columns: m:1!null
+                          │    │    ├── computed column expressions
+                          │    │    │    ├── o:3
+                          │    │    │    │    └── m:1 + n:2
+                          │    │    │    └── p:4
+                          │    │    │         └── m:1 < n:2
+                          │    │    └── key: (1)
+                          │    └── aggregations
+                          │         └── sum [as=sum:7, outer=(1)]
+                          │              └── m:1
+                          └── projections
+                               └── sum:7 [as=s:18, outer=(7)]
+
+# TODO: we do not yet use swap mutations with joins.
+
+norm
+UPDATE abc SET c = false FROM mnop WHERE a = 1 AND m = 1 AND b = n AND c
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── passthrough columns: m:11 n:12 o:13 p:14 mnop.crdb_internal_mvcc_timestamp:15 mnop.tableoid:16
+ ├── update-mapping:
+ │    └── c_new:17 => c:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: c_new:17!null a:6!null b:7!null c:8!null m:11!null n:12!null o:13 p:14 mnop.crdb_internal_mvcc_timestamp:15 mnop.tableoid:16
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(6-8,11-17), (7)==(12), (12)==(7)
+      ├── inner-join (hash)
+      │    ├── columns: a:6!null b:7!null c:8!null m:11!null n:12!null o:13 p:14 mnop.crdb_internal_mvcc_timestamp:15 mnop.tableoid:16
+      │    ├── cardinality: [0 - 1]
+      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8,11-16), (7)==(12), (12)==(7)
+      │    ├── select
+      │    │    ├── columns: a:6!null b:7 c:8!null
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(6-8)
+      │    │    ├── scan abc
+      │    │    │    ├── columns: a:6!null b:7 c:8
+      │    │    │    ├── flags: avoid-full-scan
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(7,8)
+      │    │    └── filters
+      │    │         ├── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      │    │         └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+      │    ├── project
+      │    │    ├── columns: o:13 p:14 m:11!null n:12 mnop.crdb_internal_mvcc_timestamp:15 mnop.tableoid:16
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── immutable
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(11-16)
+      │    │    ├── select
+      │    │    │    ├── columns: m:11!null n:12 mnop.crdb_internal_mvcc_timestamp:15 mnop.tableoid:16
+      │    │    │    ├── cardinality: [0 - 1]
+      │    │    │    ├── key: ()
+      │    │    │    ├── fd: ()-->(11,12,15,16)
+      │    │    │    ├── scan mnop
+      │    │    │    │    ├── columns: m:11!null n:12 mnop.crdb_internal_mvcc_timestamp:15 mnop.tableoid:16
+      │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    ├── o:13
+      │    │    │    │    │    │    └── m:11 + n:12
+      │    │    │    │    │    └── p:14
+      │    │    │    │    │         └── m:11 < n:12
+      │    │    │    │    ├── key: (11)
+      │    │    │    │    └── fd: (11)-->(12,15,16), (12)~~>(11,15,16)
+      │    │    │    └── filters
+      │    │    │         └── m:11 = 1 [outer=(11), constraints=(/11: [/1 - /1]; tight), fd=()-->(11)]
+      │    │    └── projections
+      │    │         ├── m:11 + n:12 [as=o:13, outer=(11,12), immutable]
+      │    │         └── m:11 < n:12 [as=p:14, outer=(11,12)]
+      │    └── filters
+      │         └── b:7 = n:12 [outer=(7,12), constraints=(/7: (/NULL - ]; /12: (/NULL - ]), fd=(7)==(12), (12)==(7)]
+      └── projections
+           └── false [as=c_new:17]
+
+# Test that we do use swap mutations with computed columns.
+
+exec-ddl
+CREATE TABLE qrs (
+  q STRING NOT NULL,
+  r STRING AS (q || 'r') VIRTUAL,
+  s STRING AS (q || 's') STORED,
+  PRIMARY KEY (q, s),
+  INDEX (r),
+  FAMILY (q, r, s)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE qrs SET q = q || 'q' WHERE q = 'q' AND s = 'qs'
+----
+update (swap) qrs
+ ├── columns: <none>
+ ├── fetch columns: q:14 r:7 s:15
+ ├── update-mapping:
+ │    ├── q_new:11 => qrs.q:1
+ │    ├── r_comp:12 => r:2
+ │    └── s_comp:13 => qrs.s:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: q:14!null s:15!null q_new:11!null r:7!null r_comp:12!null s_comp:13!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,11-15)
+      └── ('q', 'qs', 'qq', 'qr', 'qqr', 'qqs')
+
+# TODO: we do not yet use swap mutations without all primary index columns
+# specified, even if the missing columns are computed.
+
+norm
+UPDATE qrs SET q = q || 'q' WHERE q = 'q'
+----
+update qrs
+ ├── columns: <none>
+ ├── fetch columns: q:6 r:7 s:8
+ ├── update-mapping:
+ │    ├── q_new:11 => q:1
+ │    ├── r_comp:12 => r:2
+ │    └── s_comp:13 => s:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: r_comp:12!null s_comp:13!null q:6!null r:7!null s:8!null q_new:11!null
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(6-8,11-13)
+      ├── project
+      │    ├── columns: q_new:11!null r:7!null q:6!null s:8!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8,11)
+      │    ├── select
+      │    │    ├── columns: q:6!null s:8!null
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(6,8)
+      │    │    ├── scan qrs
+      │    │    │    ├── columns: q:6!null s:8!null
+      │    │    │    ├── computed column expressions
+      │    │    │    │    ├── r:7
+      │    │    │    │    │    └── q:6 || 'r'
+      │    │    │    │    └── s:8
+      │    │    │    │         └── q:6 || 's'
+      │    │    │    ├── flags: avoid-full-scan
+      │    │    │    ├── key: (6)
+      │    │    │    └── fd: (6)-->(8)
+      │    │    └── filters
+      │    │         └── q:6 = 'q' [outer=(6), constraints=(/6: [/'q' - /'q']; tight), fd=()-->(6)]
+      │    └── projections
+      │         ├── q:6 || 'q' [as=q_new:11, outer=(6), immutable]
+      │         └── q:6 || 'r' [as=r:7, outer=(6), immutable]
+      └── projections
+           ├── q_new:11 || 'r' [as=r_comp:12, outer=(11), immutable]
+           └── q_new:11 || 's' [as=s_comp:13, outer=(11), immutable]
+
+# Test that we do use swap mutations with expression indexes and partial indexes.
+
+exec-ddl
+CREATE TABLE ijk (
+  i INT NOT NULL,
+  j STRING NOT NULL,
+  k TIMESTAMPTZ,
+  PRIMARY KEY (i, j),
+  INDEX ((j || 'j')),
+  INDEX (k) WHERE k IS NOT NULL AND i > 0,
+  FAMILY (i, j, k)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE ijk SET i = 2, j = 'h', k = now() WHERE i = 1 AND j = 'i' AND k = '1999-12-31 23:59:59 UTC'
+----
+update (swap) ijk
+ ├── columns: <none>
+ ├── fetch columns: i:19 j:20 k:21 crdb_internal_idx_expr:12
+ ├── update-mapping:
+ │    ├── i_new:13 => ijk.i:1
+ │    ├── j_new:14 => ijk.j:2
+ │    ├── k_new:15 => ijk.k:3
+ │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:6
+ ├── partial index put columns: partial_index_put1:17
+ ├── partial index del columns: partial_index_del1:18
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: i:19!null j:20!null k:21!null partial_index_put1:17!null partial_index_del1:18!null crdb_internal_idx_expr_comp:16!null i_new:13!null j_new:14!null k_new:15!null crdb_internal_idx_expr:12!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(12-21)
+      └── (1, 'i', '1999-12-31 23:59:59+00', true, true, 'hj', 2, 'h', '2017-05-10 13:00:00+00', 'ij')
+
+norm expect=UseSwapMutation
+UPDATE ijk SET i = -1, j = 'h', k = NULL WHERE i = 1 AND j = 'i' AND k = '1999-12-31 23:59:59 UTC'
+----
+update (swap) ijk
+ ├── columns: <none>
+ ├── fetch columns: i:19 j:20 k:21 crdb_internal_idx_expr:12
+ ├── update-mapping:
+ │    ├── i_new:13 => ijk.i:1
+ │    ├── j_new:14 => ijk.j:2
+ │    ├── k_new:15 => ijk.k:3
+ │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:6
+ ├── partial index put columns: partial_index_put1:17
+ ├── partial index del columns: partial_index_del1:18
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: i:19!null j:20!null k:21!null partial_index_put1:17!null partial_index_del1:18!null crdb_internal_idx_expr_comp:16!null i_new:13!null j_new:14!null k_new:15 crdb_internal_idx_expr:12!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(12-21)
+      └── (1, 'i', '1999-12-31 23:59:59+00', false, true, 'hj', -1, 'h', NULL, 'ij')
+
+norm expect=UseSwapMutation
+UPDATE ijk SET i = -1, j = 'h', k = NULL WHERE i = -1 AND j = 'i' AND k IS NULL
+----
+update (swap) ijk
+ ├── columns: <none>
+ ├── fetch columns: i:19 j:20 k:21 crdb_internal_idx_expr:12
+ ├── update-mapping:
+ │    ├── i_new:13 => ijk.i:1
+ │    ├── j_new:14 => ijk.j:2
+ │    ├── k_new:15 => ijk.k:3
+ │    └── crdb_internal_idx_expr_comp:16 => crdb_internal_idx_expr:6
+ ├── partial index put columns: partial_index_put1:17
+ ├── partial index del columns: partial_index_del1:18
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: i:19!null j:20!null k:21 partial_index_put1:17!null partial_index_del1:18!null crdb_internal_idx_expr_comp:16!null i_new:13!null j_new:14!null k_new:15 crdb_internal_idx_expr:12!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(12-21)
+      └── (-1, 'i', NULL, false, false, 'hj', -1, 'h', NULL, 'ij')
+
+# Test that we do use swap mutations with inverted indexes.
+
+exec-ddl
+CREATE TABLE uvw (
+  u UUID NOT NULL DEFAULT gen_random_uuid(),
+  v TEXT,
+  w INT[],
+  PRIMARY KEY (u),
+  INVERTED INDEX (v),
+  INVERTED INDEX (w),
+  FAMILY (u, v, w)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE uvw SET u = gen_random_uuid(), w = w || 5 WHERE u = '3fb5c548-1497-4084-8973-7dcd2b28a1af' AND v = 'x' AND w = '{3}'
+----
+update (swap) uvw
+ ├── columns: <none>
+ ├── fetch columns: u:17 v:18 w:19
+ ├── update-mapping:
+ │    ├── u_new:15 => uvw.u:1
+ │    └── w_new:16 => uvw.w:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: u:17!null v:18!null w:19!null u_new:15 w_new:16!null
+      ├── cardinality: [1 - 1]
+      ├── volatile
+      ├── key: ()
+      ├── fd: ()-->(15-19)
+      └── ('3fb5c548-1497-4084-8973-7dcd2b28a1af', 'x', ARRAY[3], gen_random_uuid(), ARRAY[3,5])
+
+# TODO: we do not yet use swap mutations with vector indexes.
+
+exec-ddl
+CREATE TABLE efg (
+  e INT NOT NULL,
+  f INT,
+  g VECTOR(3),
+  PRIMARY KEY (e),
+  VECTOR INDEX (f, g),
+  FAMILY (e, f, g)
+)
+----
+
+norm
+UPDATE efg SET f = f + 1 WHERE e = 1 AND f = 2 AND g = '[8, 9, 10]'
+----
+update efg
+ ├── columns: <none>
+ ├── fetch columns: e:6 f:7 g:8
+ ├── update-mapping:
+ │    └── f_new:11 => f:2
+ ├── vector index del partition columns: vector_index_del_partition1:12
+ ├── vector index put partition columns: vector_index_put_partition1:13
+ ├── vector index put quantized vector columns: vector_index_put_quantized_vec1:14
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── vector-mutation-search efg@efg_f_g_idx,vector
+      ├── columns: e:6!null f:7!null g:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 f_new:11!null vector_index_del_partition1:12 vector_index_put_partition1:13 vector_index_put_quantized_vec1:14
+      ├── index put
+      ├── prefix key columns: [11]
+      ├── query vector column: g:8
+      ├── partition col: vector_index_put_partition1:13
+      ├── quantized vector col: vector_index_put_quantized_vec1:14
+      ├── cardinality: [0 - 1]
+      ├── immutable
+      ├── key: ()
+      ├── fd: ()-->(6-14)
+      └── vector-mutation-search efg@efg_f_g_idx,vector
+           ├── columns: e:6!null f:7!null g:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 f_new:11!null vector_index_del_partition1:12
+           ├── index del
+           ├── prefix key columns: [7]
+           ├── query vector column: g:8
+           ├── suffix key columns: [6]
+           ├── partition col: vector_index_del_partition1:12
+           ├── cardinality: [0 - 1]
+           ├── immutable
+           ├── key: ()
+           ├── fd: ()-->(6-12)
+           └── project
+                ├── columns: f_new:11!null e:6!null f:7!null g:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+                ├── cardinality: [0 - 1]
+                ├── immutable
+                ├── key: ()
+                ├── fd: ()-->(6-11)
+                ├── select
+                │    ├── columns: e:6!null f:7!null g:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    ├── fd: ()-->(6-10)
+                │    ├── scan efg
+                │    │    ├── columns: e:6!null f:7 g:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+                │    │    ├── flags: avoid-full-scan
+                │    │    ├── key: (6)
+                │    │    └── fd: (6)-->(7-10)
+                │    └── filters
+                │         ├── e:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+                │         ├── f:7 = 2 [outer=(7), constraints=(/7: [/2 - /2]; tight), fd=()-->(7)]
+                │         └── g:8 = '[8,9,10]' [outer=(8), constraints=(/8: [/[8,9,10] - /[8,9,10]]; tight), fd=()-->(8)]
+                └── projections
+                     └── f:7 + 1 [as=f_new:11, outer=(7), immutable]
+
+# Test that we do not use swap mutations with FK checks or cascades.
+
+exec-ddl
+CREATE TABLE parent (
+  p INT NOT NULL PRIMARY KEY
+)
+----
+
+exec-ddl
+CREATE TABLE child (
+  c INT NOT NULL PRIMARY KEY,
+  p INT,
+  INDEX (p),
+  FAMILY (c, p)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE parent SET p = 2 WHERE p = 1
+----
+update (swap) parent
+ ├── columns: <none>
+ ├── fetch columns: p:8
+ ├── update-mapping:
+ │    └── p_new:7 => parent.p:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: p:8!null p_new:7!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(7,8)
+      └── (1, 2)
+
+norm expect=UseSwapMutation
+UPDATE child SET c = 2, p = 2 WHERE c = 1 AND p = 1
+----
+update (swap) child
+ ├── columns: <none>
+ ├── fetch columns: c:10 p:11
+ ├── update-mapping:
+ │    ├── c_new:9 => child.c:1
+ │    └── c_new:9 => child.p:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: c:10!null p:11!null c_new:9!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(9-11)
+      └── (1, 1, 2)
+
+exec-ddl
+ALTER TABLE child
+ADD CONSTRAINT child_p_fkey
+FOREIGN KEY (p) REFERENCES parent (p)
+ON DELETE CASCADE ON UPDATE CASCADE
+----
+
+norm expect-not=UseSwapMutation
+UPDATE parent SET p = 2 WHERE p = 1
+----
+update parent
+ ├── columns: <none>
+ ├── fetch columns: p:4
+ ├── update-mapping:
+ │    └── p_new:7 => p:1
+ ├── input binding: &1
+ ├── cascades
+ │    └── child_p_fkey
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: p_new:7!null p:4!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(4,7)
+      ├── select
+      │    ├── columns: p:4!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(4)
+      │    ├── scan parent
+      │    │    ├── columns: p:4!null
+      │    │    ├── flags: avoid-full-scan
+      │    │    └── key: (4)
+      │    └── filters
+      │         └── p:4 = 1 [outer=(4), constraints=(/4: [/1 - /1]; tight), fd=()-->(4)]
+      └── projections
+           └── 2 [as=p_new:7]
+
+norm expect-not=UseSwapMutation
+UPDATE child SET c = 2, p = 2 WHERE c = 1 AND p = 1
+----
+update child
+ ├── columns: <none>
+ ├── fetch columns: c:5 child.p:6
+ ├── update-mapping:
+ │    ├── c_new:9 => c:1
+ │    └── c_new:9 => child.p:2
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: c_new:9!null c:5!null child.p:6!null
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(5,6,9)
+ │    ├── select
+ │    │    ├── columns: c:5!null child.p:6!null
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(5,6)
+ │    │    ├── scan child
+ │    │    │    ├── columns: c:5!null child.p:6
+ │    │    │    ├── flags: avoid-full-scan
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6)
+ │    │    └── filters
+ │    │         ├── c:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+ │    │         └── child.p:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+ │    └── projections
+ │         └── 2 [as=c_new:9]
+ └── f-k-checks
+      └── f-k-checks-item: child(p) -> parent(p)
+           └── anti-join (hash)
+                ├── columns: p:10!null
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(10)
+                ├── with-scan &1
+                │    ├── columns: p:10!null
+                │    ├── mapping:
+                │    │    └──  c_new:9 => p:10
+                │    ├── cardinality: [0 - 1]
+                │    ├── key: ()
+                │    └── fd: ()-->(10)
+                ├── scan parent
+                │    ├── columns: parent.p:11!null
+                │    ├── flags: avoid-full-scan
+                │    └── key: (11)
+                └── filters
+                     └── p:10 = parent.p:11 [outer=(10,11), constraints=(/10: (/NULL - ]; /11: (/NULL - ]), fd=(10)==(11), (11)==(10)]
+
+# Test that we do not use swap mutations with uniqueness checks.
+
+exec-ddl
+CREATE TABLE cd (
+  c INT PRIMARY KEY,
+  d INT,
+  UNIQUE WITHOUT INDEX (d),
+  FAMILY (c, d)
+)
+----
+
+norm expect-not=UseSwapMutation
+UPDATE cd SET c = 2, d = 2 WHERE c = 1 AND d = 1
+----
+update cd
+ ├── columns: <none>
+ ├── fetch columns: cd.c:5 cd.d:6
+ ├── update-mapping:
+ │    ├── c_new:9 => cd.c:1
+ │    └── c_new:9 => cd.d:2
+ ├── input binding: &1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ ├── project
+ │    ├── columns: c_new:9!null cd.c:5!null cd.d:6!null
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(5,6,9)
+ │    ├── select
+ │    │    ├── columns: cd.c:5!null cd.d:6!null
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(5,6)
+ │    │    ├── scan cd
+ │    │    │    ├── columns: cd.c:5!null cd.d:6
+ │    │    │    ├── flags: avoid-full-scan
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6), (6)~~>(5)
+ │    │    └── filters
+ │    │         ├── cd.c:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+ │    │         └── cd.d:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+ │    └── projections
+ │         └── 2 [as=c_new:9]
+ └── unique-checks
+      └── unique-checks-item: cd(d)
+           └── project
+                ├── columns: d:15!null
+                ├── cardinality: [0 - 1]
+                ├── key: ()
+                ├── fd: ()-->(15)
+                └── semi-join (hash)
+                     ├── columns: c:14!null d:15!null
+                     ├── cardinality: [0 - 1]
+                     ├── key: ()
+                     ├── fd: ()-->(14,15)
+                     ├── with-scan &1
+                     │    ├── columns: c:14!null d:15!null
+                     │    ├── mapping:
+                     │    │    ├──  c_new:9 => c:14
+                     │    │    └──  c_new:9 => d:15
+                     │    ├── cardinality: [0 - 1]
+                     │    ├── key: ()
+                     │    └── fd: ()-->(14,15)
+                     ├── scan cd
+                     │    ├── columns: cd.c:10!null cd.d:11
+                     │    ├── flags: avoid-full-scan
+                     │    ├── key: (10)
+                     │    └── fd: (10)-->(11)
+                     └── filters
+                          ├── d:15 = cd.d:11 [outer=(11,15), constraints=(/11: (/NULL - ]; /15: (/NULL - ]), fd=(11)==(15), (15)==(11)]
+                          └── c:14 != cd.c:10 [outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ])]
+
+# Test that we do use swap mutations with before triggers.
+
+exec-ddl
+CREATE TABLE trig (
+  id INT PRIMARY KEY,
+  name TEXT NOT NULL,
+  val INT NOT NULL,
+  FAMILY (id, name, val)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE trig SET val = 2 WHERE id = 1 AND name = 'n' AND val = 1
+----
+update (swap) trig
+ ├── columns: <none>
+ ├── fetch columns: id:12 name:13 val:14
+ ├── update-mapping:
+ │    └── val_new:11 => trig.val:3
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: id:12!null name:13!null val:14!null val_new:11!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(11-14)
+      └── (1, 'n', 1, 2)
+
+exec-ddl
+CREATE OR REPLACE FUNCTION clamp_val_before_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  IF (NEW).val < 5 THEN
+    NEW.val := 5;
+  END IF;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql
+----
+
+exec-ddl
+CREATE TRIGGER before_trig_update
+BEFORE UPDATE ON trig
+FOR EACH ROW
+EXECUTE FUNCTION clamp_val_before_update()
+----
+
+norm
+UPDATE trig SET val = 2 WHERE id = 1 AND name = 'n' AND val = 1
+----
+update trig
+ ├── columns: <none>
+ ├── fetch columns: id:6 name:7 val:8
+ ├── update-mapping:
+ │    ├── id_new:44 => id:1
+ │    ├── name_new:45 => name:2
+ │    └── val_new:46 => val:3
+ ├── before-triggers
+ │    └── before_trig_update
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: id_new:44 name_new:45 val_new:46 id:6!null name:7!null val:8!null
+      ├── cardinality: [0 - 1]
+      ├── volatile
+      ├── key: ()
+      ├── fd: ()-->(6-8,44-46)
+      ├── barrier
+      │    ├── columns: id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 val_new:11!null old:12!null new:13!null clamp_val_before_update:43!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── volatile
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-13,43)
+      │    └── select
+      │         ├── columns: id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 val_new:11!null old:12!null new:13!null clamp_val_before_update:43!null
+      │         ├── cardinality: [0 - 1]
+      │         ├── volatile
+      │         ├── key: ()
+      │         ├── fd: ()-->(6-13,43)
+      │         ├── project
+      │         │    ├── columns: clamp_val_before_update:43 id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 val_new:11!null old:12!null new:13!null
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── volatile
+      │         │    ├── key: ()
+      │         │    ├── fd: ()-->(6-13,43)
+      │         │    ├── barrier
+      │         │    │    ├── columns: id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10 val_new:11!null old:12!null new:13!null
+      │         │    │    ├── cardinality: [0 - 1]
+      │         │    │    ├── key: ()
+      │         │    │    ├── fd: ()-->(6-13)
+      │         │    │    └── project
+      │         │    │         ├── columns: new:13!null old:12!null val_new:11!null id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         │    │         ├── cardinality: [0 - 1]
+      │         │    │         ├── key: ()
+      │         │    │         ├── fd: ()-->(6-13)
+      │         │    │         ├── select
+      │         │    │         │    ├── columns: id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         │    │         │    ├── cardinality: [0 - 1]
+      │         │    │         │    ├── key: ()
+      │         │    │         │    ├── fd: ()-->(6-10)
+      │         │    │         │    ├── scan trig
+      │         │    │         │    │    ├── columns: id:6!null name:7!null val:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │         │    │         │    │    ├── flags: avoid-full-scan
+      │         │    │         │    │    ├── key: (6)
+      │         │    │         │    │    └── fd: (6)-->(7-10)
+      │         │    │         │    └── filters
+      │         │    │         │         ├── id:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      │         │    │         │         ├── name:7 = 'n' [outer=(7), constraints=(/7: [/'n' - /'n']; tight), fd=()-->(7)]
+      │         │    │         │         └── val:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
+      │         │    │         └── projections
+      │         │    │              ├── ((id:6, name:7, 2) AS id, name, val) [as=new:13, outer=(6,7)]
+      │         │    │              ├── ((id:6, name:7, val:8) AS id, name, val) [as=old:12, outer=(6-8)]
+      │         │    │              └── 2 [as=val_new:11]
+      │         │    └── projections
+      │         │         └── clamp_val_before_update(new:13, old:12, 'before_trig_update', 'BEFORE', 'ROW', 'UPDATE', 66, 'trig', 'trig', 'public', 0, ARRAY[]) [as=clamp_val_before_update:43, outer=(12,13), volatile, udf]
+      │         └── filters
+      │              └── clamp_val_before_update:43 IS DISTINCT FROM NULL [outer=(43), immutable, constraints=(/43: (/NULL - ]; tight)]
+      └── projections
+           ├── (clamp_val_before_update:43).id [as=id_new:44, outer=(43)]
+           ├── (clamp_val_before_update:43).name [as=name_new:45, outer=(43)]
+           └── (clamp_val_before_update:43).val [as=val_new:46, outer=(43)]
+
+exec-ddl
+DROP TRIGGER before_trig_update ON trig
+----
+
+# Test that we do not use swap mutations with after triggers.
+
+exec-ddl
+CREATE TABLE trig_log (
+  id INT NOT NULL,
+  name TEXT NOT NULL,
+  val INT NOT NULL,
+  modified_at TIMESTAMPTZ,
+  INDEX (id),
+  FAMILY (id, name, val, modified_at)
+)
+----
+
+exec-ddl
+CREATE OR REPLACE FUNCTION log_trig_update()
+RETURNS TRIGGER AS $$
+BEGIN
+  INSERT INTO trig_log VALUES (NEW.id, NEW.name, NEW.val, now());
+  RETURN NULL;
+END;
+$$ LANGUAGE plpgsql
+----
+
+exec-ddl
+CREATE TRIGGER after_trig_update
+AFTER UPDATE ON trig
+FOR EACH ROW
+EXECUTE FUNCTION log_trig_update()
+----
+
+norm
+UPDATE trig SET val = 2 WHERE id = 1 AND name = 'n' AND val = 1
+----
+update trig
+ ├── columns: <none>
+ ├── fetch columns: id:6 name:7 val:8
+ ├── update-mapping:
+ │    └── val_new:11 => val:3
+ ├── input binding: &1
+ ├── after-triggers
+ │    └── after_trig_update
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── project
+      ├── columns: val_new:11!null id:6!null name:7!null val:8!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8,11)
+      ├── select
+      │    ├── columns: id:6!null name:7!null val:8!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8)
+      │    ├── scan trig
+      │    │    ├── columns: id:6!null name:7!null val:8!null
+      │    │    ├── flags: avoid-full-scan
+      │    │    ├── key: (6)
+      │    │    └── fd: (6)-->(7,8)
+      │    └── filters
+      │         ├── id:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+      │         ├── name:7 = 'n' [outer=(7), constraints=(/7: [/'n' - /'n']; tight), fd=()-->(7)]
+      │         └── val:8 = 1 [outer=(8), constraints=(/8: [/1 - /1]; tight), fd=()-->(8)]
+      └── projections
+           └── 2 [as=val_new:11]
+
+# Test that predicates referencing other table columns are handled.
+
+exec-ddl
+CREATE TABLE hij (
+  h INT PRIMARY KEY,
+  i INT,
+  j INT,
+  INDEX (i),
+  FAMILY (h, i, j)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE hij SET i = i + 1 WHERE h = $1 AND i = $2 AND j = $3 AND i = j
+----
+update (swap) hij
+ ├── columns: <none>
+ ├── fetch columns: h:12 i:13 j:14
+ ├── update-mapping:
+ │    └── i_new:11 => hij.i:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── project
+      ├── columns: i_new:11!null h:12!null i:13!null j:14!null
+      ├── cardinality: [0 - 1]
+      ├── immutable, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(11-14), (13)==(14), (14)==(13)
+      ├── select
+      │    ├── columns: h:12!null i:13!null j:14!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(12-14), (13)==(14), (14)==(13)
+      │    ├── values
+      │    │    ├── columns: h:12 i:13 j:14
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(12-14)
+      │    │    └── ($1, $2, $3)
+      │    └── filters
+      │         ├── h:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
+      │         ├── i:13 IS NOT NULL [outer=(13), constraints=(/13: (/NULL - ]; tight)]
+      │         ├── j:14 IS NOT NULL [outer=(14), constraints=(/14: (/NULL - ]; tight)]
+      │         └── i:13 = j:14 [outer=(13,14), constraints=(/13: (/NULL - ]; /14: (/NULL - ]), fd=(13)==(14), (14)==(13)]
+      └── projections
+           └── i:13 + 1 [as=i_new:11, outer=(13), immutable]
+
+norm expect-not=UseSwapMutation
+UPDATE hij SET i = i + 1 WHERE h = $1 AND i = j + 1 AND j = h * 2
+----
+update hij
+ ├── columns: <none>
+ ├── fetch columns: h:6 i:7 j:8
+ ├── update-mapping:
+ │    └── i_new:11 => i:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations, has-placeholder
+ └── project
+      ├── columns: i_new:11!null h:6!null i:7!null j:8!null
+      ├── cardinality: [0 - 1]
+      ├── immutable, has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(6-8,11)
+      ├── select
+      │    ├── columns: h:6!null i:7!null j:8!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable, has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8)
+      │    ├── scan hij
+      │    │    ├── columns: h:6!null i:7 j:8
+      │    │    ├── flags: avoid-full-scan
+      │    │    ├── key: (6)
+      │    │    └── fd: (6)-->(7,8)
+      │    └── filters
+      │         ├── h:6 = $1 [outer=(6), constraints=(/6: (/NULL - ]), fd=()-->(6)]
+      │         ├── i:7 = (j:8 + 1) [outer=(7,8), immutable, constraints=(/7: (/NULL - ]), fd=(8)-->(7)]
+      │         └── j:8 = (h:6 * 2) [outer=(6,8), immutable, constraints=(/8: (/NULL - ]), fd=(6)-->(8)]
+      └── projections
+           └── i:7 + 1 [as=i_new:11, outer=(7), immutable]
+
+exec-ddl
+CREATE TABLE fg (
+  f INT PRIMARY KEY,
+  g INT,
+  INDEX (g),
+  FAMILY (f, g)
+)
+----
+
+norm expect=UseSwapMutation
+UPDATE fg SET f = '1', g = 2.0 WHERE f = '3' AND g = 4.0::decimal
+----
+update (swap) fg
+ ├── columns: <none>
+ ├── fetch columns: f:11 g:12
+ ├── update-mapping:
+ │    ├── f_new:9 => fg.f:1
+ │    └── g_new:10 => fg.g:2
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── values
+      ├── columns: f:11!null g:12!null f_new:9!null g_new:10!null
+      ├── cardinality: [1 - 1]
+      ├── key: ()
+      ├── fd: ()-->(9-12)
+      └── (3, 4, 1, 2)

--- a/pkg/sql/opt/norm/testdata/rules/mutation
+++ b/pkg/sql/opt/norm/testdata/rules/mutation
@@ -405,7 +405,7 @@ CREATE TABLE abc (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND b IS NOT DISTINCT FROM 2 AND c
 ----
 update (swap) abc
@@ -422,7 +422,32 @@ update (swap) abc
       ├── fd: ()-->(11-13)
       └── (1, 2, true)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=false expect-not=UseSwapMutation
+UPDATE abc SET a = b WHERE a = 1 AND b IS NOT DISTINCT FROM 2 AND c
+----
+update abc
+ ├── columns: <none>
+ ├── fetch columns: a:6 b:7 c:8
+ ├── update-mapping:
+ │    └── b:7 => a:1
+ ├── cardinality: [0 - 0]
+ ├── volatile, mutations
+ └── select
+      ├── columns: a:6!null b:7!null c:8!null
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(6-8)
+      ├── scan abc
+      │    ├── columns: a:6!null b:7 c:8
+      │    ├── flags: avoid-full-scan
+      │    ├── key: (6)
+      │    └── fd: (6)-->(7,8)
+      └── filters
+           ├── a:6 = 1 [outer=(6), constraints=(/6: [/1 - /1]; tight), fd=()-->(6)]
+           ├── b:7 = 2 [outer=(7), constraints=(/7: [/2 - /2]; tight), fd=()-->(7)]
+           └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND (b = 2 AND c = FALSE)
 ----
 update (swap) abc
@@ -441,7 +466,7 @@ update (swap) abc
 
 # Test that we do not use swap mutations with unconstrained columns.
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND b > 2
 ----
 update abc
@@ -467,7 +492,7 @@ update abc
 
 # TODO: we cannot yet constrain this to a single row.
 
-norm
+norm set=use_swap_mutations=true
 UPDATE abc SET a = b WHERE a >= 1 AND a < 2 AND b = 2 AND c
 ----
 update abc
@@ -492,7 +517,7 @@ update abc
            ├── b:7 = 2 [outer=(7), constraints=(/7: [/2 - /2]; tight), fd=()-->(7)]
            └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND b IS NULL AND c IS NULL
 ----
 update (swap) abc
@@ -509,7 +534,7 @@ update (swap) abc
       ├── fd: ()-->(11-13)
       └── (1, NULL, NULL)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND b IS NOT DISTINCT FROM NULL AND c IS NOT DISTINCT FROM NULL
 ----
 update (swap) abc
@@ -526,7 +551,7 @@ update (swap) abc
       ├── fd: ()-->(11-13)
       └── (1, NULL, NULL)
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND b IS DISTINCT FROM NULL AND c
 ----
 update abc
@@ -551,7 +576,7 @@ update abc
            ├── b:7 IS NOT NULL [outer=(7), constraints=(/7: (/NULL - ]; tight)]
            └── c:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = 1 AND b = 2 AND NOT c AND (a > b) = c
 ----
 update (swap) abc
@@ -568,7 +593,7 @@ update (swap) abc
       ├── fd: ()-->(11-13)
       └── (1, 2, false)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b IS NOT DISTINCT FROM $2 AND c IS NOT DISTINCT FROM $3
 ----
 update (swap) abc
@@ -594,7 +619,7 @@ update (swap) abc
       └── filters
            └── a:11 IS NOT NULL [outer=(11), constraints=(/11: (/NULL - ]; tight)]
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b = $2
 ----
 update abc
@@ -619,7 +644,7 @@ update abc
            ├── a:6 = $1 [outer=(6), constraints=(/6: (/NULL - ]), fd=()-->(6)]
            └── b:7 = $2 [outer=(7), constraints=(/7: (/NULL - ]), fd=()-->(7)]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b = $2 AND c = $3
 ----
 update (swap) abc
@@ -649,7 +674,7 @@ update (swap) abc
 
 # Additional predicates should become extra filters before the swap.
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b = $2 AND c AND c = $3 AND a < b
 ----
 update (swap) abc
@@ -680,7 +705,7 @@ update (swap) abc
 
 # Test that we do use swap mutations with RETURNING.
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b = $2 AND c AND a < b RETURNING a
 ----
 update (swap) abc
@@ -712,7 +737,7 @@ update (swap) abc
            ├── b:12 IS NOT NULL [outer=(12), constraints=(/12: (/NULL - ]; tight)]
            └── a:11 < b:12 [outer=(11,12), constraints=(/11: (/NULL - ]; /12: (/NULL - ])]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = b WHERE a = $1 AND b = $2 + 1 AND c RETURNING a + b
 ----
 project
@@ -754,7 +779,7 @@ project
 
 # Test delete swap for a few of the cases above.
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 DELETE FROM abc WHERE a = 1 AND b IS NOT DISTINCT FROM 1 AND c IS NOT DISTINCT FROM NULL
 ----
 delete (swap) abc
@@ -769,7 +794,7 @@ delete (swap) abc
       ├── fd: ()-->(11-13)
       └── (1, 1, NULL)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 DELETE FROM abc WHERE a = $1 AND b IS NOT DISTINCT FROM $2 AND c IS NOT DISTINCT FROM $3 RETURNING $4:::int
 ----
 project
@@ -817,7 +842,7 @@ CREATE TABLE xy (
 )
 ----
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE xy SET x = x WHERE x = 1 AND y = 2
 ----
 update xy
@@ -842,7 +867,7 @@ update xy
            ├── x:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
            └── y:6 = 2 [outer=(6), immutable, constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 DELETE FROM xy WHERE x = 1 AND y = 2
 ----
 delete xy
@@ -865,7 +890,7 @@ delete xy
            ├── x:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
            └── y:6 = 2 [outer=(6), immutable, constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = 2 WHERE a = 1 AND b IS NOT DISTINCT FROM 1 AND c
 ----
 update (swap) abc
@@ -882,7 +907,7 @@ update (swap) abc
       ├── fd: ()-->(11-14)
       └── (1, 1, true, 2)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = 1, b = 2, c = TRUE WHERE a = 4 AND b IS NOT DISTINCT FROM 5 AND c
 ----
 update (swap) abc
@@ -901,7 +926,7 @@ update (swap) abc
       ├── fd: ()-->(11-16)
       └── (4, 5, true, 1, 2, true)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET a = $1, b = $2, c = $3 WHERE a = $4 AND b IS NOT DISTINCT FROM $5 AND c IS NOT DISTINCT FROM $6
 ----
 update (swap) abc
@@ -952,7 +977,7 @@ CREATE TABLE mnop (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE mnop SET m = 1, n = 2 WHERE m = 3 AND n IS NOT DISTINCT FROM 4
 ----
 update (swap) mnop
@@ -972,7 +997,7 @@ update (swap) mnop
       ├── fd: ()-->(9,10,13-18)
       └── (3, 4, 3, true, 1, 2, 7, true)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 DELETE FROM mnop WHERE m = $1 AND n IS NOT DISTINCT FROM $2
 ----
 delete (swap) mnop
@@ -1004,7 +1029,7 @@ delete (swap) mnop
       └── projections
            └── m:13 + n:14 [as=o:9, outer=(13,14), immutable]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE mnop SET m = $1, n = $2 WHERE m = $3 AND n = $4 RETURNING o, p
 ----
 project
@@ -1066,7 +1091,7 @@ project
                 ├── m_new:13 + n_new:14 [as=o_comp:15, outer=(13,14), immutable]
                 └── m_new:13 < n_new:14 [as=p_comp:16, outer=(13,14)]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE mnop SET m = $1, n = n + $2 WHERE m = $3 AND n IS NOT DISTINCT FROM $4 AND o = $5 AND NOT p
 ----
 update (swap) mnop
@@ -1119,7 +1144,7 @@ update (swap) mnop
 
 # Test that we do use swap mutations with a subquery in the projection.
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE abc SET b = (SELECT sum(m) FROM mnop) WHERE a = 1 AND b = 2 AND c
 ----
 update (swap) abc
@@ -1161,7 +1186,7 @@ update (swap) abc
 # TODO: we do not yet use swap mutations with a subquery in a predicate, due to
 # the rule not matching the join.
 
-norm
+norm set=use_swap_mutations=true
 UPDATE abc SET b = 2 WHERE a = 1 AND b = (SELECT 1 FROM mnop LIMIT 1) AND c
 ----
 update abc
@@ -1213,7 +1238,7 @@ update abc
 
 # TODO: we do not yet use swap mutations with CTEs due to the join.
 
-norm
+norm set=use_swap_mutations=true
 WITH w AS (SELECT sum(m) AS s FROM mnop) UPDATE abc SET b = 1 FROM w WHERE a = s AND b = 2 AND c
 ----
 update abc
@@ -1269,7 +1294,7 @@ update abc
            ├── 1 [as=b_new:19]
            └── sum:7 [as=s:18, outer=(7)]
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 WITH w AS (SELECT sum(m) AS s FROM mnop) UPDATE abc SET b = (SELECT s FROM w) WHERE a = 1 AND b = 2 AND c
 ----
 update (swap) abc
@@ -1317,7 +1342,7 @@ update (swap) abc
 
 # TODO: we do not yet use swap mutations with joins.
 
-norm
+norm set=use_swap_mutations=true
 UPDATE abc SET c = false FROM mnop WHERE a = 1 AND m = 1 AND b = n AND c
 ----
 update abc
@@ -1397,7 +1422,7 @@ CREATE TABLE qrs (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE qrs SET q = q || 'q' WHERE q = 'q' AND s = 'qs'
 ----
 update (swap) qrs
@@ -1419,7 +1444,7 @@ update (swap) qrs
 # TODO: we do not yet use swap mutations without all primary index columns
 # specified, even if the missing columns are computed.
 
-norm
+norm set=use_swap_mutations=true
 UPDATE qrs SET q = q || 'q' WHERE q = 'q'
 ----
 update qrs
@@ -1481,7 +1506,7 @@ CREATE TABLE ijk (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE ijk SET i = 2, j = 'h', k = now() WHERE i = 1 AND j = 'i' AND k = '1999-12-31 23:59:59 UTC'
 ----
 update (swap) ijk
@@ -1503,7 +1528,7 @@ update (swap) ijk
       ├── fd: ()-->(12-21)
       └── (1, 'i', '1999-12-31 23:59:59+00', true, true, 'hj', 2, 'h', '2017-05-10 13:00:00+00', 'ij')
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE ijk SET i = -1, j = 'h', k = NULL WHERE i = 1 AND j = 'i' AND k = '1999-12-31 23:59:59 UTC'
 ----
 update (swap) ijk
@@ -1525,7 +1550,7 @@ update (swap) ijk
       ├── fd: ()-->(12-21)
       └── (1, 'i', '1999-12-31 23:59:59+00', false, true, 'hj', -1, 'h', NULL, 'ij')
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE ijk SET i = -1, j = 'h', k = NULL WHERE i = -1 AND j = 'i' AND k IS NULL
 ----
 update (swap) ijk
@@ -1561,7 +1586,7 @@ CREATE TABLE uvw (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE uvw SET u = gen_random_uuid(), w = w || 5 WHERE u = '3fb5c548-1497-4084-8973-7dcd2b28a1af' AND v = 'x' AND w = '{3}'
 ----
 update (swap) uvw
@@ -1593,7 +1618,7 @@ CREATE TABLE efg (
 )
 ----
 
-norm
+norm set=use_swap_mutations=true
 UPDATE efg SET f = f + 1 WHERE e = 1 AND f = 2 AND g = '[8, 9, 10]'
 ----
 update efg
@@ -1668,7 +1693,7 @@ CREATE TABLE child (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE parent SET p = 2 WHERE p = 1
 ----
 update (swap) parent
@@ -1685,7 +1710,7 @@ update (swap) parent
       ├── fd: ()-->(7,8)
       └── (1, 2)
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE child SET c = 2, p = 2 WHERE c = 1 AND p = 1
 ----
 update (swap) child
@@ -1710,7 +1735,7 @@ FOREIGN KEY (p) REFERENCES parent (p)
 ON DELETE CASCADE ON UPDATE CASCADE
 ----
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE parent SET p = 2 WHERE p = 1
 ----
 update parent
@@ -1742,7 +1767,7 @@ update parent
       └── projections
            └── 2 [as=p_new:7]
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE child SET c = 2, p = 2 WHERE c = 1 AND p = 1
 ----
 update child
@@ -1806,7 +1831,7 @@ CREATE TABLE cd (
 )
 ----
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE cd SET c = 2, d = 2 WHERE c = 1 AND d = 1
 ----
 update cd
@@ -1878,7 +1903,7 @@ CREATE TABLE trig (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE trig SET val = 2 WHERE id = 1 AND name = 'n' AND val = 1
 ----
 update (swap) trig
@@ -1914,7 +1939,7 @@ FOR EACH ROW
 EXECUTE FUNCTION clamp_val_before_update()
 ----
 
-norm
+norm set=use_swap_mutations=true
 UPDATE trig SET val = 2 WHERE id = 1 AND name = 'n' AND val = 1
 ----
 update trig
@@ -2023,7 +2048,7 @@ FOR EACH ROW
 EXECUTE FUNCTION log_trig_update()
 ----
 
-norm
+norm set=use_swap_mutations=true
 UPDATE trig SET val = 2 WHERE id = 1 AND name = 'n' AND val = 1
 ----
 update trig
@@ -2070,7 +2095,7 @@ CREATE TABLE hij (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE hij SET i = i + 1 WHERE h = $1 AND i = $2 AND j = $3 AND i = j
 ----
 update (swap) hij
@@ -2107,7 +2132,7 @@ update (swap) hij
       └── projections
            └── i:13 + 1 [as=i_new:11, outer=(13), immutable]
 
-norm expect-not=UseSwapMutation
+norm set=use_swap_mutations=true expect-not=UseSwapMutation
 UPDATE hij SET i = i + 1 WHERE h = $1 AND i = j + 1 AND j = h * 2
 ----
 update hij
@@ -2150,7 +2175,7 @@ CREATE TABLE fg (
 )
 ----
 
-norm expect=UseSwapMutation
+norm set=use_swap_mutations=true expect=UseSwapMutation
 UPDATE fg SET f = '1', g = 2.0 WHERE f = '3' AND g = 4.0::decimal
 ----
 update (swap) fg

--- a/pkg/sql/opt/ops/mutation.opt
+++ b/pkg/sql/opt/ops/mutation.opt
@@ -211,6 +211,9 @@ define MutationPrivate {
     # VectorInsert indicates that the mutation is an insert with a specialized
     # vectorized implementation used for Copy statements.
     VectorInsert bool
+
+    # Swap indicates that the mutation is an update swap or delete swap.
+    Swap bool
 }
 
 # Update evaluates a relational input expression that fetches existing rows from

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -759,6 +759,9 @@ message LocalOnlySessionData {
   // canary statistics (mode == on), stable statistics (mode == off), or
   // let the system decide based on random selection (mode == auto).
   int64 canary_stats_mode = 193 [(gogoproto.casttype) = "CanaryStatsMode"];
+  // UseSwapMutations, when true, enables use of the update swap and delete swap
+  // operators.
+  bool use_swap_mutations = 194;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sessionmutator/mutator.go
+++ b/pkg/sql/sessionmutator/mutator.go
@@ -1110,3 +1110,7 @@ func (m *SessionDataMutator) SetDisableWaitForJobsNotice(val bool) {
 func (m *SessionDataMutator) SetCanaryStatsMode(val sessiondatapb.CanaryStatsMode) {
 	m.Data.CanaryStatsMode = val
 }
+
+func (m *SessionDataMutator) SetUseSwapMutations(val bool) {
+	m.Data.UseSwapMutations = val
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4402,6 +4402,7 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// CockroachDB extension.
 	`optimizer_use_improved_hoist_join_project`: {
 		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_hoist_join_project`),
 		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
@@ -4489,6 +4490,23 @@ var varGen = map[string]sessionVar{
 		GlobalDefault: func(sv *settings.Values) string {
 			return sessiondatapb.CanaryStatsModeAuto.String()
 		},
+	},
+
+	// CockroachDB extension.
+	`use_swap_mutations`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`use_swap_mutations`),
+		Set: func(_ context.Context, m sessionmutator.SessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("use_swap_mutations", s)
+			if err != nil {
+				return err
+			}
+			m.SetUseSwapMutations(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UseSwapMutations), nil
+		},
+		GlobalDefault: globalFalse,
 	},
 }
 


### PR DESCRIPTION
Add a new normalization rule which converts Update and Delete expressions to UpdateSwap and DeleteSwap, respectively.

With this normalization rule in place, UpdateSwap and DeleteSwap should be available for use by any qualifying UPDATE and DELETE statements.

See individual commits for details and release note.

Fixes: #144503
Fixes: #85328

Release note: None