### PR TITLE
parser,scanner: fix bugs with parsing and scanning sql comments

### DIFF
--- a/pkg/sql/parser/parse.go
+++ b/pkg/sql/parser/parse.go
@@ -201,6 +201,10 @@ func (p *Parser) parse(
 		return statements.Statement[tree.Statement]{}, err
 	}
 
+	// Once a statement has been parsed, reset the comments to ensure
+	// that the next statement does not pick up comments from the previous
+	// statement.
+	defer p.scanner.ResetComments()
 	return statements.Statement[tree.Statement]{
 		AST:             p.lexer.stmt,
 		SQL:             sql,

--- a/pkg/sql/parser/scanner_test.go
+++ b/pkg/sql/parser/scanner_test.go
@@ -135,6 +135,8 @@ func TestScanComment(t *testing.T) {
 		remainder string
 	}{
 		{`/* hello */world`, "", "world"},
+		{`/* hello */
+world`, "", "\nworld"},
 		{`/* hello */*`, "", "*"},
 		{`/* /* deeply /* nested */ comment */ */`, "", ""},
 		{`/* /* */* */`, "", ""},
@@ -142,7 +144,7 @@ func TestScanComment(t *testing.T) {
 		{`/* multi line
 comment */`, "", ""},
 		{`-- hello world
-foo`, "", "foo"},
+foo`, "", "\nfoo"},
 		{`/*`, "unterminated comment", ""},
 		{`/*/`, "unterminated comment", ""},
 		{`/* /* */`, "unterminated comment", ""},

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -100,6 +100,10 @@ func (s *Scanner) RetainComments() {
 	s.retainComments = true
 }
 
+func (s *Scanner) ResetComments() {
+	s.Comments = nil
+}
+
 // Cleanup is used to avoid holding on to memory unnecessarily (for the cases
 // where we reuse a Scanner).
 func (s *Scanner) Cleanup() {
@@ -596,8 +600,13 @@ func (s *Scanner) ScanComment(lval ScanSymType) (present, ok bool) {
 			return false, true
 		}
 		for {
-			switch s.next() {
-			case eof, '\n':
+			next := s.next()
+			switch next {
+			case eof:
+				return true, true
+			case '\n':
+				// Don't include the new-line character in in-line comments.
+				s.pos--
 				return true, true
 			}
 		}


### PR DESCRIPTION
Fixes a bug in the parser where retained comments are mistakenly added to multiple statements. This when parsing a multi-statement sql containing strings with the "retainComments" bool set to true. In this case, comments in a statement are propogated to subsequent statements in the same parse.

Fixes a bug where `\n` characters are included in scanned singe- line comments. Now, these wont be included in comments and will instead be stripped out via the skipWhitespace function.

Epic: None
Release note: None