### PR TITLE
roachtest/pg_regress: accept recent diffs

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/aggregates.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/aggregates.diffs
@@ -2811,15 +2811,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- test that the aggregate transition logic correctly handles
  -- transition / combine functions returning NULL
  -- First test the case of a normal transition function returning NULL
-@@ -2701,6 +2434,7 @@
+@@ -2701,6 +2434,8 @@
      END IF;
      RETURN NULL;
  END$$;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
++ERROR:  no value provided for placeholder: $1
  CREATE AGGREGATE balk(int4)
  (
      SFUNC = balkifnull(int8, int4),
-@@ -2708,13 +2442,16 @@
+@@ -2708,13 +2443,16 @@
      PARALLEL = SAFE,
      INITCOND = '0'
  );
@@ -2841,7 +2842,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- Secondly test the case of a parallel aggregate combiner function
  -- returning NULL. For that use normal transition function, but a
  -- combiner function returning NULL.
-@@ -2730,6 +2467,23 @@
+@@ -2730,6 +2468,23 @@
      END IF;
      RETURN NULL;
  END$$;
@@ -2865,7 +2866,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE AGGREGATE balk(int4)
  (
      SFUNC = int4_sum(int8, int4),
-@@ -2738,26 +2492,27 @@
+@@ -2738,26 +2493,27 @@
      PARALLEL = SAFE,
      INITCOND = '0'
  );
@@ -2907,7 +2908,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  ROLLBACK;
  -- test multiple usage of an aggregate whose finalfn returns a R/W datum
  BEGIN;
-@@ -2767,6 +2522,8 @@
+@@ -2767,6 +2523,8 @@
      RETURN array_fill(y[1], ARRAY[4]);
  END;
  $$;
@@ -2916,7 +2917,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE FUNCTION rwagg_finalfunc(x anyarray) RETURNS anyarray
  LANGUAGE plpgsql STRICT IMMUTABLE AS $$
  DECLARE
-@@ -2777,11 +2534,25 @@
+@@ -2777,11 +2535,25 @@
      RETURN res;
  END;
  $$;
@@ -2942,7 +2943,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE FUNCTION eatarray(x real[]) RETURNS real[]
  LANGUAGE plpgsql STRICT IMMUTABLE AS $$
  BEGIN
-@@ -2789,21 +2560,44 @@
+@@ -2789,21 +2561,44 @@
      RETURN x;
  END;
  $$;
@@ -2992,7 +2993,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- variance(int4) covers numeric_poly_combine
  -- sum(int8) covers int8_avg_combine
  -- regr_count(float8, float8) covers int8inc_float8_float8 and aggregates with > 1 arg
-@@ -2813,36 +2607,17 @@
+@@ -2813,36 +2608,17 @@
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1) u;
@@ -3035,7 +3036,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- variance(int8) covers numeric_combine
  -- avg(numeric) covers numeric_avg_combine
  EXPLAIN (COSTS OFF, VERBOSE)
-@@ -2851,46 +2626,22 @@
+@@ -2851,46 +2627,22 @@
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1) u;
@@ -3090,7 +3091,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- Ensure that the STRICT checks for aggregates does not take NULLness
  -- of ORDER BY columns into account. See bug report around
  -- 2a505161-2727-2473-7c46-591ed108ac52@email.cz
-@@ -2929,27 +2680,46 @@
+@@ -2929,27 +2681,46 @@
  -- does not lead to array overflow due to unexpected duplicate hash keys
  -- see CAFeeJoKKu0u+A_A9R9316djW-YW3-+Gtgvy3ju655qRHR3jtdA@mail.gmail.com
  set enable_memoize to off;
@@ -3149,7 +3150,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  select unique1, count(*), sum(twothousand) from tenk1
  group by unique1
  having sum(fivethous) > 4975
-@@ -3007,36 +2777,84 @@
+@@ -3007,36 +2778,84 @@
  (48 rows)
  
  set work_mem to default;
@@ -3243,7 +3244,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create table agg_group_2 as
  select * from
    (values (100), (300), (500)) as r(a),
-@@ -3047,30 +2865,58 @@
+@@ -3047,30 +2866,58 @@
      from agg_data_2k
      where g < r.a
      group by g/2) as s;
@@ -3309,7 +3310,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create table agg_hash_2 as
  select * from
    (values (100), (300), (500)) as r(a),
-@@ -3081,15 +2927,43 @@
+@@ -3081,15 +2928,43 @@
      from agg_data_2k
      where g < r.a
      group by g/2) as s;

--- a/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
@@ -5216,13 +5216,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +ERROR:  index with name "tt9_c_key" already exists
  ALTER TABLE tt9 ADD CONSTRAINT foo UNIQUE(c);  -- fail, dup name
 -ERROR:  constraint "foo" for relation "tt9" already exists
-+ERROR:  error executing StatementPhase stage 1 of 1 with 7 MutationType ops: relation "tt9" (2079): duplicate constraint name: "foo"
++ERROR:  error executing StatementPhase stage 1 of 1 with 7 MutationType ops: relation "tt9": duplicate constraint name: "foo"
  ALTER TABLE tt9 ADD CONSTRAINT tt9_c_key CHECK(c > 5);  -- fail, dup name
 -ERROR:  constraint "tt9_c_key" for relation "tt9" already exists
-+ERROR:  error executing StatementPhase stage 1 of 1 with 2 MutationType ops: relation "tt9" (2079): duplicate constraint name: "tt9_c_key"
++ERROR:  error executing StatementPhase stage 1 of 1 with 2 MutationType ops: relation "tt9": duplicate constraint name: "tt9_c_key"
  ALTER TABLE tt9 ADD CONSTRAINT tt9_c_key2 CHECK(c > 6);
  ALTER TABLE tt9 ADD UNIQUE(c);  -- picks nonconflicting name
-+ERROR:  error executing StatementPhase stage 1 of 1 with 7 MutationType ops: relation "tt9" (2079): duplicate constraint name: "tt9_c_key2"
++ERROR:  error executing StatementPhase stage 1 of 1 with 7 MutationType ops: relation "tt9": duplicate constraint name: "tt9_c_key2"
  \d tt9
 -                Table "public.tt9"
 - Column |  Type   | Collation | Nullable | Default 
@@ -5417,7 +5417,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check relpersistence of an unlogged table
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^unlogged1'
  UNION ALL
-@@ -3511,21 +4295,36 @@
+@@ -3511,21 +4295,24 @@
  UNION ALL
  SELECT r.relname || ' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^unlogged1'
  ORDER BY relname;
@@ -5442,28 +5442,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +NOTICE:  using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/_version_/serial.html
 +NOTICE:  UNLOGGED TABLE will behave as a regular table in CockroachDB
  ALTER TABLE unlogged3 SET LOGGED; -- skip self-referencing foreign key
-+ERROR:  at or near "logged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE unlogged3 SET LOGGED
-+                          ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET LOGGED is not supported and has no effect
  ALTER TABLE unlogged2 SET LOGGED; -- fails because a foreign key to an unlogged table exists
 -ERROR:  could not change table "unlogged2" to logged because it references unlogged table "unlogged1"
-+ERROR:  at or near "logged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE unlogged2 SET LOGGED
-+                          ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET LOGGED is not supported and has no effect
  ALTER TABLE unlogged1 SET LOGGED;
-+ERROR:  at or near "logged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE unlogged1 SET LOGGED
-+                          ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET LOGGED is not supported and has no effect
  -- check relpersistence of an unlogged table after changing to permanent
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^unlogged1'
  UNION ALL
-@@ -3533,21 +4332,24 @@
+@@ -3533,21 +4320,20 @@
  UNION ALL
  SELECT r.relname || ' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^unlogged1'
  ORDER BY relname;
@@ -5482,11 +5470,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +(2 rows)
  
  ALTER TABLE unlogged1 SET LOGGED; -- silently do nothing
-+ERROR:  at or near "logged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE unlogged1 SET LOGGED
-+                          ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET LOGGED is not supported and has no effect
  DROP TABLE unlogged3;
  DROP TABLE unlogged2;
  DROP TABLE unlogged1;
@@ -5496,7 +5480,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check relpersistence of a permanent table
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^logged1'
  UNION ALL
-@@ -3555,22 +4357,40 @@
+@@ -3555,22 +4341,24 @@
  UNION ALL
  SELECT r.relname ||' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^logged1'
  ORDER BY relname;
@@ -5520,33 +5504,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +NOTICE:  using sequential values in a primary key does not perform as well as using random UUIDs. See https://www.cockroachlabs.com/docs/_version_/serial.html
  ALTER TABLE logged1 SET UNLOGGED; -- fails because a foreign key from a permanent table exists
 -ERROR:  could not change table "logged1" to unlogged because it references logged table "logged2"
-+ERROR:  at or near "unlogged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE logged1 SET UNLOGGED
-+                        ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET UNLOGGED is not supported and has no effect
  ALTER TABLE logged3 SET UNLOGGED; -- skip self-referencing foreign key
-+ERROR:  at or near "unlogged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE logged3 SET UNLOGGED
-+                        ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET UNLOGGED is not supported and has no effect
  ALTER TABLE logged2 SET UNLOGGED;
-+ERROR:  at or near "unlogged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE logged2 SET UNLOGGED
-+                        ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET UNLOGGED is not supported and has no effect
  ALTER TABLE logged1 SET UNLOGGED;
-+ERROR:  at or near "unlogged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE logged1 SET UNLOGGED
-+                        ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET UNLOGGED is not supported and has no effect
  -- check relpersistence of a permanent table after changing to unlogged
  SELECT relname, relkind, relpersistence FROM pg_class WHERE relname ~ '^logged1'
  UNION ALL
-@@ -3578,36 +4398,45 @@
+@@ -3578,36 +4366,41 @@
  UNION ALL
  SELECT r.relname || ' toast index', ri.relkind, ri.relpersistence FROM pg_class r join pg_class t ON t.oid = r.reltoastrelid JOIN pg_index i ON i.indrelid = t.oid JOIN pg_class ri ON ri.oid = i.indexrelid WHERE r.relname ~ '^logged1'
  ORDER BY relname;
@@ -5565,11 +5533,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +(2 rows)
  
  ALTER TABLE logged1 SET UNLOGGED; -- silently do nothing
-+ERROR:  at or near "unlogged": syntax error
-+DETAIL:  source SQL:
-+ALTER TABLE logged1 SET UNLOGGED
-+                        ^
-+HINT:  try \h ALTER TABLE
++NOTICE:  SET UNLOGGED is not supported and has no effect
  DROP TABLE logged3;
  DROP TABLE logged2;
  DROP TABLE logged1;
@@ -5611,7 +5575,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  ALTER TABLE test_add_column
  	ADD COLUMN c2 integer; -- fail because c2 already exists
  ERROR:  column "c2" of relation "test_add_column" already exists
-@@ -3615,159 +4444,132 @@
+@@ -3615,159 +4408,132 @@
  	ADD COLUMN c2 integer; -- fail because c2 already exists
  ERROR:  column "c2" of relation "test_add_column" already exists
  \d test_add_column
@@ -5863,7 +5827,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- assorted cases with multiple ALTER TABLE steps
  CREATE TABLE ataddindex(f1 INT);
  INSERT INTO ataddindex VALUES (42), (43);
-@@ -3775,100 +4577,134 @@
+@@ -3775,100 +4541,134 @@
  ALTER TABLE ataddindex
    ADD PRIMARY KEY USING INDEX ataddindexi0,
    ALTER f1 TYPE BIGINT;
@@ -6048,7 +6012,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  --
  -- ATTACH PARTITION
  --
-@@ -3878,7 +4714,11 @@
+@@ -3878,7 +4678,11 @@
  );
  CREATE TABLE fail_part (like unparted);
  ALTER TABLE unparted ATTACH PARTITION fail_part FOR VALUES IN ('a');
@@ -6061,7 +6025,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE unparted, fail_part;
  -- check that partition bound is compatible
  CREATE TABLE list_parted (
-@@ -3886,62 +4726,146 @@
+@@ -3886,62 +4690,146 @@
  	b char(2) COLLATE "C",
  	CONSTRAINT check_a CHECK (a > 0)
  ) PARTITION BY LIST (a);
@@ -6222,7 +6186,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  DROP TABLE fail_part;
  -- check that columns match in type, collation and NOT NULL status
  CREATE TABLE fail_part (
-@@ -3949,158 +4873,335 @@
+@@ -3949,158 +4837,335 @@
  	a int NOT NULL
  );
  ALTER TABLE list_parted ATTACH PARTITION fail_part FOR VALUES IN (1);
@@ -6233,7 +6197,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +                        ^
 +HINT:  try \h ALTER TABLE
  ALTER TABLE fail_part ALTER b TYPE char (2) COLLATE "POSIX";
-+ERROR:  invalid locale posix
++ERROR:  invalid locale POSIX
  ALTER TABLE list_parted ATTACH PARTITION fail_part FOR VALUES IN (1);
 -ERROR:  child table "fail_part" has different collation for column "b"
 +ERROR:  at or near "attach": syntax error
@@ -6587,7 +6551,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Check the case where attnos of the partitioning columns in the table being
  -- attached differs from the parent.  It should not affect the constraint-
  -- checking logic that allows to skip the scan.
-@@ -4109,8 +5210,15 @@
+@@ -4109,8 +5174,15 @@
  	LIKE list_parted2,
  	CONSTRAINT check_a CHECK (a IS NOT NULL AND a = 6)
  );
@@ -6603,7 +6567,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- Similar to above, but the table being attached is a partitioned table
  -- whose partition has still different attnos for the root partitioning
  -- columns.
-@@ -4118,6 +5226,14 @@
+@@ -4118,6 +5190,14 @@
  	LIKE list_parted2,
  	CONSTRAINT check_a CHECK (a IS NOT NULL AND a = 7)
  ) PARTITION BY LIST (b);
@@ -6618,7 +6582,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  CREATE TABLE part_7_a_null (
  	c int,
  	d int,
-@@ -4126,63 +5242,150 @@
+@@ -4126,63 +5206,150 @@
  	CONSTRAINT check_b CHECK (b IS NULL OR b = 'a'),
  	CONSTRAINT check_a CHECK (a IS NOT NULL AND a = 7)
  );
@@ -6782,7 +6746,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- check validation when attaching hash partitions
  -- Use hand-rolled hash functions and operator class to get predictable result
  -- on different machines. part_test_int4_ops is defined in insert.sql.
-@@ -4191,233 +5394,430 @@
+@@ -4191,233 +5358,430 @@
  	a int,
  	b int
  ) PARTITION BY HASH (a part_test_int4_ops);
@@ -7297,7 +7261,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- attnum for key attribute 'a' is different in p, p1, and p11
  select attrelid::regclass, attname, attnum
  from pg_attribute
-@@ -4426,73 +5826,156 @@
+@@ -4426,73 +5790,156 @@
     or attrelid = 'p1'::regclass
     or attrelid = 'p11'::regclass)
  order by attrelid::regclass::text;
@@ -7466,7 +7430,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create or replace function func_part_attach() returns trigger
    language plpgsql as $$
    begin
-@@ -4500,14 +5983,28 @@
+@@ -4500,14 +5947,28 @@
      execute 'alter table tab_part_attach attach partition tab_part_attach_1 for values in (1)';
      return null;
    end $$;
@@ -7498,7 +7462,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- test case where the partitioning operator is a SQL function whose
  -- evaluation results in the table's relcache being rebuilt partway through
  -- the execution of an ATTACH PARTITION command
-@@ -4517,11 +6014,43 @@
+@@ -4517,11 +5978,43 @@
      operator 1 < (int4, int4), operator 2 <= (int4, int4),
      operator 3 = (int4, int4), operator 4 >= (int4, int4),
      operator 5 > (int4, int4), function 1 at_test_sql_partop(int4, int4);
@@ -7542,7 +7506,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  drop function at_test_sql_partop;
  /* Test case for bug #16242 */
  -- We create a parent and child where the child has missing
-@@ -4529,18 +6058,25 @@
+@@ -4529,18 +6022,25 @@
  -- tuple conversion from the child to the parent tupdesc
  create table bar1 (a integer, b integer not null default 1)
    partition by range (a);
@@ -7573,7 +7537,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  -- this exercises tuple conversion:
  create function xtrig()
    returns trigger language plpgsql
-@@ -4554,22 +6090,50 @@
+@@ -4554,22 +6054,50 @@
      return NULL;
    end;
  $$;
@@ -7625,7 +7589,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create table atref (c1 int references attbl(p1));
  alter table attbl alter column p1 set data type bigint;
  alter table atref alter column c1 set data type bigint;
-@@ -4579,15 +6143,21 @@
+@@ -4579,15 +6107,21 @@
  -- for normal indexes and indexes on constraints.
  create table alttype_cluster (a int);
  alter table alttype_cluster add primary key (a);
@@ -7648,7 +7612,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
   alttype_cluster_pkey | f
  (2 rows)
  
-@@ -4597,19 +6167,24 @@
+@@ -4597,19 +6131,24 @@
    order by indexrelid::regclass::text;
        indexrelid      | indisclustered 
  ----------------------+----------------
@@ -7675,7 +7639,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (2 rows)
  
  alter table alttype_cluster alter a type int;
-@@ -4619,7 +6194,7 @@
+@@ -4619,7 +6158,7 @@
        indexrelid      | indisclustered 
  ----------------------+----------------
   alttype_cluster_ind  | f
@@ -7684,7 +7648,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  (2 rows)
  
  drop table alttype_cluster;
-@@ -4628,38 +6203,97 @@
+@@ -4628,38 +6167,97 @@
  -- to its partitions' constraint being updated to reflect the parent's
  -- newly added/removed constraint
  create table target_parted (a int, b int) partition by list (a);

--- a/pkg/cmd/roachtest/testdata/pg_regress/case.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/case.diffs
@@ -185,16 +185,25 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/case.out --label=
  (4 rows)
  
  --
-@@ -343,6 +303,7 @@
+@@ -343,6 +303,8 @@
  BEGIN;
  CREATE FUNCTION vol(text) returns text as
    'begin return $1; end' language plpgsql volatile;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
++ERROR:  no value provided for placeholder: $1
  SELECT CASE
    (CASE vol('bar')
      WHEN 'foo' THEN 'it was foo!'
-@@ -359,48 +320,70 @@
- 
+@@ -352,55 +314,73 @@
+   WHEN 'it was foo!' THEN 'foo recognized'
+   WHEN 'it was bar!' THEN 'bar recognized'
+   ELSE 'unrecognized' END;
+-      case      
+-----------------
+- bar recognized
+-(1 row)
+-
++ERROR:  unknown function: vol()
  -- In this case, we can't inline the SQL function without confusing things.
  CREATE DOMAIN foodomain AS text;
 +ERROR:  at or near "as": syntax error: unimplemented: this syntax
@@ -274,7 +283,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/case.out --label=
  SELECT
    CASE 'foo'::text
      WHEN 'foo' THEN ARRAY['a', 'b', 'c', 'd'] || enum_range(NULL::casetestenum)::text[]
-@@ -412,6 +395,7 @@
+@@ -412,6 +392,7 @@
  (1 row)
  
  ROLLBACK;

--- a/pkg/cmd/roachtest/testdata/pg_regress/collate.linux.utf8.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/collate.linux.utf8.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/collate.linux.utf8_1.out --label=/mnt/data1/postgres/src/test/regress/results/collate.linux.utf8.out /mnt/data1/postgres/src/test/regress/expected/collate.linux.utf8_1.out /mnt/data1/postgres/src/test/regress/results/collate.linux.utf8.out
 --- /mnt/data1/postgres/src/test/regress/expected/collate.linux.utf8_1.out
 +++ /mnt/data1/postgres/src/test/regress/results/collate.linux.utf8.out
-@@ -7,5 +7,1026 @@
+@@ -7,5 +7,1027 @@
         (SELECT count(*) FROM pg_collation WHERE collname IN ('de_DE', 'en_US', 'sv_SE', 'tr_TR') AND collencoding = pg_char_to_encoding('UTF8')) <> 4 OR
         version() !~ 'linux-gnu'
         AS skip_test \gset
@@ -350,10 +350,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/collate.linux.utf
 +ERROR:  lower(): unsupported binary operator: <collatedstring{en_US}> || <collatedstring{en_US}> (returning <string>)
 +SELECT table_name, view_definition FROM information_schema.views
 +  WHERE table_name LIKE 'collview%' ORDER BY 1;
-+ table_name |                                             view_definition                                              
-+------------+----------------------------------------------------------------------------------------------------------
-+ collview1  | SELECT collate_test1.a, collate_test1.b FROM root.collate_tests.collate_test1 WHERE b COLLATE c >= 'bbc'
-+ collview2  | SELECT a, b FROM root.collate_tests.collate_test1 ORDER BY b COLLATE c
++ table_name |                                              view_definition                                               
++------------+------------------------------------------------------------------------------------------------------------
++ collview1  | SELECT collate_test1.a, collate_test1.b FROM root.collate_tests.collate_test1 WHERE b COLLATE "C" >= 'bbc'
++ collview2  | SELECT a, b FROM root.collate_tests.collate_test1 ORDER BY b COLLATE "C"
 +(2 rows)
 +
 +-- collation propagation in various expression types
@@ -573,6 +573,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/collate.linux.utf
 +    AS $$ select $1 < $2 limit 1 $$;
 +CREATE FUNCTION mylt_plpgsql (text, text) RETURNS boolean LANGUAGE plpgsql
 +    AS $$ begin return $1 < $2; end $$;
++ERROR:  no value provided for placeholder: $1
 +SELECT a.b AS a, b.b AS b, a.b < b.b AS lt,
 +       mylt(a.b, b.b), mylt_noninline(a.b, b.b), mylt_plpgsql(a.b, b.b)
 +FROM collate_test1 a, collate_test1 b

--- a/pkg/cmd/roachtest/testdata/pg_regress/collate.windows.win1252.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/collate.windows.win1252.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/collate.windows.win1252_1.out --label=/mnt/data1/postgres/src/test/regress/results/collate.windows.win1252.out /mnt/data1/postgres/src/test/regress/expected/collate.windows.win1252_1.out /mnt/data1/postgres/src/test/regress/results/collate.windows.win1252.out
 --- /mnt/data1/postgres/src/test/regress/expected/collate.windows.win1252_1.out
 +++ /mnt/data1/postgres/src/test/regress/results/collate.windows.win1252.out
-@@ -9,5 +9,869 @@
+@@ -9,5 +9,870 @@
         (SELECT count(*) FROM pg_collation WHERE collname IN ('de_DE', 'en_US', 'sv_SE') AND collencoding = pg_char_to_encoding('WIN1252')) <> 3 OR
         (version() !~ 'Visual C\+\+' AND version() !~ 'mingw32' AND version() !~ 'windows')
         AS skip_test \gset
@@ -274,10 +274,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/collate.windows.w
 +CREATE VIEW collview2 AS SELECT a, b FROM collate_test1 ORDER BY b COLLATE "C";
 +SELECT table_name, view_definition FROM information_schema.views
 +  WHERE table_name LIKE 'collview%' ORDER BY 1;
-+ table_name |                                             view_definition                                              
-+------------+----------------------------------------------------------------------------------------------------------
-+ collview1  | SELECT collate_test1.a, collate_test1.b FROM root.collate_tests.collate_test1 WHERE b COLLATE c >= 'bbc'
-+ collview2  | SELECT a, b FROM root.collate_tests.collate_test1 ORDER BY b COLLATE c
++ table_name |                                              view_definition                                               
++------------+------------------------------------------------------------------------------------------------------------
++ collview1  | SELECT collate_test1.a, collate_test1.b FROM root.collate_tests.collate_test1 WHERE b COLLATE "C" >= 'bbc'
++ collview2  | SELECT a, b FROM root.collate_tests.collate_test1 ORDER BY b COLLATE "C"
 +(2 rows)
 +
 +-- collation propagation in various expression types
@@ -427,6 +427,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/collate.windows.w
 +    AS $$ select $1 < $2 limit 1 $$;
 +CREATE FUNCTION mylt_plpgsql (text, text) RETURNS boolean LANGUAGE plpgsql
 +    AS $$ begin return $1 < $2; end $$;
++ERROR:  no value provided for placeholder: $1
 +SELECT a.b AS a, b.b AS b, a.b < b.b AS lt,
 +       mylt(a.b, b.b), mylt_noninline(a.b, b.b), mylt_plpgsql(a.b, b.b)
 +FROM collate_test1 a, collate_test1 b

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_index.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_index.diffs
@@ -3577,13 +3577,26 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  CREATE OR REPLACE FUNCTION compare_relfilenode_part(tabname text)
    RETURNS TABLE (relname name, relkind "char", state text) AS
    $func$
-@@ -2412,195 +2528,248 @@
+@@ -2412,195 +2528,261 @@
             ORDER BY 1;', tabname);
    END
    $func$ LANGUAGE plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++BEGIN
++    RETURN QUERY EXECUTE
++                 ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  --  Check that expected relfilenodes are changed, non-concurrent case.
  SELECT create_relfilenode_part('reindex_index_status', 'concur_reindex_part_index');
 - create_relfilenode_part 
@@ -3939,12 +3952,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  DROP TABLE concur_reindex_tab4;
  -- Check handling of indexes with expressions and predicates.  The
  -- definitions of the rebuilt indexes should match the original
-@@ -2613,76 +2782,78 @@
-   ON concur_exprs_tab ((c1::text COLLATE "C"));
- CREATE UNIQUE INDEX concur_exprs_index_pred ON concur_exprs_tab (c1)
-   WHERE (c1::text > 500000000::text COLLATE "C");
-+ERROR:  invalid locale c: language: tag is not well-formed
- CREATE UNIQUE INDEX concur_exprs_index_pred_2
+@@ -2617,72 +2799,85 @@
    ON concur_exprs_tab ((1 / c1))
    WHERE ('-H') >= (c2::TEXT) COLLATE "C";
  ALTER INDEX concur_exprs_index_expr ALTER COLUMN 1 SET STATISTICS 100;
@@ -3980,9 +3988,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
 -                                                               pg_get_indexdef                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------
 - CREATE UNIQUE INDEX concur_exprs_index_pred ON public.concur_exprs_tab USING btree (c1) WHERE ((c1)::text > ((500000000)::text COLLATE "C"))
--(1 row)
--
-+ERROR:  relation "concur_exprs_index_pred" does not exist
++                                                             pg_get_indexdef                                                             
++-----------------------------------------------------------------------------------------------------------------------------------------
++ CREATE UNIQUE INDEX concur_exprs_index_pred ON root.public.concur_exprs_tab USING btree (c1 ASC) WHERE (c1::STRING > 500000000::STRING)
+ (1 row)
+ 
  SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
 -                                                                 pg_get_indexdef                                                                  
 ---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4011,9 +4021,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
 -                                                               pg_get_indexdef                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------
 - CREATE UNIQUE INDEX concur_exprs_index_pred ON public.concur_exprs_tab USING btree (c1) WHERE ((c1)::text > ((500000000)::text COLLATE "C"))
--(1 row)
--
-+ERROR:  relation "concur_exprs_index_pred" does not exist
++                                                             pg_get_indexdef                                                             
++-----------------------------------------------------------------------------------------------------------------------------------------
++ CREATE UNIQUE INDEX concur_exprs_index_pred ON root.public.concur_exprs_tab USING btree (c1 ASC) WHERE (c1::STRING > 500000000::STRING)
+ (1 row)
+ 
  SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
 -                                                                 pg_get_indexdef                                                                  
 ---------------------------------------------------------------------------------------------------------------------------------------------------
@@ -4042,9 +4054,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
 -                                                               pg_get_indexdef                                                                
 -----------------------------------------------------------------------------------------------------------------------------------------------
 - CREATE UNIQUE INDEX concur_exprs_index_pred ON public.concur_exprs_tab USING btree (c1) WHERE ((c1)::text > ((500000000)::text COLLATE "C"))
--(1 row)
--
-+ERROR:  relation "concur_exprs_index_pred" does not exist
++                                                             pg_get_indexdef                                                             
++-----------------------------------------------------------------------------------------------------------------------------------------
++ CREATE UNIQUE INDEX concur_exprs_index_pred ON root.public.concur_exprs_tab USING btree (c1 ASC) WHERE (c1::STRING > 500000000::STRING)
+ (1 row)
+ 
  SELECT pg_get_indexdef('concur_exprs_index_pred_2'::regclass);
 -                                                             pg_get_indexdef                                                              
 -------------------------------------------------------------------------------------------------------------------------------------------
@@ -4055,7 +4069,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  (1 row)
  
  -- Statistics should remain intact.
-@@ -2691,10 +2862,9 @@
+@@ -2691,10 +2886,9 @@
    'concur_exprs_index_pred'::regclass,
    'concur_exprs_index_pred_2'::regclass)
    GROUP BY starelid ORDER BY starelid::regclass::text;
@@ -4069,22 +4083,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  
  -- attstattarget should remain intact
  SELECT attrelid::regclass, attnum, attstattarget
-@@ -2703,13 +2873,7 @@
-     'concur_exprs_index_pred'::regclass,
-     'concur_exprs_index_pred_2'::regclass)
+@@ -2705,9 +2899,9 @@
    ORDER BY attrelid::regclass::text, attnum;
--         attrelid          | attnum | attstattarget 
-----------------------------+--------+---------------
+          attrelid          | attnum | attstattarget 
+ ---------------------------+--------+---------------
 - concur_exprs_index_expr   |      1 |           100
 - concur_exprs_index_pred   |      1 |            -1
 - concur_exprs_index_pred_2 |      1 |            -1
--(3 rows)
--
-+ERROR:  relation "concur_exprs_index_pred" does not exist
++ concur_exprs_index_expr   |      1 |             0
++ concur_exprs_index_pred   |      1 |             0
++ concur_exprs_index_pred_2 |      1 |             0
+ (3 rows)
+ 
  DROP TABLE concur_exprs_tab;
- -- Temporary tables and on-commit actions, where CONCURRENTLY is ignored.
- -- ON COMMIT PRESERVE ROWS, the default.
-@@ -2718,58 +2882,103 @@
+@@ -2718,58 +2912,103 @@
  INSERT INTO concur_temp_tab_1 VALUES (1, 'foo'), (2, 'bar');
  CREATE INDEX concur_temp_ind_1 ON concur_temp_tab_1(c2);
  REINDEX TABLE CONCURRENTLY concur_temp_tab_1;
@@ -4197,7 +4209,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  INSERT INTO table2 SELECT generate_series(1,400), 'abc';
  CREATE INDEX ON table2(col2);
  CREATE MATERIALIZED VIEW matview AS SELECT col1 FROM table2;
-@@ -2779,6 +2988,7 @@
+@@ -2779,6 +3018,7 @@
  SELECT oid, relname, relfilenode, relkind, reltoastrelid
  	FROM pg_class
  	where relnamespace = (SELECT oid FROM pg_namespace WHERE nspname = 'schema_to_reindex');
@@ -4205,7 +4217,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_index.out 
  INSERT INTO reindex_before
  SELECT oid, 'pg_toast_TABLE', relfilenode, relkind, reltoastrelid
  FROM pg_class WHERE oid IN
-@@ -2789,60 +2999,84 @@
+@@ -2789,60 +3029,84 @@
  	(select indexrelid from pg_index where indrelid in
  		(select reltoastrelid from reindex_before where reltoastrelid > 0));
  REINDEX SCHEMA schema_to_reindex;

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_role.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_role.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out --label=/mnt/data1/postgres/src/test/regress/results/create_role.out /mnt/data1/postgres/src/test/regress/expected/create_role.out /mnt/data1/postgres/src/test/regress/results/create_role.out
 --- /mnt/data1/postgres/src/test/regress/expected/create_role.out
 +++ /mnt/data1/postgres/src/test/regress/results/create_role.out
-@@ -1,98 +1,184 @@
+@@ -1,44 +1,54 @@
  -- ok, superuser can create users with any set of privileges
  CREATE ROLE regress_role_super SUPERUSER;
 +ERROR:  at or near "superuser": syntax error
@@ -10,11 +10,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
 +                               ^
 +HINT:  try \h CREATE ROLE
  CREATE ROLE regress_role_admin CREATEDB CREATEROLE REPLICATION BYPASSRLS;
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
  GRANT CREATE ON DATABASE regression TO regress_role_admin WITH GRANT OPTION;
-+ERROR:  role/user "regress_role_admin" does not exist
++ERROR:  database "regression" does not exist
  CREATE ROLE regress_role_limited_admin CREATEROLE;
  CREATE ROLE regress_role_normal;
  -- fail, CREATEROLE user can't give away role attributes without having them
@@ -36,18 +33,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
  CREATE ROLE regress_nosuch_replication_bypassrls REPLICATION BYPASSRLS;
 -ERROR:  permission denied to create role
 -DETAIL:  Only roles with the REPLICATION attribute may create roles with the REPLICATION attribute.
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
  CREATE ROLE regress_nosuch_replication REPLICATION;
 -ERROR:  permission denied to create role
 -DETAIL:  Only roles with the REPLICATION attribute may create roles with the REPLICATION attribute.
  CREATE ROLE regress_nosuch_bypassrls BYPASSRLS;
 -ERROR:  permission denied to create role
 -DETAIL:  Only roles with the BYPASSRLS attribute may create roles with the BYPASSRLS attribute.
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
  CREATE ROLE regress_nosuch_createdb CREATEDB;
 -ERROR:  permission denied to create role
 -DETAIL:  Only roles with the CREATEDB attribute may create roles with the CREATEDB attribute.
@@ -71,9 +62,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
  ALTER ROLE regress_role_limited BYPASSRLS;
 -ERROR:  permission denied to alter role
 -DETAIL:  Only roles with the BYPASSRLS attribute may change the BYPASSRLS attribute.
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
  DROP ROLE regress_role_limited;
  -- ok, can give away these role attributes if you have them
  SET SESSION AUTHORIZATION regress_role_admin;
@@ -84,23 +72,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE ROLE regress_replication_bypassrls REPLICATION BYPASSRLS;
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
  CREATE ROLE regress_replication REPLICATION;
  CREATE ROLE regress_bypassrls BYPASSRLS;
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
- CREATE ROLE regress_createdb CREATEDB;
- -- ok, can toggle these role attributes off and on if you have them
- ALTER ROLE regress_replication NOREPLICATION;
- ALTER ROLE regress_replication REPLICATION;
- ALTER ROLE regress_bypassrls NOBYPASSRLS;
-+ERROR:  role/user "regress_bypassrls" does not exist
- ALTER ROLE regress_bypassrls BYPASSRLS;
-+ERROR:  role/user "regress_bypassrls" does not exist
- ALTER ROLE regress_createdb NOCREATEDB;
+@@ -52,47 +62,103 @@
  ALTER ROLE regress_createdb CREATEDB;
  -- fail, can't toggle SUPERUSER
  ALTER ROLE regress_createdb SUPERUSER;
@@ -215,7 +189,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
  -- ok, regress_createrole can create new roles
  CREATE ROLE regress_plainrole;
  -- ok, roles with CREATEROLE can create new roles with it
-@@ -100,161 +186,280 @@
+@@ -100,161 +166,274 @@
  -- ok, roles with CREATEROLE can create new roles with different role
  -- attributes, including CREATEROLE
  CREATE ROLE regress_hasprivs CREATEROLE LOGIN INHERIT CONNECTION LIMIT 5;
@@ -295,7 +269,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
 -ERROR:  must be owner of table tenant_table
  ALTER VIEW tenant_view OWNER TO regress_role_admin;
 -ERROR:  must be owner of view tenant_view
-+ERROR:  role/user "regress_role_admin" does not exist
  DROP VIEW tenant_view;
 -ERROR:  must be owner of view tenant_view
  -- fail, can't create objects owned as regress_tenant
@@ -459,12 +432,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
 +ERROR:  role/user "regress_nosuch_superuser" does not exist
  DROP ROLE regress_nosuch_replication_bypassrls;
 -ERROR:  role "regress_nosuch_replication_bypassrls" does not exist
-+ERROR:  role/user "regress_nosuch_replication_bypassrls" does not exist
  DROP ROLE regress_nosuch_replication;
 -ERROR:  role "regress_nosuch_replication" does not exist
  DROP ROLE regress_nosuch_bypassrls;
 -ERROR:  role "regress_nosuch_bypassrls" does not exist
-+ERROR:  role/user "regress_nosuch_bypassrls" does not exist
  DROP ROLE regress_nosuch_super;
 -ERROR:  role "regress_nosuch_super" does not exist
 +ERROR:  role/user "regress_nosuch_super" does not exist
@@ -486,10 +457,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
 +                                                             ^
  -- ok, should be able to drop non-superuser roles we created
  DROP ROLE regress_replication_bypassrls;
-+ERROR:  role/user "regress_replication_bypassrls" does not exist
  DROP ROLE regress_replication;
  DROP ROLE regress_bypassrls;
-+ERROR:  role/user "regress_bypassrls" does not exist
  DROP ROLE regress_createdb;
  DROP ROLE regress_createrole;
 +ERROR:  role/user "regress_createrole" does not exist
@@ -514,7 +483,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_role.out -
 +ERROR:  role/user "regress_role_super" does not exist
  DROP ROLE regress_role_admin;
 -ERROR:  current user cannot be dropped
-+ERROR:  role/user "regress_role_admin" does not exist
  DROP ROLE regress_rolecreator;
 -ERROR:  permission denied to drop role
 -DETAIL:  Only roles with the CREATEROLE attribute and the ADMIN option on role "regress_rolecreator" may drop this role.

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_table_like.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_table_like.diffs
@@ -54,7 +54,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_table_like
  
  CREATE TABLE inhf (LIKE inhx, LIKE inhx); /* Throw error */
 -ERROR:  column "xx" specified more than once
-+ERROR:  relation "inhf" (1360): duplicate column name: "xx"
++ERROR:  relation "inhf": duplicate column name: "xx"
  CREATE TABLE inhf (LIKE inhx INCLUDING DEFAULTS INCLUDING CONSTRAINTS);
  INSERT INTO inhf DEFAULT VALUES;
  SELECT * FROM inhf; /* Single entry with value 'text' */

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_view.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_view.diffs
@@ -124,7 +124,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
 +See: https://go.crdb.dev/issue-v/48026/_version_
  CREATE VIEW key_dependent_view_no_cols AS
     SELECT FROM view_base_table GROUP BY key HAVING length(data) > 0;
-+ERROR:  relation "key_dependent_view_no_cols" (327): table must contain at least 1 column
++ERROR:  relation "key_dependent_view_no_cols": table must contain at least 1 column
  --
  -- CREATE OR REPLACE VIEW
  --
@@ -2050,13 +2050,28 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  --
  -- Check cases involving dropped/altered columns in a function's rowtype result
  --
-@@ -1581,26 +1058,18 @@
+@@ -1581,26 +1058,33 @@
  end;
  $$
  language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++    rec1 record;
++begin
++    for rec1 in select * from tt14t
++             ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  create view tt14v as select t.* from tt14f() t;
 +ERROR:  unknown function: tt14f()
 +HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
@@ -2085,7 +2100,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -1614,46 +1083,28 @@
+@@ -1614,46 +1098,28 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2142,7 +2157,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- ... but some bug might let it happen, so check defenses
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -1664,124 +1115,63 @@
+@@ -1664,124 +1130,63 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2299,7 +2314,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  select * from int8_tbl i, lateral(values(i.*::int8_tbl)) ss;
          q1        |        q2         |               column1                
  ------------------+-------------------+--------------------------------------
-@@ -1804,14 +1194,8 @@
+@@ -1804,14 +1209,8 @@
  (5 rows)
  
  select pg_get_viewdef('tt17v', true);
@@ -2316,7 +2331,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  select * from int8_tbl i where i.* in (values(i.*::int8_tbl));
          q1        |        q2         
  ------------------+-------------------
-@@ -1823,48 +1207,48 @@
+@@ -1823,48 +1222,48 @@
  (5 rows)
  
  create table tt15v_log(o tt15v, n tt15v, incr bool);
@@ -2344,12 +2359,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +\d+ tt15v
 +ERROR:  at or near ".": syntax error
 +DETAIL:  source SQL:
@@ -2397,7 +2412,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- check display of ScalarArrayOp with a sub-select
  select 'foo'::text = any(array['abc','def','foo']::text[]);
   ?column? 
-@@ -1873,10 +1257,7 @@
+@@ -1873,10 +1272,7 @@
  (1 row)
  
  select 'foo'::text = any((select array['abc','def','foo']::text[]));  -- fail
@@ -2409,7 +2424,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  select 'foo'::text = any((select array['abc','def','foo']::text[])::text[]);
   ?column? 
  ----------
-@@ -1887,12 +1268,8 @@
+@@ -1887,12 +1283,8 @@
  select 'foo'::text = any(array['abc','def','foo']::text[]) c1,
         'foo'::text = any((select array['abc','def','foo']::text[])::text[]) c2;
  select pg_get_viewdef('tt19v', true);
@@ -2424,7 +2439,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- check display of assorted RTE_FUNCTION expressions
  create view tt20v as
  select * from
-@@ -1902,23 +1279,14 @@
+@@ -1902,23 +1294,14 @@
    localtimestamp(3) as t,
    cast(1+2 as int4) as i4,
    cast(1+2 as int8) as i8;
@@ -2455,7 +2470,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- reverse-listing of various special function syntaxes required by SQL
  create view tt201v as
  select
-@@ -1974,136 +1342,41 @@
+@@ -1974,136 +1357,41 @@
    (select * from SESSION_USER) as seu2,
    SYSTEM_USER as su,
    (select * from SYSTEM_USER) as su2;
@@ -2611,7 +2626,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- test extraction of FieldSelect field names (get_name_for_var_field)
  create view tt24v as
  with cte as materialized (select r from (values(1,2),(3,4)) r)
-@@ -2111,66 +1384,29 @@
+@@ -2111,66 +1399,29 @@
    cte join (select rr from (values(1,7),(3,8)) rr limit 2) ss
    on (r).column1 = (rr).column1;
  select pg_get_viewdef('tt24v', true);
@@ -2692,7 +2707,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- test pretty-print parenthesization rules, and SubLink deparsing
  create view tt26v as
  select x + y + z as c1,
-@@ -2186,128 +1422,9 @@
+@@ -2186,128 +1437,9 @@
         (x,y) <= ANY (values(1,2),(3,4)) as c11
  from (values(1,2,3)) v(x,y,z);
  select pg_get_viewdef('tt26v', true);

--- a/pkg/cmd/roachtest/testdata/pg_regress/enum.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/enum.diffs
@@ -350,15 +350,37 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/enum.out --label=
  --
  -- Concrete function should override generic one
  --
-@@ -555,6 +563,7 @@
+@@ -544,24 +552,19 @@
+ RETURN $1::text || 'wtf';
+ END
+ $$ LANGUAGE plpgsql;
++ERROR:  no value provided for placeholder: $1
+ SELECT echo_me('red'::rainbow);
+- echo_me 
+----------
+- redwtf
+-(1 row)
+-
++ERROR:  unknown function: echo_me()
+ --
+ -- If we drop the original generic one, we don't have to qualify the type
  -- anymore, since there's only one match
  --
  DROP FUNCTION echo_me(anyenum);
-+ERROR:  type "anyenum" does not exist
++ERROR:  unknown function: echo_me()
  SELECT echo_me('red');
-  echo_me 
- ---------
-@@ -570,18 +579,17 @@
+- echo_me 
+----------
+- redwtf
+-(1 row)
+-
++ERROR:  unknown function: echo_me()
+ DROP FUNCTION echo_me(rainbow);
++ERROR:  unknown function: echo_me()
+ --
+ -- RI triggers on enum types
+ --
+@@ -570,18 +573,17 @@
  INSERT INTO enumtest_parent VALUES ('red');
  INSERT INTO enumtest_child VALUES ('red');
  INSERT INTO enumtest_child VALUES ('blue');  -- fail
@@ -382,7 +404,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/enum.out --label=
  DROP TYPE bogus;
  -- check renaming a value
  ALTER TYPE rainbow RENAME VALUE 'red' TO 'crimson';
-@@ -591,20 +599,20 @@
+@@ -591,20 +593,20 @@
  ORDER BY 2;
   enumlabel | enumsortorder 
  -----------+---------------
@@ -411,7 +433,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/enum.out --label=
  --
  -- check transactional behaviour of ALTER TYPE ... ADD VALUE
  --
-@@ -613,13 +621,17 @@
+@@ -613,13 +615,17 @@
  -- but we can't use them
  BEGIN;
  ALTER TYPE bogus ADD VALUE 'new';
@@ -433,7 +455,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/enum.out --label=
  SELECT enum_first(null::bogus);  -- safe
   enum_first 
  ------------
-@@ -627,14 +639,23 @@
+@@ -627,14 +633,23 @@
  (1 row)
  
  SELECT enum_last(null::bogus);  -- unsafe
@@ -461,7 +483,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/enum.out --label=
  SELECT 'new'::bogus;  -- now safe
   bogus 
  -------
-@@ -647,54 +668,68 @@
+@@ -647,54 +662,68 @@
  ORDER BY 2;
   enumlabel | enumsortorder 
  -----------+---------------

--- a/pkg/cmd/roachtest/testdata/pg_regress/event_trigger.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/event_trigger.diffs
@@ -455,8 +455,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE TABLE schema_one.table_one(a int);
  CREATE TABLE schema_one."table two"(a int);
  CREATE TABLE schema_one.table_three(a int);
-@@ -219,7 +400,18 @@
+@@ -217,9 +398,21 @@
+ CREATE OR REPLACE FUNCTION schema_two.add(int, int) RETURNS int LANGUAGE plpgsql
+   CALLED ON NULL INPUT
    AS $$ BEGIN RETURN coalesce($1,0) + coalesce($2,0); END; $$;
++ERROR:  incompatible COALESCE expressions: no value provided for placeholder: $1
  CREATE AGGREGATE schema_two.newton
    (BASETYPE = int, SFUNC = schema_two.add, STYPE = int);
 +ERROR:  at or near "schema_two": syntax error: unimplemented: this syntax
@@ -474,7 +477,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE TABLE undroppable_objs (
  	object_type text,
  	object_identity text
-@@ -253,8 +445,14 @@
+@@ -253,8 +446,14 @@
  	END LOOP;
  END;
  $$;
@@ -489,7 +492,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE OR REPLACE FUNCTION test_evtrig_dropped_objects() RETURNS event_trigger
  LANGUAGE plpgsql AS $$
  DECLARE
-@@ -273,99 +471,55 @@
+@@ -273,99 +472,55 @@
      END LOOP;
  END
  $$;
@@ -620,7 +623,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  -- Event triggers on relations.
  CREATE OR REPLACE FUNCTION event_trigger_report_dropped()
   RETURNS event_trigger
-@@ -383,8 +537,14 @@
+@@ -383,8 +538,14 @@
          r.object_identity, r.address_names, r.address_args;
      END LOOP;
  END; $$;
@@ -635,7 +638,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE OR REPLACE FUNCTION event_trigger_report_end()
   RETURNS event_trigger
   LANGUAGE plpgsql
-@@ -397,95 +557,105 @@
+@@ -397,95 +558,105 @@
              r.command_tag, r.object_type, r.object_identity;
      END LOOP;
  END; $$;
@@ -794,7 +797,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  -- test Table Rewrite Event Trigger
  CREATE OR REPLACE FUNCTION test_evtrig_no_rewrite() RETURNS event_trigger
  LANGUAGE plpgsql AS $$
-@@ -493,14 +663,19 @@
+@@ -493,14 +664,19 @@
    RAISE EXCEPTION 'rewrites not allowed';
  END;
  $$;
@@ -816,7 +819,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  alter table rewriteme add column baz int default 0;
  -- test with more than one reason to rewrite a single table
  CREATE OR REPLACE FUNCTION test_evtrig_no_rewrite() RETURNS event_trigger
-@@ -511,27 +686,38 @@
+@@ -511,27 +687,38 @@
                 pg_event_trigger_table_rewrite_reason();
  END;
  $$;
@@ -858,7 +861,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  -- typed tables are rewritten when their type changes.  Don't emit table
  -- name, because firing order is not stable.
  CREATE OR REPLACE FUNCTION test_evtrig_no_rewrite() RETURNS event_trigger
-@@ -541,21 +727,52 @@
+@@ -541,21 +728,52 @@
                 pg_event_trigger_table_rewrite_reason();
  END;
  $$;
@@ -914,7 +917,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  CREATE TABLE event_trigger_test (a integer, b text);
  CREATE OR REPLACE FUNCTION start_command()
  RETURNS event_trigger AS $$
-@@ -563,37 +780,46 @@
+@@ -563,37 +781,46 @@
  RAISE NOTICE '% - ddl_command_start', tg_tag;
  END;
  $$ LANGUAGE plpgsql;
@@ -970,7 +973,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/event_trigger.out
  -- Check the object addresses of all the event triggers.
  SELECT
      e.evtname,
-@@ -604,13 +830,22 @@
+@@ -604,13 +831,22 @@
      LATERAL pg_identify_object_as_address('pg_event_trigger'::regclass, e.oid, 0) as b,
      LATERAL pg_get_object_address(b.type, b.object_names, b.object_args) as a
    ORDER BY e.evtname;

--- a/pkg/cmd/roachtest/testdata/pg_regress/explain.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/explain.diffs
@@ -1,17 +1,32 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --label=/mnt/data1/postgres/src/test/regress/results/explain.out /mnt/data1/postgres/src/test/regress/expected/explain.out /mnt/data1/postgres/src/test/regress/results/explain.out
 --- /mnt/data1/postgres/src/test/regress/expected/explain.out
 +++ /mnt/data1/postgres/src/test/regress/results/explain.out
-@@ -30,6 +30,9 @@
+@@ -30,6 +30,24 @@
      end loop;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++    ln text;
++begin
++    for ln in execute $1
++           ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  -- To produce valid JSON output, replace numbers with "0" or "0.0" not "N"
  create function explain_filter_to_json(text) returns jsonb
  language plpgsql as
-@@ -47,247 +50,91 @@
+@@ -47,247 +65,91 @@
      return data::jsonb;
  end;
  $$;
@@ -324,7 +339,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  -- SETTINGS option
  -- We have to ignore other settings that might be imposed by the environment,
  -- so printing the whole Settings field unfortunately won't do.
-@@ -296,32 +143,16 @@
+@@ -296,32 +158,16 @@
  select true as "OK"
    from explain_filter('explain (settings) select * from int8_tbl i8') ln
    where ln ~ '^ *Settings: .*plan_cache_mode = ''force_generic_plan''';
@@ -361,7 +376,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  -- Test EXPLAIN (GENERIC_PLAN) with partition pruning
  -- partitions should be pruned at plan time, based on constants,
  -- but there should be no pruning based on parameter placeholders
-@@ -329,27 +160,52 @@
+@@ -329,27 +175,52 @@
    key1 integer not null,
    key2 integer not null
  ) partition by list (key1);
@@ -423,7 +438,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  --
  -- Test production of per-worker data
  --
-@@ -360,9 +216,24 @@
+@@ -360,9 +231,24 @@
  begin;
  -- encourage use of parallel plans
  set parallel_setup_cost=0;
@@ -448,7 +463,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  select jsonb_pretty(
    explain_filter_to_json('explain (analyze, verbose, buffers, format json)
                           select * from tenk1 order by tenthous')
-@@ -374,188 +245,19 @@
+@@ -374,188 +260,17 @@
    #- '{0,Plan,Plans,0,Sort Method}'
    #- '{0,Plan,Plans,0,Sort Space Type}'
  );
@@ -620,9 +635,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  create temp table t1(f1 float8);
  create function pg_temp.mysin(float8) returns float8 language plpgsql
  as 'begin return sin($1); end';
-+ERROR:  unimplemented: cannot create UDFs under a temporary schema
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/104687/_version_
++ERROR:  sin(): no value provided for placeholder: $1
  select explain_filter('explain (verbose) select * from t1 where pg_temp.mysin(f1) < 0.5');
 -                       explain_filter                       
 -------------------------------------------------------------

--- a/pkg/cmd/roachtest/testdata/pg_regress/expressions.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/expressions.diffs
@@ -188,17 +188,124 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/expressions.out -
  --
  -- Tests for ScalarArrayOpExpr with a hashfn
  --
-@@ -230,6 +191,7 @@
+@@ -230,119 +191,105 @@
  	return $1;
  end;
  $$ language plpgsql stable;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
++ERROR:  no value provided for placeholder: $1
  create function return_text_input(text) returns text as $$
  begin
  	return $1;
-@@ -327,22 +289,65 @@
- (1 row)
- 
+ end;
+ $$ language plpgsql stable;
++ERROR:  no value provided for placeholder: $1
+ select return_int_input(1) in (10, 9, 2, 8, 3, 7, 4, 6, 5, 1);
+- ?column? 
+-----------
+- t
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) in (10, 9, 2, 8, 3, 7, 4, 6, 5, null);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) in (null, null, null, null, null, null, null, null, null, null, null);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) in (10, 9, 2, 8, 3, 7, 4, 6, 5, 1, null);
+- ?column? 
+-----------
+- t
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(null::int) in (10, 9, 2, 8, 3, 7, 4, 6, 5, 1);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(null::int) in (10, 9, 2, 8, 3, 7, 4, 6, 5, null);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_text_input('a') in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j');
+- ?column? 
+-----------
+- t
+-(1 row)
+-
++ERROR:  unknown function: return_text_input()
+ -- NOT IN
+ select return_int_input(1) not in (10, 9, 2, 8, 3, 7, 4, 6, 5, 1);
+- ?column? 
+-----------
+- f
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) not in (10, 9, 2, 8, 3, 7, 4, 6, 5, 0);
+- ?column? 
+-----------
+- t
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) not in (10, 9, 2, 8, 3, 7, 4, 6, 5, 2, null);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) not in (10, 9, 2, 8, 3, 7, 4, 6, 5, 1, null);
+- ?column? 
+-----------
+- f
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(1) not in (null, null, null, null, null, null, null, null, null, null, null);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(null::int) not in (10, 9, 2, 8, 3, 7, 4, 6, 5, 1);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_int_input(null::int) not in (10, 9, 2, 8, 3, 7, 4, 6, 5, null);
+- ?column? 
+-----------
+- 
+-(1 row)
+-
++ERROR:  unknown function: return_int_input()
+ select return_text_input('a') not in ('a', 'b', 'c', 'd', 'e', 'f', 'g', 'h', 'i', 'j');
+- ?column? 
+-----------
+- f
+-(1 row)
+-
++ERROR:  unknown function: return_text_input()
  rollback;
 +WARNING:  there is no transaction in progress
  -- Test with non-strict equality function.
@@ -265,7 +372,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/expressions.out -
  create function myinteq(myint, myint) returns bool as $$
  begin
    if $1 is null and $2 is null then
-@@ -352,11 +357,13 @@
+@@ -352,11 +299,13 @@
    end if;
  end;
  $$ language plpgsql immutable;
@@ -279,7 +386,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/expressions.out -
  create operator = (
    leftarg    = myint,
    rightarg   = myint,
-@@ -367,6 +374,12 @@
+@@ -367,6 +316,12 @@
    join       = eqjoinsel,
    merges
  );
@@ -292,7 +399,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/expressions.out -
  create operator <> (
    leftarg    = myint,
    rightarg   = myint,
-@@ -377,47 +390,39 @@
+@@ -377,47 +332,39 @@
    join       = eqjoinsel,
    merges
  );

--- a/pkg/cmd/roachtest/testdata/pg_regress/generated.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/generated.diffs
@@ -9,9 +9,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/generated.out --l
 -(0 rows)
 +  attrelid  |         attname          | attgenerated 
 +------------+--------------------------+--------------
-+ 3550979019 | crdb_internal_idx_expr   | v
-+  549341432 | crdb_internal_idx_expr   | v
-+  549341438 | crdb_internal_idx_expr_1 | v
++  601088728 | crdb_internal_idx_expr   | v
++ 1634682172 | crdb_internal_idx_expr   | v
++ 1634682170 | crdb_internal_idx_expr_1 | v
 +(3 rows)
  
  CREATE TABLE gtest0 (a int PRIMARY KEY, b int GENERATED ALWAYS AS (55) STORED);

--- a/pkg/cmd/roachtest/testdata/pg_regress/gin.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/gin.diffs
@@ -175,37 +175,82 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/gin.out --label=/
  select * from t_gin_test_tbl where i @> '{}';
     i   |  j   
  -------+------
-@@ -141,6 +165,9 @@
+@@ -141,6 +165,24 @@
    return query execute 'EXPLAIN (ANALYZE, FORMAT json) ' || query_sql;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++begin
++  set enable_seqscan = off;
++  set enable_bitmapscan = on;
++  return query execute 'EXPLAIN (ANALYZE, FORMAT json) ' || query_sql;
++               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  create function execute_text_query_index(query_sql text)
  returns setof text
  language plpgsql
-@@ -152,6 +179,9 @@
+@@ -152,6 +194,24 @@
    return query execute query_sql;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++begin
++  set enable_seqscan = off;
++  set enable_bitmapscan = on;
++  return query execute query_sql;
++               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  create function execute_text_query_heap(query_sql text)
  returns setof text
  language plpgsql
-@@ -163,6 +193,9 @@
+@@ -163,6 +223,24 @@
    return query execute query_sql;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++begin
++  set enable_seqscan = on;
++  set enable_bitmapscan = off;
++  return query execute query_sql;
++               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  -- check number of rows returned by index and removed by recheck
  select
    query,
-@@ -185,88 +218,90 @@
+@@ -185,88 +263,90 @@
    lateral explain_query_json($$select * from t_gin_test_tbl where $$ || query) js,
    lateral execute_text_query_index($$select string_agg((i, j)::text, ' ') from t_gin_test_tbl where $$ || query) res_index,
    lateral execute_text_query_heap($$select string_agg((i, j)::text, ' ') from t_gin_test_tbl where $$ || query) res_heap;
@@ -345,7 +390,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/gin.out --label=/
  select count(*) from t_gin_test_tbl where j @> array[50];
   count 
  -------
-@@ -286,10 +321,24 @@
+@@ -286,10 +366,24 @@
  (1 row)
  
  reset enable_seqscan;

--- a/pkg/cmd/roachtest/testdata/pg_regress/groupingsets.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/groupingsets.diffs
@@ -18,13 +18,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  create temp table gstest_empty (a integer, b integer, v integer);
  create function gstest_data(v integer, out a integer, out b integer)
    returns setof record
-@@ -28,81 +31,92 @@
-       return query select v, i from generate_series(1,3) i;
-     end;
+@@ -30,79 +33,87 @@
    $f$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
  -- basic functionality
  set enable_hashagg = false;  -- test hashing explicitly later
 +ERROR:  unimplemented: the configuration setting "enable_hashagg" is not supported
@@ -171,7 +166,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  
  -- various types of ordered aggs
  select a, b, grouping(a,b),
-@@ -111,21 +125,20 @@
+@@ -111,21 +122,20 @@
         percentile_disc(0.5) within group (order by v),
         rank(1,2,12) within group (order by a,b,v)
    from gstest1 group by rollup (a,b) order by a,b;
@@ -207,7 +202,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  
  -- test usage of grouped columns in direct args of aggs
  select grouping(a), a, array_agg(b),
-@@ -133,232 +146,234 @@
+@@ -133,232 +143,234 @@
         rank(a) within group (order by b nulls last)
    from (values (1,1),(1,4),(1,5),(3,1),(3,2)) v(a,b)
   group by rollup (a) order by a;
@@ -611,7 +606,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  
  -- check that distinct grouping columns are kept separate
  -- even if they are equal()
-@@ -366,74 +381,70 @@
+@@ -366,74 +378,70 @@
  select g as alias1, g as alias2
    from generate_series(1,3) g
   group by alias1, rollup(alias2);
@@ -731,7 +726,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  -- check qual push-down rules for a subquery with grouping sets
  explain (verbose, costs off)
  select * from (
-@@ -442,391 +453,343 @@
+@@ -442,391 +450,343 @@
    group by grouping sets(1, 2)
  ) ss
  where x = 1 and q1 = 123;
@@ -1379,7 +1374,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  select v.c, (select count(*) from gstest2 group by () having v.c)
    from (values (false),(true)) v(c) order by v.c;
   c | count 
-@@ -838,322 +801,261 @@
+@@ -838,322 +798,261 @@
  explain (costs off)
    select v.c, (select count(*) from gstest2 group by () having v.c)
      from (values (false),(true)) v(c) order by v.c;
@@ -1897,7 +1892,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  
  explain (costs off)
    select unhashable_col, unsortable_col,
-@@ -1161,42 +1063,31 @@
+@@ -1161,42 +1060,31 @@
           count(*), sum(v)
      from gstest4 group by grouping sets ((unhashable_col),(unsortable_col))
     order by 3,5;
@@ -1960,7 +1955,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  
  explain (costs off)
    select unhashable_col, unsortable_col,
-@@ -1204,721 +1095,435 @@
+@@ -1204,721 +1092,435 @@
           count(*), sum(v)
      from gstest4 group by grouping sets ((v,unhashable_col),(v,unsortable_col))
     order by 3,5;
@@ -2990,7 +2985,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/groupingsets.out 
  --
  -- Compare results between plans using sorting and plans using hash
  -- aggregation. Force spilling in both cases by setting work_mem low
-@@ -1927,227 +1532,250 @@
+@@ -1927,227 +1529,250 @@
  create table gs_data_1 as
  select g%1000 as g1000, g%100 as g100, g%10 as g10, g
     from generate_series(0,1999) g;

--- a/pkg/cmd/roachtest/testdata/pg_regress/identity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/identity.diffs
@@ -65,7 +65,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/identity.out --la
  ALTER TABLE itest4 ALTER COLUMN a ADD GENERATED ALWAYS AS IDENTITY;  -- ok
  ALTER TABLE itest4 ALTER COLUMN a DROP NOT NULL;  -- error, disallowed
 -ERROR:  column "a" of relation "itest4" is an identity column
-+ERROR:  relation "itest4" (1033): conflicting NULL/NOT NULL declarations for column "a"
++ERROR:  relation "itest4": conflicting NULL/NOT NULL declarations for column "a"
  ALTER TABLE itest4 ALTER COLUMN a ADD GENERATED ALWAYS AS IDENTITY;  -- error, already set
  ERROR:  column "a" of relation "itest4" is already an identity column
  ALTER TABLE itest4 ALTER COLUMN b ADD GENERATED ALWAYS AS IDENTITY;  -- error, wrong data type

--- a/pkg/cmd/roachtest/testdata/pg_regress/incremental_sort.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/incremental_sort.diffs
@@ -69,17 +69,32 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  create table t(a integer, b integer);
  create or replace function explain_analyze_without_memory(query text)
  returns table (out_line text) language plpgsql
-@@ -46,6 +59,9 @@
+@@ -46,6 +59,24 @@
    end loop;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++  line text;
++begin
++  for line in
++           ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  create or replace function explain_analyze_inc_sort_nodes(query text)
  returns jsonb language plpgsql
  as
-@@ -82,6 +98,19 @@
+@@ -82,6 +113,19 @@
    return matching_nodes;
  end;
  $$;
@@ -99,7 +114,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  create or replace function explain_analyze_inc_sort_nodes_without_memory(query text)
  returns jsonb language plpgsql
  as
-@@ -104,6 +133,27 @@
+@@ -104,6 +148,27 @@
    return nodes;
  end;
  $$;
@@ -127,7 +142,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  create or replace function explain_analyze_inc_sort_nodes_verify_invariants(query text)
  returns bool language plpgsql
  as
-@@ -127,467 +177,119 @@
+@@ -127,467 +192,119 @@
    return true;
  end;
  $$;
@@ -674,7 +689,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 70;
   a | b  
  ---+----
-@@ -668,17 +370,11 @@
+@@ -668,17 +385,11 @@
  -- transition point) but only retain 5. Thus when we transition modes, all
  -- tuples in the full sort state have different prefix keys.
  explain (costs off) select * from (select * from t order by a) s order by a, b limit 5;
@@ -697,7 +712,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 5;
   a | b 
  ---+---
-@@ -694,429 +390,110 @@
+@@ -694,429 +405,110 @@
  -- We force the planner to choose a plan with incremental sort on the right side
  -- of a nested loop join node. That way we trigger the rescan code path.
  set local enable_hashjoin = off;
@@ -1197,7 +1212,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 31;
   a  | b  
  ----+----
-@@ -1154,17 +531,11 @@
+@@ -1154,17 +546,11 @@
  (31 rows)
  
  explain (costs off) select * from (select * from t order by a) s order by a, b limit 32;
@@ -1220,7 +1235,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 32;
   a  | b  
  ----+----
-@@ -1203,17 +574,11 @@
+@@ -1203,17 +589,11 @@
  (32 rows)
  
  explain (costs off) select * from (select * from t order by a) s order by a, b limit 33;
@@ -1243,7 +1258,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 33;
   a  | b  
  ----+----
-@@ -1253,17 +618,11 @@
+@@ -1253,17 +633,11 @@
  (33 rows)
  
  explain (costs off) select * from (select * from t order by a) s order by a, b limit 65;
@@ -1266,7 +1281,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 65;
   a  | b  
  ----+----
-@@ -1335,17 +694,11 @@
+@@ -1335,17 +709,11 @@
  (65 rows)
  
  explain (costs off) select * from (select * from t order by a) s order by a, b limit 66;
@@ -1289,7 +1304,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  select * from (select * from t order by a) s order by a, b limit 66;
   a  | b  
  ----+----
-@@ -1421,150 +774,224 @@
+@@ -1421,150 +789,224 @@
  drop table t;
  -- Incremental sort vs. parallel queries
  set min_parallel_table_scan_size = '1kB';
@@ -1426,11 +1441,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
 -(11 rows)
 +ERROR:  unimplemented: the configuration setting "enable_hashagg" is not supported
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -1616,7 +1631,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/incremental_sort.
  -- Parallel sort with an aggregate that can be safely generated in parallel,
  -- but we can't sort by partial aggregate values.
  explain (costs off) select count(*)
-@@ -1572,91 +999,45 @@
+@@ -1572,91 +1014,45 @@
  join tenk1 t2 on t1.unique1 = t2.unique2
  join tenk1 t3 on t2.unique1 = t3.unique1
  order by count(*);

--- a/pkg/cmd/roachtest/testdata/pg_regress/jsonb_jsonpath.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/jsonb_jsonpath.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.out --label=/mnt/data1/postgres/src/test/regress/results/jsonb_jsonpath.out /mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.out /mnt/data1/postgres/src/test/regress/results/jsonb_jsonpath.out
 --- /mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.out
 +++ /mnt/data1/postgres/src/test/regress/results/jsonb_jsonpath.out
-@@ -1,250 +1,222 @@
+@@ -1,250 +1,219 @@
  select jsonb '{"a": 12}' @? '$';
 - ?column? 
 -----------
@@ -205,43 +205,39 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('[1]', 'strict $[1]');
  ERROR:  jsonpath array subscript is out of bounds
  select jsonb_path_query('[1]', 'strict $[1]', silent => true);
+- jsonb_path_query 
+-------------------
+-(0 rows)
+-
 +ERROR:  at or near ">": syntax error
 +DETAIL:  source SQL:
 +select jsonb_path_query('[1]', 'strict $[1]', silent => true)
 +                                                      ^
 +HINT:  try \hf jsonb_path_query
-+select jsonb '[1]' @? 'lax $[10000000000000000]';
+ select jsonb '[1]' @? 'lax $[10000000000000000]';
+- ?column? 
+-----------
+- 
+-(1 row)
+-
 +ERROR:  at or near "@": syntax error
 +DETAIL:  source SQL:
 +select jsonb '[1]' @? 'lax $[10000000000000000]'
 +                   ^
-+select jsonb '[1]' @? 'strict $[10000000000000000]';
+ select jsonb '[1]' @? 'strict $[10000000000000000]';
+- ?column? 
+-----------
+- 
+-(1 row)
+-
 +ERROR:  at or near "@": syntax error
 +DETAIL:  source SQL:
 +select jsonb '[1]' @? 'strict $[10000000000000000]'
 +                   ^
-+select jsonb_path_query('[1]', 'lax $[10000000000000000]');
-  jsonb_path_query 
- ------------------
- (0 rows)
- 
--select jsonb '[1]' @? 'lax $[10000000000000000]';
-- ?column? 
------------
-- 
--(1 row)
--
--select jsonb '[1]' @? 'strict $[10000000000000000]';
-- ?column? 
------------
-- 
--(1 row)
--
--select jsonb_path_query('[1]', 'lax $[10000000000000000]');
--ERROR:  jsonpath array subscript is out of integer range
+ select jsonb_path_query('[1]', 'lax $[10000000000000000]');
+ ERROR:  jsonpath array subscript is out of integer range
  select jsonb_path_query('[1]', 'strict $[10000000000000000]');
--ERROR:  jsonpath array subscript is out of integer range
-+ERROR:  jsonpath array subscript is out of bounds
+ ERROR:  jsonpath array subscript is out of integer range
  select jsonb '[1]' @? '$[0]';
 - ?column? 
 -----------
@@ -425,7 +421,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('1', 'lax $.a');
   jsonb_path_query 
  ------------------
-@@ -255,15 +227,17 @@
+@@ -255,15 +224,17 @@
  select jsonb_path_query('1', 'strict $.*');
  ERROR:  jsonpath wildcard member accessor can only be applied to an object
  select jsonb_path_query('1', 'strict $.a', silent => true);
@@ -451,7 +447,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('[]', 'lax $.a');
   jsonb_path_query 
  ------------------
-@@ -272,10 +246,11 @@
+@@ -272,10 +243,11 @@
  select jsonb_path_query('[]', 'strict $.a');
  ERROR:  jsonpath member accessor can only be applied to an object
  select jsonb_path_query('[]', 'strict $.a', silent => true);
@@ -467,7 +463,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('{}', 'lax $.a');
   jsonb_path_query 
  ------------------
-@@ -284,10 +259,11 @@
+@@ -284,10 +256,11 @@
  select jsonb_path_query('{}', 'strict $.a');
  ERROR:  JSON object does not contain key "a"
  select jsonb_path_query('{}', 'strict $.a', silent => true);
@@ -483,7 +479,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('1', 'strict $[1]');
  ERROR:  jsonpath array accessor can only be applied to an array
  select jsonb_path_query('1', 'strict $[*]');
-@@ -297,25 +273,29 @@
+@@ -297,25 +270,29 @@
  select jsonb_path_query('[]', 'strict $["a"]');
  ERROR:  jsonpath array subscript is not a single numeric value
  select jsonb_path_query('1', 'strict $[1]', silent => true);
@@ -529,23 +525,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('{"a": 12, "b": {"a": 13}}', '$.a');
   jsonb_path_query 
  ------------------
-@@ -385,13 +365,8 @@
- select jsonb_path_query('[12, {"a": 13}, {"b": 14}]', 'lax $[0 to 10 / 0].a');
- ERROR:  division by zero
- select jsonb_path_query('[12, {"a": 13}, {"b": 14}, "ccc", true]', '$[2.5 - 1 to $.size() - 2]');
-- jsonb_path_query 
--------------------
-- {"a": 13}
-- {"b": 14}
-- "ccc"
--(3 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('1', 'lax $[0]');
-  jsonb_path_query 
- ------------------
-@@ -427,10 +402,11 @@
+@@ -427,10 +404,11 @@
  select jsonb_path_query('[1,2,3]', 'strict $[*].a');
  ERROR:  jsonpath member accessor can only be applied to an object
  select jsonb_path_query('[1,2,3]', 'strict $[*].a', silent => true);
@@ -561,7 +541,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('[]', '$[last]');
   jsonb_path_query 
  ------------------
-@@ -444,10 +420,11 @@
+@@ -444,10 +422,11 @@
  select jsonb_path_query('[]', 'strict $[last]');
  ERROR:  jsonpath array subscript is out of bounds
  select jsonb_path_query('[]', 'strict $[last]', silent => true);
@@ -577,21 +557,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('[1]', '$[last]');
   jsonb_path_query 
  ------------------
-@@ -467,18 +444,17 @@
- (1 row)
- 
- select jsonb_path_query('[1,2,3]', '$[last ? (@.type() == "number")]');
-- jsonb_path_query 
--------------------
-- 3
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+@@ -475,10 +454,11 @@
  select jsonb_path_query('[1,2,3]', '$[last ? (@.type() == "string")]');
--ERROR:  jsonpath array subscript is not a single numeric value
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ ERROR:  jsonpath array subscript is not a single numeric value
  select jsonb_path_query('[1,2,3]', '$[last ? (@.type() == "string")]', silent => true);
 - jsonb_path_query 
 -------------------
@@ -605,15 +573,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select * from jsonb_path_query('{"a": 10}', '$');
   jsonb_path_query 
  ------------------
-@@ -486,13 +462,14 @@
- (1 row)
- 
- select * from jsonb_path_query('{"a": 10}', '$ ? (@.a < $value)');
--ERROR:  could not find jsonpath variable "value"
-+ jsonb_path_query 
-+------------------
-+(0 rows)
-+
+@@ -489,10 +469,8 @@
+ ERROR:  could not find jsonpath variable "value"
  select * from jsonb_path_query('{"a": 10}', '$ ? (@.a < $value)', '1');
  ERROR:  "vars" argument is not an object
 -DETAIL:  Jsonpath parameters should be encoded as key-value pairs of "vars" object.
@@ -623,7 +584,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select * from jsonb_path_query('{"a": 10}', '$ ? (@.a < $value)', '{"value" : 13}');
   jsonb_path_query 
  ------------------
-@@ -575,216 +552,136 @@
+@@ -575,216 +553,136 @@
  (0 rows)
  
  select jsonb_path_query('{"a": {"b": 1}}', 'lax $.**');
@@ -936,42 +897,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select jsonb_path_query('{"g": {"x": 2}}', '$.g ? (exists (@.x))');
   jsonb_path_query 
  ------------------
-@@ -816,9 +713,7 @@
- select jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'lax $.g ? ((exists (@.x + "3")) is unknown)');
-  jsonb_path_query 
- ------------------
-- {"x": 2}
-- {"y": 3}
--(2 rows)
-+(0 rows)
- 
- select jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'strict $.g[*] ? (exists (@.x))');
-  jsonb_path_query 
-@@ -829,8 +724,7 @@
- select jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'strict $.g[*] ? ((exists (@.x)) is unknown)');
-  jsonb_path_query 
- ------------------
-- {"y": 3}
--(1 row)
-+(0 rows)
- 
- select jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'strict $.g ? (exists (@[*].x))');
-  jsonb_path_query 
-@@ -838,10 +732,9 @@
- (0 rows)
- 
- select jsonb_path_query('{"g": [{"x": 2}, {"y": 3}]}', 'strict $.g ? ((exists (@[*].x)) is unknown)');
--   jsonb_path_query   
------------------------
-- [{"x": 2}, {"y": 3}]
--(1 row)
-+ jsonb_path_query 
-+------------------
-+(0 rows)
- 
- --test ternary logic
- select
-@@ -856,19 +749,7 @@
+@@ -856,19 +754,7 @@
  from
  	(values (jsonb 'true'), ('false'), ('"null"')) x(x),
  	(values (jsonb 'true'), ('false'), ('"null"')) y(y);
@@ -992,7 +918,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  select
  	x, y,
  	jsonb_path_query(
-@@ -881,157 +762,114 @@
+@@ -881,157 +767,114 @@
  from
  	(values (jsonb 'true'), ('false'), ('"null"')) x(x),
  	(values (jsonb 'true'), ('false'), ('"null"')) y(y);
@@ -1235,17 +1161,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  -- arithmetic errors
  select jsonb_path_query('[1,2,0,3]', '$[*] ? (2 / @ > 0)');
   jsonb_path_query 
-@@ -1044,8 +882,7 @@
- select jsonb_path_query('[1,2,0,3]', '$[*] ? ((2 / @ > 0) is unknown)');
-  jsonb_path_query 
- ------------------
-- 0
--(1 row)
-+(0 rows)
- 
- select jsonb_path_query('0', '1 / $');
- ERROR:  division by zero
-@@ -1062,50 +899,49 @@
+@@ -1062,50 +905,49 @@
  select jsonb_path_query('[1,"2",3]', '+$');
  ERROR:  operand of unary jsonpath operator + is not a numeric value
  select jsonb_path_query('1', '$ + "2"', silent => true);
@@ -1332,7 +1248,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  -- unwrapping of operator arguments in lax mode
  select jsonb_path_query('{"a": [2]}', 'lax $.a * 3');
   jsonb_path_query 
-@@ -1131,10 +967,11 @@
+@@ -1131,10 +973,11 @@
  select jsonb_path_query('{"a": [1, 2]}', 'lax $.a * 3');
  ERROR:  left operand of jsonpath operator * is not a single numeric value
  select jsonb_path_query('{"a": [1, 2]}', 'lax $.a * 3', silent => true);
@@ -1348,7 +1264,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  -- extension: boolean expressions
  select jsonb_path_query('2', '$ > 1');
   jsonb_path_query 
-@@ -1155,437 +992,287 @@
+@@ -1155,59 +998,26 @@
  (1 row)
  
  select jsonb '2' @? '$ == "2"';
@@ -1418,23 +1334,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 -
 +ERROR:  unsupported comparison operator: <jsonb> @@ <string>
  select jsonb_path_match('[[1, true], [2, false]]', 'strict $[*] ? (@[0] > $x) [1]', '{"x": 1}');
-- jsonb_path_match 
--------------------
-- f
--(1 row)
--
-+ERROR:  jsonb_path_match(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
- select jsonb_path_match('[[1, true], [2, false]]', 'strict $[*] ? (@[0] < $x) [1]', '{"x": 2}');
-- jsonb_path_match 
--------------------
-- t
--(1 row)
--
-+ERROR:  jsonb_path_match(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
+  jsonb_path_match 
+ ------------------
+@@ -1221,29 +1031,29 @@
+ (1 row)
+ 
  select jsonb_path_match('[{"a": 1}, {"a": 2}, 3]', 'lax exists($[*].a)', silent => false);
 - jsonb_path_match 
 -------------------
@@ -1480,118 +1384,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +                                                                                    ^
 +HINT:  try \hf jsonb_path_match
  select jsonb_path_query('[null,1,true,"a",[],{}]', '$.type()');
-- jsonb_path_query 
--------------------
-- "array"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null,1,true,"a",[],{}]', 'lax $.type()');
-- jsonb_path_query 
--------------------
-- "array"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null,1,true,"a",[],{}]', '$[*].type()');
-- jsonb_path_query 
--------------------
-- "null"
-- "number"
-- "boolean"
-- "string"
-- "array"
-- "object"
--(6 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('null', 'null.type()');
-- jsonb_path_query 
--------------------
-- "null"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('null', 'true.type()');
-- jsonb_path_query 
--------------------
-- "boolean"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('null', '(123).type()');
-- jsonb_path_query 
--------------------
-- "number"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('null', '"123".type()');
-- jsonb_path_query 
--------------------
-- "string"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('{"a": 2}', '($.a - 5).abs() + 10');
-- jsonb_path_query 
--------------------
-- 13
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('{"a": 2.5}', '-($.a * $.a).floor() % 4.3');
-- jsonb_path_query 
--------------------
-- -1.7
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[1, 2, 3]', '($[*] > 2) ? (@ == true)');
-- jsonb_path_query 
--------------------
-- true
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[1, 2, 3]', '($[*] > 3).type()');
-- jsonb_path_query 
--------------------
-- "boolean"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+  jsonb_path_query 
+ ------------------
+@@ -1318,7 +1128,7 @@
  select jsonb_path_query('[1, 2, 3]', '($[*].a > 3).type()');
-- jsonb_path_query 
--------------------
+  jsonb_path_query 
+ ------------------
 - "boolean"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ "null"
+ (1 row)
+ 
  select jsonb_path_query('[1, 2, 3]', 'strict ($[*].a > 3).type()');
-- jsonb_path_query 
--------------------
-- "null"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+@@ -1330,10 +1140,11 @@
  select jsonb_path_query('[1,null,true,"11",[],[1],[1,2,3],{},{"a":1,"b":2}]', 'strict $[*].size()');
--ERROR:  jsonpath item method .size() can only be applied to an array
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ ERROR:  jsonpath item method .size() can only be applied to an array
  select jsonb_path_query('[1,null,true,"11",[],[1],[1,2,3],{},{"a":1,"b":2}]', 'strict $[*].size()', silent => true);
 - jsonb_path_query 
 -------------------
@@ -1603,81 +1409,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +                                                                                                            ^
 +HINT:  try \hf jsonb_path_query
  select jsonb_path_query('[1,null,true,"11",[],[1],[1,2,3],{},{"a":1,"b":2}]', 'lax $[*].size()');
-- jsonb_path_query 
--------------------
-- 1
-- 1
-- 1
-- 1
-- 0
-- 1
-- 3
-- 1
-- 1
--(9 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[0, 1, -2, -3.4, 5.6]', '$[*].abs()');
-- jsonb_path_query 
--------------------
-- 0
-- 1
-- 2
-- 3.4
-- 5.6
--(5 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[0, 1, -2, -3.4, 5.6]', '$[*].floor()');
-- jsonb_path_query 
--------------------
-- 0
-- 1
-- -2
-- -4
-- 5
--(5 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[0, 1, -2, -3.4, 5.6]', '$[*].ceiling()');
-- jsonb_path_query 
--------------------
-- 0
-- 1
-- -2
-- -3
-- 6
--(5 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[0, 1, -2, -3.4, 5.6]', '$[*].ceiling().abs()');
-- jsonb_path_query 
--------------------
-- 0
-- 1
-- 2
-- 3
-- 6
--(5 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[0, 1, -2, -3.4, 5.6]', '$[*].ceiling().abs().type()');
-- jsonb_path_query 
--------------------
-- "number"
-- "number"
-- "number"
-- "number"
-- "number"
--(5 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+  jsonb_path_query 
+ ------------------
+@@ -1399,124 +1210,117 @@
+ (5 rows)
+ 
  select jsonb_path_query('[{},1]', '$[*].keyvalue()');
 -ERROR:  jsonpath item method .keyvalue() can only be applied to an object
 +ERROR:  unknown signature: jsonb_path_query(string, string)
@@ -1881,17 +1617,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +                                                        ^
 +HINT:  try \hf jsonb_path_query
  select jsonb_path_query('{}', '$.abs()');
--ERROR:  jsonpath item method .abs() can only be applied to a numeric value
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ ERROR:  jsonpath item method .abs() can only be applied to a numeric value
  select jsonb_path_query('true', '$.floor()');
--ERROR:  jsonpath item method .floor() can only be applied to a numeric value
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+@@ -1524,20 +1328,23 @@
  select jsonb_path_query('"1.2"', '$.ceiling()');
--ERROR:  jsonpath item method .ceiling() can only be applied to a numeric value
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+ ERROR:  jsonpath item method .ceiling() can only be applied to a numeric value
  select jsonb_path_query('{}', '$.abs()', silent => true);
 - jsonb_path_query 
 -------------------
@@ -1923,153 +1653,29 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +                                                        ^
 +HINT:  try \hf jsonb_path_query
  select jsonb_path_query('["", "a", "abc", "abcabc"]', '$[*] ? (@ starts with "abc")');
-- jsonb_path_query 
--------------------
-- "abc"
-- "abcabc"
--(2 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('["", "a", "abc", "abcabc"]', 'strict $ ? (@[*] starts with "abc")');
--      jsonb_path_query      
------------------------------
-- ["", "a", "abc", "abcabc"]
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('["", "a", "abd", "abdabc"]', 'strict $ ? (@[*] starts with "abc")');
-- jsonb_path_query 
--------------------
--(0 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('["abc", "abcabc", null, 1]', 'strict $ ? (@[*] starts with "abc")');
-- jsonb_path_query 
--------------------
--(0 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('["abc", "abcabc", null, 1]', 'strict $ ? ((@[*] starts with "abc") is unknown)');
--      jsonb_path_query      
------------------------------
-- ["abc", "abcabc", null, 1]
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[[null, 1, "abc", "abcabc"]]', 'lax $ ? (@[*] starts with "abc")');
--      jsonb_path_query      
------------------------------
-- [null, 1, "abc", "abcabc"]
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[[null, 1, "abd", "abdabc"]]', 'lax $ ? ((@[*] starts with "abc") is unknown)');
--      jsonb_path_query      
------------------------------
-- [null, 1, "abd", "abdabc"]
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "abd", "abdabc"]', 'lax $[*] ? ((@ starts with "abc") is unknown)');
-- jsonb_path_query 
--------------------
-- null
-- 1
--(2 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\nabc", "ab\nadc"]', 'lax $[*] ? (@ like_regex "^ab.*c")');
   jsonb_path_query 
  ------------------
-@@ -1594,625 +1281,376 @@
- (2 rows)
- 
- select jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\nabc", "ab\nadc"]', 'lax $[*] ? (@ like_regex "^ab.*c" flag "i")');
-- jsonb_path_query 
--------------------
-- "abc"
-- "aBdC"
-- "abdacb"
--(3 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\nabc", "ab\nadc"]', 'lax $[*] ? (@ like_regex "^ab.*c" flag "m")');
-- jsonb_path_query 
--------------------
-- "abc"
-- "abdacb"
-- "adc\nabc"
--(3 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\nabc", "ab\nadc"]', 'lax $[*] ? (@ like_regex "^ab.*c" flag "s")');
-- jsonb_path_query 
--------------------
-- "abc"
-- "abdacb"
-- "ab\nadc"
--(3 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "a\b", "a\\b", "^a\\b$"]', 'lax $[*] ? (@ like_regex "a\\b" flag "q")');
-- jsonb_path_query 
--------------------
-- "a\\b"
-- "^a\\b$"
--(2 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+@@ -1627,8 +1434,10 @@
  select jsonb_path_query('[null, 1, "a\b", "a\\b", "^a\\b$"]', 'lax $[*] ? (@ like_regex "a\\b" flag "")');
-- jsonb_path_query 
--------------------
+  jsonb_path_query 
+ ------------------
 - "a\b"
 -(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++ "a\u0008"
++ "a\\b"
++ "^a\\b$"
++(3 rows)
+ 
  select jsonb_path_query('[null, 1, "a\b", "a\\b", "^a\\b$"]', 'lax $[*] ? (@ like_regex "^a\\b$" flag "q")');
-- jsonb_path_query 
--------------------
-- "^a\\b$"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "a\b", "a\\b", "^a\\b$"]', 'lax $[*] ? (@ like_regex "^a\\B$" flag "q")');
-- jsonb_path_query 
--------------------
--(0 rows)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
- select jsonb_path_query('[null, 1, "a\b", "a\\b", "^a\\b$"]', 'lax $[*] ? (@ like_regex "^a\\B$" flag "iq")');
-- jsonb_path_query 
--------------------
-- "^a\\b$"
--(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
+  jsonb_path_query 
+@@ -1650,569 +1459,354 @@
  select jsonb_path_query('[null, 1, "a\b", "a\\b", "^a\\b$"]', 'lax $[*] ? (@ like_regex "^a\\b$" flag "")');
-- jsonb_path_query 
--------------------
+  jsonb_path_query 
+ ------------------
 - "a\b"
 -(1 row)
--
-+ERROR:  unknown signature: jsonb_path_query(string, string)
-+HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
++(0 rows)
+ 
  select jsonb_path_query('null', '$.datetime()');
 -ERROR:  jsonpath item method .datetime() can only be applied to a string
 +ERROR:  unknown signature: jsonb_path_query(string, string)
@@ -2805,48 +2411,27 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 - true
 -(1 row)
 -
-+ERROR:  jsonb_path_query(): could not parse "$.datetime() > \"2020-01-01 12:00:00\".datetime()" as type jsonpath: at or near "(": syntax error
++ERROR:  jsonb_path_query(): could not parse "$.datetime() > \"2020-01-01 12:00:00\".datetime()" as type jsonpath: at or near ")": syntax error: unimplemented: this syntax: .datetime()
 +DETAIL:  source SQL:
 +$.datetime() > "2020-01-01 12:00:00".datetime()
-+          ^
++           ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  set time zone default;
  -- jsonpath operators
  SELECT jsonb_path_query('[{"a": 1}, {"a": 2}]', '$[*]');
-@@ -2236,95 +1674,85 @@
+@@ -2236,7 +1830,7 @@
  (1 row)
  
  SELECT jsonb_path_query_array('[{"a": 1}, {"a": 2}, {}]', 'strict $[*].a');
 -ERROR:  JSON object does not contain key "a"
-+ERROR:  jsonb_path_query_array(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
++ERROR:  jsonb_path_query_array(): JSON object does not contain key "a"
  SELECT jsonb_path_query_array('[{"a": 1}, {"a": 2}]', '$[*].a');
-- jsonb_path_query_array 
--------------------------
-- [1, 2]
--(1 row)
--
-+ERROR:  jsonb_path_query_array(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
- SELECT jsonb_path_query_array('[{"a": 1}, {"a": 2}]', '$[*].a ? (@ == 1)');
-- jsonb_path_query_array 
--------------------------
-- [1]
--(1 row)
--
-+ERROR:  jsonb_path_query_array(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
- SELECT jsonb_path_query_array('[{"a": 1}, {"a": 2}]', '$[*].a ? (@ > 10)');
-- jsonb_path_query_array 
--------------------------
-- []
--(1 row)
--
-+ERROR:  jsonb_path_query_array(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
+  jsonb_path_query_array 
+ ------------------------
+@@ -2256,25 +1850,25 @@
+ (1 row)
+ 
  SELECT jsonb_path_query_array('[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}]', '$[*].a ? (@ > $min && @ < $max)', vars => '{"min": 1, "max": 4}');
 - jsonb_path_query_array 
 -------------------------
@@ -2871,9 +2456,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +HINT:  try \hf jsonb_path_query_array
  SELECT jsonb_path_query_first('[{"a": 1}, {"a": 2}, {}]', 'strict $[*].a');
 -ERROR:  JSON object does not contain key "a"
-+ERROR:  jsonb_path_query_first(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
++ERROR:  jsonb_path_query_first(): JSON object does not contain key "a"
  SELECT jsonb_path_query_first('[{"a": 1}, {"a": 2}, {}]', 'strict $[*].a', silent => true);
 - jsonb_path_query_first 
 -------------------------
@@ -2886,32 +2469,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +                                                                                   ^
 +HINT:  try \hf jsonb_path_query_first
  SELECT jsonb_path_query_first('[{"a": 1}, {"a": 2}]', '$[*].a');
-- jsonb_path_query_first 
--------------------------
-- 1
--(1 row)
--
-+ERROR:  jsonb_path_query_first(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
- SELECT jsonb_path_query_first('[{"a": 1}, {"a": 2}]', '$[*].a ? (@ == 1)');
-- jsonb_path_query_first 
--------------------------
-- 1
--(1 row)
--
-+ERROR:  jsonb_path_query_first(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
- SELECT jsonb_path_query_first('[{"a": 1}, {"a": 2}]', '$[*].a ? (@ > 10)');
-- jsonb_path_query_first 
--------------------------
-- 
--(1 row)
--
-+ERROR:  jsonb_path_query_first(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
+  jsonb_path_query_first 
+ ------------------------
+@@ -2294,19 +1888,19 @@
+ (1 row)
+ 
  SELECT jsonb_path_query_first('[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}]', '$[*].a ? (@ > $min && @ < $max)', vars => '{"min": 1, "max": 4}');
 - jsonb_path_query_first 
 -------------------------
@@ -2936,18 +2498,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 +HINT:  try \hf jsonb_path_query_first
  SELECT jsonb_path_query_first('[{"a": 1}]', '$undefined_var');
 -ERROR:  could not find jsonpath variable "undefined_var"
-+ERROR:  jsonb_path_query_first(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
++ERROR:  jsonb_path_query_first(): could not find jsonpath variable "undefined_var"
  SELECT jsonb_path_query_first('[{"a": 1}]', 'false');
-- jsonb_path_query_first 
--------------------------
-- false
--(1 row)
--
-+ERROR:  jsonb_path_query_first(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
+  jsonb_path_query_first 
+ ------------------------
+@@ -2314,17 +1908,15 @@
+ (1 row)
+ 
  SELECT jsonb '[{"a": 1}, {"a": 2}]' @? '$[*].a ? (@ > 1)';
 - ?column? 
 -----------
@@ -2971,7 +2528,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  SELECT jsonb_path_exists('[{"a": 1}, {"a": 2}]', '$[*].a ? (@ > 1)');
   jsonb_path_exists 
  -------------------
-@@ -2332,19 +1760,19 @@
+@@ -2332,19 +1924,19 @@
  (1 row)
  
  SELECT jsonb_path_exists('[{"a": 1}, {"a": 2}, {"a": 3}, {"a": 5}]', '$[*] ? (@.a > $min && @.a < $max)', vars => '{"min": 1, "max": 4}');
@@ -3002,7 +2559,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
  SELECT jsonb_path_exists('[{"a": 1}]', 'false');
   jsonb_path_exists 
  -------------------
-@@ -2352,75 +1780,93 @@
+@@ -2352,61 +1944,81 @@
  (1 row)
  
  SELECT jsonb_path_match('true', '$', silent => false);
@@ -3124,32 +2681,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonb_jsonpath.ou
 -
 +ERROR:  unsupported comparison operator: <jsonb> @@ <string>
  SELECT jsonb_path_match('[{"a": 1}, {"a": 2}]', '$[*].a > 1');
-- jsonb_path_match 
--------------------
-- t
--(1 row)
--
-+ERROR:  jsonb_path_match(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
+  jsonb_path_match 
+ ------------------
+@@ -2414,7 +2026,7 @@
+ (1 row)
+ 
  SELECT jsonb_path_match('[{"a": 1}]', '$undefined_var');
 -ERROR:  could not find jsonpath variable "undefined_var"
-+ERROR:  jsonb_path_match(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
++ERROR:  jsonb_path_match(): could not find jsonpath variable "undefined_var"
  SELECT jsonb_path_match('[{"a": 1}]', 'false');
-- jsonb_path_match 
--------------------
-- f
--(1 row)
--
-+ERROR:  jsonb_path_match(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_
- -- test string comparison (Unicode codepoint collation)
- WITH str(j, num) AS
- (
-@@ -2436,151 +1882,15 @@
+  jsonb_path_match 
+ ------------------
+@@ -2436,151 +2048,15 @@
  	jsonb_path_query_first(s1.j, '$.s > $s', vars => s2.j) gt
  FROM str s1, str s2
  ORDER BY s1.num, s2.num;

--- a/pkg/cmd/roachtest/testdata/pg_regress/jsonpath.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/jsonpath.diffs
@@ -14,7 +14,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  select '$'::jsonpath;
   jsonpath 
  ----------
-@@ -88,101 +89,91 @@
+@@ -88,69 +89,77 @@
  (1 row)
  
  select '$.a.**.b'::jsonpath;
@@ -23,80 +23,96 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 - $."a".**."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**.b" as type jsonpath: at or near ".": syntax error
++ERROR:  could not parse "$.a.**.b" as type jsonpath: at or near ".": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**.b
 +      ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{2}.b'::jsonpath;
 -    jsonpath     
 ------------------
 - $."a".**{2}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{2}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{2}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{2}.b
-+      ^
++        ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{2 to 2}.b'::jsonpath;
 -    jsonpath     
 ------------------
 - $."a".**{2}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{2 to 2}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{2 to 2}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{2 to 2}.b
-+      ^
++             ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{2 to 5}.b'::jsonpath;
 -       jsonpath       
 -----------------------
 - $."a".**{2 to 5}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{2 to 5}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{2 to 5}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{2 to 5}.b
-+      ^
++             ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{0 to 5}.b'::jsonpath;
 -       jsonpath       
 -----------------------
 - $."a".**{0 to 5}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{0 to 5}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{0 to 5}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{0 to 5}.b
-+      ^
++             ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{5 to last}.b'::jsonpath;
 -        jsonpath         
 --------------------------
 - $."a".**{5 to last}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{5 to last}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{5 to last}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{5 to last}.b
-+      ^
++                ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{last}.b'::jsonpath;
 -      jsonpath      
 ---------------------
 - $."a".**{last}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{last}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{last}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{last}.b
-+      ^
++           ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.a.**{last to 5}.b'::jsonpath;
 -        jsonpath         
 --------------------------
 - $."a".**{last to 5}."b"
 -(1 row)
 -
-+ERROR:  could not parse "$.a.**{last to 5}.b" as type jsonpath: at or near "{": syntax error
++ERROR:  could not parse "$.a.**{last to 5}.b" as type jsonpath: at or near "}": syntax error: unimplemented: this syntax: .**
 +DETAIL:  source SQL:
 +$.a.**{last to 5}.b
-+      ^
++                ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$+1'::jsonpath;
 - jsonpath 
 -----------
@@ -116,28 +132,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  (1 row)
  
  select '$--+1'::jsonpath;
-  jsonpath 
- ----------
+- jsonpath 
+-----------
 - ($ - -1)
-+ $""
++  jsonpath  
++------------
++ ($"" - -1)
  (1 row)
  
  select '$.a/+-1'::jsonpath;
--   jsonpath   
----------------
-- ($."a" / -1)
-+     jsonpath      
-+-------------------
-+ ($."a" / (+(-1)))
- (1 row)
- 
- select '1 * 2 + 4 % -3 != false'::jsonpath;
--         jsonpath          
-----------------------------
-- (1 * 2 + 4 % -3 != false)
-+             jsonpath              
-+-----------------------------------
-+ (((1 * 2) + (4 % (-3))) != false)
+@@ -166,23 +175,21 @@
  (1 row)
  
  select '"\b\f\r\n\t\v\"\''\\"'::jsonpath;
@@ -172,214 +176,31 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  select '"\z"'::jsonpath;  -- unrecognized escape is just the literal char
   jsonpath 
  ----------
-@@ -190,63 +181,63 @@
+@@ -316,9 +323,7 @@
  (1 row)
  
- select '$.g ? ($.a == 1)'::jsonpath;
--      jsonpath      
----------------------
-- $."g"?($."a" == 1)
-+       jsonpath       
-+----------------------
-+ $."g"?(($."a" == 1))
- (1 row)
- 
- select '$.g ? (@ == 1)'::jsonpath;
--    jsonpath    
------------------
-- $."g"?(@ == 1)
-+     jsonpath     
-+------------------
-+ $."g"?((@ == 1))
- (1 row)
- 
- select '$.g ? (@.a == 1)'::jsonpath;
--      jsonpath      
----------------------
-- $."g"?(@."a" == 1)
-+       jsonpath       
-+----------------------
-+ $."g"?((@."a" == 1))
- (1 row)
- 
- select '$.g ? (@.a == 1 || @.a == 4)'::jsonpath;
--             jsonpath             
------------------------------------
-- $."g"?(@."a" == 1 || @."a" == 4)
-+                jsonpath                
-+----------------------------------------
-+ $."g"?(((@."a" == 1) || (@."a" == 4)))
- (1 row)
- 
- select '$.g ? (@.a == 1 && @.a == 4)'::jsonpath;
--             jsonpath             
------------------------------------
-- $."g"?(@."a" == 1 && @."a" == 4)
-+                jsonpath                
-+----------------------------------------
-+ $."g"?(((@."a" == 1) && (@."a" == 4)))
- (1 row)
- 
- select '$.g ? (@.a == 1 || @.a == 4 && @.b == 7)'::jsonpath;
--                    jsonpath                    
--------------------------------------------------
-- $."g"?(@."a" == 1 || @."a" == 4 && @."b" == 7)
-+                         jsonpath                         
-+----------------------------------------------------------
-+ $."g"?(((@."a" == 1) || ((@."a" == 4) && (@."b" == 7))))
- (1 row)
- 
- select '$.g ? (@.a == 1 || !(@.a == 4) && @.b == 7)'::jsonpath;
--                     jsonpath                      
-----------------------------------------------------
-- $."g"?(@."a" == 1 || !(@."a" == 4) && @."b" == 7)
-+                          jsonpath                           
-+-------------------------------------------------------------
-+ $."g"?(((@."a" == 1) || (!((@."a" == 4)) && (@."b" == 7))))
- (1 row)
- 
- select '$.g ? (@.a == 1 || !(@.x >= 123 || @.a == 4) && @.b == 7)'::jsonpath;
--                             jsonpath                              
---------------------------------------------------------------------
-- $."g"?(@."a" == 1 || !(@."x" >= 123 || @."a" == 4) && @."b" == 7)
-+                                    jsonpath                                     
-+---------------------------------------------------------------------------------
-+ $."g"?(((@."a" == 1) || (!(((@."x" >= 123) || (@."a" == 4))) && (@."b" == 7))))
- (1 row)
- 
- select '$.g ? (@.x >= @[*]?(@.a > "abc"))'::jsonpath;
--               jsonpath                
-----------------------------------------
-- $."g"?(@."x" >= @[*]?(@."a" > "abc"))
-+                 jsonpath                  
-+-------------------------------------------
-+ $."g"?((@."x" >= @[*]?((@."a" > "abc"))))
- (1 row)
- 
- select '$.g ? ((@.x >= 123 || @.a == 4) is unknown)'::jsonpath;
--                    jsonpath                     
---------------------------------------------------
-- $."g"?((@."x" >= 123 || @."a" == 4) is unknown)
-+                       jsonpath                        
-+-------------------------------------------------------
-+ $."g"?((((@."x" >= 123) || (@."a" == 4))) is unknown)
- (1 row)
- 
- select '$.g ? (exists (@.x))'::jsonpath;
-@@ -256,21 +247,21 @@
- (1 row)
- 
- select '$.g ? (exists (@.x ? (@ == 14)))'::jsonpath;
--             jsonpath             
------------------------------------
-- $."g"?(exists (@."x"?(@ == 14)))
-+              jsonpath              
-+------------------------------------
-+ $."g"?(exists (@."x"?((@ == 14))))
- (1 row)
- 
- select '$.g ? ((@.x >= 123 || @.a == 4) && exists (@.x ? (@ == 14)))'::jsonpath;
--                             jsonpath                             
--------------------------------------------------------------------
-- $."g"?((@."x" >= 123 || @."a" == 4) && exists (@."x"?(@ == 14)))
-+                                 jsonpath                                 
-+--------------------------------------------------------------------------
-+ $."g"?((((@."x" >= 123) || (@."a" == 4)) && exists (@."x"?((@ == 14)))))
- (1 row)
- 
- select '$.g ? (+@.x >= +-(+@.a + 2))'::jsonpath;
--              jsonpath              
--------------------------------------
-- $."g"?(+@."x" >= +(-(+@."a" + 2)))
-+                  jsonpath                  
-+--------------------------------------------
-+ $."g"?(((+@."x") >= (+(-((+@."a") + 2)))))
- (1 row)
- 
- select '$a'::jsonpath;
-@@ -292,9 +283,9 @@
- (1 row)
- 
- select '$.g ? (@.zip == $zip)'::jsonpath;
--         jsonpath          
-----------------------------
-- $."g"?(@."zip" == $"zip")
-+          jsonpath           
-+-----------------------------
-+ $."g"?((@."zip" == $"zip"))
- (1 row)
- 
- select '$.a[1,2, 3 to 16]'::jsonpath;
-@@ -304,21 +295,22 @@
- (1 row)
- 
- select '$.a[$a + 1, ($b[*]) to -($[0] * 2)]'::jsonpath;
--                jsonpath                
------------------------------------------
-- $."a"[$"a" + 1,$"b"[*] to -($[0] * 2)]
-+                  jsonpath                  
-+--------------------------------------------
-+ $."a"[($"a" + 1),$"b"[*] to (-($[0] * 2))]
- (1 row)
- 
- select '$.a[$.a.size() - 3]'::jsonpath;
--        jsonpath         
---------------------------
-- $."a"[$."a".size() - 3]
-+ERROR:  could not parse "$.a[$.a.size() - 3]" as type jsonpath: at or near "(": syntax error
-+DETAIL:  source SQL:
-+$.a[$.a.size() - 3]
-+            ^
-+select 'last'::jsonpath;
-+ jsonpath 
-+----------
-+ last
- (1 row)
- 
--select 'last'::jsonpath;
+ select 'last'::jsonpath;
 -ERROR:  LAST is allowed only in array subscripts
 -LINE 1: select 'last'::jsonpath;
 -               ^
++ERROR:  could not parse "last" as type jsonpath: LAST is allowed only in array subscripts
  select '"last"'::jsonpath;
   jsonpath 
  ----------
-@@ -332,9 +324,11 @@
+@@ -332,9 +337,7 @@
  (1 row)
  
  select '$ ? (last > 0)'::jsonpath;
 -ERROR:  LAST is allowed only in array subscripts
 -LINE 1: select '$ ? (last > 0)'::jsonpath;
 -               ^
-+    jsonpath    
-+----------------
-+ $?((last > 0))
-+(1 row)
-+
++ERROR:  could not parse "$ ? (last > 0)" as type jsonpath: LAST is allowed only in array subscripts
  select '$[last]'::jsonpath;
   jsonpath 
  ----------
-@@ -342,142 +336,226 @@
+@@ -354,19 +357,20 @@
  (1 row)
  
- select '$[$[0] ? (last > 0)]'::jsonpath;
--      jsonpath      
----------------------
-- $[$[0]?(last > 0)]
-+       jsonpath       
-+----------------------
-+ $[$[0]?((last > 0))]
- (1 row)
- 
- select 'null.type()'::jsonpath;
--  jsonpath   
---------------
-- null.type()
--(1 row)
--
-+ERROR:  could not parse "null.type()" as type jsonpath: at or near "(": syntax error
-+DETAIL:  source SQL:
-+null.type()
-+         ^
  select '1.type()'::jsonpath;
 -ERROR:  trailing junk after numeric literal at or near "1.t" of jsonpath input
 -LINE 1: select '1.type()'::jsonpath;
@@ -392,102 +213,78 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 -  jsonpath  
 -------------
 - (1).type()
--(1 row)
--
-+ERROR:  could not parse "(1).type()" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+(1).type()
-+   ^
++ jsonpath 
++----------
++ 1.type()
+ (1 row)
+ 
  select '1.2.type()'::jsonpath;
 -   jsonpath   
 ---------------
 - (1.2).type()
--(1 row)
--
-+ERROR:  could not parse "1.2.type()" as type jsonpath: at or near "(": syntax error
-+DETAIL:  source SQL:
-+1.2.type()
-+        ^
++  jsonpath  
++------------
++ 1.2.type()
+ (1 row)
+ 
  select '"aaa".type()'::jsonpath;
--   jsonpath   
----------------
-- "aaa".type()
--(1 row)
--
-+ERROR:  could not parse "\"aaa\".type()" as type jsonpath: at or near "(": syntax error
-+DETAIL:  source SQL:
-+"aaa".type()
-+          ^
- select 'true.type()'::jsonpath;
--  jsonpath   
---------------
-- true.type()
--(1 row)
--
-+ERROR:  could not parse "true.type()" as type jsonpath: at or near "(": syntax error
-+DETAIL:  source SQL:
-+true.type()
-+         ^
+@@ -382,29 +386,33 @@
+ (1 row)
+ 
  select '$.double().floor().ceiling().abs()'::jsonpath;
 -              jsonpath              
 -------------------------------------
 - $.double().floor().ceiling().abs()
 -(1 row)
 -
-+ERROR:  could not parse "$.double().floor().ceiling().abs()" as type jsonpath: at or near "(": syntax error
++ERROR:  could not parse "$.double().floor().ceiling().abs()" as type jsonpath: at or near "(": syntax error: unimplemented: this syntax: .double()
 +DETAIL:  source SQL:
 +$.double().floor().ceiling().abs()
 +        ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.keyvalue().key'::jsonpath;
 -      jsonpath      
 ---------------------
 - $.keyvalue()."key"
 -(1 row)
 -
-+ERROR:  could not parse "$.keyvalue().key" as type jsonpath: at or near "(": syntax error
++ERROR:  could not parse "$.keyvalue().key" as type jsonpath: at or near "(": syntax error: unimplemented: this syntax: .keyvalue()
 +DETAIL:  source SQL:
 +$.keyvalue().key
 +          ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.datetime()'::jsonpath;
 -   jsonpath   
 ---------------
 - $.datetime()
 -(1 row)
 -
-+ERROR:  could not parse "$.datetime()" as type jsonpath: at or near "(": syntax error
++ERROR:  could not parse "$.datetime()" as type jsonpath: at or near ")": syntax error: unimplemented: this syntax: .datetime()
 +DETAIL:  source SQL:
 +$.datetime()
-+          ^
++           ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$.datetime("datetime template")'::jsonpath;
 -            jsonpath             
 ----------------------------------
 - $.datetime("datetime template")
 -(1 row)
 -
-+ERROR:  could not parse "$.datetime(\"datetime template\")" as type jsonpath: at or near "(": syntax error
++ERROR:  could not parse "$.datetime(\"datetime template\")" as type jsonpath: at or near ")": syntax error: unimplemented: this syntax: .datetime()
 +DETAIL:  source SQL:
 +$.datetime("datetime template")
-+          ^
++                              ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/22513/_version_
  select '$ ? (@ starts with "abc")'::jsonpath;
--        jsonpath         
---------------------------
-- $?(@ starts with "abc")
--(1 row)
--
-+ERROR:  could not parse "$ ? (@ starts with \"abc\")" as type jsonpath: at or near "starts": syntax error
-+DETAIL:  source SQL:
-+$ ? (@ starts with "abc")
-+       ^
- select '$ ? (@ starts with $var)'::jsonpath;
--         jsonpath         
----------------------------
-- $?(@ starts with $"var")
--(1 row)
--
-+ERROR:  could not parse "$ ? (@ starts with $var)" as type jsonpath: at or near "starts": syntax error
-+DETAIL:  source SQL:
-+$ ? (@ starts with $var)
-+       ^
+         jsonpath         
+ -------------------------
+@@ -418,9 +426,10 @@
+ (1 row)
+ 
  select '$ ? (@ like_regex "(invalid pattern")'::jsonpath;
 -ERROR:  invalid regular expression: parentheses () not balanced
 -LINE 1: select '$ ? (@ like_regex "(invalid pattern")'::jsonpath;
@@ -497,317 +294,72 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 +$ ? (@ like_regex "(invalid pattern")
 +                                    ^
  select '$ ? (@ like_regex "pattern")'::jsonpath;
--          jsonpath          
------------------------------
-- $?(@ like_regex "pattern")
-+           jsonpath           
-+------------------------------
-+ $?((@ like_regex "pattern"))
+           jsonpath          
+ ----------------------------
+@@ -452,9 +461,10 @@
  (1 row)
- 
- select '$ ? (@ like_regex "pattern" flag "")'::jsonpath;
--          jsonpath          
------------------------------
-- $?(@ like_regex "pattern")
--(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"\")" as type jsonpath: at or near "": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+$ ? (@ like_regex "pattern" flag "")
-+                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
- 
- select '$ ? (@ like_regex "pattern" flag "i")'::jsonpath;
--              jsonpath               
---------------------------------------
-- $?(@ like_regex "pattern" flag "i")
--(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"i\")" as type jsonpath: at or near "i": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+$ ? (@ like_regex "pattern" flag "i")
-+                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
- 
- select '$ ? (@ like_regex "pattern" flag "is")'::jsonpath;
--               jsonpath               
----------------------------------------
-- $?(@ like_regex "pattern" flag "is")
--(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"is\")" as type jsonpath: at or near "is": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+$ ? (@ like_regex "pattern" flag "is")
-+                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
- 
- select '$ ? (@ like_regex "pattern" flag "isim")'::jsonpath;
--               jsonpath                
-----------------------------------------
-- $?(@ like_regex "pattern" flag "ism")
--(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"isim\")" as type jsonpath: at or near "isim": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+$ ? (@ like_regex "pattern" flag "isim")
-+                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
  
  select '$ ? (@ like_regex "pattern" flag "xsms")'::jsonpath;
 -ERROR:  XQuery "x" flag (expanded regular expressions) is not implemented
 -LINE 1: select '$ ? (@ like_regex "pattern" flag "xsms")'::jsonpath;
 -               ^
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"xsms\")" as type jsonpath: at or near "xsms": syntax error: unimplemented: this syntax
++ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"xsms\")" as type jsonpath: at or near "xsms": syntax error: XQuery "x" flag (expanded regular expressions) is not implemented
 +DETAIL:  source SQL:
 +$ ? (@ like_regex "pattern" flag "xsms")
 +                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
-+
  select '$ ? (@ like_regex "pattern" flag "q")'::jsonpath;
--              jsonpath               
---------------------------------------
-- $?(@ like_regex "pattern" flag "q")
--(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"q\")" as type jsonpath: at or near "q": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+$ ? (@ like_regex "pattern" flag "q")
-+                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
- 
- select '$ ? (@ like_regex "pattern" flag "iq")'::jsonpath;
--               jsonpath               
----------------------------------------
-- $?(@ like_regex "pattern" flag "iq")
--(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"iq\")" as type jsonpath: at or near "iq": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+$ ? (@ like_regex "pattern" flag "iq")
-+                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
+               jsonpath               
+ -------------------------------------
+@@ -468,16 +478,15 @@
+ (1 row)
  
  select '$ ? (@ like_regex "pattern" flag "smixq")'::jsonpath;
 -                jsonpath                 
 ------------------------------------------
 - $?(@ like_regex "pattern" flag "ismxq")
 -(1 row)
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"smixq\")" as type jsonpath: at or near "smixq": syntax error: unimplemented: this syntax
+-
++ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"smixq\")" as type jsonpath: at or near "smixq": syntax error: XQuery "x" flag (expanded regular expressions) is not implemented
 +DETAIL:  source SQL:
 +$ ? (@ like_regex "pattern" flag "smixq")
 +                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
- 
  select '$ ? (@ like_regex "pattern" flag "a")'::jsonpath;
 -ERROR:  invalid input syntax for type jsonpath
 -LINE 1: select '$ ? (@ like_regex "pattern" flag "a")'::jsonpath;
 -               ^
 -DETAIL:  Unrecognized flag character "a" in LIKE_REGEX predicate.
-+ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"a\")" as type jsonpath: at or near "a": syntax error: unimplemented: this syntax
++ERROR:  could not parse "$ ? (@ like_regex \"pattern\" flag \"a\")" as type jsonpath: at or near "a": syntax error: unrecognized flag character 'a' in LIKE_REGEX predicate
 +DETAIL:  source SQL:
 +$ ? (@ like_regex "pattern" flag "a")
 +                                 ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
-+
  select '$ < 1'::jsonpath;
   jsonpath 
  ----------
-@@ -485,51 +563,47 @@
- (1 row)
- 
- select '($ < 1) || $.a.b <= $x'::jsonpath;
--           jsonpath           
--------------------------------
-- ($ < 1 || $."a"."b" <= $"x")
-+             jsonpath             
-+----------------------------------
-+ (($ < 1) || ($."a"."b" <= $"x"))
+@@ -491,9 +500,7 @@
  (1 row)
  
  select '@ + 1'::jsonpath;
 -ERROR:  @ is not allowed in root expressions
 -LINE 1: select '@ + 1'::jsonpath;
 -               ^
--select '($).a.b'::jsonpath;
-- jsonpath  
-------------
-- $."a"."b"
-+ jsonpath 
-+----------
-+ (@ + 1)
- (1 row)
- 
-+select '($).a.b'::jsonpath;
-+ERROR:  could not parse "($).a.b" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+($).a.b
-+   ^
- select '($.a.b).c.d'::jsonpath;
--     jsonpath      
---------------------
-- $."a"."b"."c"."d"
--(1 row)
--
-+ERROR:  could not parse "($.a.b).c.d" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+($.a.b).c.d
-+       ^
- select '($.a.b + -$.x.y).c.d'::jsonpath;
--             jsonpath             
------------------------------------
-- ($."a"."b" + -$."x"."y")."c"."d"
--(1 row)
--
-+ERROR:  could not parse "($.a.b + -$.x.y).c.d" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+($.a.b + -$.x.y).c.d
-+                ^
- select '(-+$.a.b).c.d'::jsonpath;
--        jsonpath         
---------------------------
-- (-(+$."a"."b"))."c"."d"
--(1 row)
--
-+ERROR:  could not parse "(-+$.a.b).c.d" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+(-+$.a.b).c.d
-+         ^
- select '1 + ($.a.b + 2).c.d'::jsonpath;
--           jsonpath            
---------------------------------
-- (1 + ($."a"."b" + 2)."c"."d")
--(1 row)
--
-+ERROR:  could not parse "1 + ($.a.b + 2).c.d" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+1 + ($.a.b + 2).c.d
-+               ^
- select '1 + ($.a.b > 2).c.d'::jsonpath;
--           jsonpath            
---------------------------------
-- (1 + ($."a"."b" > 2)."c"."d")
--(1 row)
--
-+ERROR:  could not parse "1 + ($.a.b > 2).c.d" as type jsonpath: at or near ">": syntax error
-+DETAIL:  source SQL:
-+1 + ($.a.b > 2).c.d
-+           ^
- select '($)'::jsonpath;
-  jsonpath 
- ----------
-@@ -543,297 +617,284 @@
++ERROR:  could not parse "@ + 1" as type jsonpath: @ is not allowed in root expressions
+ select '($).a.b'::jsonpath;
+  jsonpath  
+ -----------
+@@ -543,9 +550,9 @@
  (1 row)
  
  select '((($ + 1)).a + ((2)).b ? ((((@ > 1)) || (exists(@.c)))))'::jsonpath;
 -                     jsonpath                      
 ----------------------------------------------------
 - (($ + 1)."a" + (2)."b"?(@ > 1 || exists (@."c")))
--(1 row)
--
-+ERROR:  could not parse "((($ + 1)).a + ((2)).b ? ((((@ > 1)) || (exists(@.c)))))" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+((($ + 1)).a + ((2)).b ? ((((@ > 1)) || (exists(@.c)))))
-+          ^
++                    jsonpath                     
++-------------------------------------------------
++ (($ + 1)."a" + 2."b"?(@ > 1 || exists (@."c")))
+ (1 row)
+ 
  select '$ ? (@.a < 1)'::jsonpath;
--   jsonpath    
-----------------
-- $?(@."a" < 1)
-+    jsonpath     
-+-----------------
-+ $?((@."a" < 1))
- (1 row)
- 
- select '$ ? (@.a < -1)'::jsonpath;
--    jsonpath    
------------------
-- $?(@."a" < -1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < (-1)))
- (1 row)
- 
- select '$ ? (@.a < +1)'::jsonpath;
--   jsonpath    
-----------------
-- $?(@."a" < 1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < (+1)))
+@@ -567,23 +574,20 @@
  (1 row)
  
  select '$ ? (@.a < .1)'::jsonpath;
@@ -841,84 +393,36 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 +$ ? (@.a < +.1)
 +            ^
  select '$ ? (@.a < 0.1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 0.1)
-+     jsonpath      
-+-------------------
-+ $?((@."a" < 0.1))
- (1 row)
- 
- select '$ ? (@.a < -0.1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < -0.1)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (-0.1)))
- (1 row)
- 
- select '$ ? (@.a < +0.1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 0.1)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (+0.1)))
- (1 row)
- 
- select '$ ? (@.a < 10.1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < 10.1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < 10.1))
- (1 row)
- 
- select '$ ? (@.a < -10.1)'::jsonpath;
--     jsonpath      
---------------------
-- $?(@."a" < -10.1)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (-10.1)))
- (1 row)
- 
- select '$ ? (@.a < +10.1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < 10.1)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (+10.1)))
+     jsonpath     
+ -----------------
+@@ -621,41 +625,38 @@
  (1 row)
  
  select '$ ? (@.a < 1e1)'::jsonpath;
 -    jsonpath    
 -----------------
 - $?(@."a" < 10)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < 1E+1))
++     jsonpath     
++------------------
++ $?(@."a" < 1E+1)
  (1 row)
  
  select '$ ? (@.a < -1e1)'::jsonpath;
 -    jsonpath     
 ------------------
 - $?(@."a" < -10)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (-1E+1)))
++     jsonpath      
++-------------------
++ $?(@."a" < -1E+1)
  (1 row)
  
  select '$ ? (@.a < +1e1)'::jsonpath;
 -    jsonpath    
 -----------------
 - $?(@."a" < 10)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (+1E+1)))
++     jsonpath     
++------------------
++ $?(@."a" < 1E+1)
  (1 row)
  
  select '$ ? (@.a < .1e1)'::jsonpath;
@@ -952,84 +456,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 +$ ? (@.a < +.1e1)
 +            ^
  select '$ ? (@.a < 0.1e1)'::jsonpath;
--   jsonpath    
-----------------
-- $?(@."a" < 1)
-+    jsonpath     
-+-----------------
-+ $?((@."a" < 1))
- (1 row)
- 
- select '$ ? (@.a < -0.1e1)'::jsonpath;
--    jsonpath    
------------------
-- $?(@."a" < -1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < (-1)))
- (1 row)
- 
- select '$ ? (@.a < +0.1e1)'::jsonpath;
--   jsonpath    
-----------------
-- $?(@."a" < 1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < (+1)))
- (1 row)
- 
- select '$ ? (@.a < 10.1e1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 101)
-+     jsonpath      
-+-------------------
-+ $?((@."a" < 101))
- (1 row)
- 
- select '$ ? (@.a < -10.1e1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < -101)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (-101)))
- (1 row)
- 
- select '$ ? (@.a < +10.1e1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 101)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (+101)))
- (1 row)
- 
- select '$ ? (@.a < 1e-1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 0.1)
-+     jsonpath      
-+-------------------
-+ $?((@."a" < 0.1))
- (1 row)
- 
- select '$ ? (@.a < -1e-1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < -0.1)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (-0.1)))
- (1 row)
- 
- select '$ ? (@.a < +1e-1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 0.1)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (+0.1)))
+    jsonpath    
+ ---------------
+@@ -711,23 +712,20 @@
  (1 row)
  
  select '$ ? (@.a < .1e-1)'::jsonpath;
@@ -1063,84 +492,36 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 +$ ? (@.a < +.1e-1)
 +            ^
  select '$ ? (@.a < 0.1e-1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < 0.01)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < 0.01))
- (1 row)
- 
- select '$ ? (@.a < -0.1e-1)'::jsonpath;
--     jsonpath      
---------------------
-- $?(@."a" < -0.01)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (-0.01)))
- (1 row)
- 
- select '$ ? (@.a < +0.1e-1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < 0.01)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (+0.01)))
- (1 row)
- 
- select '$ ? (@.a < 10.1e-1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < 1.01)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < 1.01))
- (1 row)
- 
- select '$ ? (@.a < -10.1e-1)'::jsonpath;
--     jsonpath      
---------------------
-- $?(@."a" < -1.01)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (-1.01)))
- (1 row)
- 
- select '$ ? (@.a < +10.1e-1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < 1.01)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (+1.01)))
+      jsonpath     
+ ------------------
+@@ -765,41 +763,38 @@
  (1 row)
  
  select '$ ? (@.a < 1e+1)'::jsonpath;
 -    jsonpath    
 -----------------
 - $?(@."a" < 10)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < 1E+1))
++     jsonpath     
++------------------
++ $?(@."a" < 1E+1)
  (1 row)
  
  select '$ ? (@.a < -1e+1)'::jsonpath;
 -    jsonpath     
 ------------------
 - $?(@."a" < -10)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (-1E+1)))
++     jsonpath      
++-------------------
++ $?(@."a" < -1E+1)
  (1 row)
  
  select '$ ? (@.a < +1e+1)'::jsonpath;
 -    jsonpath    
 -----------------
 - $?(@."a" < 10)
-+       jsonpath        
-+-----------------------
-+ $?((@."a" < (+1E+1)))
++     jsonpath     
++------------------
++ $?(@."a" < 1E+1)
  (1 row)
  
  select '$ ? (@.a < .1e+1)'::jsonpath;
@@ -1174,61 +555,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 +$ ? (@.a < +.1e+1)
 +            ^
  select '$ ? (@.a < 0.1e+1)'::jsonpath;
--   jsonpath    
-----------------
-- $?(@."a" < 1)
-+    jsonpath     
-+-----------------
-+ $?((@."a" < 1))
- (1 row)
- 
- select '$ ? (@.a < -0.1e+1)'::jsonpath;
--    jsonpath    
------------------
-- $?(@."a" < -1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < (-1)))
- (1 row)
- 
- select '$ ? (@.a < +0.1e+1)'::jsonpath;
--   jsonpath    
-----------------
-- $?(@."a" < 1)
-+      jsonpath      
-+--------------------
-+ $?((@."a" < (+1)))
- (1 row)
- 
- select '$ ? (@.a < 10.1e+1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 101)
-+     jsonpath      
-+-------------------
-+ $?((@."a" < 101))
- (1 row)
- 
- select '$ ? (@.a < -10.1e+1)'::jsonpath;
--     jsonpath     
--------------------
-- $?(@."a" < -101)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (-101)))
- (1 row)
- 
- select '$ ? (@.a < +10.1e+1)'::jsonpath;
--    jsonpath     
-------------------
-- $?(@."a" < 101)
-+       jsonpath       
-+----------------------
-+ $?((@."a" < (+101)))
- (1 row)
- 
- -- numeric literals
-@@ -844,35 +905,39 @@
+    jsonpath    
+ ---------------
+@@ -844,35 +839,39 @@
  (1 row)
  
  select '00'::jsonpath;
@@ -1278,7 +607,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  (1 row)
  
  select '0.000e3'::jsonpath;
-@@ -884,39 +949,37 @@
+@@ -884,39 +883,37 @@
  select '0.0010'::jsonpath;
   jsonpath 
  ----------
@@ -1330,7 +659,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  select '1.'::jsonpath;
   jsonpath 
  ----------
-@@ -926,130 +989,128 @@
+@@ -926,130 +923,132 @@
  select '1.e1'::jsonpath;
   jsonpath 
  ----------
@@ -1391,12 +720,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 - jsonpath  
 ------------
 - (1.2)."e"
--(1 row)
--
-+ERROR:  could not parse "(1.2).e" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+(1.2).e
-+     ^
++ jsonpath 
++----------
++ 1.2."e"
+ (1 row)
+ 
  select '1e3'::jsonpath;
   jsonpath 
  ----------
@@ -1463,51 +791,45 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
 + 1.2."e3"
  (1 row)
  
+-select '1..e3'::jsonpath;
 +select '(1.2).e3'::jsonpath;
-+ERROR:  could not parse "(1.2).e3" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+(1.2).e3
-+     ^
+  jsonpath 
+ ----------
+- (1)."e3"
++ 1.2."e3"
+ (1 row)
+ 
 +select '1..e'::jsonpath;
 +ERROR:  could not parse "1..e" as type jsonpath: at or near ".": syntax error
 +DETAIL:  source SQL:
 +1..e
 +  ^
- select '1..e3'::jsonpath;
-- jsonpath 
------------
-- (1)."e3"
--(1 row)
--
++select '1..e3'::jsonpath;
 +ERROR:  could not parse "1..e3" as type jsonpath: at or near ".": syntax error
 +DETAIL:  source SQL:
 +1..e3
 +  ^
  select '(1.).e'::jsonpath;
-- jsonpath 
------------
+  jsonpath 
+ ----------
 - (1)."e"
--(1 row)
--
-+ERROR:  could not parse "(1.).e" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+(1.).e
-+    ^
++ 1."e"
+ (1 row)
+ 
  select '(1.).e3'::jsonpath;
-- jsonpath 
------------
+  jsonpath 
+ ----------
 - (1)."e3"
--(1 row)
--
-+ERROR:  could not parse "(1.).e3" as type jsonpath: at or near ".": syntax error
-+DETAIL:  source SQL:
-+(1.).e3
-+    ^
++ 1."e3"
+ (1 row)
+ 
  select '1?(2>3)'::jsonpath;
-   jsonpath   
- -------------
+-  jsonpath   
+--------------
 - (1)?(2 > 3)
-+ 1?((2 > 3))
++ jsonpath  
++-----------
++ 1?(2 > 3)
  (1 row)
  
  -- nondecimal
@@ -1534,7 +856,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  select '0x42F'::jsonpath;
   jsonpath 
  ----------
-@@ -1058,142 +1119,153 @@
+@@ -1058,142 +1057,153 @@
  
  -- error cases
  select '0b'::jsonpath;
@@ -1793,7 +1115,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/jsonpath.out --la
  -- test non-error-throwing API
  SELECT str as jsonpath,
         pg_input_is_valid(str,'jsonpath') as ok,
-@@ -1207,12 +1279,4 @@
+@@ -1207,12 +1217,4 @@
                    '00',
                    '1a']) str,
       LATERAL pg_input_error_info(str, 'jsonpath') as errinfo;

--- a/pkg/cmd/roachtest/testdata/pg_regress/memoize.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/memoize.diffs
@@ -1,13 +1,28 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/memoize.out --label=/mnt/data1/postgres/src/test/regress/results/memoize.out /mnt/data1/postgres/src/test/regress/expected/memoize.out /mnt/data1/postgres/src/test/regress/results/memoize.out
 --- /mnt/data1/postgres/src/test/regress/expected/memoize.out
 +++ /mnt/data1/postgres/src/test/regress/results/memoize.out
-@@ -28,36 +28,48 @@
+@@ -28,36 +28,63 @@
      end loop;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++    ln text;
++begin
++    for ln in
++           ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  -- Ensure we get a memoize node on the inner side of the nested loop
  SET enable_hashjoin TO off;
 +ERROR:  unimplemented: the configuration setting "enable_hashjoin" is not supported
@@ -69,7 +84,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/memoize.out --lab
  (1 row)
  
  -- Try with LATERAL joins
-@@ -66,36 +78,46 @@
+@@ -66,36 +93,46 @@
  LATERAL (SELECT t2.unique1 FROM tenk1 t2
           WHERE t1.twenty = t2.unique1 OFFSET 0) t2
  WHERE t1.unique1 < 1000;', false);
@@ -135,7 +150,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/memoize.out --lab
  -- Ensure we get some evictions.  We're unable to validate the hits and misses
  -- here as the number of entries that fit in the cache at once will vary
  -- between different machines.
-@@ -103,61 +125,21 @@
+@@ -103,61 +140,21 @@
  SELECT COUNT(*),AVG(t1.unique1) FROM tenk1 t1
  INNER JOIN tenk1 t2 ON t1.unique1 = t2.thousand
  WHERE t2.unique1 < 1200;', true);
@@ -201,7 +216,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/memoize.out --lab
  DROP TABLE flt;
  -- Exercise Memoize in binary mode with a large fixed width type and a
  -- varlena type.
-@@ -165,103 +147,65 @@
+@@ -165,103 +162,65 @@
  CREATE INDEX strtest_n_idx ON strtest (n);
  CREATE INDEX strtest_t_idx ON strtest (t);
  INSERT INTO strtest VALUES('one','one'),('two','two'),('three',repeat(fipshash('three'),100));
@@ -334,7 +349,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/memoize.out --lab
  -- Exercise Memoize code that flushes the cache when a parameter changes which
  -- is not part of the cache key.
  -- Ensure we get a Memoize plan
-@@ -272,23 +216,11 @@
+@@ -272,23 +231,11 @@
  	SELECT 1 FROM tenk1 t1
  	INNER JOIN tenk1 t2 ON t1.unique1 = t2.hundred
  	WHERE t0.ten = t1.twenty AND t0.two <> t2.four OFFSET 0);
@@ -363,7 +378,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/memoize.out --lab
  -- Ensure the above query returns the correct result
  SELECT unique1 FROM tenk1 t0
  WHERE unique1 < 3
-@@ -302,49 +234,182 @@
+@@ -302,49 +249,182 @@
  (1 row)
  
  RESET enable_seqscan;

--- a/pkg/cmd/roachtest/testdata/pg_regress/merge.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/merge.diffs
@@ -1519,13 +1519,27 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO ex_mtarget SELECT i, i*10 FROM generate_series(1,100,2) i;
  INSERT INTO ex_msource SELECT i, i*10 FROM generate_series(1,100,1) i;
  CREATE FUNCTION explain_merge(query text) RETURNS SETOF text
-@@ -1340,48 +1389,21 @@
+@@ -1340,48 +1389,35 @@
      END LOOP;
  END;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++DECLARE ln text;
++BEGIN
++    FOR ln IN
++           ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  -- only updates
  SELECT explain_merge('
  MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
@@ -1573,7 +1587,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- updates + deletes
  SELECT explain_merge('
  MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
-@@ -1389,43 +1411,13 @@
+@@ -1389,43 +1425,13 @@
  	UPDATE SET b = t.b + 1
  WHEN MATCHED AND t.a >= 10 AND t.a <= 20 THEN
  	DELETE');
@@ -1619,7 +1633,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- all three
  SELECT explain_merge('
  MERGE INTO ex_mtarget t USING ex_msource s ON t.a = s.a
-@@ -1435,45 +1427,16 @@
+@@ -1435,45 +1441,16 @@
  	DELETE
  WHEN NOT MATCHED AND s.a < 20 THEN
  	INSERT VALUES (a, b)');
@@ -1668,7 +1682,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- Subqueries
  BEGIN;
  MERGE INTO sq_target t
-@@ -1481,12 +1444,12 @@
+@@ -1481,12 +1458,12 @@
  ON tid = sid
  WHEN MATCHED THEN
      UPDATE SET balance = (SELECT count(*) FROM sq_target);
@@ -1686,7 +1700,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  BEGIN;
  MERGE INTO sq_target t
-@@ -1494,12 +1457,12 @@
+@@ -1494,12 +1471,12 @@
  ON tid = sid
  WHEN MATCHED AND (SELECT count(*) > 0 FROM sq_target) THEN
      UPDATE SET balance = 42;
@@ -1704,7 +1718,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  BEGIN;
  MERGE INTO sq_target t
-@@ -1507,30 +1470,57 @@
+@@ -1507,30 +1484,57 @@
  ON tid = sid AND (SELECT count(*) > 0 FROM sq_target)
  WHEN MATCHED THEN
      UPDATE SET balance = 42;
@@ -1768,7 +1782,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- try simple MERGE
  BEGIN;
  MERGE INTO pa_target t
-@@ -1540,25 +1530,12 @@
+@@ -1540,25 +1544,12 @@
      UPDATE SET balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (sid, delta, 'inserted by merge');
@@ -1799,7 +1813,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  -- same with a constant qual
  BEGIN;
-@@ -1569,31 +1546,12 @@
+@@ -1569,31 +1560,12 @@
      UPDATE SET balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (sid, delta, 'inserted by merge');
@@ -1836,7 +1850,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  -- try updating the partition key column
  BEGIN;
-@@ -1614,52 +1572,82 @@
+@@ -1614,52 +1586,82 @@
  RETURN result;
  END;
  $$;
@@ -1942,7 +1956,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- try simple MERGE
  BEGIN;
  MERGE INTO pa_target t
-@@ -1669,25 +1657,12 @@
+@@ -1669,25 +1671,12 @@
      UPDATE SET balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (sid, delta, 'inserted by merge');
@@ -1973,7 +1987,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  -- same with a constant qual
  BEGIN;
-@@ -1699,29 +1674,12 @@
+@@ -1699,29 +1688,12 @@
      UPDATE SET balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (sid, delta, 'inserted by merge');
@@ -2008,7 +2022,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  -- try updating the partition key column
  BEGIN;
-@@ -1732,64 +1690,100 @@
+@@ -1732,64 +1704,100 @@
      UPDATE SET tid = tid + 1, balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (sid, delta, 'inserted by merge');
@@ -2128,7 +2142,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- try simple MERGE
  BEGIN;
  MERGE INTO pa_target t
-@@ -1799,91 +1793,78 @@
+@@ -1799,91 +1807,78 @@
      UPDATE SET balance = balance + delta, val = val || ' updated by merge'
    WHEN NOT MATCHED THEN
      INSERT VALUES (slogts::timestamp, sid, delta, 'inserted by merge');
@@ -2260,7 +2274,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO cj_source1 VALUES (1, 10, 100);
  INSERT INTO cj_source1 VALUES (1, 20, 200);
  INSERT INTO cj_source1 VALUES (2, 20, 300);
-@@ -1898,6 +1879,10 @@
+@@ -1898,6 +1893,10 @@
  ON t.tid = sid1
  WHEN NOT MATCHED THEN
  	INSERT VALUES (sid1, delta, sval);
@@ -2271,7 +2285,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- try accessing columns from either side of the source join
  MERGE INTO cj_target t
  USING cj_source2 s2
-@@ -1907,6 +1892,10 @@
+@@ -1907,6 +1906,10 @@
  	INSERT VALUES (sid2, delta, sval)
  WHEN MATCHED THEN
  	DELETE;
@@ -2282,7 +2296,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  -- some simple expressions in INSERT targetlist
  MERGE INTO cj_target t
  USING cj_source2 s2
-@@ -1916,20 +1905,24 @@
+@@ -1916,20 +1919,24 @@
  	INSERT VALUES (sid2, delta + scat, sval)
  WHEN MATCHED THEN
  	UPDATE SET val = val || ' updated by merge';
@@ -2314,7 +2328,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  
  -- try it with an outer join and PlaceHolderVar
  MERGE INTO cj_target t
-@@ -1938,19 +1931,14 @@
+@@ -1938,19 +1945,14 @@
  ON t.tid = fj.scat
  WHEN NOT MATCHED THEN
  	INSERT (tid, balance, val) VALUES (fj.scat, fj.delta, fj.phv);
@@ -2341,7 +2355,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  
  ALTER TABLE cj_source1 RENAME COLUMN sid1 TO sid;
  ALTER TABLE cj_source2 RENAME COLUMN sid2 TO sid;
-@@ -1961,10 +1949,15 @@
+@@ -1961,10 +1963,15 @@
  ON t.tid = s1.sid
  WHEN NOT MATCHED THEN
  	INSERT VALUES (s2.sid, delta, sval);
@@ -2357,7 +2371,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  MERGE INTO fs_target t
  USING generate_series(1,100,1) AS id
  ON t.a = id
-@@ -1972,6 +1965,10 @@
+@@ -1972,6 +1979,10 @@
  	UPDATE SET b = b + id
  WHEN NOT MATCHED THEN
  	INSERT VALUES (id, -1);
@@ -2368,7 +2382,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  MERGE INTO fs_target t
  USING generate_series(1,100,2) AS id
  ON t.a = id
-@@ -1979,10 +1976,14 @@
+@@ -1979,10 +1990,14 @@
  	UPDATE SET b = b + id, c = 'updated '|| id.*::text
  WHEN NOT MATCHED THEN
  	INSERT VALUES (id, -1, 'inserted ' || id.*::text);
@@ -2384,7 +2398,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  (1 row)
  
  DROP TABLE fs_target;
-@@ -1995,12 +1996,29 @@
+@@ -1995,12 +2010,29 @@
      peaktemp        int,
      unitsales       int
  ) WITH (autovacuum_enabled=off);
@@ -2414,7 +2428,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  CREATE TABLE measurement_y2007m01 (
      filler          text,
      peaktemp        int,
-@@ -2009,8 +2027,14 @@
+@@ -2009,8 +2041,14 @@
      unitsales       int
      CHECK ( logdate >= DATE '2007-01-01' AND logdate < DATE '2007-02-01')
  ) WITH (autovacuum_enabled=off);
@@ -2429,7 +2443,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO measurement VALUES (0, '2005-07-21', 5, 15);
  CREATE OR REPLACE FUNCTION measurement_insert_trigger()
  RETURNS TRIGGER AS $$
-@@ -2034,6 +2058,7 @@
+@@ -2034,6 +2072,7 @@
  CREATE TRIGGER insert_measurement_trigger
      BEFORE INSERT ON measurement
      FOR EACH ROW EXECUTE PROCEDURE measurement_insert_trigger();
@@ -2437,7 +2451,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO measurement VALUES (1, '2006-02-10', 35, 10);
  INSERT INTO measurement VALUES (1, '2006-02-16', 45, 20);
  INSERT INTO measurement VALUES (1, '2006-03-17', 25, 10);
-@@ -2041,18 +2066,19 @@
+@@ -2041,18 +2080,19 @@
  INSERT INTO measurement VALUES (1, '2007-01-15', 10, 10);
  INSERT INTO measurement VALUES (1, '2007-01-17', 10, 10);
  SELECT tableoid::regclass, * FROM measurement ORDER BY city_id, logdate;
@@ -2466,7 +2480,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  INSERT INTO new_measurement VALUES (0, '2005-07-21', 25, 20);
  INSERT INTO new_measurement VALUES (1, '2006-03-01', 20, 10);
  INSERT INTO new_measurement VALUES (1, '2006-02-16', 50, 10);
-@@ -2072,25 +2098,12 @@
+@@ -2072,25 +2112,12 @@
  WHEN NOT MATCHED THEN INSERT
       (city_id, logdate, peaktemp, unitsales)
     VALUES (city_id, logdate, peaktemp, unitsales);
@@ -2497,7 +2511,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/merge.out --label
  ROLLBACK;
  MERGE into measurement m
   USING new_measurement nm ON
-@@ -2102,56 +2115,64 @@
+@@ -2102,56 +2129,64 @@
  WHEN NOT MATCHED THEN INSERT
       (city_id, logdate, peaktemp, unitsales)
     VALUES (city_id, logdate, peaktemp, unitsales);

--- a/pkg/cmd/roachtest/testdata/pg_regress/partition_prune.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/partition_prune.diffs
@@ -2829,7 +2829,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  --
  -- Test Partition pruning for HASH partitioning
  --
-@@ -1745,402 +1384,393 @@
+@@ -1745,402 +1384,394 @@
  --
  create table hp (a int, b text, c int)
    partition by hash (a part_test_int4_ops, b part_test_text_ops);
@@ -3449,6 +3449,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  -- Test run-time pruning using stable functions
  create function list_part_fn(int) returns int as $$ begin return $1; end;$$ language plpgsql stable;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
++ERROR:  no value provided for placeholder: $1
  -- Ensure pruning works using a stable function containing no Vars
  explain (analyze, costs off, summary off, timing off) select * from list_part where a = list_part_fn(1);
 -                            QUERY PLAN                            
@@ -3515,13 +3516,28 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  -- Parallel append
  -- Parallel queries won't necessarily get as many workers as the planner
  -- asked for.  This affects not only the "Workers Launched:" field of EXPLAIN
-@@ -2167,111 +1797,81 @@
+@@ -2167,111 +1798,96 @@
      end loop;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++    ln text;
++begin
++    for ln in
++           ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  prepare ab_q4 (int, int) as
  select avg(a) from ab where a between $1 and $2 and b < 4;
 +ERROR:  relation "ab" does not exist
@@ -3592,9 +3608,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select explain_parallel_append('execute ab_q4 (2, 2)');
 +ERROR:  unknown function: explain_parallel_append()
  -- Test run-time pruning with IN lists.
@@ -3685,7 +3701,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  -- Test pruning during parallel nested loop query
  create table lprt_a (a int not null);
  -- Insert some values we won't find in ab
-@@ -2280,344 +1880,198 @@
+@@ -2280,344 +1896,198 @@
  insert into lprt_a values(1),(1);
  analyze lprt_a;
  create index ab_a2_b1_a_idx on ab_a2_b1 (a);
@@ -4181,7 +4197,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  prepare ab_q6 as
  select * from (
  	select tableoid::regclass,a,b from ab
-@@ -2626,587 +2080,522 @@
+@@ -2626,587 +2096,522 @@
  union all
  	select tableoid::regclass,a,b from ab
  ) ab where a = $1 and b = (select -10);
@@ -5110,7 +5126,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  --
  -- Check that pruning with composite range partitioning works correctly when
  -- a combination of runtime parameters is specified, not all of whose values
-@@ -3214,529 +2603,666 @@
+@@ -3214,529 +2619,666 @@
  --
  prepare ps1 as
    select * from mc3p where a = $1 and abs(b) < (select 3);
@@ -5892,9 +5908,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +explain (costs off) select * from pp_lp where a = 1;
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
@@ -6147,7 +6163,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  explain (costs off)
  select *
  from (
-@@ -3747,19 +3273,11 @@
+@@ -3747,19 +3289,11 @@
        select 1, 1, 1
       ) s(a, b, c)
  where s.a = 1 and s.b = 1 and s.c = (select 1);
@@ -6172,7 +6188,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  select *
  from (
        select * from p
-@@ -3769,11 +3287,7 @@
+@@ -3769,11 +3303,7 @@
        select 1, 1, 1
       ) s(a, b, c)
  where s.a = 1 and s.b = 1 and s.c = (select 1);
@@ -6185,7 +6201,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  prepare q (int, int) as
  select *
  from (
-@@ -3784,116 +3298,186 @@
+@@ -3784,116 +3314,186 @@
        select 1, 1, 1
       ) s(a, b, c)
  where s.a = $1 and s.b = $2 and s.c = (select 1);
@@ -6291,9 +6307,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +explain (costs off) select * from listp1 where a = 2;
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
@@ -6327,10 +6343,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +explain (costs off) select * from listp1 where a = 2;
@@ -6440,7 +6456,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  -- Like the above but throw some more complexity at the planner by adding
  -- a UNION ALL.  We expect both sides of the union not to scan the
  -- non-required partitions.
-@@ -3901,136 +3485,236 @@
+@@ -3901,136 +3501,236 @@
  'select * from listp where a = (select 1)
    union all
  select * from listp where a = (select 2);');
@@ -6753,7 +6769,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/partition_prune.o
  --
  -- Check that gen_partprune_steps() detects self-contradiction from clauses
  -- regardless of the order of the clauses (Here we use a custom operator to
-@@ -4043,28 +3727,84 @@
+@@ -4043,28 +3743,84 @@
     commutator = ===,
     hashes
  );

--- a/pkg/cmd/roachtest/testdata/pg_regress/plancache.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/plancache.diffs
@@ -73,7 +73,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plancache.out --l
  begin
  	return f1 from v1;
  end$$ language plpgsql;
-+ERROR:  at or near ";": at or near "from": syntax error
++ERROR:  at or near "v1": at or near "from": syntax error
 +DETAIL:  source SQL:
 +SET ROW (f1 from v1)
 +            ^
@@ -81,7 +81,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plancache.out --l
 +source SQL:
 +begin
 +	return f1 from v1;
-+                  ^
++                ^
 +HINT:  try \h SET SESSION
  select cache_test_2();
 - cache_test_2 

--- a/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
@@ -531,10 +531,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +    select into psrec * from PSlot where slotname = $1;
      if not found then
 -        return '''';
--    end if;
++        return '';
+     end if;
 -    if rec.slotlink = '''' then
 -        return ''-'';
-+        return '';
++    if psrec.slotlink = '' then
++        return '-';
      end if;
 -    sltype := substr(rec.slotlink, 1, 2);
 -    if sltype = ''PH'' then
@@ -546,9 +548,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -	    retval := retval || '')'';
 -	end if;
 -	return retval;
-+    if psrec.slotlink = '' then
-+        return '-';
-     end if;
+-    end if;
 -    if sltype = ''IF'' then
 -	declare
 -	    syrow	System%RowType;
@@ -973,7 +973,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
      END IF;
      RETURN rslt;
  END;' LANGUAGE plpgsql;
-+ERROR:  unknown function: recursion_test()
++ERROR:  no value provided for placeholder: $2
  SELECT recursion_test(4,3);
 - recursion_test 
 -----------------
@@ -1012,14 +1012,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  --
  -- Test set-returning functions for PL/pgSQL
-@@ -1638,17 +1795,11 @@
+@@ -1638,17 +1795,26 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from test_table_func_rec();
+-select * from test_table_func_rec();
 -  a  
 ------
 -   2
@@ -1029,18 +1026,41 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -   5
 -   6
 -(6 rows)
--
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++DECLARE
++	rec RECORD;
++BEGIN
++	FOR rec IN select * from found_test_tbl LOOP
++         ^
++HINT:  You have attempted to use a feature that is not yet implemented.
+ 
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
++select * from test_table_func_rec();
 +ERROR:  unknown function: test_table_func_rec()
  create function test_table_func_row() returns setof found_test_tbl as '
  DECLARE
  	row found_test_tbl%ROWTYPE;
-@@ -1658,17 +1809,11 @@
+@@ -1658,17 +1824,16 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  at or near "rowtype": syntax error: unable to parse type of variable declaration
++DETAIL:  source SQL:
++DECLARE
++	row found_test_tbl%ROWTYPE;
++                    ^
++HINT:  you may have attempted to use %TYPE or %ROWTYPE syntax, which is unsupported.
++--
++See: https://go.crdb.dev/issue-v/114676/_version_
  select * from test_table_func_row();
 -  a  
 ------
@@ -1056,13 +1076,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_set_scalar(int,int) returns setof int as '
  DECLARE
  	i int;
-@@ -1678,21 +1823,11 @@
+@@ -1678,21 +1843,13 @@
  	END LOOP;
  	RETURN;
  END;' language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  unimplemented: variable shadowing is not yet implemented
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++See: https://go.crdb.dev/issue-v/117508/_version_
++--
++variable "i" shadows a previously defined variable
  select * from test_ret_set_scalar(1,10);
 - test_ret_set_scalar 
 ----------------------
@@ -1082,13 +1104,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_set_rec_dyn(int) returns setof record as '
  DECLARE
  	retval RECORD;
-@@ -1708,20 +1843,21 @@
+@@ -1708,20 +1865,21 @@
  	END IF;
  	RETURN;
  END;' language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  unimplemented: RECORD type for PL/pgSQL variables is not yet supported
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++See: https://go.crdb.dev/issue-v/114874/_version_
  SELECT * FROM test_ret_set_rec_dyn(1500) AS (a int, b int, c int);
 - a | b  | c  
 ----+----+----
@@ -1116,7 +1138,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function test_ret_rec_dyn(int) returns record as '
  DECLARE
  	retval RECORD;
-@@ -1734,18 +1870,21 @@
+@@ -1734,18 +1892,21 @@
  		RETURN retval;
  	END IF;
  END;' language plpgsql;
@@ -1148,7 +1170,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test some simple polymorphism cases.
  --
-@@ -1753,31 +1892,37 @@
+@@ -1753,31 +1914,37 @@
  begin
    return x + 1;
  end$$ language plpgsql;
@@ -1202,7 +1224,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(x anyarray) returns anyelement as $$
  begin
    return x[1];
-@@ -1789,7 +1934,10 @@
+@@ -1789,7 +1956,10 @@
  (1 row)
  
  select f1(stavalues1) from pg_statistic;  -- fail, can't infer element type
@@ -1214,7 +1236,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function f1(x anyarray);
  create function f1(x anyarray) returns anyarray as $$
  begin
-@@ -1802,72 +1950,61 @@
+@@ -1802,72 +1972,61 @@
  (1 row)
  
  select f1(stavalues1) from pg_statistic;  -- fail, can't infer element type
@@ -1306,7 +1328,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(a anyelement, b anyarray,
                     c anycompatible, d anycompatible,
                     OUT x anyarray, OUT y anycompatiblearray)
-@@ -1876,35 +2013,30 @@
+@@ -1876,35 +2035,30 @@
    x := a || b;
    y := array[c, d];
  end$$ language plpgsql;
@@ -1356,7 +1378,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of OUT parameters, including polymorphic cases.
  -- Note that RETURN is optional with OUT params; we try both ways.
-@@ -1915,8 +2047,6 @@
+@@ -1915,8 +2069,6 @@
    return i+1;
  end$$ language plpgsql;
  ERROR:  RETURN cannot have a parameter in function with OUT parameters
@@ -1365,47 +1387,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function f1(in i int, out j int) as $$
  begin
    j := i+1;
-@@ -1959,14 +2089,13 @@
-   return next;
-   return;
- end$$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from f1(42);
-- j  
------
-- 43
-- 44
--(2 rows)
--
-+ERROR:  unknown function: f1()
- drop function f1(int);
-+ERROR:  unknown function: f1()
- create function f1(in i int, out j int, out k text) as $$
- begin
-   j := i;
-@@ -1995,14 +2124,13 @@
-   k := 'foot';
-   return next;
- end$$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from f1(42);
-- j  |  k   
------+------
-- 43 | foo
-- 44 | foot
--(2 rows)
--
-+ERROR:  unknown function: f1()
- drop function f1(int);
-+ERROR:  unknown function: f1()
- create function duplic(in i anyelement, out j anyelement, out k anyarray) as $$
- begin
-   j := i;
-@@ -2028,19 +2156,13 @@
+@@ -2028,19 +2180,13 @@
    k := array[lower(i),upper(i)];
    return;
  end$$ language plpgsql;
@@ -1429,7 +1411,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test PERFORM
  --
-@@ -2057,6 +2179,7 @@
+@@ -2057,6 +2203,7 @@
  		RETURN FALSE;
  	END IF;
  END;' language plpgsql;
@@ -1437,7 +1419,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function perform_test_func() returns void as '
  BEGIN
  	IF FOUND then
-@@ -2077,19 +2200,32 @@
+@@ -2077,19 +2224,32 @@
  
  	RETURN;
  END;' language plpgsql;
@@ -1456,14 +1438,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +	PERFORM perform_simple_func(5);
 +                               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +SELECT perform_test_func();
@@ -1481,7 +1463,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  drop table perform_test;
  --
-@@ -2103,19 +2239,12 @@
+@@ -2103,19 +2263,12 @@
    if found then return x; end if;
    return 0;
  end$$ language plpgsql stable;
@@ -1504,7 +1486,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function sp_add_user(a_login text) returns int as $$
  declare my_id_user int;
  begin
-@@ -2130,38 +2259,21 @@
+@@ -2130,38 +2283,21 @@
    END IF;
    RETURN my_id_user;
  end$$ language plpgsql;
@@ -1551,7 +1533,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- tests for refcursors
  --
-@@ -2185,12 +2297,13 @@
+@@ -2185,12 +2321,13 @@
      return x.a;
  end
  $$ language plpgsql;
@@ -1570,7 +1552,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function return_refcursor(rc refcursor) returns refcursor as $$
  begin
      open rc for select a from rc_test;
-@@ -2203,33 +2316,31 @@
+@@ -2203,33 +2340,31 @@
      return $1;
  end
  $$ language plpgsql;
@@ -1624,7 +1606,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  commit;
  -- should fail
  fetch next from test1;
-@@ -2249,13 +2360,25 @@
+@@ -2249,13 +2384,25 @@
      end if;
  end
  $$ language plpgsql;
@@ -1655,7 +1637,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- should fail
  create function constant_refcursor() returns refcursor as $$
  declare
-@@ -2266,8 +2389,11 @@
+@@ -2266,8 +2413,11 @@
  end
  $$ language plpgsql;
  select constant_refcursor();
@@ -1669,7 +1651,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- but it's okay like this
  create or replace function constant_refcursor() returns refcursor as $$
  declare
-@@ -2301,13 +2427,25 @@
+@@ -2301,13 +2451,25 @@
      end if;
  end
  $$ language plpgsql;
@@ -1700,7 +1682,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional argument notations
  create function namedparmcursor_test2(int, int) returns boolean as $$
  declare
-@@ -2324,12 +2462,24 @@
+@@ -2324,12 +2486,24 @@
      end if;
  end
  $$ language plpgsql;
@@ -1715,14 +1697,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +    c1 cursor (param1 int, param2 int) for select * from rc_test where a > param1 and b > param2;
 +              ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select namedparmcursor_test2(20, 20);
@@ -1730,7 +1712,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional: param2 is given twice, once in named notation
  -- and second time in positional notation. Should throw an error at parse time
  create function namedparmcursor_test3() returns void as $$
-@@ -2339,9 +2489,22 @@
+@@ -2339,9 +2513,22 @@
      open c1(param2 := 20, 21);
  end
  $$ language plpgsql;
@@ -1756,7 +1738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- mixing named and positional: same as previous test, but param1 is duplicated
  create function namedparmcursor_test4() returns void as $$
  declare
-@@ -2350,9 +2513,22 @@
+@@ -2350,9 +2537,22 @@
      open c1(20, param1 := 21);
  end
  $$ language plpgsql;
@@ -1782,7 +1764,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- duplicate named parameter, should throw an error at parse time
  create function namedparmcursor_test5() returns void as $$
  declare
-@@ -2362,9 +2538,22 @@
+@@ -2362,9 +2562,22 @@
    open c1 (p2 := 77, p2 := 42);
  end
  $$ language plpgsql;
@@ -1808,7 +1790,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- not enough parameters, should throw an error at parse time
  create function namedparmcursor_test6() returns void as $$
  declare
-@@ -2374,9 +2563,22 @@
+@@ -2374,9 +2587,22 @@
    open c1 (p2 := 77);
  end
  $$ language plpgsql;
@@ -1834,7 +1816,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- division by zero runtime error, the context given in the error message
  -- should be sensible
  create function namedparmcursor_test7() returns void as $$
-@@ -2386,10 +2588,24 @@
+@@ -2386,10 +2612,24 @@
  begin
    open c1 (p2 := 77, p1 := 42/0);
  end $$ language plpgsql;
@@ -1862,7 +1844,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check that line comments work correctly within the argument list (there
  -- is some special handling of this case in the code: the newline after the
  -- comment must be preserved when the argument-evaluating query is
-@@ -2406,12 +2622,24 @@
+@@ -2406,12 +2646,24 @@
    fetch c1 into n;
    return n;
  end $$ language plpgsql;
@@ -1892,7 +1874,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- cursor parameter name can match plpgsql variable or unreserved keyword
  create function namedparmcursor_test9(p1 int) returns int4 as $$
  declare
-@@ -2425,12 +2653,24 @@
+@@ -2425,12 +2677,24 @@
    fetch c1 into n;
    return n;
  end $$ language plpgsql;
@@ -1911,10 +1893,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select namedparmcursor_test9(6);
@@ -1922,7 +1904,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- tests for "raise" processing
  --
-@@ -2441,28 +2681,22 @@
+@@ -2441,28 +2705,22 @@
  end;
  $$ language plpgsql;
  ERROR:  too many parameters specified for RAISE
@@ -1954,7 +1936,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test re-RAISE inside a nested exception block.  This case is allowed
  -- by Oracle's PL/SQL but was handled differently by PG before 9.1.
  CREATE FUNCTION reraise_test() RETURNS void AS $$
-@@ -2484,14 +2718,30 @@
+@@ -2484,14 +2742,30 @@
         raise notice 'WRONG - exception % caught in outer block', sqlerrm;
  END;
  $$ LANGUAGE plpgsql;
@@ -1984,15 +1966,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +SELECT reraise_test();
 +ERROR:  unknown function: reraise_test()
  --
  -- reject function definitions that contain malformed SQL queries at
  -- compile-time, where possible
-@@ -2504,9 +2754,17 @@
+@@ -2504,9 +2778,17 @@
      a := 10;
      return a;
  end$$ language plpgsql;
@@ -2013,7 +1995,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function bad_sql2() returns int as $$
  declare r record;
  begin
-@@ -2515,81 +2773,115 @@
+@@ -2515,81 +2797,115 @@
      end loop;
      return 5;
  end;$$ language plpgsql;
@@ -2074,10 +2056,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +-- select void_return_expr();
@@ -2171,7 +2153,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- SQLSTATE and SQLERRM test
  --
-@@ -2597,14 +2889,11 @@
+@@ -2597,14 +2913,11 @@
  begin
      raise notice '% %', sqlstate, sqlerrm;
  end; $$ language plpgsql;
@@ -2188,7 +2170,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test2() returns void as $$
  begin
      begin
-@@ -2613,13 +2902,10 @@
+@@ -2613,13 +2926,10 @@
          end;
      end;
  end; $$ language plpgsql;
@@ -2204,7 +2186,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test3() returns void as $$
  begin
      begin
-@@ -2639,31 +2925,61 @@
+@@ -2639,31 +2949,61 @@
  	    raise notice '% %', sqlstate, sqlerrm;
      end;
  end; $$ language plpgsql;
@@ -2233,10 +2215,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select excpt_test3();
@@ -2261,10 +2243,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +select excpt_test4();
@@ -2280,7 +2262,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- parameters of raise stmt can be expressions
  create function raise_exprs() returns void as $$
  declare
-@@ -2714,13 +3030,11 @@
+@@ -2714,13 +3054,11 @@
    insert into foo values(5,6) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2298,7 +2280,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2728,10 +3042,11 @@
+@@ -2728,10 +3066,11 @@
    insert into foo values(7,8),(9,10) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2313,7 +2295,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2739,13 +3054,11 @@
+@@ -2739,13 +3078,11 @@
    execute 'insert into foo values(5,6) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2331,7 +2313,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2753,23 +3066,17 @@
+@@ -2753,23 +3090,17 @@
    execute 'insert into foo values(7,8),(9,10) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2360,7 +2342,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  create or replace function stricttest() returns void as $$
  declare x record;
-@@ -2778,13 +3085,11 @@
+@@ -2778,13 +3109,11 @@
    select * from foo where f1 = 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2378,7 +2360,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2792,9 +3097,11 @@
+@@ -2792,9 +3121,11 @@
    select * from foo where f1 = 0 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2392,7 +2374,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2802,10 +3109,11 @@
+@@ -2802,10 +3133,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2407,7 +2389,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2813,13 +3121,11 @@
+@@ -2813,13 +3145,11 @@
    execute 'select * from foo where f1 = 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2425,7 +2407,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2827,9 +3133,11 @@
+@@ -2827,9 +3157,11 @@
    execute 'select * from foo where f1 = 0' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2439,7 +2421,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2837,12 +3145,17 @@
+@@ -2837,12 +3169,17 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2459,7 +2441,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2853,10 +3166,11 @@
+@@ -2853,10 +3190,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2474,7 +2456,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2867,10 +3181,11 @@
+@@ -2867,10 +3205,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2489,7 +2471,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2881,11 +3196,11 @@
+@@ -2881,11 +3220,11 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2505,7 +2487,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2893,10 +3208,11 @@
+@@ -2893,10 +3232,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2520,7 +2502,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2904,10 +3220,11 @@
+@@ -2904,10 +3244,11 @@
    execute 'select * from foo where f1 = $1 or f1::text = $2' using 0, 'foo' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2535,7 +2517,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2915,10 +3232,11 @@
+@@ -2915,10 +3256,11 @@
    execute 'select * from foo where f1 > $1' using 1 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2550,7 +2532,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2926,9 +3244,11 @@
+@@ -2926,9 +3268,11 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2564,7 +2546,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  -- override the global
  #print_strict_params off
-@@ -2941,10 +3261,12 @@
+@@ -2941,10 +3285,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2580,7 +2562,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.print_strict_params;
  create or replace function stricttest() returns void as $$
  -- override the global
-@@ -2958,11 +3280,12 @@
+@@ -2958,11 +3304,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2597,7 +2579,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test warnings and errors
  set plpgsql.extra_warnings to 'all';
  set plpgsql.extra_warnings to 'none';
-@@ -2979,23 +3302,14 @@
+@@ -2979,23 +3326,16 @@
  begin
  end
  $$ language plpgsql;
@@ -2607,9 +2589,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -WARNING:  variable "out1" shadows a previously defined variable
 -LINE 5: out1 int;
 -        ^
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  unimplemented: variable shadowing is not yet implemented
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++See: https://go.crdb.dev/issue-v/117508/_version_
++--
++variable "in1" shadows a previously defined variable
  select shadowtest(1);
 - shadowtest 
 -------------
@@ -2626,7 +2610,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function shadowtest(in1 int)
  	returns table (out1 int) as $$
  declare
-@@ -3004,18 +3318,13 @@
+@@ -3004,18 +3344,15 @@
  begin
  end
  $$ language plpgsql;
@@ -2636,9 +2620,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -WARNING:  variable "out1" shadows a previously defined variable
 -LINE 5: out1 int;
 -        ^
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  unimplemented: variable shadowing is not yet implemented
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++See: https://go.crdb.dev/issue-v/117508/_version_
++--
++variable "in1" shadows a previously defined variable
  select shadowtest(1);
 - shadowtest 
 -------------
@@ -2650,7 +2636,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in a second DECLARE block
  create or replace function shadowtest()
  	returns void as $$
-@@ -3027,10 +3336,13 @@
+@@ -3027,10 +3364,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2667,7 +2653,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- several levels of shadowing
  create or replace function shadowtest(in1 int)
  	returns void as $$
-@@ -3042,13 +3354,13 @@
+@@ -3042,13 +3382,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2687,7 +2673,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in cursor definitions
  create or replace function shadowtest()
  	returns void as $$
-@@ -3057,34 +3369,49 @@
+@@ -3057,34 +3397,49 @@
  c1 cursor (f1 int) for select 1;
  begin
  end$$ language plpgsql;
@@ -2752,7 +2738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- runtime extra checks
  set plpgsql.extra_warnings to 'too_many_rows';
  do $$
-@@ -3093,8 +3420,6 @@
+@@ -3093,8 +3448,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2761,7 +2747,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'too_many_rows';
  do $$
  declare x int;
-@@ -3102,9 +3427,6 @@
+@@ -3102,9 +3455,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2771,7 +2757,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
  set plpgsql.extra_warnings to 'strict_multi_assignment';
-@@ -3118,12 +3440,6 @@
+@@ -3118,12 +3468,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2784,7 +2770,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'strict_multi_assignment';
  do $$
  declare
-@@ -3135,10 +3451,6 @@
+@@ -3135,10 +3479,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2795,7 +2781,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create table test_01(a int, b int, c int);
  alter table test_01 drop column a;
  -- the check is active only when source table is not empty
-@@ -3154,10 +3466,6 @@
+@@ -3154,10 +3494,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2806,7 +2792,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3168,10 +3476,6 @@
+@@ -3168,10 +3504,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2817,7 +2803,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3179,10 +3483,6 @@
+@@ -3179,10 +3511,6 @@
    select 1 into t; -- should fail;
  end;
  $$;
@@ -2828,13 +2814,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table test_01;
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
-@@ -3201,16 +3501,11 @@
+@@ -3201,16 +3529,9 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  column "found" does not exist
  select * from sc_test();
 -   sc_test   
 --------------
@@ -2849,13 +2833,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c no scroll cursor for select f1 from int4_tbl;
-@@ -3225,10 +3520,11 @@
+@@ -3225,10 +3546,9 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  column "found" does not exist
  select * from sc_test();  -- fails because of NO SCROLL specification
 -ERROR:  cursor can only scan forward
 -HINT:  Declare it with SCROLL option to enable backward scan.
@@ -2864,13 +2846,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3243,16 +3539,11 @@
+@@ -3243,16 +3563,11 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  unimplemented: DECLARE SCROLL CURSOR
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++See: https://go.crdb.dev/issue-v/77102/_version_
  select * from sc_test();
 -   sc_test   
 --------------
@@ -2885,50 +2867,80 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3267,14 +3558,11 @@
+@@ -3267,14 +3582,27 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from sc_test();
+-select * from sc_test();
 -   sc_test   
 --------------
 - -2147483647
 -     -123456
 -           0
 -(3 rows)
--
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++  c refcursor;
++  x integer;
++begin
++  open c scroll for execute 'select f1 from int4_tbl';
++                    ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
+ 
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
++select * from sc_test();
 +ERROR:  unknown function: sc_test()
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3290,13 +3578,11 @@
+@@ -3290,13 +3618,27 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from sc_test();
+-select * from sc_test();
 -   sc_test   
 --------------
 - -2147483647
 -      123456
 -(2 rows)
--
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++  c refcursor;
++  x integer;
++begin
++  open c scroll for execute 'select f1 from int4_tbl';
++                    ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
+ 
++select * from sc_test();
 +ERROR:  unknown function: sc_test()
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3316,14 +3602,11 @@
+@@ -3316,14 +3658,9 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  column "found" does not exist
  select * from sc_test();
 - sc_test 
 ----------
@@ -2941,13 +2953,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3338,13 +3621,13 @@
+@@ -3338,13 +3675,11 @@
    close c;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  column "found" does not exist
  select * from sc_test();
 - sc_test 
 ----------
@@ -2960,7 +2970,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test qualified variable names
  create function pl_qual_names (param1 int) returns void as $$
  <<outerblock>>
-@@ -3362,17 +3645,15 @@
+@@ -3362,17 +3697,15 @@
    end;
  end;
  $$ language plpgsql;
@@ -2985,13 +2995,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- tests for RETURN QUERY
  create function ret_query1(out int, out int) returns setof record as $$
  begin
-@@ -3383,24 +3664,11 @@
+@@ -3383,24 +3716,13 @@
      return next;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  at or near "$": syntax error
++DETAIL:  source SQL:
++begin
++    $1 := -1;
++    ^
  select * from ret_query1();
 - column1 | column2 
 ----------+---------
@@ -3014,13 +3026,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type record_type as (x text, y int, z boolean);
  create or replace function ret_query2(lim int) returns setof record_type as $$
  begin
-@@ -3408,20 +3676,11 @@
+@@ -3408,20 +3730,9 @@
                   from generate_series(-8, lim) s (x) where s.x % 2 = 0;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  unknown function: fipshash()
  select * from ret_query2(8);
 -                x                 | y  | z 
 -----------------------------------+----+---
@@ -3039,7 +3049,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test EXECUTE USING
  create function exc_using(int, text) returns int as $$
  declare i int;
-@@ -3433,19 +3692,27 @@
+@@ -3433,19 +3744,27 @@
    return i;
  end
  $$ language plpgsql;
@@ -3078,7 +3088,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function exc_using(int) returns void as $$
  declare
    c refcursor;
-@@ -3461,19 +3728,29 @@
+@@ -3461,19 +3780,29 @@
    return;
  end;
  $$ language plpgsql;
@@ -3106,12 +3116,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
-+
+ 
 +select exc_using(5);
 +ERROR:  unknown function: exc_using()
  drop function exc_using(int);
@@ -3119,7 +3129,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test FOR-over-cursor
  create or replace function forc01() returns void as $$
  declare
-@@ -3513,32 +3790,28 @@
+@@ -3513,32 +3842,28 @@
    return;
  end;
  $$ language plpgsql;
@@ -3155,12 +3165,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +select forc01();
 +ERROR:  unknown function: forc01()
  -- try updating the cursor's current row
@@ -3170,7 +3180,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function forc01() returns void as $$
  declare
    c cursor for select * from forc_test;
-@@ -3549,35 +3822,39 @@
+@@ -3549,35 +3874,39 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3201,10 +3211,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select forc01();
@@ -3237,7 +3247,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (10 rows)
  
  -- same, with a cursor whose portal name doesn't match variable name
-@@ -3595,38 +3872,42 @@
+@@ -3595,38 +3924,42 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3307,7 +3317,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- it's okay to re-use a cursor variable name, even when bound
  do $$
  declare cnt int := 0;
-@@ -3642,7 +3923,24 @@
+@@ -3642,7 +3975,24 @@
    end loop;
    raise notice 'cnt = %', cnt;
  end $$;
@@ -3333,7 +3343,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail because cursor has no query bound to it
  create or replace function forc_bad() returns void as $$
  declare
-@@ -3653,9 +3951,24 @@
+@@ -3653,9 +4003,24 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3361,14 +3371,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY EXECUTE
  create or replace function return_dquery()
  returns setof int as $$
-@@ -3664,16 +3977,13 @@
+@@ -3664,16 +4029,26 @@
    return query execute 'select * from (values($1),($2)) f' using 40,50;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from return_dquery();
+-select * from return_dquery();
 - return_dquery 
 ----------------
 -            10
@@ -3376,21 +3383,34 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -            40
 -            50
 -(4 rows)
--
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++begin
++  return query execute 'select * from (values(10),(20)) f';
++               ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
+ 
++We appreciate your feedback.
++
++select * from return_dquery();
 +ERROR:  unknown function: return_dquery()
  drop function return_dquery();
 +ERROR:  unknown function: return_dquery()
  -- test RETURN QUERY with dropped columns
  create table tabwithcols(a int, b int, c int, d int);
  insert into tabwithcols values(10,20,30,40),(50,60,70,80);
-@@ -3684,46 +3994,22 @@
+@@ -3684,46 +4059,36 @@
    return query execute 'select * from tabwithcols';
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from returnqueryf();
+-select * from returnqueryf();
 - a  | b  | c  | d  
 -----+----+----+----
 - 10 | 20 | 30 | 40
@@ -3398,7 +3418,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 - 10 | 20 | 30 | 40
 - 50 | 60 | 70 | 80
 -(4 rows)
--
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++begin
++  return query select * from tabwithcols;
++  return query execute 'select * from tabwithcols';
++               ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
+ 
++We appreciate your feedback.
++
++select * from returnqueryf();
 +ERROR:  unknown function: returnqueryf()
  alter table tabwithcols drop column b;
  select * from returnqueryf();
@@ -3438,7 +3475,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table tabwithcols;
  --
  -- Tests for composite-type results
-@@ -3753,6 +4039,9 @@
+@@ -3753,6 +4118,9 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3448,7 +3485,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select compos();
    compos   
  -----------
-@@ -3778,9 +4067,11 @@
+@@ -3778,9 +4146,11 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3463,7 +3500,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ... but this does
  create or replace function compos() returns compostype as $$
  begin
-@@ -3803,12 +4094,11 @@
+@@ -3803,12 +4173,11 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3480,29 +3517,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: return row expr in return statement.
  create or replace function composrec() returns record as $$
  begin
-@@ -3833,26 +4123,22 @@
-   return next (2, 'goodbye')::compostype;
- end;
- $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from compos();
-- x |    y    
-----+---------
-- 1 | hello
-- 1 | hello
-- 1 | hello
--   | 
-- 2 | goodbye
--(5 rows)
--
-+ERROR:  unknown function: compos()
- drop function compos();
-+ERROR:  unknown function: compos()
- -- test: use invalid expr in return statement.
- create or replace function compos() returns compostype as $$
- begin
+@@ -3850,9 +4219,9 @@
    return 1 + 1;
  end;
  $$ language plpgsql;
@@ -3514,7 +3529,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- RETURN variable is a different code path ...
  create or replace function compos() returns compostype as $$
  declare x int := 42;
-@@ -3861,8 +4147,7 @@
+@@ -3861,8 +4230,7 @@
  end;
  $$ language plpgsql;
  select * from compos();
@@ -3524,7 +3539,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  -- test: invalid use of composite variable in scalar-returning function
  create or replace function compos() returns int as $$
-@@ -3874,8 +4159,7 @@
+@@ -3874,8 +4242,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3534,7 +3549,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: invalid use of composite expression in scalar-returning function
  create or replace function compos() returns int as $$
  begin
-@@ -3883,8 +4167,7 @@
+@@ -3883,8 +4250,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3544,7 +3559,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  drop type compostype;
  --
-@@ -3904,7 +4187,6 @@
+@@ -3904,7 +4270,6 @@
  HINT:  some hint
  ERROR:  1 2 3
  DETAIL:  some detail info
@@ -3552,7 +3567,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Since we can't actually see the thrown SQLSTATE in default psql output,
  -- test it like this; this also tests re-RAISE
  create or replace function raise_test() returns void as $$
-@@ -3917,11 +4199,33 @@
+@@ -3917,11 +4282,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3589,7 +3604,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise 'check me'
-@@ -3932,11 +4236,33 @@
+@@ -3932,11 +4319,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3626,7 +3641,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- SQLSTATE specification in WHEN
  create or replace function raise_test() returns void as $$
  begin
-@@ -3948,11 +4274,33 @@
+@@ -3948,11 +4357,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3663,7 +3678,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using detail = 'some detail info';
-@@ -3962,11 +4310,32 @@
+@@ -3962,11 +4393,32 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3699,7 +3714,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero;
-@@ -3974,7 +4343,6 @@
+@@ -3974,7 +4426,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  division_by_zero
@@ -3707,7 +3722,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise sqlstate '1234F';
-@@ -3982,7 +4350,6 @@
+@@ -3982,7 +4433,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  1234F
@@ -3715,7 +3730,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using message = 'custom' || ' message';
-@@ -3990,7 +4357,6 @@
+@@ -3990,7 +4440,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3723,7 +3738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise using message = 'custom' || ' message', errcode = '22012';
-@@ -3998,34 +4364,48 @@
+@@ -3998,34 +4447,48 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3779,7 +3794,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test access to exception data
  create function zero_divide() returns int as $$
  declare v int := 0;
-@@ -4033,6 +4413,7 @@
+@@ -4033,6 +4496,7 @@
    return 10 / v;
  end;
  $$ language plpgsql;
@@ -3787,7 +3802,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise exception 'custom exception'
-@@ -4055,13 +4436,27 @@
+@@ -4055,13 +4519,27 @@
      _sqlstate, _message, replace(_context, E'\n', ' <- ');
  end;
  $$ language plpgsql;
@@ -3821,7 +3836,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
          _hint text;
-@@ -4076,13 +4471,27 @@
+@@ -4076,13 +4554,27 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3855,7 +3870,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail, cannot use stacked diagnostics statement outside handler
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
-@@ -4096,11 +4505,25 @@
+@@ -4096,11 +4588,25 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3883,7 +3898,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check cases where implicit SQLSTATE variable could be confused with
  -- SQLSTATE as a keyword, cf bug #5524
  create or replace function raise_test() returns void as $$
-@@ -4112,10 +4535,26 @@
+@@ -4112,10 +4618,26 @@
      raise sqlstate '22012' using message = 'substitute message';
  end;
  $$ language plpgsql;
@@ -3913,7 +3928,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function raise_test();
  -- test passing column_name, constraint_name, datatype_name, table_name
  -- and schema_name error fields
-@@ -4143,14 +4582,23 @@
+@@ -4143,14 +4665,23 @@
      _column_name, _constraint_name, _datatype_name, _table_name, _schema_name;
  end;
  $$ language plpgsql;
@@ -3943,7 +3958,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test variadic functions
  create or replace function vari(variadic int[])
  returns void as $$
-@@ -4159,36 +4607,34 @@
+@@ -4159,36 +4690,34 @@
      raise notice '%', $1[i];
    end loop; end;
  $$ language plpgsql;
@@ -4003,7 +4018,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- coercion test
  create or replace function pleast(variadic numeric[])
  returns numeric as $$
-@@ -4200,30 +4646,20 @@
+@@ -4200,30 +4729,20 @@
    return aux;
  end;
  $$ language plpgsql immutable strict;
@@ -4044,7 +4059,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- in case of conflict, non-variadic version is preferred
  create or replace function pleast(numeric)
  returns numeric as $$
-@@ -4232,31 +4668,24 @@
+@@ -4232,15 +4751,13 @@
    return $1;
  end;
  $$ language plpgsql immutable strict;
@@ -4064,12 +4079,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test table functions
  create function tftest(int) returns table(a int, b int) as $$
  begin
-   return query select $1, $1+i from generate_series(1,5) g(i);
+@@ -4248,13 +4765,13 @@
  end;
  $$ language plpgsql immutable strict;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
  select * from tftest(10);
 - a  | b  
 -----+----
@@ -4078,40 +4090,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 - 10 | 13
 - 10 | 14
 - 10 | 15
--(5 rows)
--
-+ERROR:  unknown function: tftest()
++ a | b 
++---+---
++   |  
++   |  
++   |  
++   |  
++   |  
+ (5 rows)
+ 
  create or replace function tftest(a1 int) returns table(a int, b int) as $$
- begin
-   a := a1; b := a1 + 1;
-@@ -4265,14 +4694,13 @@
-   return next;
- end;
- $$ language plpgsql immutable strict;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from tftest(10);
--  a  |  b  
-------+-----
--  10 |  11
-- 100 | 101
--(2 rows)
--
-+ERROR:  unknown function: tftest()
- drop function tftest(int);
-+ERROR:  unknown function: tftest()
- create function rttest()
- returns setof int as $$
- declare rc int;
-@@ -4291,19 +4719,11 @@
+@@ -4291,19 +4808,31 @@
    raise notice '% %', found, rc;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from rttest();
+-select * from rttest();
 -NOTICE:  t 2
 -NOTICE:  f 0
 -NOTICE:  t 2
@@ -4123,18 +4116,47 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 -     10
 -     20
 -(4 rows)
--
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare rc int;
++begin
++  return query values(10),(20);
++  get diagnostics rc = row_count;
++  raise notice '% %', found, rc;
++  return query select * from (values(10),(20)) f(a) where false;
++  get diagnostics rc = row_count;
++  raise notice '% %', found, rc;
++  return query execute 'values(10),(20)';
++               ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
+ 
++We appreciate your feedback.
++
++select * from rttest();
 +ERROR:  unknown function: rttest()
  -- check some error cases, too
  create or replace function rttest()
  returns setof int as $$
-@@ -4311,25 +4731,26 @@
+@@ -4311,25 +4840,45 @@
    return query select 10 into no_such_table;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  at or near "no_such_table": at or near "into": syntax error
++DETAIL:  source SQL:
++select 10 into no_such_table
++          ^
++--
++source SQL:
++begin
++  return query select 10 into no_such_table;
++                              ^
  select * from rttest();
 -ERROR:  SELECT INTO query does not return tuples
 -CONTEXT:  SQL statement "select 10 into no_such_table"
@@ -4146,9 +4168,22 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
    return query execute 'select 10 into no_such_table';
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "execute": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++begin
++  return query execute 'select 10 into no_such_table';
++               ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  select * from rttest();
 -ERROR:  SELECT INTO query does not return tuples
 -CONTEXT:  SQL statement "select 10 into no_such_table"
@@ -4163,7 +4198,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test for proper cleanup at subtransaction exit.  This example
  -- exposed a bug in PG 8.2.
  CREATE FUNCTION leaker_1(fail BOOL) RETURNS INTEGER AS $$
-@@ -4344,6 +4765,7 @@
+@@ -4344,6 +4893,7 @@
    RETURN 1;
  END;
  $$ LANGUAGE plpgsql;
@@ -4171,7 +4206,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION leaker_2(fail BOOL, OUT error_code INTEGER, OUT new_id INTEGER)
    RETURNS RECORD AS $$
  BEGIN
-@@ -4356,18 +4778,11 @@
+@@ -4356,18 +4906,11 @@
  END;
  $$ LANGUAGE plpgsql;
  SELECT * FROM leaker_1(false);
@@ -4193,7 +4228,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DROP FUNCTION leaker_2(bool);
  -- Test for appropriate cleanup of non-simple expression evaluations
  -- (bug in all versions prior to August 2010)
-@@ -4385,13 +4800,27 @@
+@@ -4385,13 +4928,27 @@
    RETURN arr;
  END;
  $$ LANGUAGE plpgsql;
@@ -4226,7 +4261,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION nonsimple_expr_test() RETURNS integer AS $$
  declare
     i integer NOT NULL := 0;
-@@ -4405,13 +4834,13 @@
+@@ -4405,13 +4962,13 @@
    return i;
  end;
  $$ LANGUAGE plpgsql;
@@ -4245,7 +4280,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test cases involving recursion and error recovery in simple expressions
  -- (bugs in all versions before October 2010).  The problems are most
-@@ -4427,15 +4856,13 @@
+@@ -4427,15 +4984,13 @@
    end if;
  end;
  $$ language plpgsql;
@@ -4264,7 +4299,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function error1(text) returns text language sql as
  $$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $$;
  create function error2(p_name_table text) returns text language plpgsql as $$
-@@ -4444,12 +4871,13 @@
+@@ -4444,12 +4999,13 @@
  end$$;
  BEGIN;
  create table public.stuffs (stuff text);
@@ -4281,7 +4316,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select error2('public.stuffs');
   error2 
  --------
-@@ -4457,13 +4885,30 @@
+@@ -4457,70 +5013,72 @@
  (1 row)
  
  rollback;
@@ -4312,68 +4347,70 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function cast_invoker(integer) returns date as $$
  begin
    return $1;
-@@ -4471,56 +4916,67 @@
+ end$$ language plpgsql;
++ERROR:  no value provided for placeholder: $1
  select cast_invoker(20150717);
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-17-2015
-+ 2015-07-17
- (1 row)
- 
+-(1 row)
+-
++ERROR:  unknown function: cast_invoker()
  select cast_invoker(20150718);  -- second call crashed in pre-release 9.5
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-18-2015
-+ 2015-07-18
- (1 row)
- 
+-(1 row)
+-
++ERROR:  unknown function: cast_invoker()
  begin;
  select cast_invoker(20150717);
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-17-2015
-+ 2015-07-17
- (1 row)
- 
+-(1 row)
+-
++ERROR:  unknown function: cast_invoker()
  select cast_invoker(20150718);
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-18-2015
-+ 2015-07-18
- (1 row)
- 
+-(1 row)
+-
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
  savepoint s1;
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
  select cast_invoker(20150718);
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-18-2015
-+ 2015-07-18
- (1 row)
- 
+-(1 row)
+-
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
  select cast_invoker(-1); -- fails
 -ERROR:  invalid input syntax for type date: "-1"
 -CONTEXT:  SQL function "sql_to_date" statement 1
 -PL/pgSQL function cast_invoker(integer) while casting return value to function's return type
-+ERROR:  parsing as type date: missing required date fields
-+DETAIL:  Wanted: [ Year Day Era Hour Minute Second Nanos Meridian TZHour TZMinute TZSecond ]
-+Already found in input: [ Month ]
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
  rollback to savepoint s1;
++ERROR:  savepoint "s1" does not exist
  select cast_invoker(20150719);
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-19-2015
-+ 2015-07-19
- (1 row)
- 
+-(1 row)
+-
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
  select cast_invoker(20150720);
-  cast_invoker 
- --------------
+- cast_invoker 
+---------------
 - 07-20-2015
-+ 2015-07-20
- (1 row)
- 
+-(1 row)
+-
++ERROR:  current transaction is aborted, commands ignored until end of transaction block
  commit;
  drop function cast_invoker(integer);
++ERROR:  unknown function: cast_invoker()
  drop function sql_to_date(integer) cascade;
 -NOTICE:  drop cascades to cast from integer to date
 +ERROR:  unimplemented: drop function cascade not supported
@@ -4391,7 +4428,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test handling of cast cache inside DO blocks
  -- (to check the original crash case, this must be a cast not previously
  -- used in this session)
-@@ -4534,45 +4990,29 @@
+@@ -4534,45 +5092,29 @@
    return 1/0;
  end
  $$;
@@ -4448,7 +4485,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  create or replace function strtest() returns text as $$
-@@ -4625,21 +5065,26 @@
+@@ -4625,21 +5167,26 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4488,7 +4525,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DO $$
  DECLARE r record;
  BEGIN
-@@ -4648,11 +5093,23 @@
+@@ -4648,11 +5195,23 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4517,7 +4554,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of errors thrown from/into anonymous code blocks.
  do $outer$
  begin
-@@ -4672,16 +5129,19 @@
+@@ -4672,16 +5231,19 @@
    end loop;
  end;
  $outer$;
@@ -4547,7 +4584,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check variable scoping -- a var is not available in its own or prior
  -- default expressions, but it is available in later ones.
  do $$
-@@ -4691,10 +5151,6 @@
+@@ -4691,10 +5253,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4558,7 +4595,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare y int := x + 1;  -- error
          x int := 42;
-@@ -4703,10 +5159,6 @@
+@@ -4703,10 +5261,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4569,7 +4606,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare x int := 42;
          y int := x + 1;
-@@ -4726,7 +5178,11 @@
+@@ -4726,7 +5280,11 @@
    end;
  end;
  $$;
@@ -4582,13 +4619,28 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of conflicts between plpgsql vars and table columns.
  set plpgsql.variable_conflict = error;
  create function conflict_test() returns setof int8_tbl as $$
-@@ -4738,13 +5194,11 @@
+@@ -4738,13 +5296,26 @@
    end loop;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare r record;
++  q1 bigint := 42;
++begin
++  for r in select q1,q2 from int8_tbl loop
++        ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  select * from conflict_test();
 -ERROR:  column reference "q1" is ambiguous
 -LINE 1: select q1,q2 from int8_tbl
@@ -4600,13 +4652,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_variable
  declare r record;
-@@ -4755,16 +5209,11 @@
+@@ -4755,16 +5326,12 @@
    end loop;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  at or near "#": syntax error
++DETAIL:  source SQL:
++#variable_conflict use_variable
++^
  select * from conflict_test();
 - q1 |        q2         
 -----+-------------------
@@ -4621,13 +4674,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_column
  declare r record;
-@@ -4775,17 +5224,13 @@
+@@ -4775,17 +5342,14 @@
    end loop;
  end;
  $$ language plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  at or near "#": syntax error
++DETAIL:  source SQL:
++#variable_conflict use_column
++^
  select * from conflict_test();
 -        q1        |        q2         
 -------------------+-------------------
@@ -4644,7 +4698,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check that an unreserved keyword can be used as a variable name
  create function unreserved_test() returns int as $$
  declare
-@@ -4795,12 +5240,15 @@
+@@ -4795,12 +5359,15 @@
    return forward;
  end
  $$ language plpgsql;
@@ -4665,11 +4719,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    return int := 42;
-@@ -4809,12 +5257,20 @@
+@@ -4809,12 +5376,20 @@
    return return;
  end
  $$ language plpgsql;
-+ERROR:  at or near ";": at or near ":": syntax error
++ERROR:  at or near "1": at or near ":": syntax error
 +DETAIL:  source SQL:
 +SET ROW (:= return + 1)
 +         ^
@@ -4679,7 +4733,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  return int := 42;
 +begin
 +  return := return + 1;
-+                      ^
++                     ^
 +HINT:  try \h SET SESSION
  select unreserved_test();
 - unreserved_test 
@@ -4691,7 +4745,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    comment int := 21;
-@@ -4824,19 +5280,26 @@
+@@ -4824,19 +5399,26 @@
    return comment;
  end
  $$ language plpgsql;
@@ -4728,7 +4782,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test FOREACH over arrays
  --
-@@ -4850,26 +5313,27 @@
+@@ -4850,26 +5432,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4764,9 +4818,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4774,7 +4828,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int;
-@@ -4880,13 +5344,28 @@
+@@ -4880,13 +5463,28 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4807,7 +4861,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int[];
-@@ -4897,21 +5376,27 @@
+@@ -4897,21 +5495,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4838,9 +4892,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4848,7 +4902,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- higher level of slicing
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -4923,26 +5408,31 @@
+@@ -4923,26 +5527,31 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4895,7 +4949,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type xy_tuple AS (x int, y int);
  -- iteration over array of records
  create or replace function foreach_test(anyarray)
-@@ -4955,25 +5445,27 @@
+@@ -4955,25 +5564,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4940,7 +4994,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int; y int;
-@@ -4984,25 +5476,27 @@
+@@ -4984,25 +5595,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4975,9 +5029,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select foreach_test(ARRAY[(10,20),(40,69),(35,78)]::xy_tuple[]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[(10,20),(40,69)],[(35,78),(88,76)]]::xy_tuple[]);
@@ -4985,7 +5039,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- slicing over array of composite types
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -5014,22 +5508,29 @@
+@@ -5014,22 +5627,29 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5028,7 +5082,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop type xy_tuple;
  --
  -- Assorted tests for array subscript assignment
-@@ -5043,28 +5544,30 @@
+@@ -5043,28 +5663,30 @@
    r.ar[2] := 'replace';
    return r.ar;
  end$$;
@@ -5075,7 +5129,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function testoa(x1 int, x2 int, x3 int) returns orderedarray
  language plpgsql as $$
  declare res orderedarray;
-@@ -5073,26 +5576,19 @@
+@@ -5073,26 +5695,19 @@
    res[2] := x3;
    return res;
  end$$;
@@ -5109,7 +5163,25 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of expanded arrays
  --
-@@ -5116,17 +5612,11 @@
+@@ -5101,72 +5716,48 @@
+   declare r int[];
+   begin r := array[$1, $1]; return r; end;
+ $$ stable;
++ERROR:  no value provided for placeholder: $1
+ create function consumes_rw_array(int[]) returns int
+ language plpgsql as $$
+   begin return $1[1]; end;
+ $$ stable;
++ERROR:  no value provided for placeholder: $1
+ select consumes_rw_array(returns_rw_array(42));
+- consumes_rw_array 
+--------------------
+-                42
+-(1 row)
+-
++ERROR:  unknown function: consumes_rw_array()
+ -- bug #14174
+ explain (verbose, costs off)
  select i, a from
    (select returns_rw_array(1) as a offset 0) ss,
    lateral consumes_rw_array(a) i;
@@ -5132,8 +5204,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select i, a from
    (select returns_rw_array(1) as a offset 0) ss,
    lateral consumes_rw_array(a) i;
-@@ -5137,13 +5627,11 @@
- 
+- i |   a   
+----+-------
+- 1 | {1,1}
+-(1 row)
+-
++ERROR:  unknown function: returns_rw_array()
  explain (verbose, costs off)
  select consumes_rw_array(a), a from returns_rw_array(1) a;
 -                 QUERY PLAN                 
@@ -5149,9 +5225,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +                        ^
 +HINT:  try \h <SELECTCLAUSE>
  select consumes_rw_array(a), a from returns_rw_array(1) a;
-  consumes_rw_array |   a   
- -------------------+-------
-@@ -5153,12 +5641,11 @@
+- consumes_rw_array |   a   
+--------------------+-------
+-                 1 | {1,1}
+-(1 row)
+-
++ERROR:  unknown function: returns_rw_array()
  explain (verbose, costs off)
  select consumes_rw_array(a), a from
    (values (returns_rw_array(1)), (returns_rw_array(2))) v(a);
@@ -5168,8 +5247,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +HINT:  try \h <SELECTCLAUSE>
  select consumes_rw_array(a), a from
    (values (returns_rw_array(1)), (returns_rw_array(2))) v(a);
-  consumes_rw_array |   a   
-@@ -5190,6 +5677,19 @@
+- consumes_rw_array |   a   
+--------------------+-------
+-                 1 | {1,1}
+-                 2 | {2,2}
+-(2 rows)
+-
++ERROR:  unknown function: returns_rw_array()
+ do $$
+ declare a int[] := array[1,2];
+ begin
+@@ -5190,6 +5781,19 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5189,7 +5277,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5201,6 +5701,7 @@
+@@ -5201,6 +5805,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5197,7 +5285,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5212,44 +5713,18 @@
+@@ -5212,44 +5817,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5248,7 +5336,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- access to call stack from exception
  create function inner_func(int)
  returns int as $$
-@@ -5272,6 +5747,26 @@
+@@ -5272,6 +5851,26 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5275,7 +5363,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5283,6 +5778,7 @@
+@@ -5283,6 +5882,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5283,7 +5371,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5294,44 +5790,18 @@
+@@ -5294,44 +5894,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5334,7 +5422,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test pg_routine_oid
  create function current_function(text)
  returns regprocedure as $$
-@@ -5342,13 +5812,17 @@
+@@ -5342,13 +5916,17 @@
    return fn_oid;
  end;
  $$ language plpgsql;
@@ -5357,7 +5445,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shouldn't fail in DO, even though there's no useful data
  do $$
  declare
-@@ -5358,7 +5832,13 @@
+@@ -5358,7 +5936,13 @@
    raise notice 'pg_routine_oid = %', fn_oid;
  end;
  $$;
@@ -5372,7 +5460,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test ASSERT
  --
-@@ -5367,20 +5847,55 @@
+@@ -5367,20 +5951,55 @@
    assert 1=1;  -- should succeed
  end;
  $$;
@@ -5432,7 +5520,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check controlling GUC
  set plpgsql.check_asserts = off;
  do $$
-@@ -5388,6 +5903,19 @@
+@@ -5388,6 +6007,19 @@
    assert 1=0;  -- won't be tested
  end;
  $$;
@@ -5452,7 +5540,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.check_asserts;
  -- test custom message
  do $$
-@@ -5396,8 +5924,19 @@
+@@ -5396,8 +6028,19 @@
    assert 1=0, format('assertion failed, var = "%s"', var);
  end;
  $$;
@@ -5474,7 +5562,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ensure assertions are not trapped by 'others'
  do $$
  begin
-@@ -5406,32 +5945,55 @@
+@@ -5406,32 +6049,55 @@
    null; -- do nothing
  end;
  $$;
@@ -5534,7 +5622,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare v_test plpgsql_arr_domain;
  begin
-@@ -5439,14 +6001,14 @@
+@@ -5439,14 +6105,14 @@
    v_test := v_test || 2;
  end;
  $$;
@@ -5551,7 +5639,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test usage of transition tables in AFTER triggers
  --
-@@ -5472,25 +6034,40 @@
+@@ -5472,25 +6138,40 @@
    RETURN new;
  END;
  $$;
@@ -5599,7 +5687,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION transition_table_base_upd_func()
    RETURNS trigger
    LANGUAGE plpgsql
-@@ -5512,30 +6089,42 @@
+@@ -5512,30 +6193,42 @@
    RETURN new;
  END;
  $$;
@@ -5652,7 +5740,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_level2
  (
        level2_no serial NOT NULL ,
-@@ -5543,6 +6132,7 @@
+@@ -5543,6 +6236,7 @@
        level1_node_name varchar(255),
         PRIMARY KEY (level2_no)
  ) WITHOUT OIDS;
@@ -5660,7 +5748,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_status
  (
        level int NOT NULL,
-@@ -5563,11 +6153,29 @@
+@@ -5563,11 +6257,29 @@
      RETURN NULL;
    END;
  $$;
@@ -5690,7 +5778,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level1_ri_parent_upd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5595,6 +6203,9 @@
+@@ -5595,6 +6307,9 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level1_ri_parent_upd_func();
@@ -5700,7 +5788,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level2_ri_child_insupd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5610,16 +6221,37 @@
+@@ -5610,16 +6325,37 @@
      RETURN NULL;
    END;
  $$;
@@ -5738,7 +5826,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- create initial test data
  INSERT INTO transition_table_level1 (level1_no)
    SELECT generate_series(1,200);
-@@ -5627,6 +6259,7 @@
+@@ -5627,6 +6363,7 @@
  INSERT INTO transition_table_level2 (level2_no, parent_no)
    SELECT level2_no, level2_no / 50 + 1 AS parent_no
      FROM generate_series(1,9999) level2_no;
@@ -5746,7 +5834,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  ANALYZE transition_table_level2;
  INSERT INTO transition_table_status (level, node_no, status)
    SELECT 1, level1_no, 0 FROM transition_table_level1;
-@@ -5651,30 +6284,23 @@
+@@ -5651,30 +6388,23 @@
    REFERENCING OLD TABLE AS dx
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level2_bad_usage_func();
@@ -5781,7 +5869,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- attempt modifications which would not break RI (should all succeed)
  DELETE FROM transition_table_level1
    WHERE level1_no BETWEEN 201 AND 1000;
-@@ -5683,7 +6309,7 @@
+@@ -5683,7 +6413,7 @@
  SELECT count(*) FROM transition_table_level1;
   count 
  -------
@@ -5790,7 +5878,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  DELETE FROM transition_table_level2
-@@ -5691,7 +6317,7 @@
+@@ -5691,7 +6421,7 @@
  SELECT count(*) FROM transition_table_level2;
   count 
  -------
@@ -5799,7 +5887,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  CREATE TABLE alter_table_under_transition_tables
-@@ -5717,36 +6343,30 @@
+@@ -5717,36 +6447,30 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      alter_table_under_transition_tables_upd_func();
@@ -5840,7 +5928,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test multiple reference to a transition table
  --
-@@ -5764,19 +6384,37 @@
+@@ -5764,19 +6488,37 @@
  CREATE TRIGGER my_trigger AFTER UPDATE ON multi_test
    REFERENCING NEW TABLE AS new_test OLD TABLE as old_test
    FOR EACH STATEMENT EXECUTE PROCEDURE multi_test_trig();
@@ -5880,7 +5968,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION get_from_partitioned_table(partitioned_table.a%type)
  RETURNS partitioned_table AS $$
  DECLARE
-@@ -5787,13 +6425,13 @@
+@@ -5787,13 +6529,13 @@
      SELECT * INTO result FROM partitioned_table WHERE a = a_val;
      RETURN result;
  END; $$ LANGUAGE plpgsql;
@@ -5900,7 +5988,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION list_partitioned_table()
  RETURNS SETOF partitioned_table.a%TYPE AS $$
  DECLARE
-@@ -5806,14 +6444,13 @@
+@@ -5806,14 +6548,13 @@
      END LOOP;
      RETURN;
  END; $$ LANGUAGE plpgsql;
@@ -5921,7 +6009,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Check argument name is used instead of $n in error message
  --
-@@ -5822,6 +6459,16 @@
+@@ -5822,6 +6563,16 @@
    GET DIAGNOSTICS x = ROW_COUNT;
    RETURN;
  END; $$ LANGUAGE plpgsql;

--- a/pkg/cmd/roachtest/testdata/pg_regress/portals.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/portals.diffs
@@ -799,7 +799,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  END;
  --
  -- Cursors outside transaction blocks
-@@ -743,78 +218,53 @@
+@@ -743,78 +218,59 @@
  
  BEGIN;
  DECLARE foo25 SCROLL CURSOR WITH HOLD FOR SELECT * FROM tenk2;
@@ -878,15 +878,19 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
 +(0 rows)
  
  FETCH ABSOLUTE 4 FROM foo25ns;
-- unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
-----------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
+  unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
+ ---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
 -    9850 |       3 |   0 |    2 |   0 |     10 |      50 |      850 |        1850 |      4850 |     9850 | 100 |  101 | WOAAAA   | DAAAAA   | VVVVxx
 -(1 row)
--
-+ERROR:  cursor can only scan forward
++(0 rows)
+ 
  FETCH ABSOLUTE 4 FROM foo25ns; -- fail
- ERROR:  cursor can only scan forward
+-ERROR:  cursor can only scan forward
 -HINT:  Declare it with SCROLL option to enable backward scan.
++ unique1 | unique2 | two | four | ten | twenty | hundred | thousand | twothousand | fivethous | tenthous | odd | even | stringu1 | stringu2 | string4 
++---------+---------+-----+------+-----+--------+---------+----------+-------------+-----------+----------+-----+------+----------+----------+---------
++(0 rows)
++
  SELECT name, statement, is_holdable, is_binary, is_scrollable FROM pg_cursors;
 -  name   |                              statement                              | is_holdable | is_binary | is_scrollable 
 ----------+---------------------------------------------------------------------+-------------+-----------+---------------
@@ -897,7 +901,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  (1 row)
  
  CLOSE foo25ns;
-@@ -835,33 +285,25 @@
+@@ -835,33 +291,25 @@
     RETURNS void
     AS 'DECLARE c CURSOR FOR SELECT stringu1 FROM tenk1 WHERE stringu1 LIKE $1;'
     LANGUAGE SQL;
@@ -935,9 +939,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
 -(15 rows)
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +SELECT declares_cursor('AB%');
 +ERROR:  unknown function: declares_cursor()
 +FETCH ALL FROM c;
@@ -947,7 +951,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  --
  -- Test behavior of both volatile and stable functions inside a cursor;
  -- in particular we want to see what happens during commit of a holdable
-@@ -879,7 +321,7 @@
+@@ -879,7 +327,7 @@
  fetch all from c1;
   count_tt1_v | count_tt1_s 
  -------------+-------------
@@ -956,7 +960,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  (1 row)
  
  rollback;
-@@ -892,36 +334,40 @@
+@@ -892,36 +340,40 @@
  fetch all from c2;
   count_tt1_v | count_tt1_s 
  -------------+-------------
@@ -1010,7 +1014,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  (1 row)
  
  -- test CLOSE ALL;
-@@ -978,39 +424,30 @@
+@@ -978,39 +430,30 @@
  (2 rows)
  
  DELETE FROM uctest WHERE CURRENT OF c1;
@@ -1060,7 +1064,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  
  -- Check UPDATE WHERE CURRENT; this time use FOR UPDATE
  BEGIN;
-@@ -1022,144 +459,133 @@
+@@ -1022,144 +465,133 @@
  (1 row)
  
  UPDATE uctest SET f1 = 8 WHERE CURRENT OF c1;
@@ -1278,7 +1282,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  
  -- Check insensitive cursor with INSERT
  -- (The above tests don't test the SQL notion of an insensitive cursor
-@@ -1170,151 +596,183 @@
+@@ -1170,151 +602,183 @@
  DECLARE c1 INSENSITIVE CURSOR FOR SELECT * FROM uctest;
  INSERT INTO uctest VALUES (10, 'ten');
  FETCH NEXT FROM c1;
@@ -1526,7 +1530,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/portals.out --lab
  ROLLBACK;
  BEGIN;
  DECLARE c1 CURSOR FOR SELECT MIN(f1) FROM uctest FOR UPDATE;
-@@ -1325,239 +783,208 @@
+@@ -1325,239 +789,208 @@
  CREATE TEMP VIEW ucview AS SELECT * FROM uctest;
  CREATE RULE ucrule AS ON DELETE TO ucview DO INSTEAD
    DELETE FROM uctest WHERE f1 = OLD.f1;

--- a/pkg/cmd/roachtest/testdata/pg_regress/privileges.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/privileges.diffs
@@ -3075,9 +3075,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
 -(1 row)
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +SELECT brin_desummarize_range('sro_brin', 0);
 +ERROR:  unknown function: brin_desummarize_range()
 +SELECT brin_summarize_range('sro_brin', 0);
@@ -4018,7 +4018,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  (1 row)
  
  DROP OWNED BY regress_priv_user2, regress_priv_user2;
-@@ -2368,46 +3737,76 @@
+@@ -2368,46 +3737,61 @@
  (1 row)
  
  ROLLBACK;
@@ -4070,21 +4070,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  (1 row)
  
  ALTER DEFAULT PRIVILEGES IN SCHEMA testns GRANT EXECUTE ON ROUTINES to public;
-+ERROR:  at or near "to": syntax error: unimplemented: this syntax
-+DETAIL:  source SQL:
-+ALTER DEFAULT PRIVILEGES IN SCHEMA testns GRANT EXECUTE ON ROUTINES to public
-+                                                                    ^
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
-+
  DROP FUNCTION testns.foo();
  CREATE FUNCTION testns.foo() RETURNS int AS 'select 1' LANGUAGE sql;
  DROP AGGREGATE testns.agg1(int);
@@ -4104,7 +4089,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  DROP PROCEDURE testns.bar();
  CREATE PROCEDURE testns.bar() AS 'select 1' LANGUAGE sql;
  SELECT has_function_privilege('regress_priv_user2', 'testns.foo()', 'EXECUTE'); -- yes
-@@ -2417,11 +3816,7 @@
+@@ -2417,11 +3801,7 @@
  (1 row)
  
  SELECT has_function_privilege('regress_priv_user2', 'testns.agg1(int)', 'EXECUTE'); -- yes
@@ -4117,7 +4102,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT has_function_privilege('regress_priv_user2', 'testns.bar()', 'EXECUTE'); -- yes (counts as function here)
   has_function_privilege 
  ------------------------
-@@ -2430,36 +3825,57 @@
+@@ -2430,25 +3810,47 @@
  
  DROP FUNCTION testns.foo();
  DROP AGGREGATE testns.agg1(int);
@@ -4175,11 +4160,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  RESET ROLE;
  SELECT count(*)
    FROM pg_default_acl d LEFT JOIN pg_namespace n ON defaclnamespace = n.oid
-   WHERE nspname = 'testns';
-  count 
- -------
--     3
-+     2
+@@ -2459,7 +3861,6 @@
  (1 row)
  
  DROP SCHEMA testns CASCADE;
@@ -4187,7 +4168,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  DROP SCHEMA testns2 CASCADE;
  DROP SCHEMA testns3 CASCADE;
  DROP SCHEMA testns4 CASCADE;
-@@ -2510,6 +3926,12 @@
+@@ -2510,6 +3911,12 @@
  
  CREATE FUNCTION testns.priv_testfunc(int) RETURNS int AS 'select 3 * $1;' LANGUAGE sql;
  CREATE AGGREGATE testns.priv_testagg(int) (sfunc = int4pl, stype = int4);
@@ -4200,7 +4181,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  CREATE PROCEDURE testns.priv_testproc(int) AS 'select 3' LANGUAGE sql;
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE'); -- true by default
   has_function_privilege 
-@@ -2518,11 +3940,7 @@
+@@ -2518,11 +3925,7 @@
  (1 row)
  
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testagg(int)', 'EXECUTE'); -- true by default
@@ -4213,7 +4194,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- true by default
   has_function_privilege 
  ------------------------
-@@ -2533,15 +3951,11 @@
+@@ -2533,15 +3936,11 @@
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE'); -- false
   has_function_privilege 
  ------------------------
@@ -4231,7 +4212,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- still true, not a function
   has_function_privilege 
  ------------------------
-@@ -2552,10 +3966,15 @@
+@@ -2552,7 +3951,7 @@
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- now false
   has_function_privilege 
  ------------------------
@@ -4240,15 +4221,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  (1 row)
  
  GRANT ALL ON ALL ROUTINES IN SCHEMA testns TO PUBLIC;
-+ERROR:  at or near "routines": syntax error
-+DETAIL:  source SQL:
-+GRANT ALL ON ALL ROUTINES IN SCHEMA testns TO PUBLIC
-+                 ^
-+HINT:  try \h GRANT
- SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testfunc(int)', 'EXECUTE'); -- true
-  has_function_privilege 
- ------------------------
-@@ -2563,11 +3982,7 @@
+@@ -2563,11 +3962,7 @@
  (1 row)
  
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testagg(int)', 'EXECUTE'); -- true
@@ -4261,7 +4234,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT has_function_privilege('regress_priv_user1', 'testns.priv_testproc(int)', 'EXECUTE'); -- true
   has_function_privilege 
  ------------------------
-@@ -2575,38 +3990,52 @@
+@@ -2575,38 +3970,52 @@
  (1 row)
  
  DROP SCHEMA testns CASCADE;
@@ -4326,7 +4299,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  -- test that dependent privileges are revoked (or not) properly
  \c -
  set session role regress_priv_user1;
-@@ -2620,59 +4049,179 @@
+@@ -2620,59 +4029,179 @@
  set session role regress_priv_user4;
  grant select on dep_priv_test to regress_priv_user5;
  \dp dep_priv_test
@@ -4537,7 +4510,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  DROP TABLE atest1;
  DROP TABLE atest2;
  DROP TABLE atest3;
-@@ -2680,108 +4229,214 @@
+@@ -2680,108 +4209,214 @@
  DROP TABLE atest5;
  DROP TABLE atest6;
  DROP TABLE atestc;
@@ -4765,7 +4738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  -- clean up
  DROP TABLE lock_table;
  DROP USER regress_locktable_user;
-@@ -2791,24 +4446,17 @@
+@@ -2791,24 +4426,17 @@
  \c -
  CREATE ROLE regress_readallstats;
  SELECT has_table_privilege('regress_readallstats','pg_backend_memory_contexts','SELECT'); -- no
@@ -4794,7 +4767,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT has_table_privilege('regress_readallstats','pg_shmem_allocations','SELECT'); -- yes
   has_table_privilege 
  ---------------------
-@@ -2818,11 +4466,7 @@
+@@ -2818,11 +4446,7 @@
  -- run query to ensure that functions within views can be executed
  SET ROLE regress_readallstats;
  SELECT COUNT(*) >= 0 AS ok FROM pg_backend_memory_contexts;
@@ -4807,7 +4780,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT COUNT(*) >= 0 AS ok FROM pg_shmem_allocations;
   ok 
  ----
-@@ -2838,28 +4482,48 @@
+@@ -2838,28 +4462,48 @@
  CREATE ROLE regress_group_indirect_manager;
  CREATE ROLE regress_group_member;
  GRANT regress_group TO regress_group_direct_manager WITH INHERIT FALSE, ADMIN TRUE;
@@ -4866,7 +4839,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  DROP ROLE regress_group;
  DROP ROLE regress_group_direct_manager;
  DROP ROLE regress_group_indirect_manager;
-@@ -2871,22 +4535,59 @@
+@@ -2871,22 +4515,59 @@
  CREATE SCHEMA regress_roleoption;
  GRANT CREATE, USAGE ON SCHEMA regress_roleoption TO PUBLIC;
  GRANT regress_roleoption_donor TO regress_roleoption_protagonist WITH INHERIT TRUE, SET FALSE;

--- a/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
@@ -463,7 +463,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- sql, proretset = t, prorettype = record
  CREATE FUNCTION getrngfunc7(int) RETURNS setof record AS 'SELECT * FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
  SELECT * FROM getrngfunc7(1) AS t1(rngfuncid int, rngfuncsubid int, rngfuncname text);
-@@ -544,143 +445,126 @@
+@@ -544,143 +445,119 @@
  (2 rows)
  
  SELECT * FROM ROWS FROM( getrngfunc7(1) AS (rngfuncid int, rngfuncsubid int, rngfuncname text) ) WITH ORDINALITY;
@@ -517,20 +517,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +ERROR:  relation "vw_getrngfunc" does not exist
  -- plpgsql, proretset = f, prorettype = b
  CREATE FUNCTION getrngfunc8(int) RETURNS int AS 'DECLARE rngfuncint int; BEGIN SELECT rngfuncid into rngfuncint FROM rngfunc WHERE rngfuncid = $1; RETURN rngfuncint; END;' LANGUAGE plpgsql;
++ERROR:  no value provided for placeholder: $1
  SELECT * FROM getrngfunc8(1) AS t1;
-  t1 
- ----
+- t1 
+-----
 -  1
-+   
- (1 row)
- 
+-(1 row)
+-
++ERROR:  unknown function: getrngfunc8()
  SELECT * FROM getrngfunc8(1) WITH ORDINALITY AS t1(v,o);
-  v | o 
- ---+---
+- v | o 
+----+---
 - 1 | 1
-+   | 1
- (1 row)
- 
+-(1 row)
+-
++ERROR:  unknown function: getrngfunc8()
  CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc8(1);
 +ERROR:  unknown function: getrngfunc8()
 +HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
@@ -672,28 +673,28 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP FUNCTION getrngfunc1(int);
  DROP FUNCTION getrngfunc2(int);
  DROP FUNCTION getrngfunc3(int);
-@@ -690,6 +574,7 @@
+@@ -689,7 +566,9 @@
+ DROP FUNCTION getrngfunc6(int);
  DROP FUNCTION getrngfunc7(int);
  DROP FUNCTION getrngfunc8(int);
++ERROR:  unknown function: getrngfunc8()
  DROP FUNCTION getrngfunc9(int);
 +ERROR:  unknown function: getrngfunc9()
  DROP FUNCTION rngfunct(int);
  DROP TABLE rngfunc2;
  DROP TABLE rngfunc;
-@@ -698,8 +583,12 @@
+@@ -698,8 +577,10 @@
  CREATE TEMPORARY SEQUENCE rngfunc_rescan_seq2;
  CREATE TYPE rngfunc_rescan_t AS (i integer, s bigint);
  CREATE FUNCTION rngfunc_sql(int,int) RETURNS setof rngfunc_rescan_t AS 'SELECT i, nextval(''rngfunc_rescan_seq1'') FROM generate_series($1,$2) i;' LANGUAGE SQL;
 +ERROR:  cannot create function using temp tables
  -- plpgsql functions use materialize mode
  CREATE FUNCTION rngfunc_mat(int,int) RETURNS setof rngfunc_rescan_t AS 'begin for i in $1..$2 loop return next (i, nextval(''rngfunc_rescan_seq2'')); end loop; end;' LANGUAGE plpgsql;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  no value provided for placeholder: $1
  --invokes ExecReScanFunctionScan - all these cases should materialize the function only once
  -- LEFT JOIN on a condition that the planner can't prove to be true is used to ensure the function
  -- is on the inner path of a nestloop join
-@@ -710,19 +599,7 @@
+@@ -710,19 +591,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_sql(11,13) ON (r+i)<100;
@@ -714,7 +715,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -730,19 +607,7 @@
+@@ -730,19 +599,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_sql(11,13) WITH ORDINALITY AS f(i,s,o) ON (r+i)<100;
@@ -735,7 +736,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -750,19 +615,7 @@
+@@ -750,19 +607,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_mat(11,13) ON (r+i)<100;
@@ -756,7 +757,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -770,19 +623,7 @@
+@@ -770,19 +615,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_mat(11,13) WITH ORDINALITY AS f(i,s,o) ON (r+i)<100;
@@ -777,7 +778,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -790,30 +631,18 @@
+@@ -790,30 +623,18 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN ROWS FROM( rngfunc_sql(11,13), rngfunc_mat(11,13) ) WITH ORDINALITY AS f(i1,s1,i2,s2,o) ON (r+i1+i2)<100;
@@ -813,7 +814,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
   3 | 13
  (9 rows)
  
-@@ -821,13 +650,13 @@
+@@ -821,13 +642,13 @@
   r | i  | o 
  ---+----+---
   1 | 11 | 1
@@ -831,7 +832,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
   3 | 13 | 3
  (9 rows)
  
-@@ -867,16 +696,7 @@
+@@ -867,16 +688,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(10+r,13);
@@ -849,7 +850,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -884,16 +704,7 @@
+@@ -884,16 +696,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(10+r,13) WITH ORDINALITY AS f(i,s,o);
@@ -867,7 +868,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -901,16 +712,7 @@
+@@ -901,16 +704,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(11,10+r);
@@ -885,7 +886,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -918,16 +720,7 @@
+@@ -918,16 +712,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(11,10+r) WITH ORDINALITY AS f(i,s,o);
@@ -903,7 +904,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -935,20 +728,7 @@
+@@ -935,20 +720,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_sql(r1,r2);
@@ -925,7 +926,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -956,20 +736,7 @@
+@@ -956,20 +728,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_sql(r1,r2) WITH ORDINALITY AS f(i,s,o);
@@ -947,7 +948,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -977,16 +744,7 @@
+@@ -977,16 +736,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(10+r,13);
@@ -965,7 +966,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -994,16 +752,7 @@
+@@ -994,16 +744,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(10+r,13) WITH ORDINALITY AS f(i,s,o);
@@ -983,7 +984,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1011,16 +760,7 @@
+@@ -1011,16 +752,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(11,10+r);
@@ -1001,7 +1002,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1028,16 +768,7 @@
+@@ -1028,16 +760,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(11,10+r) WITH ORDINALITY AS f(i,s,o);
@@ -1019,7 +1020,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1045,20 +776,7 @@
+@@ -1045,20 +768,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_mat(r1,r2);
@@ -1041,7 +1042,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1066,20 +784,7 @@
+@@ -1066,20 +776,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_mat(r1,r2) WITH ORDINALITY AS f(i,s,o);
@@ -1063,7 +1064,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- selective rescan of multiple functions:
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
-@@ -1088,16 +793,7 @@
+@@ -1088,16 +785,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), ROWS FROM( rngfunc_sql(11,11), rngfunc_mat(10+r,13) );
@@ -1081,7 +1082,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1105,16 +801,7 @@
+@@ -1105,16 +793,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), ROWS FROM( rngfunc_sql(10+r,13), rngfunc_mat(11,11) );
@@ -1099,7 +1100,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1122,16 +809,7 @@
+@@ -1122,16 +801,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), ROWS FROM( rngfunc_sql(10+r,13), rngfunc_mat(10+r,13) );
@@ -1117,7 +1118,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1139,23 +817,7 @@
+@@ -1139,23 +809,7 @@
  (1 row)
  
  SELECT * FROM generate_series(1,2) r1, generate_series(r1,3) r2, ROWS FROM( rngfunc_sql(10+r1,13), rngfunc_mat(10+r2,13) );
@@ -1142,7 +1143,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT * FROM (VALUES (1),(2),(3)) v(r), generate_series(10+r,20-r) f(i);
   r | i  
  ---+----
-@@ -1243,31 +905,31 @@
+@@ -1243,31 +897,31 @@
   r1 | r1 | r2 | i  
  ----+----+----+----
    1 |  1 | 10 | 21
@@ -1192,7 +1193,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
    3 |  3 | 30 | 23
  (27 rows)
  
-@@ -1302,95 +964,47 @@
+@@ -1302,95 +956,47 @@
   r1 | r1 | r2 | i  
  ----+----+----+----
    1 |  1 | 10 | 10
@@ -1311,7 +1312,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- check handling of FULL JOIN with multiple lateral references (bug #15741)
  SELECT *
  FROM (VALUES (1),(2)) v1(r1)
-@@ -1404,20 +1018,11 @@
+@@ -1404,20 +1010,11 @@
          ) AS ss1 ON TRUE
          FULL JOIN generate_series(1, v1.r1) AS gs4 ON FALSE
      ) AS ss0 ON TRUE;
@@ -1335,7 +1336,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP SEQUENCE rngfunc_rescan_seq1;
  DROP SEQUENCE rngfunc_rescan_seq2;
  --
-@@ -1449,7 +1054,7 @@
+@@ -1449,7 +1046,7 @@
  -- error, wrong result type
  CREATE OR REPLACE FUNCTION rngfunc(in f1 int, out f2 int) RETURNS float
  AS 'select $1+1' LANGUAGE sql;
@@ -1344,7 +1345,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- with multiple OUT params you must get a RECORD result
  CREATE OR REPLACE FUNCTION rngfunc(in f1 int, out f2 int, out f3 text) RETURNS int
  AS 'select $1+1' LANGUAGE sql;
-@@ -1457,8 +1062,8 @@
+@@ -1457,8 +1054,8 @@
  CREATE OR REPLACE FUNCTION rngfunc(in f1 int, out f2 int, out f3 text)
  RETURNS record
  AS 'select $1+1' LANGUAGE sql;
@@ -1355,7 +1356,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  CREATE OR REPLACE FUNCTION rngfuncr(in f1 int, out f2 int, out text)
  AS $$select $1-1, $1::text || 'z'$$ LANGUAGE sql;
  SELECT f1, rngfuncr(f1) FROM int4_tbl;
-@@ -1486,15 +1091,7 @@
+@@ -1486,15 +1083,7 @@
  CREATE OR REPLACE FUNCTION rngfuncb(in f1 int, inout f2 int, out text)
  AS $$select $2-1, $1::text || 'z'$$ LANGUAGE sql;
  SELECT f1, rngfuncb(f1, f1/2) FROM int4_tbl;
@@ -1372,7 +1373,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT * FROM rngfuncb(42, 99);
   f2 | column2 
  ----+---------
-@@ -1523,7 +1120,11 @@
+@@ -1523,7 +1112,11 @@
  (1 row)
  
  SELECT dup('xyz');	-- fails
@@ -1385,7 +1386,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT dup('xyz'::text);
          dup        
  -------------------
-@@ -1540,7 +1141,6 @@
+@@ -1540,7 +1133,6 @@
  CREATE OR REPLACE FUNCTION dup (inout f2 anyelement, out f3 anyarray)
  AS 'select $1, array[$1,$1]' LANGUAGE sql;
  ERROR:  cannot change name of input parameter "f1"
@@ -1393,7 +1394,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP FUNCTION dup(anyelement);
  -- equivalent behavior, though different name exposed for input arg
  CREATE OR REPLACE FUNCTION dup (inout f2 anyelement, out f3 anyarray)
-@@ -1559,57 +1159,32 @@
+@@ -1559,57 +1151,32 @@
  DETAIL:  A result of type anyelement requires at least one input of type anyelement, anyarray, anynonarray, anyenum, anyrange, or anymultirange.
  CREATE FUNCTION dup (f1 anycompatible, f2 anycompatiblearray, f3 out anycompatible, f4 out anycompatiblearray)
  AS 'select $1, $2' LANGUAGE sql;
@@ -1463,7 +1464,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- table functions
  --
-@@ -1661,100 +1236,77 @@
+@@ -1661,100 +1228,77 @@
  --
  -- some tests on SQL functions with RETURNING
  --
@@ -1595,7 +1596,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  
  -- triggers will fire, too
  create function noticetrigger() returns trigger as $$
-@@ -1764,70 +1316,55 @@
+@@ -1764,70 +1308,55 @@
  end $$ language plpgsql;
  create trigger tnoticetrigger after insert on tt for each row
  execute procedure noticetrigger();
@@ -1702,7 +1703,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  
  -- test case for a whole-row-variable bug
  create function rngfunc1(n integer, out a text, out b text)
-@@ -1835,6 +1372,18 @@
+@@ -1835,6 +1364,18 @@
    language sql
    as $$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $$;
  set work_mem='64kB';
@@ -1721,7 +1722,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1842,6 +1391,18 @@
+@@ -1842,6 +1383,18 @@
  (1 row)
  
  reset work_mem;
@@ -1740,7 +1741,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1871,31 +1432,24 @@
+@@ -1871,31 +1424,24 @@
  
  select * from array_to_set(array['one', 'two']); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1784,7 +1785,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- but without, it can be:
  create or replace function array_to_set(anyarray) returns setof record as $$
    select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
-@@ -1914,26 +1468,21 @@
+@@ -1914,26 +1460,21 @@
    2 | two
  (2 rows)
  
@@ -1823,7 +1824,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  create temp table rngfunc(f1 int8, f2 int8);
  create function testrngfunc() returns record as $$
    insert into rngfunc values (1,2) returning *;
-@@ -1952,8 +1501,6 @@
+@@ -1952,8 +1493,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1832,7 +1833,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  create function testrngfunc() returns setof record as $$
    insert into rngfunc values (1,2), (3,4) returning *;
-@@ -1974,8 +1521,6 @@
+@@ -1974,8 +1513,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1841,7 +1842,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  -- Check that typmod imposed by a composite type is honored
  create type rngfunc_type as (f1 numeric(35,6), f2 numeric(35,2));
-@@ -1984,12 +1529,11 @@
+@@ -1984,12 +1521,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1859,7 +1860,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -1998,13 +1542,11 @@
+@@ -1998,13 +1534,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1878,7 +1879,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2016,12 +1558,11 @@
+@@ -2016,12 +1550,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1896,7 +1897,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2030,13 +1571,11 @@
+@@ -2030,13 +1563,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1915,7 +1916,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2049,13 +1588,11 @@
+@@ -2049,13 +1580,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1934,7 +1935,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2064,12 +1601,11 @@
+@@ -2064,12 +1593,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1952,7 +1953,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2081,13 +1617,11 @@
+@@ -2081,13 +1609,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1971,7 +1972,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2096,13 +1630,11 @@
+@@ -2096,13 +1622,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1990,7 +1991,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2112,62 +1644,45 @@
+@@ -2112,62 +1636,45 @@
  create or replace function testrngfunc() returns setof rngfunc_type as $$
    select 1, 2 union select 3, 4 order by 1;
  $$ language sql immutable;
@@ -2074,7 +2075,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- Check some cases involving added/dropped columns in a rowtype result
  --
-@@ -2178,79 +1693,37 @@
+@@ -2178,79 +1685,37 @@
  create or replace function get_first_user() returns users as
  $$ SELECT * FROM users ORDER BY userid LIMIT 1; $$
  language sql stable;
@@ -2167,7 +2168,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -2264,18 +1737,14 @@
+@@ -2264,18 +1729,14 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2190,7 +2191,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- likewise, check we don't crash if the dependency goes wrong
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -2286,19 +1755,18 @@
+@@ -2286,19 +1747,18 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2216,7 +2217,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop table users;
  -- check behavior with type coercion required for a set-op
  create or replace function rngfuncbar() returns setof text as
-@@ -2320,17 +1788,11 @@
+@@ -2320,17 +1780,11 @@
  
  -- this function is now inlinable, too:
  explain (verbose, costs off) select * from rngfuncbar();
@@ -2239,7 +2240,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function rngfuncbar();
  -- check handling of a SQL function with multiple OUT params (bug #5777)
  create or replace function rngfuncbar(out integer, out numeric) as
-@@ -2344,115 +1806,93 @@
+@@ -2344,115 +1798,93 @@
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2) $$ language sql;
  select * from rngfuncbar();  -- fail
@@ -2406,7 +2407,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (0 rows)
  
  drop type rngfunc2;
-@@ -2463,25 +1903,16 @@
+@@ -2463,18 +1895,11 @@
     from unnest(array['{"lectures": [{"id": "1"}]}'::jsonb])
          as unnested_modules(module)) as ss,
    jsonb_to_recordset(ss.lecture) as j (id text);
@@ -2430,13 +2431,3 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from
    (select jsonb_path_query_array(module->'lectures', '$[*]') as lecture
     from unnest(array['{"lectures": [{"id": "1"}]}'::jsonb])
-         as unnested_modules(module)) as ss,
-   jsonb_to_recordset(ss.lecture) as j (id text);
--    lecture    | id 
-----------------+----
-- [{"id": "1"}] | 1
--(1 row)
--
-+ERROR:  jsonb_path_query_array(): unimplemented: this function is not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/22513/_version_

--- a/pkg/cmd/roachtest/testdata/pg_regress/roleattributes.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/roleattributes.diffs
@@ -274,7 +274,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/roleattributes.ou
  (1 row)
  
  -- default for bypassrls is false
-@@ -206,35 +230,39 @@
+@@ -206,35 +230,37 @@
  SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, rolpassword, rolvaliduntil FROM pg_authid WHERE rolname = 'regress_test_def_bypassrls';
            rolname           | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
  ----------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
@@ -283,39 +283,28 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/roleattributes.ou
  (1 row)
  
  CREATE ROLE regress_test_bypassrls WITH BYPASSRLS;
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
  SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, rolpassword, rolvaliduntil FROM pg_authid WHERE rolname = 'regress_test_bypassrls';
--        rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
--------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
+         rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
+ ------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
 - regress_test_bypassrls | f        | t          | f             | f           | f           | f              | t            |           -1 |             | 
--(1 row)
-+ rolname | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
-+---------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
-+(0 rows)
++ regress_test_bypassrls | f        | t          | f             | f           | f           | f              | f            |           -1 | ********    | 
+ (1 row)
  
  ALTER ROLE regress_test_bypassrls WITH NOBYPASSRLS;
-+ERROR:  role/user "regress_test_bypassrls" does not exist
  SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, rolpassword, rolvaliduntil FROM pg_authid WHERE rolname = 'regress_test_bypassrls';
--        rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
--------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
+         rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
+ ------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
 - regress_test_bypassrls | f        | t          | f             | f           | f           | f              | f            |           -1 |             | 
--(1 row)
-+ rolname | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
-+---------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
-+(0 rows)
++ regress_test_bypassrls | f        | t          | f             | f           | f           | f              | f            |           -1 | ********    | 
+ (1 row)
  
  ALTER ROLE regress_test_bypassrls WITH BYPASSRLS;
-+ERROR:  role/user "regress_test_bypassrls" does not exist
  SELECT rolname, rolsuper, rolinherit, rolcreaterole, rolcreatedb, rolcanlogin, rolreplication, rolbypassrls, rolconnlimit, rolpassword, rolvaliduntil FROM pg_authid WHERE rolname = 'regress_test_bypassrls';
--        rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
--------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
+         rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
+ ------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
 - regress_test_bypassrls | f        | t          | f             | f           | f           | f              | t            |           -1 |             | 
--(1 row)
-+ rolname | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
-+---------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
-+(0 rows)
++ regress_test_bypassrls | f        | t          | f             | f           | f           | f              | f            |           -1 | ********    | 
+ (1 row)
  
  -- clean up roles
  DROP ROLE regress_test_def_superuser;
@@ -327,8 +316,3 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/roleattributes.ou
  DROP ROLE regress_test_def_createrole;
  DROP ROLE regress_test_createrole;
  DROP ROLE regress_test_def_createdb;
-@@ -247,3 +275,4 @@
- DROP ROLE regress_test_replication;
- DROP ROLE regress_test_def_bypassrls;
- DROP ROLE regress_test_bypassrls;
-+ERROR:  role/user "regress_test_bypassrls" does not exist

--- a/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
@@ -1,17 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out --label=/mnt/data1/postgres/src/test/regress/results/rowsecurity.out /mnt/data1/postgres/src/test/regress/expected/rowsecurity.out /mnt/data1/postgres/src/test/regress/results/rowsecurity.out
 --- /mnt/data1/postgres/src/test/regress/expected/rowsecurity.out
 +++ /mnt/data1/postgres/src/test/regress/results/rowsecurity.out
-@@ -19,6 +19,9 @@
- CREATE USER regress_rls_carol NOLOGIN;
- CREATE USER regress_rls_dave NOLOGIN;
- CREATE USER regress_rls_exempt_user BYPASSRLS NOLOGIN;
-+ERROR:  unimplemented: the BYPASSRLS and NOBYPASSRLS options for roles are not currently supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/136910/_version_
- CREATE ROLE regress_rls_group1 NOLOGIN;
- CREATE ROLE regress_rls_group2 NOLOGIN;
- GRANT regress_rls_group1 TO regress_rls_bob;
-@@ -27,12 +30,12 @@
+@@ -27,12 +27,12 @@
  GRANT ALL ON SCHEMA regress_rls_schema to public;
  SET search_path = regress_rls_schema;
  -- setup of malicious function
@@ -27,7 +17,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE uaccount (
      pguser      name primary key,
      seclv       int
-@@ -76,13 +79,15 @@
+@@ -76,13 +76,15 @@
  -- user's security level must be higher than or equal to document's
  CREATE POLICY p1 ON document AS PERMISSIVE
      USING (dlevel <= (SELECT seclv FROM uaccount WHERE pguser = current_user));
@@ -47,7 +37,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- but Dave isn't allowed to anything at cid 50 or above
  -- this is to make sure that we sort the policies by name first
  -- when applying WITH CHECK, a later INSERT by Dave should fail due
-@@ -93,390 +98,184 @@
+@@ -93,390 +95,184 @@
  CREATE POLICY p1r ON document AS RESTRICTIVE TO regress_rls_dave
      USING (cid <> 44);
  \dp
@@ -549,7 +539,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM document WHERE did = 8; -- and confirm we can't see it
   did | cid | dlevel | dauthor | dtitle 
  -----+-----+--------+---------+--------
-@@ -486,9 +285,8 @@
+@@ -486,9 +282,8 @@
  INSERT INTO document VALUES (8, 44, 1, 'regress_rls_carol', 'my third manga'); -- Should fail with RLS check violation, not duplicate key violation
  ERROR:  new row violates row-level security policy for table "document"
  UPDATE document SET did = 8, dauthor = 'regress_rls_carol' WHERE did = 5; -- Should fail with RLS check violation, not duplicate key violation
@@ -560,7 +550,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO ON;
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |         dtitle          
-@@ -503,8 +301,7 @@
+@@ -503,8 +298,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -570,7 +560,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -516,7 +313,7 @@
+@@ -516,7 +310,7 @@
  (4 rows)
  
  -- database superuser does bypass RLS policy when disabled
@@ -579,7 +569,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO OFF;
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |         dtitle          
-@@ -531,8 +328,7 @@
+@@ -531,8 +325,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -589,17 +579,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -544,7 +340,8 @@
+@@ -544,7 +337,7 @@
  (4 rows)
  
  -- database non-superuser with bypass privilege can bypass RLS policy when disabled
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
 +SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |         dtitle          
-@@ -559,8 +356,7 @@
+@@ -559,8 +352,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -609,7 +598,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -572,7 +368,7 @@
+@@ -572,7 +364,7 @@
  (4 rows)
  
  -- RLS policy does not apply to table owner when RLS enabled.
@@ -618,7 +607,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO ON;
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |         dtitle          
-@@ -587,8 +383,7 @@
+@@ -587,8 +379,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -628,7 +617,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -600,7 +395,7 @@
+@@ -600,7 +391,7 @@
  (4 rows)
  
  -- RLS policy does not apply to table owner when RLS disabled.
@@ -637,7 +626,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO OFF;
  SELECT * FROM document;
   did | cid | dlevel |      dauthor      |         dtitle          
-@@ -615,8 +410,7 @@
+@@ -615,8 +406,7 @@
     8 |  44 |      1 | regress_rls_carol | great manga
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction
    10 |  33 |      2 | regress_rls_dave  | awesome technology book
@@ -647,7 +636,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT * FROM category;
   cid |      cname      
-@@ -630,279 +424,190 @@
+@@ -630,279 +420,189 @@
  --
  -- Table inheritance and RLS policy
  --
@@ -1001,7 +990,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- non-superuser with bypass privilege can bypass RLS policy when disabled
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
 +SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  SELECT * FROM t1 WHERE f_leak(b);
 -NOTICE:  f_leak => aba
@@ -1058,7 +1046,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE part_document (
      did         int,
      cid         int,
-@@ -910,14 +615,44 @@
+@@ -910,14 +610,44 @@
      dauthor     name,
      dtitle      text
  ) PARTITION BY RANGE (cid);
@@ -1103,7 +1091,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  INSERT INTO part_document VALUES
      ( 1, 11, 1, 'regress_rls_bob', 'my first novel'),
      ( 2, 11, 2, 'regress_rls_bob', 'my second novel'),
-@@ -929,1067 +664,589 @@
+@@ -929,1067 +659,588 @@
      ( 8, 55, 2, 'regress_rls_carol', 'great satire'),
      ( 9, 11, 1, 'regress_rls_dave', 'awesome science fiction'),
      (10, 99, 2, 'regress_rls_dave', 'awesome technology book');
@@ -1523,7 +1511,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- database non-superuser with bypass privilege can bypass RLS policy when disabled
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
 +SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  SELECT * FROM part_document ORDER BY did;
 - did | cid | dlevel |      dauthor      |           dtitle            
@@ -2501,37 +2488,50 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Exists...
  SELECT * FROM document WHERE did = 2;
   did | cid | dlevel |     dauthor     |     dtitle      
-@@ -2010,7 +1267,6 @@
+@@ -2010,16 +1261,12 @@
  INSERT INTO document VALUES (33, 22, 1, 'regress_rls_bob', 'okay science fiction'); -- preparation for next statement
  INSERT INTO document VALUES (33, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'Some novel, replaces sci-fi') -- takes UPDATE path
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle;
 -ERROR:  new row violates row-level security policy (USING expression) for table "document"
++ERROR:  new row violates row-level security policy for table "document"
  -- Fine (we UPDATE, since INSERT WCOs and UPDATE security barrier quals + WCOs
  -- not violated):
  INSERT INTO document VALUES (2, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'my first novel')
-@@ -2041,7 +1297,11 @@
+     ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
+- did | cid | dlevel |     dauthor     |     dtitle     
+------+-----+--------+-----------------+----------------
+-   2 |  11 |      2 | regress_rls_bob | my first novel
+-(1 row)
+-
++ERROR:  new row violates row-level security policy for table "document"
+ -- Fine (we INSERT, so "cid = 33" ("technology") isn't evaluated):
+ INSERT INTO document VALUES (78, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'some technology novel')
+     ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33 RETURNING *;
+@@ -2032,16 +1279,12 @@
+ -- case in respect of *existing* tuple):
+ INSERT INTO document VALUES (78, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'some technology novel')
+     ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33 RETURNING *;
+- did | cid | dlevel |     dauthor     |        dtitle         
+------+-----+--------+-----------------+-----------------------
+-  78 |  33 |      1 | regress_rls_bob | some technology novel
+-(1 row)
+-
++ERROR:  new row violates row-level security policy for table "document"
+ -- Same query a third time, but now fails due to existing tuple finally not
  -- passing quals:
  INSERT INTO document VALUES (78, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'some technology novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33 RETURNING *;
 -ERROR:  new row violates row-level security policy (USING expression) for table "document"
-+ did | cid | dlevel |     dauthor     |        dtitle         
-+-----+-----+--------+-----------------+-----------------------
-+  78 |  33 |      1 | regress_rls_bob | some technology novel
-+(1 row)
-+
++ERROR:  new row violates row-level security policy for table "document"
  -- Don't fail just because INSERT doesn't satisfy WITH CHECK option that
  -- originated as a barrier/USING() qual from the UPDATE.  Note that the UPDATE
  -- path *isn't* taken, and so UPDATE-related policy does not apply:
-@@ -2058,15 +1318,21 @@
+@@ -2058,15 +1301,17 @@
  -- irrelevant, in fact.
  INSERT INTO document VALUES (79, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'technology book, can only insert')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle RETURNING *;
 -ERROR:  new row violates row-level security policy (USING expression) for table "document"
-+ did | cid | dlevel |     dauthor     |              dtitle              
-+-----+-----+--------+-----------------+----------------------------------
-+  79 |  33 |      1 | regress_rls_bob | technology book, can only insert
-+(1 row)
-+
++ERROR:  new row violates row-level security policy for table "document"
  -- Test default USING qual enforced as WCO
 -SET SESSION AUTHORIZATION regress_rls_alice;
 +SET ROLE regress_rls_alice;
@@ -2547,7 +2547,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Just because WCO-style enforcement of USING quals occurs with
  -- existing/target tuple does not mean that the implementation can be allowed
  -- to fail to also enforce this qual against the final tuple appended to
-@@ -2088,8 +1354,9 @@
+@@ -2088,8 +1333,9 @@
  INSERT INTO document VALUES (2, (SELECT cid from category WHERE cname = 'technology'), 1, 'regress_rls_bob', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET cid = EXCLUDED.cid, dtitle = EXCLUDED.dtitle RETURNING *;
  ERROR:  new row violates row-level security policy for table "document"
@@ -2558,7 +2558,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  --
  -- Test ALL policies with ON CONFLICT DO UPDATE (much the same as existing UPDATE
  -- tests)
-@@ -2097,7 +1364,8 @@
+@@ -2097,7 +1343,8 @@
  CREATE POLICY p3_with_all ON document FOR ALL
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dauthor = current_user);
@@ -2568,7 +2568,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Fails, since ALL WCO is enforced in insert path:
  INSERT INTO document VALUES (80, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_carol', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle, cid = 33;
-@@ -2106,7 +1374,7 @@
+@@ -2106,7 +1353,7 @@
  -- violation, since it has the "manga" cid):
  INSERT INTO document VALUES (4, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dtitle = EXCLUDED.dtitle;
@@ -2577,7 +2577,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Fails, since ALL WCO are enforced:
  INSERT INTO document VALUES (1, (SELECT cid from category WHERE cname = 'novel'), 1, 'regress_rls_bob', 'my first novel')
      ON CONFLICT (did) DO UPDATE SET dauthor = 'regress_rls_carol';
-@@ -2114,8 +1382,9 @@
+@@ -2114,8 +1361,9 @@
  --
  -- MERGE
  --
@@ -2588,7 +2588,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  ALTER TABLE document ADD COLUMN dnotes text DEFAULT '';
  -- all documents are readable
  CREATE POLICY p1 ON document FOR SELECT USING (true);
-@@ -2125,13 +1394,16 @@
+@@ -2125,13 +1373,16 @@
  CREATE POLICY p3 ON document FOR UPDATE
    USING (cid = (SELECT cid from category WHERE cname = 'novel'))
    WITH CHECK (dlevel > 0);
@@ -2601,19 +2601,19 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
   did | cid | dlevel |      dauthor      |              dtitle              | dnotes 
  -----+-----+--------+-------------------+----------------------------------+--------
     1 |  11 |      1 | regress_rls_bob   | my first novel                   | 
-+   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
++   2 |  11 |      2 | regress_rls_bob   | my second novel                  | 
     3 |  22 |      2 | regress_rls_bob   | my science fiction               | 
     4 |  44 |      1 | regress_rls_bob   | my first manga                   | 
     5 |  44 |      2 | regress_rls_bob   | my second manga                  | 
-@@ -2140,33 +1412,42 @@
+@@ -2140,33 +1391,42 @@
     8 |  44 |      1 | regress_rls_carol | great manga                      | 
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction          | 
    10 |  33 |      2 | regress_rls_dave  | awesome technology book          | 
 -  11 |  33 |      1 | regress_rls_carol | hoge                             | 
--  33 |  22 |      1 | regress_rls_bob   | okay science fiction             | 
+   33 |  22 |      1 | regress_rls_bob   | okay science fiction             | 
 -   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
-+  33 |  22 |      1 | regress_rls_bob   | Some novel, replaces sci-fi      | 
-   78 |  33 |      1 | regress_rls_bob   | some technology novel            | 
+-  78 |  33 |      1 | regress_rls_bob   | some technology novel            | 
++  78 |  11 |      1 | regress_rls_bob   | some technology novel            | 
    79 |  33 |      1 | regress_rls_bob   | technology book, can only insert | 
 -(14 rows)
 +(13 rows)
@@ -2654,7 +2654,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- There is a MATCH for did = 3, but UPDATE's USING qual does not allow
  -- updating an item in category 'science fiction'
  MERGE INTO document d
-@@ -2174,7 +1455,10 @@
+@@ -2174,7 +1434,10 @@
  ON did = s.sdid
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge ';
@@ -2666,7 +2666,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- The same thing with DELETE action, but fails again because no permissions
  -- to delete items in 'science fiction' category that did 3 belongs to.
  MERGE INTO document d
-@@ -2182,7 +1466,10 @@
+@@ -2182,7 +1445,10 @@
  ON did = s.sdid
  WHEN MATCHED THEN
  	DELETE;
@@ -2678,7 +2678,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Document with did 4 belongs to 'manga' category which is allowed for
  -- deletion. But this fails because the UPDATE action is matched first and
  -- UPDATE policy does not allow updation in the category.
-@@ -2193,7 +1480,10 @@
+@@ -2193,7 +1459,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -2690,7 +2690,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- UPDATE action is not matched this time because of the WHEN qual.
  -- DELETE still fails because role regress_rls_bob does not have SELECT
  -- privileges on 'manga' category row in the category table.
-@@ -2204,7 +1494,10 @@
+@@ -2204,7 +1473,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -2702,7 +2702,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- OK if DELETE is replaced with DO NOTHING
  MERGE INTO document d
  USING (SELECT 4 as sdid) s
-@@ -2213,6 +1506,10 @@
+@@ -2213,6 +1485,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DO NOTHING;
@@ -2713,7 +2713,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM document WHERE did = 4;
   did | cid | dlevel |     dauthor     |     dtitle     | dnotes 
  -----+-----+--------+-----------------+----------------+--------
-@@ -2221,8 +1518,8 @@
+@@ -2221,8 +1497,8 @@
  
  -- Switch to regress_rls_carol role and try the DELETE again. It should succeed
  -- this time
@@ -2724,7 +2724,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  MERGE INTO document d
  USING (SELECT 4 as sdid) s
  ON did = s.sdid
-@@ -2230,9 +1527,13 @@
+@@ -2230,9 +1506,13 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge '
  WHEN MATCHED THEN
  	DELETE;
@@ -2740,7 +2740,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Try INSERT action. This fails because we are trying to insert
  -- dauthor = regress_rls_dave and INSERT's WITH CHECK does not allow
  -- that
-@@ -2243,7 +1544,10 @@
+@@ -2243,7 +1523,10 @@
  	DELETE
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_dave', 'another novel');
@@ -2752,7 +2752,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- This should be fine
  MERGE INTO document d
  USING (SELECT 12 as sdid) s
-@@ -2252,6 +1556,10 @@
+@@ -2252,6 +1535,10 @@
  	DELETE
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -2763,7 +2763,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- ok
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2260,13 +1568,18 @@
+@@ -2260,13 +1547,18 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge4 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -2784,7 +2784,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- MERGE can no longer see the matching row and hence attempts the
  -- NOT MATCHED action, which results in unique key violation
  MERGE INTO document d
-@@ -2276,7 +1589,10 @@
+@@ -2276,7 +1568,10 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge5 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (12, 11, 1, 'regress_rls_bob', 'another novel');
@@ -2796,7 +2796,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- UPDATE action fails if new row is not visible
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2284,7 +1600,10 @@
+@@ -2284,7 +1579,10 @@
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge6 ',
  			   cid = (SELECT cid from category WHERE cname = 'technology');
@@ -2808,7 +2808,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- but OK if new row is visible
  MERGE INTO document d
  USING (SELECT 1 as sdid) s
-@@ -2292,6 +1611,10 @@
+@@ -2292,6 +1590,10 @@
  WHEN MATCHED THEN
  	UPDATE SET dnotes = dnotes || ' notes added by merge7 ',
  			   cid = (SELECT cid from category WHERE cname = 'novel');
@@ -2819,7 +2819,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- OK to insert a new row that is not visible
  MERGE INTO document d
  USING (SELECT 13 as sdid) s
-@@ -2300,35 +1623,38 @@
+@@ -2300,35 +1602,38 @@
  	UPDATE SET dnotes = dnotes || ' notes added by merge8 '
  WHEN NOT MATCHED THEN
  	INSERT VALUES (13, 44, 1, 'regress_rls_bob', 'new manga');
@@ -2840,7 +2840,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 + did | cid | dlevel |      dauthor      |              dtitle              | dnotes 
 +-----+-----+--------+-------------------+----------------------------------+--------
 +   1 |  11 |      1 | regress_rls_bob   | my first novel                   | 
-+   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
++   2 |  11 |      2 | regress_rls_bob   | my second novel                  | 
     3 |  22 |      2 | regress_rls_bob   | my science fiction               | 
 +   4 |  44 |      1 | regress_rls_bob   | my first manga                   | 
     5 |  44 |      2 | regress_rls_bob   | my second manga                  | 
@@ -2850,10 +2850,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
     9 |  22 |      1 | regress_rls_dave  | awesome science fiction          | 
    10 |  33 |      2 | regress_rls_dave  | awesome technology book          | 
 -  11 |  33 |      1 | regress_rls_carol | hoge                             | 
--  33 |  22 |      1 | regress_rls_bob   | okay science fiction             | 
+   33 |  22 |      1 | regress_rls_bob   | okay science fiction             | 
 -   2 |  11 |      2 | regress_rls_bob   | my first novel                   | 
-+  33 |  22 |      1 | regress_rls_bob   | Some novel, replaces sci-fi      | 
-   78 |  33 |      1 | regress_rls_bob   | some technology novel            | 
+-  78 |  33 |      1 | regress_rls_bob   | some technology novel            | 
++  78 |  11 |      1 | regress_rls_bob   | some technology novel            | 
    79 |  33 |      1 | regress_rls_bob   | technology book, can only insert | 
 -  12 |  11 |      1 | regress_rls_bob   | another novel                    | 
 -   1 |  11 |      1 | regress_rls_bob   | my first novel                   |  notes added by merge2  notes added by merge3  notes added by merge4  notes added by merge7 
@@ -2869,23 +2869,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE z1 (a int, b text);
  CREATE TABLE z2 (a int, b text);
  GRANT SELECT ON z1,z2 TO regress_rls_group1, regress_rls_group2,
-@@ -2341,57 +1667,39 @@
+@@ -2341,7 +1646,7 @@
  CREATE POLICY p1 ON z1 TO regress_rls_group1 USING (a % 2 = 0);
  CREATE POLICY p2 ON z1 TO regress_rls_group2 USING (a % 2 = 1);
  ALTER TABLE z1 ENABLE ROW LEVEL SECURITY;
 -SET SESSION AUTHORIZATION regress_rls_bob;
 +SET ROLE regress_rls_bob;
  SELECT * FROM z1 WHERE f_leak(b);
--NOTICE:  f_leak => bbb
--NOTICE:  f_leak => dad
-- a |  b  
-----+-----
-- 2 | bbb
-- 4 | dad
--(2 rows)
-+ a | b 
-+---+---
-+(0 rows)
+ NOTICE:  f_leak => bbb
+ NOTICE:  f_leak => dad
+@@ -2352,46 +1657,32 @@
+ (2 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
 -               QUERY PLAN                
@@ -2951,7 +2945,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET ROLE regress_rls_group1;
  SELECT * FROM z1 WHERE f_leak(b);
  NOTICE:  f_leak => bbb
-@@ -2403,91 +1711,59 @@
+@@ -2403,44 +1694,30 @@
  (2 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
@@ -3015,16 +3009,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +HINT:  try \h <SELECTCLAUSE>
 +SET ROLE regress_rls_carol;
  SELECT * FROM z1 WHERE f_leak(b);
--NOTICE:  f_leak => aba
--NOTICE:  f_leak => ccc
-- a |  b  
-----+-----
-- 1 | aba
-- 3 | ccc
--(2 rows)
-+ a | b 
-+---+---
-+(0 rows)
+ NOTICE:  f_leak => aba
+ NOTICE:  f_leak => ccc
+@@ -2451,43 +1728,29 @@
+ (2 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
 -               QUERY PLAN                
@@ -3087,7 +3075,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET ROLE regress_rls_group2;
  SELECT * FROM z1 WHERE f_leak(b);
  NOTICE:  f_leak => aba
-@@ -2499,422 +1775,324 @@
+@@ -2499,422 +1762,324 @@
  (2 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
@@ -3719,7 +3707,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE x1 (a int, b text, c text);
  GRANT ALL ON x1 TO PUBLIC;
  INSERT INTO x1 VALUES
-@@ -2932,7 +2110,7 @@
+@@ -2932,7 +2097,7 @@
  CREATE POLICY p3 ON x1 FOR UPDATE USING (a % 2 = 0);
  CREATE POLICY p4 ON x1 FOR DELETE USING (a < 8);
  ALTER TABLE x1 ENABLE ROW LEVEL SECURITY;
@@ -3728,7 +3716,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM x1 WHERE f_leak(b) ORDER BY a ASC;
  NOTICE:  f_leak => abc
  NOTICE:  f_leak => bcd
-@@ -2967,13 +2145,13 @@
+@@ -2967,13 +2132,13 @@
   8 | fgh_updt | regress_rls_carol
  (6 rows)
  
@@ -3745,7 +3733,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  NOTICE:  f_leak => fgh_updt
   a |    b     |         c         
  ---+----------+-------------------
-@@ -2986,50 +2164,50 @@
+@@ -2986,50 +2151,50 @@
  (6 rows)
  
  UPDATE x1 SET b = b || '_updt' WHERE f_leak(b) RETURNING *;
@@ -3806,7 +3794,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON y2 FOR ALL USING (a % 2 = 0);  --OK
  ALTER TABLE y1 ENABLE ROW LEVEL SECURITY;
  ALTER TABLE y2 ENABLE ROW LEVEL SECURITY;
-@@ -3037,189 +2215,105 @@
+@@ -3037,189 +2202,105 @@
  -- Expression structure with SBV
  --
  -- Create view as table owner.  RLS should NOT be applied.
@@ -4050,7 +4038,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE t1 (a integer);
  GRANT SELECT ON t1 TO regress_rls_bob, regress_rls_carol;
  CREATE POLICY p1 ON t1 TO regress_rls_bob USING ((a % 2) = 0);
-@@ -3230,97 +2324,62 @@
+@@ -3230,97 +2311,62 @@
  PREPARE role_inval AS SELECT * FROM t1;
  -- Check plan
  EXPLAIN (COSTS OFF) EXECUTE role_inval;
@@ -4181,7 +4169,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  WITH cte1 AS (INSERT INTO t1 VALUES (21, 'Fail') RETURNING *) SELECT * FROM cte1; --fail
  ERROR:  new row violates row-level security policy for table "t1"
-@@ -3333,9 +2392,8 @@
+@@ -3333,9 +2379,8 @@
  --
  -- Rename Policy
  --
@@ -4192,7 +4180,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT polname, relname
      FROM pg_policy pol
      JOIN pg_class pc ON (pc.oid = pol.polrelid)
-@@ -3358,80 +2416,46 @@
+@@ -3358,80 +2403,46 @@
  --
  -- Check INSERT SELECT
  --
@@ -4297,7 +4285,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE blog (id integer, author text, post text);
  CREATE TABLE comment (blog_id integer, message text);
  GRANT ALL ON blog, comment TO regress_rls_bob;
-@@ -3450,7 +2474,7 @@
+@@ -3450,7 +2461,7 @@
      (5, 'what?'),
      (4, 'insane!'),
      (2, 'who did it?');
@@ -4306,7 +4294,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Check RLS JOIN with Non-RLS.
  SELECT id, author, message FROM blog JOIN comment ON id = blog_id;
   id | author |   message   
-@@ -3467,10 +2491,10 @@
+@@ -3467,10 +2478,10 @@
    2 | bob    | who did it?
  (2 rows)
  
@@ -4319,7 +4307,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Check RLS JOIN RLS
  SELECT id, author, message FROM blog JOIN comment ON id = blog_id;
   id | author |   message   
-@@ -3484,86 +2508,44 @@
+@@ -3484,86 +2495,44 @@
    2 | bob    | who did it?
  (1 row)
  
@@ -4427,7 +4415,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO ON;
  SELECT * FROM t1;
   a | b 
-@@ -3571,221 +2553,194 @@
+@@ -3571,221 +2540,158 @@
  (0 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM t1;
@@ -4473,7 +4461,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON copy_t USING (a % 2 = 0);
  ALTER TABLE copy_t ENABLE ROW LEVEL SECURITY;
  GRANT ALL ON copy_t TO regress_rls_bob, regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  INSERT INTO copy_t (SELECT x, public.fipshash(x::text) FROM generate_series(0,10) x);
 +ERROR:  unknown function: public.fipshash()
  -- Check COPY TO as Superuser/owner.
@@ -4511,7 +4498,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO OFF;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_t"
-+ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  SET row_security TO ON;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --ok
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -4520,11 +4506,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -6,e7f6c011776e8db7cd330b54174fd76f
 -8,2c624232cdd221771294dfbb310aca00
 -10,4a44dc15364204a80fe80e9039455cc1
-+ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  -- Check COPY TO as user with permissions and BYPASSRLS
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
 +SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --ok
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -4538,7 +4522,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -8,2c624232cdd221771294dfbb310aca00
 -9,19581e27de7ced00ff1ce50b2047e7a5
 -10,4a44dc15364204a80fe80e9039455cc1
-+ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  SET row_security TO ON;
  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH DELIMITER ','; --ok
 -0,5feceb66ffc86f38d952786c6d696c79
@@ -4552,7 +4535,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -8,2c624232cdd221771294dfbb310aca00
 -9,19581e27de7ced00ff1ce50b2047e7a5
 -10,4a44dc15364204a80fe80e9039455cc1
-+ERROR:  COPY (SELECT * FROM copy_t ORDER BY a ASC) TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_t
  -- Check COPY TO as user without permissions. SET row_security TO OFF;
 -SET SESSION AUTHORIZATION regress_rls_carol;
 +SET ROLE regress_rls_carol;
@@ -4572,7 +4554,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON copy_rel_to USING (a % 2 = 0);
  ALTER TABLE copy_rel_to ENABLE ROW LEVEL SECURITY;
  GRANT ALL ON copy_rel_to TO regress_rls_bob, regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  INSERT INTO copy_rel_to VALUES (1, public.fipshash('1'));
 +ERROR:  unknown function: public.fipshash()
  -- Check COPY TO as Superuser/owner.
@@ -4590,22 +4571,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_rel_to"
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user with permissions and BYPASSRLS
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
 +SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user without permissions. SET row_security TO OFF;
 -SET SESSION AUTHORIZATION regress_rls_carol;
 +SET ROLE regress_rls_carol;
@@ -4645,22 +4621,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --fail - would be affected by RLS
 -ERROR:  query would be affected by row-level security policy for table "copy_rel_to"
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user with permissions and BYPASSRLS
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
 +SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
  SET row_security TO OFF;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  SET row_security TO ON;
  COPY copy_rel_to TO STDOUT WITH DELIMITER ','; --ok
 -1,6b86b273ff34fce19d6b804eff5a3f57
-+ERROR:  COPY copy_rel_to TO STDOUT WITH (DELIMITER ','): user regress_rls_bob does not have SELECT privilege on relation copy_rel_to
  -- Check COPY TO as user without permissions. SET row_security TO OFF;
 -SET SESSION AUTHORIZATION regress_rls_carol;
 +SET ROLE regress_rls_carol;
@@ -4685,41 +4656,27 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO OFF;
  COPY copy_t FROM STDIN; --fail - would be affected by RLS.
 -ERROR:  query would be affected by row-level security policy for table "copy_t"
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
- SET row_security TO ON;
- COPY copy_t FROM STDIN; --fail - COPY FROM not supported by RLS.
+-SET row_security TO ON;
+-COPY copy_t FROM STDIN; --fail - COPY FROM not supported by RLS.
 -ERROR:  COPY FROM not supported with row-level security
 -HINT:  Use INSERT statements instead.
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
- -- Check COPY FROM as user with permissions and BYPASSRLS
+--- Check COPY FROM as user with permissions and BYPASSRLS
 -SET SESSION AUTHORIZATION regress_rls_exempt_user;
-+SET ROLE regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
- SET row_security TO ON;
- COPY copy_t FROM STDIN; --ok
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
-+1	abc
-+2	bcd
-+3	cde
-+4	def
-+\.
-+invalid command \.
+-SET row_security TO ON;
+-COPY copy_t FROM STDIN; --ok
++ERROR:  expected 2 values, got 1
  -- Check COPY FROM as user without permissions.
 -SET SESSION AUTHORIZATION regress_rls_carol;
 +SET ROLE regress_rls_carol;
-+ERROR:  at or near "1": syntax error
-+DETAIL:  source SQL:
-+1	abc
-+^
  SET row_security TO OFF;
  COPY copy_t FROM STDIN; --fail - permission denied.
 -ERROR:  permission denied for table copy_t
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
++ERROR:  user regress_rls_carol does not have INSERT privilege on relation copy_t
  SET row_security TO ON;
  COPY copy_t FROM STDIN; --fail - permission denied.
 -ERROR:  permission denied for table copy_t
 -RESET SESSION AUTHORIZATION;
-+ERROR:  user regress_rls_bob does not have INSERT privilege on relation copy_t
++ERROR:  user regress_rls_carol does not have INSERT privilege on relation copy_t
 +RESET ROLE;
  DROP TABLE copy_t;
  DROP TABLE copy_rel_to CASCADE;
@@ -4730,7 +4687,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE current_check (currentid int, payload text, rlsuser text);
  GRANT ALL ON current_check TO PUBLIC;
  INSERT INTO current_check VALUES
-@@ -3797,7 +2752,7 @@
+@@ -3797,7 +2703,7 @@
  CREATE POLICY p2 ON current_check FOR DELETE USING (currentid = 4 AND rlsuser = current_user);
  CREATE POLICY p3 ON current_check FOR UPDATE USING (currentid = 4) WITH CHECK (rlsuser = current_user);
  ALTER TABLE current_check ENABLE ROW LEVEL SECURITY;
@@ -4739,7 +4696,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Can SELECT even rows
  SELECT * FROM current_check;
   currentid | payload |     rlsuser     
-@@ -3814,112 +2769,74 @@
+@@ -3814,112 +2720,74 @@
  
  BEGIN;
  DECLARE current_check_cursor SCROLL CURSOR FOR SELECT * FROM current_check;
@@ -4889,35 +4846,31 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT attname, most_common_vals FROM pg_stats
    WHERE tablename = 'current_check'
    ORDER BY 1;
-@@ -3932,31 +2849,35 @@
+@@ -3932,16 +2800,18 @@
  --
  BEGIN;
  CREATE TABLE coll_t (c) AS VALUES ('bar'::text);
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 +NOTICE:  CREATE TABLE ... AS does not copy over indexes, default expressions, or constraints; the new table has a hidden rowid primary key column
  CREATE POLICY coll_p ON coll_t USING (c < ('foo'::text COLLATE "C"));
-+ERROR:  invalid locale c: language: tag is not well-formed
  ALTER TABLE coll_t ENABLE ROW LEVEL SECURITY;
  GRANT SELECT ON coll_t TO regress_rls_alice;
  SELECT (string_to_array(polqual, ':'))[7] AS inputcollid FROM pg_policy WHERE polrelid = 'coll_t'::regclass;
 -   inputcollid    
 -------------------
 - inputcollid 950 
--(1 row)
 + inputcollid 
 +-------------
-+(0 rows)
++ 
+ (1 row)
  
 -SET SESSION AUTHORIZATION regress_rls_alice;
 +SET ROLE regress_rls_alice;
  SELECT * FROM coll_t;
--  c  
-------
-- bar
--(1 row)
-+ c 
-+---
-+(0 rows)
+   c  
+ -----
+@@ -3949,14 +2819,17 @@
+ (1 row)
  
  ROLLBACK;
 +WARNING:  there is no transaction in progress
@@ -4935,7 +4888,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  GRANT SELECT ON TABLE tbl1 TO regress_rls_eve;
  CREATE POLICY P ON tbl1 TO regress_rls_eve, regress_rls_frank USING (true);
  SELECT refclassid::regclass, deptype
-@@ -3965,8 +2886,7 @@
+@@ -3965,8 +2838,7 @@
    AND refobjid = 'tbl1'::regclass;
   refclassid | deptype 
  ------------+---------
@@ -4945,7 +4898,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT refclassid::regclass, deptype
    FROM pg_shdepend
-@@ -3974,48 +2894,58 @@
+@@ -3974,48 +2846,58 @@
    AND refobjid IN ('regress_rls_eve'::regrole, 'regress_rls_frank'::regrole);
   refclassid | deptype 
  ------------+---------
@@ -5014,7 +4967,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE r1 (a int);
  CREATE TABLE r2 (a int);
  INSERT INTO r1 VALUES (10), (20);
-@@ -4028,7 +2958,7 @@
+@@ -4028,7 +2910,7 @@
  CREATE POLICY p3 ON r2 FOR UPDATE USING (false);
  CREATE POLICY p4 ON r2 FOR DELETE USING (false);
  ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
@@ -5023,7 +4976,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM r1;
   a  
  ----
-@@ -4092,13 +3022,13 @@
+@@ -4092,13 +2974,13 @@
   20
  (2 rows)
  
@@ -5039,7 +4992,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int);
  INSERT INTO r1 VALUES (10), (20);
-@@ -4131,19 +3061,17 @@
+@@ -4131,19 +3013,17 @@
  SET row_security = off;
  -- these all fail, would be affected by RLS
  TABLE r1;
@@ -5064,7 +5017,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int PRIMARY KEY);
  CREATE TABLE r2 (a int REFERENCES r1);
-@@ -4157,7 +3085,7 @@
+@@ -4157,7 +3037,7 @@
  ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
  -- Errors due to rows in r2
  DELETE FROM r1;
@@ -5073,26 +5026,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DETAIL:  Key (a)=(10) is still referenced from table "r2".
  -- Reset r2 to no-RLS
  DROP POLICY p1 ON r2;
-@@ -4216,6 +3144,7 @@
- ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
- -- Updates records in both
- UPDATE r1 SET a = a+5;
-+ERROR:  new row violates row-level security policy for table "r2"
- -- Remove FORCE from r2
- ALTER TABLE r2 NO FORCE ROW LEVEL SECURITY;
- -- As owner, we now bypass RLS
-@@ -4223,8 +3152,8 @@
- TABLE r2;
-  a  
- ----
-- 15
-- 25
-+ 10
-+ 20
- (2 rows)
- 
- DROP TABLE r2;
-@@ -4233,7 +3162,7 @@
+@@ -4233,7 +3113,7 @@
  -- Test INSERT+RETURNING applies SELECT policies as
  -- WithCheckOptions (meaning an error is thrown)
  --
@@ -5101,7 +5035,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int);
  CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-@@ -4251,18 +3180,25 @@
+@@ -4251,8 +3131,10 @@
  SET row_security = off;
  -- fail, would be affected by RLS
  TABLE r1;
@@ -5114,15 +5048,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  -- Error
  INSERT INTO r1 VALUES (10), (20) RETURNING *;
--ERROR:  new row violates row-level security policy for table "r1"
-+ a  
-+----
-+ 10
-+ 20
-+(2 rows)
-+
- DROP TABLE r1;
- --
+@@ -4262,7 +3144,7 @@
  -- Test UPDATE+RETURNING applies SELECT policies as
  -- WithCheckOptions (meaning an error is thrown)
  --
@@ -5131,7 +5057,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int PRIMARY KEY);
  CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
-@@ -4273,12 +3209,13 @@
+@@ -4273,12 +3155,13 @@
  ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
  -- Works fine
  UPDATE r1 SET a = 30;
@@ -5146,26 +5072,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- reset value in r1 for test with RETURNING
-@@ -4297,39 +3234,46 @@
- -- UPDATE path of INSERT ... ON CONFLICT DO UPDATE should also error out
- INSERT INTO r1 VALUES (10)
-     ON CONFLICT (a) DO UPDATE SET a = 30 RETURNING *;
--ERROR:  new row violates row-level security policy for table "r1"
-+ a  
-+----
-+ 30
-+(1 row)
-+
- -- Should still error out without RETURNING (use of arbiter always requires
- -- SELECT permissions)
- INSERT INTO r1 VALUES (10)
-     ON CONFLICT (a) DO UPDATE SET a = 30;
--ERROR:  new row violates row-level security policy for table "r1"
- INSERT INTO r1 VALUES (10)
-     ON CONFLICT ON CONSTRAINT r1_pkey DO UPDATE SET a = 30;
--ERROR:  new row violates row-level security policy for table "r1"
-+ERROR:  duplicate key value violates unique constraint "r1_pkey"
-+DETAIL:  Key (a)=(30) already exists.
+@@ -4308,28 +3191,31 @@
+ ERROR:  new row violates row-level security policy for table "r1"
  DROP TABLE r1;
  -- Check dependency handling
 -RESET SESSION AUTHORIZATION;
@@ -5199,7 +5107,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Should return one
-@@ -4338,7 +3282,7 @@
+@@ -4338,7 +3224,7 @@
  					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_carol');
   ?column? 
  ----------
@@ -5208,7 +5116,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Should return zero
-@@ -4351,15 +3295,19 @@
+@@ -4351,15 +3237,19 @@
  (1 row)
  
  -- DROP OWNED BY testing
@@ -5230,7 +5138,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
  DROP OWNED BY regress_rls_dob_role1;
  DROP POLICY p1 ON dob_t1; -- should succeed
-@@ -4367,14 +3315,15 @@
+@@ -4367,14 +3257,15 @@
  CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1 USING (true);
  DROP OWNED BY regress_rls_dob_role1;
  DROP POLICY p1 ON dob_t1; -- should fail, already gone
@@ -5247,7 +5155,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DROP USER regress_rls_dob_role1;
  DROP USER regress_rls_dob_role2;
  -- Bug #15708: view + table with RLS should check policies as view owner
-@@ -4384,81 +3333,97 @@
+@@ -4384,81 +3275,97 @@
  INSERT INTO rls_tbl VALUES (10);
  ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
  CREATE POLICY p1 ON rls_tbl USING (EXISTS (SELECT 1 FROM ref_tbl));
@@ -5379,7 +5287,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- CVE-2023-2455: inlining an SRF may introduce an RLS dependency
  create table rls_t (c text);
  insert into rls_t values ('invisible to bob');
-@@ -4489,44 +3454,14 @@
+@@ -4489,39 +3396,8 @@
  --
  -- Clean up objects
  --
@@ -5420,9 +5328,3 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DROP USER regress_rls_alice;
  DROP USER regress_rls_bob;
  DROP USER regress_rls_carol;
- DROP USER regress_rls_dave;
- DROP USER regress_rls_exempt_user;
-+ERROR:  role/user "regress_rls_exempt_user" does not exist
- DROP ROLE regress_rls_group1;
- DROP ROLE regress_rls_group2;
- -- Arrange to have a few policies left over, for testing

--- a/pkg/cmd/roachtest/testdata/pg_regress/stats_ext.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/stats_ext.diffs
@@ -1,13 +1,30 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --label=/mnt/data1/postgres/src/test/regress/results/stats_ext.out /mnt/data1/postgres/src/test/regress/expected/stats_ext.out /mnt/data1/postgres/src/test/regress/results/stats_ext.out
 --- /mnt/data1/postgres/src/test/regress/expected/stats_ext.out
 +++ /mnt/data1/postgres/src/test/regress/results/stats_ext.out
-@@ -24,95 +24,171 @@
+@@ -24,95 +24,188 @@
      end loop;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare
++    ln text;
++    tmp text[];
++    first_row bool := true;
++begin
++    for ln in
++           ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  -- Verify failures
  CREATE TABLE ext_stats_test (x text, y int, z int);
  CREATE STATISTICS tst;
@@ -215,7 +232,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  
  DROP TABLE ab1;
  SELECT stxname FROM pg_statistic_ext WHERE stxname LIKE 'ab1%';
-@@ -123,177 +199,244 @@
+@@ -123,177 +216,244 @@
  -- Ensure things work sanely with SET STATISTICS 0
  CREATE TABLE ab1 (a INTEGER, b INTEGER);
  ALTER TABLE ab1 ALTER a SET STATISTICS 0;
@@ -542,7 +559,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE ab1;
  -- Verify supported object types for extended statistics
  CREATE schema tststats;
-@@ -304,27 +447,119 @@
+@@ -304,27 +464,119 @@
  CREATE MATERIALIZED VIEW tststats.mv AS SELECT * FROM tststats.t;
  CREATE TYPE tststats.ty AS (a int, b int, c text);
  CREATE FOREIGN DATA WRAPPER extstats_dummy_fdw;
@@ -670,7 +687,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DO $$
  DECLARE
  	relname text := reltoastrelid::regclass FROM pg_class WHERE oid = 'tststats.t'::regclass;
-@@ -334,18 +569,33 @@
+@@ -334,18 +586,33 @@
  	RAISE NOTICE 'stats on toast table not created';
  END;
  $$;
@@ -714,7 +731,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- n-distinct tests
  CREATE TABLE ndistinct (
      filler1 TEXT,
-@@ -357,66 +607,38 @@
+@@ -357,66 +624,38 @@
      d INT
  )
  WITH (autovacuum_enabled = off);
@@ -798,7 +815,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- correct command
  CREATE STATISTICS s10 ON a, b, c FROM ndistinct;
  ANALYZE ndistinct;
-@@ -424,149 +646,84 @@
+@@ -424,149 +663,84 @@
    FROM pg_statistic_ext s, pg_statistic_ext_data d
   WHERE s.stxrelid = 'ndistinct'::regclass
     AND d.stxoid = s.oid;
@@ -986,7 +1003,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  SELECT s.stxkind, d.stxdndistinct
    FROM pg_statistic_ext s, pg_statistic_ext_data d
   WHERE s.stxrelid = 'ndistinct'::regclass
-@@ -577,157 +734,91 @@
+@@ -577,157 +751,91 @@
  
  -- dropping the statistics results in under-estimates
  SELECT * FROM check_estimated_rows('SELECT COUNT(*) FROM ndistinct GROUP BY a, b');
@@ -1191,7 +1208,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- combination of multiple ndistinct statistics, with/without expressions
  TRUNCATE ndistinct;
  -- two mostly independent groups of columns
-@@ -736,283 +827,185 @@
+@@ -736,283 +844,185 @@
         FROM generate_series(1,1000) s(i);
  ANALYZE ndistinct;
  SELECT * FROM check_estimated_rows('SELECT COUNT(*) FROM ndistinct GROUP BY a, b');
@@ -1587,7 +1604,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- functional dependencies tests
  CREATE TABLE functional_dependencies (
      filler1 TEXT,
-@@ -1024,6 +1017,7 @@
+@@ -1024,6 +1034,7 @@
      d TEXT
  )
  WITH (autovacuum_enabled = off);
@@ -1595,7 +1612,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  CREATE INDEX fdeps_ab_idx ON functional_dependencies (a, b);
  CREATE INDEX fdeps_abc_idx ON functional_dependencies (a, b, c);
  -- random data (no functional dependencies)
-@@ -1031,737 +1025,335 @@
+@@ -1031,737 +1042,335 @@
       SELECT mod(i, 5), mod(i, 7), mod(i, 11), i FROM generate_series(1,1000) s(i);
  ANALYZE functional_dependencies;
  SELECT * FROM check_estimated_rows('SELECT * FROM functional_dependencies WHERE a = 1 AND b = ''1''');
@@ -2489,7 +2506,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- check the ability to use multiple functional dependencies
  CREATE TABLE functional_dependencies_multi (
  	a INTEGER,
-@@ -1770,6 +1362,7 @@
+@@ -1770,6 +1379,7 @@
  	d INTEGER
  )
  WITH (autovacuum_enabled = off);
@@ -2497,7 +2514,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  INSERT INTO functional_dependencies_multi (a, b, c, d)
      SELECT
           mod(i,7),
-@@ -1780,69 +1373,39 @@
+@@ -1780,69 +1390,39 @@
  ANALYZE functional_dependencies_multi;
  -- estimates without any functional dependencies
  SELECT * FROM check_estimated_rows('SELECT * FROM functional_dependencies_multi WHERE a = 0 AND b = 0');
@@ -2587,7 +2604,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE functional_dependencies_multi;
  -- MCV lists
  CREATE TABLE mcv_lists (
-@@ -1856,374 +1419,172 @@
+@@ -1856,374 +1436,172 @@
      ia INT[]
  )
  WITH (autovacuum_enabled = off);
@@ -3045,7 +3062,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- check change of unrelated column type does not reset the MCV statistics
  ALTER TABLE mcv_lists ALTER COLUMN d TYPE VARCHAR(64);
  SELECT d.stxdmcv IS NOT NULL
-@@ -2232,233 +1593,145 @@
+@@ -2232,233 +1610,145 @@
     AND d.stxoid = s.oid;
   ?column? 
  ----------
@@ -3358,7 +3375,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  INSERT INTO mcv_lists (a, b, c, filler1)
       SELECT
           (CASE WHEN mod(i,100) = 1 THEN NULL ELSE mod(i,100) END),
-@@ -2468,68 +1741,33 @@
+@@ -2468,68 +1758,33 @@
       FROM generate_series(1,5000) s(i);
  ANALYZE mcv_lists;
  SELECT * FROM check_estimated_rows('SELECT * FROM mcv_lists WHERE a IS NULL AND b IS NULL');
@@ -3442,7 +3459,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- test pg_mcv_list_items with a very simple (single item) MCV list
  TRUNCATE mcv_lists;
  INSERT INTO mcv_lists (a, b, c) SELECT 1, 2, 3 FROM generate_series(1,1000) s(i);
-@@ -2539,14 +1777,15 @@
+@@ -2539,14 +1794,15 @@
         pg_mcv_list_items(d.stxdmcv) m
   WHERE s.stxname = 'mcv_lists_stats'
     AND d.stxoid = s.oid;
@@ -3463,7 +3480,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  INSERT INTO mcv_lists (a, b, c, d)
       SELECT
           NULL, -- always NULL
-@@ -2556,25 +1795,18 @@
+@@ -2556,25 +1812,18 @@
       FROM generate_series(1,5000) s(i);
  ANALYZE mcv_lists;
  SELECT * FROM check_estimated_rows('SELECT * FROM mcv_lists WHERE b = ''x'' OR d = ''x''');
@@ -3497,7 +3514,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  ANALYZE mcv_lists;
  -- test pg_mcv_list_items with MCV list containing variable-length data and NULLs
  SELECT m.*
-@@ -2582,30 +1814,13 @@
+@@ -2582,30 +1831,13 @@
         pg_mcv_list_items(d.stxdmcv) m
   WHERE s.stxname = 'mcv_lists_stats'
     AND d.stxoid = s.oid;
@@ -3532,7 +3549,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- mcv with pass-by-ref fixlen types, e.g. uuid
  CREATE TABLE mcv_lists_uuid (
      a UUID,
-@@ -2613,40 +1828,31 @@
+@@ -2613,40 +1845,31 @@
      c UUID
  )
  WITH (autovacuum_enabled = off);
@@ -3584,7 +3601,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE mcv_lists_uuid;
  -- mcv with arrays
  CREATE TABLE mcv_lists_arrays (
-@@ -2655,14 +1861,21 @@
+@@ -2655,14 +1878,21 @@
      c INT[]
  )
  WITH (autovacuum_enabled = off);
@@ -3606,7 +3623,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  ANALYZE mcv_lists_arrays;
  -- mcv with bool
  CREATE TABLE mcv_lists_bool (
-@@ -2671,62 +1884,36 @@
+@@ -2671,62 +1901,36 @@
      c BOOL
  )
  WITH (autovacuum_enabled = off);
@@ -3683,7 +3700,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  -- mcv covering just a small fraction of data
  CREATE TABLE mcv_lists_partial (
      a INT,
-@@ -2756,104 +1943,45 @@
+@@ -2756,104 +1960,45 @@
       FROM generate_series(0,3999) s(i);
  ANALYZE mcv_lists_partial;
  SELECT * FROM check_estimated_rows('SELECT * FROM mcv_lists_partial WHERE a = 0 AND b = 0 AND c = 0');
@@ -3809,7 +3826,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE mcv_lists_partial;
  -- check the ability to use multiple MCV lists
  CREATE TABLE mcv_lists_multi (
-@@ -2863,6 +1991,7 @@
+@@ -2863,6 +2008,7 @@
  	d INTEGER
  )
  WITH (autovacuum_enabled = off);
@@ -3817,7 +3834,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  INSERT INTO mcv_lists_multi (a, b, c, d)
      SELECT
           mod(i,5),
-@@ -2873,187 +2002,114 @@
+@@ -2873,187 +2019,114 @@
  ANALYZE mcv_lists_multi;
  -- estimates without any mcv statistics
  SELECT * FROM check_estimated_rows('SELECT * FROM mcv_lists_multi WHERE a = 0 AND b = 0');
@@ -4062,7 +4079,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE expr_stats;
  -- test handling of a mix of compatible and incompatible expressions
  CREATE TABLE expr_stats_incompatible_test (
-@@ -3069,10 +2125,7 @@
+@@ -3069,10 +2142,7 @@
    AND
    (c0 IN (0, 1) OR c1)
  );
@@ -4074,7 +4091,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
  DROP TABLE expr_stats_incompatible_test;
  -- Permission tests. Users should not be able to see specific data values in
  -- the extended statistics, if they lack permission to see those values in
-@@ -3088,205 +2141,508 @@
+@@ -3088,205 +2158,508 @@
       SELECT mod(i,5), mod(i,10) FROM generate_series(1,100) s(i);
  CREATE STATISTICS tststats.priv_test_stats (mcv) ON a, b
    FROM tststats.priv_test_tbl;

--- a/pkg/cmd/roachtest/testdata/pg_regress/subselect.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/subselect.diffs
@@ -1039,14 +1039,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
  select * from
    (select 9 as x, unnest(array[1,2,3,11,12,13]) as u) ss
    where tattle(x, u);
-@@ -1632,26 +1404,21 @@
+@@ -1632,26 +1404,35 @@
      end loop;
  end;
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
- select * from explain_sq_limit();
+-select * from explain_sq_limit();
 -                        explain_sq_limit                        
 -----------------------------------------------------------------
 - Limit (actual rows=3 loops=1)
@@ -1056,7 +1053,24 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
 -               Sort Method: top-N heapsort  Memory: xxx
 -               ->  Seq Scan on sq_limit (actual rows=8 loops=1)
 -(6 rows)
--
++ERROR:  at or near "in": syntax error: unimplemented: this syntax
++DETAIL:  source SQL:
++declare ln text;
++begin
++    for ln in
++           ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
+ 
++We appreciate your feedback.
++
++select * from explain_sq_limit();
 +ERROR:  unknown function: explain_sq_limit()
  select * from (select pk,c2 from sq_limit order by c1,pk) as x limit 3;
   pk | c2 
@@ -1072,7 +1086,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
  drop table sq_limit;
  --
  -- Ensure that backward scan direction isn't propagated into
-@@ -1661,14 +1428,13 @@
+@@ -1661,14 +1442,13 @@
  declare c1 scroll cursor for
   select * from generate_series(1,4) i
    where i <> all (values (2),(3));
@@ -1092,7 +1106,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
  commit;
  --
  -- Tests for CTE inlining behavior
-@@ -1677,112 +1443,64 @@
+@@ -1677,112 +1457,64 @@
  explain (verbose, costs off)
  with x as (select * from (select f1 from subselect_tbl) ss)
  select * from x where f1 = 1;
@@ -1240,7 +1254,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
  -- Multiply-referenced CTEs can't be inlined if they contain outer self-refs
  explain (verbose, costs off)
  with recursive x(a) as
-@@ -1792,26 +1510,11 @@
+@@ -1792,26 +1524,11 @@
      select z.a || z1.a as a from z cross join z as z1
      where length(z.a || z1.a) < 5))
  select * from x;
@@ -1272,7 +1286,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
  with recursive x(a) as
    ((values ('a'), ('b'))
     union all
-@@ -1824,24 +1527,24 @@
+@@ -1824,24 +1541,24 @@
   a
   b
   aa
@@ -1313,7 +1327,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
   bbbb
  (22 rows)
  
-@@ -1853,19 +1556,11 @@
+@@ -1853,19 +1570,11 @@
      select z.a || z.a as a from z
      where length(z.a || z.a) < 5))
  select * from x;
@@ -1338,7 +1352,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/subselect.out --l
  with recursive x(a) as
    ((values ('a'), ('b'))
     union all
-@@ -1887,42 +1582,35 @@
+@@ -1887,42 +1596,35 @@
  explain (verbose, costs off)
  with x as (select * from int4_tbl)
  select * from (with y as (select * from x) select * from y) ss;

--- a/pkg/cmd/roachtest/testdata/pg_regress/temp.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/temp.diffs
@@ -422,7 +422,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  -- Tests with two-phase commit
  -- Transactions creating objects in a temporary namespace cannot be used
  -- with two-phase commit.
-@@ -327,33 +422,144 @@
+@@ -327,33 +422,99 @@
  begin;
  create function pg_temp.twophase_func() returns void as
    $$ select '2pc_func'::text $$ language sql;
@@ -461,52 +461,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  begin;
  create type pg_temp.twophase_type as (a int);
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-+ERROR:  internal error: invalid schema kind for getNonTemporarySchemaForCreate: 2
-+DETAIL:  stack trace:
-+pkg/sql/create_table.go:108: getNonTemporarySchemaForCreate()
-+pkg/sql/create_type.go:145: getCreateTypeParams()
-+pkg/sql/create_type.go:493: createCompositeWithID()
-+pkg/sql/create_type.go:314: createUserDefinedType()
-+pkg/sql/create_type.go:104: startExec()
-+pkg/sql/plan.go:578: startExec()
-+pkg/sql/plan_node_to_row_source.go:181: Start()
-+pkg/sql/colexec/columnarizer.go:178: Init()
-+pkg/sql/colflow/stats.go:96: init()
-+pkg/sql/colexecerror/error.go:162: CatchVectorizedRuntimeError()
-+pkg/sql/colflow/stats.go:105: Init()
-+pkg/sql/colflow/flow_coordinator.go:236: func2()
-+pkg/sql/colexecerror/error.go:162: CatchVectorizedRuntimeError()
-+pkg/sql/colflow/flow_coordinator.go:235: init()
-+pkg/sql/colflow/flow_coordinator.go:269: Run()
-+pkg/sql/colflow/vectorized_flow.go:316: Run()
-+pkg/sql/distsql_running.go:985: Run()
-+pkg/sql/distsql_running.go:2088: PlanAndRun()
-+pkg/sql/distsql_running.go:1792: func3()
-+pkg/sql/distsql_running.go:1795: PlanAndRunAll()
-+pkg/sql/conn_executor_exec.go:3449: execWithDistSQLEngine()
-+pkg/sql/conn_executor_exec.go:2980: dispatchToExecutionEngine()
-+pkg/sql/conn_executor_exec.go:1077: execStmtInOpenState()
-+pkg/sql/conn_executor_exec.go:170: func2()
-+pkg/sql/conn_executor_exec.go:4457: execWithProfiling()
-+pkg/sql/conn_executor_exec.go:169: execStmt()
-+pkg/sql/conn_executor.go:2438: func1()
-+pkg/sql/conn_executor.go:2443: execCmd()
-+pkg/sql/conn_executor.go:2360: run()
-+pkg/sql/conn_executor.go:1026: ServeConn()
-+pkg/sql/pgwire/conn.go:252: processCommands()
-+pkg/sql/pgwire/server.go:1197: func4()
-+
-+HINT:  You have encountered an unexpected error.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
-+
++ERROR:  cannot create type "twophase_type" in temporary schema
  prepare transaction 'twophase_type';
 -ERROR:  cannot PREPARE a transaction that has operated on temporary objects
 +WARNING:  there is no transaction in progress
@@ -515,10 +470,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
 +ERROR:  internal error: invalid schema kind for getNonTemporarySchemaForCreate: 2
 +DETAIL:  stack trace:
-+pkg/sql/create_table.go:108: getNonTemporarySchemaForCreate()
-+pkg/sql/create_table.go:159: getSchemaForCreateTable()
++pkg/sql/create_table.go:109: getNonTemporarySchemaForCreate()
++pkg/sql/create_table.go:160: getSchemaForCreateTable()
 +pkg/sql/create_view.go:135: startExec()
-+pkg/sql/plan.go:578: startExec()
++pkg/sql/plan.go:580: startExec()
 +pkg/sql/plan_node_to_row_source.go:181: Start()
 +pkg/sql/colexec/columnarizer.go:178: Init()
 +pkg/sql/colflow/stats.go:96: init()
@@ -529,20 +484,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
 +pkg/sql/colflow/flow_coordinator.go:235: init()
 +pkg/sql/colflow/flow_coordinator.go:269: Run()
 +pkg/sql/colflow/vectorized_flow.go:316: Run()
-+pkg/sql/distsql_running.go:985: Run()
-+pkg/sql/distsql_running.go:2088: PlanAndRun()
-+pkg/sql/distsql_running.go:1792: func3()
-+pkg/sql/distsql_running.go:1795: PlanAndRunAll()
-+pkg/sql/conn_executor_exec.go:3449: execWithDistSQLEngine()
-+pkg/sql/conn_executor_exec.go:2980: dispatchToExecutionEngine()
-+pkg/sql/conn_executor_exec.go:1077: execStmtInOpenState()
-+pkg/sql/conn_executor_exec.go:170: func2()
-+pkg/sql/conn_executor_exec.go:4457: execWithProfiling()
-+pkg/sql/conn_executor_exec.go:169: execStmt()
-+pkg/sql/conn_executor.go:2438: func1()
-+pkg/sql/conn_executor.go:2443: execCmd()
-+pkg/sql/conn_executor.go:2360: run()
-+pkg/sql/conn_executor.go:1026: ServeConn()
++pkg/sql/distsql_running.go:990: Run()
++pkg/sql/distsql_running.go:2093: PlanAndRun()
++pkg/sql/distsql_running.go:1797: func3()
++pkg/sql/distsql_running.go:1800: PlanAndRunAll()
++pkg/sql/conn_executor_exec.go:3452: execWithDistSQLEngine()
++pkg/sql/conn_executor_exec.go:2983: dispatchToExecutionEngine()
++pkg/sql/conn_executor_exec.go:1079: execStmtInOpenState()
++pkg/sql/conn_executor_exec.go:171: func2()
++pkg/sql/conn_executor_exec.go:4460: execWithProfiling()
++pkg/sql/conn_executor_exec.go:170: execStmt()
++pkg/sql/conn_executor.go:2342: func1()
++pkg/sql/conn_executor.go:2347: execCmd()
++pkg/sql/conn_executor.go:2264: run()
++pkg/sql/conn_executor.go:1048: ServeConn()
 +pkg/sql/pgwire/conn.go:252: processCommands()
 +pkg/sql/pgwire/server.go:1197: func4()
 +src/runtime/asm_amd64.s:1700: goexit()
@@ -573,7 +528,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  -- Temporary tables cannot be used with two-phase commit.
  create temp table twophase_tab (a int);
  begin;
-@@ -363,19 +569,22 @@
+@@ -363,19 +524,22 @@
  (0 rows)
  
  prepare transaction 'twophase_tab';
@@ -600,7 +555,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  -- Corner case: current_schema may create a temporary schema if namespace
  -- creation is pending, so check after that.  First reset the connection
  -- to remove the temporary namespace.
-@@ -385,8 +594,7 @@
+@@ -385,8 +549,7 @@
  SELECT current_schema() ~ 'pg_temp' AS is_temp_schema;
   is_temp_schema 
  ----------------

--- a/pkg/cmd/roachtest/testdata/pg_regress/truncate.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/truncate.diffs
@@ -501,13 +501,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/truncate.out --la
  CREATE FUNCTION tp_chk_data(OUT pktb regclass, OUT pkval int, OUT fktb regclass, OUT fkval int)
    RETURNS SETOF record LANGUAGE plpgsql AS $$
    BEGIN
-@@ -481,114 +456,160 @@
+@@ -481,114 +456,158 @@
      ORDER BY 2, 4;
    END
  $$;
-+ERROR:  unimplemented: set-returning PL/pgSQL functions are not yet supported
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/105240/_version_
++ERROR:  relation "NULL" does not exist
  CREATE TABLE truncprim (a int PRIMARY KEY);
  CREATE TABLE truncpart (a int REFERENCES truncprim)
    PARTITION BY RANGE (a);

--- a/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
@@ -40,7 +40,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 +   2278 | void
 +   2950 | uuid
 +  90004 | box2d
-+ 100185 | two_ints
++ 100184 | two_ints
 +(9 rows)
  
  -- Look for "toastable" types that aren't varlena.
@@ -74,23 +74,23 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 +     100116 | tenk2
 +     100137 | bit_defaults
 +     100140 | float4_tbl
-+     100162 | num_data
-+     100163 | num_exp_add
-+     100164 | num_exp_sub
-+     100165 | num_exp_div
-+     100166 | num_exp_mul
-+     100167 | num_exp_sqrt
-+     100168 | num_exp_ln
-+     100169 | num_exp_log10
-+     100170 | num_exp_power_10_ln
-+     100171 | num_result
-+     100175 | num_input_test
-+     100191 | timetz_tbl
-+     100197 | time_tbl
-+     100198 | date_tbl
-+     100199 | interval_tbl
-+     100214 | timestamp_tbl
-+     100215 | timestamptz_tbl
++     100161 | num_data
++     100162 | num_exp_add
++     100163 | num_exp_sub
++     100164 | num_exp_div
++     100165 | num_exp_mul
++     100166 | num_exp_sqrt
++     100167 | num_exp_ln
++     100168 | num_exp_log10
++     100169 | num_exp_power_10_ln
++     100170 | num_result
++     100174 | num_input_test
++     100190 | timetz_tbl
++     100196 | time_tbl
++     100197 | date_tbl
++     100198 | interval_tbl
++     100213 | timestamp_tbl
++     100214 | timestamptz_tbl
 + 4294966962 | spatial_ref_sys
 + 4294966963 | geometry_columns
 + 4294966964 | geography_columns
@@ -445,8 +445,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 -(0 rows)
 + oid  | typname 
 +------+---------
-+ 2279 | trigger
 + 2276 | any
++ 2279 | trigger
 +(2 rows)
  
  -- Check for bogus typinput routines


### PR DESCRIPTION
This commit accepts the recent diffs. Several issues have been filed for the differences observed (some are actually already fixed, plus this commit assumes that #145246 is fixed too - it currently has a fix in review).

Most notable changes in the diff:
- jsonpath improvements,
- RLS changes,
- fix to $1 notation of PLpgSQL as well as support of set-returning PLpgSQL functions.

Additionally, this commit improves the runner a bit to remove table IDs from error messages to reduce diff churn.

Fixes: #144338
Release note: None