### PR TITLE
release-25.1: storage: minor cleanups around pebble compaction concurrency

### DIFF
--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1106,10 +1106,6 @@ type Engine interface {
 	// concurrency. It returns the previous compaction concurrency.
 	SetCompactionConcurrency(n uint64) uint64
 
-	// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-	// the passed delta, down to a minimum of 1.
-	AdjustCompactionConcurrency(delta int64) uint64
-
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object
 	// creator ID (if shared object storage is configured).

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1005,21 +1005,6 @@ func (p *Pebble) RegisterDiskSlowCallback(f func(vfs.DiskSlowInfo)) {
 	p.diskSlowFunc.Store(&f)
 }
 
-// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-// the passed delta, down to a minimum of 1.
-func (p *Pebble) AdjustCompactionConcurrency(delta int64) uint64 {
-	for {
-		current := atomic.LoadUint64(&p.atomic.compactionConcurrency)
-		adjusted := int64(current) + delta
-		if adjusted < 1 {
-			adjusted = 1
-		}
-		if atomic.CompareAndSwapUint64(&p.atomic.compactionConcurrency, current, uint64(adjusted)) {
-			return uint64(adjusted)
-		}
-	}
-}
-
 // SetStoreID adds the store id to pebble logs.
 func (p *Pebble) SetStoreID(ctx context.Context, storeID int32) error {
 	if p == nil {


### PR DESCRIPTION
Backport 4/4 commits from #145288.

/cc @cockroachdb/release

---

#### storage: remove AdjustCompactionConcurrency

This is not used.

Epic: none
Release note: None

#### storage: remove unnecessary initialization in newPebble

We now only call this function from Open and we always have options
set.

Epic: none
Release note: None

#### pebble: separate compaction concurrency override logic

Separate the logic that allows temporarily overriding compaction
concurrency.

Epic: none
Release note: None

#### storage: cleanup default max concurrent compactions code

Refactor this code so we statically initialize the default value.

Epic: none
Release note: None
