### PR TITLE
exec/explain: bump test timeout to 5 minutes

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -52,7 +52,7 @@ go_library(
 
 go_test(
     name = "explain_test",
-    size = "small",
+    size = "medium",
     srcs = [
         "explain_factory_test.go",
         "main_test.go",


### PR DESCRIPTION
We recently added TestMaximumMemoryUsage that is pretty heavy and just saw the package time out with 1 minute, so let's bump the size to 5 minutes.

Fixes: #145027.

Release note: None