### PR TITLE
kvserver,kvcoord: remove wrapping of some hot-path errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -3121,7 +3121,7 @@ func (ds *DistSender) sendToReplicas(
 			if ambiguousError != nil {
 				err = kvpb.NewAmbiguousResultError(errors.Wrapf(ambiguousError, "context done during DistSender.Send"))
 			} else {
-				err = errors.Wrap(ctx.Err(), "aborted during DistSender.Send")
+				err = ctx.Err()
 			}
 			log.Eventf(ctx, "%v", err)
 			return nil, err

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -428,7 +428,7 @@ func (r *Replica) executeBatchWithConcurrencyRetries(
 	for {
 		// Exit loop if context has been canceled or timed out.
 		if err := ctx.Err(); err != nil {
-			return nil, nil, kvpb.NewError(errors.Wrap(err, "aborted during Replica.Send"))
+			return nil, nil, kvpb.NewError(err)
 		}
 
 		// Determine the maximal set of key spans that the batch will operate on.


### PR DESCRIPTION
We have seen some error wrapping show up prominently in CPU profiles in at least one escalation. This can be particulary expensive on the hot path of context cancelations for requests when the cluster is experiencing issues (e.g. overload).

This commit removes the wrapping for a couple of these cases: one on the server side, and one on the client side.

Fixes: #143442

Release note: None