### PR TITLE
kvserver: use vanilla truncation in applySnapshotRaftMuLocked

### DIFF
--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -162,7 +162,7 @@ type pendingTruncation struct {
 	// ReplicatedEvalResult.RaftLogDelta, this is <= 0.
 	logDeltaBytes  int64
 	isDeltaTrusted bool
-	// hasSideloaded is true if the truncated interval contains at least one
+	// hasSideloaded is true if the truncated interval could contain at least one
 	// sideloaded entry.
 	hasSideloaded bool
 }

--- a/pkg/kv/kvserver/replica_application_result.go
+++ b/pkg/kv/kvserver/replica_application_result.go
@@ -551,8 +551,8 @@ func (r *replicaLogStorage) stagePendingTruncationOnSnapshotRaftMuLocked(
 	// up that it wants to append to the log[1] (on top of the snapshot), as these
 	// entries are not yet stable and thus not in the log/cache yet.
 	//
-	// [1]: this is not properly supported yet and will currently fatal, see:
-	// TODO(during review) I couldn't find the issue, but I'm pretty sure we have one?
+	// [1]: this is not properly supported yet and will currently fatal.
+	// See: https://github.com/cockroachdb/cockroach/pull/125530
 	r.stagePendingTruncationSharedRaftMuLockedMuLocked(pendingTruncation{
 		RaftTruncatedState: truncState,
 		expectedFirstIndex: r.shMu.trunc.Index + 1,

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -206,13 +206,8 @@ func (sm *replicaStateMachine) ApplySideEffects(
 		// Some tests (TestRangeStatsInit) assumes that once the store has started
 		// and the first range has a lease that there will not be a later hard-state.
 		if shouldAssert {
-			// Assert that the on-disk state doesn't diverge from the in-memory
+			// Queue a check that the on-disk state doesn't diverge from the in-memory
 			// state as a result of the side effects.
-			sm.r.mu.RLock()
-			// TODO(sep-raft-log): either check only statemachine invariants or
-			// pass both engines in.
-			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
-			sm.r.mu.RUnlock()
 			sm.applyStats.assertionsRequested++
 		}
 	} else if res := cmd.ReplicatedResult(); !res.IsZero() {

--- a/pkg/kv/kvserver/replica_application_state_machine.go
+++ b/pkg/kv/kvserver/replica_application_state_machine.go
@@ -42,7 +42,7 @@ type applyCommittedEntriesStats struct {
 	appBatchStats
 	followerStoreWriteBytes kvadmission.FollowerStoreWriteBytes
 	numBatchesProcessed     int // TODO(sep-raft-log): numBatches
-	stateAssertions         int
+	assertionsRequested     int
 	numConfChangeEntries    int
 }
 
@@ -213,7 +213,7 @@ func (sm *replicaStateMachine) ApplySideEffects(
 			// pass both engines in.
 			sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
 			sm.r.mu.RUnlock()
-			sm.applyStats.stateAssertions++
+			sm.applyStats.assertionsRequested++
 		}
 	} else if res := cmd.ReplicatedResult(); !res.IsZero() {
 		log.Fatalf(ctx, "failed to handle all side-effects of ReplicatedEvalResult: %v", res)

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1282,7 +1282,6 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		// pass both engines in.
 		sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
 		sm.r.mu.RUnlock()
-
 	}
 
 	if refreshReason != noReason {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -823,7 +823,7 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 	}
 	p.SafeString("]")
 
-	if n := s.apply.stateAssertions; n > 0 {
+	if n := s.apply.assertionsRequested; n > 0 {
 		p.Printf(", state_assertions=%d", n)
 	}
 	if s.snap.offered {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1082,6 +1082,11 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 	}
 
+	// If this field is set, by the end of the method (after snapshot, append,
+	// apply handling), we will verify invariants including checking that
+	// in-memory state is congruent with disk state.
+	var shouldAssert bool
+
 	// Grab the known leaseholder before applying to the state machine.
 	startingLeaseholderID := r.shMu.state.Lease.Replica.ReplicaID
 	refreshReason := noReason
@@ -1111,6 +1116,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		}
 
 		if app.Snapshot != nil {
+			shouldAssert = true
 			if inSnap.Desc == nil {
 				// If we didn't expect Raft to have a snapshot but it has one
 				// regardless, that is unexpected and indicates a programming
@@ -1236,6 +1242,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 			// it is now marked as destroyed.
 			return stats, err
 		}
+		shouldAssert = shouldAssert || stats.apply.assertionsRequested > 0
 
 		if r.store.cfg.KVAdmissionController != nil &&
 			stats.apply.followerStoreWriteBytes.NumEntries > 0 {
@@ -1268,6 +1275,16 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 	if r.store.TestingKnobs().EnableUnconditionalRefreshesInRaftReady {
 		refreshReason = reasonNewLeaderOrConfigChange
 	}
+
+	if shouldAssert {
+		sm.r.mu.RLock()
+		// TODO(sep-raft-log): either check only statemachine invariants or
+		// pass both engines in.
+		sm.r.assertStateRaftMuLockedReplicaMuRLocked(ctx, sm.r.store.TODOEngine())
+		sm.r.mu.RUnlock()
+
+	}
+
 	if refreshReason != noReason {
 		r.mu.Lock()
 		r.refreshProposalsLocked(ctx, 0 /* refreshAtDelta */, refreshReason)

--- a/pkg/kv/kvserver/replica_raft_test.go
+++ b/pkg/kv/kvserver/replica_raft_test.go
@@ -103,7 +103,7 @@ func Test_handleRaftReadyStats_SafeFormat(t *testing.T) {
 				numAddSST:                3,
 				numAddSSTCopies:          1,
 			},
-			stateAssertions:      4,
+			assertionsRequested:  4,
 			numConfChangeEntries: 6,
 		},
 		append: logstore.AppendStats{

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -651,7 +651,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 		writeBytes = uint64(inSnap.SSTSize)
 	}
 	// The snapshot is visible, so finalize the truncation.
-	r.finalizeTruncationRaftMuLocked(ctx)
+	ls.finalizeApplySnapshotRaftMuLocked(ctx)
 
 	// The "ignored" here is to ignore the writes to create the AC linear models
 	// for LSM writes. Since these writes typically correspond to actual writes

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -775,14 +775,6 @@ func (r *Replica) applySnapshotRaftMuLocked(
 
 	r.mu.Unlock()
 
-	// Assert that the in-memory and on-disk states of the Replica are congruent
-	// after the application of the snapshot. Do so under a read lock, as this
-	// operation can be expensive. This is safe, as we hold the Replica.raftMu
-	// across both Replica.mu critical sections.
-	r.mu.RLock()
-	r.assertStateRaftMuLockedReplicaMuRLocked(ctx, r.store.TODOEngine())
-	r.mu.RUnlock()
-
 	// The rangefeed processor is listening for the logical ops attached to
 	// each raft command. These will be lost during a snapshot, so disconnect
 	// the rangefeed, if one exists.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -610,7 +610,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 
 	// Stage the truncation, so that in-memory state reflects an
 	// empty log.
-	ls.stageApplySnapshot(truncState)
+	ls.stageApplySnapshotRaftMuLocked(truncState)
 
 	stats.subsumedReplicas = timeutil.Now()
 
@@ -682,7 +682,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 			state.RaftAppliedIndexTerm, nonemptySnap.Metadata.Term)
 	}
 	if ls.shMu.size != 0 {
-		log.Fatalf(ctx, "expected empty raftLogSize after snapshot, got %d", ls.shMu.size)
+		log.Fatalf(ctx, "expected empty raft log after snapshot, got %d", ls.shMu.size)
 	}
 
 	// Read the prior read summary for this range, which was included in the

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -610,7 +610,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 
 	// Stage the truncation, so that in-memory state reflects an
 	// empty log.
-	ls.stagePendingTruncationOnSnapshotRaftMuLocked(truncState)
+	ls.stageApplySnapshot(truncState)
 
 	stats.subsumedReplicas = timeutil.Now()
 

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage/snaprecv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/readsummary"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/spanset"
@@ -607,15 +606,11 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	clearedSpans = append(clearedSpans, clearedUnreplicatedSpan)
 	clearedSpans = append(clearedSpans, clearedSubsumedSpans...)
 
-	// Drop the entry cache before ingestion, like a real truncation would.
-	//
-	// TODO(sep-raft-log): like a real truncation, we should also bump the
-	// in-memory truncated state to the snapshot index. We should also assert
-	// that this leads to a (logically) empty log (otherwise we wouldn't have
-	// accepted the snapshot).
-	//
-	// See: https://github.com/cockroachdb/cockroach/pull/145328#discussion_r2068209588
-	r.store.raftEntryCache.Drop(r.RangeID)
+	ls := r.asLogStorage()
+
+	// Stage the truncation, so that in-memory state reflects an
+	// empty log.
+	ls.stagePendingTruncationOnSnapshotRaftMuLocked(truncState)
 
 	stats.subsumedReplicas = timeutil.Now()
 
@@ -655,6 +650,9 @@ func (r *Replica) applySnapshotRaftMuLocked(
 		// snapshot.
 		writeBytes = uint64(inSnap.SSTSize)
 	}
+	// The snapshot is visible, so finalize the truncation.
+	r.finalizeTruncationRaftMuLocked(ctx)
+
 	// The "ignored" here is to ignore the writes to create the AC linear models
 	// for LSM writes. Since these writes typically correspond to actual writes
 	// onto the disk, we account for them separately in
@@ -682,6 +680,9 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	if uint64(state.RaftAppliedIndexTerm) != nonemptySnap.Metadata.Term {
 		log.Fatalf(ctx, "snapshot RaftAppliedIndexTerm %d doesn't match its metadata term %d",
 			state.RaftAppliedIndexTerm, nonemptySnap.Metadata.Term)
+	}
+	if ls.shMu.size != 0 {
+		log.Fatalf(ctx, "expected empty raftLogSize after snapshot, got %d", ls.shMu.size)
 	}
 
 	// Read the prior read summary for this range, which was included in the
@@ -736,23 +737,6 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	// lock ordering rules described on Store.mu), it is safe to drop it first
 	// without risking a lock-ordering deadlock.
 	r.store.mu.Unlock()
-
-	// The log has been cleared and reset to start at the snapshot's applied
-	// index/term. Update the in-memory metadata accordingly.
-	r.asLogStorage().updateStateRaftMuLockedMuLocked(logstore.RaftState{
-		LastIndex: truncState.Index,
-		LastTerm:  truncState.Term,
-		ByteSize:  0, // the log is empty now
-	})
-	ls := r.asLogStorage()
-	ls.shMu.trunc = truncState
-	// Snapshots typically have fewer log entries than the leaseholder. The next
-	// time we hold the lease, recompute the log size before making decisions.
-	//
-	// TODO(pav-kv): does this assume that snapshots can contain log entries,
-	// which is no longer true? The comment needs an update, and the decision to
-	// set this flag to false revisited.
-	ls.shMu.sizeTrusted = false
 
 	// Update the store stats for the data in the snapshot.
 	r.store.metrics.subtractMVCCStats(ctx, r.tenantMetricsRef, *r.shMu.state.Stats)


### PR DESCRIPTION
Previously, applySnapshotRaftMuLocked performed the log truncation
that comes with snapshot application in an "ad-hoc" way. In particular,
it wasn't clearing the sideloaded storage.

We know call the same methods {stage,finalize}TruncationRaftMuLocked
that are also called in the regular truncation code, which also clears
the sideloaded storage.

We also ensure that the raft log size is zero and trusted after the
snapshot.

Follow-up to https://github.com/cockroachdb/cockroach/pull/145328.

Epic: CRDB-46488