### PR TITLE
release-24.1: changefeedccl: fix mock kafka server shutdown

### DIFF
--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -1813,11 +1813,15 @@ func (s *fakeKafkaSinkV2) Dial() error {
 			if m.Key != nil {
 				key = sarama.ByteEncoder(m.Key)
 			}
-			s.feedCh <- &sarama.ProducerMessage{
+			select {
+			case <-ctx.Done():
+				return kgo.ProduceResults{kgo.ProduceResult{Err: ctx.Err()}}
+			case s.feedCh <- &sarama.ProducerMessage{
 				Topic:     m.Topic,
 				Key:       key,
 				Value:     sarama.ByteEncoder(m.Value),
 				Partition: m.Partition,
+			}:
 			}
 		}
 		return nil


### PR DESCRIPTION
Backport 1/1 commits from #144497.

/cc @cockroachdb/release

Release justification: test-only fix

---

Fix a test timeout due to a batching sink worker
being blocked on Flush after the context was
cancelled.

Fixes: #144213

Release note: None

