### PR TITLE
sql: disable buffered writes when changing txn isolation

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3536,6 +3536,11 @@ func (ex *connExecutor) setTransactionModes(
 		if err := ex.state.setIsolationLevel(level); err != nil {
 			return pgerror.WithCandidateCode(err, pgcode.ActiveSQLTransaction)
 		}
+		if level != isolation.Serializable {
+			// TODO(#143497): we currently only support buffered writes under
+			// serializable isolation.
+			ex.state.mu.txn.SetBufferedWritesEnabled(false)
+		}
 	}
 	rwMode := modes.ReadWriteMode
 	if modes.AsOf.Expr != nil && asOfTs.IsEmpty() {


### PR DESCRIPTION
We currently only support write buffering under serializable isolation, and we explicitly disable that on the txn creation. However, we forgot to do so in one spot where we might be changing the isolation of already created txn, and this commit fixes that oversight.

Epic: None
Release note: None