### PR TITLE
kvserver: avoid rangefeedMu deadlock

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -105,10 +105,10 @@ type Config struct {
 	// Only has an effect when Scheduler is used.
 	Priority bool
 
-	// UnregisterFromReplica is a callback provided from the
+	// UnsetFromReplica is a callback provided from the
 	// replica that this processor can call when shutting down to
 	// remove itself from the replica.
-	UnregisterFromReplica func(Processor)
+	UnsetFromReplica func(Processor)
 }
 
 // SetDefaults initializes unset fields in Config to values
@@ -165,6 +165,10 @@ type Processor interface {
 	//
 	// It is not valid to restart a processor after it has been stopped.
 	StopWithErr(pErr *kvpb.Error)
+
+	// Stopped returns a channel that is closed during the processor's cleanup
+	// routine.
+	Stopped() <-chan struct{}
 
 	// Lifecycle of registrations.
 

--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -170,6 +170,9 @@ type Processor interface {
 	// routine.
 	Stopped() <-chan struct{}
 
+	// Returns true if a Stop() has already been issued against this processor.
+	StopEnqueued() bool
+
 	// Lifecycle of registrations.
 
 	// Register registers the stream over the specified span of keys.

--- a/pkg/kv/kvserver/rangefeed/scheduled_processor.go
+++ b/pkg/kv/kvserver/rangefeed/scheduled_processor.go
@@ -255,8 +255,8 @@ func (p *ScheduledProcessor) cleanup() {
 	p.taskCancel()
 	close(p.stoppedC)
 	p.MemBudget.Close(ctx)
-	if p.UnregisterFromReplica != nil {
-		p.UnregisterFromReplica(p)
+	if p.UnsetFromReplica != nil {
+		p.UnsetFromReplica(p)
 	}
 
 }
@@ -276,6 +276,11 @@ func (p *ScheduledProcessor) StopWithErr(pErr *kvpb.Error) {
 	p.syncEventC()
 	// Send the processor a stop signal.
 	p.sendStop(pErr)
+}
+
+// Stopped returns a channel that is closed when the process is being shut down.
+func (p *ScheduledProcessor) Stopped() <-chan struct{} {
+	return p.stoppedC
 }
 
 // DisconnectSpanWithErr disconnects all rangefeed registrations that overlap


### PR DESCRIPTION
In #132857 we allowed a processor to unregister itself from a scheduler and (more importantly here) to unset itself from the replica when stopping.

Readers should not that the word "register" is used to describe the processor being added to the schedule and the rangefeed registration being added to the processor.

When making this change, we did not remove the other places where we proactively unset the processor from the replica. I am not able to reconstruct why, but my best guess is that when thinking about whether it would be a problem to unset from the replica twice, we were considering whether the function was safe to call twice in terms of removing the wrong processor rather than the locking around rangefeedMu.

But, this change introduces an important point of contention:

1. Before calling p.Register, the thread processing the rangefeed registration locks rangefeedMu on replica r1.

2. A previously enqueued Stop() request for the processor owned by r1 is picked up by the scheduler and executed. It then blocks waiting on rangefeedMu of r1 via a callback that was passed to it at startup.

3. Back in our rangefeed registration thread, to unlock rangefeedMu we need to return from p.Register(). But, p.Register makes a syncronous request whose return requires that either p.stoppedC is closed or the scheduler processes our sync request.

So, how does this _ever_ resolve?

In the happiest case, the processor we are stopping in (2) is the same processor that we are waiting on in (3). In this case, the stop routine closes p.stoppedC before blocking on rangefeedMu. Closing that channel allows p.Register to return and rangefeedMu to eventually be released.

However, some unhappy cases occur if the processor in step 2 (say p1) and step 3 say (p2) are not the same processor. This can occur if p1 was unset from the replica and then a newly created p2 was set on the replica and then the rangefeed registration request arrived. While these are two different processors, they will both interact with the same rangefeedMu from r1.

In this case, p.Register is not unblocked (because it's stoppedC channel won't be closed), so it _requires_ that the scheduler make progress on its request.  But there are at least two cases where it will make no progress:

1. During server shutdown, the worker that handles that shard of processors may have already exited.

2. If the two processors happen to get assigned to the same worker, the worker could be blocked processing the stop request on processor p1 and never make it to p2's register request.

Here, I attempt to resolve this by making the processor's stop function the only place where we remove the processor from the replica.

All other removals should have been in response to a processor that is stopped or stopping and as a result we should still be removing the processor in all of the same conditions, however potentially with a little higher latency. I think the main cause of this latency would be failed rangefeed registration requests that might have otherwise succeed.

The reasoning for why this fixes the bug is that:

1. The only place a blocking call is made while holding rangefeedMu of range r1 is when registering a new rangefeed on its existing processor p1

2. If a concurrent stop request require the rangefeedMu of r1 then it must be the stop request for processor p1 since a stop request is the only thing that can change the processor on r1.

3. A stop request for processor p1 will ensure any currently blocking Register requests for p1 return by closing stoppedC before attempting to unset the replica.

I've re-arranged the code a bit to make (1) more easily reviewable.

Fixes: #144828
Epic: None

Release Note(bug): Fix a bug that could lead to rangefeed for node deadlocks.