### PR TITLE
workflows: run automerge on schedule only

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -3,8 +3,6 @@ name: Auto-Merge Test Backport PRs
 on:
   schedule:
     - cron: "0 * * * *"  # Every hour
-  workflow_dispatch:
-  push:
 
 jobs:
   auto-merge:


### PR DESCRIPTION
Previously, the automerge workflow was triggered on every push to any branch. This commit changes the workflow to run only on a schedule, also removing the `on: workflow_dispatch` trigger.

Epic: none
Release note: none