### PR TITLE
build: allow customizing Pebble ycsb benchmark runs

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_common.sh
@@ -38,11 +38,14 @@ BAZEL_BIN=$(bazel info bazel-bin -c opt)
 cp $BAZEL_BIN/pkg/cmd/roachtest/roachtest_/roachtest bin
 chmod a+w bin/roachtest
 
-# Pull in the latest version of Pebble from upstream. The benchmarks run
-# against the tip of the 'master' branch. We do this by `go get`ting the
-# latest version of the module, and then running `mirror` to update `DEPS.bzl`
+# Pull in the version of Pebble from upstream. If none is specified, the
+# benchmarks run against the tip of the 'master' branch. We do this by `go
+# get`ting the SHA of the module, and then running `mirror` to update `DEPS.bzl`
 # accordingly.
-bazel run @go_sdk//:bin/go get github.com/cockroachdb/pebble@master
+pebble_go_get_version="${PEBBLE_SHA:-master}"
+echo "Benchmarking against: ${pebble_go_get_version}"
+
+bazel run @go_sdk//:bin/go get "github.com/cockroachdb/pebble@${pebble_go_get_version}"
 NEW_DEPS_BZL_CONTENT=$(bazel run //pkg/cmd/mirror/go:mirror)
 echo "$NEW_DEPS_BZL_CONTENT" > DEPS.bzl
 bazel build @com_github_cockroachdb_pebble//cmd/pebble -c opt

--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh
@@ -19,6 +19,11 @@ _dir="$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )"
 # prevent roachtest from complaining (and failing) when it can't find
 # them. The pebble roachtests don't actually use either cockroach or
 # workload.
+#
+# NB: The ROACHTEST_NAME and ROACHTEST_SUITE variables can be explicitly set to
+# run variants, like the YCSB roachtests that run for 10m per run instead of
+# 90m: pebble/ycsb/size=64/duration=10 and pebble/ycsb/size=1024/duration=10
+# tests are in the "pebble" suite.
 timeout -s INT $((1000*60)) bin/roachtest run \
   --slack-token "${SLACK_TOKEN-}" \
   --cluster-id "${TC_BUILD_ID-$(date +"%Y%m%d%H%M%S")}" \
@@ -30,21 +35,30 @@ timeout -s INT $((1000*60)) bin/roachtest run \
   --parallelism 3 \
   --teamcity \
   --cpu-quota=384 \
-  --suite pebble_nightly_ycsb \
-  pebble
+  --suite "${ROACHTEST_SUITE:-pebble_nightly_ycsb}" \
+  "${ROACHTEST_NAME:-pebble}"
 
 exit_status=$?
 
-build_mkbench
-prepare_datadir
+# If the PEBBLE_SHA is not set, we're running against the tip of master as a
+# part of nightly benchmarks and we should report the benchmark results into the
+# s3 bucket. If PEBBLE_SHA is set, we don't pollute the nightly benchmark
+# results with our non-master runs.
 
-# Parse the YCSB data. We first pull down the existing data.js file from S3,
-# which will be merged with the data from this run. We then push the merged
-# file back to S3.
-aws s3 cp s3://pebble-benchmarks/data.js data.js
-./mkbench ycsb
-aws s3 cp data.js s3://pebble-benchmarks/data.js
+if [ -z "$PEBBLE_SHA" ]; then
+  build_mkbench
 
-sync_data_dir
+  prepare_datadir
+
+  # Parse the YCSB data. We first pull down the existing data.js file from S3,
+  # which will be merged with the data from this run. We then push the merged
+  # file back to S3.
+  aws s3 cp s3://pebble-benchmarks/data.js data.js
+  ./mkbench ycsb
+  aws s3 cp data.js s3://pebble-benchmarks/data.js
+
+  sync_data_dir
+fi
+
 
 exit "$exit_status"


### PR DESCRIPTION
This commit adapts the scripts used for running nightly Pebble ycsb benchmarks to support customizing the SHA tested against, and the variants of the roachtests that we run.

I intend to use this to trigger new Pebble ycsb teamcity runs against non-master SHAs when benchmarking unmerged changes.

Epic: none
Release note: none