### PR TITLE
sql: fix ALTER TABLE SET LOGGED/UNLOGGED

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4563,3 +4563,22 @@ statement ok
 DROP TYPE e1;
 
 subtest end
+
+subtest set_logged
+
+statement ok
+CREATE TABLE t_set_logged (a INT PRIMARY KEY);
+
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE t_set_logged SET LOGGED;
+----
+NOTICE: SET LOGGED is not supported and has no effect
+
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE t_set_logged SET UNLOGGED;
+----
+NOTICE: SET UNLOGGED is not supported and has no effect
+
+subtest end

--- a/pkg/sql/unimplemented.go
+++ b/pkg/sql/unimplemented.go
@@ -91,5 +91,5 @@ func (p *planner) AlterTableSetLogged(
 			operation,
 		),
 	)
-	return nil, nil
+	return &zeroNode{}, nil
 }


### PR DESCRIPTION
This was recently added in b614b04304e2bc4da9763ecb96fe9497c161d038, but for the notice to display correctly we must not return a nil planNode.

No release note since the bug has not been released.

informs #144727
Release note: None