### PR TITLE
vecindex: add vector search cases to canWrap

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -310,6 +310,8 @@ func canWrap(mode sessiondatapb.VectorizeExecMode, core *execinfrapb.ProcessorCo
 	case core.StreamIngestionFrontier != nil:
 		return errStreamIngestionWrap
 	case core.HashGroupJoiner != nil:
+	case core.VectorSearch != nil:
+	case core.VectorMutationSearch != nil:
 	default:
 		return errors.AssertionFailedf("unexpected processor core %q", core)
 	}

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -568,7 +568,7 @@ query T
 EXPLAIN SELECT * FROM t1 ORDER BY v <-> '[3,1,2]' LIMIT 5;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • top-k
 │ order: +column9

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_search
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_search
@@ -24,7 +24,7 @@ query T
 EXPLAIN SELECT * FROM t ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • top-k
 │ order: +column7
@@ -45,7 +45,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (k, v)
@@ -80,7 +80,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM t ORDER BY v <-> '[1, 2, 3]' LIMIT 5;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (k, v)
@@ -115,7 +115,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM t_multi WHERE a = 1 AND b = 2 ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (x, y, a, b, c, v)
@@ -155,7 +155,7 @@ query T
 EXPLAIN (VERBOSE) SELECT * FROM t_multi WHERE (a, b) IN ((1, 2), (3, 4), (5, 6)) ORDER BY v <-> '[1, 2, 3]' LIMIT 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • project
 │ columns: (x, y, a, b, c, v)
@@ -199,7 +199,7 @@ query T
 EXPLAIN INSERT INTO t VALUES (1, '[1, 2, 3]');
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ into: t(k, v)
@@ -217,7 +217,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO t VALUES (2, '[1, 2, 3]');
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ columns: ()
@@ -242,7 +242,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t SET v = '[1, 2, 3]' WHERE k = 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -289,7 +289,7 @@ query T
 EXPLAIN (VERBOSE) DELETE FROM t WHERE k = 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ columns: ()
@@ -318,7 +318,7 @@ query T
 EXPLAIN (VERBOSE) INSERT INTO t_multi VALUES (1, 2, 1, 2, 3, '[1, 2, 3]');
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • insert
 │ columns: ()
@@ -348,7 +348,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t_multi SET v = '[1, 2, 3]' WHERE a = 1 AND b = 2;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -406,7 +406,7 @@ query T
 EXPLAIN (VERBOSE) UPDATE t_multi SET a = 2 WHERE a = 1;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • update
 │ columns: ()
@@ -464,7 +464,7 @@ query T
 EXPLAIN (VERBOSE) DELETE FROM t_multi WHERE a = 1 AND b = 2;
 ----
 distribution: local
-vectorized: false
+vectorized: true
 ·
 • delete
 │ columns: ()


### PR DESCRIPTION
This commit fixes an oversight from when the vector search operators were added - I forgot to add a case to `canWrap`, so that they could be wrapped into a vectorized (columnar) execution plan. The vector search operators aren't themselves implemented in the vectorized engine, and I don't expect them to be producing many rows that would make the vectorized engine really useful, but this fix will avoid the overhead of constructing an error in `canWrap`.

Epic: CRDB-42943

Release note: None