### PR TITLE
release-25.2: jsonpath: add support for `like_regex` flags

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -1804,3 +1804,91 @@ SELECT jsonb_path_query('"1"', '$.abs()');
 
 statement error pgcode 22036 pq: jsonpath item method .floor\(\) can only be applied to a numeric value
 SELECT jsonb_path_query('{}', '(null).floor()');
+
+query T
+SELECT jsonb_path_query('"Hello"', '$ like_regex "hello" flag "i"');
+----
+true
+
+query T
+SELECT jsonb_path_query('"HELLO"', '$ like_regex "hello" flag "i"');
+----
+true
+
+# Use the same pattern but different flags to ensure that ReCache recognizes
+# the change of flags.
+query T
+SELECT jsonb_path_query('"HELLO"', '$ like_regex "hello" flag ""');
+----
+false
+
+query T
+SELECT jsonb_path_query('"Hello\nWorld"', '$ like_regex "Hello.World" flag "s"');
+----
+true
+
+query T
+SELECT jsonb_path_query('"Hello\nWorld"', '$ like_regex "Hello.World" flag ""');
+----
+false
+
+query T
+SELECT jsonb_path_query('"Line1\nLine2"', '$ like_regex "^Line2$" flag "m"');
+----
+true
+
+query T
+SELECT jsonb_path_query('"Line1\nLine2"', '$ like_regex "^Line2$" flag ""');
+----
+false
+
+query T
+SELECT jsonb_path_query('"Hello123World"', '$ like_regex "Hello.*World" flag "q"');
+----
+false
+
+query T
+SELECT jsonb_path_query('"Hello123World"', '$ like_regex "Hello.*World" flag ""');
+----
+true
+
+# Case insensitive and dot matches newline
+query T
+SELECT jsonb_path_query('"Hello\nWorld"', '$ like_regex "hello.world" flag "is"');
+----
+true
+
+# Case insensitive and multiline
+query T
+SELECT jsonb_path_query('"Line1\nline2"', '$ like_regex "^LINE2$" flag "im"');
+----
+true
+
+# Case insensitive and literal matching
+query T
+SELECT jsonb_path_query('"Hello123World"', '$ like_regex "HELLO.*WORLD" flag "iq"');
+----
+false
+
+# Dot matches newline and multiline
+query T
+SELECT jsonb_path_query('"Line1\nLine2\nLine3"', '$ like_regex "^Line1.Line2.Line3$" flag "ms"');
+----
+true
+
+query T
+SELECT jsonb_path_query('"Line1\nLine2\nLine3"', '$ like_regex "^Line1.Line2.Line3$" flag "m"');
+----
+false
+
+# Dot matches newline and literal matching
+query T
+SELECT jsonb_path_query('"Hello\nWorld"', '$ like_regex "Hello.World" flag "sq"');
+----
+false
+
+# Multiline and literal matching
+query T
+SELECT jsonb_path_query('"Line1\nLine2"', '$ like_regex "^Line1\nLine2$" flag "mq"');
+----
+false

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -160,9 +160,6 @@ statement error pgcode 42601 pq: could not parse "@" as type jsonpath: @ is not 
 SELECT '@'::JSONPATH
 
 statement error unimplemented
-SELECT '$ ? (@ like_regex ".*" flag "i")'::JSONPATH;
-
-statement error unimplemented
 SELECT '$.keyvalue()'::JSONPATH;
 
 statement error unimplemented

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -10806,7 +10806,9 @@ type regexpEscapeKey struct {
 	sqlEscape  string
 }
 
-// Pattern implements the RegexpCacheKey interface.
+var _ tree.RegexpCacheKey = regexpEscapeKey{}
+
+// Pattern implements the tree.RegexpCacheKey interface.
 func (k regexpEscapeKey) Pattern() (string, error) {
 	pattern := k.sqlPattern
 	if k.sqlEscape != `\` {
@@ -10838,7 +10840,9 @@ type regexpFlagKey struct {
 	sqlFlags   string
 }
 
-// Pattern implements the RegexpCacheKey interface.
+var _ tree.RegexpCacheKey = regexpFlagKey{}
+
+// Pattern implements the tree.RegexpCacheKey interface.
 func (k regexpFlagKey) Pattern() (string, error) {
 	return regexpEvalFlags(k.sqlPattern, k.sqlFlags)
 }

--- a/pkg/sql/sem/eval/match.go
+++ b/pkg/sql/sem/eval/match.go
@@ -315,6 +315,8 @@ type likeKey struct {
 	escape          rune
 }
 
+var _ tree.RegexpCacheKey = likeKey{}
+
 // LikeEscape converts a like pattern to a regexp pattern.
 func LikeEscape(pattern string) (string, error) {
 	key := likeKey{s: pattern, caseInsensitive: false, escape: '\\'}
@@ -770,7 +772,8 @@ func (k likeKey) patternNoAnchor() (string, error) {
 	return pattern, nil
 }
 
-// Pattern implements the RegexpCacheKey interface.
+// Pattern implements the tree.RegexpCacheKey interface.
+//
 // The strategy for handling custom escape character
 // is to convert all unescaped escape character into '\'.
 // k.escape can either be empty or a single character.
@@ -787,7 +790,9 @@ type similarToKey struct {
 	escape rune
 }
 
-// Pattern implements the RegexpCacheKey interface.
+var _ tree.RegexpCacheKey = similarToKey{}
+
+// Pattern implements the tree.RegexpCacheKey interface.
 func (k similarToKey) Pattern() (string, error) {
 	pattern := similarEscapeCustomChar(k.s, k.escape, k.escape != 0)
 	return anchorPattern(pattern, false), nil
@@ -834,7 +839,9 @@ type regexpKey struct {
 	caseInsensitive bool
 }
 
-// Pattern implements the RegexpCacheKey interface.
+var _ tree.RegexpCacheKey = regexpKey{}
+
+// Pattern implements the tree.RegexpCacheKey interface.
 func (k regexpKey) Pattern() (string, error) {
 	if k.caseInsensitive {
 		return caseInsensitive(k.s), nil

--- a/pkg/sql/sem/tree/regexp_cache.go
+++ b/pkg/sql/sem/tree/regexp_cache.go
@@ -7,6 +7,7 @@ package tree
 
 import (
 	"regexp"
+	"regexp/syntax"
 
 	"github.com/cockroachdb/cockroach/pkg/util/cache"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -47,6 +48,22 @@ func NewRegexpCache(size int) *RegexpCache {
 // the given key, compiling the key's pattern if it is not already
 // in the cache.
 func (rc *RegexpCache) GetRegexp(key RegexpCacheKey) (*regexp.Regexp, error) {
+	// syntax.Perl is the default flag for regexp.Compile.
+	return rc.getRegexpInternal(key, syntax.Perl)
+}
+
+// GetRegexpWithFlags consults the cache for the regular expressions stored for
+// the given key, compiling the key's pattern with the given flags if it is not
+// already in the cache.
+func (rc *RegexpCache) GetRegexpWithFlags(
+	key RegexpCacheKey, flags syntax.Flags,
+) (*regexp.Regexp, error) {
+	return rc.getRegexpInternal(key, flags)
+}
+
+func (rc *RegexpCache) getRegexpInternal(
+	key RegexpCacheKey, flags syntax.Flags,
+) (*regexp.Regexp, error) {
 	if rc != nil {
 		re := rc.lookup(key)
 		if re != nil {
@@ -58,8 +75,19 @@ func (rc *RegexpCache) GetRegexp(key RegexpCacheKey) (*regexp.Regexp, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	re, err := regexp.Compile(pattern)
+	var re *regexp.Regexp
+	if flags == syntax.Perl {
+		// Avoid the redundant 'parse - stringify - parse (within Compile)'
+		// sequence in the common case.
+		re, err = regexp.Compile(pattern)
+	} else {
+		var parsed *syntax.Regexp
+		parsed, err = syntax.Parse(pattern, flags)
+		if err != nil {
+			return nil, err
+		}
+		re, err = regexp.Compile(parsed.String())
+	}
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/util/jsonpath/eval/operation.go
+++ b/pkg/util/jsonpath/eval/operation.go
@@ -183,7 +183,7 @@ func evalRegexFunc(op jsonpath.Operation, l, _ json.JSON) (jsonpathBool, error) 
 		return jsonpathBoolUnknown, err
 	}
 
-	r, err := parser.ReCache.GetRegexp(regexOp)
+	r, err := parser.ReCache.GetRegexpWithFlags(regexOp, regexOp.Flags)
 	if err != nil {
 		return jsonpathBoolUnknown, err
 	}

--- a/pkg/util/jsonpath/parser/jsonpath.y
+++ b/pkg/util/jsonpath/parser/jsonpath.y
@@ -171,9 +171,13 @@ func extractNumericScalar(expr jsonpath.Path) (jsonpath.Scalar, bool) {
   return scalar, true
 }
 
-func regexBinaryOp(left jsonpath.Path, regex string) (jsonpath.Operation, error) {
-  r := jsonpath.Regex{Regex: regex}
-  _, err := ReCache.GetRegexp(r)
+func regexBinaryOp(left jsonpath.Path, regex string, flags string) (jsonpath.Operation, error) {
+  goFlags, err := jsonpath.RegexFlagsToGoFlags(flags)
+  if err != nil {
+    return jsonpath.Operation{}, err
+  }
+  r := jsonpath.Regex{Regex: regex, Flags: goFlags}
+  _, err = ReCache.GetRegexpWithFlags(r, goFlags)
   if err != nil {
     return jsonpath.Operation{}, pgerror.Wrapf(err, pgcode.InvalidRegularExpression,
       "invalid regular expression")
@@ -493,7 +497,7 @@ predicate:
   }
 | expr LIKE_REGEX STR
   {
-    regex, err := regexBinaryOp($1.path(), $3)
+    regex, err := regexBinaryOp($1.path(), $3, "")
     if err != nil {
       return setErr(jsonpathlex, err)
     }
@@ -501,8 +505,11 @@ predicate:
   }
 | expr LIKE_REGEX STR FLAG STR
   {
-    // TODO(normanchenn): implement regex flags.
-    return unimplemented(jsonpathlex, "regex with flags")
+    regex, err := regexBinaryOp($1.path(), $3, $5)
+    if err != nil {
+      return setErr(jsonpathlex, err)
+    }
+    $$.val = regex
   }
 ;
 

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -697,6 +697,50 @@ $.a.ceiling()
 ----
 $."a".ceiling() -- normalized!
 
+parse
+"a" like_regex ".*" flag ""
+----
+("a" like_regex ".*") -- normalized!
+
+error
+"a" like_regex ".*" flag " "
+----
+at or near " ": syntax error: unrecognized flag character ' ' in LIKE_REGEX predicate
+DETAIL: source SQL:
+"a" like_regex ".*" flag " "
+                         ^
+
+error
+"a" like_regex ".*" flag "foo"
+----
+at or near "foo": syntax error: unrecognized flag character 'f' in LIKE_REGEX predicate
+DETAIL: source SQL:
+"a" like_regex ".*" flag "foo"
+                         ^
+
+error
+"a" like_regex ".*" flag "x"
+----
+at or near "x": syntax error: XQuery "x" flag (expanded regular expressions) is not implemented
+DETAIL: source SQL:
+"a" like_regex ".*" flag "x"
+                         ^
+
+parse
+"a" like_regex ".*" flag "ii"
+----
+("a" like_regex ".*" flag "i") -- normalized!
+
+parse
+"a" like_regex ".*" flag "si"
+----
+("a" like_regex ".*" flag "is") -- normalized!
+
+parse
+"a" like_regex ".*" flag "qqqmmmsssiii"
+----
+("a" like_regex ".*" flag "ismq") -- normalized!
+
 # parse
 # $.1a
 # ----


### PR DESCRIPTION
Backport 1/1 commits from #144658.

/cc @cockroachdb/release

---

This commit adds support for regex flags for JSONPath's `like_regex`
predicate. The supported flags are:
- 'i': Case-insensitive matching
- 's': Dot matches newline
- 'm': Multiline mode (^\$ match at newlines)
- 'x': Ignore whitespace mode (Not implemented in Postgres, we return
  the same error)
- 'q': No special characters (treat pattern as a literal)

Epic: None
Release note (sql change): Add support for `like_regex` flags in
JSONPath queries. For example, `SELECT jsonb_path_query('{}', '"a"
like_regex ".*" flag "i"');`.

Release justification: new functionality.