### PR TITLE
requestbatcher,intentresolver: set tenant ID on outbound context

### DIFF
--- a/pkg/internal/client/requestbatcher/BUILD.bazel
+++ b/pkg/internal/client/requestbatcher/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/internal/client/requestbatcher",
     visibility = ["//pkg:__subpackages__"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
@@ -22,6 +23,7 @@ go_test(
     srcs = ["batcher_test.go"],
     embed = [":requestbatcher"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
         "//pkg/testutils",

--- a/pkg/kv/kvserver/intentresolver/BUILD.bazel
+++ b/pkg/kv/kvserver/intentresolver/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/kv/kvserver/intentresolver/admission.go
+++ b/pkg/kv/kvserver/intentresolver/admission.go
@@ -146,14 +146,13 @@ import "github.com/cockroachdb/cockroach/pkg/settings"
 // resolve using priority +10 and will acquire subsequent intents with
 // priority +10.
 
-// sendImmediatelyBypassAdmissionControl sets the admission control behavior
-// for the less commonly used sendImmediately option. Since that option is
-// used when a waiter on the lock table is trying to resolve one intent, and
-// the waiter has already been admitted, the default is to bypass admission
-// control.
-var sendImmediatelyBypassAdmissionControl = settings.RegisterBoolSetting(
+// sendOneImmediatelyBypassAdmissionControl sets the admission control behavior
+// for the less commonly used sendOneImmediately option. Since that option is
+// used when a waiter on the lock table is trying to resolve one intent, and the
+// waiter has already been admitted, the default is to bypass admission control.
+var sendOneImmediatelyBypassAdmissionControl = settings.RegisterBoolSetting(
 	settings.SystemOnly, "kv.intent_resolver.send_immediately.bypass_admission_control.enabled",
-	"determines whether the sendImmediately option on intent resolution bypasses admission control",
+	"determines whether the sendOneImmediately option on intent resolution bypasses admission control",
 	true)
 
 // batchBypassAdmissionControl sets the admission control behavior for the


### PR DESCRIPTION
Previously, the tenant ID was not set on the outbound client context for
intent resolution on a range. In a multi-tenant cluster, this would
incorrectly associate intent resolution with the system tenant
exclusively.

Set the tenant ID, when applicable, to the tenant associated with the
range.

For batched resolution, the tenant ID is set per-range in the
RequestBatcher. For point intent resolution, which is more performance
sensitive, the same tenant ID is duplicated inline in the
IntentResolver.

Fixes https://github.com/cockroachdb/cockroach/issues/135853.

Epic: None.

Release note (bug fix): In a multi-tenant cluster, intent resolution
resource consumption is now associated with the tenant for the range on
which the intents are being resolved. Previously it was always charged
to the system tenant.