### PR TITLE
release-23.2: sql: optimize SHOW CREATE TABLE performance with many schema objects

### DIFF
--- a/pkg/ccl/benchccl/rttanalysisccl/multi_region_bench_test.go
+++ b/pkg/ccl/benchccl/rttanalysisccl/multi_region_bench_test.go
@@ -7,7 +7,9 @@ package rttanalysisccl
 
 import (
 	gosql "database/sql"
+	"fmt"
 	"net/url"
+	"strings"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -68,6 +70,36 @@ CREATE TABLE test41 (p int) LOCALITY REGIONAL BY TABLE IN "us-east2";
 CREATE TABLE test42 (p int) LOCALITY REGIONAL BY TABLE IN "us-east2";
 `
 )
+
+// multipleTableFixtures creates multiple tables with different localities.
+func multipleTableFixtures(n int) string {
+	b := strings.Builder{}
+
+	b.WriteString(`CREATE DATABASE test PRIMARY REGION "us-east1" REGIONS "us-east1", "us-east2", "us-east3";
+USE test;`)
+	b.WriteString("BEGIN;\n")
+	for i := 0; i < n; i++ {
+		b.WriteString(fmt.Sprintf("CREATE TABLE test%d (p int)", i))
+
+		locality := i % 5
+
+		switch locality {
+		case 0:
+			b.WriteString(" LOCALITY GLOBAL")
+		case 1:
+			b.WriteString(" LOCALITY REGIONAL BY ROW")
+		case 2:
+			b.WriteString(" LOCALITY REGIONAL BY TABLE IN \"us-east1\"")
+		case 3:
+			b.WriteString(" LOCALITY REGIONAL BY TABLE IN \"us-east2\"")
+		case 4:
+			b.WriteString(" LOCALITY REGIONAL BY TABLE IN \"us-east3\"")
+		}
+		b.WriteString(";\n")
+	}
+	b.WriteString("COMMIT;\n")
+	return b.String()
+}
 
 func BenchmarkAlterRegions(b *testing.B) { reg.Run(b) }
 func init() {
@@ -234,6 +266,31 @@ USE test;
 CREATE TABLE test (p int) LOCALITY REGIONAL BY ROW;
 `,
 			Stmt:  `ALTER TABLE test SET LOCALITY GLOBAL`,
+			Reset: "DROP DATABASE test",
+		},
+	})
+}
+
+func BenchmarkVirtualTableQueries(b *testing.B) { reg.Run(b) }
+func init() {
+	reg.Register("VirtualTableQueries", []rttanalysis.RoundTripBenchTestCase{
+		{
+			Name:  "select from crdb_internal.zones (10 tables)",
+			Setup: multipleTableFixtures(10),
+			Stmt:  `select * from crdb_internal.zones`,
+			Reset: "DROP DATABASE test",
+		},
+		{
+			Name:  "select from crdb_internal.zones (50 tables)",
+			Setup: multipleTableFixtures(50),
+			Stmt:  `select * from crdb_internal.zones`,
+			Reset: "DROP DATABASE test",
+		},
+
+		{
+			Name:  "select from crdb_internal.zones (100 tables)",
+			Setup: multipleTableFixtures(100),
+			Stmt:  `select * from crdb_internal.zones`,
 			Reset: "DROP DATABASE test",
 		},
 	})

--- a/pkg/ccl/benchccl/rttanalysisccl/testdata/benchmark_expectations
+++ b/pkg/ccl/benchccl/rttanalysisccl/testdata/benchmark_expectations
@@ -17,3 +17,6 @@ exp,benchmark
 13,AlterTableLocality/alter_from_rbr_to_regional_by_table
 16,AlterTableLocality/alter_from_regional_by_table_to_global
 25,AlterTableLocality/alter_from_regional_by_table_to_rbr
+9,VirtualTableQueries/select_from_crdb_internal.zones_(100_tables)
+9,VirtualTableQueries/select_from_crdb_internal.zones_(10_tables)
+9,VirtualTableQueries/select_from_crdb_internal.zones_(50_tables)

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -4748,6 +4748,33 @@ CREATE TABLE crdb_internal.zones (
 			return err
 		}
 		values := make(tree.Datums, len(showZoneConfigColumns))
+		descIDs := catalog.DescriptorIDSet{}
+		for _, r := range rows {
+			id := uint32(tree.MustBeDInt(r[0]))
+			zs, err := zonepb.ZoneSpecifierFromID(id, resolveID)
+			if err != nil {
+				// We can have valid zoneSpecifiers whose table/database has been
+				// deleted because zoneSpecifiers are collected asynchronously.
+				// In this case, just don't show the zoneSpecifier in the
+				// output of the table.
+				continue
+			}
+			if zs.TableOrIndex.Table.Object() == "" && zs.Database == "" {
+				continue
+			}
+			descIDs.Add(descpb.ID(id))
+		}
+		// Fetch all of the descriptors needed for format the zone configuration
+		// information.
+		zcDescMap := make(map[catid.DescID]catalog.Descriptor)
+		zcDescs, err := p.Descriptors().ByID(p.Txn()).Get().Descs(ctx, descIDs.Ordered())
+		if err != nil {
+			return err
+		}
+		for _, desc := range zcDescs {
+			zcDescMap[desc.GetID()] = desc
+		}
+
 		for _, r := range rows {
 			id := uint32(tree.MustBeDInt(r[0]))
 
@@ -4780,26 +4807,23 @@ CREATE TABLE crdb_internal.zones (
 
 			var table catalog.TableDescriptor
 			if zs.Database != "" {
-				database, err := p.Descriptors().ByID(p.txn).WithoutNonPublic().Get().Database(ctx, descpb.ID(id))
-				if err != nil {
-					return err
-				}
+				database := zcDescMap[catid.DescID(id)]
 				if ok, err := p.HasAnyPrivilege(ctx, database); err != nil {
 					return err
 				} else if !ok {
 					continue
 				}
 			} else if zoneSpecifier.TableOrIndex.Table.ObjectName != "" {
-				tableEntry, err := p.Descriptors().ByID(p.txn).WithoutDropped().Get().Table(ctx, descpb.ID(id))
-				if err != nil {
-					return err
-				}
+				tableEntry := zcDescMap[catid.DescID(id)]
 				if ok, err := p.HasAnyPrivilege(ctx, tableEntry); err != nil {
 					return err
 				} else if !ok {
 					continue
 				}
-				table = tableEntry
+				table, err = catalog.AsTableDescriptor(tableEntry)
+				if err != nil {
+					return err
+				}
 			}
 
 			// Write down information about the zone in the table.


### PR DESCRIPTION
Backport 1/1 commits from #144900.

/cc @cockroachdb/release

---

Previously, SHOW CREATE TABLE queried the crdb_internal.zones table to extract the zone configuration. This could be slow with a large number of objects because the subquery needed to scan the entirety of crdb_internal.zones, which would do one round-trip per zone config (to fetch descriptors). This patch optimizes crdb_internal.zones to fetch all required descriptors in a single request, instead of performing a round trip for each descriptor. Additionally, this patch adds a new BenchmarkORMQueries test in the rttanalysisccl package, configured for multi-region testing.

Fixes: #141827

Release note (bug fix): Improve slow SHOW CREATE TABLE on multi-region
databases with large number of objects

Release justification: low risk fix that addresses a performance issue with SHOW CREATE TABLE on multiregion clusters or clusters with a large number of zone configs