### PR TITLE
colbuilder: don't use direct scans in an invalid case

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -603,6 +603,13 @@ func TestTenantLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestTenantLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestTenantLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -615,6 +615,13 @@ func TestReadCommittedLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestReadCommittedLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestReadCommittedLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -608,6 +608,13 @@ func TestRepeatableReadLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestRepeatableReadLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestRepeatableReadLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/colexec/colbuilder/BUILD.bazel
+++ b/pkg/sql/colexec/colbuilder/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/col/coldata",
         "//pkg/col/coldataext",
         "//pkg/col/typeconv",
+        "//pkg/keys",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/settings",
         "//pkg/sql/catalog/descpb",

--- a/pkg/sql/logictest/testdata/logic_test/direct_columnar_scans
+++ b/pkg/sql/logictest/testdata/logic_test/direct_columnar_scans
@@ -1,0 +1,26 @@
+statement ok
+SET direct_columnar_scans_enabled = true
+
+statement ok
+CREATE TABLE t145232 (
+      k INT PRIMARY KEY,
+      a INT NOT NULL,
+      b INT NOT NULL,
+      c INT NOT NULL,
+      v INT NOT NULL DEFAULT 5,
+      FAMILY (c),
+      FAMILY (v),
+      FAMILY (k),
+      FAMILY (a),
+      FAMILY (b)
+);
+
+statement ok
+INSERT INTO t145232 VALUES (2,2,2,2);
+
+# Regression test for #145232 where we tried to use direct columnar scans even
+# though a single SQL row is handled by multiple Scan requests.
+query IIIII
+SELECT * FROM t145232 WHERE k = 2
+----
+2  2  2  2  5

--- a/pkg/sql/logictest/testdata/logic_test/distsql_enum
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_enum
@@ -88,11 +88,11 @@ SELECT t1.x from t1 INNER LOOKUP JOIN t2 ON t1.x=t2.x WHERE t2.y='hello'
 ├ Node 2
 │ └ *colrpc.Outbox
 │   └ *rowexec.joinReader
-│     └ *colfetcher.ColBatchDirectScan
+│     └ *colfetcher.ColBatchScan
 └ Node 3
   └ *colrpc.Outbox
     └ *rowexec.joinReader
-      └ *colfetcher.ColBatchDirectScan
+      └ *colfetcher.ColBatchScan
 
 query I
 SELECT t1.x from t1 INNER LOOKUP JOIN t2 ON t1.x=t2.x WHERE t2.y='hello'

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -577,6 +577,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -577,6 +577,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -577,6 +577,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -563,6 +563,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
@@ -577,6 +577,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
@@ -577,6 +577,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -577,6 +577,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -598,6 +598,13 @@ func TestLogic_dependencies(
 	runLogicTest(t, "dependencies")
 }
 
+func TestLogic_direct_columnar_scans(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "direct_columnar_scans")
+}
+
 func TestLogic_discard(
 	t *testing.T,
 ) {


### PR DESCRIPTION
We have an experimental feature to build `coldata.Batch`es directly on the KV server side when handling Scan and ReverseScan requests. It assumes that each request corresponds to any number of full SQL rows, but previously we didn't disable usage of this feature when a single SQL row is populated via multiple requests. This is the case when we have multiple column families, and since we don't support Gets in the direct scans machinery right now, we need at least 5 column families - so that we get Scan for 0-1 and 3-4 CFs. This commit fixes this oversight to ensure that if we have two consecutive key spans that come from the same SQL row, we don't use the direct scans even if they are enabled.

There is no release note since this feature is disabled by default.

Fixes: #145232.

Release note: None