### PR TITLE
release-24.1: storage: minor cleanups around pebble compaction concurrency

### DIFF
--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -199,11 +199,11 @@ func (is Server) SetCompactionConcurrency(
 	resp := &CompactionConcurrencyResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			prevConcurrency := s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
+			s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
 
 			// Wait for cancellation, and once cancelled, reset the compaction concurrency.
 			<-ctx.Done()
-			s.TODOEngine().SetCompactionConcurrency(prevConcurrency)
+			s.TODOEngine().SetCompactionConcurrency(0)
 			return nil
 		})
 	return resp, err

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -191,8 +191,9 @@ func (is Server) ScanStorageInternalKeys(
 // SetCompactionConcurrency implements PerStoreServer. It changes the compaction
 // concurrency of a store. While SetCompactionConcurrency is safe for concurrent
 // use, it adds uncertainty about the compaction concurrency actually set on
-// the store. It also adds uncertainty about the compaction concurrency set on
-// the store once the request is cancelled.
+// the store. We do guarantee that once all SetCompactionConcurrency requests
+// are finished (cancelled), the override is removed and the original
+// concurrency is restored.
 func (is Server) SetCompactionConcurrency(
 	ctx context.Context, req *CompactionConcurrencyRequest,
 ) (*CompactionConcurrencyResponse, error) {
@@ -201,7 +202,8 @@ func (is Server) SetCompactionConcurrency(
 		func(ctx context.Context, s *Store) error {
 			s.TODOEngine().SetCompactionConcurrency(req.CompactionConcurrency)
 
-			// Wait for cancellation, and once cancelled, reset the compaction concurrency.
+			// Wait for cancellation, and once cancelled, reset the compaction
+			// concurrency.
 			<-ctx.Done()
 			s.TODOEngine().SetCompactionConcurrency(0)
 			return nil

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1106,10 +1106,6 @@ type Engine interface {
 	// concurrency. It returns the previous compaction concurrency.
 	SetCompactionConcurrency(n uint64) uint64
 
-	// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-	// the passed delta, down to a minimum of 1.
-	AdjustCompactionConcurrency(delta int64) uint64
-
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object
 	// creator ID (if shared object storage is configured).

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -1102,9 +1102,9 @@ type Engine interface {
 	// version that it must maintain compatibility with.
 	SetMinVersion(version roachpb.Version) error
 
-	// SetCompactionConcurrency is used to set the engine's compaction
-	// concurrency. It returns the previous compaction concurrency.
-	SetCompactionConcurrency(n uint64) uint64
+	// SetCompactionConcurrency is used to override the engine's max compaction
+	// concurrency. A value of 0 removes any existing override.
+	SetCompactionConcurrency(n uint64)
 
 	// SetStoreID informs the engine of the store ID, once it is known.
 	// Used to show the store ID in logs and to initialize the shared object

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -98,46 +98,32 @@ var TargetBytesPerLockConflictError = settings.RegisterIntSetting(
 	settings.WithName("storage.mvcc.target_bytes_per_lock_conflict_error"),
 )
 
-// getMaxConcurrentCompactions wraps the maxConcurrentCompactions env var in a
-// func that may be installed on Options.MaxConcurrentCompactions. It also
-// imposes a floor on the max, so that an engine is always created with at least
-// 1 slot for a compactions.
-//
-// NB: This function inspects the environment every time it's called. This is
-// okay, because Engine construction in NewPebble will invoke it and store the
-// value on the Engine itself.
-func getMaxConcurrentCompactions() int {
-	n := envutil.EnvOrDefaultInt(
-		"COCKROACH_CONCURRENT_COMPACTIONS", func() int {
-			// The old COCKROACH_ROCKSDB_CONCURRENCY environment variable was never
-			// documented, but customers were told about it and use today in
-			// production. We don't want to break them, so if the new env var
-			// is unset but COCKROACH_ROCKSDB_CONCURRENCY is set, use the old env
-			// var's value. This old env var has a wart in that it's expressed as a
-			// number of concurrency slots to make available to both flushes and
-			// compactions (a vestige of the corresponding RocksDB option's
-			// mechanics). We need to adjust it to be in terms of just compaction
-			// concurrency by subtracting the flushing routine's dedicated slot.
-			//
-			// TODO(jackson): Should envutil expose its `getEnv` internal func for
-			// cases like this where we actually want to know whether it's present
-			// or not; not just fallback to a default?
-			if oldV := envutil.EnvOrDefaultInt("COCKROACH_ROCKSDB_CONCURRENCY", 0); oldV > 0 {
-				return oldV - 1
-			}
+var defaultMaxConcurrentCompactions = getDefaultMaxConcurrentCompactions()
 
-			// By default use up to min(numCPU-1, 3) threads for background
-			// compactions per store (reserving the final process for flushes).
-			const max = 3
-			if n := runtime.GOMAXPROCS(0); n-1 < max {
-				return n - 1
-			}
-			return max
-		}())
-	if n < 1 {
-		return 1
+func getDefaultMaxConcurrentCompactions() int {
+	if v := envutil.EnvOrDefaultInt("COCKROACH_CONCURRENT_COMPACTIONS", 0); v > 0 {
+		return v
 	}
-	return n
+	// The old COCKROACH_ROCKSDB_CONCURRENCY environment variable was never
+	// documented, but customers were told about it and use today in
+	// production. We don't want to break them, so if the new env var
+	// is unset but COCKROACH_ROCKSDB_CONCURRENCY is set, use the old env
+	// var's value. This old env var has a wart in that it's expressed as a
+	// number of concurrency slots to make available to both flushes and
+	// compactions (a vestige of the corresponding RocksDB option's
+	// mechanics). We need to adjust it to be in terms of just compaction
+	// concurrency by subtracting the flushing routine's dedicated slot.
+	if oldV := envutil.EnvOrDefaultInt("COCKROACH_ROCKSDB_CONCURRENCY", 0); oldV > 0 {
+		return max(oldV-1, 1)
+	}
+
+	// By default use up to min(GOMAXPROCS-1, 3) threads for background
+	// compactions per store (reserving the final process for flushes).
+	const upperLimit = 3
+	if n := runtime.GOMAXPROCS(0); n-1 < upperLimit {
+		return max(n-1, 1)
+	}
+	return upperLimit
 }
 
 // l0SubLevelCompactionConcurrency is the sub-level threshold at which to

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -808,7 +808,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		// NB: Options.MaxConcurrentCompactions may be "wrapped" in NewPebble to
 		// allow overriding the max at runtime through
 		// Engine.SetCompactionConcurrency.
-		MaxConcurrentCompactions:    getMaxConcurrentCompactions,
+		MaxConcurrentCompactions:    func() int { return defaultMaxConcurrentCompactions },
 		MemTableSize:                64 << 20, // 64 MB
 		MemTableStopWritesThreshold: 4,
 		Merger:                      MVCCMerger,
@@ -1100,7 +1100,9 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 		}
 	}
 
-	cfg.opts.MaxConcurrentCompactions = getMaxConcurrentCompactions
+	if cfg.opts.MaxConcurrentCompactions == nil {
+		cfg.opts.MaxConcurrentCompactions = func() int { return defaultMaxConcurrentCompactions }
+	}
 
 	if buildutil.CrdbTestBuild {
 		cfg.opts.Experimental.CheckExternalIngestions = true

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1012,21 +1012,6 @@ func (p *Pebble) SetCompactionConcurrency(n uint64) uint64 {
 	return prevConcurrency
 }
 
-// AdjustCompactionConcurrency adjusts the compaction concurrency up or down by
-// the passed delta, down to a minimum of 1.
-func (p *Pebble) AdjustCompactionConcurrency(delta int64) uint64 {
-	for {
-		current := atomic.LoadUint64(&p.atomic.compactionConcurrency)
-		adjusted := int64(current) + delta
-		if adjusted < 1 {
-			adjusted = 1
-		}
-		if atomic.CompareAndSwapUint64(&p.atomic.compactionConcurrency, current, uint64(adjusted)) {
-			return uint64(adjusted)
-		}
-	}
-}
-
 // SetStoreID adds the store id to pebble logs.
 func (p *Pebble) SetStoreID(ctx context.Context, storeID int32) error {
 	if p == nil {

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1083,17 +1083,11 @@ var ConfigureForSharedStorage func(opts *pebble.Options, storage remote.Storage)
 // Direct users of NewPebble: cfs.opts.{Logger,LoggerAndTracer} must not be
 // set.
 func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
-	if cfg.opts == nil {
-		cfg.opts = DefaultPebbleOptions()
-	} else {
-		// Open also causes DefaultPebbleOptions before calling NewPebble, so we
-		// are tolerant of Logger being set to pebble.DefaultLogger.
-		if cfg.opts.Logger != nil && cfg.opts.Logger != pebble.DefaultLogger {
-			return nil, errors.AssertionFailedf("Options.Logger is set to unexpected value")
-		}
-		// Clone the given options so that we are free to modify them.
-		cfg.opts = cfg.opts.Clone()
+	if cfg.opts.Logger != nil {
+		return nil, errors.AssertionFailedf("Options.Logger is set to unexpected value")
 	}
+	// Clone the given options so that we are free to modify them.
+	cfg.opts = cfg.opts.Clone()
 	if cfg.opts.FormatMajorVersion < MinimumSupportedFormatVersion {
 		return nil, errors.AssertionFailedf(
 			"FormatMajorVersion is %d, should be at least %d",

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -805,7 +805,7 @@ func DefaultPebbleOptions() *pebble.Options {
 		L0StopWritesThreshold: 1000,
 		LBaseMaxBytes:         64 << 20, // 64 MB
 		Levels:                make([]pebble.LevelOptions, 7),
-		// NB: Options.MaxConcurrentCompactions may be overidden in NewPebble to
+		// NB: Options.MaxConcurrentCompactions may be "wrapped" in NewPebble to
 		// allow overriding the max at runtime through
 		// Engine.SetCompactionConcurrency.
 		MaxConcurrentCompactions:    getMaxConcurrentCompactions,
@@ -935,23 +935,14 @@ type engineConfig struct {
 
 // Pebble is a wrapper around a Pebble database instance.
 type Pebble struct {
-	atomic struct {
-		// compactionConcurrency is the current compaction concurrency set on
-		// the Pebble store. The compactionConcurrency option in the Pebble
-		// Options struct is a closure which will return
-		// Pebble.atomic.compactionConcurrency.
-		//
-		// This mechanism allows us to change the Pebble compactionConcurrency
-		// on the fly without restarting Pebble.
-		compactionConcurrency uint64
-	}
-
 	cfg         engineConfig
 	db          *pebble.DB
 	closed      bool
 	auxDir      string
 	ballastPath string
 	properties  roachpb.StoreProperties
+
+	cco compactionConcurrencyOverride
 
 	// Stats updated by pebble.EventListener invocations, and returned in
 	// GetMetrics. Updated and retrieved atomically.
@@ -1006,10 +997,10 @@ var _ Engine = &Pebble{}
 // WorkloadCollectorEnabled specifies if the workload collector will be enabled
 var WorkloadCollectorEnabled = envutil.EnvOrDefaultBool("COCKROACH_STORAGE_WORKLOAD_COLLECTOR", false)
 
-// SetCompactionConcurrency will return the previous compaction concurrency.
-func (p *Pebble) SetCompactionConcurrency(n uint64) uint64 {
-	prevConcurrency := atomic.SwapUint64(&p.atomic.compactionConcurrency, n)
-	return prevConcurrency
+// SetCompactionConcurrency is used to override the engine's max compaction
+// concurrency. A value of 0 removes any existing override.
+func (p *Pebble) SetCompactionConcurrency(n uint64) {
+	p.cco.Set(uint32(n))
 }
 
 // SetStoreID adds the store id to pebble logs.
@@ -1108,6 +1099,8 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 			return int(concurrentDownloadCompactions.Get(&cfg.settings.SV))
 		}
 	}
+
+	cfg.opts.MaxConcurrentCompactions = getMaxConcurrentCompactions
 
 	if buildutil.CrdbTestBuild {
 		cfg.opts.Experimental.CheckExternalIngestions = true
@@ -1241,15 +1234,9 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 
 	// MaxConcurrentCompactions can be set by multiple sources, but all the
 	// sources will eventually call NewPebble. So, we override
-	// cfg.opts.MaxConcurrentCompactions to a closure which will return
-	// Pebble.atomic.compactionConcurrency. This will allow us to both honor
-	// the compactions concurrency which has already been set and allow us
-	// to update the compactionConcurrency on the fly by changing the
-	// Pebble.atomic.compactionConcurrency variable.
-	p.atomic.compactionConcurrency = uint64(cfg.opts.MaxConcurrentCompactions())
-	cfg.opts.MaxConcurrentCompactions = func() int {
-		return int(atomic.LoadUint64(&p.atomic.compactionConcurrency))
-	}
+	// cfg.opts.MaxConcurrentCompactions to a closure which allows ovderriding the
+	// value.
+	cfg.opts.MaxConcurrentCompactions = p.cco.Wrap(cfg.opts.MaxConcurrentCompactions)
 
 	// NB: The ordering of the event listeners passed to TeeEventListener is
 	// deliberate. The listener returned by makeMetricEtcEventListener is
@@ -3195,4 +3182,25 @@ var _ error = &ExceedMaxSizeError{}
 
 func (e *ExceedMaxSizeError) Error() string {
 	return fmt.Sprintf("export size (%d bytes) exceeds max size (%d bytes)", e.reached, e.maxSize)
+}
+
+// compactionConcurrencyOverride allows overriding the max concurrent
+// compactions.
+type compactionConcurrencyOverride struct {
+	override atomic.Uint32
+}
+
+// Set the override value. If the value is 0, the override is cancelled.
+func (cco *compactionConcurrencyOverride) Set(value uint32) {
+	cco.override.Store(value)
+}
+
+// Wrap a MaxConcurrentCompactions function to take into account the override.
+func (cco *compactionConcurrencyOverride) Wrap(maxConcurrentCompactions func() int) func() int {
+	return func() int {
+		if o := cco.override.Load(); o > 0 {
+			return int(o)
+		}
+		return maxConcurrentCompactions()
+	}
 }

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1494,7 +1494,7 @@ func TestCompactionConcurrencyEnvVars(t *testing.T) {
 				} else {
 					defer envutil.TestSetEnv(t, "COCKROACH_CONCURRENT_COMPACTIONS", tc.cockroachConcurrency)()
 				}
-				require.Equal(t, tc.want, getMaxConcurrentCompactions())
+				require.Equal(t, tc.want, getDefaultMaxConcurrentCompactions())
 			})
 	}
 }
@@ -1582,4 +1582,21 @@ func TestPebbleLoggingSlowReads(t *testing.T) {
 		}
 	}
 	require.Less(t, 0, slowCount)
+}
+
+func TestPebbleSetCompactionConcurrency(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	settings := cluster.MakeTestingClusterSettings()
+	p, err := Open(ctx, InMemory(), settings, CacheSize(1<<20 /* 1 MiB */), MaxConcurrentCompactions(4))
+	require.NoError(t, err)
+	defer p.Close()
+
+	require.Equal(t, 4, p.cfg.opts.MaxConcurrentCompactions())
+	p.SetCompactionConcurrency(10)
+	require.Equal(t, 10, p.cfg.opts.MaxConcurrentCompactions())
+	p.SetCompactionConcurrency(0)
+	require.Equal(t, 4, p.cfg.opts.MaxConcurrentCompactions())
 }


### PR DESCRIPTION
Backport 1/1 commits from #145483.

/cc @cockroachdb/release

---

Backport 4/4 commits from #145288.

/cc @cockroachdb/release

---

#### storage: remove AdjustCompactionConcurrency

This is not used.

Epic: none
Release note: None

#### storage: remove unnecessary initialization in newPebble

We now only call this function from Open and we always have options
set.

Epic: none
Release note: None

#### pebble: separate compaction concurrency override logic

Separate the logic that allows temporarily overriding compaction
concurrency.

Epic: none
Release note: None

#### storage: cleanup default max concurrent compactions code

Refactor this code so we statically initialize the default value.

Epic: none
Release note: None

