### PR TITLE
vecindex: add Level field to metadata KV key encoding

### DIFF
--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -172,7 +172,7 @@ func TestEncodeKeys(t *testing.T) {
 
 	// EncodeMetadataKey.
 	encodedMeta := vecencoding.EncodeMetadataKey(input, input, 10)
-	require.Equal(t, roachpb.Key{1, 2, 3, 1, 2, 3, 146, 136}, encodedMeta)
+	require.Equal(t, roachpb.Key{1, 2, 3, 1, 2, 3, 146, 136, 136}, encodedMeta)
 
 	// EncodeStartVectorKey.
 	encodedStart := vecencoding.EncodeStartVectorKey(encodedMeta)
@@ -190,7 +190,7 @@ func TestEncodeKeys(t *testing.T) {
 	require.Equal(t, roachpb.Key{1, 2, 3, 1, 2, 3, 146, 138}, encodedPrefix)
 	require.Negative(t, bytes.Compare(encodedStart, encodedPrefix))
 	require.Negative(t, bytes.Compare(encodedPrefix, encodedEnd))
-	require.Equal(t, 3, vecencoding.EncodedPrefixVectorKeyLen(input, cspann.SecondLevel))
+	require.Equal(t, 8, vecencoding.EncodedPrefixVectorKeyLen(encodedMeta, cspann.SecondLevel))
 
 	// EncodeMetadataValue and DecodeMetadataValue.
 	metadata1 := cspann.PartitionMetadata{


### PR DESCRIPTION
Previously, the Metadata KV Key for a vector index partition had these fields:

│Index Prefix│Prefix Columns│PartitionKey│Family ID 0│

This commit adds a Level field, which always has the value of zero:

│Index Prefix│Prefix Columns│PartitionKey│Level 0│Family ID 0│

This is needed because the KV splits do not handle cases where one KV key is a prefix of other keys. It can cause an unsplittable range to form. By adding the Level field with value zero, we guarantee that the Metadata KV key always sorts before all Vector KV keys in the partition, and yet isn't a prefix of them.

Epic: CRDB-42943
Release note: Vector indexes created in beta releases have an encoding issue that may result in failed inserts. These indexes should be dropped and re-created before being used with later releases.