### PR TITLE
release-25.2: cli, security: add support for configurable TLS cipher suites

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -927,6 +927,17 @@ provided for node user if this flag is set.
 `,
 	}
 
+	TLSCipherSuites = FlagInfo{
+		Name: "tls-cipher-suites",
+		Description: `
+A string of comma separated list of cipher suites to be used for all incoming
+TLS connections to the node. For TLS 1.2, this should strictly be a subset of
+suites defined in security/tls_ciphersuites.go as RecommendedCipherSuites or
+OldCipherSuites. For TLS 1.3, this should be configured to a subset of ciphers
+in crypto/tls/cipher_suites.go, e.g. TLS_AES_256_GCM_SHA384.
+`,
+	}
+
 	CAKey = FlagInfo{
 		Name:        "ca-key",
 		EnvVar:      "COCKROACH_CA_KEY",

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -483,6 +483,7 @@ var startCtx struct {
 	serverListenAddr       string
 	serverRootCertDN       string
 	serverNodeCertDN       string
+	serverTLSCipherSuites  []string
 
 	// The TLS auto-handshake parameters.
 	initToken             string

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -555,6 +555,9 @@ func init() {
 		// Node cert distinguished name
 		cliflagcfg.StringFlag(f, &startCtx.serverNodeCertDN, cliflags.NodeCertDistinguishedName)
 
+		// TLS Cipher Suites configured
+		cliflagcfg.StringSliceFlag(f, &startCtx.serverTLSCipherSuites, cliflags.TLSCipherSuites)
+
 		// Cluster name verification.
 		cliflagcfg.VarFlag(f, clusterNameSetter{&baseCfg.ClusterName}, cliflags.ClusterName)
 		cliflagcfg.BoolFlag(f, &baseCfg.DisableClusterNameVerification, cliflags.DisableClusterNameVerification)
@@ -1159,6 +1162,12 @@ func extraServerFlagInit(cmd *cobra.Command) error {
 		return err
 	}
 	if err := security.SetNodeSubject(startCtx.serverNodeCertDN); err != nil {
+		return err
+	}
+	// Currently we don't handle the case where we are setting the --insecure flag
+	// as well as providing the --tls-cipher-suites, we should probably error out
+	// if both are set, issue: #144935.
+	if err := security.SetTLSCipherSuitesConfigured(startCtx.serverTLSCipherSuites); err != nil {
 		return err
 	}
 	serverCfg.User = username.NodeUserName()

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -115,7 +115,7 @@ func NewServerEx(
 		if err != nil {
 			return nil, nil, sii, err
 		}
-		grpcOpts = append(grpcOpts, grpc.Creds(credentials.NewTLS(tlsConfig)))
+		grpcOpts = append(grpcOpts, grpc.Creds(newTLSCipherRestrictCred(tlsConfig)))
 	}
 
 	// These interceptors will be called in the order in which they appear, i.e.

--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
         "@com_github_go_ldap_ldap_v3//:ldap",
         "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_crypto//ocsp",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
     ],
 )
@@ -96,10 +97,12 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_go_ldap_ldap_v3//:ldap",
+        "@com_github_jackc_pgx_v4//:pgx",
         "@com_github_stretchr_testify//require",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [

--- a/pkg/security/tls_ciphersuites.go
+++ b/pkg/security/tls_ciphersuites.go
@@ -5,7 +5,14 @@
 
 package security
 
-import "crypto/tls"
+import (
+	"crypto/tls"
+	"net"
+
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
+	"golang.org/x/exp/slices"
+)
 
 // RecommendedCipherSuites returns a list of enabled TLS 1.2 cipher
 // suites. The order of the list is ignored; prioritization of cipher
@@ -69,3 +76,164 @@ func OldCipherSuites() []uint16 {
 		tls.TLS_RSA_WITH_AES_256_CBC_SHA,
 	}
 }
+
+type tlsRestrictConfiguration struct {
+	syncutil.RWMutex
+	c          []string
+	restrictFn func(*tls.Conn) (error net.Error)
+}
+
+var tlsRestrictConfig = tlsRestrictConfiguration{
+	c:          []string{},
+	restrictFn: func(tlsConn *tls.Conn) (error net.Error) { return },
+}
+
+type allowedTLSCiphers struct {
+	ciphersMapByName map[string]uint16
+	ciphersMapByID   map[uint16]string
+}
+
+// getAllowedCiphersMapByName returns map of allowed cipher names to cipher ID.
+func (ciphers *allowedTLSCiphers) getAllowedCiphersMapByName() map[string]uint16 {
+	return ciphers.ciphersMapByName
+}
+
+// getAllowedCiphersMapByID returns map of allowed cipher ID to cipher names.
+func (ciphers *allowedTLSCiphers) getAllowedCiphersMapByID() map[uint16]string {
+	return ciphers.ciphersMapByID
+}
+
+// newAllowedTLSCiphers instantiates allowedTLSCiphers with all the ciphers
+// which golang implements and have been allowed for cockroach in
+// RecommendedCipherSuites, OldCipherSuites or as part of TLS 1.3 ciphers in
+// crypto/tls.
+func newAllowedTLSCiphers() (ciphers *allowedTLSCiphers) {
+	ciphers = &allowedTLSCiphers{}
+	ciphers.ciphersMapByName = map[string]uint16{}
+	ciphers.ciphersMapByID = map[uint16]string{}
+	cockroachEnabledCiphers := append(RecommendedCipherSuites(), OldCipherSuites()...)
+	for _, cipher := range tls.CipherSuites() {
+		if slices.Contains(cockroachEnabledCiphers, cipher.ID) || slices.Contains(cipher.SupportedVersions, tls.VersionTLS13) {
+			ciphers.ciphersMapByName[cipher.Name] = cipher.ID
+			ciphers.ciphersMapByID[cipher.ID] = cipher.Name
+		}
+	}
+	for _, cipher := range tls.InsecureCipherSuites() {
+		if slices.Contains(cockroachEnabledCiphers, cipher.ID) || slices.Contains(cipher.SupportedVersions, tls.VersionTLS13) {
+			ciphers.ciphersMapByName[cipher.Name] = cipher.ID
+			ciphers.ciphersMapByID[cipher.ID] = cipher.Name
+		}
+	}
+	return
+}
+
+var allowedCiphers = newAllowedTLSCiphers()
+
+// getCipherID verifies if provided cipher is implemented by crypto/tls and
+// return the corresponding cipherID
+func getCipherNameFromID(cid uint16) (cipher string, ok bool) {
+	allowedCiphersMap := allowedCiphers.getAllowedCiphersMapByID()
+	cipher, ok = allowedCiphersMap[cid]
+	return
+}
+
+// SetTLSCipherSuitesConfigured sets the global TLS cipher suites for all
+// incoming connections(sql/rpc/http, etc.) of a node. The entries in the list
+// should be a subset of RecommendedCipherSuites or OldCipherSuites in case of
+// TLS 1.2. For TLS 1.3, they should be a subset of ciphers list defined at
+// https://github.com/golang/go/blob/4aa1efed4853ea067d665a952eee77c52faac774/src/crypto/tls/cipher_suites.go#L676-L679
+// for TLS 1.3.
+func SetTLSCipherSuitesConfigured(ciphers []string) error {
+	allowedCiphersMap := allowedCiphers.getAllowedCiphersMapByName()
+	for _, cipher := range ciphers {
+		if _, ok := allowedCiphersMap[cipher]; !ok {
+			return &cipherRestrictError{errors.Errorf("invalid cipher provided in tls cipher suites: %s", cipher)}
+		}
+	}
+
+	tlsRestrictConfig.configureTLSRestrict(ciphers)
+	return nil
+}
+
+func (*tlsRestrictConfiguration) configureTLSRestrict(ciphers []string) {
+	tlsRestrictConfig.Lock()
+	defer tlsRestrictConfig.Unlock()
+	tlsRestrictConfig.restrictFn = func(tlsConn *tls.Conn) (error net.Error) { return }
+	tlsRestrictConfig.c = ciphers
+	if len(ciphers) == 0 {
+		return
+	}
+
+	tlsRestrictConfig.restrictFn = func(tlsConn *tls.Conn) (error net.Error) {
+		if !tlsConn.ConnectionState().HandshakeComplete {
+			// TODO(souravcrl): we need to provide a timebound context for handshake as it
+			// ensures client failures are properly handled, issue: #144754
+			if err := tlsConn.Handshake(); err != nil {
+				// we don't want to close the connection for handshake errors
+				return nil //nolint:returnerrcheck
+			}
+		}
+		selectedCipherID := tlsConn.ConnectionState().CipherSuite
+		cName, ok := getCipherNameFromID(selectedCipherID)
+		if !ok {
+			return &cipherRestrictError{errors.Errorf("cipher id %v does match implemented tls ciphers", selectedCipherID)}
+		}
+		if !slices.Contains(tlsRestrictConfig.c, cName) {
+			return &cipherRestrictError{errors.Newf("presented cipher %s not in allowed cipher suite list", cName)}
+		}
+		return
+	}
+}
+
+// TLSCipherRestrict restricts the cipher suites used for tls connections to
+// ones specified by tls-cipher-suites cli flag. If the flag is not set, we do
+// not check for used ciphers in the connection. It returns an error if the used
+// cipher is not present in the configured ciphers for the node.
+var TLSCipherRestrict = func(conn net.Conn) (err net.Error) {
+	var tlsRestrictFn func(*tls.Conn) (error net.Error)
+	{
+		tlsRestrictConfig.Lock()
+		defer tlsRestrictConfig.Unlock()
+		tlsRestrictFn = tlsRestrictConfig.restrictFn
+	}
+	// we always expect a TLS connection here, since this is executed on the
+	// tls.Listener or post applying tls.Server on the incoming connection
+	tlsConn, _ := conn.(*tls.Conn)
+	return tlsRestrictFn(tlsConn)
+}
+
+// cipherRestrictError implements net.Error interface so that we can override
+// the error handling in net/http package as it only considers a net.Error type
+// for error rule matching. The cipher restrict error is overridden by net.Error
+// in TLSCipherRestrict fn.
+type cipherRestrictError struct {
+	err error
+}
+
+// Error implements net.Error.
+func (e *cipherRestrictError) Error() string { return e.err.Error() }
+
+// Unwrap implements net.Error.
+func (e *cipherRestrictError) Unwrap() error { return e.err }
+
+// Timeout implements net.Error.
+func (e *cipherRestrictError) Timeout() bool { return false }
+
+// Temporary implements net.Error. We need to set this to true since
+// http/server.go:func Serve(l net.Listener) error
+// https://github.com/golang/go/blob/go1.23.7/src/net/http/server.go#L3329-L3349
+// uses this value to resume serving on the connection without explicitly
+// registering an error. As mentioned in net/net.go Error interface temporary
+// errors are deprecated and may not be supported in the future:
+// https://github.com/golang/go/blob/go1.23.7/src/net/net.go#L419, hence we need
+// a check that cipherRestrictError always implements the net.Error interface
+// fully.
+// TODO(souravcrl): update the accept handler to just log an error and continue
+// processing new connection requests
+func (e *cipherRestrictError) Temporary() bool { return true }
+
+var _ error = (*cipherRestrictError)(nil)
+
+// We implement net.Error the same way that context.DeadlineExceeded does, so
+// that people looking for net.Error attributes will still find them.
+var _ net.Error = (*cipherRestrictError)(nil)

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -6,14 +6,27 @@
 package security_test
 
 import (
+	"context"
 	"crypto/tls"
 	"crypto/x509"
+	"io"
+	"net"
+	"net/http"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/security/certnames"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/jackc/pgx/v4"
 	"github.com/stretchr/testify/require"
 )
 
@@ -105,4 +118,134 @@ func verifyX509Cert(cert *x509.Certificate, dnsName string, roots *x509.CertPool
 	}
 	_, err := cert.Verify(verifyOptions)
 	return err
+}
+
+func TestTLSCipherRestrict(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// since the listener does not return rpc/sql/http connection errors, we
+	// need to have a separate hook to obtain and validate it.
+	type cipherErrContainer struct {
+		syncutil.Mutex
+		err net.Error
+	}
+
+	cipherErrC := &cipherErrContainer{}
+	cipherRestrictFn := security.TLSCipherRestrict
+	defer testutils.TestingHook(&security.TLSCipherRestrict, func(conn net.Conn) (err net.Error) {
+		err = cipherRestrictFn(conn)
+		cipherErrC.Lock()
+		cipherErrC.err = err
+		cipherErrC.Unlock()
+		return err
+	})()
+
+	ctx := context.Background()
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	defer require.NoError(t, security.SetTLSCipherSuitesConfigured([]string{}))
+
+	// setup for db console tests
+	httpClient, err := s.GetUnauthenticatedHTTPClient()
+	require.NoError(t, err)
+	httpClient.Timeout = 2 * time.Second
+	defer httpClient.CloseIdleConnections()
+
+	secureClient, err := s.GetAuthenticatedHTTPClient(false, serverutils.SingleTenantSession)
+	require.NoError(t, err)
+	secureClient.Timeout = 2 * time.Second
+	defer secureClient.CloseIdleConnections()
+
+	urlsToTest := []string{"/_status/vars", "/index.html", "/"}
+	adminURLHTTPS := s.AdminURL().String()
+	adminURLHTTP := strings.Replace(adminURLHTTPS, "https", "http", 1)
+
+	tests := []struct {
+		name      string
+		ciphers   []string
+		wantErr   bool
+		httpsErr  []string
+		sqlErr    string
+		rpcErr    string
+		cipherErr string
+	}{
+		{name: "no cipher set", ciphers: []string{}, wantErr: false},
+		{name: "valid ciphers", ciphers: []string{"TLS_AES_256_GCM_SHA384", "TLS_AES_128_GCM_SHA256"},
+			wantErr: false},
+		{name: "invalid ciphers", ciphers: []string{"TLS_ECDHE_RSA_WITH_CHACHA20_POLY1305_SHA256"}, wantErr: true,
+			httpsErr:  []string{"\": EOF", "connect: connection refused", "read: connection reset by peer", "http: server closed idle connection"},
+			sqlErr:    "failed to connect to `host=127.0.0.1 user=root database=`: failed to receive message (unexpected EOF)",
+			rpcErr:    "initial connection heartbeat failed: grpc:",
+			cipherErr: "^presented cipher [^ ]+ not in allowed cipher suite list$"},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			// set the custom test ciphers
+			err := security.SetTLSCipherSuitesConfigured(tt.ciphers)
+			require.NoError(t, err)
+			// unset the ciphers after test
+			defer func() { _ = security.SetTLSCipherSuitesConfigured([]string{}) }()
+
+			// test db console tls access for cipher restriction.
+			for _, u := range urlsToTest {
+				for _, client := range []http.Client{httpClient, secureClient} {
+					resp, err := client.Get(adminURLHTTP + u)
+					if (err == nil) == tt.wantErr {
+						var body []byte
+						if resp != nil && resp.Body != nil {
+							defer resp.Body.Close()
+							body, err = io.ReadAll(resp.Body)
+						}
+						t.Fatalf("expected wantError=%t, got err=%v, resp=%v", tt.wantErr, err, string(body))
+					}
+					if tt.wantErr {
+						cipherErrC.Lock()
+						errVal := cipherErrC.err
+						cipherErrC.Unlock()
+						require.Regexp(t, tt.cipherErr, errVal.Error())
+						var errMatch bool
+						for idx := range tt.httpsErr {
+							errMatch = errMatch || strings.Contains(err.Error(), tt.httpsErr[idx])
+						}
+						if !errMatch {
+							t.Fatalf("the provided error %s does not match any of the expected errors: %v", err.Error(), strings.Join(tt.httpsErr, ", "))
+						}
+					}
+				}
+			}
+
+			// test pgx connection for root user with cert auth
+			pgURL, cleanup := s.PGUrl(t, serverutils.User(username.RootUser), serverutils.ClientCerts(true))
+			defer cleanup()
+			rootConn, err := pgx.Connect(ctx, pgURL.String())
+			if (err == nil) == tt.wantErr {
+				t.Fatalf("expected wantError=%t, got err=%v", tt.wantErr, err)
+			}
+			if err != nil {
+				cipherErrC.Lock()
+				errVal := cipherErrC.err
+				cipherErrC.Unlock()
+				require.Regexp(t, tt.cipherErr, errVal.Error())
+				require.Equal(t, tt.sqlErr, err.Error())
+			} else {
+				require.NoError(t, rootConn.Close(ctx))
+			}
+
+			// test rpc connection for root user.
+			conn, err := s.RPCClientConnE(username.RootUserName())
+			if (err == nil) == tt.wantErr {
+				t.Fatalf("expected wantError=%t, got err=%v", tt.wantErr, err)
+			}
+			if err != nil {
+				cipherErrC.Lock()
+				errVal := cipherErrC.err
+				cipherErrC.Unlock()
+				require.Regexp(t, tt.cipherErr, errVal.Error())
+				require.Contains(t, err.Error(), tt.rpcErr)
+			} else {
+				require.NoError(t, conn.Close()) // nolint:grpcconnclose
+			}
+		})
+	}
 }

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"crypto/tls"
 	"encoding/json"
+	"net"
 	"net/http"
 	"strings"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/cockroachdb/cmux"
 	"github.com/cockroachdb/cockroach/pkg/inspectz"
 	"github.com/cockroachdb/cockroach/pkg/rpc"
+	"github.com/cockroachdb/cockroach/pkg/security"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/debug"
@@ -330,7 +332,7 @@ func startHTTPService(
 			return err
 		}
 
-		httpLn = tls.NewListener(tlsL, uiTLSConfig)
+		httpLn = newTLSRestrictLn(tlsL, uiTLSConfig)
 	}
 
 	// The connManager is responsible for tearing down the net.Conn
@@ -344,6 +346,28 @@ func startHTTPService(
 	return stopper.RunAsyncTask(workersCtx, "server-http", func(context.Context) {
 		netutil.FatalIfUnexpected(connManager.Serve(httpLn))
 	})
+}
+
+type tlsRestrictLn struct {
+	net.Listener
+}
+
+// Accept wraps the net.Listener Accept method to apply http based tls
+// constraints on the incoming connection.
+func (l tlsRestrictLn) Accept() (c net.Conn, err error) {
+	if c, err = l.Listener.Accept(); err == nil {
+		if err = security.TLSCipherRestrict(c); err != nil {
+			_ = c.Close()
+			return
+		}
+	}
+	return
+}
+
+func newTLSRestrictLn(ln net.Listener, config *tls.Config) tlsRestrictLn {
+	return tlsRestrictLn{
+		Listener: tls.NewListener(ln, config),
+	}
 }
 
 // baseHandler is the top-level HTTP handler for all HTTP traffic, before


### PR DESCRIPTION
Backport 1/1 commits from #143554.

/cc @cockroachdb/release

---

fixes #136999
Epic CRDB-45351

Release Note(security,ops): We will be providing a new cockroach start command cli flag `tls-cipher-suites` which is a string of comma separated list of cipher suites to be used for all incoming TLS connections to the node. For TLS 1.2, this should strictly be a subset of suites defined in security/tls_ciphersuites.go as RecommendedCipherSuites or OldCipherSuites. For TLS 1.3, this should be configured to a subset of ciphers in crypto/tls/cipher_suites.go. The flag will restrict TLS connections to the node for all 3 types of connection(i.e. sql, rpc, http) where node acts as the server for the connections and close non-conforming ones.

The updated cockroach start command with the ciphers argument is as follows:

```
cockroach start --certs-dir=certs \
--listen-addr=localhost:26257 \
--http-addr=localhost:8080 \
--tls-cipher-suites=TLS_AES_256_GCM_SHA384,TLS_AES_128_GCM_SHA256
```

Release justification: tls cipher feature is planned for 25.2 and needs to backported.