### PR TITLE
backfill: fix a panic when backfilling a NULL vector

### DIFF
--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -1134,6 +1134,8 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 			}
 
 			if ib.rowVals[vectorIndexHelper.vectorOrd] == tree.DNull {
+				ib.vectorEncodingHelper.QuantizedVecs[indexID] = tree.DNull
+				ib.vectorEncodingHelper.PartitionKeys[indexID] = tree.DNull
 				continue
 			}
 

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -663,3 +663,16 @@ statement ok
 DROP TABLE import_test
 
 subtest end
+
+subtest test_145973
+
+statement ok
+CREATE TABLE test_145973 (a INT PRIMARY KEY, v VECTOR(3))
+
+statement ok
+INSERT INTO test_145973 VALUES (1)
+
+statement ok
+CREATE VECTOR INDEX vec_idx ON test_145973 (v)
+
+subtest end


### PR DESCRIPTION
Previously, the backfiller would provide nil values in the VectorIndexHelper to rowenc when encoding NULL vectors. This signals an error condition to rowenc, which wants to see DNull values for "don't encode the vector index". This patch changes that to DNull so that the vector index rows are correctly skipped.

Fixes: #145973
Release note (bug fix): Creating a vector index on a table with a NULL vector value in it will no longer cause an internal error.