### PR TITLE
raft: improve findConflictByTerm

### DIFF
--- a/pkg/raft/log_test.go
+++ b/pkg/raft/log_test.go
@@ -82,7 +82,7 @@ func TestFindConflictByTerm(t *testing.T) {
 		want  uint64
 	}{
 		// Log starts from index 1.
-		{sl: noSnap.append(2, 2, 5, 5, 5), index: 100, term: 2, want: 100}, // ErrUnavailable
+		{sl: noSnap.append(2, 2, 5, 5, 5), index: 100, term: 2, want: 2},
 		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 6, want: 5},
 		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 5, want: 5},
 		{sl: noSnap.append(2, 2, 5, 5, 5), index: 5, term: 4, want: 2},
@@ -92,7 +92,7 @@ func TestFindConflictByTerm(t *testing.T) {
 		{sl: noSnap.append(2, 2, 5, 5, 5), index: 1, term: 1, want: 0},
 		{sl: noSnap.append(2, 2, 5, 5, 5), index: 0, term: 0, want: 0},
 		// Log with compacted entries.
-		{sl: snap10.append(3, 3, 4, 4, 4), index: 30, term: 3, want: 30}, // ErrUnavailable
+		{sl: snap10.append(3, 3, 4, 4, 4), index: 30, term: 3, want: 12},
 		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 9, want: 14},
 		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 4, want: 14},
 		{sl: snap10.append(3, 3, 4, 4, 4), index: 14, term: 3, want: 12},

--- a/pkg/raft/raft.go
+++ b/pkg/raft/raft.go
@@ -2395,8 +2395,7 @@ func (r *raft) handleAppendEntries(m pb.Message) {
 	// the valid interval, which then will return a valid (index, term) pair with
 	// a non-zero term (unless the log is empty). However, it is safe to send a zero
 	// LogTerm in this response in any case, so we don't verify it here.
-	hintIndex := min(m.Index, r.raftLog.lastIndex())
-	hintIndex, hintTerm := r.raftLog.findConflictByTerm(hintIndex, m.LogTerm)
+	hintIndex, hintTerm := r.raftLog.findConflictByTerm(m.Index, m.LogTerm)
 	r.send(pb.Message{
 		To:    m.From,
 		Type:  pb.MsgAppResp,


### PR DESCRIPTION
See proof in the code comment.

Factored out from #143713, idea from @hakuuww.

Epic: none
Release note: none