### PR TITLE
security: fix TestTLSCipherRestrict no_cipher_set failure

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -93,6 +93,7 @@ go_test(
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
The test seems to fail under stress when http connection is closed by the server even when no ciphers were set for the server. This seems like  a timing or state persistence issue where the previous test's restriction function is still being used.

fixes #145275
Epic CRDB-49822

Release Note: None