### PR TITLE
release-24.3: upgrades: swallow setting override error in diagnostics migration

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
+++ b/pkg/ccl/logictestccl/testdata/logic_test/tenant_settings
@@ -109,10 +109,10 @@ SHOW CLUSTER SETTING sql.notices.enabled
 true
 
 # Verify that we disallow setting a ApplicationLevel setting that is overridden.
-statement error cluster setting 'sql.notices.enabled' is currently overridden by the operator
+statement error cluster setting 'sql.notices.enabled' cannot be set: cluster setting is overridden by system virtual cluster
 SET CLUSTER SETTING sql.notices.enabled = false
 
-statement error cluster setting 'sql.notices.enabled' is currently overridden by the operator
+statement error cluster setting 'sql.notices.enabled' cannot be set: cluster setting is overridden by system virtual cluster
 RESET CLUSTER SETTING sql.notices.enabled
 
 user host-cluster-root

--- a/pkg/settings/cluster/cluster_settings.go
+++ b/pkg/settings/cluster/cluster_settings.go
@@ -64,6 +64,8 @@ type OverridesInformer interface {
 	IsOverridden(settingKey settings.InternalKey) bool
 }
 
+var SettingOverrideErr = errors.New("cluster setting is overridden by system virtual cluster")
+
 // TelemetryOptOut controls whether to opt out of telemetry (including Sentry) or not.
 var TelemetryOptOut = envutil.EnvOrDefaultBool("COCKROACH_SKIP_ENABLING_DIAGNOSTIC_REPORTING", false)
 

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -224,7 +224,7 @@ func (p *planner) SetClusterSetting(
 	}
 
 	if st.OverridesInformer != nil && st.OverridesInformer.IsOverridden(setting.InternalKey()) {
-		return nil, errors.Errorf("cluster setting '%s' is currently overridden by the operator", name)
+		return nil, errors.Wrapf(cluster.SettingOverrideErr, "cluster setting '%s' cannot be set", name)
 	}
 
 	value, err := p.getAndValidateTypedClusterSetting(ctx, name, n.Value, setting)

--- a/pkg/upgrade/upgrades/permanent_upgrades.go
+++ b/pkg/upgrade/upgrades/permanent_upgrades.go
@@ -148,6 +148,9 @@ func optInToDiagnosticsStatReporting(
 	_, err := deps.InternalExecutor.Exec(
 		ctx, "optInToDiagnosticsStatReporting", nil, /* txn */
 		`SET CLUSTER SETTING diagnostics.reporting.enabled = true`)
+	if errors.Is(err, cluster.SettingOverrideErr) {
+		return nil
+	}
 	return err
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #145332.

/cc @cockroachdb/release

---

Previously if a tenant ran the optInToDiagnosticsStatReporting migration, which sets diagnostics.reporting.enabled, after the system tenant already overrode this setting, the migration would enter a fail loop. With this patch, the migration instead noops.

Epic: none

Release note: none
