### PR TITLE
workload: add support to csv generation for decimal

### DIFF
--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -72,5 +72,6 @@ go_test(
         "//pkg/workload/bank",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpch",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -38,6 +38,8 @@ func columnByteSize(col *coldata.Vec) int64 {
 		return col.Bytes().Size() - coldata.FlatBytesOverhead
 	case types.TimestampTZFamily:
 		return int64(col.Timestamp().Len()) * memsize.Time
+	case types.DecimalFamily:
+		return int64(col.Decimal().Len()) * memsize.Decimal
 	default:
 		panic(fmt.Sprintf(`unhandled type %s`, t))
 	}

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -86,6 +86,8 @@ func colDatumToCSVString(col *coldata.Vec, rowIdx int) string {
 		return *(*string)(unsafe.Pointer(&bytes))
 	case types.TimestampTZFamily:
 		return col.Timestamp()[rowIdx].Format(timestampOutputFormat)
+	case types.DecimalFamily:
+		return col.Decimal()[rowIdx].String()
 	}
 	panic(fmt.Sprintf(`unhandled type %s`, col.Type()))
 }

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleCSV(t *testing.T) {
@@ -65,6 +66,45 @@ func TestHandleCSV(t *testing.T) {
 			if d, e := strings.TrimSpace(string(data)), strings.TrimSpace(test.expected); d != e {
 				t.Errorf("got [\n%s\n] expected [\n%s\n]", d, e)
 			}
+		})
+	}
+}
+
+func TestHandleCSVTpcc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		params, expected string
+	}{
+		{
+			`?rows=1`, `
+0,9,10,17,16,RG,955311111,0.1622,300000.00`,
+		},
+		{
+			`?rows=5&row-start=1&row-end=3`, `
+1,10,20,13,20,RG,327711111,0.1625,300000.00
+2,9,18,12,10,QN,533211111,0.1000,300000.00`,
+		},
+	}
+
+	// assertions depend on this seed
+	tpcc.RandomSeed.Set(1)
+	meta := tpcc.FromWarehouses(1).Meta()
+	for _, test := range tests {
+		t.Run(test.params, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, workload.HandleCSV(w, r, `/tpcc/`, meta))
+			}))
+			defer ts.Close()
+
+			res, err := httputil.Get(context.Background(), ts.URL+`/tpcc/warehouse`+test.params)
+			require.NoError(t, err)
+
+			data, err := io.ReadAll(res.Body)
+			res.Body.Close()
+			require.NoError(t, err)
+
+			require.Equal(t, strings.TrimSpace(test.expected), strings.TrimSpace(string(data)))
 		})
 	}
 }


### PR DESCRIPTION
PR #144818 modified the tpcc workload so that it generates decimals instead of floats. Usually fixture generation uses a special case in process data generator, but the import roachtests uses a datum -> csv conversation code path that was missing support for the decimal type.

Fixes: #145058
Fixes: #145058
Fixes: #145185

Release note: none