### PR TITLE
sql: revert disabling buffered writes for EXPLAIN of a DDL

### DIFF
--- a/pkg/sql/conn_executor_ddl.go
+++ b/pkg/sql/conn_executor_ddl.go
@@ -87,12 +87,6 @@ func (ex *connExecutor) maybeAdjustTxnForDDL(ctx context.Context, stmt Statement
 				return txnSchemaChangeErr
 			}
 		}
-	}
-	// For buffered writes, we need to check for DDL statements as well as EXPLAIN
-	// with DDL statements to avoid errors with the declarative schema changer
-	// (see #144274).
-	ast := tree.UnwrapExplain(stmt.AST)
-	if tree.CanModifySchema(ast) {
 		if ex.state.mu.txn.BufferedWritesEnabled() {
 			ex.state.mu.txn.SetBufferedWritesEnabled(false /* enabled */)
 			p.BufferClientNotice(ctx, pgnotice.Newf("disabling buffered writes on the current txn due to schema change"))

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -209,18 +209,6 @@ func ReturnsAtMostOneRow(stmt Statement) bool {
 
 }
 
-// UnwrapExplain returns the inner statement if the outer statement is an EXPLAIN
-// or EXPLAIN ANALYZE statement. Otherwise, it just returns the original statemnt.
-func UnwrapExplain(stmt Statement) Statement {
-	switch t := stmt.(type) {
-	case *Explain:
-		return t.Statement
-	case *ExplainAnalyze:
-		return t.Statement
-	}
-	return stmt
-}
-
 // HiddenFromShowQueries is a pseudo-interface to be implemented
 // by statements that should not show up in SHOW QUERIES (and are hence
 // not cancellable using CANCEL QUERIES either). Usually implemented by


### PR DESCRIPTION
This is no longer needed as of fad25b413e79b14a2d04902c02275eb543850172.

Epic: None
Release note: None