### PR TITLE
kvserver: mv entries cache update out of logstore

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -456,7 +456,6 @@ go_test(
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptstorage",
         "//pkg/kv/kvserver/protectedts/ptutil",
-        "//pkg/kv/kvserver/raftentry",
         "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/rafttrace",
         "//pkg/kv/kvserver/raftutil",

--- a/pkg/kv/kvserver/client_manual_proposal_test.go
+++ b/pkg/kv/kvserver/client_manual_proposal_test.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/batcheval"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/uncertainty"
@@ -223,7 +222,6 @@ LIMIT
 			Sideload:    nil,
 			StateLoader: rsl,
 			SyncWaiter:  swl,
-			EntryCache:  raftentry.NewCache(1024),
 			Settings:    st,
 		}
 

--- a/pkg/kv/kvserver/logstore/logstore_bench_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_bench_test.go
@@ -11,7 +11,6 @@ import (
 	"math/rand"
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftentry"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/raft"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
@@ -48,8 +47,6 @@ func BenchmarkLogStore_StoreEntries(b *testing.B) {
 
 func runBenchmarkLogStore_StoreEntries(b *testing.B, bytes int64) {
 	ctx := context.Background()
-	const tenMB = 10 * 1 << 20
-	ec := raftentry.NewCache(tenMB)
 	const rangeID = 1
 	eng := storage.NewDefaultInMemForTesting()
 	defer eng.Close()
@@ -59,7 +56,6 @@ func runBenchmarkLogStore_StoreEntries(b *testing.B, bytes int64) {
 		RangeID:     rangeID,
 		Engine:      eng,
 		StateLoader: NewStateLoader(rangeID),
-		EntryCache:  ec,
 		Settings:    st,
 	}
 

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -222,7 +222,6 @@ func newUninitializedReplicaWithoutRaftGroup(
 		// NOTE: use the same SyncWaiter loop for all raft log writes performed by a
 		// given range ID, to ensure that callbacks are processed in order.
 		SyncWaiter: store.syncWaiters[int(rangeID)%len(store.syncWaiters)],
-		EntryCache: store.raftEntryCache,
 		Settings:   store.cfg.Settings,
 		DisableSyncLogWriteToss: buildutil.CrdbTestBuild &&
 			store.TestingKnobs().DisableSyncLogWriteToss,

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -143,8 +143,13 @@ func (r *Replica) raftTermShMuLocked(index kvpb.RaftIndex) (kvpb.RaftTerm, error
 	}
 	// Cache the entry except if it is sideloaded. We don't load/inline the
 	// sideloaded entries here to keep the term fetching cheap.
-	// TODO(pav-kv): consider not caching here, after measuring if it makes any
-	// difference.
+	//
+	// TODO(pav-kv): consider not caching here, after measuring or guessing
+	// whether it makes any difference. It might be harmful to the cache since
+	// terms tend to be loaded randomly, and the cache assumes moving forward. We
+	// also now have the term cache in raft which makes optimizations here
+	// unnecessary. Plus, there is a longer-term better solution not involving
+	// entry loads: the term cache can be maintained in storage. See #136296.
 	if typ, _, err := raftlog.EncodingOf(entry); err != nil {
 		return 0, err
 	} else if !typ.IsSideloaded() {


### PR DESCRIPTION
The current rough split between `LogStore` and `replicaLogStorage` is that the latter is responsible for the in-memory state and keeping it consistent with storage, and the former is just the storage part. This commit moves the code in that direction by placing the raft entries cache update in `replicaLogStorage`.

Related to #136109
Epic: CRDB-46488