### PR TITLE
sql: fix a bug when persisting some cursors

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -920,3 +920,23 @@ statement ok
 CLOSE curs;
 
 subtest end
+
+# Regression test for incorrectly advancing internal position when persisting
+# the WITH HOLD cursor (#145362).
+subtest regression_145362
+
+statement ok
+CREATE TABLE empty (k INT PRIMARY KEY)
+
+statement ok
+BEGIN;
+DECLARE foo CURSOR WITH HOLD FOR SELECT * FROM empty;
+COMMIT;
+
+query empty
+FETCH ABSOLUTE 1 FROM foo;
+
+statement ok
+CLOSE foo;
+
+subtest end

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -365,7 +365,7 @@ type sqlCursor struct {
 // Next implements the Rows interface.
 func (s *sqlCursor) Next(ctx context.Context) (bool, error) {
 	more, err := s.Rows.Next(ctx)
-	if err == nil {
+	if more && err == nil {
 		s.curRow++
 	}
 	return more, err


### PR DESCRIPTION
We recently added support for WITH HOLD cursors which are persisted, which exposed a bug with tracking of the internal position of the current row. IIUC the pre-existing bug didn't have any effect without WITH HOLD option.

Fixes: #145362.

Release note (bug fix): CockroachDB could previously encounter an internal error when fetching from the WITH HOLD cursor with FETCH FIRST and FETCH ABSOLUTE. The bug is only present in 25.2 alpha and beta versions.