### PR TITLE
catalog/replication: fix validation errors when updating catalog

### DIFF
--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -334,8 +334,9 @@ func (tc *Collection) WriteDescToBatch(
 	}
 	desc.MaybeIncrementVersion()
 	// Replicated PCR descriptors cannot be modified unless the collection
-	// is setup for updating them.
-	if !tc.readerCatalogSetup && desc.GetReplicatedPCRVersion() != 0 {
+	// is setup for updating them. If write validation is disabled then, allow
+	// PCR reader catalog descriptors to be modified, otherwise repair is impossible.
+	if !tc.readerCatalogSetup && desc.GetReplicatedPCRVersion() != 0 && !tc.skipValidationOnWrite {
 		return pgerror.Newf(pgcode.ReadOnlySQLTransaction,
 			"replicated %s %s (%d) cannot be mutated",
 			desc.GetObjectTypeString(),


### PR DESCRIPTION
Previously, updating PCR reader catalog descriptors involved processing and flushing one at a time. This worked unless a subsequent descriptor depended on the current one. However, it could fail when, for example, removing a column dependency (i.e., ALTER COLUMN .. SET DEFAULT NULL). To address this, this patch first generates the mutated descriptors and then flushes them into the collections.

Fixes: #145971

Release note (bug fix): addressed a bug where the PCR reader catalog job could hit validation errors, when schema object dependencies between them (for example a sequence default expression was being removed).