### PR TITLE
release-25.2: cspann: improve TestIndexConcurrency and fix issues it found

### DIFF
--- a/pkg/sql/vecindex/cspann/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/BUILD.bazel
@@ -76,6 +76,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/num32",
         "//pkg/util/stop",
+        "//pkg/util/syncutil",
         "//pkg/util/vector",
         "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_datadriven//:datadriven",

--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -289,9 +289,12 @@ func (suite *StoreTestSuite) TestRemoveFromPartition() {
 			err = txn.AddToPartition(suite.ctx, treeKey, cspann.RootKey, cspann.LeafLevel,
 				vec1, primaryKey1, valueBytes1)
 			suite.NoError(err)
+		})
+		CheckPartitionCount(suite.ctx, suite.T(), store, treeKey, cspann.RootKey, 1)
 
-			// Remove that vector.
-			err = txn.RemoveFromPartition(suite.ctx, treeKey, cspann.RootKey,
+		// Remove the vector that was added to the root.
+		RunTransaction(suite.ctx, suite.T(), store, func(txn cspann.Txn) {
+			err := txn.RemoveFromPartition(suite.ctx, treeKey, cspann.RootKey,
 				cspann.LeafLevel, primaryKey1)
 			suite.NoError(err)
 		})

--- a/pkg/sql/vecindex/cspann/fixup_split.go
+++ b/pkg/sql/vecindex/cspann/fixup_split.go
@@ -209,7 +209,7 @@ func (fw *fixupWorker) splitPartition(
 		if err != nil || partition == nil {
 			return err
 		}
-	} else if metadata.StateDetails.State == DrainingForSplitState {
+	} else if metadata.StateDetails.State != MissingState {
 		leftMetadata, err = fw.getPartitionMetadata(ctx, leftPartitionKey)
 		if err != nil {
 			return err

--- a/pkg/sql/vecindex/cspann/fixup_worker.go
+++ b/pkg/sql/vecindex/cspann/fixup_worker.go
@@ -176,23 +176,6 @@ func (fw *fixupWorker) deleteVector(
 			return nil
 		}
 
-		// If removing from a root partition, check that its level is LeafLevel. It
-		// might not be if it was recently split.
-		if partitionKey == RootKey {
-			metadata, err := txn.GetPartitionMetadata(
-				ctx, fw.treeKey, partitionKey, false /* forUpdate */)
-			if metadata.Level != LeafLevel {
-				// Root partition's level has been updated, so just abort.
-				return nil
-			} else if err != nil {
-				if errors.Is(err, ErrPartitionNotFound) {
-					log.VEventf(ctx, 2, "partition %d no longer exists, do not delete vector", partitionKey)
-					return nil
-				}
-				return errors.Wrapf(err, "getting root partition's level")
-			}
-		}
-
 		err = fw.index.removeFromPartition(ctx, txn, fw.treeKey, partitionKey, LeafLevel, childKey)
 		if errors.Is(err, ErrPartitionNotFound) {
 			log.VEventf(ctx, 2, "partition %d no longer exists, do not delete vector", partitionKey)

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -727,7 +727,8 @@ func (vi *Index) fallbackOnTargets(
 	vec vector.T,
 	state PartitionStateDetails,
 ) error {
-	if state.State == DrainingForSplitState {
+	switch state.State {
+	case DrainingForSplitState:
 		// Synthesize one search result for each split target partition to pass
 		// to getFullVectors.
 		idxCtx.tempResults[0] = SearchResult{
@@ -754,6 +755,11 @@ func (vi *Index) fallbackOnTargets(
 			searchSet.Add(&tempResults[i])
 		}
 
+		return nil
+
+	case DeletingForSplitState:
+		// The partition is ready for deletion; its target partitions have already
+		// been built and may themselves been split or deleted, so don't use them.
 		return nil
 	}
 

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -764,7 +764,8 @@ func (s *testState) loadIndexFromFormat(
 	line = line[idx:]
 
 	// Parse centroid and state.
-	details := cspann.MakeReadyDetails()
+	var details cspann.PartitionStateDetails
+	details.MakeReady()
 	idx = strings.Index(line, "[")
 	if idx != -1 {
 		require.True(s.T, strings.HasSuffix(line, "]"))

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -13,12 +13,10 @@ import (
 	"math"
 	"math/rand"
 	"regexp"
-	"runtime"
 	"sort"
 	"strconv"
 	"strings"
 	"sync"
-	"sync/atomic"
 	"testing"
 	"time"
 
@@ -33,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/errors"
@@ -418,7 +417,7 @@ func (s *testState) Delete(d *datadriven.TestData) string {
 			// the primary index, but it cannot be found in the secondary index.
 			if !notFound {
 				idxCtx.Init(txn)
-				err := s.Index.Delete(s.Ctx, &idxCtx, s.TreeKey, vec, key)
+				_, err := s.Index.Delete(s.Ctx, &idxCtx, s.TreeKey, vec, key)
 				require.NoError(s.T, err)
 			}
 			s.MemStore.DeleteVector(key)
@@ -946,7 +945,8 @@ func TestIndexConcurrency(t *testing.T) {
 	defer stopper.Stop(ctx)
 
 	// Load features.
-	features := testutils.LoadFeatures(t, 2000)
+	const featureCount = 128
+	features := testutils.LoadFeatures(t, featureCount)
 
 	// Trim feature dimensions from 512 to 4, in order to make the test run
 	// faster and hit more interesting concurrency combinations.
@@ -962,29 +962,65 @@ func TestIndexConcurrency(t *testing.T) {
 	for i := range 10 {
 		log.Infof(ctx, "iteration %d", i)
 
-		// Set small partition size and beam size to trigger frequent splits and
-		// merges.
-		options := cspann.IndexOptions{
-			MinPartitionSize: 2,
-			MaxPartitionSize: 8,
-			BaseBeamSize:     2,
-			QualitySamples:   4,
-		}
-		seed := int64(i)
+		// Construct store. Multiple index instances running on different goroutines
+		// will use this store.
+		const seed = 42
 		quantizer := quantize.NewRaBitQuantizer(vectors.Dims, seed)
 		store := memstore.New(quantizer, seed)
-		index, err := cspann.NewIndex(ctx, store, quantizer, seed, &options, stopper)
-		require.NoError(t, err)
 
-		expected := buildIndex(ctx, t, store, index, vectors, primaryKeys)
+		// Create 8 instances of the index, all using the same shared Store.
+		const instances = 8
+		var expectedKeys syncutil.Set[string]
 
-		vectorCount := validateIndex(ctx, t, store)
-		require.Equal(t, expected, vectorCount)
+		options := cspann.IndexOptions{
+			MinPartitionSize: 2,
+			MaxPartitionSize: 4,
+			BaseBeamSize:     2,
+			QualitySamples:   4,
+			// Eliminate the delay for one instance assisting another, in order
+			// to maximize the possibility of race conditions.
+			StalledOpTimeout: func() time.Duration { return 0 },
+		}
 
-		index.Close()
+		var wait sync.WaitGroup
+		vecsPerInstance := vectors.Count / instances
+		for i := 0; i < vectors.Count; i += vecsPerInstance {
+			wait.Add(1)
+			go func(start, end int) {
+				defer wait.Done()
+
+				// Set small partition size and beam size to trigger frequent splits and
+				// merges.
+				index, err := cspann.NewIndex(ctx, store, quantizer, seed, &options, stopper)
+				require.NoError(t, err)
+
+				vectorSubset := vectors.Slice(start, end-start)
+				keySubset := primaryKeys[start:end]
+				deletedKeySubset := buildIndex(ctx, t, store, index, vectorSubset, keySubset)
+
+				// Add any keys that were deleted into the shared map.
+				for i := range keySubset {
+					key := string(keySubset[i])
+					if !deletedKeySubset.Contains(key) {
+						expectedKeys.Add(key)
+					}
+				}
+
+				// Process any remaining fixups and close the index.
+				index.ProcessFixups()
+				index.Close()
+			}(i, min(i+vecsPerInstance, vectors.Count))
+		}
+
+		wait.Wait()
+
+		validateIndex(ctx, t, store, &expectedKeys)
 	}
 }
 
+// buildIndex inserts the vectors in batches, and tries to delete one vector in
+// each batch. It returns the subset of keys it successfully deleted (as
+// strings).
 func buildIndex(
 	ctx context.Context,
 	t *testing.T,
@@ -992,8 +1028,8 @@ func buildIndex(
 	index *cspann.Index,
 	vectors vector.Set,
 	primaryKeys []cspann.KeyBytes,
-) int {
-	var insertCount, deleteCount atomic.Uint64
+) (deletedKeys *syncutil.Set[string]) {
+	deletedKeys = new(syncutil.Set[string])
 
 	// Insert block of vectors within the scope of a transaction.
 	insertVectors := func(idxCtx *cspann.Context, start, end int) {
@@ -1004,23 +1040,25 @@ func buildIndex(
 				require.NoError(t,
 					index.Insert(ctx, idxCtx, nil /* treeKey */, vectors.At(i), primaryKeys[i]))
 			})
-			insertCount.Add(1)
 		}
 	}
 
 	deleteVector := func(idxCtx *cspann.Context, vec vector.T, key cspann.KeyBytes) {
 		commontest.RunTransaction(ctx, t, store, func(txn cspann.Txn) {
 			idxCtx.Init(txn)
-			require.NoError(t, index.Delete(ctx, idxCtx, nil /* treeKey */, vec, key))
-			store.DeleteVector(key)
+			deleted, err := index.Delete(ctx, idxCtx, nil /* treeKey */, vec, key)
+			require.NoError(t, err)
+			if deleted {
+				store.DeleteVector(key)
+				deletedKeys.Add(string(key))
+			}
 		})
-		deleteCount.Add(1)
 	}
 
 	// Insert vectors into the store on multiple goroutines. Delete the first
 	// vector in each block.
 	var wait sync.WaitGroup
-	procs := runtime.GOMAXPROCS(-1)
+	const procs = 4
 	countPerProc := (vectors.Count + procs) / procs
 	blockSize := index.Options().MinPartitionSize
 	for i := 0; i < vectors.Count; i += countPerProc {
@@ -1039,44 +1077,18 @@ func buildIndex(
 			}
 		}(i, end)
 	}
-
-	logProgress := func() {
-		log.Infof(ctx, "%d vectors inserted, %d vectors deleted",
-			insertCount.Load(), deleteCount.Load())
-	}
-
-	info := log.Every(time.Second)
-	for int(insertCount.Load()) < vectors.Count {
-		time.Sleep(10 * time.Millisecond)
-
-		if info.ShouldLog() {
-			logProgress()
-		}
-
-		// Fail on foreground goroutine if any background goroutines failed.
-		if t.Failed() {
-			t.FailNow()
-		}
-	}
-
 	wait.Wait()
 
-	// Process any remaining fixups.
-	index.ProcessFixups()
-
-	logProgress()
-
-	return int(insertCount.Load() - deleteCount.Load())
+	return deletedKeys
 }
 
-func validateIndex(ctx context.Context, t *testing.T, store *memstore.Store) int {
+// validateIndex tests that the store contains exactly the set of expected keys.
+// Note that dangling vectors are treated as if they're missing from the index,
+// for validation purposes.
+func validateIndex(
+	ctx context.Context, t *testing.T, store *memstore.Store, expectedKeys *syncutil.Set[string],
+) {
 	treeKey := memstore.ToTreeKey(memstore.TreeID(0))
-
-	// Duplicate vectors are possible in the index, so the total count of vectors
-	// is not deterministc. Instead, return the number of unique vectors, which
-	// should be stable.
-	var deDup cspann.ChildKeyDeDup
-	deDup.Init(1000)
 
 	partitionKeys := []cspann.PartitionKey{cspann.RootKey}
 	for {
@@ -1084,11 +1096,26 @@ func validateIndex(ctx context.Context, t *testing.T, store *memstore.Store) int
 		var childKeys []cspann.ChildKey
 		for _, key := range partitionKeys {
 			partition, err := store.TryGetPartition(ctx, treeKey, key)
-			if !errors.Is(err, cspann.ErrPartitionNotFound) {
+			if errors.Is(err, cspann.ErrPartitionNotFound) {
 				// Ignore ErrPartitionNotFound, as splits can cause dangling
 				// partition keys.
-				require.NoError(t, err)
-				childKeys = append(childKeys, partition.ChildKeys()...)
+				continue
+			}
+
+			require.NoError(t, err)
+			childKeys = append(childKeys, partition.ChildKeys()...)
+
+			// Append target partitions of the root, if they exist. These may not
+			// yet have been added to the root partition, and so may not be
+			// accessible in any other way.
+			if key == cspann.RootKey {
+				state := partition.Metadata().StateDetails
+				if state.Target1 != cspann.InvalidKey {
+					childKeys = append(childKeys, cspann.ChildKey{PartitionKey: state.Target1})
+				}
+				if state.Target2 != cspann.InvalidKey {
+					childKeys = append(childKeys, cspann.ChildKey{PartitionKey: state.Target2})
+				}
 			}
 		}
 
@@ -1097,8 +1124,7 @@ func validateIndex(ctx context.Context, t *testing.T, store *memstore.Store) int
 		}
 
 		if childKeys[0].KeyBytes != nil {
-			// This is the leaf level, so verify that full vectors exist. Count
-			// the number of unique vectors.
+			// This partition contains leaf-level vectors.
 			commontest.RunTransaction(ctx, t, store, func(txn cspann.Txn) {
 				refs := make([]cspann.VectorWithKey, len(childKeys))
 				for i := range childKeys {
@@ -1108,7 +1134,8 @@ func validateIndex(ctx context.Context, t *testing.T, store *memstore.Store) int
 				require.NoError(t, err)
 				for i := range refs {
 					if refs[i].Vector != nil {
-						deDup.TryAdd(refs[i].Key)
+						// Vector is in the tree, so remove it from the expected map.
+						expectedKeys.Remove(string(refs[i].Key.KeyBytes))
 					}
 				}
 			})
@@ -1124,5 +1151,12 @@ func validateIndex(ctx context.Context, t *testing.T, store *memstore.Store) int
 		}
 	}
 
-	return deDup.Count()
+	// Validate that there are no remaining keys that were expected to be present
+	// in the index.
+	var missingKeys []string
+	expectedKeys.Range(func(value string) bool {
+		missingKeys = append(missingKeys, value)
+		return true
+	})
+	require.Empty(t, missingKeys)
 }

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -981,6 +981,9 @@ func TestIndexConcurrency(t *testing.T) {
 			// Eliminate the delay for one instance assisting another, in order
 			// to maximize the possibility of race conditions.
 			StalledOpTimeout: func() time.Duration { return 0 },
+			// Set MaxInsertAttempts really high so that test is very unlikely
+			// to fail because it can't find a partition that allows inserts.
+			MaxInsertAttempts: 100,
 		}
 
 		var wait sync.WaitGroup

--- a/pkg/sql/vecindex/cspann/memstore/memstore.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.go
@@ -815,11 +815,7 @@ func (s *Store) makeEmptyRootMetadataLocked() cspann.PartitionMetadata {
 	if s.mu.emptyVec == nil {
 		s.mu.emptyVec = make(vector.T, s.dims)
 	}
-	return cspann.PartitionMetadata{
-		Level:        cspann.LeafLevel,
-		Centroid:     s.mu.emptyVec,
-		StateDetails: cspann.MakeReadyDetails(),
-	}
+	return cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, s.mu.emptyVec)
 }
 
 // tryCreateEmptyPartition creates a empty partition with the given metadata and

--- a/pkg/sql/vecindex/cspann/memstore/memstore.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.go
@@ -134,12 +134,6 @@ type Store struct {
 	rootQuantizer quantize.Quantizer
 	quantizer     quantize.Quantizer
 
-	// structureLock must be acquired by transactions that intend to modify the
-	// structure of a tree, e.g. splitting or merging a partition. This ensures
-	// that only one split or merge can be running at any given time, so that
-	// deadlocks are not possible.
-	structureLock memLock
-
 	mu struct {
 		syncutil.Mutex
 
@@ -185,7 +179,6 @@ func New(quantizer quantize.Quantizer, seed int64) *Store {
 	st.mu.vectors = make(map[string]vector.T)
 	st.mu.clock = 2
 	st.mu.nextKey = cspann.RootKey + 1
-	st.mu.stats.NumPartitions = 1
 	st.mu.pending.Init()
 	return st
 }
@@ -326,24 +319,15 @@ func (s *Store) TryCreateEmptyPartition(
 	partitionKey cspann.PartitionKey,
 	metadata cspann.PartitionMetadata,
 ) error {
-	memPart := s.lockPartition(treeKey, partitionKey, uniqueOwner, false /* isExclusive */)
-	if memPart != nil {
-		// Partition already exists, so return a ConditionFailedError.
-		defer memPart.lock.ReleaseShared()
-		return cspann.NewConditionFailedError(*memPart.lock.partition.Metadata())
+	memPart, ok := s.tryCreateEmptyPartition(treeKey, partitionKey, metadata)
+	if ok {
+		return nil
 	}
 
-	s.mu.Lock()
-	defer s.mu.Unlock()
-
-	// Create the new empty partition.
-	partition := cspann.CreateEmptyPartition(s.quantizer, metadata)
-	_ = s.insertPartitionLocked(treeKey, partitionKey, partition)
-
-	// Update stats.
-	s.mu.stats.NumPartitions++
-
-	return nil
+	// Partition already exists, so return a ConditionFailedError.
+	memPart.lock.AcquireShared(uniqueOwner)
+	defer memPart.lock.ReleaseShared()
+	return cspann.NewConditionFailedError(*memPart.lock.partition.Metadata())
 }
 
 // TryDeletePartition implements the Store interface.
@@ -765,15 +749,6 @@ func (s *Store) tickLocked() uint64 {
 	return val
 }
 
-// updatedStructureLocked marks the transaction as having updated the K-means
-// tree. It also pushes the transactions current time forward so that it can
-// always observe its changes.
-// NOTE: Callers must have locked the s.mu mutex.
-func (s *Store) updatedStructureLocked(tx *memTxn) {
-	tx.updated = true
-	tx.current = s.tickLocked()
-}
-
 // getPartition returns a partition by its key, or ErrPartitionNotFound if no
 // such partition exists.
 func (s *Store) getPartition(
@@ -845,6 +820,37 @@ func (s *Store) makeEmptyRootMetadataLocked() cspann.PartitionMetadata {
 		Centroid:     s.mu.emptyVec,
 		StateDetails: cspann.MakeReadyDetails(),
 	}
+}
+
+// tryCreateEmptyPartition creates a empty partition with the given metadata and
+// inserts it into the tree if there is no existing partition with the same key.
+// If there is an existing partition, it returns that and ok=false; otherwise,
+// it returns the newly created partition and ok=true.
+func (s *Store) tryCreateEmptyPartition(
+	treeKey cspann.TreeKey, partitionKey cspann.PartitionKey, metadata cspann.PartitionMetadata,
+) (memPart *memPartition, ok bool) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check for race condition where another thread already created the
+	// partition.
+	memPart, ok = s.getPartitionLocked(treeKey, partitionKey)
+	if ok {
+		return memPart, false
+	}
+
+	// Create the new empty partition.
+	quantizer := s.quantizer
+	if partitionKey == cspann.RootKey {
+		quantizer = s.rootQuantizer
+	}
+	partition := cspann.CreateEmptyPartition(quantizer, metadata)
+	memPart = s.insertPartitionLocked(treeKey, partitionKey, partition)
+
+	// Update stats.
+	s.mu.stats.NumPartitions++
+
+	return memPart, true
 }
 
 // processPendingActionsLocked iterates over pending actions to:

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -110,6 +110,10 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 	store := New(quantizer, 42)
 	treeKey := ToTreeKey(TreeID(0))
 
+	// Construct an empty root partition.
+	metadata := store.makeEmptyRootMetadata()
+	require.NoError(t, store.TryCreateEmptyPartition(ctx, treeKey, cspann.RootKey, metadata))
+
 	var wait sync.WaitGroup
 	wait.Add(1)
 	commontest.RunTransaction(ctx, t, store, func(txn cspann.Txn) {
@@ -161,6 +165,10 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 	quantizer := quantize.NewUnQuantizer(2)
 	store := New(quantizer, 42)
 	treeKey := ToTreeKey(TreeID(0))
+
+	// Construct an empty root partition.
+	metadata := store.makeEmptyRootMetadata()
+	require.NoError(t, store.TryCreateEmptyPartition(ctx, treeKey, cspann.RootKey, metadata))
 
 	commontest.RunTransaction(ctx, t, store, func(txn cspann.Txn) {
 		childKey10 := cspann.ChildKey{PartitionKey: 10}

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -215,11 +215,7 @@ func TestInMemoryStoreUpdateStats(t *testing.T) {
 		require.NoError(t, err)
 
 		partitionKey := store.MakePartitionKey()
-		nonRootMetadata := cspann.PartitionMetadata{
-			Level:        3,
-			Centroid:     vector.T{1, 2},
-			StateDetails: cspann.MakeReadyDetails(),
-		}
+		nonRootMetadata := cspann.MakeReadyPartitionMetadata(3, vector.T{1, 2})
 		err = store.TryCreateEmptyPartition(ctx, treeKey, partitionKey, nonRootMetadata)
 		require.NoError(t, err)
 
@@ -250,7 +246,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 
 	memPart := &memPartition{}
 	memPart.lock.partition = cspann.NewPartition(
-		cspann.PartitionMetadata{Level: 1, Centroid: centroid, StateDetails: cspann.MakeReadyDetails()},
+		cspann.MakeReadyPartitionMetadata(1, centroid),
 		unquantizer,
 		&quantize.UnQuantizedVectorSet{
 			Centroid:          centroid,
@@ -268,7 +264,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 
 	memPart = &memPartition{}
 	memPart.lock.partition = cspann.NewPartition(
-		cspann.PartitionMetadata{Level: 2, Centroid: centroid, StateDetails: cspann.MakeReadyDetails()},
+		cspann.MakeReadyPartitionMetadata(2, centroid),
 		raBitQuantizer,
 		&quantize.UnQuantizedVectorSet{
 			Centroid:          centroid,

--- a/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
@@ -198,7 +198,7 @@ func (tx *memTxn) SearchPartitions(
 			if toSearch[i].Key == cspann.RootKey {
 				// Root partition has not yet been created, so it must be empty.
 				toSearch[i].Level = cspann.LeafLevel
-				toSearch[i].StateDetails = cspann.MakeReadyDetails()
+				toSearch[i].StateDetails.MakeReady()
 				toSearch[i].Count = 0
 			} else {
 				// Partition does not exist, so return InvalidLevel, MissingState

--- a/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_txn.go
@@ -84,7 +84,7 @@ func (tx *memTxn) GetPartitionMetadata(
 	if forUpdate && !metadata.StateDetails.State.AllowAddOrRemove() {
 		err = cspann.NewConditionFailedError(*metadata)
 		return cspann.PartitionMetadata{}, errors.Wrapf(err,
-			"getting partition metadata %d (state=%s)",
+			"getting metadata for partition %d (state=%s)",
 			partitionKey, metadata.StateDetails.State.String())
 	}
 
@@ -125,8 +125,8 @@ func (tx *memTxn) AddToPartition(
 	// Add the vector to the partition.
 	if level != partition.Level() {
 		return errors.Wrapf(cspann.ErrRestartOperation,
-			"adding to partition %d (expected: %d, actual: %d)",
-			partitionKey, level, partition.Level())
+			"partition %d level %d does not match expected level %d",
+			partitionKey, partition.Level(), level)
 	}
 
 	if partition.Add(&tx.workspace, vec, childKey, valueBytes, true /* overwrite */) {

--- a/pkg/sql/vecindex/cspann/partition_metadata.go
+++ b/pkg/sql/vecindex/cspann/partition_metadata.go
@@ -246,6 +246,11 @@ func (psd *PartitionStateDetails) MaybeMergeStalled(stalledOpTimeout time.Durati
 //	Splitting:2,3
 //	Updating:4
 func (psd *PartitionStateDetails) String() string {
+	if psd.State == ReadyState {
+		// Short-circuit the common case.
+		return "Ready"
+	}
+
 	var buf bytes.Buffer
 	buf.WriteString(psd.State.String())
 	if psd.Target1 != InvalidKey {

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -54,12 +54,7 @@ func TestPartition(t *testing.T) {
 		quantizedSet := quantizer.Quantize(&workspace, vectors)
 		childKeys := []ChildKey{childKey10, childKey20, childKey30}
 		valueBytes := []ValueBytes{valueBytes10, valueBytes20, valueBytes30}
-		metadata := PartitionMetadata{
-			Level:        1,
-			Centroid:     quantizedSet.GetCentroid(),
-			StateDetails: MakeReadyDetails(),
-		}
-		metadata.StateDetails.State = ReadyState
+		metadata := MakeReadyPartitionMetadata(1, quantizedSet.GetCentroid())
 		return NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 	}
 

--- a/pkg/sql/vecindex/cspann/store.go
+++ b/pkg/sql/vecindex/cspann/store.go
@@ -234,16 +234,15 @@ type Txn interface {
 	) error
 
 	// GetFullVectors fetches the original full-size vectors that are referenced
-	// by the given child keys and stores them in "refs". If a vector has been
-	// deleted, then its corresponding reference will be set to nil. If a
-	// partition cannot be found, GetFullVectors returns ErrPartitionNotFound.
+	// by the given child keys and stores them in "refs". This can either be
+	// interior partition centroids or leaf primary index vectors, depending on
+	// whether the child key's PartitionKey or KeyBytes field is set. Each call
+	// to GetFullVectors can only request one or the other; it cannot interleave
+	// requests for both in "refs". If a vector has been deleted, then its
+	// corresponding reference will be set to nil. If a partition cannot be found,
+	// GetFullVectors returns ErrPartitionNotFound.
 	//
 	// NOTE: The caller takes ownership of any vector memory returned in "refs".
 	// The Store implementation should not try to use it after returning it.
-	//
-	// TODO(andyk): what if the row exists but the vector column is NULL? Right
-	// now, this whole library expects vectors passed to it to be non-nil and have
-	// the same number of dims. We should look into how pgvector handles NULL
-	// values - could we just treat them as if they were missing, for example?
 	GetFullVectors(ctx context.Context, treeKey TreeKey, refs []VectorWithKey) error
 }

--- a/pkg/sql/vecindex/cspann/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-features.ddt
@@ -5,7 +5,7 @@
 new-index dims=512 min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4 load-features=1000 hide-tree
 ----
 Created index with 1000 vectors with 512 dimensions.
-3 levels, 107 partitions.
+3 levels, 209 partitions.
 CV stats:
   level 2 - mean: 0.1160, stdev: 0.0241
   level 3 - mean: 0.1595, stdev: 0.0192

--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -2,7 +2,7 @@
 # Step through typical split of a non-root partition.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=3 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
 • 1 (6.8, 4.2)
 │
 └───• 2 (6.8, 4.2)
@@ -121,18 +121,44 @@ force-split partition-key=2 parent-partition-key=1 steps=1
     ├───• vec3 (4, 3)
     └───• vec1 (1, 2)
 
-# Update left sub-partition #3 to Ready state.
+# Clear all vectors from splitting partition #2.
 force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
 │
 ├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
+├───• 3 (10.5, 2.5) [Updating:2]
 │   │
-│   ├───• vec1 (1, 2)
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (4, 3)
-│   └───• vec5 (14, 1)
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
 │
+└───• 4 (2.5, 2.5) [Updating:2]
+    │
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
+
+# Update splitting partition #2 to DeletingForSplit state.
+force-split partition-key=2 parent-partition-key=1 steps=1
+----
+• 1 (6.8, 4.2)
+│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
+├───• 3 (10.5, 2.5) [Updating:2]
+│   │
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
+│
+└───• 4 (2.5, 2.5) [Updating:2]
+    │
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
+
+# Update left sub-partition #3 to Ready state.
+force-split partition-key=2 parent-partition-key=1 steps=1
+----
+• 1 (6.8, 4.2)
+│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 ├───• 3 (10.5, 2.5)
 │   │
 │   ├───• vec5 (14, 1)
@@ -148,13 +174,7 @@ force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
 │
-├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
-│   │
-│   ├───• vec1 (1, 2)
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (4, 3)
-│   └───• vec5 (14, 1)
-│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 ├───• 3 (10.5, 2.5)
 │   │
 │   ├───• vec5 (14, 1)
@@ -165,7 +185,7 @@ force-split partition-key=2 parent-partition-key=1 steps=1
     ├───• vec3 (4, 3)
     └───• vec1 (1, 2)
 
-# Remove splitting partition #2 from parent and delete it.
+# Remove splitting partition #2 from its parent.
 force-split partition-key=2 parent-partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2)
@@ -180,14 +200,15 @@ force-split partition-key=2 parent-partition-key=1 steps=1
     ├───• vec5 (14, 1)
     └───• vec2 (7, 4)
 
+# The metadata record for partition #2 should be left behind as a tombstone.
 format-tree root=2
 ----
-• 2 (MISSING)
+• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 
 # ----------------------------------------------------------------------
 # Interleaved parent and child splits.
 # ----------------------------------------------------------------------
-load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=2 beam-size=2
 • 1 (2.4583, 4.6667)
 │
 └───• 2 (3.75, 6.9167)
@@ -286,7 +307,7 @@ force-split partition-key=2 parent-partition-key=1 steps=5
 
 # Attempt to continue split of child. This should abort, since the parent is
 # still not in the Ready state.
-force-split partition-key=4 parent-partition-key=2 steps=1
+force-split partition-key=4 parent-partition-key=2
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -307,7 +328,7 @@ force-split partition-key=4 parent-partition-key=2 steps=1
 └───• 8 (5, 2) [Updating:2]
 
 # Finish split of parent.
-force-split partition-key=2 parent-partition-key=1 steps=7
+force-split partition-key=2 parent-partition-key=1
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -329,7 +350,7 @@ force-split partition-key=2 parent-partition-key=1 steps=7
 # Now split of child #4 should be able to continue with new parent #7. Notice
 # that partition #7's centroid is not exact, since it was computed while child
 # #4's split was in progress.
-force-split partition-key=4 parent-partition-key=7 steps=7
+force-split partition-key=4 parent-partition-key=7 steps=5
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -341,7 +362,7 @@ force-split partition-key=4 parent-partition-key=7 steps=7
 │
 └───• 7 (5.5, 6.25)
     │
-    ├───• 5 (6, 6.5)
+    ├───• 5 (6, 6.5) [Updating:4]
     │   │
     │   ├───• vec4 (6, 5)
     │   └───• vec3 (6, 8)
@@ -352,12 +373,12 @@ force-split partition-key=4 parent-partition-key=7 steps=7
     │   ├───• vec3 (6, 8)
     │   └───• vec4 (6, 5)
     │
-    └───• 6 (3, 5)
+    └───• 6 (3, 5) [Updating:4]
         │
         └───• vec2 (3, 5)
 
 # Start new split of parent #7, moving it to the DrainingForSplit state.
-force-split partition-key=7 parent-partition-key=1 steps=10
+force-split partition-key=7 parent-partition-key=1 steps=8
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -369,7 +390,7 @@ force-split partition-key=7 parent-partition-key=1 steps=10
 │
 ├───• 7 (5.5, 6.25) [DrainingForSplit:9,10]
 │   │
-│   ├───• 5 (6, 6.5)
+│   ├───• 5 (6, 6.5) [Updating:4]
 │   │   │
 │   │   ├───• vec4 (6, 5)
 │   │   └───• vec3 (6, 8)
@@ -380,13 +401,13 @@ force-split partition-key=7 parent-partition-key=1 steps=10
 │   │   ├───• vec3 (6, 8)
 │   │   └───• vec4 (6, 5)
 │   │
-│   └───• 6 (3, 5)
+│   └───• 6 (3, 5) [Updating:4]
 │       │
 │       └───• vec2 (3, 5)
 │
-├───• 9 (5.5, 6.25)
+├───• 9 (5.5, 6.25) [Updating:7]
 │   │
-│   ├───• 5 (6, 6.5)
+│   ├───• 5 (6, 6.5) [Updating:4]
 │   │   │
 │   │   ├───• vec4 (6, 5)
 │   │   └───• vec3 (6, 8)
@@ -397,15 +418,16 @@ force-split partition-key=7 parent-partition-key=1 steps=10
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
-└───• 10 (3, 5)
+└───• 10 (3, 5) [Updating:7]
     │
-    └───• 6 (3, 5)
+    └───• 6 (3, 5) [Updating:4]
         │
         └───• vec2 (3, 5)
 
-# Continue split of child #4. This should be a no-op, since its parent is in the
+# Continue split of child #4. This should only progress to DeletingForSplit,
+# since it cannot be removed from its parent #7, which is still in the
 # DrainingForSplit state.
-force-split partition-key=4 parent-partition-key=7 steps=2
+force-split partition-key=4 parent-partition-key=7
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -422,37 +444,27 @@ force-split partition-key=4 parent-partition-key=7 steps=2
 │   │   ├───• vec4 (6, 5)
 │   │   └───• vec3 (6, 8)
 │   │
-│   ├───• 4 (5, 6) [DrainingForSplit:5,6]
-│   │   │
-│   │   ├───• vec2 (3, 5)
-│   │   ├───• vec3 (6, 8)
-│   │   └───• vec4 (6, 5)
-│   │
+│   ├───• 4 (5, 6) [DeletingForSplitState:5,6]
 │   └───• 6 (3, 5)
 │       │
 │       └───• vec2 (3, 5)
 │
-├───• 9 (5.5, 6.25)
+├───• 9 (5.5, 6.25) [Updating:7]
 │   │
 │   ├───• 5 (6, 6.5)
 │   │   │
 │   │   ├───• vec4 (6, 5)
 │   │   └───• vec3 (6, 8)
 │   │
-│   └───• 4 (5, 6) [DrainingForSplit:5,6]
-│       │
-│       ├───• vec2 (3, 5)
-│       ├───• vec3 (6, 8)
-│       └───• vec4 (6, 5)
-│
-└───• 10 (3, 5)
+│   └───• 4 (5, 6) [DeletingForSplitState:5,6]
+└───• 10 (3, 5) [Updating:7]
     │
     └───• 6 (3, 5)
         │
         └───• vec2 (3, 5)
 
 # Finish the split of parent #7.
-force-split partition-key=7 parent-partition-key=1 steps=2
+force-split partition-key=7 parent-partition-key=1
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -475,14 +487,10 @@ force-split partition-key=7 parent-partition-key=1 steps=2
     │   ├───• vec4 (6, 5)
     │   └───• vec3 (6, 8)
     │
-    └───• 4 (5, 6) [DrainingForSplit:5,6]
-        │
-        ├───• vec2 (3, 5)
-        ├───• vec3 (6, 8)
-        └───• vec4 (6, 5)
+    └───• 4 (5, 6) [DeletingForSplitState:5,6]
 
 # Finally, the split of #4 should be able to complete with new parent #9.
-force-split partition-key=4 parent-partition-key=9 steps=2
+force-split partition-key=4 parent-partition-key=9
 ----
 • 1 (2.4583, 4.6667)
 │
@@ -505,11 +513,16 @@ force-split partition-key=4 parent-partition-key=9 steps=2
         ├───• vec4 (6, 5)
         └───• vec3 (6, 8)
 
+# Tombstone left behind for partition #4.
+format-tree root=4
+----
+• 4 (5, 6) [DeletingForSplitState:5,6]
+
 # ----------------------------------------------------------------------
 # Try to split a non-leaf partition with only 1 vector.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=2 beam-size=2
 • 1 (3, 6)
 │
 └───• 2 (3, 6)
@@ -523,7 +536,7 @@ load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
 Loaded 3 vectors.
 
 # Step to point where target sub-partition #5 is empty.
-force-split partition-key=2 parent-partition-key=1 steps=8
+force-split partition-key=2 parent-partition-key=1 steps=7
 ----
 • 1 (3, 6)
 │
@@ -544,21 +557,15 @@ force-split partition-key=2 parent-partition-key=1 steps=8
 │       └───• vec4 (6, 5)
 │
 └───• 5 (5, 6) [Updating:2]
-    │
-    └───• 3 (5, 6)
-        │
-        ├───• vec2 (3, 5)
-        ├───• vec3 (6, 8)
-        └───• vec4 (6, 5)
 
 # Next steps should duplicate the last remaining vector in sub-partition #5
-# rather than leave it empty. An empty non-leaf partition is a violation of a
-# key balanced K-means tree constraint.
+# rather than leave it empty.
 force-split partition-key=2 parent-partition-key=1 steps=2
 ----
 • 1 (3, 6)
 │
 ├───• 2 (3, 6) [DrainingForSplit:4,5]
+├───• 4 (5, 6) [Updating:2]
 │   │
 │   └───• 3 (5, 6)
 │       │
@@ -566,15 +573,7 @@ force-split partition-key=2 parent-partition-key=1 steps=2
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
-├───• 4 (5, 6)
-│   │
-│   └───• 3 (5, 6)
-│       │
-│       ├───• vec2 (3, 5)
-│       ├───• vec3 (6, 8)
-│       └───• vec4 (6, 5)
-│
-└───• 5 (5, 6)
+└───• 5 (5, 6) [Updating:2]
     │
     └───• 3 (5, 6)
         │
@@ -584,11 +583,12 @@ force-split partition-key=2 parent-partition-key=1 steps=2
 
 # Finish split. Partition #3 should be referenced by both partition #4 and
 # partition #5.
-force-split partition-key=2 parent-partition-key=1 steps=2
+force-split partition-key=2 parent-partition-key=1
 ----
 • 1 (3, 6)
 │
-├───• 5 (5, 6)
+├───• 2 (3, 6) [DrainingForSplit:4,5]
+├───• 4 (5, 6) [Updating:2]
 │   │
 │   └───• 3 (5, 6)
 │       │
@@ -596,7 +596,7 @@ force-split partition-key=2 parent-partition-key=1 steps=2
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
-└───• 4 (5, 6)
+└───• 5 (5, 6) [Updating:2]
     │
     └───• 3 (5, 6)
         │
@@ -608,7 +608,7 @@ force-split partition-key=2 parent-partition-key=1 steps=2
 # Multiple attempts to find an insert partition.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=3 beam-size=3 new-fixups
+load-index min-partition-size=1 max-partition-size=3 beam-size=3
 • 1 (2, -4)
 │
 ├───• 2 (2, -4)
@@ -623,16 +623,12 @@ load-index min-partition-size=1 max-partition-size=3 beam-size=3 new-fixups
 ----
 Loaded 4 vectors.
 
-# Run split of partition #2 until it's in DrainingForSplit state.
-force-split partition-key=2 parent-partition-key=1 steps=10
+# Run split of partition #2 until it's in DeletingForSplitState state.
+force-split partition-key=2 parent-partition-key=1 steps=12
 ----
 • 1 (2, -4)
 │
-├───• 2 (2, -4) [DrainingForSplit:4,5]
-│   │
-│   ├───• vec1 (4, 0)
-│   └───• vec2 (0, -8)
-│
+├───• 2 (2, -4) [DeletingForSplitState:4,5]
 ├───• 3 (2, -4)
 │   │
 │   ├───• vec3 (2, -5)
@@ -646,16 +642,12 @@ force-split partition-key=2 parent-partition-key=1 steps=10
     │
     └───• vec1 (4, 0)
 
-# Run split of partition #3 until it's also in DrainingForSplit state.
+# Run split of partition #3 until it's in DrainingForSplit state.
 force-split partition-key=3 parent-partition-key=1 steps=8
 ----
 • 1 (2, -4)
 │
-├───• 2 (2, -4) [DrainingForSplit:4,5]
-│   │
-│   ├───• vec1 (4, 0)
-│   └───• vec2 (0, -8)
-│
+├───• 2 (2, -4) [DeletingForSplitState:4,5]
 ├───• 3 (2, -4) [DrainingForSplit:6,7]
 │   │
 │   ├───• vec3 (2, -5)
@@ -682,11 +674,7 @@ force-split partition-key=4 parent-partition-key=1 steps=6
 ----
 • 1 (2, -4)
 │
-├───• 2 (2, -4) [DrainingForSplit:4,5]
-│   │
-│   ├───• vec1 (4, 0)
-│   └───• vec2 (0, -8)
-│
+├───• 2 (2, -4) [DeletingForSplitState:4,5]
 ├───• 3 (2, -4) [DrainingForSplit:6,7]
 │   │
 │   ├───• vec3 (2, -5)
@@ -716,11 +704,7 @@ force-split partition-key=5 parent-partition-key=1 steps=6
 ----
 • 1 (2, -4)
 │
-├───• 2 (2, -4) [DrainingForSplit:4,5]
-│   │
-│   ├───• vec1 (4, 0)
-│   └───• vec2 (0, -8)
-│
+├───• 2 (2, -4) [DeletingForSplitState:4,5]
 ├───• 3 (2, -4) [DrainingForSplit:6,7]
 │   │
 │   ├───• vec3 (2, -5)
@@ -761,11 +745,7 @@ vec5: (2, -4)
 ----
 • 1 (2, -4)
 │
-├───• 2 (2, -4) [DrainingForSplit:4,5]
-│   │
-│   ├───• vec1 (4, 0)
-│   └───• vec2 (0, -8)
-│
+├───• 2 (2, -4) [DeletingForSplitState:4,5]
 ├───• 3 (2, -4) [DrainingForSplit:6,7]
 │   │
 │   ├───• vec3 (2, -5)
@@ -801,7 +781,7 @@ search beam-size=16
 (2, -4)
 ----
 vec5: 0 (centroid=1)
-9 leaf vectors, 19 vectors, 3 full vectors, 11 partitions
+7 leaf vectors, 17 vectors, 3 full vectors, 11 partitions
 
 format-tree
 ----
@@ -814,10 +794,7 @@ format-tree
 │   │   └───• vec2 (0, -8)
 │   │
 │   ├───• 9 (0, -8)
-│   ├───• 4 (0, -8) [DrainingForSplit:8,9]
-│   │   │
-│   │   └───• vec2 (0, -8)
-│   │
+│   ├───• 4 (0, -8) [DeletingForSplitState:8,9]
 │   └───• 6 (2, -5)
 │       │
 │       ├───• vec3 (2, -5)
@@ -825,24 +802,13 @@ format-tree
 │
 └───• 13 (3, -1.8333)
     │
-    ├───• 5 (4, 0) [DrainingForSplit:10,11]
-    │   │
-    │   └───• vec1 (4, 0)
-    │
+    ├───• 5 (4, 0) [DeletingForSplitState:10,11]
     ├───• 7 (2, -3)
     │   │
     │   └───• vec4 (2, -3)
     │
-    ├───• 2 (2, -4) [DrainingForSplit:4,5]
-    │   │
-    │   ├───• vec1 (4, 0)
-    │   └───• vec2 (0, -8)
-    │
-    ├───• 3 (2, -4) [DrainingForSplit:6,7]
-    │   │
-    │   ├───• vec3 (2, -5)
-    │   └───• vec4 (2, -3)
-    │
+    ├───• 2 (2, -4) [DeletingForSplitState:4,5]
+    ├───• 3 (2, -4) [DeletingForSplitState:6,7]
     ├───• 10 (4, 0)
     │   │
     │   └───• vec1 (4, 0)
@@ -854,7 +820,7 @@ search beam-size=16
 (2, -4)
 ----
 vec5: 0 (centroid=1)
-11 leaf vectors, 23 vectors, 3 full vectors, 13 partitions
+5 leaf vectors, 17 vectors, 3 full vectors, 13 partitions
 
 format-tree
 ----
@@ -862,10 +828,7 @@ format-tree
 │
 ├───• 17 (1, -6.5)
 │   │
-│   ├───• 4 (0, -8) [DrainingForSplit:8,9]
-│   │   │
-│   │   └───• vec2 (0, -8)
-│   │
+│   ├───• 4 (0, -8) [DeletingForSplitState:8,9]
 │   └───• 6 (2, -5)
 │       │
 │       ├───• vec3 (2, -5)
@@ -873,10 +836,7 @@ format-tree
 │
 ├───• 15 (4, 0)
 │   │
-│   ├───• 5 (4, 0) [DrainingForSplit:10,11]
-│   │   │
-│   │   └───• vec1 (4, 0)
-│   │
+│   ├───• 5 (4, 0) [DeletingForSplitState:10,11]
 │   ├───• 10 (4, 0)
 │   │   │
 │   │   └───• vec1 (4, 0)
@@ -884,20 +844,12 @@ format-tree
 │   └───• 11 (4, 0)
 ├───• 14 (2, -3.6667)
 │   │
-│   ├───• 3 (2, -4) [DrainingForSplit:6,7]
-│   │   │
-│   │   ├───• vec3 (2, -5)
-│   │   └───• vec4 (2, -3)
-│   │
+│   ├───• 3 (2, -4) [DeletingForSplitState:6,7]
 │   ├───• 7 (2, -3)
 │   │   │
 │   │   └───• vec4 (2, -3)
 │   │
-│   └───• 2 (2, -4) [DrainingForSplit:4,5]
-│       │
-│       ├───• vec1 (4, 0)
-│       └───• vec2 (0, -8)
-│
+│   └───• 2 (2, -4) [DeletingForSplitState:4,5]
 └───• 16 (0, -8)
     │
     ├───• 8 (0, -8)
@@ -911,7 +863,7 @@ search beam-size=16
 (2, -4)
 ----
 vec5: 0 (centroid=1)
-11 leaf vectors, 25 vectors, 3 full vectors, 15 partitions
+5 leaf vectors, 19 vectors, 3 full vectors, 15 partitions
 
 format-tree
 ----
@@ -952,7 +904,7 @@ format-tree
 # Attempt to split the target partition of another split.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=4 beam-size=3 new-fixups
+load-index min-partition-size=1 max-partition-size=4 beam-size=3
 • 1 (6.8, 4.2)
 │
 └───• 2 (6.8, 4.2)
@@ -967,18 +919,11 @@ Loaded 5 vectors.
 
 # Split partition #2, to the point where it's about to be removed from its
 # parent.
-force-split partition-key=2 parent-partition-key=1 steps=10
+force-split partition-key=2 parent-partition-key=1 steps=12
 ----
 • 1 (6.8, 4.2)
 │
-├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
-│   │
-│   ├───• vec1 (1, 2)
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (4, 3)
-│   ├───• vec4 (-3, 2)
-│   └───• vec5 (14, 1)
-│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 ├───• 3 (-1, 2)
 │   │
 │   ├───• vec1 (1, 2)
@@ -990,20 +935,13 @@ force-split partition-key=2 parent-partition-key=1 steps=10
     ├───• vec2 (7, 4)
     └───• vec5 (14, 1)
 
-# Split partition #3 in this state, so that the DrainingForSplit target now
+# Split partition #3 in this state, so that the DeletingForSplitState target now
 # points to a non-existent partition.
 force-split partition-key=3 parent-partition-key=1
 ----
 • 1 (6.8, 4.2)
 │
-├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
-│   │
-│   ├───• vec1 (1, 2)
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (4, 3)
-│   ├───• vec4 (-3, 2)
-│   └───• vec5 (14, 1)
-│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 ├───• 6 (2.5, 2.5)
 │   │
 │   ├───• vec1 (1, 2)
@@ -1025,14 +963,7 @@ vec6: (7, 4)
 ----
 • 1 (6.8, 4.2)
 │
-├───• 2 (6.8, 4.2) [DrainingForSplit:3,4]
-│   │
-│   ├───• vec1 (1, 2)
-│   ├───• vec2 (7, 4)
-│   ├───• vec3 (4, 3)
-│   ├───• vec4 (-3, 2)
-│   └───• vec5 (14, 1)
-│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 ├───• 6 (2.5, 2.5)
 │   │
 │   ├───• vec1 (1, 2)
@@ -1048,30 +979,94 @@ vec6: (7, 4)
     │
     └───• vec4 (-3, 2)
 
-# Trigger completion of partition #2 split.
-# NOTE: vec6 is an extra duplicate zero (within error bound of zero).
-search
-(7, 4)
-----
-vec2: 0 (centroid=0.28)
-vec6: 0 (centroid=3.81)
-10 leaf vectors, 14 vectors, 3 full vectors, 4 partitions
-
-format-tree
+# Split away partition #4 as well, so that #2 has two non-existent target
+# partitions.
+force-split partition-key=4 parent-partition-key=1
 ----
 • 1 (6.8, 4.2)
 │
-├───• 5 (-3, 2)
-│   │
-│   └───• vec4 (-3, 2)
-│
+├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
 ├───• 6 (2.5, 2.5)
 │   │
 │   ├───• vec1 (1, 2)
 │   └───• vec3 (4, 3)
 │
-└───• 4 (10.5, 2.5)
+├───• 8 (14, 1)
+│   │
+│   └───• vec5 (14, 1)
+│
+├───• 5 (-3, 2)
+│   │
+│   └───• vec4 (-3, 2)
+│
+└───• 7 (7, 4)
     │
     ├───• vec2 (7, 4)
-    ├───• vec5 (14, 1)
     └───• vec6 (7, 4)
+
+# Insert another vector that would go to partition #2.
+insert
+vec7: (7, 4)
+----
+• 1 (6.8, 4.2)
+│
+├───• 9 (-0.25, 2.25)
+│   │
+│   ├───• 5 (-3, 2)
+│   │   │
+│   │   └───• vec4 (-3, 2)
+│   │
+│   └───• 6 (2.5, 2.5)
+│       │
+│       ├───• vec1 (1, 2)
+│       └───• vec3 (4, 3)
+│
+└───• 10 (9.2667, 3.0667)
+    │
+    ├───• 8 (14, 1)
+    │   │
+    │   └───• vec5 (14, 1)
+    │
+    ├───• 2 (6.8, 4.2) [DeletingForSplitState:3,4]
+    └───• 7 (7, 4)
+        │
+        ├───• vec2 (7, 4)
+        ├───• vec6 (7, 4)
+        └───• vec7 (7, 4)
+
+# Trigger completion of partition #2 split.
+# NOTE: vec7 is an extra duplicate zero (within error bound of zero).
+search
+(7, 4)
+----
+vec2: 0 (centroid=0)
+vec6: 0 (centroid=0)
+vec7: 0 (centroid=0)
+5 leaf vectors, 12 vectors, 4 full vectors, 6 partitions
+
+format-tree
+----
+• 1 (6.8, 4.2)
+│
+├───• 9 (-0.25, 2.25)
+│   │
+│   ├───• 5 (-3, 2)
+│   │   │
+│   │   └───• vec4 (-3, 2)
+│   │
+│   └───• 6 (2.5, 2.5)
+│       │
+│       ├───• vec1 (1, 2)
+│       └───• vec3 (4, 3)
+│
+└───• 10 (9.2667, 3.0667)
+    │
+    ├───• 8 (14, 1)
+    │   │
+    │   └───• vec5 (14, 1)
+    │
+    └───• 7 (7, 4)
+        │
+        ├───• vec2 (7, 4)
+        ├───• vec6 (7, 4)
+        └───• vec7 (7, 4)

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -2,7 +2,7 @@
 # Step through typical split of a root partition.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=3 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
 • 1 (6.8, 4.2)
 │
 ├───• vec1 (1, 2)
@@ -58,22 +58,6 @@ force-split partition-key=1 root=3 steps=1
 ├───• vec3 (4, 3)
 └───• vec1 (1, 2)
 
-# Update left sub-partition #2 to Ready state.
-force-split partition-key=1 root=2 steps=1
-----
-• 2 (10.5, 2.5)
-│
-├───• vec5 (14, 1)
-└───• vec2 (7, 4)
-
-# Update right sub-partition #3 to Ready state.
-force-split partition-key=1 root=3 steps=1
-----
-• 3 (2.5, 2.5)
-│
-├───• vec3 (4, 3)
-└───• vec1 (1, 2)
-
 # Remove children from root partition.
 force-split partition-key=1 steps=1
 ----
@@ -89,12 +73,37 @@ force-split partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2) [AddingLevel:2,3]
 │
+└───• 2 (10.5, 2.5) [Updating:1]
+    │
+    ├───• vec5 (14, 1)
+    └───• vec2 (7, 4)
+
+# Update left sub-partition #2 to Ready state.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [AddingLevel:2,3]
+│
 └───• 2 (10.5, 2.5)
     │
     ├───• vec5 (14, 1)
     └───• vec2 (7, 4)
 
 # Add right sub-partition #3 to root partition.
+force-split partition-key=1 steps=1
+----
+• 1 (6.8, 4.2) [AddingLevel:2,3]
+│
+├───• 2 (10.5, 2.5)
+│   │
+│   ├───• vec5 (14, 1)
+│   └───• vec2 (7, 4)
+│
+└───• 3 (2.5, 2.5) [Updating:1]
+    │
+    ├───• vec3 (4, 3)
+    └───• vec1 (1, 2)
+
+# Update right sub-partition #3 to Ready state.
 force-split partition-key=1 steps=1
 ----
 • 1 (6.8, 4.2) [AddingLevel:2,3]
@@ -128,7 +137,7 @@ force-split partition-key=1 steps=1
 # Try to split a root partition with only 1 vector.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=2 beam-size=2
 • 1 (6.8, 4.2)
 │
 └───• 2 (2.5, 2.5)
@@ -184,7 +193,7 @@ force-split partition-key=1
 # Search the tree when the root is in splitting states.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=3 beam-size=4 new-fixups
+load-index min-partition-size=1 max-partition-size=3 beam-size=4
 • 1 (7.25, 4.75)
 │
 ├───• 2 (11, 6)
@@ -302,7 +311,7 @@ vec4: 26 (centroid=1.05)
 9 leaf vectors, 15 vectors, 6 full vectors, 7 partitions
 
 # Move to the point where partition #1 children have been cleared.
-force-split partition-key=1 steps=4
+force-split partition-key=1 steps=2
 ----
 • 1 (7.25, 4.75) [DrainingForSplit:6,7]
 
@@ -334,7 +343,7 @@ vec4: 26 (centroid=1.05)
 9 leaf vectors, 13 vectors, 6 full vectors, 7 partitions
 
 # Move to point where sub-partitions #6 and #7 have been added to the root.
-force-split partition-key=1 steps=2
+force-split partition-key=1 steps=4
 ----
 • 1 (7.25, 4.75) [AddingLevel:6,7]
 │
@@ -419,7 +428,7 @@ vec4: 26 (centroid=1.05)
 # Insert into the tree when the root is in splitting states.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=4 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=4 beam-size=2
 • 1 (6.8, 4.2)
 │
 ├───• vec1 (1, 2)
@@ -486,9 +495,9 @@ format-tree root=2
 └───• vec5 (10, 5)
 
 # Copy vectors to sub-partitions.
-force-split partition-key=1 steps=4 root=2
+force-split partition-key=1 steps=2 root=2
 ----
-• 2 (10.5, 2.5)
+• 2 (10.5, 2.5) [Updating:1]
 │
 ├───• vec5 (10, 5)
 ├───• vec3 (14, 1)
@@ -503,7 +512,7 @@ partition 3, centroid=(-1, 4), sqdist=17
 insert discard-fixups root=3
 vec6: (0, 0)
 ----
-• 3 (-1, 4)
+• 3 (-1, 4) [Updating:1]
 │
 ├───• vec1 (1, 2)
 ├───• vec4 (-3, 6)
@@ -523,7 +532,7 @@ partition 2, centroid=(10.5, 2.5), sqdist=36.5
 insert discard-fixups root=2
 vec7: (8, 8)
 ----
-• 2 (10.5, 2.5)
+• 2 (10.5, 2.5) [Updating:1]
 │
 ├───• vec5 (10, 5)
 ├───• vec3 (14, 1)
@@ -531,9 +540,22 @@ vec7: (8, 8)
 └───• vec7 (8, 8)
 
 # Move to the AddingLevel state in the root partition.
-force-split partition-key=1 steps=1
+force-split partition-key=1 steps=5
 ----
 • 1 (6.8, 4.2) [AddingLevel:2,3]
+│
+├───• 2 (10.5, 2.5)
+│   │
+│   ├───• vec5 (10, 5)
+│   ├───• vec3 (14, 1)
+│   ├───• vec2 (7, 4)
+│   └───• vec7 (8, 8)
+│
+└───• 3 (-1, 4)
+    │
+    ├───• vec1 (1, 2)
+    ├───• vec4 (-3, 6)
+    └───• vec6 (0, 0)
 
 # Start split of child partition #2. This should only get to the Splitting step
 # before aborting, since its parent partition #1 is not in the Ready state.
@@ -566,7 +588,7 @@ vec8: (15, 5)
 └───• vec8 (15, 5)
 
 # Finish split of root partition.
-force-split partition-key=1 steps=3
+force-split partition-key=1
 ----
 • 1 (6.8, 4.2)
 │
@@ -610,7 +632,7 @@ force-split partition-key=2 parent-partition-key=1
 # Delete from the tree when the root is in splitting states.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=4 beam-size=2 discard-fixups new-fixups
+load-index min-partition-size=1 max-partition-size=4 beam-size=2 discard-fixups
 • 1 (0, 0)
 │
 ├───• vec1 (1, 2)
@@ -692,7 +714,7 @@ vec2
 # Delete vector after vectors have been copied to sub-partitions. This should
 # delete the vector in sub-partition #2, but leave it dangling in the root
 # partition.
-force-split partition-key=1 steps=4
+force-split partition-key=1 steps=2
 ----
 • 1 (0, 0) [DrainingForSplit:2,3]
 │
@@ -708,7 +730,7 @@ force-split partition-key=1 steps=4
 
 format-tree root=2
 ----
-• 2 (5.3333, 6.6667)
+• 2 (5.3333, 6.6667) [Updating:1]
 │
 ├───• vec10 (5, 8)
 ├───• vec7 (3, 5)
@@ -733,7 +755,7 @@ vec3
 
 format-tree root=2
 ----
-• 2 (5.3333, 6.6667)
+• 2 (5.3333, 6.6667) [Updating:1]
 │
 ├───• vec10 (5, 8)
 ├───• vec7 (3, 5)
@@ -749,7 +771,7 @@ force-split partition-key=1 steps=1
 delete discard-fixups root=3
 vec4
 ----
-• 3 (9.6667, 3.6667)
+• 3 (9.6667, 3.6667) [Updating:1]
 │
 ├───• vec6 (8, 6)
 ├───• vec9 (6, 5)
@@ -764,7 +786,7 @@ force-split partition-key=1 steps=1
 delete discard-fixups root=3
 vec5
 ----
-• 3 (9.6667, 3.6667)
+• 3 (9.6667, 3.6667) [Updating:1]
 │
 ├───• vec6 (8, 6)
 └───• vec9 (6, 5)

--- a/pkg/sql/vecindex/cspann/testdata/split.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split.ddt
@@ -537,7 +537,7 @@ force-split partition-key=5 parent-partition-key=1
 # Split partitions with less than 2 vectors.
 # ----------------------------------------------------------------------
 
-load-index min-partition-size=1 max-partition-size=2 beam-size=2 new-fixups
+load-index min-partition-size=1 max-partition-size=2 beam-size=2
 • 1 (2.4583, 4.6667)
 │
 └───• 2 (3.75, 6.9167)

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -72,10 +72,10 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 						valueBytes[i] = randutil.RandBytes(rnd, 10)
 					}
 					metadata := cspann.PartitionMetadata{
-						Level:        level,
-						Centroid:     quantizedSet.GetCentroid(),
-						StateDetails: cspann.MakeSplittingDetails(10, 20),
+						Level:    level,
+						Centroid: quantizedSet.GetCentroid(),
 					}
+					metadata.StateDetails.MakeSplitting(10, 20)
 					originalPartition := cspann.NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 
 					// Encode the partition.
@@ -194,10 +194,10 @@ func TestEncodeKeys(t *testing.T) {
 
 	// EncodeMetadataValue and DecodeMetadataValue.
 	metadata1 := cspann.PartitionMetadata{
-		Level:        cspann.LeafLevel,
-		Centroid:     vector.T{4, 3},
-		StateDetails: cspann.MakeDrainingForMergeDetails(10),
+		Level:    cspann.LeafLevel,
+		Centroid: vector.T{4, 3},
 	}
+	metadata1.StateDetails.MakeDrainingForMerge(10)
 	encoded := vecencoding.EncodeMetadataValue(metadata1)
 	metadata2, err := vecencoding.DecodeMetadataValue(encoded)
 	require.NoError(t, err)

--- a/pkg/sql/vecindex/vecstore/codec_test.go
+++ b/pkg/sql/vecindex/vecstore/codec_test.go
@@ -54,11 +54,7 @@ func testEncodeDecode(
 	centroid vector.T,
 ) {
 	codec := makePartitionCodec(rootQuantizer, nonRootQuantizer)
-	metadata := cspann.PartitionMetadata{
-		Level:        cspann.LeafLevel,
-		Centroid:     centroid,
-		StateDetails: cspann.MakeReadyDetails(),
-	}
+	metadata := cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, centroid)
 
 	// Encode vectors and child keys.
 	encodedVectors := make([][]byte, len(vectors))

--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -515,12 +515,7 @@ func (s *Store) getMetadataFromKVResult(
 		}
 
 		// Construct synthetic metadata.
-		metadata := cspann.PartitionMetadata{
-			Level:        cspann.LeafLevel,
-			Centroid:     s.emptyVec,
-			StateDetails: cspann.MakeReadyDetails(),
-		}
-		return metadata, nil
+		return cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, s.emptyVec), nil
 	}
 
 	return vecencoding.DecodeMetadataValue(value)

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -293,20 +293,19 @@ func (tx *Txn) SearchPartitions(
 // getFullVectorsFromPK fills in refs that are specified by primary key. Refs
 // that specify a partition ID are ignored. The values are returned in-line in
 // the refs slice.
-func (tx *Txn) getFullVectorsFromPK(
-	ctx context.Context, refs []cspann.VectorWithKey, numPKLookups int,
-) (err error) {
-	if cap(tx.tmpSpans) >= numPKLookups {
+func (tx *Txn) getFullVectorsFromPK(ctx context.Context, refs []cspann.VectorWithKey) (err error) {
+	if cap(tx.tmpSpans) >= len(refs) {
 		tx.tmpSpans = tx.tmpSpans[:0]
 		tx.tmpSpanIDs = tx.tmpSpanIDs[:0]
 	} else {
-		tx.tmpSpans = make([]roachpb.Span, 0, numPKLookups)
-		tx.tmpSpanIDs = make([]int, 0, numPKLookups)
+		tx.tmpSpans = make([]roachpb.Span, 0, len(refs))
+		tx.tmpSpanIDs = make([]int, 0, len(refs))
 	}
 
 	for refIdx, ref := range refs {
 		if ref.Key.PartitionKey != cspann.InvalidKey {
-			continue
+			return errors.AssertionFailedf(
+				"cannot mix partition key and primary key requests to GetFullVectors")
 		}
 
 		key := make(roachpb.Key, len(tx.store.pkPrefix)+len(ref.Key.KeyBytes))
@@ -364,13 +363,13 @@ func (tx *Txn) getFullVectorsFromPK(
 // specified by partition ID. Primary key references are ignored.
 func (tx *Txn) getFullVectorsFromPartitionMetadata(
 	ctx context.Context, treeKey cspann.TreeKey, refs []cspann.VectorWithKey,
-) (numPKLookups int, err error) {
+) error {
 	var b *kv.Batch
 
 	for _, ref := range refs {
 		if ref.Key.PartitionKey == cspann.InvalidKey {
-			numPKLookups++
-			continue
+			return errors.AssertionFailedf(
+				"cannot mix partition key and primary key requests to GetFullVectors")
 		}
 		metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, ref.Key.PartitionKey)
 		if b == nil {
@@ -379,20 +378,12 @@ func (tx *Txn) getFullVectorsFromPartitionMetadata(
 		b.Get(metadataKey)
 	}
 
-	if numPKLookups == len(refs) {
-		// All of the lookups are for leaf vectors, so don't fetch any centroids.
-		return numPKLookups, nil
-	}
 	if err := tx.kv.Run(ctx, b); err != nil {
-		return 0, err
+		return errors.Wrapf(err, "fetching partition metadata for GetFullVectors")
 	}
 
 	idx := 0
 	for _, result := range b.Results {
-		// Skip past primary key references.
-		for ; refs[idx].Key.PartitionKey == cspann.InvalidKey; idx++ {
-		}
-
 		if result.Rows[0].ValueBytes() == nil {
 			// If this is the root partition, then the metadata row is missing;
 			// it is only created when the first split of the root happens.
@@ -405,27 +396,31 @@ func (tx *Txn) getFullVectorsFromPartitionMetadata(
 			// Get the centroid from the partition metadata.
 			metadata, err := vecencoding.DecodeMetadataValue(result.Rows[0].ValueBytes())
 			if err != nil {
-				return 0, err
+				return err
 			}
 			refs[idx].Vector = metadata.Centroid
 		}
 		idx++
 	}
-	return numPKLookups, nil
+	return nil
 }
 
 // GetFullVectors implements the cspann.Txn interface.
 func (tx *Txn) GetFullVectors(
 	ctx context.Context, treeKey cspann.TreeKey, refs []cspann.VectorWithKey,
 ) error {
-	numPKLookups, err := tx.getFullVectorsFromPartitionMetadata(ctx, treeKey, refs)
-	if err != nil {
-		return err
+	if len(refs) == 0 {
+		return nil
 	}
-	if numPKLookups > 0 {
-		err = tx.getFullVectorsFromPK(ctx, refs, numPKLookups)
+
+	// All vectors must be at the same level of the tree.
+	if refs[0].Key.PartitionKey != cspann.InvalidKey {
+		// Get partition centroids.
+		return tx.getFullVectorsFromPartitionMetadata(ctx, treeKey, refs)
 	}
-	return err
+
+	// Get vectors from primary index.
+	return tx.getFullVectorsFromPK(ctx, refs)
 }
 
 // createRootPartition uses the KV CPut operation to create metadata for the

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -437,11 +437,7 @@ func (tx *Txn) createRootPartition(
 	ctx context.Context, metadataKey roachpb.Key,
 ) (cspann.PartitionMetadata, error) {
 	b := tx.kv.NewBatch()
-	metadata := cspann.PartitionMetadata{
-		Level:        cspann.LeafLevel,
-		Centroid:     tx.store.emptyVec,
-		StateDetails: cspann.MakeReadyDetails(),
-	}
+	metadata := cspann.MakeReadyPartitionMetadata(cspann.LeafLevel, tx.store.emptyVec)
 	encoded := vecencoding.EncodeMetadataValue(metadata)
 
 	// Use CPut to detect the case where another transaction is racing to create


### PR DESCRIPTION
Backport 10/10 commits from #144800.

/cc @cockroachdb/release

---

Improve the TestIndexConcurrency test and fix issues it found.

#### cspann: fix buglet in searcher

Fix a small bug, where we were not setting s.levels in the case where
we're inserting into the root partition. This was causing crdb_test runs
to fail, since it reallocates the s.levels buffer every time..

#### cspann: fix data race in memstore.GetFullVectors

The race detector found a data race in MemStore's GetFullVectors that was
caused by not locking when accessing a partition's centroid. This was
deliberate, because the centroid was thought to be immutable, but the
TryClearPartition code sets the centroid to itself, which triggers the
race detector. While we could change TryClearPartition to avoid that, it's
probably best to just do the locking.

However, that causes another problem, which is that the MemStore locking
needed for getting partition centroids is different than the locking
needed to get primary key vectors. Update the GetFullVectors API to make
it clear that we can only ask for one or the other in a single call, so
that we don't need to handle the case where partition keys and primary
keys are interleaved in the same request.

#### cspann: set correct parent partition in fallbackOnTargets

If an insert fails to insert a vector into a partition that does not allow
it, it calls fallbackOnTargets to redirect to one of the target partitions.
However, the existing code does not set the parent partition correctly for
target partitions. A split of a non-root partition should set the target
partitions' parent as the parent of the splitting partition, not the
splitting partition itself.

#### cspann: add better control over search for update retries

The retry logic in searchForUpdateHelper has a couple of problems:

- In the event of an infinite retry loop bug, it can stack overflow, since
  it recursively calls itself.
- Race conditions with the MemStore can cause it to not find a valid insert
  partition. Reads of MemStore partitions race with background fixups that
  update and delete the partitions.

This commit improves the situation by specifying the maximum number of
insert/delete attempts we'll make before giving up. The remaining attempts
are preserved when making recursive retry calls, which prevents infinite
retry loops.

#### cspann: add DeletingForSplit state to split fixup flow

Under heavy stress, a target partition can be split and deleted before
its source partition finishes its own split. This results in a situation
where the source partition is still pointing to target partitions that are
now deleted. To prevent that state, this commit adds a new DeletingForSplit
state into the split fixup flow, to be used for non-root partitions. After
vectors have been copied to target partitions, the splitting partition is
marked as DeletingForSplit. Next, the target partitions are marked Ready,
and can now safely be split or merged themselves. Finally, the splitting
partition is actually removed from the tree and deleted.

#### cspann: fix partition reload race condition

During split, we reload a partition's vectors, in case any have changed
while we created target partitions. However, it's also possible that
another worker has updated the splitting partition. In that case, we
should abort and let the racing worker take over. The existing code
was not doing that, and ended up trying to continue the split, but
with incorrect target partition keys.

#### cspann: improve logging during concurrent splits

The existing logging makes it difficult to debug bugs caused by multiple
concurrent workers racing to split a partition. This commit updates the
logging to:

- log after every key step in the split process
- only log for the worker that actually wins the race for this step

These changes reduce logging noise while still improving what does get
logged.

#### memstore: restart operation when reading a deleted partition

When the memstore comes across a deleted partition, there are two cases:

1. The txn was started before the deletion, in which case it should be
   restarted, so that any search can find a different path through the tree.
2. The txn was started after the deletion, in which case ErrPartitionNotFound
   should be returned.

#### memstore: fix race condition creating an empty partition

The memstore.TryCreateEmptyPartition method has a race condition, such
that two callers can end up creating different instances of the same
partition. This commit fixes that by checking whether the partition
already exists and then creating it if needed, all within the scope of
the same lock.

This change also uncovered an existing bug in splitPartition, in which
we weren't fetching metadata for the left and right sub-partitions when
restarting the split in the AddingLevel state.

#### cspann: simulate multiple index instances in TestIndexConcurrency

Create multiple index instances in the TestIndexConcurrency test, all hooked
up to the same store. This simulates multiple CRDB nodes, each independently
inserting, removing, searching, and splitting a shared index. Eliminate the
delay for one instance assisting another, in order to maximize the possibility
of race conditions.

Release justification: Vector indexing is a business priority. These changes are
all in the vecindex package, for a feature that is protected by a default-off
feature flag.