### PR TITLE
workload: add a literal implementation of tpcc

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -760,6 +760,26 @@ func registerTPCC(r registry.Registry) {
 	})
 
 	r.Add(registry.TestSpec{
+		Name:                      "tpcc-nowait/literal/w=1000/nodes=5/cpu=16",
+		Owner:                     registry.OwnerTestEng,
+		Benchmark:                 true,
+		Cluster:                   r.MakeClusterSpec(6, spec.CPU(16), spec.WorkloadNode()),
+		CompatibleClouds:          registry.AllExceptAzure,
+		Suites:                    registry.Suites(registry.Nightly),
+		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			runTPCC(ctx, t, t.L(), c, tpccOptions{
+				Warehouses:                    1000,
+				Duration:                      10 * time.Minute,
+				ExtraRunArgs:                  "--wait=false --tolerate-errors --workers=200 --literal-implementation",
+				SetupType:                     usingImport,
+				ExpensiveChecks:               true, // Run expensive checks here to catch any issues with the literal implementation
+				DisableDefaultScheduledBackup: true,
+			})
+		},
+	})
+
+	r.Add(registry.TestSpec{
 		Name:              "tpcc-nowait/nodes=3/w=1",
 		Owner:             registry.OwnerTestEng,
 		Benchmark:         true,

--- a/pkg/workload/tpcc/payment.go
+++ b/pkg/workload/tpcc/payment.go
@@ -71,6 +71,7 @@ type payment struct {
 	mcp    *workload.MultiConnPool
 	sr     workload.SQLRunner
 
+	// Optimized implementation statements
 	updateWarehouse   workload.StmtHandle
 	updateDistrict    workload.StmtHandle
 	selectByLastName  workload.StmtHandle
@@ -78,6 +79,16 @@ type payment struct {
 	insertHistory     workload.StmtHandle
 	resetWarehouse    workload.StmtHandle
 	resetDistrict     workload.StmtHandle
+
+	// Literal implementation statements (without RETURNING clause)
+	literalUpdateWarehouse          workload.StmtHandle
+	literalUpdateDistrict           workload.StmtHandle
+	literalSelectWarehouse          workload.StmtHandle
+	literalSelectDistrict           workload.StmtHandle
+	literalSelectByLastName         workload.StmtHandle
+	literalUpdateCustomer           workload.StmtHandle
+	literalSelectDataForCustomerBad workload.StmtHandle
+	literalUpdateCustomerBad        workload.StmtHandle
 
 	a bufalloc.ByteAllocator
 }
@@ -90,7 +101,7 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		mcp:    mcp,
 	}
 
-	// Update warehouse with payment
+	// Update warehouse with payment (optimized with RETURNING)
 	p.updateWarehouse = p.sr.Define(`
 		UPDATE warehouse
 		SET w_ytd = w_ytd + $1
@@ -98,7 +109,7 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		RETURNING w_name, w_street_1, w_street_2, w_city, w_state, w_zip`,
 	)
 
-	// Update district with payment
+	// Update district with payment (optimized with RETURNING)
 	p.updateDistrict = p.sr.Define(`
 		UPDATE district
 		SET d_ytd = d_ytd + $1
@@ -114,7 +125,7 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 		ORDER BY c_first ASC`,
 	)
 
-	// Update customer with payment.
+	// Update customer with payment (optimized with RETURNING).
 	// If the customer has bad credit, update the customer's C_DATA and return
 	// the first 200 characters of it, which is supposed to get displayed by
 	// the terminal. See 2.5.3.3 and 2.5.2.2.
@@ -132,10 +143,77 @@ func createPayment(ctx context.Context, config *tpcc, mcp *workload.MultiConnPoo
 	)
 
 	// Insert history line.
-
 	p.insertHistory = p.sr.Define(`
 		INSERT INTO history (h_c_id, h_c_d_id, h_c_w_id, h_d_id, h_w_id, h_amount, h_date, h_data)
 		VALUES ($1, $2, $3, $4, $5, $6, $7, $8)`,
+	)
+
+	// Literal implementation statements (without RETURNING clause)
+
+	// Update warehouse with payment (literal without RETURNING)
+	p.literalUpdateWarehouse = p.sr.Define(`
+		UPDATE warehouse
+		SET w_ytd = w_ytd + $1
+		WHERE w_id = $2`,
+	)
+
+	// Select warehouse data after update
+	p.literalSelectWarehouse = p.sr.Define(`
+		SELECT w_name, w_street_1, w_street_2, w_city, w_state, w_zip
+		FROM warehouse
+		WHERE w_id = $1
+        FOR UPDATE`,
+	)
+
+	// Update district with payment (literal without RETURNING)
+	p.literalUpdateDistrict = p.sr.Define(`
+		UPDATE district
+		SET d_ytd = d_ytd + $1
+		WHERE d_w_id = $2 AND d_id = $3`,
+	)
+
+	// Select district data after update
+	p.literalSelectDistrict = p.sr.Define(`
+		SELECT d_name, d_street_1, d_street_2, d_city, d_state, d_zip
+		FROM district
+		WHERE d_w_id = $1 AND d_id = $2
+		FOR UPDATE`,
+	)
+
+	// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
+	p.literalSelectByLastName = p.sr.Define(`
+		SELECT c_first, c_middle, c_last, c_id, c_street_1, c_street_2,
+			c_city, c_state, c_zip, c_phone, c_since, c_credit,
+			c_credit_lim, c_discount, c_balance
+		FROM customer
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_last = $3
+		ORDER BY c_first ASC`,
+	)
+
+	// Update customer with payment (for good credit customers)
+	p.literalUpdateCustomer = p.sr.Define(`
+		UPDATE customer
+		SET c_balance = c_balance - ($1:::float)::decimal,
+			c_ytd_payment = c_ytd_payment + ($1:::float)::decimal,
+			c_payment_cnt = c_payment_cnt + 1
+		WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4`,
+	)
+
+	// Select the CDATA for a customer (for bad credit customers)
+	p.literalSelectDataForCustomerBad = p.sr.Define(`
+		SELECT c_data
+		FROM customer
+		WHERE c_w_id = $1 AND c_d_id = $2 AND c_id = $3`,
+	)
+
+	// Update customer with payment (for bad credit customers)
+	p.literalUpdateCustomerBad = p.sr.Define(`
+		UPDATE customer
+		SET c_balance = c_balance - ($1:::float)::decimal,
+			c_ytd_payment = c_ytd_payment + ($1:::float)::decimal,
+			c_payment_cnt = c_payment_cnt + 1,
+			c_data = left(c_id::text || c_d_id::text || c_w_id::text || ($5:::int)::text || ($6:::int)::text || ($1:::float)::text || c_data, 500)
+		WHERE c_w_id = $2 AND c_d_id = $3 AND c_id = $4`,
 	)
 
 	if p.config.isLongDurationWorkload {
@@ -252,77 +330,243 @@ func (p *payment) run(ctx context.Context, wID int) (interface{}, time.Duration,
 		d.cID = p.config.randCustomerID(rng)
 	}
 
-	onTxnStartDuration, err := p.config.executeTx(
-		ctx, p.mcp.Get(),
-		func(tx pgx.Tx) error {
-			var wName, dName string
+	var onTxnStartDuration time.Duration
+	var err error
 
-			// Update warehouse with payment
-			if err := p.updateWarehouse.QueryRowTx(
-				ctx, tx, d.hAmount, wID,
-			).Scan(&wName, &d.wStreet1, &d.wStreet2, &d.wCity, &d.wState, &d.wZip); err != nil {
-				return errors.Wrap(err, "update warehouse failed")
-			}
+	if p.config.literalImplementation {
+		// Literal implementation without optimizations.
+		onTxnStartDuration, err = p.config.executeTx(
+			ctx, p.mcp.Get(),
+			func(tx pgx.Tx) error {
+				var wName, dName string
 
-			// Update district with payment
-			if err := p.updateDistrict.QueryRowTx(
-				ctx, tx, d.hAmount, wID, d.dID,
-			).Scan(&dName, &d.dStreet1, &d.dStreet2, &d.dCity, &d.dState, &d.dZip); err != nil {
-				return errors.Wrap(err, "update district failed")
-			}
+				// Select the warehouse data
+				if err := p.literalSelectWarehouse.QueryRowTx(
+					ctx, tx, wID,
+				).Scan(&wName, &d.wStreet1, &d.wStreet2, &d.wCity, &d.wState, &d.wZip); err != nil {
+					return errors.Wrap(err, "select warehouse failed")
+				}
 
-			// If we are selecting by last name, first find the relevant customer id and
-			// then proceed.
-			if d.cID == 0 {
-				// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
-				customers := make([]int, 0, 1)
-				if err := func() error {
-					rows, err := p.selectByLastName.QueryTx(ctx, tx, wID, d.dID, d.cLast)
-					if err != nil {
-						return err
-					}
-					defer rows.Close()
+				// Update warehouse with payment
+				if _, err := p.literalUpdateWarehouse.ExecTx(
+					ctx, tx, d.hAmount, wID,
+				); err != nil {
+					return errors.Wrap(err, "update warehouse failed")
+				}
 
-					for rows.Next() {
-						var cID int
-						if err := rows.Scan(&cID); err != nil {
+				// Select district data before updating it below.
+				if err := p.literalSelectDistrict.QueryRowTx(
+					ctx, tx, wID, d.dID,
+				).Scan(&dName, &d.dStreet1, &d.dStreet2, &d.dCity, &d.dState, &d.dZip); err != nil {
+					return errors.Wrap(err, "select district failed")
+				}
+
+				// Update district with payment.
+				if _, err := p.literalUpdateDistrict.ExecTx(
+					ctx, tx, d.hAmount, wID, d.dID,
+				); err != nil {
+					return errors.Wrap(err, "update district failed")
+				}
+
+				// If we are selecting by last name, first find the relevant customer id and
+				// then proceed.
+				if d.cID == 0 {
+					// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
+					// The number of customers returned will typically be in the 1-5 range. Size the
+					// slice for 10 customers to be safe.
+					customers := make([]paymentData, 0, 10)
+					if err := func() error {
+						rows, err := p.literalSelectByLastName.QueryTx(ctx, tx, d.cWID, d.cDID, d.cLast)
+						if err != nil {
 							return err
 						}
-						customers = append(customers, cID)
+						defer rows.Close()
+
+						for rows.Next() {
+							// This data must all be returned by the transaction. See 2.5.3.4.
+							// Unfortunately, this code isn't pretty to look at, but appears to be
+							// necessary. The TPC-C search by last name requires us to query the
+							// table and return all customers with the same last name, then pick
+							// the middle row (rounded up), in the sorted result. To do this with
+							// only one query, we have to return all the data for each customer,
+							// store them all in memory, determine the correct row, and then store
+							// that row for use later. We can't do this without caching all the
+							// rows in memory because pgx4 doesn't allow us to scan rows multiple
+							// times with the same query.
+							var cFirst, cMiddle, cLast, cStreet1, cStreet2, cCity, cState, cZip, cPhone, cCredit string
+							var cID int
+							var cCreditLim, cDiscount, cBalance float64
+							var cSince time.Time
+
+							if err := rows.Scan(&cFirst, &cMiddle, &cLast, &cID, &cStreet1, &cStreet2,
+								&cCity, &cState, &cZip, &cPhone, &cSince, &cCredit,
+								&cCreditLim, &cDiscount, &cBalance); err != nil {
+								return err
+							}
+
+							customers = append(customers,
+								paymentData{
+									cFirst:     cFirst,
+									cMiddle:    cMiddle,
+									cLast:      cLast,
+									cStreet1:   cStreet1,
+									cStreet2:   cStreet2,
+									cCity:      cCity,
+									cState:     cState,
+									cZip:       cZip,
+									cPhone:     cPhone,
+									cCredit:    cCredit,
+									cID:        cID,
+									cCreditLim: cCreditLim,
+									cDiscount:  cDiscount,
+									cBalance:   cBalance,
+									cSince:     cSince,
+								})
+						}
+						return rows.Err()
+					}(); err != nil {
+						return errors.Wrap(err, "select customer failed")
 					}
-					return rows.Err()
-				}(); err != nil {
-					return errors.Wrap(err, "select customer failed")
+					cIdx := (len(customers) - 1) / 2
+					d.cFirst = customers[cIdx].cFirst
+					d.cMiddle = customers[cIdx].cMiddle
+					d.cLast = customers[cIdx].cLast
+					d.cID = customers[cIdx].cID
+					d.cStreet1 = customers[cIdx].cStreet1
+					d.cStreet2 = customers[cIdx].cStreet2
+					d.cCity = customers[cIdx].cCity
+					d.cState = customers[cIdx].cState
+					d.cZip = customers[cIdx].cZip
+					d.cPhone = customers[cIdx].cPhone
+					d.cCredit = customers[cIdx].cCredit
+					d.cCreditLim = customers[cIdx].cCreditLim
+					d.cDiscount = customers[cIdx].cDiscount
+					d.cBalance = customers[cIdx].cBalance
+					d.cSince = customers[cIdx].cSince
 				}
-				cIdx := (len(customers) - 1) / 2
-				d.cID = customers[cIdx]
-			}
 
-			// Update customer with payment.
-			// If the customer has bad credit, update the customer's C_DATA and return
-			// the first 200 characters of it, which is supposed to get displayed by
-			// the terminal. See 2.5.3.3 and 2.5.2.2.
-			if err := p.updateWithPayment.QueryRowTx(
-				ctx, tx, d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID,
-			).Scan(&d.cFirst, &d.cMiddle, &d.cLast, &d.cStreet1, &d.cStreet2,
-				&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
-				&d.cCreditLim, &d.cDiscount, &d.cBalance, &d.cData,
-			); err != nil {
-				return errors.Wrap(err, "update customer failed")
-			}
+				// Update the customer with payment based on credit status
+				if d.cCredit == "BC" {
+					// In the bad credit case, the literal implementation should really retrieve the
+					// c_data field, manipulate it on the application side, and then update it.
+					// Doing that, however, would require extra logic here and likely wouldn't
+					// change the efficiency much since it's the same number of round-trips to the
+					// database. Instead, we retrieve the c_data field here but then update it using
+					// the optimized update statement below (where the c_data update is prepared and
+					// performed wholly in the SQL query). As a result, the retrieved c_data field
+					// is scanned but not used.
+					// FUTURE READER: please don't remove this select in an attempt to optimize this
+					// code.
+					if err := p.literalSelectDataForCustomerBad.QueryRowTx(
+						ctx, tx, d.cWID, d.cDID, d.cID,
+					).Scan(&d.cData); err != nil {
+						return errors.Wrap(err, "selecting for customer with bad credit failed")
+					}
 
-			hData := fmt.Sprintf("%s    %s", wName, dName)
+					// Bad credit - need to update c_data and return it
+					if _, err := p.literalUpdateCustomerBad.ExecTx(
+						ctx, tx, d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID,
+					); err != nil {
+						return errors.Wrap(err, "update customer with bad credit failed")
+					}
+				} else {
+					// Good credit - simpler update
+					if _, err := p.literalUpdateCustomer.ExecTx(
+						ctx, tx, d.hAmount, d.cWID, d.cDID, d.cID,
+					); err != nil {
+						return errors.Wrap(err, "update customer with good credit failed")
+					}
+					d.cData = "" // No data to return for good credit customers
+				}
 
-			// Insert history line.
-			if _, err := p.insertHistory.ExecTx(
-				ctx, tx,
-				d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount, d.hDate.Format("2006-01-02 15:04:05"), hData,
-			); err != nil {
-				return errors.Wrap(err, "insert history failed")
-			}
+				// Update balance after the update
+				d.cBalance -= d.hAmount
 
-			return nil
-		})
+				hData := fmt.Sprintf("%s    %s", wName, dName)
+
+				// Insert the history row.
+				if _, err := p.insertHistory.ExecTx(
+					ctx, tx,
+					d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount, d.hDate.Format("2006-01-02 15:04:05"), hData,
+				); err != nil {
+					return errors.Wrap(err, "insert history failed")
+				}
+
+				return nil
+			})
+	} else {
+		// Optimized implementation (original)
+		onTxnStartDuration, err = p.config.executeTx(
+			ctx, p.mcp.Get(),
+			func(tx pgx.Tx) error {
+				var wName, dName string
+
+				// Update warehouse with payment
+				if err := p.updateWarehouse.QueryRowTx(
+					ctx, tx, d.hAmount, wID,
+				).Scan(&wName, &d.wStreet1, &d.wStreet2, &d.wCity, &d.wState, &d.wZip); err != nil {
+					return errors.Wrap(err, "update warehouse failed")
+				}
+
+				// Update district with payment
+				if err := p.updateDistrict.QueryRowTx(
+					ctx, tx, d.hAmount, wID, d.dID,
+				).Scan(&dName, &d.dStreet1, &d.dStreet2, &d.dCity, &d.dState, &d.dZip); err != nil {
+					return errors.Wrap(err, "update district failed")
+				}
+
+				// If we are selecting by last name, first find the relevant customer id and
+				// then proceed.
+				if d.cID == 0 {
+					// 2.5.2.2 Case 2: Pick the middle row, rounded up, from the selection by last name.
+					customers := make([]int, 0, 1)
+					if err := func() error {
+						rows, err := p.selectByLastName.QueryTx(ctx, tx, wID, d.dID, d.cLast)
+						if err != nil {
+							return err
+						}
+						defer rows.Close()
+						for rows.Next() {
+							var cID int
+							if err := rows.Scan(&cID); err != nil {
+								return err
+							}
+							customers = append(customers, cID)
+						}
+						return rows.Err()
+					}(); err != nil {
+						return errors.Wrap(err, "select customer failed")
+					}
+					cIdx := (len(customers) - 1) / 2
+					d.cID = customers[cIdx]
+				}
+
+				// Update customer with payment.
+				// If the customer has bad credit, update the customer's C_DATA and return
+				// the first 200 characters of it, which is supposed to get displayed by
+				// the terminal. See 2.5.3.3 and 2.5.2.2.
+				if err := p.updateWithPayment.QueryRowTx(
+					ctx, tx, d.hAmount, d.cWID, d.cDID, d.cID, d.dID, wID,
+				).Scan(&d.cFirst, &d.cMiddle, &d.cLast, &d.cStreet1, &d.cStreet2,
+					&d.cCity, &d.cState, &d.cZip, &d.cPhone, &d.cSince, &d.cCredit,
+					&d.cCreditLim, &d.cDiscount, &d.cBalance, &d.cData,
+				); err != nil {
+					return errors.Wrap(err, "update customer failed")
+				}
+
+				hData := fmt.Sprintf("%s    %s", wName, dName)
+
+				// Insert history line.
+				if _, err := p.insertHistory.ExecTx(
+					ctx, tx,
+					d.cID, d.cDID, d.cWID, d.dID, wID, d.hAmount, d.hDate.Format("2006-01-02 15:04:05"), hData,
+				); err != nil {
+					return errors.Wrap(err, "insert history failed")
+				}
+
+				return nil
+			})
+	}
 	if err != nil {
 		return nil, 0, err
 	}

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -136,6 +136,14 @@ type tpcc struct {
 	resetTableCancelFn context.CancelFunc
 
 	asOfSystemTime string
+
+	// Set to true if a literal implemenation of the workload is desired. In
+	// this case "literal" means that the New Order and Payments transactions
+	// are implemented statement-by-statement as specified in the specification.
+	// This avoids the use of RETURNING clauses to batch updates together with
+	// selects, and performs each row select/update separately, as opposed to
+	// batching them using an IN list.
+	literalImplementation bool
 }
 
 type waitSetter struct {
@@ -316,6 +324,7 @@ var tpccMeta = workload.Meta{
 		g.flags.StringVar(&g.asOfSystemTime, "aost", "",
 			"This is an optional parameter to specify AOST; used exclusively in conjunction with the TPC-C consistency "+
 				"check. Example values are (\"'-1m'\", \"'-1h'\")")
+		g.flags.BoolVar(&g.literalImplementation, "literal-implementation", false, "If true, use a literal implementation of the TPC-C kit instead of an optimized version")
 
 		RandomSeed.AddFlag(&g.flags)
 		g.connFlags = workload.NewConnFlags(&g.flags)


### PR DESCRIPTION
Our current TPC-C kit is heavily optimized. For example, in several places we combine an update and a select with an UPDATE...RETURNING statement. In other places, we use IN lists to reduce the number of round-trips from the client to the server. As best I can tell, all of this is acceptable according to the specification (after all, you can reduce the round-trips to 1 by implementing each transaction as a stored procedure), however some kits implement things much more literally, with one client-server roundtrip for each step of each transaction.

This commit adds a literal implementation for the New Order and Payment transactions. We're focusing our attention there for now, as these two transactions comprise 88% of the workload.

One change made in this commit which isn't fully explained by code comments is the movement of the inserts into the orders and new orders table higher up in the New Order transaction. This shouldn't have any bearing on the transaction logic, but is moved up to allow for more common code, and also since according to the spec, it should occur before the items are processed.

NOTE: There's a significant amount of whitespace changes in this commit. When reviewing, you'll want to turn off the whitespace changes to avoid having to review all of them.

Epic: none
Release note: none