### PR TITLE
release-24.1: ci: bump timeout for lint

### DIFF
--- a/build/github/lint.sh
+++ b/build/github/lint.sh
@@ -28,7 +28,7 @@ bazel test \
   --sandbox_writable_path=$HOME \
   --test_env=GO_SDK=$(dirname $(dirname $(bazel run @go_sdk//:bin/go --run_under=realpath))) \
   --test_env=COCKROACH_WORKSPACE=$WORKSPACE \
-  --test_timeout=1800 \
+  --test_timeout=3600 \
   --build_event_binary_file=bes.bin \
   --jobs 50 \
   --remote_download_minimal $(./build/github/engflow-args.sh)


### PR DESCRIPTION
Backport 1/1 commits from #145445 on behalf of @rickystewart.

----

... from 30m to 60m. This timed out in #145433.

Epic: none
Release note: None

----

Release justification: Non-production code changes