### PR TITLE
release-25.2: storage: minor cleanups around pebble compaction concurrency

### DIFF
--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -199,11 +199,11 @@ func (is Server) SetCompactionConcurrency(
 	resp := &CompactionConcurrencyResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			prevConcurrency := s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
+			s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
 
 			// Wait for cancellation, and once cancelled, reset the compaction concurrency.
 			<-ctx.Done()
-			s.TODOEngine().SetCompactionConcurrency(prevConcurrency)
+			s.TODOEngine().SetCompactionConcurrency(0)
 			return nil
 		})
 	return resp, err

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -191,8 +191,9 @@ func (is Server) ScanStorageInternalKeys(
 // SetCompactionConcurrency implements PerStoreServer. It changes the compaction
 // concurrency of a store. While SetCompactionConcurrency is safe for concurrent
 // use, it adds uncertainty about the compaction concurrency actually set on
-// the store. It also adds uncertainty about the compaction concurrency set on
-// the store once the request is cancelled.
+// the store. We do guarantee that once all SetCompactionConcurrency requests
+// are finished (cancelled), the override is removed and the original
+// concurrency is restored.
 func (is Server) SetCompactionConcurrency(
 	ctx context.Context, req *CompactionConcurrencyRequest,
 ) (*CompactionConcurrencyResponse, error) {
@@ -201,7 +202,8 @@ func (is Server) SetCompactionConcurrency(
 		func(ctx context.Context, s *Store) error {
 			s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
 
-			// Wait for cancellation, and once cancelled, reset the compaction concurrency.
+			// Wait for cancellation, and once cancelled, reset the compaction
+			// concurrency.
 			<-ctx.Done()
 			s.TODOEngine().SetCompactionConcurrency(0)
 			return nil

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1103,9 +1103,9 @@ type Engine interface {
 	// version that it must maintain compatibility with.
 	SetMinVersion(version roachpb.Version) error
 
-	// SetCompactionConcurrency is used to set the engine's compaction
-	// concurrency. It returns the previous compaction concurrency.
-	SetCompactionConcurrency(n uint64) uint64
+	// SetCompactionConcurrency is used to override the engine's max compaction
+	// concurrency. A value of 0 removes any existing override.
+	SetCompactionConcurrency(n uint64)
 
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1107,10 +1107,6 @@ type Engine interface {
 	// concurrency. It returns the previous compaction concurrency.
 	SetCompactionConcurrency(n uint64) uint64
 
-	// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-	// the passed delta, down to a minimum of 1.
-	AdjustCompactionConcurrency(delta int64) uint64
-
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object
 	// creator ID (if shared object storage is configured).

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -367,7 +367,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		// NB: Options.MaxConcurrentCompactions may be "wrapped" in NewPebble to
 		// allow overriding the max at runtime through
 		// Engine.SetCompactionConcurrency.
-		MaxConcurrentCompactions:    getMaxConcurrentCompactions,
+		MaxConcurrentCompactions:    func() int { return defaultMaxConcurrentCompactions },
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
 		Merger:                      MVCCMerger,
@@ -683,7 +683,9 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		}
 	}
 
-	cfg.opts.MaxConcurrentCompactions = getMaxConcurrentCompactions
+	if cfg.opts.MaxConcurrentCompactions == nil {
+		cfg.opts.MaxConcurrentCompactions = func() int { return defaultMaxConcurrentCompactions }
+	}
 
 	cfg.opts.EnsureDefaults()
 

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -364,7 +364,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		L0StopWritesThreshold: 1000,
 		LBaseMaxBytes:         64 << 20, // 64 MB
 		Levels:                make([]pebble.LevelOptions, 7),
-		// NB: Options.MaxConcurrentCompactions may be overidden in NewPebble to
+		// NB: Options.MaxConcurrentCompactions may be "wrapped" in NewPebble to
 		// allow overriding the max at runtime through
 		// Engine.SetCompactionConcurrency.
 		MaxConcurrentCompactions:    getMaxConcurrentCompactions,
@@ -501,23 +501,14 @@ type engineConfig struct {
 
 // Pebble is a wrapper around a Pebble database instance.
 type Pebble struct {
-	atomic struct {
-		// compactionConcurrency is the current compaction concurrency set on
-		// the Pebble store. The compactionConcurrency option in the Pebble
-		// Options struct is a closure which will return
-		// Pebble.atomic.compactionConcurrency.
-		//
-		// This mechanism allows us to change the Pebble compactionConcurrency
-		// on the fly without restarting Pebble.
-		compactionConcurrency uint64
-	}
-
 	cfg         engineConfig
 	db          *pebble.DB
 	closed      bool
 	auxDir      string
 	ballastPath string
 	properties  roachpb.StoreProperties
+
+	cco compactionConcurrencyOverride
 
 	// Stats updated by pebble.EventListener invocations, and returned in
 	// GetMetrics. Updated and retrieved atomically.
@@ -575,10 +566,10 @@ var _ Engine = &Pebble{}
 // WorkloadCollectorEnabled specifies if the workload collector will be enabled
 var WorkloadCollectorEnabled = envutil.EnvOrDefaultBool("COCKROACH_STORAGE_WORKLOAD_COLLECTOR", false)
 
-// SetCompactionConcurrency will return the previous compaction concurrency.
-func (p *Pebble) SetCompactionConcurrency(n uint64) uint64 {
-	prevConcurrency := atomic.SwapUint64(&p.atomic.compactionConcurrency, n)
-	return prevConcurrency
+// SetCompactionConcurrency is used to override the engine's max compaction
+// concurrency. A value of 0 removes any existing override.
+func (p *Pebble) SetCompactionConcurrency(n uint64) {
+	p.cco.Set(uint32(n))
 }
 
 // RegisterDiskSlowCallback registers a callback that will be run when a write
@@ -692,6 +683,8 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		}
 	}
 
+	cfg.opts.MaxConcurrentCompactions = getMaxConcurrentCompactions
+
 	cfg.opts.EnsureDefaults()
 
 	// The context dance here is done so that we have a clean context without
@@ -798,15 +791,9 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 
 	// MaxConcurrentCompactions can be set by multiple sources, but all the
 	// sources will eventually call NewPebble. So, we override
-	// cfg.opts.MaxConcurrentCompactions to a closure which will return
-	// Pebble.atomic.compactionConcurrency. This will allow us to both honor
-	// the compactions concurrency which has already been set and allow us
-	// to update the compactionConcurrency on the fly by changing the
-	// Pebble.atomic.compactionConcurrency variable.
-	p.atomic.compactionConcurrency = uint64(cfg.opts.MaxConcurrentCompactions())
-	cfg.opts.MaxConcurrentCompactions = func() int {
-		return int(atomic.LoadUint64(&p.atomic.compactionConcurrency))
-	}
+	// cfg.opts.MaxConcurrentCompactions to a closure which allows ovderriding the
+	// value.
+	cfg.opts.MaxConcurrentCompactions = p.cco.Wrap(cfg.opts.MaxConcurrentCompactions)
 
 	// NB: The ordering of the event listeners passed to TeeEventListener is
 	// deliberate. The listener returned by makeMetricEtcEventListener is
@@ -2750,4 +2737,25 @@ var _ error = &ExceedMaxSizeError{}
 
 func (e *ExceedMaxSizeError) Error() string {
 	return fmt.Sprintf("export size (%d bytes) exceeds max size (%d bytes)", e.reached, e.maxSize)
+}
+
+// compactionConcurrencyOverride allows overriding the max concurrent
+// compactions.
+type compactionConcurrencyOverride struct {
+	override atomic.Uint32
+}
+
+// Set the override value. If the value is 0, the override is cancelled.
+func (cco *compactionConcurrencyOverride) Set(value uint32) {
+	cco.override.Store(value)
+}
+
+// Wrap a MaxConcurrentCompactions function to take into account the override.
+func (cco *compactionConcurrencyOverride) Wrap(maxConcurrentCompactions func() int) func() int {
+	return func() int {
+		if o := cco.override.Load(); o > 0 {
+			return int(o)
+		}
+		return maxConcurrentCompactions()
+	}
 }

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -595,21 +595,6 @@ func (p *Pebble) RegisterLowDiskSpaceCallback(f func(info pebble.LowDiskSpaceInf
 	p.lowDiskSpaceFunc.Store(&f)
 }
 
-// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-// the passed delta, down to a minimum of 1.
-func (p *Pebble) AdjustCompactionConcurrency(delta int64) uint64 {
-	for {
-		current := atomic.LoadUint64(&p.atomic.compactionConcurrency)
-		adjusted := int64(current) + delta
-		if adjusted < 1 {
-			adjusted = 1
-		}
-		if atomic.CompareAndSwapUint64(&p.atomic.compactionConcurrency, current, uint64(adjusted)) {
-			return uint64(adjusted)
-		}
-	}
-}
-
 // SetStoreID adds the store id to pebble logs.
 func (p *Pebble) SetStoreID(ctx context.Context, storeID int32) error {
 	if p == nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -666,17 +666,11 @@ var ConfigureForSharedStorage func(opts *pebble.Options, storage remote.Storage)
 // Direct users of NewPebble: cfs.opts.{Logger,LoggerAndTracer} must not be
 // set.
 func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
-	if cfg.opts == nil {
-		cfg.opts = DefaultPebbleOptions()
-	} else {
-		// Open also causes DefaultPebbleOptions before calling NewPebble, so we
-		// are tolerant of Logger being set to pebble.DefaultLogger.
-		if cfg.opts.Logger != nil && cfg.opts.Logger != pebble.DefaultLogger {
-			return nil, errors.AssertionFailedf("Options.Logger is set to unexpected value")
-		}
-		// Clone the given options so that we are free to modify them.
-		cfg.opts = cfg.opts.Clone()
+	if cfg.opts.Logger != nil {
+		return nil, errors.AssertionFailedf("Options.Logger is set to unexpected value")
 	}
+	// Clone the given options so that we are free to modify them.
+	cfg.opts = cfg.opts.Clone()
 	if cfg.opts.FormatMajorVersion < MinimumSupportedFormatVersion {
 		return nil, errors.AssertionFailedf(
 			"FormatMajorVersion is %d, should be at least %d",


### PR DESCRIPTION
Backport 4/4 commits from #145288.

/cc @cockroachdb/release

Release justification:


---

#### storage: remove AdjustCompactionConcurrency

This is not used.

Epic: none
Release note: None

#### storage: remove unnecessary initialization in newPebble

We now only call this function from Open and we always have options
set.

Epic: none
Release note: None

#### pebble: separate compaction concurrency override logic

Separate the logic that allows temporarily overriding compaction
concurrency.

Epic: none
Release note: None

#### storage: cleanup default max concurrent compactions code

Refactor this code so we statically initialize the default value.

Epic: none
Release note: None
