### PR TITLE
release-25.2: sql: prohibit jsonpath as element in composite type

### DIFF
--- a/pkg/sql/create_type.go
+++ b/pkg/sql/create_type.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/enum"
+	"github.com/cockroachdb/cockroach/pkg/sql/oidext"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
@@ -391,6 +392,10 @@ func CreateEnumTypeDesc(
 	}).BuildCreatedMutableType(), nil
 }
 
+var jsonpathInCompositeErr = unimplemented.NewWithIssueDetailf(
+	144910, "", "jsonpath cannot be used in a composite type",
+)
+
 // createCompositeTypeDesc creates a new composite type descriptor.
 func createCompositeTypeDesc(
 	params runParams,
@@ -416,6 +421,10 @@ func createCompositeTypeDesc(
 		}
 		if typ.Identical(types.Trigger) {
 			return nil, tree.CannotAcceptTriggerErr
+		}
+		if typ.Oid() == oidext.T_jsonpath || typ.Oid() == oidext.T__jsonpath {
+			// TODO(#144910): this is unsupported for now, out of caution.
+			return nil, jsonpathInCompositeErr
 		}
 		if err = tree.CheckUnsupportedType(params.ctx, &params.p.semaCtx, typ); err != nil {
 			return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -10,11 +10,14 @@ SELECT '$.a'::JSONPATH
 ----
 $."a"
 
-statement error pq: value type jsonpath cannot be used for table columns
+statement error pq: unimplemented: jsonpath unsupported as column type
 CREATE TABLE a (j JSONPATH)
 
-statement error pq: value type jsonpath cannot be used for table columns
+statement error pq: unimplemented: arrays of jsonpath unsupported as column type
 CREATE TABLE a (j JSONPATH[])
+
+statement error pq: unimplemented: jsonpath cannot be used in a composite type
+CREATE TYPE typ AS (j JSONPATH);
 
 query T
 SELECT '$'::JSONPATH

--- a/pkg/sql/sem/tree/create.go
+++ b/pkg/sql/sem/tree/create.go
@@ -370,7 +370,7 @@ type CreateType struct {
 	Variety  CreateTypeVariety
 	// EnumLabels is set when this represents a CREATE TYPE ... AS ENUM statement.
 	EnumLabels EnumValueList
-	// CompositeTypeList is set when this repesnets a CREATE TYPE ... AS ( )
+	// CompositeTypeList is set when this represents a CREATE TYPE ... AS ( )
 	// statement.
 	CompositeTypeList []CompositeTypeElem
 	// IfNotExists is true if IF NOT EXISTS was requested.


### PR DESCRIPTION
Backport 1/1 commits from #145456 on behalf of @yuzefovich.

----

This commit ties a few loose ends around the jsonpath data type:
- it prohibits creation of a composite type with jsonpath as an element (it should be fine, but we're doing this out of caution until we have encoding for jsonpath)
- it adds a validation for each element of a composite type for whether it can be used as a column type (under an assumption that if a type cannot be used as a column type, then any composite types consisting of that type cannot either)
- it also adds the issue number to the errors.

Informs: #144910.
Fixes: #144911.

Release note: None

----

Release justification: new functionality.