### PR TITLE
vecstore: switch partition id generation to GenerateUniqueUnorderedID

### DIFF
--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -175,7 +175,7 @@ func (s *Store) RunTransaction(ctx context.Context, fn func(txn cspann.Txn) erro
 // unique partition key.
 func (s *Store) MakePartitionKey() cspann.PartitionKey {
 	instanceID := s.kv.Context().NodeID.SQLInstanceID()
-	return cspann.PartitionKey(unique.GenerateUniqueInt(unique.ProcessUniqueID(instanceID)))
+	return cspann.PartitionKey(unique.GenerateUniqueUnorderedID(unique.ProcessUniqueID(instanceID)))
 }
 
 // EstimatePartitionCount is part of the cspann.Store interface. It returns an


### PR DESCRIPTION
Previously we used GenerateUniqueInt to generate vector index partition IDs. While functional, this method ensured that new partitions would generally have higher values than older partitions. This has the potential to create hot spots in the kv range, leading to poor scalability and performance.

This patch switches the generation function to
GenerateUniqueUnorderedID, which creates new partition ids scattered over the value space which should lead to fewer hot spots.

Epic: CRDB-42943
Release note (backwards-incompatible change): Vector indexes created before 25.2 release (e.g. during the beta) will have to be rebuilt.