### PR TITLE
rpc, server: properly handle DRPC stream context cancellations

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -110,6 +110,7 @@ func dialDRPC(rpcCtx *Context) func(ctx context.Context, target string) (drpcpoo
 					Stream: drpcstream.Options{
 						MaximumBufferSize: 0, // unlimited
 					},
+					SoftCancel: true, // don't close the transport when stream context is canceled
 				},
 			}
 			var conn *drpcconn.Conn

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -10,6 +10,7 @@ import (
 	"crypto/tls"
 	"math"
 	"net"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -27,6 +28,9 @@ import (
 // ErrDRPCDisabled is returned from hosts that in principle could but do not
 // have the DRPC server enabled.
 var ErrDRPCDisabled = errors.New("DRPC is not enabled")
+
+// Default idle connection timeout for DRPC connections in the pool.
+var defaultDRPCConnIdleTimeout = 5 * time.Minute
 
 type drpcServerI interface {
 	Serve(ctx context.Context, lis net.Listener) error
@@ -93,7 +97,9 @@ func newDRPCServer(_ context.Context, rpcCtx *Context) (*DRPCServer, error) {
 func dialDRPC(rpcCtx *Context) func(ctx context.Context, target string) (drpcpool.Conn, error) {
 	return func(ctx context.Context, target string) (drpcpool.Conn, error) {
 		// TODO(server): could use connection class instead of empty key here.
-		pool := drpcpool.New[struct{}, drpcpool.Conn](drpcpool.Options{})
+		pool := drpcpool.New[struct{}, drpcpool.Conn](drpcpool.Options{
+			Expiration: defaultDRPCConnIdleTimeout,
+		})
 		pooledConn := pool.Get(ctx /* unused */, struct{}{}, func(ctx context.Context,
 			_ struct{}) (drpcpool.Conn, error) {
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -618,6 +618,7 @@ go_test(
         "@in_gopkg_yaml_v2//:yaml_v2",
         "@io_opentelemetry_go_otel//attribute",
         "@io_storj_drpc//drpcconn",
+        "@io_storj_drpc//drpcmanager",
         "@io_storj_drpc//drpcmigrate",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",


### PR DESCRIPTION
The graceful way to cancel a stream in DRPC is to close the stream. When stream context is canceled, DRPC closes the underlying transport by default as we see `<manager closed>` errors as a result. https://github.com/storj/drpc/blob/a5d487af8ae33deb7913b0f7c06b2c7ec7cd4dcc/drpcmanager/manager.go#L363-L377

`SoftClose` option on the DRPC manager allows for reusing the underlying transport as long as it's not busy (active write). In our case, since the stream is idle and at any point in time only one stream can use a connection we can use that option to avoid too many connection reopens. storj/drpc@a5d487a/drpcmanager/manager.go#L348-L363

Fixes: https://github.com/cockroachdb/cockroach/issues/140670
Epic: CRDB-48929
Release note: none