### PR TITLE
release-24.3: colfetcher: do not enable direct scans metamorphically

### DIFF
--- a/pkg/sql/colfetcher/cfetcher_wrapper.go
+++ b/pkg/sql/colfetcher/cfetcher_wrapper.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
-	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 )
@@ -36,11 +35,6 @@ var DirectScansEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.distsql.direct_columnar_scans.enabled",
 	"set to true to enable the 'direct' columnar scans in the KV layer",
-	directScansEnabledDefault,
-)
-
-var directScansEnabledDefault = metamorphic.ConstantWithTestBool(
-	"direct-scans-enabled",
 	false,
 )
 


### PR DESCRIPTION
Backport 1/1 commits from #145247 on behalf of @yuzefovich.

----

We don't have immediate plans to productionize this feature, so enabling it metamorphically can only lead to wasted effort / increased flaking in case of bugs in the feature.

Informs: #145232.
Epic: None
Release note: None

----

Release justification: test-only change.