### PR TITLE
roachtest: deflake lease-preferences roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/lease_preferences.go
+++ b/pkg/cmd/roachtest/tests/lease_preferences.go
@@ -179,12 +179,6 @@ func runLeasePreferences(
 		allNodes = append(allNodes, i)
 	}
 
-	// TODO(kvoli): temporary workaround for
-	// https://github.com/cockroachdb/cockroach/issues/105274
-	settings := install.MakeClusterSettings()
-	settings.ClusterSettings["server.span_stats.span_batch_limit"] = "4096"
-	settings.ClusterSettings["kv.enqueue_in_replicate_queue_on_span_config_update.enabled"] = "true"
-
 	startNodes := func(nodes ...int) {
 		for _, node := range nodes {
 			// Don't start a backup schedule because this test is timing sensitive.
@@ -198,7 +192,7 @@ func runLeasePreferences(
 				// dc=N: n2N-1 n2N
 				fmt.Sprintf("--locality=region=fake-region,zone=fake-zone,dc=%d", (node-1)/2+1),
 				"--vmodule=replica_proposal=2,lease_queue=3,lease=3")
-			c.Start(ctx, t.L(), opts, settings, c.Node(node))
+			c.Start(ctx, t.L(), opts, install.MakeClusterSettings(), c.Node(node))
 
 		}
 	}

--- a/pkg/cmd/roachtest/tests/lease_preferences.go
+++ b/pkg/cmd/roachtest/tests/lease_preferences.go
@@ -172,6 +172,9 @@ func runLeasePreferences(
 	// waitForLessPreferred=false). This duration is used to ensure the lease
 	// preference satisfaction is reasonably permanent.
 	const stableDuration = 30 * time.Second
+	// initialWaitDuration is how long the test will wait for initial lease
+	// preference conformance. This duration is approx. a replica scanner cycle.
+	const initialWaitDuration = 10 * time.Minute
 
 	numNodes := c.Spec().NodeCount
 	allNodes := make([]int, 0, numNodes)
@@ -209,9 +212,13 @@ func runLeasePreferences(
 	conn := c.Conn(ctx, t.L(), numNodes)
 	defer conn.Close()
 
-	checkLeasePreferenceConformance := func(ctx context.Context) {
+	checkLeasePreferenceConformance := func(ctx context.Context, initial bool) {
+		duration := spec.postEventWaitDuration
+		if initial {
+			duration = initialWaitDuration
+		}
 		result, err := waitForLeasePreferences(
-			ctx, t, c, spec.checkNodes, spec.waitForLessPreferred, stableDuration, spec.postEventWaitDuration)
+			ctx, t, c, spec.checkNodes, spec.waitForLessPreferred, stableDuration, duration)
 		require.NoError(t, err, result)
 		require.Truef(t, !result.violating(), "violating lease preferences %s", result)
 		if spec.waitForLessPreferred {
@@ -254,7 +261,7 @@ func runLeasePreferences(
 		leasePreference: spec.preferences,
 	})
 	t.L().Printf("waiting for initial lease preference conformance")
-	checkLeasePreferenceConformance(ctx)
+	checkLeasePreferenceConformance(ctx, true /* initial */)
 
 	// Run the spec event function. The event function will move leases to
 	// non-conforming localities.
@@ -267,7 +274,7 @@ func runLeasePreferences(
 	// Wait for the preference conformance with some leases in non-conforming
 	// localities.
 	t.L().Printf("waiting for post-event lease preference conformance")
-	checkLeasePreferenceConformance(ctx)
+	checkLeasePreferenceConformance(ctx, false /* initial */)
 }
 
 type leasePreferencesResult struct {


### PR DESCRIPTION
`server.span_stats.span_batch_limit` no longer needs to be set after

`kv.enqueue_in_replicate_queue_on_span_config_update.enabled` defaults
to true in versions on or after `v24.1`.

Informs: #141359
Informs: #145055

---


The `lease-preferences/*` roachtests wait for lease preferences to be
initially conformed before purposefully forcing leases out of
conformance.

Its possible to the initial lease preference conformance to take up to
10 minutes (a replica scanner cycle). Allow this much time. Note the
non-initial conformance should be quicker, as leases are checked on
acquisition, to see whether they violate the lease preferences.

Resolves: https://github.com/cockroachdb/cockroach/issues/141359
Resolves: https://github.com/cockroachdb/cockroach/issues/145055
Release note: None