### PR TITLE
release-24.3.12-rc: release-24.3: streamclient: add internal app name prefix

### DIFF
--- a/pkg/ccl/crosscluster/physical/testdata/simple
+++ b/pkg/ccl/crosscluster/physical/testdata/simple
@@ -32,9 +32,9 @@ postgres://root@?redacted
 
 # The session on the source should have an app name set.
 query-sql as=source-system
-SELECT application_name FROM [SHOW SESSIONS] WHERE application_name LIKE '%repstream%' LIMIT 1
+SELECT application_name FROM [SHOW ALL SESSIONS] WHERE application_name LIKE '%repstream%' LIMIT 1
 ----
-repstream job id=$_producerJobID
+$ internal repstream job id=$_producerJobID
 
 
 query-sql as=source-system

--- a/pkg/ccl/crosscluster/streamclient/BUILD.bazel
+++ b/pkg/ccl/crosscluster/streamclient/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/sql/catalog/descs",
         "//pkg/sql/isql",
         "//pkg/sql/pgwire/pgcode",
+        "//pkg/sql/sem/catconstants",
         "//pkg/util/ctxgroup",
         "//pkg/util/hlc",
         "//pkg/util/log",

--- a/pkg/ccl/crosscluster/streamclient/client.go
+++ b/pkg/ccl/crosscluster/streamclient/client.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
@@ -317,11 +318,13 @@ type options struct {
 }
 
 func (o *options) appName() string {
-	const appNameBase = "repstream"
+	// NOTE: use an internal app name prefix so that the sql.*.internal metrics
+	// are used instead of the user facing metrics. The logic responsible for
+	// picking the metric family lives in conn_executor.go:SetupConn.
 	if o.streamID != 0 {
-		return fmt.Sprintf("%s job id=%d", appNameBase, o.streamID)
+		return fmt.Sprintf("%s repstream job id=%d", catconstants.InternalAppNamePrefix, o.streamID)
 	} else {
-		return appNameBase
+		return fmt.Sprintf("%s repstream", catconstants.InternalAppNamePrefix)
 	}
 }
 

--- a/pkg/ccl/crosscluster/streamclient/client_test.go
+++ b/pkg/ccl/crosscluster/streamclient/client_test.go
@@ -340,3 +340,21 @@ func ExampleClient() {
 	// kv: "key_1"->value_1@1
 	// resolved 100
 }
+
+func TestStreamClientAppName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	expectAppName := func(t *testing.T, name string, options ...Option) {
+		o := processOptions(options)
+		cfg, err := setupPGXConfig(&url.URL{
+			Scheme: "postgresql",
+			Host:   "localhost:26257",
+		}, o)
+		require.NoError(t, err)
+		require.Equal(t, name, cfg.RuntimeParams["application_name"])
+	}
+
+	expectAppName(t, "$ internal repstream")
+	expectAppName(t, "$ internal repstream job id=1337", WithStreamID(1337))
+}


### PR DESCRIPTION
Backport 1/1 commits from #145114.

/cc @cockroachdb/release

---

Backport 1/1 commits from #145088.

/cc @cockroachdb/release

Release justification: low risk change that makes it easier to monitor application SLAs in LDR source clusters.

---

Previously, the replication queries executed by LDR and PCR were reported as user queries. Reporting user latency metrics for the replication streams is misleading because they are intended to have long execution times.

Now, the LDR/PCR queries set an internal app name so the .internal metrics are used instead.

Fixes: #144253
Release note: SQL queries run on the source cluster by LDR and PCR will account to internal metrics like sql.statements.active.internal instead of the metrics like sql.statements.active that are used to monitor application workload.

