### PR TITLE
importer: disable import into tables with vector indexes

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -88,6 +88,7 @@ go_library(
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
         "//pkg/sql/sem/eval",
+        "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sqlclustersettings",

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -623,3 +623,28 @@ SELECT a FROM test_144621@vec_idx ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 
 subtest end
+
+subtest import_into
+
+statement ok
+CREATE TABLE import_test (a INT PRIMARY KEY, v VECTOR(3))
+
+statement ok
+INSERT INTO import_test VALUES (1, '[1, 2, 3]')
+
+let $exp_file
+WITH cte AS (EXPORT INTO CSV 'nodelocal://1/vector_import_test' FROM SELECT * FROM import_test) SELECT filename FROM cte;
+
+statement ok
+TRUNCATE TABLE import_test
+
+statement ok
+CREATE VECTOR INDEX vec_idx ON import_test (v)
+
+statement error IMPORT INTO is not supported for tables with vector indexes
+IMPORT INTO import_test (a, v) CSV DATA ('nodelocal://1/vector_import_test/$exp_file')
+
+statement ok
+DROP TABLE import_test
+
+subtest end


### PR DESCRIPTION
Import into vector indexes is not yet implemented. Disable it for this release to prevent wildly unexpected behaviors.

Fixes: #145105
Informs: #145227
Release note (sql change): IMPORT into tables with vector indexes is not supported in 25.2.