### PR TITLE
metric: update tick in SQL histogram

### DIFF
--- a/pkg/util/metric/aggmetric/agg_metric.go
+++ b/pkg/util/metric/aggmetric/agg_metric.go
@@ -268,6 +268,8 @@ func (sm *SQLMetric) getChildByLabelConfig(
 ) (ChildMetric, bool) {
 	var childMetric ChildMetric
 	switch sm.labelConfig.Load() {
+	case uint64(metric.LabelConfigDisabled):
+		return nil, false
 	case uint64(metric.LabelConfigDB):
 		childMetric = sm.getOrAddChild(f, db)
 		return childMetric, true

--- a/pkg/util/metric/aggmetric/histogram.go
+++ b/pkg/util/metric/aggmetric/histogram.go
@@ -294,6 +294,11 @@ func (sh *SQLHistogram) GetMetadata() metric.Metadata {
 
 // Inspect is part of the metric.Iterable interface.
 func (sh *SQLHistogram) Inspect(f func(interface{})) {
+	func() {
+		sh.ticker.Lock()
+		defer sh.ticker.Unlock()
+		tick.MaybeTick(&sh.ticker)
+	}()
 	f(sh)
 }
 


### PR DESCRIPTION
Previously, we were not performing tick/rotate histogram during persisting parent histogram metrics. This was resulting higher quantile values for recorded parent metrics values. This patch introduces changes which make sure to tick/rotate if next tick time is before current time. This aligned with existing agg histogram persistence.

Fixes: #145056
Epic: CRDB-43153
Release note: None

---
(failure) before changes:
<img width="1914" alt="failure before changes" src="https://github.com/user-attachments/assets/2d3d2d52-3c05-4a45-ae24-de4c609663ed" />

(success) after changes (first run):
<img width="1894" alt="success after changes (run 1)" src="https://github.com/user-attachments/assets/94c0338d-1400-41ed-aa8f-6d128685f5d2" />

(success) after changes (second run):
<img width="1885" alt="success after changes (run 2)" src="https://github.com/user-attachments/assets/35a11e9b-ff57-4ace-8555-6c933fb122b5" />
