### PR TITLE
sql: fix execution stats for mutations with RETURNING

### DIFF
--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -360,6 +360,9 @@ func (e *distSQLSpecExecFactory) ConstructScan(
 	return makePlanMaybePhysical(p, nil /* planNodesToClose */), err
 }
 
+// DisableSpoolElision implements the Factory interface.
+func (e *distSQLSpecExecFactory) DisableSpoolElision() {}
+
 // Ctx implements the Factory interface.
 func (e *distSQLSpecExecFactory) Ctx() context.Context {
 	return e.ctx

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -202,3 +202,78 @@ quality of service: regular
               execution time: 0µs
               table: tables@tables_database_name_idx (partial index)
               spans: [/'test' - /'test']
+
+# Regression test for not showing execution stats for mutation nodes when they
+# are wrapped in a spoolNode (which is the case when RETURNING is present)
+# (#139378).
+query T
+EXPLAIN ANALYZE DELETE FROM kv WHERE true RETURNING *;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+rows decoded from KV: 4 (32 B, 8 KVs, 4 gRPC calls)
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• delete
+│ sql nodes: <hidden>
+│ regions: <hidden>
+│ actual row count: 4
+│ execution time: 0µs
+│ from: kv
+│ auto commit
+│
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 4
+      KV time: 0µs
+      KV rows decoded: 4
+      KV pairs read: 8
+      KV bytes read: 32 B
+      KV gRPC calls: 4
+      estimated max memory allocated: 0 B
+      missing stats
+      table: kv@kv_pkey
+      spans: FULL SCAN
+      locking strength: for update
+
+query T
+EXPLAIN ANALYZE INSERT INTO kv VALUES (1, 10) RETURNING k + v;
+----
+planning time: 10µs
+execution time: 100µs
+distribution: <hidden>
+vectorized: <hidden>
+plan type: custom
+maximum memory usage: <hidden>
+DistSQL network usage: <hidden>
+regions: <hidden>
+isolation level: serializable
+priority: normal
+quality of service: regular
+·
+• render
+│
+└── • insert
+    │ sql nodes: <hidden>
+    │ regions: <hidden>
+    │ actual row count: 1
+    │ execution time: 0µs
+    │ estimated row count: 1
+    │ into: kv(k, v)
+    │
+    └── • values
+          sql nodes: <hidden>
+          regions: <hidden>
+          actual row count: 1
+          execution time: 0µs
+          size: 2 columns, 1 row

--- a/pkg/sql/opt/exec/explain/explain_factory.go
+++ b/pkg/sql/opt/exec/explain/explain_factory.go
@@ -29,6 +29,11 @@ type Factory struct {
 
 var _ exec.ExplainFactory = &Factory{}
 
+// DisableSpoolElision implements the Factory interface.
+func (f *Factory) DisableSpoolElision() {
+	f.wrappedFactory.DisableSpoolElision()
+}
+
 // Ctx implements the Factory interface.
 func (f *Factory) Ctx() context.Context {
 	return f.wrappedFactory.Ctx()

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -102,6 +102,11 @@ type PlanGistFactory struct {
 
 var _ exec.Factory = &PlanGistFactory{}
 
+// DisableSpoolElision implements the Factory interface.
+func (f *PlanGistFactory) DisableSpoolElision() {
+	f.wrappedFactory.DisableSpoolElision()
+}
+
 // Ctx implements the Factory interface.
 func (f *PlanGistFactory) Ctx() context.Context {
 	return f.wrappedFactory.Ctx()

--- a/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/exec_factory_gen.go
@@ -82,6 +82,11 @@ func (g *execFactoryGen) genExecFactory() {
 	g.w.unnest(") (Plan, error)\n")
 
 	g.w.write("\n")
+	g.w.nest("// DisableSpoolElision instructs the factory to not remove the spoolNode at the root.\n")
+	g.w.writeIndent("DisableSpoolElision()\n")
+	g.w.unnest("\n")
+
+	g.w.write("\n")
 	g.w.nest("// Ctx returns the ctx of this execution.\n")
 	g.w.writeIndent("Ctx() context.Context\n")
 	g.w.unnest("\n")
@@ -121,6 +126,8 @@ func (g *execFactoryGen) genStubFactory() {
 	g.w.unnest(") (Plan, error) {\n")
 	g.w.nestIndent("return struct{}{}, nil\n")
 	g.w.unnest("}\n")
+
+	g.w.nest("\nfunc (StubFactory) DisableSpoolElision() {}\n")
 
 	g.w.write("\n")
 	g.w.nest("func (StubFactory) Ctx() context.Context {\n")

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/execfactory
@@ -74,6 +74,9 @@ type Factory interface {
 		flags PlanFlags,
 	) (Plan, error)
 
+	// DisableSpoolElision instructs the factory to not remove the spoolNode at the root.
+	DisableSpoolElision()
+
 	// Ctx returns the ctx of this execution.
 	Ctx() context.Context
 
@@ -113,6 +116,8 @@ func (StubFactory) ConstructPlan(
 ) (Plan, error) {
 	return struct{}{}, nil
 }
+
+func (StubFactory) DisableSpoolElision() {}
 
 func (StubFactory) Ctx() context.Context {
 	return context.Background()

--- a/pkg/sql/plan.go
+++ b/pkg/sql/plan.go
@@ -294,31 +294,6 @@ var _ planNodeReadingOwnWrites = &dropTypeNode{}
 var _ planNodeReadingOwnWrites = &refreshMaterializedViewNode{}
 var _ planNodeReadingOwnWrites = &setZoneConfigNode{}
 
-// planNodeRequireSpool serves as marker for nodes whose parent must
-// ensure that the node is fully run to completion (and the results
-// spooled) during the start phase. This is currently implemented by
-// all mutation statements except for upsert.
-type planNodeRequireSpool interface {
-	requireSpool()
-}
-
-var _ planNodeRequireSpool = &serializeNode{}
-
-// planNodeSpool serves as marker for nodes that can perform all their
-// execution during the start phase. This is different from the "fast
-// path" interface because a node that performs all its execution
-// during the start phase might still have some result rows and thus
-// not implement the fast path.
-//
-// This interface exists for the following optimization: nodes
-// that require spooling but are the children of a spooled node
-// do not require the introduction of an explicit spool.
-type planNodeSpooled interface {
-	spooled()
-}
-
-var _ planNodeSpooled = &spoolNode{}
-
 type flowInfo struct {
 	typ     planComponentType
 	diagram execinfrapb.FlowDiagram

--- a/pkg/sql/plan_batch.go
+++ b/pkg/sql/plan_batch.go
@@ -154,9 +154,6 @@ func (s *serializeNode) rowsWritten() int64 {
 	return m.rowsWritten()
 }
 
-// requireSpool implements the planNodeRequireSpool interface.
-func (s *serializeNode) requireSpool() {}
-
 // rowCountNode serializes the results of a batchedPlanNode into a
 // plain planNode interface that has guaranteed FastPathResults
 // behavior and no result columns (i.e. just the count of rows

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -926,6 +926,9 @@ func (opc *optPlanningCtx) runExecBuilder(
 	} else {
 		// Create an explain factory and record the explain.Plan.
 		explainFactory := explain.NewFactory(f, semaCtx, evalCtx)
+		// Disable elision of a spoolNode at the root in order to have valid
+		// association with exec metadata.
+		explainFactory.DisableSpoolElision()
 		bld = execbuilder.New(
 			ctx, explainFactory, &opc.optimizer, mem, opc.catalog, mem.RootExpr(),
 			semaCtx, evalCtx, allowAutoCommit, statements.IsANSIDML(stmt.AST),

--- a/pkg/sql/spool.go
+++ b/pkg/sql/spool.go
@@ -80,9 +80,6 @@ func (s *spoolNode) FastPathResults() (int, bool) {
 	return 0, false
 }
 
-// spooled implements the planNodeSpooled interface.
-func (s *spoolNode) spooled() {}
-
 // Next is part of the planNode interface.
 func (s *spoolNode) Next(params runParams) (bool, error) {
 	s.curRowIdx++


### PR DESCRIPTION
We have an optimization in `ConstructPlan` of the exec factory that if
we have a spoolNode at the root, we remove it. However, this
optimization can break the association of planNodes with exec metadata
(because the explain factory has already captured the spoolNode and is
unaware of the removal later), which makes it so that we currently don't
get any execution statistics for mutation planNodes when RETURNING
clause is specified.

This commit fixes this problem by disabling the spoolNode eliding
optimization when we know that we'll build the explain plan. I chose to
do this by adding a method to the Factory interface (another alternative
could have been to add a parameter to `Build` method but that seemed
less clean). Disabling the optimization comes with some performance
penalty - namely, since we no longer remove the spoolNode from the root,
it'll do its job and will store all rows produced by its input (i.e. for
handling RETURNING clause) in the in-memory row container. I'm not too
happy about this, but it'll only apply with explicit EXPLAIN ANALYZE or
when the query is chosen for collecting exec stats on it (either because
of the stmt diagnostics request or because of the query execution being
sampled).

An alternative solution I tried was to teach the explain factory to also
remove the spoolNode, to match the exec factory. However, that seemed
rather hacky and error-prone - not only do we need to update
`p.Root.wrappedNode`, we also need to peek into (and update)
`explain.Node.children` as well since those children nodes are what we're
walking over when emitting the explain output.

Fixes: #139378

Release note (bug fix): Previously, CockroachDB would omit execution
statistics in EXPLAIN ANALYZE output for mutation nodes when RETURNING
clause was used. The bug has been present since before v21.1 and is now fixed.