### PR TITLE
changefeedccl: fix decimal writes into parquet

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -189,6 +189,7 @@ func RandDatumWithNullChance(
 		d := &tree.DDecimal{}
 		// int64(rng.Uint64()) to get negative numbers, too
 		d.Decimal.SetFinite(int64(rng.Uint64()), int32(rng.Intn(40)-20))
+		d.Exponent = typ.Scale()
 		return d
 	case types.DateFamily:
 		d, err := pgdate.MakeDateFromUnixEpoch(int64(rng.Intn(10000)))
@@ -385,7 +386,7 @@ func RandArrayWithCommonDataChance(
 // it returns nil if there are no such Datums. Note that it pays attention
 // to the width of the requested type for Int and Float type families.
 func randInterestingDatum(rng *rand.Rand, typ *types.T) tree.Datum {
-	specials, ok := getRandInterestingDatums(typ.Family())
+	specials, ok := getRandInterestingDatums(typ)
 	if !ok || len(specials) == 0 {
 		for _, sc := range types.Scalar {
 			// Panic if a scalar type doesn't have an interesting datum.
@@ -456,7 +457,7 @@ func randCommonDatum(rng *rand.Rand, typ *types.T) tree.Datum {
 	typeFamily := typ.Family()
 	switch typeFamily {
 	case types.GeographyFamily, types.GeometryFamily:
-		dataSet, ok = getRandInterestingDatums(typeFamily)
+		dataSet, ok = getRandInterestingDatums(typ)
 	default:
 		dataSet, ok = randCommonDatums[typeFamily]
 	}
@@ -472,6 +473,9 @@ func randCommonDatum(rng *rand.Rand, typ *types.T) tree.Datum {
 	}
 
 	datum := dataSet[rng.Intn(len(dataSet))]
+	if typ.Family() == types.DecimalFamily {
+		datum.(*tree.DDecimal).Exponent = typ.Scale()
+	}
 	return adjustDatum(datum, typ)
 }
 
@@ -500,6 +504,7 @@ func RandDatumSimple(rng *rand.Rand, typ *types.T) tree.Datum {
 	case types.DecimalFamily:
 		dd := &tree.DDecimal{}
 		dd.SetInt64(rng.Int63n(simpleRange))
+		dd.Exponent = typ.Scale()
 		datum = dd
 	case types.IntFamily:
 		datum = tree.NewDInt(tree.DInt(rng.Intn(simpleRange)))
@@ -613,7 +618,7 @@ var randInterestingDatums map[types.Family][]tree.Datum
 // randInterestingDatums from getting initialized unless it is needed.
 // Preventing it's initialization significantly speeds up the tests by reducing
 // heap allocation.
-func getRandInterestingDatums(typ types.Family) ([]tree.Datum, bool) {
+func getRandInterestingDatums(typ *types.T) ([]tree.Datum, bool) {
 	once.Do(func() {
 
 		randTimestampSpecials := []time.Time{
@@ -657,28 +662,6 @@ func getRandInterestingDatums(typ types.Family) ([]tree.Datum, bool) {
 				tree.NewDFloat(tree.DFloat(math.Inf(-1))),
 				tree.NewDFloat(tree.DFloat(math.NaN())),
 			},
-			types.DecimalFamily: func() []tree.Datum {
-				var res []tree.Datum
-				for _, s := range []string{
-					"-0",
-					"0",
-					"1",
-					"1.0",
-					"-1",
-					"-1.0",
-					"Inf",
-					"-Inf",
-					"NaN",
-					"-12.34e400",
-				} {
-					d, err := tree.ParseDDecimal(s)
-					if err != nil {
-						panic(err)
-					}
-					res = append(res, d)
-				}
-				return res
-			}(),
 			types.DateFamily: {
 				tree.NewDDate(pgdate.MakeCompatibleDateFromDisk(0)),
 				tree.NewDDate(pgdate.LowDate),
@@ -887,7 +870,33 @@ func getRandInterestingDatums(typ types.Family) ([]tree.Datum, bool) {
 		}
 
 	})
-	datums, ok := randInterestingDatums[typ]
+	if typ.Family() == types.DecimalFamily {
+		randInterestingDatums[typ.Family()] = func() []tree.Datum {
+			var res []tree.Datum
+			for _, s := range []string{
+				"-0",
+				"0",
+				"1",
+				"1.0",
+				"-1",
+				"-1.0",
+				"Inf",
+				"-Inf",
+				"nan",
+				"-12.34e400",
+				"12.34e400",
+			} {
+				d, err := tree.ParseDDecimalWithPrecisionAndScale(s, typ.Precision(), typ.Scale())
+				if err != nil {
+					panic(err)
+				}
+				d.Exponent = typ.Scale()
+				res = append(res, d)
+			}
+			return res
+		}()
+	}
+	datums, ok := randInterestingDatums[typ.Family()]
 	return datums, ok
 }
 

--- a/pkg/sql/randgen/type.go
+++ b/pkg/sql/randgen/type.go
@@ -7,6 +7,7 @@ package randgen
 
 import (
 	"context"
+	"fmt"
 	"math/rand"
 	"sort"
 
@@ -14,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc/valueside"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/lib/pq/oid"
 )
@@ -138,6 +140,11 @@ func RandTypeFromSlice(rng *rand.Rand, typs []*types.T) *types.T {
 			return typ
 		}
 		return RandTupleFromSlice(rng, typs)
+	case types.DecimalFamily:
+		precision := rand.Int31n(tree.DecimalMaxPrecision)
+		scale := rand.Int31n(min(precision, tree.DecimalMaxScale))
+		fmt.Println("made", precision, scale)
+		return types.MakeDecimal(precision, scale)
 	}
 	return typ
 }

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -1020,11 +1020,30 @@ func AsDDecimal(e Expr) (*DDecimal, bool) {
 	return nil, false
 }
 
+// These are the maximum decimal precision and scale values as outlined in
+// https://www.postgresql.org/docs/10/datatype-numeric.html#DATATYPE-NUMERIC-TABLE
+const DecimalMaxPrecision = 131072
+const DecimalMaxScale = 16383
+
 // ParseDDecimal parses and returns the *DDecimal Datum value represented by the
 // provided string, or an error if parsing is unsuccessful.
 func ParseDDecimal(s string) (*DDecimal, error) {
 	dd := &DDecimal{}
 	err := dd.SetString(s)
+	return dd, err
+}
+
+func ParseDDecimalWithPrecisionAndScale(s string, precision int32, scale int32) (*DDecimal, error) {
+	dd := &DDecimal{}
+	err := dd.SetString(s)
+	if precision == 0 {
+		precision = DecimalMaxPrecision
+	}
+	if scale == 0 {
+		dd.Exponent = min(DecimalMaxScale, precision)
+	} else {
+		dd.Exponent = scale
+	}
 	return dd, err
 }
 

--- a/pkg/util/parquet/BUILD.bazel
+++ b/pkg/util/parquet/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "@com_github_apache_arrow_go_v11//parquet/file",
         "@com_github_apache_arrow_go_v11//parquet/metadata",
         "@com_github_apache_arrow_go_v11//parquet/schema",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_lib_pq//oid",
         "@com_github_stretchr_testify//require",

--- a/pkg/util/parquet/writer_test.go
+++ b/pkg/util/parquet/writer_test.go
@@ -89,6 +89,9 @@ func makeRandDatums(numRows int, sch *colSchema, rng *rand.Rand, nullsAllowed bo
 		datums[i] = make([]tree.Datum, len(sch.columnTypes))
 		for j := 0; j < len(sch.columnTypes); j++ {
 			datums[i][j] = randgen.RandDatum(rng, sch.columnTypes[j], nullsAllowed)
+			if datums[i][j].ResolvedType().Family() == types.DecimalFamily {
+				fmt.Println("makerandatums", datums[i][j].(*tree.DDecimal))
+			}
 		}
 	}
 	return datums
@@ -141,12 +144,39 @@ func TestRandomDatums(t *testing.T) {
 	err = writer.Close()
 	require.NoError(t, err)
 
+	for _, row := range datums {
+		for j := range row {
+			if row[j].ResolvedType().Family() != types.DecimalFamily {
+				continue
+			}
+			fmt.Println("type", sch.columnTypes[j])
+
+			decimalTupleType := types.MakeLabeledTuple([]*types.T{sch.columnTypes[j], types.String},
+				[]string{"decimal", "string"})
+			if row[j].(*tree.DDecimal).Form != 0 {
+				row[j] = tree.NewDTuple(decimalTupleType, tree.DNull, row[j])
+			} else {
+				row[j] = tree.NewDTuple(decimalTupleType, row[j], tree.DNull)
+			}
+		}
+	}
+
 	ReadFileAndVerifyDatums(t, f.Name(), numRows, numCols, datums)
 }
 
 // TestBasicDatums tests roundtripability for all supported scalar data types
 // and one simple array type.
 func TestBasicDatums(t *testing.T) {
+	decimalColumnTypes := []*types.T{
+		types.Decimal, types.Decimal,
+		types.Decimal, types.Decimal,
+		types.Decimal, types.Decimal,
+		types.Decimal, types.Decimal,
+		types.Decimal, types.Decimal,
+		types.MakeDecimal(7, 2), types.MakeDecimal(7, 2),
+		types.Decimal, types.Decimal,
+	}
+
 	for _, tc := range []struct {
 		name   string
 		sch    *colSchema
@@ -223,22 +253,52 @@ func TestBasicDatums(t *testing.T) {
 		{
 			name: "decimal",
 			sch: &colSchema{
-				columnTypes: []*types.T{types.Decimal, types.Decimal, types.Decimal, types.Decimal},
-				columnNames: []string{"a", "b", "c", "d"},
+				columnTypes: decimalColumnTypes,
+				columnNames: []string{"a", "b", "c", "d", "e", "f", "g", "h", "i", "j", "k", "l", "m", "n"},
 			},
 			datums: func() ([][]tree.Datum, error) {
 				var err error
-				datums := make([]tree.Datum, 4)
-				if datums[0], err = tree.ParseDDecimal("-1.222"); err != nil {
+				datums := make([]tree.Datum, 14)
+				if datums[0], err = tree.ParseDDecimalWithPrecisionAndScale("-1.222", decimalColumnTypes[0].Precision(), decimalColumnTypes[0].Scale()); err != nil {
 					return nil, err
 				}
-				if datums[1], err = tree.ParseDDecimal("-inf"); err != nil {
+				if datums[1], err = tree.ParseDDecimalWithPrecisionAndScale("1.222", decimalColumnTypes[1].Precision(), decimalColumnTypes[1].Scale()); err != nil {
 					return nil, err
 				}
-				if datums[2], err = tree.ParseDDecimal("inf"); err != nil {
+				if datums[2], err = tree.ParseDDecimalWithPrecisionAndScale("0.1", decimalColumnTypes[2].Precision(), decimalColumnTypes[2].Scale()); err != nil {
 					return nil, err
 				}
-				if datums[3], err = tree.ParseDDecimal("nan"); err != nil {
+				if datums[3], err = tree.ParseDDecimalWithPrecisionAndScale("-0.1", decimalColumnTypes[3].Precision(), decimalColumnTypes[3].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[4], err = tree.ParseDDecimalWithPrecisionAndScale("1.0", decimalColumnTypes[4].Precision(), decimalColumnTypes[4].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[5], err = tree.ParseDDecimalWithPrecisionAndScale("-1.0", decimalColumnTypes[5].Precision(), decimalColumnTypes[5].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[6], err = tree.ParseDDecimalWithPrecisionAndScale("0.0", decimalColumnTypes[6].Precision(), decimalColumnTypes[6].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[7], err = tree.ParseDDecimalWithPrecisionAndScale("0", decimalColumnTypes[7].Precision(), decimalColumnTypes[7].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[8], err = tree.ParseDDecimalWithPrecisionAndScale("123456789.987654321", decimalColumnTypes[8].Precision(), decimalColumnTypes[8].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[9], err = tree.ParseDDecimalWithPrecisionAndScale("-3456789.98765", decimalColumnTypes[9].Precision(), decimalColumnTypes[9].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[10], err = tree.ParseDDecimalWithPrecisionAndScale("12345.54321", decimalColumnTypes[10].Precision(), decimalColumnTypes[10].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[11], err = tree.ParseDDecimalWithPrecisionAndScale("-12345.54321", decimalColumnTypes[11].Precision(), decimalColumnTypes[11].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[12], err = tree.ParseDDecimalWithPrecisionAndScale("nan", decimalColumnTypes[12].Precision(), decimalColumnTypes[12].Scale()); err != nil {
+					return nil, err
+				}
+				if datums[13], err = tree.ParseDDecimalWithPrecisionAndScale("inf", decimalColumnTypes[13].Precision(), decimalColumnTypes[13].Scale()); err != nil {
 					return nil, err
 				}
 				return [][]tree.Datum{datums}, nil
@@ -524,6 +584,20 @@ func TestBasicDatums(t *testing.T) {
 
 			err = writer.Close()
 			require.NoError(t, err)
+
+			if tc.name == "decimal" {
+				for _, row := range datums {
+					for j := range row {
+						decimalTupleType := types.MakeLabeledTuple([]*types.T{decimalColumnTypes[j], types.String},
+							[]string{"decimal", "string"})
+						if row[j].(*tree.DDecimal).Form != 0 {
+							row[j] = tree.NewDTuple(decimalTupleType, tree.DNull, row[j])
+						} else {
+							row[j] = tree.NewDTuple(decimalTupleType, row[j], tree.DNull)
+						}
+					}
+				}
+			}
 
 			meta := ReadFileAndVerifyDatums(t, f.Name(), numRows, numCols, datums)
 			expectedNumRowGroups := int(math.Ceil(float64(numRows) / float64(maxRowGroupSize)))


### PR DESCRIPTION
Previously we wrote decimals into parquet as
string bytes. This caused issues when being read
since the readers expect the bytes to be a valid
decimal representation.

Epic: CRDB-41784
Fixes: #130909
Release note (bug fix): Fix decimal writes into parquet files from
changefeeds and exports.