### PR TITLE
sql: support buffered writes in TestRetriableErrorDuringTransactionHoldsLocks

### DIFF
--- a/pkg/sql/conn_executor_test.go
+++ b/pkg/sql/conn_executor_test.go
@@ -12,6 +12,7 @@ import (
 	"database/sql/driver"
 	"fmt"
 	"net/url"
+	"slices"
 	"strings"
 	"sync"
 	"sync/atomic"
@@ -23,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/kvcoord"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -1471,7 +1473,7 @@ func TestShowLastQueryStatistics(t *testing.T) {
 			expectNonTrivialSchemaChangeTime: false,
 		},
 		{
-			stmt: `CREATE TABLE t1(a INT); 
+			stmt: `CREATE TABLE t1(a INT);
 INSERT INTO t1 SELECT i FROM generate_series(1, 10000) AS g(i);
 ALTER TABLE t1 ADD COLUMN b INT DEFAULT 1`,
 			usesExecEngine:                   true,
@@ -2009,91 +2011,115 @@ func TestRetriableErrorDuringTransactionHoldsLocks(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 
-	filter := newDynamicRequestFilter()
-	s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
-		Knobs: base.TestingKnobs{
-			Store: &kvserver.StoreTestingKnobs{
-				TestingRequestFilter: filter.filter,
+	testutils.RunTrueAndFalse(t, "buffered_writes", func(t *testing.T, bufferedWrites bool) {
+		st := cluster.MakeClusterSettings()
+
+		kvcoord.BufferedWritesEnabled.Override(ctx, &st.SV, bufferedWrites)
+		filter := newDynamicRequestFilter()
+		s, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{
+			Settings: st,
+			Knobs: base.TestingKnobs{
+				Store: &kvserver.StoreTestingKnobs{
+					TestingRequestFilter: filter.filter,
+				},
 			},
-		},
-	})
-	defer s.Stopper().Stop(ctx)
-	codec := s.ApplicationLayer().Codec()
+		})
+		defer s.Stopper().Stop(ctx)
+		codec := s.ApplicationLayer().Codec()
 
-	conn, err := sqlDB.Conn(ctx)
-	require.NoError(t, err)
-	testDB := sqlutils.MakeSQLRunner(conn)
+		conn, err := sqlDB.Conn(ctx)
+		require.NoError(t, err)
+		testDB := sqlutils.MakeSQLRunner(conn)
 
-	var barTableID uint32
-	testDB.Exec(t, "SET enable_implicit_transaction_for_batch_statements = true")
-	testDB.Exec(t, "CREATE TABLE foo (a INT PRIMARY KEY, b INT)")
-	testDB.Exec(t, "INSERT INTO foo VALUES(1, 1)")
-	testDB.Exec(t, "CREATE TABLE bar (a INT PRIMARY KEY)")
-	testDB.QueryRow(t, "SELECT 'bar'::regclass::oid").Scan(&barTableID)
+		var barTableID uint32
+		testDB.Exec(t, "SET enable_implicit_transaction_for_batch_statements = true")
+		testDB.Exec(t, "CREATE TABLE foo (a INT PRIMARY KEY, b INT)")
+		testDB.Exec(t, "INSERT INTO foo VALUES(1, 1)")
+		testDB.Exec(t, "CREATE TABLE bar (a INT PRIMARY KEY)")
+		testDB.QueryRow(t, "SELECT 'bar'::regclass::oid").Scan(&barTableID)
 
-	// Inject an error that will happen during execution.
-	injectedRetry := false
-	var injectedRetryWG, secondConnWG sync.WaitGroup
-	injectedRetryWG.Add(1)
-	secondConnWG.Add(1)
-	filter.setFilter(func(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
-		if ba.Txn == nil {
-			return nil
+		// Inject an error that will happen during execution.
+		injectedRetry := false
+		var injectedRetryWG, secondConnWG sync.WaitGroup
+		injectedRetryWG.Add(1)
+		secondConnWG.Add(1)
+
+		interceptedMethods := []kvpb.Method{kvpb.ConditionalPut}
+		if bufferedWrites {
+			interceptedMethods = []kvpb.Method{kvpb.ConditionalPut, kvpb.Put}
 		}
-		if req, ok := ba.GetArg(kvpb.ConditionalPut); ok {
-			put := req.(*kvpb.ConditionalPutRequest)
-			_, tableID, err := codec.DecodeTablePrefix(put.Key)
-			if err != nil || tableID != barTableID {
+		filter.setFilter(func(ctx context.Context, ba *kvpb.BatchRequest) *kvpb.Error {
+			if ba.Txn == nil {
 				return nil
 			}
-			if !injectedRetry {
-				injectedRetry = true
-				defer injectedRetryWG.Done()
-				return kvpb.NewErrorWithTxn(
-					kvpb.NewTransactionRetryError(kvpb.RETRY_REASON_UNKNOWN, "injected retry error"), ba.Txn,
-				)
-			} else {
-				secondConnWG.Wait()
+
+			maybeInject := func(r kvpb.Request) *kvpb.Error {
+				_, tableID, err := codec.DecodeTablePrefix(r.Header().Key)
+				if err != nil || tableID != barTableID {
+					return nil
+				}
+				if !injectedRetry {
+					t.Logf("injecting error for %s on %s", r.Method(), r.Header().Key)
+					injectedRetry = true
+					defer injectedRetryWG.Done()
+					return kvpb.NewErrorWithTxn(
+						kvpb.NewTransactionRetryError(kvpb.RETRY_REASON_UNKNOWN, "injected retry error"), ba.Txn,
+					)
+				} else {
+					t.Logf("waiting on second conn for %s on %s", r.Method(), r.Header().Key)
+					secondConnWG.Wait()
+					return nil
+				}
 			}
-		}
-		return nil
+			for _, ru := range ba.Requests {
+				req := ru.GetInner()
+				if slices.Contains(interceptedMethods, req.Method()) {
+					if err := maybeInject(req); err != nil {
+						return err
+					}
+				}
+			}
+			return nil
+		})
+
+		g := ctxgroup.WithContext(ctx)
+		g.GoCtx(func(ctx context.Context) error {
+			defer secondConnWG.Done()
+			conn2, err := sqlDB.Conn(ctx)
+			if err != nil {
+				return err
+			}
+			_, err = conn2.ExecContext(ctx, "SET statement_timeout = '1s'")
+			if err != nil {
+				return err
+			}
+
+			t.Log("second conn: waiting on injection")
+			injectedRetryWG.Wait()
+			t.Log("second conn: running UPDATE")
+			_, err = conn2.ExecContext(ctx, "UPDATE foo SET b = 100 WHERE a = 1")
+			if !testutils.IsError(err, "query execution canceled due to statement timeout") {
+				// NB: errors.Wrapf(nil, ...) returns nil.
+				// nolint:errwrap
+				return errors.Newf("expected a statement timeout error, got: %v", err)
+			}
+
+			return nil
+		})
+
+		t.Log("first conn: running txn")
+		testDB.Exec(t, "UPDATE foo SET b = 10 WHERE a = 1; INSERT INTO bar VALUES(2); COMMIT;")
+
+		// Verify that the implicit transaction completed successfully, and the second
+		// transaction did not.
+		var x int
+		testDB.QueryRow(t, "SELECT b FROM foo WHERE a = 1").Scan(&x)
+		require.Equal(t, 10, x)
+		testDB.QueryRow(t, "SELECT a FROM bar").Scan(&x)
+		require.Equal(t, 2, x)
+
+		require.NoError(t, g.Wait())
 	})
-
-	g := ctxgroup.WithContext(ctx)
-	g.GoCtx(func(ctx context.Context) error {
-		defer secondConnWG.Done()
-		conn2, err := sqlDB.Conn(ctx)
-		if err != nil {
-			return err
-		}
-		_, err = conn2.ExecContext(ctx, "SET statement_timeout = '1s'")
-		if err != nil {
-			return err
-		}
-
-		injectedRetryWG.Wait()
-		_, err = conn2.ExecContext(ctx, "UPDATE foo SET b = 100 WHERE a = 1")
-		if !testutils.IsError(err, "query execution canceled due to statement timeout") {
-			// NB: errors.Wrapf(nil, ...) returns nil.
-			// nolint:errwrap
-			return errors.Newf("expected a statement timeout error, got: %v", err)
-		}
-
-		return nil
-	})
-
-	fmt.Printf("running txn\n")
-	testDB.Exec(t, "UPDATE foo SET b = 10 WHERE a = 1; INSERT INTO bar VALUES(2); COMMIT;")
-
-	// Verify that the implicit transaction completed successfully, and the second
-	// transaction did not.
-	var x int
-	testDB.QueryRow(t, "SELECT b FROM foo WHERE a = 1").Scan(&x)
-	require.Equal(t, 10, x)
-	testDB.QueryRow(t, "SELECT a FROM bar").Scan(&x)
-	require.Equal(t, 2, x)
-
-	require.NoError(t, g.Wait())
 }
 
 func TestTrackOnlyUserOpenTransactionsAndActiveStatements(t *testing.T) {
@@ -2415,7 +2441,7 @@ func noopRequestFilter(ctx context.Context, request *kvpb.BatchRequest) *kvpb.Er
 func getTxnID(t *testing.T, tx *gosql.Tx) (id string) {
 	t.Helper()
 	sqlutils.MakeSQLRunner(tx).QueryRow(t, `
-SELECT id 
+SELECT id
   FROM crdb_internal.node_transactions a
   JOIN [SHOW session_id] b ON a.session_id = b.session_id
 `,


### PR DESCRIPTION
This test depends on a request filter that injects errors. Since buffered writes sends Put requests rather than ConditionalPut requests, the test now matches either type of request.

Epic: none

Release note: None