### PR TITLE
ui: fix pagination page size selector

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.tsx
@@ -41,7 +41,6 @@ export const Pagination: React.FC<AntPaginationProps> = props => {
       {...props}
       size="small"
       itemRender={itemRenderer}
-      hideOnSinglePage
       className={cx("root")}
     />
   );


### PR DESCRIPTION
Fixes a bug where the page size selector would disappear when the page size selected was greate than the total number of results being paginated. Specifically, this happens when the hideOnSinglePage prop is used on the AntD Pagination component. It's not clear if this is intended functionality or if it is a bug.

To fix, the setting of this prop has been removed in the wrapper component.

Epic: CC-31904
Release note: None