### PR TITLE
roachtest/tlp: randomly force generic query plans

### DIFF
--- a/pkg/cmd/roachtest/tests/tlp.go
+++ b/pkg/cmd/roachtest/tests/tlp.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	gosql "database/sql"
 	"fmt"
+	"math/rand"
 	"os"
 	"path/filepath"
 	"strings"
@@ -172,7 +173,7 @@ func runOneTLP(
 			continue
 		}
 
-		if err := runTLPQuery(t, conn, tlpSmither, logStmt); err != nil {
+		if err := runTLPQuery(t, conn, rnd, tlpSmither, logStmt); err != nil {
 			t.Fatal(err)
 		}
 	}
@@ -209,14 +210,28 @@ func runMutationStatement(
 // partitioned query. See GenerateTLP for more information on TLP and the
 // generated queries.
 func runTLPQuery(
-	t task.Tasker, conn *gosql.DB, smither *sqlsmith.Smither, logStmt func(string),
-) error {
+	t task.Tasker, conn *gosql.DB, rnd *rand.Rand, smither *sqlsmith.Smither, logStmt func(string),
+) (err error) {
 	// Ignore panics from GenerateTLP.
 	defer func() {
 		if r := recover(); r != nil {
 			return
 		}
 	}()
+
+	// Force generic query plans for 25% of queries.
+	generic := false
+	const forceGeneric = "SET plan_cache_mode = force_generic_plan"
+	if rnd.Intn(4) == 0 {
+		generic = true
+		_, err = conn.Exec(forceGeneric)
+		if err != nil {
+			return err
+		}
+		defer func() {
+			_, err = conn.Exec("RESET plan_cache_mode")
+		}()
+	}
 
 	unpartitioned, partitioned, args := smither.GenerateTLP()
 	combined := sqlsmith.CombinedTLP(unpartitioned, partitioned)
@@ -263,6 +278,9 @@ func runTLPQuery(
 		}
 
 		diff := unsortedMatricesDiff(unpartitionedRows, partitionedRows)
+		if generic {
+			logStmt(forceGeneric)
+		}
 		logStmt(unpartitioned)
 		logStmt(partitioned)
 		return errors.Newf(


### PR DESCRIPTION
Generic query plans are now forced for 25% of TLP queries. Note that
only one type of TLP query uses placeholders, which are required for
"interesting" generic query plans, simple `SELECT .. WHERE ..` queries.
Joins and grouping do not yet use placeholders.

Fixes #128912

Release note: None
