### PR TITLE
log: increase read bytes for log format extraction

### DIFF
--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -122,7 +122,7 @@ func ReadFormatFromLogFile(in io.Reader) (read io.Reader, format string, err err
 	var buf bytes.Buffer
 	rest := bufio.NewReader(in)
 	r := io.TeeReader(rest, &buf)
-	const headerBytes = 8096
+	const headerBytes = 4 * 8192
 	header := make([]byte, headerBytes)
 	n, err := r.Read(header)
 	if err != nil {


### PR DESCRIPTION
Previously, we are reading first 8096 bytes from log file to figure of the file format. If the first line has more bytes than 8096 then it will try to decode format from the read 8096 bytes and give log format extraction error. We observed this error when we try to give inline log config using `--log` flag. This patch increases default byte read size to 32768 so that we will read entire first header line to decode the log format.

Fixes: #138842
Release note (bug fix): inline log configuration no longer results in internal errors in db console node's log page (node/{nodeID}/logs).