### PR TITLE
roachprod: add CLI option to download certs dir

### DIFF
--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -2207,3 +2207,31 @@ If the time is not provided, it downloads the latest pprof file across all clust
 		}),
 	}
 }
+
+func (cr *commandRegistry) buildFetchCertsDir() *cobra.Command {
+	return &cobra.Command{
+		Use:   "fetch-certs <cluster> [<dest-dir>]",
+		Short: "downloads the PGUrl certs directory from the cluster",
+		Long: fmt.Sprintf(`
+Downloads the PGUrl certs directory from the cluster. In addition to downloading the
+certs, it also makes sure the files are not world readable so lib/pq doesn't complain.
+If a destination is not provided, the certs will be downloaded to a default %s directory.
+
+--certs-dir: specify the directory to download the certs from
+
+`, install.CockroachNodeCertsDir),
+		Args: cobra.RangeArgs(1, 2),
+		Run: wrap(func(cmd *cobra.Command, args []string) error {
+			cluster := args[0]
+			// If a destination is not provided, download the certs to a default directory
+			// for safety. FetchCertsDir will walk the entire directory and chmod each file
+			// so we want to avoid side effects.
+			dest := fmt.Sprintf("./%s", install.CockroachNodeCertsDir)
+			if len(args) == 2 {
+				dest = args[1]
+			}
+			ctx := context.Background()
+			return roachprod.FetchCertsDir(ctx, config.Logger, cluster, pgurlCertsDir, dest)
+		}),
+	}
+}

--- a/pkg/cmd/roachprod/cli/resgistry.go
+++ b/pkg/cmd/roachprod/cli/resgistry.go
@@ -70,5 +70,6 @@ func (cr *commandRegistry) register() {
 		cr.buildOpentelemetryStopCmd(),
 		cr.buildFetchLogsCmd(),
 		cr.buildGetLatestPProfCmd(),
+		cr.buildFetchCertsDir(),
 	})
 }


### PR DESCRIPTION
This change adds a fetch-certs command that will download the pgurl certs from a cluster locally. We need a separate command for certs as opposed to just using roachprod get as lib/pq will complain about world-readable files.

One benefactor of this command is testing out new roachtest operations locally. Many operations require certs and having to manually remember to make them non world readable each time is non obvious and cumbersome.

Release Note: none
Epic: none