### PR TITLE
workflow: auto-merge-backports should skip blathers PRs

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -24,7 +24,7 @@ jobs:
 
             const query = `
               query SearchPRs() {
-                search(query: "repo:${context.repo.owner}/${context.repo.repo} is:pr is:open label:backport label:blathers-backport label:backport-test-only", type: ISSUE, first: 100) {
+                search(query: "repo:${context.repo.owner}/${context.repo.repo} is:pr is:open label:backport label:blathers-backport label:backport-test-only -author:blathers-crl[bot]", type: ISSUE, first: 100) {
                   nodes {
                     ... on PullRequest {
                       number


### PR DESCRIPTION
Previously, the search included PRs that are created by blathers. These PRs cannot be approved by blathers, so they should be skipped.

Release note: none
Epic: none