### PR TITLE
logictest: reduce flakiness in computed column tests in row_level_security

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -2236,7 +2236,8 @@ CREATE TABLE t (
       a INT,
       b INT,
       c INT,
-      v INT AS (c + 1) VIRTUAL
+      v INT AS (c + 1) VIRTUAL,
+      FAMILY (k, a, b, c)
 );
 
 statement ok
@@ -2334,7 +2335,8 @@ CREATE TABLE t (
       a INT,
       b INT,
       c INT,
-      v INT AS (c + 1) STORED
+      v INT AS (c + 1) STORED,
+      FAMILY (k, a, b, c, v)
 );
 
 statement ok


### PR DESCRIPTION
New computed column tests in the row_level_security logic test have been flaky, particularly when an `UPDATE ... RETURNING` statement follows an `INSERT`. In these cases, returned computed column values are occasionally NULL.

This behaviour seems mitigated when all columns are part of the same column group. While this is not the root cause, it appears to alleviate the issue and reduce test flakes. This change applies that workaround to stabilize test behaviour.

Issue #145232 is opened for the root cause, which isn't related to RLS at all.

Closes #145031
Closes #145160

Epic: none
Release note: none