### PR TITLE
build: pass through additional env vars to pebble nightly

### DIFF
--- a/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb.sh
+++ b/build/teamcity/cockroach/nightlies/pebble_nightly_ycsb.sh
@@ -18,5 +18,5 @@ dir="$(dirname $(dirname $(dirname $(dirname "${0}"))))"
 source "$dir/teamcity-support.sh"  # For $root
 source "$dir/teamcity-bazel-support.sh"  # For run_bazel
 
-BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e GOOGLE_EPHEMERAL_CREDENTIALS -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL" \
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e LITERAL_ARTIFACTS_DIR=$root/artifacts -e AWS_ACCESS_KEY_ID -e AWS_SECRET_ACCESS_KEY -e GOOGLE_EPHEMERAL_CREDENTIALS -e TC_BUILDTYPE_ID -e TC_BUILD_BRANCH -e TC_BUILD_ID -e TC_SERVER_URL -e PEBBLE_SHA -e ROACHTEST_NAME -e ROACHTEST_SUITE" \
                                run_bazel build/teamcity/cockroach/nightlies/pebble_nightly_ycsb_impl.sh


### PR DESCRIPTION
In e0a038080965a80b5ab1521c24a24c43a5a9d8ab the pebble nightly ycsb benchmark script was edited to allow configuration of the Pebble SHA tested and the roachtest used through environment variables. These environment variables need to be explicitly propagated to the docker container.

Epic: none
Release note: none