### PR TITLE
storeliveness: use large test size

### DIFF
--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
 
 go_test(
     name = "storeliveness_test",
+    size = "large",
     srcs = [
         "main_test.go",
         "multi_store_test.go",


### PR DESCRIPTION
The tests within this pkg sometimes use multiple (in-memory) stores over a 3 node cluster. Use a large test size.

Informs: #145335
Release note: None