### PR TITLE
release-25.2: vecindex: fix bugs found during testing of vector indexes

### DIFF
--- a/pkg/sql/vecindex/cspann/fixup_processor.go
+++ b/pkg/sql/vecindex/cspann/fixup_processor.go
@@ -287,9 +287,10 @@ func (fp *FixupProcessor) DelayInsertOrDelete(ctx context.Context) error {
 
 // AddDeleteVector enqueues a vector deletion fixup for later processing.
 func (fp *FixupProcessor) AddDeleteVector(
-	ctx context.Context, partitionKey PartitionKey, vectorKey KeyBytes,
+	ctx context.Context, treeKey TreeKey, partitionKey PartitionKey, vectorKey KeyBytes,
 ) {
 	fp.addFixup(ctx, fixup{
+		TreeKey:      treeKey,
 		Type:         vectorDeleteFixup,
 		PartitionKey: partitionKey,
 		VectorKey:    vectorKey,

--- a/pkg/sql/vecindex/cspann/fixup_processor.go
+++ b/pkg/sql/vecindex/cspann/fixup_processor.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 	"runtime"
+	"slices"
 	"sync"
 	"time"
 
@@ -290,7 +291,8 @@ func (fp *FixupProcessor) AddDeleteVector(
 	ctx context.Context, treeKey TreeKey, partitionKey PartitionKey, vectorKey KeyBytes,
 ) {
 	fp.addFixup(ctx, fixup{
-		TreeKey:      treeKey,
+		// Clone the tree key, since we don't own the memory.
+		TreeKey:      slices.Clone(treeKey),
 		Type:         vectorDeleteFixup,
 		PartitionKey: partitionKey,
 		VectorKey:    vectorKey,
@@ -306,7 +308,8 @@ func (fp *FixupProcessor) AddSplit(
 	singleStep bool,
 ) {
 	fp.addFixup(ctx, fixup{
-		TreeKey:            treeKey,
+		// Clone the tree key, since we don't own the memory.
+		TreeKey:            slices.Clone(treeKey),
 		Type:               splitFixup,
 		ParentPartitionKey: parentPartitionKey,
 		PartitionKey:       partitionKey,
@@ -323,7 +326,8 @@ func (fp *FixupProcessor) AddMerge(
 	singleStep bool,
 ) {
 	fp.addFixup(ctx, fixup{
-		TreeKey:            treeKey,
+		// Clone the tree key, since we don't own the memory.
+		TreeKey:            slices.Clone(treeKey),
 		Type:               mergeFixup,
 		ParentPartitionKey: parentPartitionKey,
 		PartitionKey:       partitionKey,

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -1107,17 +1107,6 @@ func (vi *Index) Format(
 	return buf.String(), nil
 }
 
-// ensureSliceCap returns a slice of length = 0, of the given capacity and
-// generic type. If the existing slice has enough capacity, that slice is
-// returned after setting its length to zero. Otherwise, a new, larger slice is
-// allocated.
-func ensureSliceCap[T any](s []T, c int) []T {
-	if cap(s) < c {
-		return make([]T, 0, c)
-	}
-	return s[:0]
-}
-
 // ensureSliceLen returns a slice of the given length and generic type. If the
 // existing slice has enough capacity, that slice is returned after adjusting
 // its length. Otherwise, a new, larger slice is allocated.

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -921,8 +921,8 @@ func (vi *Index) getFullVectors(
 			// the case of a dangling partition key.
 			if candidates[i].ChildKey.KeyBytes != nil {
 				// Vector was deleted, so add fixup to delete it.
-				vi.fixups.AddDeleteVector(
-					ctx, candidates[i].ParentPartitionKey, candidates[i].ChildKey.KeyBytes)
+				vi.fixups.AddDeleteVector(ctx, idxCtx.treeKey,
+					candidates[i].ParentPartitionKey, candidates[i].ChildKey.KeyBytes)
 			}
 
 			// Move the last candidate to the current position and reduce size

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -350,6 +350,10 @@ func (vi *Index) Close() {
 // before Insert when a vector is updated. Even then, it's not guaranteed that
 // Delete will find the old vector. The search set handles this rare case by
 // filtering out results with duplicate key bytes.
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
+// TODO(andyk): This is not true of the MemStore.
 func (vi *Index) Insert(
 	ctx context.Context, idxCtx *Context, treeKey TreeKey, vec vector.T, key KeyBytes,
 ) error {
@@ -393,6 +397,10 @@ func (vi *Index) Insert(
 //
 // NOTE: Even if the vector is removed, there may still be duplicate dangling
 // instances of the vector still remaining in the index.
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
+// TODO(andyk): This is not true of the MemStore.
 func (vi *Index) Delete(
 	ctx context.Context, idxCtx *Context, treeKey TreeKey, vec vector.T, key KeyBytes,
 ) (deleted bool, err error) {
@@ -423,6 +431,10 @@ func (vi *Index) Delete(
 // and returns them in the search set. Set searchSet.MaxResults to limit the
 // number of results. This is called within the scope of a transaction so that
 // the index does not appear to change during the search.
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
+// TODO(andyk): This is not true of the MemStore.
 func (vi *Index) Search(
 	ctx context.Context,
 	idxCtx *Context,
@@ -440,6 +452,10 @@ func (vi *Index) Search(
 // partition, as well as the centroid of the partition (in the Vector field).
 // This is useful for callers that directly insert KV rows rather than using
 // this library to do it.
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
+// TODO(andyk): This is not true of the MemStore.
 func (vi *Index) SearchForInsert(
 	ctx context.Context, idxCtx *Context, treeKey TreeKey, vec vector.T,
 ) (*SearchResult, error) {
@@ -471,6 +487,10 @@ func (vi *Index) SearchForInsert(
 // It returns a single search result containing the key of that partition, or
 // nil if the vector cannot be found. This is useful for callers that directly
 // delete KV rows rather than using this library to do it.
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
+// TODO(andyk): This is not true of the MemStore.
 func (vi *Index) SearchForDelete(
 	ctx context.Context, idxCtx *Context, treeKey TreeKey, vec vector.T, key KeyBytes,
 ) (*SearchResult, error) {

--- a/pkg/sql/vecindex/cspann/searcher.go
+++ b/pkg/sql/vecindex/cspann/searcher.go
@@ -120,8 +120,10 @@ func (s *searcher) Next(ctx context.Context) (ok bool, err error) {
 				maxResults = s.searchSet.MaxResults
 				maxExtraResults = s.searchSet.MaxExtraResults
 				if !s.idxCtx.options.SkipRerank {
-					maxResults = int(math.Ceil(float64(maxResults) * DeletedMultiplier))
-					maxExtraResults = maxResults * RerankMultiplier
+					maxResults, maxExtraResults = IncreaseRerankResults(maxResults)
+					if s.searchSet.MaxExtraResults > maxExtraResults {
+						maxExtraResults = s.searchSet.MaxExtraResults
+					}
 				}
 				if s.idxCtx.level != LeafLevel && s.idxCtx.options.UpdateStats {
 					maxResults = max(maxResults, s.idx.options.QualitySamples)

--- a/pkg/sql/vecindex/cspann/searcher.go
+++ b/pkg/sql/vecindex/cspann/searcher.go
@@ -93,7 +93,7 @@ func (s *searcher) Next(ctx context.Context) (ok bool, err error) {
 			// Next must have been called by an insert operation. This code path
 			// should only be hit when the insert needs to go into the root partition.
 			if root.Level() != s.idxCtx.level-1 {
-				panic(errors.AssertionFailedf("caller passed invalid level %d", s.idxCtx.level))
+				return false, errors.AssertionFailedf("caller passed invalid level %d", s.idxCtx.level)
 			}
 			s.searchSet.Add(&SearchResult{
 				ChildKey: ChildKey{PartitionKey: RootKey},
@@ -479,10 +479,14 @@ func (s *levelSearcher) searchChildPartitions(
 		// In the DrainingForSplit state, the target partitions are still at
 		// the same level as the root partition, so merge their contents into
 		// the search set (which will remove any duplicates).
-		s.idxCtx.tempToSearch = ensureSliceCap(s.idxCtx.tempToSearch, 2)
-		level, err = s.searchChildPartitions(ctx, s.tempResults[:2])
+		targetLevel, err := s.searchChildPartitions(ctx, s.tempResults[:2])
 		if err != nil {
 			return InvalidLevel, err
+		}
+		if targetLevel != level {
+			return InvalidLevel, errors.AssertionFailedf(
+				"target partitions cannot have level %d when DrainingForSplit root has level %d",
+				targetLevel, level)
 		}
 	} else if rootState.State == AddingLevelState {
 		// In the AddingLevel state, the target partitions should be treated as

--- a/pkg/sql/vecindex/cspann/testdata/read-only.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/read-only.ddt
@@ -37,7 +37,7 @@ vec4: 2 (centroid=1.25)
 vec10: 4 (centroid=1.75)
 vec5: 4 (centroid=2.02)
 vec8: 4 (centroid=2.25)
-13 leaf vectors, 16 vectors, 5 full vectors, 4 partitions
+13 leaf vectors, 16 vectors, 13 full vectors, 4 partitions
 
 format-tree
 ----
@@ -71,7 +71,7 @@ search max-results=3 beam-size=3
 vec9: 18 (centroid=4.95)
 vec11: 25 (centroid=2.36)
 vec5: 26 (centroid=2.02)
-13 leaf vectors, 16 vectors, 10 full vectors, 4 partitions
+13 leaf vectors, 16 vectors, 11 full vectors, 4 partitions
 
 format-tree
 ----

--- a/pkg/sql/vecindex/cspann/testdata/search-features.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-features.ddt
@@ -14,7 +14,7 @@ CV stats:
 search max-results=1 use-feature=5000 beam-size=1
 ----
 vec771: 0.5624 (centroid=0.63)
-23 leaf vectors, 43 vectors, 2 full vectors, 4 partitions
+23 leaf vectors, 43 vectors, 12 full vectors, 4 partitions
 
 # Search for additional results.
 search max-results=6 use-feature=5000 beam-size=1
@@ -36,7 +36,7 @@ vec640: 0.6525 (centroid=0.52)
 vec329: 0.6871 (centroid=0.52)
 vec95: 0.7008 (centroid=0.61)
 vec386: 0.7301 (centroid=0.61)
-85 leaf vectors, 141 vectors, 13 full vectors, 13 partitions
+85 leaf vectors, 141 vectors, 18 full vectors, 13 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-feature=5000 beam-size=4 skip-rerank

--- a/pkg/sql/vecindex/cspann/testdata/search-for-insert.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-for-insert.ddt
@@ -108,3 +108,74 @@ format-tree
     ├───• vec2 (7, 4)
     ├───• vec4 (5, 5)
     └───• vec5 (8, 11)
+
+# ----------------------------------------------------------------------
+# Search for insert when tree is empty in various states.
+# ----------------------------------------------------------------------
+
+# Splitting state.
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
+• 1 (0, 0) [Splitting:2,3]
+----
+Loaded 0 vectors.
+
+search-for-insert
+(1, 1)
+----
+partition 1, centroid=(0, 0), sqdist=0
+
+# DrainingForSplit state.
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
+• 1 (0, 0)
+----
+Loaded 0 vectors.
+
+force-split partition-key=1 steps=4
+----
+• 1 (0, 0) [DrainingForSplit:2,3]
+
+search-for-insert
+(1, 1)
+----
+partition 2, centroid=(0, 0), sqdist=2
+
+# AddingLevel state before sub-partitions have been added.
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
+• 1 (0, 0) [AddingLevel:2,3]
+----
+Loaded 0 vectors.
+
+search-for-insert
+(1, 1)
+----
+partition 1, centroid=(0, 0), sqdist=0
+
+# AddingLevel state after sub-partitions have been added.
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
+• 1 (0, 0) [AddingLevel:2,3]
+│
+├───• 2 (1, 1)
+│
+└───• 3 (2, 2)
+----
+Loaded 0 vectors.
+
+search-for-insert
+(1, 1)
+----
+partition 2, centroid=(1, 1), sqdist=0
+
+# DeletingForSplit state.
+load-index min-partition-size=1 max-partition-size=3 beam-size=2
+• 1 (0, 0)
+│
+├───• 2 (1, 1) [DeletingForSplit:2,3]
+│
+└───• 3 (2, 2)
+----
+Loaded 0 vectors.
+
+search-for-insert
+(1, 1)
+----
+partition 3, centroid=(2, 2), sqdist=2

--- a/pkg/sql/vecindex/cspann/testdata/search.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search.ddt
@@ -217,3 +217,64 @@ vec2: 28.1958 ±10.12 (centroid=1.58)
 vec3: 45.6359 ±15.23 (centroid=1.41)
 vec5: 74.3641 ±15.23 (centroid=1.41)
 4 leaf vectors, 7 vectors, 0 full vectors, 3 partitions
+
+# ----------------------------------------------------------------------
+# Search tree with many deleted vectors.
+# ----------------------------------------------------------------------
+new-index min-partition-size=1 max-partition-size=4 beam-size=3
+vec1: (0, 0)
+vec2: (100, 100)
+vec3: (200, 200)
+vec4: (300, 300)
+vec5: (400, 400)
+vec6: (500, 500)
+----
+• 1 (0, 0)
+│
+├───• 5 (450, 450)
+│   │
+│   ├───• vec5 (400, 400)
+│   └───• vec6 (500, 500)
+│
+├───• 3 (50, 50)
+│   │
+│   ├───• vec1 (0, 0)
+│   └───• vec2 (100, 100)
+│
+└───• 4 (250, 250)
+    │
+    ├───• vec3 (200, 200)
+    └───• vec4 (300, 300)
+
+# Delete all but one vector.
+delete not-found
+vec1
+vec2
+vec3
+vec4
+vec5
+----
+• 1 (0, 0)
+│
+├───• 5 (450, 450)
+│   │
+│   ├───• vec5 (MISSING)
+│   └───• vec6 (500, 500)
+│
+├───• 3 (50, 50)
+│   │
+│   ├───• vec1 (MISSING)
+│   └───• vec2 (MISSING)
+│
+└───• 4 (250, 250)
+    │
+    ├───• vec3 (MISSING)
+    └───• vec4 (MISSING)
+
+# Search for the vector that's farthest from vec6, so it's last in the result
+# set. This ensures that DeletedMinCount is working as intended.
+search max-results=1
+(0, 0)
+----
+vec6: 500000 (centroid=70.71)
+6 leaf vectors, 9 vectors, 6 full vectors, 4 partitions

--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -781,7 +781,7 @@ search beam-size=16
 (2, -4)
 ----
 vec5: 0 (centroid=1)
-7 leaf vectors, 17 vectors, 3 full vectors, 11 partitions
+7 leaf vectors, 17 vectors, 5 full vectors, 11 partitions
 
 format-tree
 ----
@@ -820,7 +820,7 @@ search beam-size=16
 (2, -4)
 ----
 vec5: 0 (centroid=1)
-5 leaf vectors, 17 vectors, 3 full vectors, 13 partitions
+5 leaf vectors, 17 vectors, 5 full vectors, 13 partitions
 
 format-tree
 ----
@@ -863,7 +863,7 @@ search beam-size=16
 (2, -4)
 ----
 vec5: 0 (centroid=1)
-5 leaf vectors, 19 vectors, 3 full vectors, 15 partitions
+5 leaf vectors, 19 vectors, 5 full vectors, 15 partitions
 
 format-tree
 ----
@@ -1042,7 +1042,7 @@ search
 vec2: 0 (centroid=0)
 vec6: 0 (centroid=0)
 vec7: 0 (centroid=0)
-5 leaf vectors, 12 vectors, 4 full vectors, 6 partitions
+5 leaf vectors, 12 vectors, 5 full vectors, 6 partitions
 
 format-tree
 ----

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -255,7 +255,7 @@ vec7: 5 (centroid=1.67)
 vec8: 5 (centroid=2.24)
 vec3: 26 (centroid=1.05)
 vec4: 26 (centroid=1.05)
-9 leaf vectors, 13 vectors, 6 full vectors, 5 partitions
+9 leaf vectors, 13 vectors, 9 full vectors, 5 partitions
 
 # Move to the DrainingForSplit state, where sub-partition #6 has vectors.
 force-split partition-key=1 steps=4
@@ -308,7 +308,7 @@ vec7: 5 (centroid=1.67)
 vec8: 5 (centroid=2.24)
 vec3: 26 (centroid=1.05)
 vec4: 26 (centroid=1.05)
-9 leaf vectors, 15 vectors, 6 full vectors, 7 partitions
+9 leaf vectors, 15 vectors, 9 full vectors, 7 partitions
 
 # Move to the point where partition #1 children have been cleared.
 force-split partition-key=1 steps=2
@@ -324,7 +324,7 @@ vec7: 5 (centroid=1.67)
 vec8: 5 (centroid=2.24)
 vec3: 26 (centroid=1.05)
 vec4: 26 (centroid=1.05)
-9 leaf vectors, 13 vectors, 6 full vectors, 7 partitions
+9 leaf vectors, 13 vectors, 9 full vectors, 7 partitions
 
 # Move to the AddingLevel state, where root partition's level has increased.
 force-split partition-key=1 steps=1
@@ -340,7 +340,7 @@ vec7: 5 (centroid=1.67)
 vec8: 5 (centroid=2.24)
 vec3: 26 (centroid=1.05)
 vec4: 26 (centroid=1.05)
-9 leaf vectors, 13 vectors, 6 full vectors, 7 partitions
+9 leaf vectors, 13 vectors, 9 full vectors, 7 partitions
 
 # Move to point where sub-partitions #6 and #7 have been added to the root.
 force-split partition-key=1 steps=4
@@ -381,7 +381,7 @@ vec7: 5 (centroid=1.67)
 vec8: 5 (centroid=2.24)
 vec3: 26 (centroid=1.05)
 vec4: 26 (centroid=1.05)
-9 leaf vectors, 15 vectors, 6 full vectors, 7 partitions
+9 leaf vectors, 15 vectors, 9 full vectors, 7 partitions
 
 # Finish the split.
 force-split partition-key=1 steps=1
@@ -422,7 +422,7 @@ vec7: 5 (centroid=1.67)
 vec8: 5 (centroid=2.24)
 vec3: 26 (centroid=1.05)
 vec4: 26 (centroid=1.05)
-9 leaf vectors, 15 vectors, 6 full vectors, 7 partitions
+9 leaf vectors, 15 vectors, 9 full vectors, 7 partitions
 
 # ----------------------------------------------------------------------
 # Insert into the tree when the root is in splitting states.

--- a/pkg/sql/vecindex/cspann/testdata/split.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split.ddt
@@ -147,7 +147,7 @@ search max-results=3 beam-size=3
 vec7: 2 (centroid=2.12)
 vec10: 5 (centroid=0.71)
 vec12: 9 (centroid=0.71)
-6 leaf vectors, 14 vectors, 5 full vectors, 6 partitions
+6 leaf vectors, 14 vectors, 6 full vectors, 6 partitions
 
 # ----------------------------------------------------------------------
 # Test linking nearby vectors from other partitions.

--- a/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
@@ -106,3 +106,70 @@ format-tree
 ├───• vec1 (1, 2)
 ├───• vec2 (7, 4)
 └───• vec3 (4, 3)
+
+# ----------------------------------------------------------------------
+# Test delete vector fixup in non-default tree.
+# ----------------------------------------------------------------------
+new-index min-partition-size=2 max-partition-size=4 beam-size=2 tree=1
+vec1: (1, 2)
+vec2: (7, 4)
+vec3: (4, 3)
+vec4: (8, 11)
+vec5: (14, 1)
+vec6: (0, 0)
+----
+• 1 (0, 0)
+│
+├───• 2 (1.6667, 1.6667)
+│   │
+│   ├───• vec1 (1, 2)
+│   ├───• vec6 (0, 0)
+│   └───• vec3 (4, 3)
+│
+└───• 3 (9.6667, 5.3333)
+    │
+    ├───• vec4 (8, 11)
+    ├───• vec5 (14, 1)
+    └───• vec2 (7, 4)
+
+# Delete vector from primary index, but not from secondary index.
+delete not-found tree=1
+vec1
+----
+• 1 (0, 0)
+│
+├───• 2 (1.6667, 1.6667)
+│   │
+│   ├───• vec1 (MISSING)
+│   ├───• vec6 (0, 0)
+│   └───• vec3 (4, 3)
+│
+└───• 3 (9.6667, 5.3333)
+    │
+    ├───• vec4 (8, 11)
+    ├───• vec5 (14, 1)
+    └───• vec2 (7, 4)
+
+# Ensure deleted vector is not returned by search. This should enqueue a fixup
+# that removes the vector from the index.
+search max-results=1 tree=1
+(1, 2)
+----
+vec6: 5 (centroid=2.36)
+6 leaf vectors, 8 vectors, 2 full vectors, 3 partitions
+
+# Vector should now be gone from the index.
+format-tree tree=1
+----
+• 1 (0, 0)
+│
+├───• 2 (1.6667, 1.6667)
+│   │
+│   ├───• vec3 (4, 3)
+│   └───• vec6 (0, 0)
+│
+└───• 3 (9.6667, 5.3333)
+    │
+    ├───• vec4 (8, 11)
+    ├───• vec5 (14, 1)
+    └───• vec2 (7, 4)

--- a/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
@@ -156,7 +156,7 @@ search max-results=1 tree=1
 (1, 2)
 ----
 vec6: 5 (centroid=2.36)
-6 leaf vectors, 8 vectors, 2 full vectors, 3 partitions
+6 leaf vectors, 8 vectors, 6 full vectors, 3 partitions
 
 # Vector should now be gone from the index.
 format-tree tree=1

--- a/pkg/sql/vecindex/mutation_searcher.go
+++ b/pkg/sql/vecindex/mutation_searcher.go
@@ -45,6 +45,9 @@ func (s *MutationSearcher) Init(idx *cspann.Index, txn *kv.Txn) {
 // SearchForInsert triggers a search for the partition in which to insert the
 // input vector. The partition's key is returned by PartitionKey() and the
 // input vector's quantized and encoded form is returned by EncodedVector().
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
 func (s *MutationSearcher) SearchForInsert(
 	ctx context.Context, prefix roachpb.Key, vec vector.T,
 ) error {
@@ -73,6 +76,9 @@ func (s *MutationSearcher) SearchForInsert(
 // SearchForDelete triggers a search for the partition which contains the vector
 // to be deleted, identified by its primary key. If the input vector is found,
 // its partition is returned by PartitionKey().
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
 func (s *MutationSearcher) SearchForDelete(
 	ctx context.Context, prefix roachpb.Key, vec vector.T, key cspann.KeyBytes,
 ) error {

--- a/pkg/sql/vecindex/searcher.go
+++ b/pkg/sql/vecindex/searcher.go
@@ -7,7 +7,6 @@ package vecindex
 
 import (
 	"context"
-	"math"
 
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -48,8 +47,7 @@ func (s *Searcher) Init(idx *cspann.Index, txn *kv.Txn, baseBeamSize, maxResults
 		BaseBeamSize: baseBeamSize,
 		SkipRerank:   true,
 	}
-	s.searchSet.MaxResults = int(math.Ceil(float64(maxResults) * cspann.DeletedMultiplier))
-	s.searchSet.MaxExtraResults = s.searchSet.MaxResults * cspann.RerankMultiplier
+	s.searchSet.MaxResults, s.searchSet.MaxExtraResults = cspann.IncreaseRerankResults(maxResults)
 }
 
 // Search triggers a search over the index for the given vector, within the

--- a/pkg/sql/vecindex/searcher.go
+++ b/pkg/sql/vecindex/searcher.go
@@ -55,6 +55,9 @@ func (s *Searcher) Init(idx *cspann.Index, txn *kv.Txn, baseBeamSize, maxResults
 // Search triggers a search over the index for the given vector, within the
 // scope of the given prefix. "maxResults" specifies the maximum number of
 // results that will be returned.
+//
+// NOTE: The caller is assumed to own the memory for all parameters and can
+// reuse the memory after the call returns.
 func (s *Searcher) Search(ctx context.Context, prefix roachpb.Key, vec vector.T) error {
 	err := s.idx.Search(ctx, &s.idxCtx, cspann.TreeKey(prefix), vec, &s.searchSet, s.options)
 	if err != nil {

--- a/pkg/sql/vecindex/searcher_test.go
+++ b/pkg/sql/vecindex/searcher_test.go
@@ -7,6 +7,7 @@ package vecindex
 
 import (
 	"context"
+	"slices"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -89,22 +90,40 @@ func TestSearcher(t *testing.T) {
 	// Insert two vectors into root partition.
 	var mutator MutationSearcher
 	mutator.Init(idx, tx)
-	prefix := keys.MakeFamilyKey(encoding.EncodeVarintAscending([]byte{}, 100), 0 /* famID */)
+
+	// Reuse prefix, key bytes, value bytes and vector memory, to ensure it's
+	// allowed.
+	var prefix, keyBytes, valueBytes []byte
+	var original, randomized vector.T
 
 	insertVector := func(vec vector.T, key int64, val cspann.ValueBytes) vector.T {
+		prefix = prefix[:0]
+		keyBytes = keyBytes[:0]
+		randomized = randomized[:0]
+
+		prefix = encoding.EncodeVarintAscending(prefix, 100)
 		require.NoError(t, mutator.SearchForInsert(ctx, prefix, vec))
+
 		partitionKey := cspann.PartitionKey(*mutator.PartitionKey().(*tree.DInt))
-		keyBytes := keys.MakeFamilyKey(encoding.EncodeVarintAscending([]byte{}, key), 0 /* famID */)
-		randomizedVec := make(vector.T, len(vec))
-		idx.RandomizeVector(vec, randomizedVec)
+		keyBytes = keys.MakeFamilyKey(encoding.EncodeVarintAscending(keyBytes, key), 0 /* famID */)
+
+		randomized = slices.Grow(randomized, len(vec))[:len(vec)]
+		idx.RandomizeVector(vec, randomized)
 		err = mutator.txn.AddToPartition(ctx, cspann.TreeKey(prefix), partitionKey, cspann.LeafLevel,
-			randomizedVec, cspann.ChildKey{KeyBytes: keyBytes}, val)
+			randomized, cspann.ChildKey{KeyBytes: keyBytes}, val)
 		require.NoError(t, err)
-		return randomizedVec
+		return randomized
 	}
 
-	insertVector(vector.T{1, 2}, 1, cspann.ValueBytes{1, 2})
-	randomizedVec := insertVector(vector.T{5, 3}, 2, cspann.ValueBytes{3, 4})
+	// Reuse vector and value memory, to ensure it's allowed.
+	original = vector.T{1, 2}
+	valueBytes = []byte{1, 2}
+	insertVector(original, 1, cspann.ValueBytes(valueBytes))
+	original[0] = 5
+	original[1] = 3
+	valueBytes[0] = 3
+	valueBytes[1] = 4
+	randomized = insertVector(original, 2, cspann.ValueBytes(valueBytes))
 
 	// Validate that search vector was correctly encoded and quantized.
 	encodedVec := mutator.EncodedVector()
@@ -113,28 +132,51 @@ func TestSearcher(t *testing.T) {
 		[]byte(*encodedVec.(*tree.DBytes)), &vecSet)
 	require.NoError(t, err)
 	require.Empty(t, remainder)
-	require.Equal(t, randomizedVec, vecSet.Vectors.At(0))
+	require.Equal(t, randomized, vecSet.Vectors.At(0))
 
-	// Use the Searcher.
+	// Search for a vector that doesn't exist in the tree (reuse memory).
+	prefix = prefix[:0]
+	prefix = encoding.EncodeVarintAscending(prefix, 200)
+	original[0] = 1
+	original[1] = 1
 	var searcher Searcher
 	searcher.Init(idx, tx, 8 /* baseBeamSize */, 2 /* maxResults */)
-	require.NoError(t, searcher.Search(ctx, prefix, vector.T{1, 1}))
+	require.NoError(t, searcher.Search(ctx, prefix, original))
+	require.Nil(t, searcher.NextResult())
+
+	// Search for a vector that does exist (reuse memory).
+	prefix = prefix[:0]
+	prefix = encoding.EncodeVarintAscending(prefix, 100)
+	require.NoError(t, searcher.Search(ctx, prefix, original))
 	res := searcher.NextResult()
 	require.InDelta(t, float32(1), res.QuerySquaredDistance, 0.01)
 	res = searcher.NextResult()
 	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
 	require.Nil(t, searcher.NextResult())
 
-	// Search for a vector to delete.
-	keyBytes := keys.MakeFamilyKey(encoding.EncodeVarintAscending([]byte{}, 1), 0 /* famID */)
-	require.NoError(t, mutator.SearchForDelete(ctx, prefix, vector.T{1, 2}, keyBytes))
-	require.Equal(t, tree.NewDInt(tree.DInt(1)), mutator.PartitionKey())
+	// Search for a vector to delete that doesn't exist (reuse memory).
+	keyBytes = keyBytes[:0]
+	original[0] = 1
+	original[1] = 2
+	keyBytes = keys.MakeFamilyKey(encoding.EncodeVarintAscending(keyBytes, 123), 0 /* famID */)
+	require.NoError(t, mutator.SearchForDelete(ctx, prefix, original, keyBytes))
+	require.Equal(t, tree.DNull, mutator.PartitionKey())
 	require.Nil(t, mutator.EncodedVector())
 
-	// Search for a vector to delete that doesn't exist.
-	keyBytes = keys.MakeFamilyKey(encoding.EncodeVarintAscending([]byte{}, 123), 0 /* famID */)
-	require.NoError(t, mutator.SearchForDelete(ctx, prefix, vector.T{1, 2}, keyBytes))
+	// Search for a vector to delete that doesn't exist in the tree (reuse memory).
+	prefix = prefix[:0]
+	prefix = encoding.EncodeVarintAscending(prefix, 200)
+	require.NoError(t, mutator.SearchForDelete(ctx, prefix, original, keyBytes))
 	require.Equal(t, tree.DNull, mutator.PartitionKey())
+	require.Nil(t, mutator.EncodedVector())
+
+	// Search for a vector to delete (reuse memory).
+	prefix = prefix[:0]
+	prefix = encoding.EncodeVarintAscending(prefix, 100)
+	keyBytes = keyBytes[:0]
+	keyBytes = keys.MakeFamilyKey(encoding.EncodeVarintAscending(keyBytes, 1), 0 /* famID */)
+	require.NoError(t, mutator.SearchForDelete(ctx, prefix, original, keyBytes))
+	require.Equal(t, tree.NewDInt(tree.DInt(1)), mutator.PartitionKey())
 	require.Nil(t, mutator.EncodedVector())
 
 	require.NoError(t, tx.Commit(ctx))


### PR DESCRIPTION
Backport 4/4 commits from #145274.

/cc @cockroachdb/release

---

#### cspann: do not overwrite root level when searching targets

In the case where the root partition is in a non-Ready state, we need
to search its target partitions. Previously, we were overwriting the
root partition's level, which should be the same as the target partition's
level. However, if there's a bug, it can be different, and overriding
the root level causes cascading problems downstream, including a panic
that can take down the server. This commit adds code to check the level
and assert that it's equal to the root partition level rather than
silently overwriting it.

#### vecindex: clone treeKey when creating fixups

Previously, the C-SPANN index assumed that it owned the memory for
the vector index prefix value (called the "tree key" in C-SPANN).
However, the backfiller assumed the opposite, and reuses the memory
between SearchForInsert calls. This commit resolves the conflict by
always cloning the tree key when it's enqueued as part of a fixup,
so that callers can reuse the memory.

Fixes: #145261

#### cspann: pass tree key to delete vector fixup

Previously, the delete vector fixup did not take a tree key parameter,
which meant it always searched the default tree for the vector to
delete. This commit fixes that by passing the tree key to the fixup.

#### vecindex: return minimum number of results from Search

When vector deletion is enabled in TestVecIndexConcurrency, it occasionally
fails under stress with zero results. This is because searching with a LIMIT
of one was returning only 2 results. If both of those results point to deleted
primary key rows, then zero results get returned. The fix is to return at
least 10 candidate vectors from searches. While all 10 vectors could be deleted,
this at least makes this scenario much less common. The longer-term fix is to
switch to an iterator execution model, where we continue to "pull" additional
vectors until we get the desired number of results.

Release justification: Vector indexing is a business priority. These changes are all in the vecindex package, for a feature that is protected by a default-off feature flag.