### PR TITLE
logstore: move checks up the stack

### DIFF
--- a/pkg/kv/kvserver/logstore/logstore.go
+++ b/pkg/kv/kvserver/logstore/logstore.go
@@ -617,11 +617,7 @@ func LoadEntries(
 		return nil, 0, 0, raft.ErrCompacted
 	}
 
-	n := hi - lo
-	if n > 100 {
-		n = 100
-	}
-	ents := make([]raftpb.Entry, 0, n)
+	ents := make([]raftpb.Entry, 0, min(hi-lo, 100))
 	ents, _, hitIndex, _ := eCache.Scan(ents, rangeID, lo, hi, maxBytes)
 
 	// TODO(pav-kv): pass the sizeHelper to eCache.Scan above, to avoid scanning

--- a/pkg/kv/kvserver/raft_log_queue_test.go
+++ b/pkg/kv/kvserver/raft_log_queue_test.go
@@ -722,7 +722,7 @@ func TestTruncateLog(t *testing.T) {
 
 		// The term of the last truncated entry is still available.
 		tc.repl.mu.Lock()
-		term, err := tc.repl.raftTermLocked(indexes[4])
+		term, err := tc.repl.raftTermShMuLocked(indexes[4])
 		tc.repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)
@@ -733,7 +733,7 @@ func TestTruncateLog(t *testing.T) {
 
 		// The terms of older entries are gone.
 		tc.repl.mu.Lock()
-		_, err = tc.repl.raftTermLocked(indexes[3])
+		_, err = tc.repl.raftTermShMuLocked(indexes[3])
 		tc.repl.mu.Unlock()
 		if !errors.Is(err, raft.ErrCompacted) {
 			t.Errorf("expected ErrCompacted, got %s", err)
@@ -755,7 +755,7 @@ func TestTruncateLog(t *testing.T) {
 
 		tc.repl.mu.Lock()
 		// The term of the last truncated entry is still available.
-		term, err = tc.repl.raftTermLocked(indexes[4])
+		term, err = tc.repl.raftTermShMuLocked(indexes[4])
 		tc.repl.mu.Unlock()
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -124,6 +124,10 @@ func (r *Replica) raftTermShMuLocked(index kvpb.RaftIndex) (kvpb.RaftTerm, error
 	} else if index > r.shMu.lastIndexNotDurable {
 		return 0, raft.ErrUnavailable
 	}
+	// Check if the entry is cached, to avoid storage access.
+	if entry, found := r.store.raftEntryCache.Get(r.RangeID, index); found {
+		return kvpb.RaftTerm(entry.Term), nil
+	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
 		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache, index)
 }

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -80,8 +80,8 @@ func (r *replicaLogStorage) entriesLocked(
 	// can remember the readable bounds, and assert that reads do not cross them.
 	entries, _, loadedSize, err := logstore.LoadEntries(
 		r.AnnotateCtx(context.TODO()),
-		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
-		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes,
+		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache, r.raftMu.sideloaded,
+		r.shMu.raftTruncState, lo, hi, maxBytes,
 		nil, // bytesAccount is not used when reading under Replica.mu
 	)
 	r.store.metrics.RaftStorageReadBytes.Inc(int64(loadedSize))
@@ -245,8 +245,8 @@ func (r *replicaRaftMuLogSnap) entriesRaftMuLocked(
 	// TODO(pav-kv): de-duplicate this code and the one where r.mu must be held.
 	entries, _, loadedSize, err := logstore.LoadEntries(
 		r.AnnotateCtx(context.TODO()),
-		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
-		r.store.raftEntryCache, r.raftMu.sideloaded, lo, hi, maxBytes,
+		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache, r.raftMu.sideloaded,
+		r.shMu.raftTruncState, lo, hi, maxBytes,
 		&r.raftMu.bytesAccount,
 	)
 	r.store.metrics.RaftStorageReadBytes.Inc(int64(loadedSize))

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -112,8 +112,8 @@ func (r *replicaLogStorage) termLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) 
 		return r.shMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
-		r.mu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
-		r.store.raftEntryCache, i,
+		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache,
+		r.shMu.raftTruncState, i,
 	)
 }
 
@@ -241,14 +241,12 @@ func (r *replicaRaftMuLogSnap) Term(i uint64) (uint64, error) {
 // termRaftMuLocked implements the Term() call.
 func (r *replicaRaftMuLogSnap) termRaftMuLocked(i kvpb.RaftIndex) (kvpb.RaftTerm, error) {
 	r.raftMu.AssertHeld()
-	// NB: the r.mu fields accessed here are always written under both r.raftMu
-	// and r.mu, and the reads are safe under r.raftMu.
 	if r.shMu.lastIndexNotDurable == i {
 		return r.shMu.lastTermNotDurable, nil
 	}
 	return logstore.LoadTerm(r.AnnotateCtx(context.TODO()),
-		r.raftMu.stateLoader.StateLoader, r.store.TODOEngine(), r.RangeID,
-		r.store.raftEntryCache, i,
+		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache,
+		r.shMu.raftTruncState, i,
 	)
 }
 

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -86,7 +86,7 @@ func (r *replicaLogStorage) entriesLocked(
 	// can remember the readable bounds, and assert that reads do not cross them.
 	entries, _, loadedSize, err := logstore.LoadEntries(
 		r.AnnotateCtx(context.TODO()),
-		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache, r.raftMu.sideloaded,
+		r.store.LogEngine(), r.RangeID, r.store.raftEntryCache, r.raftMu.sideloaded,
 		lo, hi, maxBytes,
 		nil, // bytesAccount is not used when reading under Replica.mu
 	)
@@ -137,7 +137,7 @@ func (r *Replica) raftTermShMuLocked(index kvpb.RaftIndex) (kvpb.RaftTerm, error
 	}
 
 	entry, err := logstore.LoadEntry(r.AnnotateCtx(context.TODO()),
-		r.store.TODOEngine(), r.RangeID, index)
+		r.store.LogEngine(), r.RangeID, index)
 	if err != nil {
 		return 0, err
 	}
@@ -257,7 +257,7 @@ func (r *replicaRaftMuLogSnap) entriesRaftMuLocked(
 	}
 	entries, _, loadedSize, err := logstore.LoadEntries(
 		r.AnnotateCtx(context.TODO()),
-		r.store.TODOEngine(), r.RangeID, r.store.raftEntryCache, r.raftMu.sideloaded,
+		r.store.LogEngine(), r.RangeID, r.store.raftEntryCache, r.raftMu.sideloaded,
 		lo, hi, maxBytes,
 		&r.raftMu.bytesAccount,
 	)

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -173,14 +173,13 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	tc.repl.mu.Lock()
 	defer tc.repl.mu.Unlock()
 
-	trunc := tc.repl.shMu.raftTruncState
-	comp := trunc.Index
+	comp := tc.repl.shMu.raftTruncState.Index
 	last := tc.repl.shMu.lastIndexNotDurable
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, last)
 	ents, cachedBytes, _, err := logstore.LoadEntries(
 		ctx, tc.store.TODOEngine(), tc.repl.RangeID, tc.store.raftEntryCache,
-		tc.repl.raftMu.sideloaded, trunc, comp+1, last+1, math.MaxUint64, nil /* account */)
+		tc.repl.raftMu.sideloaded, comp+1, last+1, math.MaxUint64, nil /* account */)
 	require.NoError(t, err)
 	require.Len(t, ents, int(last-comp))
 	require.Zero(t, cachedBytes)

--- a/pkg/kv/kvserver/replica_sideload_test.go
+++ b/pkg/kv/kvserver/replica_sideload_test.go
@@ -173,14 +173,14 @@ func TestRaftSSTableSideloading(t *testing.T) {
 	tc.repl.mu.Lock()
 	defer tc.repl.mu.Unlock()
 
-	rsl := logstore.NewStateLoader(tc.repl.RangeID)
-	comp := tc.repl.shMu.raftTruncState.Index
+	trunc := tc.repl.shMu.raftTruncState
+	comp := trunc.Index
 	last := tc.repl.shMu.lastIndexNotDurable
 
 	tc.store.raftEntryCache.Clear(tc.repl.RangeID, last)
 	ents, cachedBytes, _, err := logstore.LoadEntries(
-		ctx, rsl, tc.store.TODOEngine(), tc.repl.RangeID, tc.store.raftEntryCache,
-		tc.repl.raftMu.sideloaded, comp+1, last+1, math.MaxUint64, nil /* account */)
+		ctx, tc.store.TODOEngine(), tc.repl.RangeID, tc.store.raftEntryCache,
+		tc.repl.raftMu.sideloaded, trunc, comp+1, last+1, math.MaxUint64, nil /* account */)
 	require.NoError(t, err)
 	require.Len(t, ents, int(last-comp))
 	require.Zero(t, cachedBytes)

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7594,19 +7594,19 @@ func TestTerm(t *testing.T) {
 		}
 
 		// Truncated logs should return an ErrCompacted error.
-		if _, err := tc.repl.raftTermLocked(indexes[1]); !errors.Is(err, raft.ErrCompacted) {
+		if _, err := tc.repl.raftTermShMuLocked(indexes[1]); !errors.Is(err, raft.ErrCompacted) {
 			t.Errorf("expected ErrCompacted, got %s", err)
 		}
-		if _, err := tc.repl.raftTermLocked(indexes[3]); !errors.Is(err, raft.ErrCompacted) {
+		if _, err := tc.repl.raftTermShMuLocked(indexes[3]); !errors.Is(err, raft.ErrCompacted) {
 			t.Errorf("expected ErrCompacted, got %s", err)
 		}
 
-		firstIndexTerm, err := tc.repl.raftTermLocked(firstIndex)
+		firstIndexTerm, err := tc.repl.raftTermShMuLocked(firstIndex)
 		if err != nil {
 			t.Errorf("expect no error, got %s", err)
 		}
 
-		term, err := tc.repl.raftTermLocked(indexes[4])
+		term, err := tc.repl.raftTermShMuLocked(indexes[4])
 		if err != nil {
 			t.Errorf("expect no error, got %s", err)
 		}
@@ -7617,15 +7617,15 @@ func TestTerm(t *testing.T) {
 		lastIndex := repl.raftLastIndexRLocked()
 
 		// Last index should return correctly.
-		if _, err := tc.repl.raftTermLocked(lastIndex); err != nil {
+		if _, err := tc.repl.raftTermShMuLocked(lastIndex); err != nil {
 			t.Errorf("expected no error, got %s", err)
 		}
 
 		// Terms for after the last index should return ErrUnavailable.
-		if _, err := tc.repl.raftTermLocked(lastIndex + 1); !errors.Is(err, raft.ErrUnavailable) {
+		if _, err := tc.repl.raftTermShMuLocked(lastIndex + 1); !errors.Is(err, raft.ErrUnavailable) {
 			t.Errorf("expected ErrUnavailable, got %s", err)
 		}
-		if _, err := tc.repl.raftTermLocked(indexes[9] + 1000); !errors.Is(err, raft.ErrUnavailable) {
+		if _, err := tc.repl.raftTermShMuLocked(indexes[9] + 1000); !errors.Is(err, raft.ErrUnavailable) {
 			t.Errorf("expected ErrUnavailable, got %s", err)
 		}
 	})


### PR DESCRIPTION
`Replica` and its in-memory `replicaLogStorage` maintain the log truncated state and the last index accurately, so we can use them to fast-path `LoadTerm` and `LoadEntries` when the requested indices are at/below/above the boundaries.

An additional benefit is that `LoadTerm` and `LoadEntries` no longer need a `StateLoader`, and so both callers (`Replica.mu` and `raftMu` version) don't need to use their corresponding state loaders. This allows multiple code simplifications, and cleaner separation of concerns between `logstore` and `replicaLogStorage`. 

Part of #136109