### PR TITLE
vecindex: reset result index when Search is repeatedly called

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -404,6 +404,7 @@ INSERT INTO exec_test (a, b, vec1) VALUES
   (6, NULL, '[16, 17, 18]'),
   (7, NULL, '[1, 1, 1]');
 
+# Search index with no prefix.
 query IT rowsort
 SELECT a, vec1 FROM exec_test@idx1 ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 3;
 ----
@@ -411,22 +412,34 @@ SELECT a, vec1 FROM exec_test@idx1 ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 3;
 1  [1,2,3]
 2  [4,5,6]
 
+# Search index with prefix.
 query IT rowsort
 SELECT a, vec1 FROM exec_test@idx2 WHERE b = 1 ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 1;
 ----
 1  [1,2,3]
 
+# Multiple results.
 query IT rowsort
 SELECT a, vec1 FROM exec_test@idx2 WHERE b = 2 ORDER BY vec1 <-> '[15, 15, 15]' LIMIT 2;
 ----
 5  [13,14,15]
 4  [10,11,12]
 
+# NULL prefix value.
 query IT rowsort
 SELECT a, vec1 FROM exec_test WHERE b IS NULL ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 3;
 ----
 7  [1,1,1]
 6  [16,17,18]
+
+# Multiple prefix values.
+query IIT rowsort
+SELECT a, b, vec1 FROM exec_test WHERE b IN (1, 2) ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 4;
+----
+1  1  [1,2,3]
+2  1  [4,5,6]
+3  2  [7,8,9]
+4  2  [10,11,12]
 
 statement ok
 DROP TABLE exec_test

--- a/pkg/sql/vecindex/searcher.go
+++ b/pkg/sql/vecindex/searcher.go
@@ -68,6 +68,7 @@ func (s *Searcher) Search(ctx context.Context, prefix roachpb.Key, vec vector.T)
 		return err
 	}
 	s.results = s.searchSet.PopResults()
+	s.resultIdx = 0
 	return nil
 }
 

--- a/pkg/sql/vecindex/searcher_test.go
+++ b/pkg/sql/vecindex/searcher_test.go
@@ -154,6 +154,14 @@ func TestSearcher(t *testing.T) {
 	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
 	require.Nil(t, searcher.NextResult())
 
+	// Search again to ensure search state is reset.
+	require.NoError(t, searcher.Search(ctx, prefix, original))
+	res = searcher.NextResult()
+	require.InDelta(t, float32(1), res.QuerySquaredDistance, 0.01)
+	res = searcher.NextResult()
+	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
+	require.Nil(t, searcher.NextResult())
+
 	// Search for a vector to delete that doesn't exist (reuse memory).
 	keyBytes = keyBytes[:0]
 	original[0] = 1


### PR DESCRIPTION
The Searcher.Search method can be called repeatedly by the vector search operator in the case where multiple prefix columns are specified, e.g.:

  SELECT a, b, vec1
  FROM exec_test
  WHERE b IN (1, 2)
  ORDER BY vec1 <-> '[1, 1, 2]'
  LIMIT 4;

However, the Search method was not resetting the result index when it's called. This caused it to skip past results for later prefixes. For example, if the search of the first prefix returned 2 results, then the search of the second prefix would skip the first 2 results.

Epic: CRDB-42943
Release note: None