### PR TITLE
crosscluster/physical: add verbose logging to reader standby job

### DIFF
--- a/pkg/crosscluster/physical/standby_read_ts_poller_job.go
+++ b/pkg/crosscluster/physical/standby_read_ts_poller_job.go
@@ -140,6 +140,10 @@ func (r *standbyReadTSPollerResumer) poll(ctx context.Context, execCfg *sql.Exec
 			if replicatedTime.Equal(previousReplicatedTimestamp) {
 				continue
 			}
+			if log.V(1) {
+				log.Infof(ctx, "attempting to advance reader tenant catalog to %s",
+					replicatedTime)
+			}
 			previousReplicatedTimestamp = replicatedTime
 			if err = replication.SetupOrAdvanceStandbyReaderCatalog(
 				ctx,


### PR DESCRIPTION
Epic: none

Release note: none