### PR TITLE
changefeedccl: add changefeed.checkpoint.timestamp_count metric

### DIFF
--- a/docs/generated/metrics/metrics.html
+++ b/docs/generated/metrics/metrics.html
@@ -932,6 +932,7 @@
 <tr><td>APPLICATION</td><td>changefeed.bytes.messages_pushback_nanos</td><td>Total time spent throttled for bytes quota</td><td>Nanoseconds</td><td>COUNTER</td><td>NANOSECONDS</td><td>AVG</td><td>NON_NEGATIVE_DERIVATIVE</td></tr>
 <tr><td>APPLICATION</td><td>changefeed.checkpoint.create_nanos</td><td>Time it takes to create a changefeed checkpoint</td><td>Nanoseconds</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>changefeed.checkpoint.span_count</td><td>Number of spans in a changefeed checkpoint</td><td>Spans</td><td>HISTOGRAM</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
+<tr><td>APPLICATION</td><td>changefeed.checkpoint.timestamp_count</td><td>Number of unique timestamps in a changefeed checkpoint</td><td>Timestamps</td><td>HISTOGRAM</td><td>COUNT</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>changefeed.checkpoint.total_bytes</td><td>Total size of a changefeed checkpoint</td><td>Bytes</td><td>HISTOGRAM</td><td>BYTES</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>changefeed.checkpoint_hist_nanos</td><td>Time spent checkpointing changefeed progress</td><td>Changefeeds</td><td>HISTOGRAM</td><td>NANOSECONDS</td><td>AVG</td><td>NONE</td></tr>
 <tr><td>APPLICATION</td><td>changefeed.checkpoint_progress</td><td>The earliest timestamp of any changefeed&#39;s persisted checkpoint (values prior to this timestamp will never need to be re-emitted)</td><td>Unix Timestamp Nanoseconds</td><td>GAUGE</td><td>TIMESTAMP_NS</td><td>AVG</td><td>NONE</td></tr>

--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint.go
@@ -62,6 +62,7 @@ func Make(
 	if metrics != nil {
 		metrics.CreateNanos.RecordValue(int64(timeutil.Since(start)))
 		metrics.TotalBytes.RecordValue(int64(cp.Size()))
+		metrics.TimestampCount.RecordValue(int64(cp.TimestampCount()))
 		metrics.SpanCount.RecordValue(int64(cp.SpanCount()))
 	}
 

--- a/pkg/ccl/changefeedccl/checkpoint/checkpoint_test.go
+++ b/pkg/ccl/changefeedccl/checkpoint/checkpoint_test.go
@@ -165,10 +165,12 @@ func TestCheckpointMake(t *testing.T) {
 			if actualCheckpoint != nil {
 				require.Greater(t, aggMetrics.CreateNanos.CumulativeSnapshot().Mean(), float64(0))
 				require.Equal(t, aggMetrics.TotalBytes.CumulativeSnapshot().Mean(), float64(actualCheckpoint.Size()))
+				require.Equal(t, aggMetrics.TimestampCount.CumulativeSnapshot().Mean(), float64(actualCheckpoint.TimestampCount()))
 				require.Equal(t, aggMetrics.SpanCount.CumulativeSnapshot().Mean(), float64(actualCheckpoint.SpanCount()))
 			} else {
 				require.True(t, math.IsNaN(aggMetrics.CreateNanos.CumulativeSnapshot().Mean()))
 				require.True(t, math.IsNaN(aggMetrics.TotalBytes.CumulativeSnapshot().Mean()))
+				require.True(t, math.IsNaN(aggMetrics.TimestampCount.CumulativeSnapshot().Mean()))
 				require.True(t, math.IsNaN(aggMetrics.SpanCount.CumulativeSnapshot().Mean()))
 			}
 		})

--- a/pkg/ccl/changefeedccl/checkpoint/metrics.go
+++ b/pkg/ccl/changefeedccl/checkpoint/metrics.go
@@ -26,6 +26,13 @@ var (
 		Measurement: "Bytes",
 	}
 
+	metaTimestampCount = metric.Metadata{
+		Name:        "changefeed.checkpoint.timestamp_count",
+		Help:        "Number of unique timestamps in a changefeed checkpoint",
+		Unit:        metric.Unit_COUNT,
+		Measurement: "Timestamps",
+	}
+
 	metaSpanCount = metric.Metadata{
 		Name:        "changefeed.checkpoint.span_count",
 		Help:        "Number of spans in a changefeed checkpoint",
@@ -35,9 +42,10 @@ var (
 )
 
 type AggMetrics struct {
-	CreateNanos *aggmetric.AggHistogram
-	TotalBytes  *aggmetric.AggHistogram
-	SpanCount   *aggmetric.AggHistogram
+	CreateNanos    *aggmetric.AggHistogram
+	TotalBytes     *aggmetric.AggHistogram
+	TimestampCount *aggmetric.AggHistogram
+	SpanCount      *aggmetric.AggHistogram
 }
 
 func NewAggMetrics(b aggmetric.Builder) *AggMetrics {
@@ -54,6 +62,12 @@ func NewAggMetrics(b aggmetric.Builder) *AggMetrics {
 			Duration:     base.DefaultHistogramWindowInterval(),
 			BucketConfig: metric.MemoryUsage64MBBuckets,
 		}),
+		TimestampCount: b.Histogram(metric.HistogramOptions{
+			Mode:         metric.HistogramModePrometheus,
+			Metadata:     metaTimestampCount,
+			Duration:     base.DefaultHistogramWindowInterval(),
+			BucketConfig: metric.DataCount16MBuckets,
+		}),
 		SpanCount: b.Histogram(metric.HistogramOptions{
 			Mode:         metric.HistogramModePrometheus,
 			Metadata:     metaSpanCount,
@@ -65,9 +79,10 @@ func NewAggMetrics(b aggmetric.Builder) *AggMetrics {
 
 func (a *AggMetrics) AddChild(labelVals ...string) *Metrics {
 	return &Metrics{
-		CreateNanos: a.CreateNanos.AddChild(labelVals...),
-		TotalBytes:  a.TotalBytes.AddChild(labelVals...),
-		SpanCount:   a.SpanCount.AddChild(labelVals...),
+		CreateNanos:    a.CreateNanos.AddChild(labelVals...),
+		TotalBytes:     a.TotalBytes.AddChild(labelVals...),
+		TimestampCount: a.TimestampCount.AddChild(labelVals...),
+		SpanCount:      a.SpanCount.AddChild(labelVals...),
 	}
 }
 
@@ -77,9 +92,10 @@ func (*AggMetrics) MetricStruct() {}
 var _ metric.Struct = (*AggMetrics)(nil)
 
 type Metrics struct {
-	CreateNanos *aggmetric.Histogram
-	TotalBytes  *aggmetric.Histogram
-	SpanCount   *aggmetric.Histogram
+	CreateNanos    *aggmetric.Histogram
+	TotalBytes     *aggmetric.Histogram
+	TimestampCount *aggmetric.Histogram
+	SpanCount      *aggmetric.Histogram
 }
 
 // MetricStruct implements the metric.Struct interface.

--- a/pkg/jobs/jobspb/BUILD.bazel
+++ b/pkg/jobs/jobspb/BUILD.bazel
@@ -79,9 +79,15 @@ go_proto_library(
 
 go_test(
     name = "jobspb_test",
-    srcs = ["wrap_test.go"],
+    srcs = [
+        "jobs_test.go",
+        "wrap_test.go",
+    ],
     deps = [
         ":jobspb",
+        "//pkg/roachpb",
+        "//pkg/util/hlc",
         "@com_github_stretchr_testify//assert",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/jobs/jobspb/jobs.go
+++ b/pkg/jobs/jobspb/jobs.go
@@ -107,6 +107,14 @@ func (tsm *TimestampSpansMap) MinTimestamp() hlc.Timestamp {
 	return iterutil.MinFunc(iterutil.Keys(tsm.All()), hlc.Timestamp.Compare)
 }
 
+// TimestampCount returns the number of unique timestamps in the map.
+func (tsm *TimestampSpansMap) TimestampCount() (count int) {
+	for range tsm.All() {
+		count += 1
+	}
+	return count
+}
+
 // SpanCount returns the number of spans in the map.
 func (tsm *TimestampSpansMap) SpanCount() (count int) {
 	for _, sp := range tsm.All() {

--- a/pkg/jobs/jobspb/jobs_test.go
+++ b/pkg/jobs/jobspb/jobs_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package jobspb_test
+
+import (
+	"maps"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/stretchr/testify/require"
+)
+
+func TestTimestampSpansMap(t *testing.T) {
+	type expected struct {
+		minTimestamp   hlc.Timestamp
+		timestampCount int
+		spanCount      int
+	}
+
+	for name, tc := range map[string]struct {
+		m        map[hlc.Timestamp]roachpb.Spans
+		expected expected
+	}{
+		"empty map": {
+			m: map[hlc.Timestamp]roachpb.Spans{},
+			expected: expected{
+				minTimestamp:   hlc.Timestamp{},
+				timestampCount: 0,
+				spanCount:      0,
+			},
+		},
+		"map with single timestamp": {
+			m: map[hlc.Timestamp]roachpb.Spans{
+				{WallTime: 1}: {
+					{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+					{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				},
+			},
+			expected: expected{
+				minTimestamp:   hlc.Timestamp{WallTime: 1},
+				timestampCount: 1,
+				spanCount:      2,
+			},
+		},
+		"map with multiple timestamps": {
+			m: map[hlc.Timestamp]roachpb.Spans{
+				{WallTime: 1}: {
+					{Key: roachpb.Key("a"), EndKey: roachpb.Key("b")},
+					{Key: roachpb.Key("c"), EndKey: roachpb.Key("d")},
+				},
+				{WallTime: 2}: {
+					{Key: roachpb.Key("b"), EndKey: roachpb.Key("c")},
+				},
+			},
+			expected: expected{
+				minTimestamp:   hlc.Timestamp{WallTime: 1},
+				timestampCount: 2,
+				spanCount:      3,
+			},
+		},
+	} {
+		t.Run(name, func(t *testing.T) {
+			m := jobspb.NewTimestampSpansMap(tc.m)
+			require.Equal(t, tc.m, maps.Collect(m.All()))
+			require.Equal(t, tc.expected.minTimestamp, m.MinTimestamp())
+			require.Equal(t, tc.expected.timestampCount, m.TimestampCount())
+			require.Equal(t, tc.expected.spanCount, m.SpanCount())
+			require.True(t, m.Equal(jobspb.NewTimestampSpansMap(tc.m)))
+			require.Equal(t, len(tc.m) == 0, m.IsEmpty())
+		})
+	}
+}


### PR DESCRIPTION
Informs #137690

Release note (ops change): A new metric that measures the number
of unique timestamps in a changefeed span-level checkpoint named
`changefeed.checkpoint.timestamp_count` has been added. It may
be useful to monitor this metric to determine if quantization
settings should be tweaked.