### PR TITLE
sql: disallow name-only cols in column definition lists

### DIFF
--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -4566,8 +4566,10 @@ rowsfrom_list ::=
 	( rowsfrom_item ) ( ( ',' rowsfrom_item ) )*
 
 func_alias_clause ::=
-	'AS' table_alias_name opt_col_def_list
-	| table_alias_name opt_col_def_list
+	alias_clause
+	| 'AS' '(' col_def_list ')'
+	| 'AS' table_alias_name '(' col_def_list ')'
+	| table_alias_name '(' col_def_list ')'
 
 opt_asc_desc ::=
 	'ASC'
@@ -4864,8 +4866,8 @@ join_outer ::=
 rowsfrom_item ::=
 	func_expr_windowless opt_func_alias_clause
 
-opt_col_def_list ::=
-	'(' col_def_list ')'
+col_def_list ::=
+	( col_def ) ( ( ',' col_def ) )*
 
 group_by_item ::=
 	a_expr
@@ -5029,8 +5031,8 @@ create_as_col_qualification_elem ::=
 create_as_params ::=
 	( create_as_param ) ( ( ',' create_as_param ) )*
 
-col_def_list ::=
-	( col_def ) ( ( ',' col_def ) )*
+col_def ::=
+	name typename
 
 char_aliases ::=
 	'CHAR'
@@ -5087,10 +5089,6 @@ opt_partition_by ::=
 
 create_as_param ::=
 	column_name
-
-col_def ::=
-	name
-	| name typename
 
 col_qualification_elem ::=
 	'NOT' 'NULL'

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_srf
@@ -591,3 +591,25 @@ CREATE FUNCTION f(OUT x INT, OUT y INT) RETURNS SETOF RECORD LANGUAGE PLpgSQL AS
 $$;
 
 subtest end
+
+# Do not panic when the column definition list for a generator function does
+# not define types for all columns.
+subtest regression_145414
+
+statement ok
+CREATE FUNCTION f145414() RETURNS SETOF RECORD LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN QUERY SELECT 1, 2;
+  END
+$$;
+
+statement error pgcode 42601 pq: at or near "int": syntax error
+SELECT * FROM f145414() AS foo(x, y INT);
+
+statement error pgcode 42601 pq: at or near "\)": syntax error
+SELECT * FROM f145414() AS foo(x INT, y);
+
+statement ok
+DROP FUNCTION f145414;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_setof
+++ b/pkg/sql/logictest/testdata/logic_test/udf_setof
@@ -307,3 +307,21 @@ CREATE FUNCTION err() RETURNS TABLE (x INT) STRICT LANGUAGE SQL AS $$
 $$
 
 subtest end
+
+# Do not panic when the column definition list for a generator function does
+# not define types for all columns.
+subtest regression_145414
+
+statement ok
+CREATE FUNCTION f145414() RETURNS SETOF RECORD LANGUAGE SQL AS $$ SELECT 1, 2; $$;
+
+statement error pgcode 42601 pq: at or near "int": syntax error
+SELECT * FROM f145414() AS foo(x, y INT);
+
+statement error pgcode 42601 pq: at or near "\)": syntax error
+SELECT * FROM f145414() AS foo(x INT, y);
+
+statement ok
+DROP FUNCTION f145414;
+
+subtest end

--- a/pkg/sql/parser/testdata/user_defined_functions
+++ b/pkg/sql/parser/testdata/user_defined_functions
@@ -38,3 +38,37 @@ SELECT btrim()
 SELECT (btrim()) -- fully parenthesized
 SELECT btrim() -- literals removed
 SELECT _() -- identifiers removed
+
+parse
+SELECT * FROM f() AS foo(x INT, y INT);
+----
+SELECT * FROM ROWS FROM (f()) AS foo (x INT8, y INT8) -- normalized!
+SELECT (*) FROM ROWS FROM ((f())) AS foo (x INT8, y INT8) -- fully parenthesized
+SELECT * FROM ROWS FROM (f()) AS foo (x INT8, y INT8) -- literals removed
+SELECT * FROM ROWS FROM (_()) AS _ (_ INT8, _ INT8) -- identifiers removed
+
+parse
+SELECT * FROM f() AS foo(x, y);
+----
+SELECT * FROM ROWS FROM (f()) AS foo (x, y) -- normalized!
+SELECT (*) FROM ROWS FROM ((f())) AS foo (x, y) -- fully parenthesized
+SELECT * FROM ROWS FROM (f()) AS foo (x, y) -- literals removed
+SELECT * FROM ROWS FROM (_()) AS _ (_, _) -- identifiers removed
+
+error
+SELECT * FROM f() AS foo(x, y INT);
+----
+at or near "int": syntax error
+DETAIL: source SQL:
+SELECT * FROM f() AS foo(x, y INT)
+                              ^
+HINT: try \h <SOURCE>
+
+error
+SELECT * FROM f() AS foo(x INT, y);
+----
+at or near ")": syntax error
+DETAIL: source SQL:
+SELECT * FROM f() AS foo(x INT, y)
+                                 ^
+HINT: try \h <SOURCE>


### PR DESCRIPTION
The column definition list for a set-returning function must either provide types for all named columns, or none of them. This commit removes the "name only" case from the `col_def` production, and adds an `alias_clause` case to the `func_alias_clause` production. This ensures that attempts to specify types for only some columns results in a syntax error. This is consistent with Postgres, and also prevents internal errors due to code that assumes all-or-nothing behavior.

Fixes #145414

Release note (bug fix): Specifying types for a subset of columns in a generator function's column definition list now results in a syntax error instead of an internal error.