### PR TITLE
release-25.2: sql/explain: show RLS info for empty VALUES plans

### DIFF
--- a/pkg/sql/opt/exec/explain/emit.go
+++ b/pkg/sql/opt/exec/explain/emit.go
@@ -1422,6 +1422,8 @@ func (e *emitter) emitPolicies(ob *OutputBuilder, table cat.Table, n *Node) {
 
 	if applied.PoliciesSkippedForRole {
 		ob.AddField("policies", "exempt for role")
+	} else if applied.PoliciesFilteredAllRows {
+		ob.AddField("policies", "applied (filtered all rows)")
 	} else if applied.Policies.Len() == 0 {
 		ob.AddField("policies", "row-level security enabled, no policies applied.")
 	} else {

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -93,11 +93,11 @@ SET ROLE rls_accessor
 # ----------------------------------------------------------------------
 
 exec-ddl
-CREATE POLICY "policy 1" ON t1 USING (true);
+CREATE POLICY "policy 1" ON t1 USING (c1 > 0);
 ----
 
 exec-ddl
-CREATE POLICY t2_pol_1 on t2 FOR SELECT USING (true);
+CREATE POLICY t2_pol_1 on t2 FOR SELECT USING (c1 > 0);
 ----
 
 plan
@@ -108,15 +108,32 @@ select count(*) from t1,t2 where t1.c1 = t2.c1;
 └── • hash join
     │ equality: (c1) = (c1)
     │
-    ├── • scan
-    │     table: t1@t1_pkey
-    │     spans: FULL SCAN
-    │     policies: policy 1
+    ├── • filter
+    │   │ filter: c1 > _
+    │   │
+    │   └── • scan
+    │         table: t1@t1_pkey
+    │         spans: FULL SCAN
+    │         policies: policy 1
     │
-    └── • scan
-          table: t2@t2_pkey
-          spans: FULL SCAN
-          policies: t2_pol_1
+    └── • filter
+        │ filter: c1 > _
+        │
+        └── • scan
+              table: t2@t2_pkey
+              spans: FULL SCAN
+              policies: t2_pol_1
+
+# Ensure that when the optimizer replaces a scan with a "norows" VALUES clause
+# due to RLS filtering, the plan still includes appropriate policy information.
+# ----------------------------------------------------------------------
+plan
+select count(*) from t1,t2 where t1.c1 = t2.c1 and t1.c1 < 0;
+----
+• group (scalar)
+│
+└── • norows
+      policies: applied (filtered all rows)
 
 # Add multiple policies on the same table
 # ----------------------------------------------------------------------
@@ -395,10 +412,13 @@ select count(*) from t1,t2 where t1.c1 = t2.c1;
     │     spans: FULL SCAN
     │     policies: exempt for role
     │
-    └── • scan
-          table: t2@t2_pkey
-          spans: FULL SCAN
-          policies: t2_pol_1
+    └── • filter
+        │ filter: c1 > _
+        │
+        └── • scan
+              table: t2@t2_pkey
+              spans: FULL SCAN
+              policies: t2_pol_1
 
 exec-ddl
 ALTER TABLE t1 FORCE ROW LEVEL SECURITY
@@ -417,10 +437,13 @@ select count(*) from t1,t2 where t1.c1 = t2.c1;
     │     spans: FULL SCAN
     │     policies: policy 1, p2, p3, r1, r2
     │
-    └── • scan
-          table: t2@t2_pkey
-          spans: FULL SCAN
-          policies: t2_pol_1
+    └── • filter
+        │ filter: c1 > _
+        │
+        └── • scan
+              table: t2@t2_pkey
+              spans: FULL SCAN
+              policies: t2_pol_1
 
 # Show that policies are shown for UPSERT (and its variations).
 # ----------------------------------------------------------------------

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -551,6 +551,14 @@ type RLSPoliciesApplied struct {
 	// PoliciesSkippedForRole is true if the user is a member of a role that is
 	// exempt from all policies (e.g., admin).
 	PoliciesSkippedForRole bool
+
+	// PoliciesFilteredAllRows is true if RLS was enforced, and although policies
+	// were applied, the result was that no rows were returned (typically represented
+	// by an empty VALUES node). This is used when it's not possible to attribute
+	// the result to specific table-level policy details (e.g., due to an empty
+	// VALUES node replacing a scan).
+	PoliciesFilteredAllRows bool
+
 	// Policies is the list of policy IDs applied to the scan of a single table.
 	// This applies to the table that this annotation was attached to. If this is
 	// empty, it either means policies were skipped due to the role, or none were

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -60,6 +60,30 @@ project
       └── filters
            └── c1:1 > 0
 
+# Introduce a contradiction with the policy expression to verify that
+# the optimizer eliminates the scan.
+build
+SELECT c1 FROM T1 where c1 < 0;
+----
+project
+ ├── columns: c1:1!null
+ └── select
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      ├── select
+      │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    ├── scan t1
+      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │    └── filters
+      │         └── c1:1 > 0
+      └── filters
+           └── c1:1 < 0
+
+opt
+SELECT c1 FROM T1 where c1 < 0;
+----
+values
+ └── columns: c1:1!null
+
 exec-ddl
 DROP POLICY p1 on t1;
 ----


### PR DESCRIPTION
Backport 1/1 commits from #144891 on behalf of @spilchen.

----

Previously, we added RLS policy information to EXPLAIN output by listing the policies applied to scan nodes. However, one case was missed: when a query's WHERE clause contradicts the RLS policy condition (e.g., the policy is a = 1 and the query has a = 0), the optimizer can eliminate the scan and replace it with an empty VALUES node.

In this situation, we were not surfacing any RLS-related information, even though policies were enforced. Additionally, since the VALUES node no longer references a specific table, we can't attribute the outcome to any specific policy by name.

This change adds a catch-all indicator for such cases, displaying:
```
policies: applied (filtered all rows)
```

Fixes #144794

Epic: CRDB-11724
Release note: None

----

Release justification: bug fix that should be included but not until after 25.2.0 ships