### PR TITLE
logictest: deflake recent addition to select_for_update

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -1,4 +1,4 @@
-# LogicTest: !weak-iso-level-configs
+# LogicTest: !weak-iso-level-configs !metamorphic-batch-sizes
 # This test assumes that SERIALIZABLE isolation is being used. See
 # select_for_update_read_committed for READ COMMITTED testing.
 


### PR DESCRIPTION
The testcases I added in #144449 depend on a large enough batch size to match the expected tracing.

Fixes: #144830

Release note: None