### PR TITLE
release-24.1: sql: optimize SHOW CREATE TABLE performance with many schema objects

### DIFF
--- a/pkg/ccl/benchccl/rttanalysisccl/testdata/benchmark_expectations
+++ b/pkg/ccl/benchccl/rttanalysisccl/testdata/benchmark_expectations
@@ -17,3 +17,6 @@ exp,benchmark
 13,AlterTableLocality/alter_from_rbr_to_regional_by_table
 16,AlterTableLocality/alter_from_regional_by_table_to_global
 25,AlterTableLocality/alter_from_regional_by_table_to_rbr
+9,VirtualTableQueries/select_from_crdb_internal.zones_(100_tables)
+9,VirtualTableQueries/select_from_crdb_internal.zones_(10_tables)
+9,VirtualTableQueries/select_from_crdb_internal.zones_(50_tables)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4773,6 +4773,33 @@ CREATE TABLE crdb_internal.zones (
 			return err
 		}
 		values := make(tree.Datums, len(showZoneConfigColumns))
+		descIDs := catalog.DescriptorIDSet{}
+		for _, r := range rows {
+			id := uint32(tree.MustBeDInt(r[0]))
+			zs, err := zonepb.ZoneSpecifierFromID(id, resolveID)
+			if err != nil {
+				// We can have valid zoneSpecifiers whose table/database has been
+				// deleted because zoneSpecifiers are collected asynchronously.
+				// In this case, just don't show the zoneSpecifier in the
+				// output of the table.
+				continue
+			}
+			if zs.TableOrIndex.Table.Object() == "" && zs.Database == "" {
+				continue
+			}
+			descIDs.Add(descpb.ID(id))
+		}
+		// Fetch all of the descriptors needed for format the zone configuration
+		// information.
+		zcDescMap := make(map[catid.DescID]catalog.Descriptor)
+		zcDescs, err := p.Descriptors().ByID(p.Txn()).Get().Descs(ctx, descIDs.Ordered())
+		if err != nil {
+			return err
+		}
+		for _, desc := range zcDescs {
+			zcDescMap[desc.GetID()] = desc
+		}
+
 		for _, r := range rows {
 			id := uint32(tree.MustBeDInt(r[0]))
 
@@ -4805,26 +4832,23 @@ CREATE TABLE crdb_internal.zones (
 
 			var table catalog.TableDescriptor
 			if zs.Database != "" {
-				database, err := p.Descriptors().ByID(p.txn).Get().Database(ctx, descpb.ID(id))
-				if err != nil {
-					return err
-				}
+				database := zcDescMap[catid.DescID(id)]
 				if ok, err := p.HasAnyPrivilege(ctx, database); err != nil {
 					return err
 				} else if !ok {
 					continue
 				}
 			} else if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
-				tableEntry, err := p.Descriptors().ByID(p.txn).Get().Table(ctx, descpb.ID(id))
-				if err != nil {
-					return err
-				}
+				tableEntry := zcDescMap[catid.DescID(id)]
 				if ok, err := p.HasAnyPrivilege(ctx, tableEntry); err != nil {
 					return err
 				} else if !ok {
 					continue
 				}
-				table = tableEntry
+				table, err = catalog.AsTableDescriptor(tableEntry)
+				if err != nil {
+					return err
+				}
 			}
 
 			// Write down information about the zone in the table.


### PR DESCRIPTION
Backport 1/1 commits from #144900.

/cc @cockroachdb/release

---

Previously, SHOW CREATE TABLE queried the crdb_internal.zones table to extract the zone configuration. This could be slow with a large number of objects because the subquery needed to scan the entirety of crdb_internal.zones, which would do one round-trip per zone config (to fetch descriptors). This patch optimizes crdb_internal.zones to fetch all required descriptors in a single request, instead of performing a round trip for each descriptor. Additionally, this patch adds a new BenchmarkORMQueries test in the rttanalysisccl package, configured for multi-region testing.

Fixes: #141827

Release note (bug fix): Improve slow SHOW CREATE TABLE on multi-region
databases with large number of objects

Release justification: low risk fix that addresses a performance issue with SHOW CREATE TABLE on multiregion clusters or clusters with a large number of zone configs
