### PR TITLE
jobs: log reason a job was canceled

### DIFF
--- a/pkg/jobs/update.go
+++ b/pkg/jobs/update.go
@@ -444,7 +444,11 @@ func (ju *JobUpdater) PauseRequestedWithFunc(
 	ju.UpdateState(StatePauseRequested)
 	md.Payload.PauseReason = reason
 	ju.UpdatePayload(md.Payload)
-	log.Infof(ctx, "job %d: pause requested recorded with reason %s", md.ID, reason)
+	if reason == "" {
+		log.Infof(ctx, "job %d: pause requested recorded", md.ID)
+	} else {
+		log.Infof(ctx, "job %d: pause requested recorded with reason: %s", md.ID, reason)
+	}
 	return nil
 }
 
@@ -494,6 +498,7 @@ func (ju *JobUpdater) CancelRequestedWithReason(
 		ju.UpdatePayload(md.Payload)
 	}
 	ju.UpdateState(StateCancelRequested)
+	log.Infof(ctx, "job %d: cancel requested recorded with reason: %v", md.ID, reason)
 	return nil
 }
 


### PR DESCRIPTION
This patch adds a log that logs the reason a job was canceled.
The log will also include any contextual information about the
session that canceled the job.

Epic: None

Release note: None