### PR TITLE
sql: prohibit jsonpath as element in composite type

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -10,11 +10,14 @@ SELECT '$.a'::JSONPATH
 ----
 $."a"
 
-statement error pq: value type jsonpath cannot be used for table columns
+statement error pq: unimplemented: jsonpath unsupported as column type
 CREATE TABLE a (j JSONPATH)
 
-statement error pq: value type jsonpath cannot be used for table columns
+statement error pq: unimplemented: arrays of jsonpath unsupported as column type
 CREATE TABLE a (j JSONPATH[])
+
+statement error pq: unimplemented: jsonpath cannot be used in a composite type
+CREATE TYPE typ AS (j JSONPATH);
 
 query T
 SELECT '$'::JSONPATH

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -370,7 +370,7 @@ type CreateType struct {
 	Variety  CreateTypeVariety
 	// EnumLabels is set when this represents a CREATE TYPE ... AS ENUM statement.
 	EnumLabels EnumValueList
-	// CompositeTypeList is set when this repesnets a CREATE TYPE ... AS ( )
+	// CompositeTypeList is set when this represents a CREATE TYPE ... AS ( )
 	// statement.
 	CompositeTypeList []CompositeTypeElem
 	// IfNotExists is true if IF NOT EXISTS was requested.


### PR DESCRIPTION
This commit ties a few loose ends around the jsonpath data type:
- it prohibits creation of a composite type with jsonpath as an element (it should be fine, but we're doing this out of caution until we have encoding for jsonpath)
- it adds a validation for each element of a composite type for whether it can be used as a column type (under an assumption that if a type cannot be used as a column type, then any composite types consisting of that type cannot either)
- it also adds the issue number to the errors.

Informs: #144910.
Fixes: #144911.

Release note: None