### PR TITLE
sql/rls: apply SELECT policies for UPDATE only if columns are referenced

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -4337,6 +4337,172 @@ DROP USER ups;
 
 subtest end
 
+# An UPDATE statement enforces SELECT policies on new rows if columns are
+# referenced in SET or WHERE expressions, or if a RETURNING clause is present.
+subtest update_with_no_select_policies
+
+statement ok
+CREATE ROLE alice LOGIN;
+
+statement ok
+CREATE ROLE bob LOGIN;
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b BOOL,
+  FAMILY f (k, a, b)
+);
+
+statement ok
+INSERT INTO t VALUES (1, 10, true);
+
+statement ok
+GRANT SELECT, INSERT, UPDATE, DELETE ON t TO alice, bob;
+
+statement ok
+ALTER TABLE t ENABLE ROW LEVEL SECURITY;
+
+# Include in the policy a column ('b') that is not referenced or modified by any
+# UPDATE statements, except within the policy expression itself.
+statement ok
+CREATE POLICY select_policy_alice
+ON t
+FOR SELECT
+TO alice
+USING (a > 0 AND b IS true);
+
+statement ok
+CREATE POLICY update_policy_alice
+ON t
+FOR UPDATE
+TO alice
+USING (true);
+
+statement ok
+CREATE POLICY select_policy_bob
+ON t
+FOR SELECT
+TO bob
+USING (true);
+
+statement ok
+CREATE POLICY update_policy_bob
+ON t
+FOR UPDATE
+TO bob
+USING (true);
+
+statement ok
+SET ROLE alice;
+
+statement ok
+UPDATE t SET a = 0 WHERE true;
+
+statement ok
+SET ROLE bob;
+
+query II
+SELECT k, a FROM t;
+----
+1 0
+
+statement ok
+SET ROLE alice;
+
+# TODO(145894): This UPDATE is incorrectly filtered by SELECT policies, even
+# though no columns are referenced in SET or WHERE. Unlike postgres, we apply
+# policies unnecessarily.
+statement ok
+UPDATE t SET a = -1 WHERE true;
+
+statement ok
+SET ROLE bob;
+
+query II
+SELECT k, a FROM t;
+----
+1 0
+
+# Reset the row.
+statement ok
+UPDATE t SET k = 1, a = 10 WHERE true;
+
+statement ok
+SET ROLE alice;
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = a - 10 WHERE true;
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE k = 1;
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE true RETURNING k;
+
+# TODO(144951): the RETURNING clause doesn't reference a column, so the SELECT
+# policy shouldn't apply.
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE true RETURNING 'foo';
+
+statement ok
+SET ROLE root;
+
+# Create another table to test UPDATE .. FROM. Confirm that SELECT policies on 't'
+# are not applied, even if the UPDATE references columns from this table.
+statement ok
+CREATE TABLE other (k INT PRIMARY KEY, a INT);
+
+# Insert a row into 'other' that will cause the UPDATE on 't' to violate its
+# SELECT policies. The second column will be used in the SET clause when
+# updating 't'.
+statement ok
+INSERT INTO other VALUES (1, -1);
+
+statement ok
+GRANT ALL ON other TO alice;
+
+statement ok
+SET ROLE alice;
+
+statement ok
+UPDATE t SET a = other.a FROM other WHERE true;
+
+statement ok
+SET ROLE root;
+
+query I
+SELECT a FROM t;
+----
+-1
+
+# Reset the row.
+statement ok
+UPDATE t SET k = 1, a = 10 WHERE true;
+
+statement ok
+SET ROLE alice;
+
+statement ok
+UPDATE t SET a = -2 FROM other WHERE other.k = 1;
+
+statement ok
+SET ROLE root;
+
+query I
+SELECT a FROM t;
+----
+-2
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP TABLE other;
+
+statement ok
+DROP ROLE alice, bob;
 
 subtest policy_with_schema_locked
 

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -350,6 +350,26 @@ UPDATE writer SET value = value WHERE key = 5;
           locking strength: for update
           policies: p_select, p_update1
 
+# Should not apply select policy for the new row because columns weren't
+# referenced in the SET or WHERE clause.
+plan
+UPDATE writer SET key = 10 WHERE true;
+----
+• update
+│ table: writer
+│ set: key
+│ auto commit
+│ policies: p_update1, p_update2
+│
+└── • render
+    │
+    └── • scan
+          table: writer@writer_pkey
+          spans: 1+ spans
+          locking strength: for update
+          policies: p_select, p_update1
+
+
 # Show policy information for delete
 # ----------------------------------------------------------------------
 

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -515,7 +515,7 @@ func (cb *onDeleteSetBuilder) Build(
 					updateExprs[i].Expr = tree.DefaultVal{}
 				}
 			}
-			mb.addUpdateCols(updateExprs)
+			mb.addUpdateCols(updateExprs, nil /* colRefs */)
 
 			// Register the mutation with the statementTree
 			b.checkMultipleMutations(mb.tab, generalMutation)
@@ -528,7 +528,7 @@ func (cb *onDeleteSetBuilder) Build(
 			// cases this is safe (e.g. other cascades could have messed with the parent
 			// table in the meantime).
 			// The exempt policy is used for RLS to maintain data integrity.
-			mb.buildUpdate(nil /* returning */, cat.PolicyScopeExempt)
+			mb.buildUpdate(nil /* returning */, cat.PolicyScopeExempt, nil /* colRefs */)
 			return mb.outScope.expr
 		})
 }
@@ -776,7 +776,7 @@ func (cb *onUpdateCascadeBuilder) Build(
 					panic(errors.AssertionFailedf("unsupported action"))
 				}
 			}
-			mb.addUpdateCols(updateExprs)
+			mb.addUpdateCols(updateExprs, nil /* colRefs */)
 
 			// Register the mutation with the statementTree
 			b.checkMultipleMutations(mb.tab, generalMutation)
@@ -785,7 +785,7 @@ func (cb *onUpdateCascadeBuilder) Build(
 			mb.buildRowLevelBeforeTriggers(tree.TriggerEventUpdate, true /* cascade */)
 
 			// The exempt policy is used for RLS to maintain data integrity.
-			mb.buildUpdate(nil /* returning */, cat.PolicyScopeExempt)
+			mb.buildUpdate(nil /* returning */, cat.PolicyScopeExempt, nil /* colRefs */)
 			return mb.outScope.expr
 		})
 }

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -389,7 +389,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		mb.addTargetColsForUpdate(ins.OnConflict.Exprs)
 
 		// Build each of the SET expressions.
-		mb.addUpdateCols(ins.OnConflict.Exprs)
+		mb.addUpdateCols(ins.OnConflict.Exprs, nil /* colRefs */)
 
 		// Project row-level BEFORE triggers for UPDATE.
 		mb.buildRowLevelBeforeTriggers(tree.TriggerEventUpdate, false /* cascade */)
@@ -762,7 +762,7 @@ func (mb *mutationBuilder) buildInsert(
 
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols(false, /* isUpdate */
-		cat.PolicyScopeInsert, returning != nil || hasOnConflict /* includeSelectOnInsert */)
+		cat.PolicyScopeInsert, returning != nil || hasOnConflict /* includeSelectPolicies */)
 
 	// Project partial index PUT boolean columns.
 	mb.projectPartialIndexPutCols()
@@ -968,7 +968,7 @@ func (mb *mutationBuilder) buildUpsert(returning *tree.ReturningExprs) {
 
 	// Add any check constraint boolean columns to the input.
 	mb.addCheckConstraintCols(false, /* isUpdate */
-		cat.PolicyScopeUpsert, false /* includeSelectOnInsert */)
+		cat.PolicyScopeUpsert, false /* includeSelectPolicies */)
 
 	// Add the partial index predicate expressions to the table metadata.
 	// These expressions are used to prune fetch columns during
@@ -1105,5 +1105,5 @@ func (mb *mutationBuilder) buildOnConflictWhereClause(
 			Right: whereClause.Expr,
 		},
 	}
-	mb.b.buildWhere(where, mb.outScope)
+	mb.b.buildWhere(where, mb.outScope, nil /* colRefs */)
 }

--- a/pkg/sql/opt/optbuilder/limit.go
+++ b/pkg/sql/opt/optbuilder/limit.go
@@ -22,14 +22,14 @@ func (b *Builder) buildLimit(limit *tree.Limit, parentScope, inScope *scope) {
 	if limit.Offset != nil {
 		input := inScope.expr
 		offset := b.resolveAndBuildScalar(
-			limit.Offset, types.Int, exprKindOffset, tree.RejectSpecial, parentScope,
+			limit.Offset, types.Int, exprKindOffset, tree.RejectSpecial, parentScope, nil, /* colRefs */
 		)
 		inScope.expr = b.factory.ConstructOffset(input, offset, inScope.makeOrderingChoice())
 	}
 	if limit.Count != nil {
 		input := inScope.expr
 		limit := b.resolveAndBuildScalar(
-			limit.Count, types.Int, exprKindLimit, tree.RejectSpecial, parentScope,
+			limit.Count, types.Int, exprKindLimit, tree.RejectSpecial, parentScope, nil, /* colRefs */
 		)
 		inScope.expr = b.factory.ConstructLimit(input, limit, inScope.makeOrderingChoice())
 	}

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1222,7 +1222,7 @@ func (b *Builder) buildSelectClause(
 	fromScope := b.buildFrom(sel.From, lockCtx, inScope)
 
 	b.processWindowDefs(sel, fromScope)
-	b.buildWhere(sel.Where, fromScope)
+	b.buildWhere(sel.Where, fromScope, nil /* colRefs */)
 
 	projectionsScope := fromScope.replace()
 
@@ -1335,9 +1335,13 @@ func (b *Builder) processWindowDefs(sel *tree.SelectClause, fromScope *scope) {
 
 // buildWhere builds a set of memo groups that represent the given WHERE clause.
 //
+// colRefs is an optional output parameter that, if provided, is populated
+// with the columns referenced in the WHERE clause expression. Pass nil if the
+// referenced columns are not needed.
+//
 // See Builder.buildStmt for a description of the remaining input and return
 // values.
-func (b *Builder) buildWhere(where *tree.Where, inScope *scope) {
+func (b *Builder) buildWhere(where *tree.Where, inScope *scope, colRefs *opt.ColSet) {
 	if where == nil {
 		return
 	}
@@ -1348,6 +1352,7 @@ func (b *Builder) buildWhere(where *tree.Where, inScope *scope) {
 		exprKindWhere,
 		tree.RejectGenerators|tree.RejectWindowApplications|tree.RejectProcedures,
 		inScope,
+		colRefs,
 	)
 
 	// Wrap the filter in a FiltersOp.

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -156,6 +156,288 @@ update t1
       └── projections
            └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
 
+# Verify that UPDATE applies SELECT policies if columns are referenced in SET or
+# WHERE, or if a RETURNING clause is present (regardless of column references).
+
+build
+UPDATE T1 SET c1 = 2 WHERE true;
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── update-mapping:
+ │    └── c1_new:13 => c1:1
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+      ├── project
+      │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── select
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── select
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── scan t1
+      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    └── filters
+      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    └── filters
+      │    │         └── true
+      │    └── projections
+      │         └── 2 [as=c1_new:13]
+      └── projections
+           └── c1_new:13 < 100 [as=rls:14]
+
+build
+UPDATE T1 SET c1 = 2 WHERE true RETURNING 'foo';
+----
+project
+ ├── columns: "?column?":15!null
+ ├── update t1
+ │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null
+ │    ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ │    ├── update-mapping:
+ │    │    └── c1_new:13 => c1:1
+ │    ├── return-mapping:
+ │    │    ├── c1_new:13 => c1:1
+ │    │    ├── c2:8 => c2:2
+ │    │    ├── c3:9 => c3:3
+ │    │    └── rowid:10 => rowid:4
+ │    ├── check columns: rls:14
+ │    └── project
+ │         ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+ │         ├── project
+ │         │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    ├── select
+ │         │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    ├── select
+ │         │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    │    ├── scan t1
+ │         │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    │    │    └── flags: avoid-full-scan
+ │         │    │    │    └── filters
+ │         │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+ │         │    │    └── filters
+ │         │    │         └── true
+ │         │    └── projections
+ │         │         └── 2 [as=c1_new:13]
+ │         └── projections
+ │              └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
+ └── projections
+      └── 'foo' [as="?column?":15]
+
+build
+UPDATE T1 SET c1 = c1 + 1 WHERE true;
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── update-mapping:
+ │    └── c1_new:13 => c1:1
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+      ├── project
+      │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── select
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── select
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── scan t1
+      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    └── filters
+      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    └── filters
+      │    │         └── true
+      │    └── projections
+      │         └── c1:7 + 1 [as=c1_new:13]
+      └── projections
+           └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
+
+build
+UPDATE T1 SET c1 = 2 WHERE c1 > 0;
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── update-mapping:
+ │    └── c1_new:13 => c1:1
+ ├── check columns: rls:14
+ └── project
+      ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+      ├── project
+      │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    ├── select
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    ├── select
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    ├── scan t1
+      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    └── filters
+      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    └── filters
+      │    │         └── c1:7 > 0
+      │    └── projections
+      │         └── 2 [as=c1_new:13]
+      └── projections
+           └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
+
+build
+UPDATE T1 SET c1 = 2 WHERE true RETURNING c1;
+----
+project
+ ├── columns: c1:1!null
+ └── update t1
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null
+      ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+      ├── update-mapping:
+      │    └── c1_new:13 => c1:1
+      ├── return-mapping:
+      │    ├── c1_new:13 => c1:1
+      │    ├── c2:8 => c2:2
+      │    ├── c3:9 => c3:3
+      │    └── rowid:10 => rowid:4
+      ├── check columns: rls:14
+      └── project
+           ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+           ├── project
+           │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+           │    ├── select
+           │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+           │    │    ├── select
+           │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+           │    │    │    ├── scan t1
+           │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+           │    │    │    │    └── flags: avoid-full-scan
+           │    │    │    └── filters
+           │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+           │    │    └── filters
+           │    │         └── true
+           │    └── projections
+           │         └── 2 [as=c1_new:13]
+           └── projections
+                └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
+
+exec-ddl
+CREATE TABLE other (k INT PRIMARY KEY, a INT);
+----
+
+# Ensure that column references to the 'other' table in the SET expression
+# do not result in the SELECT policy being applied.
+build
+UPDATE T1 SET c1 = other.a FROM other WHERE true;
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── passthrough columns: k:13 a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+ ├── update-mapping:
+ │    └── a:14 => c1:1
+ ├── check columns: rls:17
+ └── project
+      ├── columns: rls:17 c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      ├── distinct-on
+      │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    ├── grouping columns: rowid:10!null
+      │    ├── select
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    ├── inner-join (cross)
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    │    ├── select
+      │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │    ├── scan t1
+      │    │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    └── filters
+      │    │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    ├── scan other
+      │    │    │    │    └── columns: k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    │    └── filters (true)
+      │    │    └── filters
+      │    │         └── true
+      │    └── aggregations
+      │         ├── first-agg [as=c1:7]
+      │         │    └── c1:7
+      │         ├── first-agg [as=c2:8]
+      │         │    └── c2:8
+      │         ├── first-agg [as=c3:9]
+      │         │    └── c3:9
+      │         ├── first-agg [as=t1.crdb_internal_mvcc_timestamp:11]
+      │         │    └── t1.crdb_internal_mvcc_timestamp:11
+      │         ├── first-agg [as=t1.tableoid:12]
+      │         │    └── t1.tableoid:12
+      │         ├── first-agg [as=k:13]
+      │         │    └── k:13
+      │         ├── first-agg [as=a:14]
+      │         │    └── a:14
+      │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:15]
+      │         │    └── other.crdb_internal_mvcc_timestamp:15
+      │         └── first-agg [as=other.tableoid:16]
+      │              └── other.tableoid:16
+      └── projections
+           └── a:14 < 100 [as=rls:17]
+
+# Ensure that column references to the 'other' table in the WHERE clause
+# do not result in the SELECT policy being applied.
+build
+UPDATE T1 SET c1 = -2 FROM other WHERE other.k = 1;
+----
+update t1
+ ├── columns: <none>
+ ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+ ├── passthrough columns: k:13 a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+ ├── update-mapping:
+ │    └── c1_new:17 => c1:1
+ ├── check columns: rls:18
+ └── project
+      ├── columns: rls:18!null c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16 c1_new:17!null
+      ├── project
+      │    ├── columns: c1_new:17!null c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    ├── distinct-on
+      │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    ├── grouping columns: rowid:10!null
+      │    │    ├── select
+      │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    │    ├── inner-join (cross)
+      │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │    │    ├── scan t1
+      │    │    │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    │    ├── scan other
+      │    │    │    │    │    └── columns: k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      │    │    │    │    └── filters (true)
+      │    │    │    └── filters
+      │    │    │         └── k:13 = 1
+      │    │    └── aggregations
+      │    │         ├── first-agg [as=c1:7]
+      │    │         │    └── c1:7
+      │    │         ├── first-agg [as=c2:8]
+      │    │         │    └── c2:8
+      │    │         ├── first-agg [as=c3:9]
+      │    │         │    └── c3:9
+      │    │         ├── first-agg [as=t1.crdb_internal_mvcc_timestamp:11]
+      │    │         │    └── t1.crdb_internal_mvcc_timestamp:11
+      │    │         ├── first-agg [as=t1.tableoid:12]
+      │    │         │    └── t1.tableoid:12
+      │    │         ├── first-agg [as=k:13]
+      │    │         │    └── k:13
+      │    │         ├── first-agg [as=a:14]
+      │    │         │    └── a:14
+      │    │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:15]
+      │    │         │    └── other.crdb_internal_mvcc_timestamp:15
+      │    │         └── first-agg [as=other.tableoid:16]
+      │    │              └── other.tableoid:16
+      │    └── projections
+      │         └── -2 [as=c1_new:17]
+      └── projections
+           └── c1_new:17 < 100 [as=rls:18]
+
 # Verify a DELETE won't use policies for UPDATE.
 
 build
@@ -283,7 +565,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── true AND (column1:7 > 0) [as=rls:11]
+           └── column1:7 > 0 [as=rls:11]
 
 # Verify policies apply to table with an existing check constraint.
 
@@ -321,7 +603,7 @@ insert t1_with_check
       │         └── unique_rowid() [as=rowid_default:8]
       └── projections
            ├── column1:6 > 0 [as=check1:9]
-           └── true AND (c2_default:7 > 2) [as=rls:10]
+           └── c2_default:7 > 2 [as=rls:10]
 
 # Verify a policy that has no WITH CHECK will use the USING expression for new rows.
 
@@ -360,7 +642,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── true AND ((c2_default:8 = 'Hello, World') OR (c3_default:9 = '2024-12-24')) [as=rls:11]
+           └── (c2_default:8 = 'Hello, World') OR (c3_default:9 = '2024-12-24') [as=rls:11]
 
 build
 UPDATE t1 SET c2 = 'new val';
@@ -385,7 +667,7 @@ update t1
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections
-           └── (true OR ((c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24'))) AND ((c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24')) [as=rls:14]
+           └── (c2_new:13 = 'Hello, World') OR (c3:9 = '2024-12-24') [as=rls:14]
 
 # Verify insert and update code path when no policy applies to role.
 
@@ -416,7 +698,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── true AND false [as=rls:11]
+           └── false [as=rls:11]
 
 build
 UPDATE t1 SET c2 = 'new val';
@@ -441,7 +723,7 @@ update t1
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections
-           └── true AND false [as=rls:14]
+           └── false [as=rls:14]
 
 # Verify that an INSERT ... SELECT statement applies the RLS check constraint
 # and uses different policies for the SELECT and INSERT portions of the query.
@@ -484,7 +766,7 @@ insert t1
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:13]
       └── projections
-           └── true AND (char_length(c2:8) < 10) [as=rls:14]
+           └── char_length(c2:8) < 10 [as=rls:14]
 
 # Apply SELECT policies on inserted rows if a RETURNING clause is present.
 # The first case handles inserts without RETURNING; the second handles inserts
@@ -513,7 +795,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── true AND (char_length(c2_default:8) < 10) [as=rls:11]
+           └── char_length(c2_default:8) < 10 [as=rls:11]
 
 build
 INSERT INTO t1(c1) VALUES (10) RETURNING c1, c2;
@@ -894,7 +1176,7 @@ insert t1_explicit_pk
       │    ├── columns: column1:6!null column2:7!null column3:8!null
       │    └── (8, 'eight', '2002-05-04')
       └── projections
-           └── true AND ((((((column1:6 = 1) OR (column1:6 = 2)) OR (column1:6 = 3)) OR (column1:6 = 4)) AND ((column1:6 % 2) = 0)) AND ((column1:6 % 3) = 0)) [as=rls:9]
+           └── (((((column1:6 = 1) OR (column1:6 = 2)) OR (column1:6 = 3)) OR (column1:6 = 4)) AND ((column1:6 % 2) = 0)) AND ((column1:6 % 3) = 0) [as=rls:9]
 
 build
 UPDATE t1_explicit_pk SET c3 = 'updated value' WHERE c1 = 18;
@@ -1022,7 +1304,7 @@ insert t1
       │         ├── NULL::DATE [as=c3_default:9]
       │         └── unique_rowid() [as=rowid_default:10]
       └── projections
-           └── true AND (c3_default:9 >= '2025-01-01') [as=rls:11]
+           └── c3_default:9 >= '2025-01-01' [as=rls:11]
 
 # Tests for when stored virtual column is used in an RLS expression
 
@@ -1129,7 +1411,7 @@ insert t
       │    └── projections
       │         └── column4:11 + 1 [as=v_comp:12]
       └── projections
-           └── true AND (v_comp:12 > 1) [as=rls:13]
+           └── v_comp:12 > 1 [as=rls:13]
 
 build
 UPDATE t SET c = -10 WHERE k = 1;
@@ -1273,7 +1555,7 @@ insert t
       │    └── projections
       │         └── column4:11 + 1 [as=v_comp:12]
       └── projections
-           └── true AND (v_comp:12 > 1) [as=rls:13]
+           └── v_comp:12 > 1 [as=rls:13]
 
 build
 UPDATE t SET c = -10 WHERE k = 1;

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -445,6 +445,7 @@ func (b *Builder) resolveAndBuildScalar(
 	context exprKind,
 	flags tree.SemaRejectFlags,
 	inScope *scope,
+	colRefs *opt.ColSet,
 ) opt.ScalarExpr {
 	// We need to save and restore the previous value of the field in
 	// semaCtx in case we are recursively called within a subquery
@@ -454,7 +455,7 @@ func (b *Builder) resolveAndBuildScalar(
 
 	inScope.context = context
 	texpr := inScope.resolveAndRequireType(expr, requiredType)
-	return b.buildScalar(texpr, inScope, nil, nil, nil)
+	return b.buildScalar(texpr, inScope, nil, nil, colRefs)
 }
 
 // In Postgres, qualifying an object name with pg_temp is equivalent to explicitly


### PR DESCRIPTION
Previously, SELECT policies were applied for the new updated row on every UPDATE operation, regardless of whether any columns were referenced in the SET or WHERE clauses. This behavior was inconsistent with postgres, where SELECT policies should only be applied if an UPDATE references a column in either the SET or WHERE expression.

Note: This change does not yet handle the RETURNING clause, which will be addressed separately.

Fixes #144943

Epic: CRDB-11724
Release note (bug fix): SELECT policies during UPDATE operations are now only applied when referenced columns appear in the SET or WHERE clauses, matching postgres' behavior. This improves compatibility.