### PR TITLE
row: remove an allocation when handling Scan responses

### DIFF
--- a/pkg/sql/row/kv_fetcher.go
+++ b/pkg/sql/row/kv_fetcher.go
@@ -300,9 +300,12 @@ func (f *KVFetcher) nextKV(
 				// If we've made it to the very last key in the batch, copy out
 				// the key so that the GC can reclaim the large backing slice
 				// before nextKV() is called again.
-				f.kv.Key = make(roachpb.Key, len(key))
+				//
+				// Combine two allocations into one.
+				buf := make([]byte, len(key)+len(rawBytes))
+				f.kv.Key = buf[:len(key):len(key)]
 				copy(f.kv.Key, key)
-				f.kv.Value.RawBytes = make([]byte, len(rawBytes))
+				f.kv.Value.RawBytes = buf[len(key):]
 				copy(f.kv.Value.RawBytes, rawBytes)
 			}
 			return true, f.kv, f.spanID, nil


### PR DESCRIPTION
Whenever we're decoding the last KV from `[]byte` that came from `[][]byte BatchResponse` field of a Scan response, we need to make a copy to avoid keeping the whole `[]byte` alive. Previously, we would allocate two slices for the key and the value parts, and this commit switches things to a single allocation instead.

Epic: None
Release note: None