### PR TITLE
catalog/lease: purge old versions on range feed recovery

### DIFF
--- a/pkg/sql/catalog/lease/helpers_test.go
+++ b/pkg/sql/catalog/lease/helpers_test.go
@@ -290,7 +290,7 @@ func (m *Manager) Publish(
 }
 
 func (m *Manager) TestingRefreshSomeLeases(ctx context.Context) {
-	m.refreshSomeLeases(ctx, false /*refreshAll*/)
+	m.refreshSomeLeases(ctx, false /*refreshAndPurgeAllDescriptors*/)
 }
 
 func (m *Manager) TestingDescriptorStateIsNil(id descpb.ID) bool {

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1886,7 +1886,7 @@ func (m *Manager) RunBackgroundLeasingTask(ctx context.Context) {
 					// If the range feed recovers after a failure, re-read all
 					// descriptors.
 					if refreshAllDescriptors {
-						m.refreshSomeLeases(ctx, true /*refreshAll*/)
+						m.refreshSomeLeases(ctx, true /*refreshAndPurgeAllDescriptors*/)
 					}
 				}
 				rangeFeedProgressWatchDogTimeout,
@@ -1895,7 +1895,7 @@ func (m *Manager) RunBackgroundLeasingTask(ctx context.Context) {
 			case err := <-m.rangefeedErrCh:
 				log.Warningf(ctx, "lease rangefeed failed with error: %s", err.Error())
 				m.handleRangeFeedError(ctx)
-				m.refreshSomeLeases(ctx, true /*refreshAll*/)
+				m.refreshSomeLeases(ctx, true /*refreshAndPurgeAllDescriptors*/)
 			case <-refreshTimer.C:
 				refreshTimer.Reset(getRefreshTimerDuration() / 2)
 
@@ -1999,8 +1999,9 @@ func (m *Manager) cleanupExpiredSessionLeases(ctx context.Context) {
 	}
 }
 
-// Refresh some of the current leases.
-func (m *Manager) refreshSomeLeases(ctx context.Context, includeAll bool) {
+// Refresh some of the current leases. If refreshAndPurgeAllDescriptors is set,
+// then all descriptors are refreshed, and old versions are purged.
+func (m *Manager) refreshSomeLeases(ctx context.Context, refreshAndPurgeAllDescriptors bool) {
 	limit := leaseRefreshLimit.Get(&m.storage.settings.SV)
 	if limit <= 0 {
 		return
@@ -2013,7 +2014,7 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, includeAll bool) {
 		ids := make([]descpb.ID, 0, len(m.mu.descriptors))
 		var i int64
 		for k, desc := range m.mu.descriptors {
-			if i++; i > limit && !includeAll {
+			if i++; i > limit && !refreshAndPurgeAllDescriptors {
 				break
 			}
 			takenOffline := func() bool {
@@ -2048,7 +2049,6 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, includeAll bool) {
 						return
 					}
 				}
-
 				if _, err := acquireNodeLease(ctx, m, id, AcquireBackground); err != nil {
 					log.Errorf(ctx, "refreshing descriptor: %d lease failed: %s", id, err)
 
@@ -2057,7 +2057,7 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, includeAll bool) {
 						if err := purgeOldVersions(
 							ctx, m.storage.db.KV(), id, true /* dropped */, 0 /* minVersion */, m,
 						); err != nil {
-							log.Warningf(ctx, "error purging leases for descriptor %d: %s",
+							log.Warningf(ctx, "error purging leases for descriptor %d: %v",
 								id, err)
 						}
 						func() {
@@ -2065,6 +2065,15 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, includeAll bool) {
 							defer m.mu.Unlock()
 							delete(m.mu.descriptors, id)
 						}()
+					}
+				}
+				if refreshAndPurgeAllDescriptors {
+					// If we are refreshing all descriptors, then we want to purge older versions as
+					// we are doing this operation.
+					err := purgeOldVersions(ctx, m.storage.db.KV(), id, false /* dropped */, 0 /* minVersion */, m)
+					if err != nil {
+						log.Warningf(ctx, "error purging leases for descriptor %d: %v",
+							id, err)
 					}
 				}
 			}); err != nil {


### PR DESCRIPTION
catalog/lease: purge old versions on range feed recovery

Previously, the lease manager range feed recovery logic would pick up
newer versions of descriptors after a range feed failure. However, it
would not purge old versions, which could lead to old versions still
being in use. To address this, this patch always purges old versions
when refreshing during a range feed failure.

Fixes: #145422

Release note (bug fix): Addresses a bug that can lead to hung schema
changes after recovery from availability issues.

This patch also fixes TestLeaseDescriptorRangeFeedFailure which did not work correctly when the range feed recovery logic was added.