### PR TITLE
concurrency: disable durability upgrades for lease transfer and merges

### DIFF
--- a/pkg/kv/kvserver/concurrency/concurrency_manager.go
+++ b/pkg/kv/kvserver/concurrency/concurrency_manager.go
@@ -131,7 +131,7 @@ var UnreplicatedLockReliabilityLeaseTransfer = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lock_table.unreplicated_lock_reliability.lease_transfer.enabled",
 	"whether the replica should attempt to keep unreplicated locks during lease transfers",
-	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability.lease_transfer.enabled", true),
+	false,
 )
 
 // UnreplicatedLockReliabilityMerge controls whether the replica will
@@ -140,7 +140,7 @@ var UnreplicatedLockReliabilityMerge = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"kv.lock_table.unreplicated_lock_reliability.merge.enabled",
 	"whether the replica should attempt to keep unreplicated locks during range merges",
-	metamorphic.ConstantWithTestBool("kv.lock_table.unreplicated_lock_reliability.merge.enabled", true),
+	false,
 )
 
 var MaxLockFlushSize = settings.RegisterByteSizeSetting(


### PR DESCRIPTION
In #145164 we identified a problem with durability upgrades with respect to transaction recovery after the loss of a pipelined replicated lock acquisition.

This PR disables durability upgrades during lease transfers and merges until this is resolved.

Informs #145164

Epic: None

Release Justification: Disable new, preview feature because of recently discovered correctness issue.