### PR TITLE
drtprod: add YAML files for PUA tests

### DIFF
--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
@@ -15,6 +15,7 @@ import (
 	"slices"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/drtprod/helpers"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
@@ -116,6 +117,7 @@ type step struct {
 	Flags             map[string]interface{} `yaml:"flags"`               // Flags to pass to the command or script
 	ContinueOnFailure bool                   `yaml:"continue_on_failure"` // Whether to continue on failure
 	OnRollback        []step                 `yaml:"on_rollback"`         // Steps to execute if rollback is needed
+	Wait              int                    `yaml:"wait"`                // Wait time in seconds before executing the next step
 }
 
 // target defines a target cluster with associated steps to be executed.
@@ -140,6 +142,7 @@ type command struct {
 	args              []string   // Command arguments
 	continueOnFailure bool       // Whether to continue on failure
 	rollbackCmds      []*command // Rollback commands to execute in case of failure
+	wait              int        // Wait time in seconds before executing the next step
 }
 
 // String returns the command as a string for easy printing.
@@ -547,6 +550,10 @@ func executeCommands(ctx context.Context, logPrefix string, cmds []*command) err
 			fmt.Printf("[%s] Failed <%v>, Error Ignored: %v\n", logPrefix, cmd, err)
 		} else {
 			fmt.Printf("[%s] Completed <%v>\n", logPrefix, cmd)
+			if cmd.wait > 0 {
+				fmt.Printf("[%s] Waiting for %d seconds\n", logPrefix, cmd.wait)
+				time.Sleep(time.Duration(cmd.wait) * time.Second)
+			}
 		}
 
 		// Add rollback commands if specified
@@ -604,6 +611,7 @@ func generateStepCmd(clusterName string, s step) (*command, error) {
 			return nil, err
 		}
 	}
+	cmd.wait = s.Wait
 	return cmd, err
 }
 

--- a/pkg/cmd/drtprod/configs/drt_pua_9.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_9.yaml
@@ -1,0 +1,350 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# YAML configuration to create and set up a 9-node single-region cluster.
+# It also creates a workload cluster with 1 node in the same region as the primary cluster.
+# Additionally, it configures Datadog and includes scripts for running workload and roachtest operations.
+
+environment:
+  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
+  ROACHPROD_DNS: drt.crdb.io
+  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
+  ROACHPROD_GCE_DNS_ZONE: drt
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
+  CLUSTER: drt-pua-9
+  CLUSTER_NODES: 9
+  WORKLOAD_CLUSTER: workload-pua-9
+  WORKLOAD_NODES: 1
+  STORE_COUNT: 2
+  COCKROACH_VERSION: v25.1.1
+
+  TPCC_WAREHOUSES: 6000
+  TPCC_ACTIVE_WAREHOUSES: 6000
+  DB_NAME: cct_tpcc
+  RUN_DURATION: 12h
+  MAX_CONN_LIFETIME: 3m
+
+dependent_file_locations:
+  - artifacts/roachprod
+  - artifacts/roachtest
+  - artifacts/drtprod
+  - pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
+  - pkg/cmd/drtprod/scripts/setup_datadog_cluster
+  - pkg/cmd/drtprod/scripts/setup_datadog_workload
+  - pkg/cmd/drtprod/scripts/tpcc_init.sh
+  - pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
+  - pkg/cmd/drtprod/scripts/generate_kv_run.sh
+  - pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+  - pkg/cmd/drtprod/scripts/pua_operations.sh
+
+targets:
+  - target_name: "Cluster Setup"
+    steps:
+      - command: create
+        args:
+          - $CLUSTER
+        flags:
+          clouds: gce
+          gce-managed: true
+          gce-enable-multiple-stores: true
+          gce-zones: "us-east1-d,us-east1-b,us-east1-c"
+          nodes: $CLUSTER_NODES
+          gce-machine-type: n2-standard-16
+          local-ssd: true
+          gce-local-ssd-count: $STORE_COUNT
+          username: drt
+          lifetime: 8760h
+          gce-image: "ubuntu-2204-jammy-v20240319"
+        on_rollback:
+          - command: destroy
+            args:
+              - $CLUSTER
+      - command: sync
+        flags:
+          clouds: gce
+      - command: stage
+        args:
+          - $CLUSTER
+          - release
+          - $COCKROACH_VERSION
+      - script: "pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller"
+      - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
+      - command: start
+        args:
+          - $CLUSTER
+          - "--binary"
+          - "./cockroach"
+        flags:
+          enable-fluent-sink: true
+          store-count: $STORE_COUNT
+          args: --wal-failover=among-stores
+          restart: false
+          sql-port: 26257
+        on_rollback:
+          - command: stop
+            args:
+              - $CLUSTER
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING kv.rangefeed.enabled = true"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING server.shutdown.connections.timeout = '200s'"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING server.shutdown.drain_wait = '15s'"
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
+      - command: load-balancer
+        args:
+          - create
+          - $CLUSTER
+  - target_name: "Workload Setup"
+    dependent_targets:
+      - "Cluster Setup"
+    steps:
+      - command: create
+        args:
+          - $WORKLOAD_CLUSTER
+        flags:
+          clouds: gce
+          gce-zones: "us-east1-c"
+          nodes: $WORKLOAD_NODES
+          gce-machine-type: n2-standard-8
+          os-volume-size: 100
+          username: workload
+          lifetime: 8760h
+        on_rollback:
+          - command: destroy
+            args:
+              - $WORKLOAD_CLUSTER
+      - command: sync
+        flags:
+          clouds: gce
+      - command: stage
+        args:
+          - $WORKLOAD_CLUSTER
+          - release
+          - $COCKROACH_VERSION
+      - command: stage
+        args:
+          - $WORKLOAD_CLUSTER
+          - workload
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - artifacts/roachprod
+          - roachprod
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - artifacts/drtprod
+          - drtprod
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - artifacts/roachtest
+          - roachtest
+      - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
+  - target_name: "Setup Certs & SSH Keys"
+    dependent_targets:
+      - "Workload Setup"
+    steps:
+      - script: rm
+        args:
+          - -rf
+          - certs-$CLUSTER
+      - command: get
+        args:
+          - $CLUSTER:1
+          - certs
+          - certs-$CLUSTER
+      - command: ssh
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - sudo
+          - rm
+          - -rf
+          - certs
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - certs-$CLUSTER
+          - certs
+      - command: ssh
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - chmod
+          - 600
+          - './certs/*'
+      - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
+        args:
+          - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh
+          - false # determines whether to execute the script immediately on workload node
+        flags:
+          warehouses: $TPCC_WAREHOUSES
+          db: $DB_NAME
+      - script: "pkg/cmd/drtprod/scripts/generate_tpcc_run.sh"
+        args:
+          - cct_tpcc # suffix added to script name tpcc_run.sh
+          - false # determines whether to execute the script immediately on workload node
+        flags:
+          db: $DB_NAME
+          warehouses: $TPCC_WAREHOUSES
+          active-warehouses: $TPCC_ACTIVE_WAREHOUSES
+          duration: $RUN_DURATION
+          ramp: 5m
+          wait: true
+          max-conn-lifetime: $MAX_CONN_LIFETIME
+      - script: "pkg/cmd/drtprod/scripts/pua_operations.sh"
+        wait: 10
+  - target_name: "Data Import"
+    dependent_targets:
+      - "Setup Certs & SSH Keys"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "sudo systemd-run --unit tpcc_init --same-dir --uid $(id -u) --gid $(id -g) bash ./tpcc_init_cct_tpcc.sh"
+        wait: 3600
+  - target_name: "Phase-1: Baseline TPC-C Performance"
+    dependent_targets:
+      - "Data Import"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - "sudo systemd-run --unit tpcc_run --same-dir --uid $(id -u) --gid $(id -g) bash ./tpcc_run_cct_tpcc.sh"
+        wait: 3600
+  - target_name: "Phase-2: Endogenous Stress"
+    dependent_targets:
+      - "Phase-1: Baseline TPC-C Performance"
+    steps:
+      - command: sql # create backup schedule
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - |
+            BACKUP INTO 'gs://cockroach-drt-backup-us-east1/drt-pua-9?AUTH=implicit'
+            WITH OPTIONS (revision_history = true, detached)
+        wait: 1800
+      - command: sql # create changefeed without initial scan
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "CREATE CHANGEFEED FOR TABLE cct_tpcc.public.order_line INTO 'null://' WITH initial_scan = 'no'"
+        wait: 600
+      - command: sql # create index on order table
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "CREATE INDEX add_index_o_w_id ON cct_tpcc.public.order (o_w_id)"
+        wait: 700
+  - target_name: "Phase-3: Rolling Upgrade"
+    dependent_targets:
+      - "Phase-2: Endogenous Stress"
+    steps:
+      - command: deploy # rolling upgrade
+        args:
+          - $CLUSTER
+          - release
+          - v25.1.2
+        flags:
+          pause: 5m
+          grace-period: 500
+        wait: 300
+  - target_name: "Phase-4: Flaky Disks"
+    dependent_targets:
+      - "Phase-3: Rolling Upgrade"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "./run_ops_disk-stall.sh"
+        wait: 1200
+  - target_name: "Phase-5: Network Partition"
+    dependent_targets:
+      - "Phase-4: Flaky Disks"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "./run_ops_network-partition-partial.sh"
+        wait: 1500
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "./run_ops_network-partition-full.sh"
+        wait: 1500
+  - target_name: "Phase-6: Node Restarts"
+    dependent_targets:
+      - "Phase-5: Network Partition"
+    steps:
+      - command: stop # ungraceful shutdown of node 2
+        args:
+          - $CLUSTER:2
+        wait: 30
+      - command: start # restart node 2
+        args:
+          - $CLUSTER:2
+        flags:
+          restart: true
+        wait: 600
+      - command: stop # ungraceful shutdown of node 6
+        args:
+          - $CLUSTER:6
+        wait: 30
+      - command: start # restart node 6
+        args:
+          - $CLUSTER:6
+        flags:
+          restart: true
+        wait: 1500
+      - command: stop # ungraceful shutdown of node 7
+        args:
+          - $CLUSTER:7
+        wait: 30
+      - command: start # restart node 7
+        args:
+          - $CLUSTER:7
+        flags:
+          restart: true
+        wait: 1500
+  - target_name: "Phase-7: Zone Outages"
+    dependent_targets:
+      - "Phase-6: Node Restarts"
+    steps:
+      - command: stop # ungraceful shutdown of nodes 7-9 to simulate zone outage
+        args:
+          - $CLUSTER:7-9
+        wait: 300
+      - command: start # restart nodes 7-9
+        args:
+          - $CLUSTER:7-9
+        flags:
+          restart: true
+        wait: 3300

--- a/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
@@ -1,0 +1,369 @@
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# Yaml for creating and configuring a 15 node multi-region cluster spread across 3 regions.
+# This yaml also creates a workload cluster with 3 nodes in 3 regions, 1 node in each region.
+# This also configures datadog and scripts for running workload and roachtest operations.
+environment:
+  ROACHPROD_GCE_DEFAULT_SERVICE_ACCOUNT: 622274581499-compute@developer.gserviceaccount.com
+  ROACHPROD_DNS: drt.crdb.io
+  ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
+  ROACHPROD_GCE_DNS_ZONE: drt
+  ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
+  CLUSTER: drt-pua-15
+  WORKLOAD_CLUSTER: workload-pua-15
+  CLUSTER_NODES: 15
+  WORKLOAD_NODES: 3
+  STORE_COUNT: 2
+  COCKROACH_VERSION: v25.1.1
+
+  # variables used by tpcc_run_multiregion.sh
+  NUM_REGIONS: 3
+  NODES_PER_REGION: 5
+  REGIONS: northamerica-northeast2,us-east5,us-east1
+  TPCC_WAREHOUSES: 10000
+  TPCC_ACTIVE_WAREHOUSES: 7000
+  DB_NAME: cct_tpcc
+  SURVIVAL_GOAL: region
+  RUN_DURATION: 15h
+  NUM_CONNECTIONS: 500
+  NUM_WORKERS: 500
+  MAX_RATE: 500
+  MAX_CONN_LIFETIME: 3m
+
+dependent_file_locations:
+  - artifacts/roachprod
+  - artifacts/roachtest
+  - pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
+  - pkg/cmd/drtprod/scripts/setup_datadog_cluster
+  - pkg/cmd/drtprod/scripts/create_decommission_node.sh
+  - pkg/cmd/drtprod/scripts/setup_datadog_workload
+  - pkg/cmd/drtprod/scripts/tpcc_init.sh
+  - pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+  - pkg/cmd/drtprod/scripts/pua_operations.sh
+
+targets:
+  - target_name: "Cluster Setup"
+    steps:
+      - command: create
+        args:
+          - $CLUSTER
+        flags:
+          clouds: gce
+          gce-managed: true
+          gce-enable-multiple-stores: true
+          gce-zones: "northamerica-northeast2-a:2,northamerica-northeast2-b:2,northamerica-northeast2-c:1,us-east5-a:2,us-east5-b:2,us-east5-c:1,us-east1-b:2,us-east1-c:2,us-east1-d:1"
+          nodes: $CLUSTER_NODES
+          gce-machine-type: n2-standard-16
+          local-ssd: true
+          gce-local-ssd-count: $STORE_COUNT
+          os-volume-size: 100
+          username: drt
+          lifetime: 8760h
+        on_rollback:
+          - command: destroy
+            args:
+              - $CLUSTER
+      - command: sync
+        flags:
+          clouds: gce
+      - command: stage
+        args:
+          - $CLUSTER
+          - release
+          - $COCKROACH_VERSION
+      - script: "pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller"
+      - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
+      - command: start
+        args:
+          - $CLUSTER
+          - "--binary"
+          - "./cockroach"
+        flags:
+          enable-fluent-sink: true
+          store-count: $STORE_COUNT
+          args: --wal-failover=among-stores
+          restart: false
+          sql-port: 26257
+        on_rollback:
+          - command: stop
+            args:
+              - $CLUSTER
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING kv.rangefeed.enabled = true"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "ALTER RANGE timeseries CONFIGURE ZONE USING num_replicas=5,num_voters=5"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "ALTER RANGE default CONFIGURE ZONE USING num_replicas=5,num_voters=5"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING server.shutdown.connections.timeout = '200s'"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING server.shutdown.drain_wait = '15s'"
+      - command: run
+        args:
+          - $CLUSTER
+          - --
+          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
+      - command: load-balancer
+        args:
+          - create
+          - $CLUSTER
+  - target_name: "Workload Setup"
+    dependent_targets:
+      - "Cluster Setup"
+    steps:
+      - command: create
+        args:
+          - $WORKLOAD_CLUSTER
+        flags:
+          clouds: gce
+          gce-zones: "northamerica-northeast2-a,us-east5-a,us-east1-b"
+          nodes: $NUM_REGIONS
+          gce-machine-type: n2d-standard-4
+          os-volume-size: 100
+          username: workload
+          lifetime: 8760h
+        on_rollback:
+          - command: destroy
+            args:
+              - $WORKLOAD_CLUSTER
+      - command: sync
+        flags:
+          clouds: gce
+      - command: stage
+        args:
+          - $WORKLOAD_CLUSTER
+          - release
+          - $COCKROACH_VERSION
+      - command: stage
+        args:
+          - $WORKLOAD_CLUSTER
+          - workload
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - artifacts/roachprod
+          - roachprod
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - artifacts/roachtest
+          - roachtest
+      - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
+  - target_name: "Setup Certs & SSH Keys"
+    dependent_targets:
+      - "Workload Setup"
+    steps:
+      - script: rm
+        args:
+          - -rf
+          - certs-$CLUSTER
+      - command: get
+        args:
+          - $CLUSTER:1
+          - certs
+          - certs-$CLUSTER
+      - command: ssh
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - sudo
+          - rm
+          - -rf
+          - certs
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - certs-$CLUSTER
+          - certs
+      - command: ssh
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - chmod
+          - 600
+          - './certs/*'
+      - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
+        args:
+          - cct_tpcc # suffix added to script name tpcc_init_cct_tpcc.sh
+          - false # determines whether to execute the script immediately on workload node
+        flags:
+          warehouses: $TPCC_WAREHOUSES
+          partitions: $NUM_REGIONS
+          db: $DB_NAME
+          survival-goal: $SURVIVAL_GOAL
+          regions: $REGIONS
+      - script: "pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh"
+      - script: "pkg/cmd/drtprod/scripts/pua_operations.sh"
+        wait: 10
+  - target_name: "Data Import"
+    dependent_targets:
+      - "Setup Certs & SSH Keys"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "sudo systemd-run --unit tpcc_init --same-dir --uid $(id -u) --gid $(id -g) bash ./tpcc_init_cct_tpcc.sh"
+        wait: 3600
+  - target_name: "Phase-1: Baseline TPC-C Performance"
+    dependent_targets:
+      - "Data Import"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER
+          - --
+          - "sudo systemd-run --unit tpcc_run --same-dir --uid $(id -u) --gid $(id -g) bash ./tpcc_run.sh"
+        wait: 3600
+  - target_name: "Phase-2: Endogenous Stress"
+    dependent_targets:
+      - "Phase-1: Baseline TPC-C Performance"
+    steps:
+      - command: sql # create backup schedule
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - |
+            BACKUP INTO ('gs://cockroach-drt-backup-northamerica-northeast2/drt-pua-15?AUTH=implicit&COCKROACH_LOCALITY=default',
+                            'gs://cockroach-drt-backup-us-east5/drt-pua-15?AUTH=implicit&COCKROACH_LOCALITY=region%3Dus-east5',
+                            'gs://cockroach-drt-backup-us-east1/drt-pua-15?AUTH=implicit&COCKROACH_LOCALITY=region%3Dus-east1')
+            WITH OPTIONS (revision_history = true, detached)
+        wait: 1500
+      - command: sql # create changefeed without initial scan
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "CREATE CHANGEFEED FOR TABLE cct_tpcc.public.order_line INTO 'null://' WITH initial_scan = 'no'"
+        wait: 900
+      - command: sql # create index on order table
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "CREATE INDEX add_index_o_w_id ON cct_tpcc.public.order (o_w_id)"
+        wait: 700
+  - target_name: "Phase-3: Rolling Upgrade"
+    dependent_targets:
+      - "Phase-2: Endogenous Stress"
+    steps:
+      - command: deploy # rolling upgrade
+        args:
+          - $CLUSTER
+          - release
+          - v25.1.2
+        flags:
+          pause: 5m
+          grace-period: 500
+        wait: 300
+  - target_name: "Phase-4: Flaky Disks"
+    dependent_targets:
+      - "Phase-3: Rolling Upgrade"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "./run_ops_disk-stall.sh"
+        wait: 1200
+  - target_name: "Phase-5: Network Partition"
+    dependent_targets:
+      - "Phase-4: Flaky Disks"
+    steps:
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "./run_ops_network-partition-partial.sh"
+        wait: 1500
+      - command: run
+        args:
+          - $WORKLOAD_CLUSTER:1
+          - --
+          - "./run_ops_network-partition-full.sh"
+        wait: 1500
+  - target_name: "Phase-6: Node Restarts"
+    dependent_targets:
+      - "Phase-5: Network Partition"
+    steps:
+      - command: stop # ungraceful shutdown of node 4
+        args:
+          - $CLUSTER:4
+        wait: 30
+      - command: start # restart node 4
+        args:
+          - $CLUSTER:4
+        flags:
+          restart: true
+        wait: 600
+      - command: stop # ungraceful shutdown of node 6
+        args:
+          - $CLUSTER:6
+        wait: 30
+      - command: start # restart node 6
+        args:
+          - $CLUSTER:6
+        flags:
+          restart: true
+        wait: 1500
+      - command: stop # ungraceful shutdown of node 15
+        args:
+          - $CLUSTER:15
+        wait: 30
+      - command: start # restart node 15
+        args:
+          - $CLUSTER:15
+        flags:
+          restart: true
+        wait: 1500
+  - target_name: "Phase-7: Zone Outages"
+    dependent_targets:
+      - "Phase-6: Node Restarts"
+    steps:
+      - command: stop # ungraceful shutdown of nodes 3, 4 to simulate zone outage
+        args:
+          - $CLUSTER:3-4
+        wait: 300
+      - command: start # restart nodes 3, 4
+        args:
+          - $CLUSTER:3-4
+        flags:
+          restart: true
+        wait: 3300
+  - target_name: "Phase-8: Region Outages"
+    dependent_targets:
+      - "Phase-7: Zone Outages"
+    steps:
+      - command: stop # ungraceful shutdown of nodes 11-15 to simulate region outage
+        args:
+          - $CLUSTER:11-15
+        wait: 300
+      - command: start # restart nodes 11-15
+        args:
+          - $CLUSTER:11-15
+        flags:
+          restart: true

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
@@ -101,7 +101,11 @@ for ((NODE=0; NODE<WORKLOAD_NODES; NODE++)); do
 
 ./drtprod sync
 $([ "$execute_script" = "true" ] && [ "$NODE" -eq 0 ] && echo "${pwd}/tpcc_init_${suffix}.sh")
-PGURLS=\$(./drtprod pgurl $CLUSTER | sed s/\'//g)
+PGURLS=\$(./drtprod load-balancer pgurl $CLUSTER | sed s/\'//g)
+if [ -z "\$PGURLS" ]; then
+    echo ">> No load-balancer configured; falling back to direct pgurl"
+    PGURLS=\$(./drtprod pgurl $CLUSTER | sed s/\'//g)
+fi
 read -r -a PGURLS_ARR <<< "\$PGURLS"
 j=0
 while true; do

--- a/pkg/cmd/drtprod/scripts/pua_operations.sh
+++ b/pkg/cmd/drtprod/scripts/pua_operations.sh
@@ -1,0 +1,129 @@
+#!/bin/bash
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+# This script sets up operation-specific execution scripts on a workload cluster.
+# It verifies required environment variables, retrieves Datadog API credentials,
+# generates operation scripts for predefined scenarios (disk stall, full network partition,
+# partial network partition), and deploys these scripts to the workload cluster nodes.
+
+# Check required environment variables
+check_env_vars() {
+    local required_vars=("CLUSTER" "WORKLOAD_CLUSTER")
+    for var in "${required_vars[@]}"; do
+        if [ -z "${!var}" ]; then
+            echo "environment ${var} is not set"
+            exit 1
+        fi
+    done
+}
+
+# Get Datadog API key
+get_dd_api_key() {
+    if [ -z "${DD_API_KEY}" ]; then
+        DD_API_KEY="$(gcloud --project=cockroach-drt secrets versions access latest --secret datadog-api-key)"
+        if [ -z "${DD_API_KEY}" ]; then
+            echo "Missing Datadog API key!"
+            exit 1
+        fi
+    fi
+}
+
+# Sanitize operation name for filename
+sanitize_filename() {
+    local operation=$1
+    echo "${operation//\//-}"  # Replace / with -
+}
+
+# Create operation script
+create_operation_script() {
+    local operation=$1
+    local safe_name=$(sanitize_filename "$operation")
+    local filename="run_ops_${safe_name}.sh"
+    local iterations=${2:-1}  # Default to 1 if not specified
+    local wait_time=${3:-"10s"}  # Default wait time
+    
+    local script_content="#!/bin/bash
+
+export ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT}
+export ROACHPROD_DNS=${ROACHPROD_DNS}
+"
+
+    if [ "$iterations" -gt 1 ]; then
+        script_content+="
+for i in {1..$iterations}; do
+    echo \"Running ${operation} iteration \$i/$iterations...\"
+"
+    fi
+
+    script_content+="
+    /home/ubuntu/roachtest run-operation ${CLUSTER} \"${operation}\" --datadog-api-key ${DD_API_KEY} \
+    --datadog-tags env:development,cluster:${WORKLOAD_CLUSTER},team:drt,service:drt-cockroachdb \
+    --datadog-app-key 1 --certs-dir ./certs --wait-before-cleanup ${wait_time} | tee -a roachtest_ops_${safe_name}.log
+"
+
+    if [ "$iterations" -gt 1 ]; then
+        script_content+="
+    SLEEP_TIME=\$((20 + RANDOM % 11))
+    echo \"Sleeping for \$SLEEP_TIME seconds before next iteration...\"
+    sleep \$SLEEP_TIME
+done"
+    fi
+
+    drtprod ssh "${WORKLOAD_CLUSTER}":1 -- "tee /home/ubuntu/${filename} > /dev/null << 'EOF'
+${script_content}
+EOF"
+
+    drtprod ssh "${WORKLOAD_CLUSTER}":1 -- chmod +x /home/ubuntu/"${filename}"
+}
+
+# Get operation configuration
+get_operation_config() {
+    local op=$1
+    case "$op" in
+        "disk-stall")
+            echo "disk-stall,50,10s"
+            ;;
+        "network-partition-full")
+            echo "network-partition/full,1,5m"
+            ;;
+        "network-partition-partial")
+            echo "network-partition/partial,1,5m"
+            ;;
+        *)
+            echo ""
+            ;;
+    esac
+}
+
+# List available operations
+list_operations() {
+    echo "Available operations:"
+    echo "  - disk-stall"
+    echo "  - network-partition-full"
+    echo "  - network-partition-partial"
+}
+
+# Main execution
+main() {
+    check_env_vars
+    get_dd_api_key
+
+    # the ssh keys of all workload nodes should be setup on the crdb nodes for the operations
+    drtprod ssh ${CLUSTER} -- "echo \"$(drtprod run "${WORKLOAD_CLUSTER}":1 -- cat ./.ssh/id_rsa.pub|grep ssh-rsa)\" >> ./.ssh/authorized_keys"
+
+    local operations=("disk-stall" "network-partition-full" "network-partition-partial")
+    
+    for opname in "${operations[@]}"; do
+        echo "Setting up script for operation: ${opname}"
+        local config=$(get_operation_config "$opname")
+        IFS=',' read -r op_name op_iterations op_wait <<< "$config"
+        create_operation_script "$op_name" "$op_iterations" "$op_wait"
+        echo "Script for operation: ${opname} complete"
+        echo "----------------------------------------"
+    done
+}
+
+main "$@"

--- a/pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
+++ b/pkg/cmd/drtprod/scripts/setup_dmsetup_disk_staller
@@ -8,9 +8,9 @@ if [ -z "${CLUSTER}" ]; then
   exit 1
 fi
 
-roachprod ssh "$CLUSTER" -- "sudo apt-get purge -y snapd"
-roachprod ssh "$CLUSTER" -- "sudo umount -f /mnt/data1"
-roachprod ssh "$CLUSTER" -- "sudo dmsetup remove_all"
-roachprod ssh "$CLUSTER" -- "sudo tune2fs -O ^has_journal /dev/nvme0n1"
-roachprod ssh "$CLUSTER" -- 'echo "0 $(sudo blockdev --getsz /dev/nvme0n1) linear /dev/nvme0n1 0" | sudo dmsetup create data1'
-roachprod ssh "$CLUSTER" -- "sudo mount /dev/mapper/data1 /mnt/data1"
+drtprod ssh "$CLUSTER" -- "sudo apt-get purge -y snapd"
+drtprod ssh "$CLUSTER" -- "sudo umount -f /mnt/data1"
+drtprod ssh "$CLUSTER" -- "sudo dmsetup remove_all"
+drtprod ssh "$CLUSTER" -- "sudo tune2fs -O ^has_journal /dev/nvme0n1"
+drtprod ssh "$CLUSTER" -- 'echo "0 $(sudo blockdev --getsz /dev/nvme0n1) linear /dev/nvme0n1 0" | sudo dmsetup create data1'
+drtprod ssh "$CLUSTER" -- "sudo mount /dev/mapper/data1 /mnt/data1"


### PR DESCRIPTION
This PR introduces the following changes:

1. Adds YAML configuration files to run Performance Under Adversity (PUA) tests end-to-end.
2. Includes a wait time in the drtprod execution steps.

Epic: none

Release note: None