### PR TITLE
backup: enforce a minimum compaction window size of 3

### DIFF
--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -52,7 +52,7 @@ var (
 		"the required backup chain length for compaction to be triggered (0 to disable compactions)",
 		0,
 		settings.WithVisibility(settings.Reserved),
-		settings.IntInRangeOrZeroDisable(3, math.MaxInt64),
+		settings.IntInRangeOrZeroDisable(4, math.MaxInt64),
 	)
 )
 

--- a/pkg/backup/compaction_policy.go
+++ b/pkg/backup/compaction_policy.go
@@ -20,10 +20,10 @@ var (
 	backupCompactionWindow = settings.RegisterIntSetting(
 		settings.ApplicationLevel,
 		"backup.compaction.window_size",
-		"the number of backups to compact per compaction (must be greater than one and less than threshold)",
+		"the number of backups to compact per compaction (must be greater than two and less than threshold)",
 		3,
 		settings.WithVisibility(settings.Reserved),
-		settings.IntWithMinimum(2),
+		settings.IntWithMinimum(3),
 	)
 )
 

--- a/pkg/backup/compaction_test.go
+++ b/pkg/backup/compaction_test.go
@@ -458,8 +458,8 @@ func TestScheduledBackupCompaction(t *testing.T) {
 	// impacted by when the test runs.
 	th.env.SetTime(time.Date(2025, 3, 27, 1, 0, 0, 0, time.UTC))
 
-	th.sqlDB.Exec(t, "SET CLUSTER SETTING backup.compaction.threshold = 3")
-	th.sqlDB.Exec(t, "SET CLUSTER SETTING backup.compaction.window_size = 2")
+	th.sqlDB.Exec(t, "SET CLUSTER SETTING backup.compaction.threshold = 4")
+	th.sqlDB.Exec(t, "SET CLUSTER SETTING backup.compaction.window_size = 3")
 	schedules, err := th.createBackupSchedule(
 		t, "CREATE SCHEDULE FOR BACKUP INTO $1 RECURRING '@hourly'", "nodelocal://1/backup",
 	)
@@ -477,21 +477,15 @@ func TestScheduledBackupCompaction(t *testing.T) {
 	var backupPath string
 	th.sqlDB.QueryRow(t, "SHOW BACKUPS IN 'nodelocal://1/backup'").Scan(&backupPath)
 
-	inc, err = jobs.ScheduledJobDB(th.internalDB()).
-		Load(context.Background(), th.env, inc.ScheduleID())
-	require.NoError(t, err)
+	for range 3 {
+		inc, err = jobs.ScheduledJobDB(th.internalDB()).
+			Load(context.Background(), th.env, inc.ScheduleID())
+		require.NoError(t, err)
 
-	th.env.SetTime(inc.NextRun().Add(time.Second))
-	require.NoError(t, th.executeSchedules())
-	th.waitForSuccessfulScheduledJob(t, inc.ScheduleID())
-
-	inc, err = jobs.ScheduledJobDB(th.internalDB()).
-		Load(context.Background(), th.env, inc.ScheduleID())
-	require.NoError(t, err)
-
-	th.env.SetTime(inc.NextRun().Add(time.Second))
-	require.NoError(t, th.executeSchedules())
-	th.waitForSuccessfulScheduledJob(t, inc.ScheduleID())
+		th.env.SetTime(inc.NextRun().Add(time.Second))
+		require.NoError(t, th.executeSchedules())
+		th.waitForSuccessfulScheduledJob(t, inc.ScheduleID())
+	}
 
 	if blockCompaction != nil {
 		t.Log("executing second full backup before compaction job resolves destination")
@@ -535,7 +529,7 @@ func TestScheduledBackupCompaction(t *testing.T) {
 		fmt.Sprintf("SELECT count(DISTINCT (start_time, end_time)) FROM "+
 			"[SHOW BACKUP FROM '%s' IN 'nodelocal://1/backup']", backupPath),
 	).Scan(&numBackups)
-	require.Equal(t, 4, numBackups)
+	require.Equal(t, 5, numBackups)
 }
 
 func TestBackupCompactionUnsupportedOptions(t *testing.T) {


### PR DESCRIPTION
Previously, the minimum compaction window size was set to 2. With a compaction window of 2, if a chain is at length `n` prior to a backup that triggers a compaction, the length of the chain after compaction is also `n`. Under these conditions, if compactions fail/are blocked for any reason and the length of the chain exceeds the threshold set by `backup.compaction.threshold`, the chain will never recover and drop below the threshold.

This patch enforces that the minimum compaction window size is at least 3. That way, if the length of the chain exceeds the threshold, each successful compaction afterwards will always bring the chain closer to the threshold. This allows compactions to self-correct the chain to be under the threshold.

Epic: None

Release note: `backup.compaction.window_size` must be at least 3 instead of 2.