### PR TITLE
roachprod/azure: use premium ssdv2 by default

### DIFF
--- a/pkg/roachprod/vm/azure/azure.go
+++ b/pkg/roachprod/vm/azure/azure.go
@@ -1062,7 +1062,7 @@ func (p *Provider) createVM(
 			// premium-disk specific disk configurations.
 			dataDisks[0].CreateOption = compute.DiskCreateOptionTypesEmpty
 			dataDisks[0].ManagedDisk = &compute.ManagedDiskParameters{
-				StorageAccountType: compute.StorageAccountTypesPremiumLRS,
+				StorageAccountType: compute.StorageAccountTypesPremiumV2LRS,
 			}
 		default:
 			err = errors.Newf("unsupported network disk type: %s", providerOpts.NetworkDiskType)


### PR DESCRIPTION
Switch to using the SSDv2 offering from Azure by default.

Release note: None.

Epic: None.