### PR TITLE
roachtest: expect new attr column in decom test

### DIFF
--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1193,7 +1193,7 @@ var decommissionFooter = []string{
 
 // Header from the output of `cockroach node status`.
 var statusHeader = []string{
-	"id", "address", "sql_address", "build", "started_at", "updated_at", "locality", "is_available", "is_live",
+	"id", "address", "sql_address", "build", "started_at", "updated_at", "locality", "attrs", "is_available", "is_live",
 }
 
 // Header from the output of `cockroach node status --decommission`.


### PR DESCRIPTION
`decommission/randomized` began failing after #143421, which introduced a new column to `node status`.

Expect that new column in the roachtest.

Fixes: #145522
Release note: None