### PR TITLE
trace segfault repro

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -21,6 +21,7 @@ import (
 	"path"
 	"reflect"
 	"regexp"
+	"runtime/trace"
 	"slices"
 	"sort"
 	"strconv"
@@ -4538,6 +4539,20 @@ func TestChangefeedEnrichedSourceWithDataAvro(t *testing.T) {
 }
 
 func TestChangefeedEnrichedSourceWithDataJSON(t *testing.T) {
+	tf, err := os.CreateTemp("", "")
+	require.NoError(t, err)
+	require.NoError(t, trace.Start(tf))
+	defer tf.Close()
+
+	defer func() {
+		trace.Stop()
+		if t.Failed() {
+			t.Logf("trace file: %s", tf.Name())
+		} else {
+			require.NoError(t, os.Remove(tf.Name()))
+		}
+	}()
+
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
run: `until 2>&1 ./dev test pkg/ccl/changefeedccl -f 'TestChangefeedEnrichedSourceWithDataJSON' --stress | tee /proc/$$/fd/1 | grep -i 'segmentation' ; do sleep 1; done`

ignore the leaked goroutines error -- that's the one i wanted to collect traces for.

encountered on my gceworker. example incidence:
[segtrace.log.gz](https://github.com/user-attachments/files/19947180/segtrace.log.gz)
