### PR TITLE
release-24.3: ui: fix pagination page size selector

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "24.3.7",
+  "version": "24.3.8",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pagination/pagination.tsx
@@ -41,7 +41,6 @@ export const Pagination: React.FC<AntPaginationProps> = props => {
       {...props}
       size="small"
       itemRender={itemRenderer}
-      hideOnSinglePage
       className={cx("root")}
     />
   );


### PR DESCRIPTION
Backport 1/1 commits from #145561 on behalf of @kyle-a-wong.

----

Fixes a bug where the page size selector would disappear when the page size selected was greate than the total number of results being paginated. Specifically, this happens when the hideOnSinglePage prop is used on the AntD Pagination component. It's not clear if this is intended functionality or if it is a bug.

To fix, the setting of this prop has been removed in the wrapper component.

Epic: CC-31904
Release note: None

----

Release justification: