### PR TITLE
kvserver: prevent consistency queue from immediately running on new ranges

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -297,7 +297,6 @@ func registerSysbench(r registry.Registry) {
 					`set cluster setting sql.stats.flush.enabled = false`,
 					`set cluster setting sql.metrics.statement_details.enabled = false`,
 					`set cluster setting kv.split_queue.enabled = false`,
-					`set cluster setting kv.consistency_queue.enabled = false`,
 					`set cluster setting kv.transaction.write_buffering.enabled = true`,
 				},
 				useDRPC: true,


### PR DESCRIPTION
This commit stops the current behaviour of making new ranges immediately eligible for the consistency checker queue. This helps to improve the performance while ranges are being split.

It does this by setting the last consistency run timestamp to "now" instead of 0 initially. After that, this value is copied from the LHS to the RHS on splits, and the LHS remains on merged. This ensures two things:

1. We don't immediately make new ranges eligible for the consistency queue.

2. We don't indifferently ignore running the consistency queue on some part of the keyspace. This could have happened if we initialize the last queue timestamp to "now" for the RHS upon splits. Corner cases might happen that a range keeps splitting once before the 24 hours end, making part of the keyspace ineligible for consistency checks indifferently.

Sysbench before/after (almost the same exact performance as expected):

```
│ Metric        │ old.txt        │ new.txt        │ vs base         │
├───────────────┼────────────────┼────────────────┼──────────────-──┤
│ queries/sec   │ 30.00k ± 2%    │ 29.94k ± 1%    │ ~ (p=0.994 n=30)│
│ txns/sec      │ 1.500k ± 2%    │ 1.497k ± 1%    │ ~ (p=0.994 n=30)│
│ ms/min        │ 11.84 ± 2%     │ 11.84 ± 2%     │ ~ (p=0.959 n=30)│
│ ms/avg        │ 42.67 ± 2%     │ 42.75 ± 1%     │ ~ (p=0.994 n=30)│
│ ms/p95        │ 66.25 ± 5%     │ 66.84 ± 2%     │ ~ (p=0.586 n=30)│
│ ms/max        │ 263.3 ± 21%    │ 247.6 ± 18%    │ ~ (p=0.697 n=30)│
```

Fixes: #143136

Release note: None