### PR TITLE
release-25.2: vecindex: reset result index when Search is repeatedly called

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -435,6 +435,15 @@ SELECT a FROM exec_test WHERE b IS NULL ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 3;
 7
 6
 
+# Multiple prefix values.
+query IIT rowsort
+SELECT a, b, vec1 FROM exec_test WHERE b IN (1, 2) ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 4;
+----
+1  1  [1,2,3]
+2  1  [4,5,6]
+3  2  [7,8,9]
+4  2  [10,11,12]
+
 statement ok
 DROP TABLE exec_test
 

--- a/pkg/sql/vecindex/searcher.go
+++ b/pkg/sql/vecindex/searcher.go
@@ -62,6 +62,7 @@ func (s *Searcher) Search(ctx context.Context, prefix roachpb.Key, vec vector.T)
 		return err
 	}
 	s.results = s.searchSet.PopResults()
+	s.resultIdx = 0
 	return nil
 }
 

--- a/pkg/sql/vecindex/searcher_test.go
+++ b/pkg/sql/vecindex/searcher_test.go
@@ -154,6 +154,14 @@ func TestSearcher(t *testing.T) {
 	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
 	require.Nil(t, searcher.NextResult())
 
+	// Search again to ensure search state is reset.
+	require.NoError(t, searcher.Search(ctx, prefix, original))
+	res = searcher.NextResult()
+	require.InDelta(t, float32(1), res.QuerySquaredDistance, 0.01)
+	res = searcher.NextResult()
+	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
+	require.Nil(t, searcher.NextResult())
+
 	// Search for a vector to delete that doesn't exist (reuse memory).
 	keyBytes = keyBytes[:0]
 	original[0] = 1


### PR DESCRIPTION
Backport 1/1 commits from #145935.

/cc @cockroachdb/release

---

The Searcher.Search method can be called repeatedly by the vector search operator in the case where multiple prefix columns are specified, e.g.:

  SELECT a, b, vec1
  FROM exec_test
  WHERE b IN (1, 2)
  ORDER BY vec1 <-> '[1, 1, 2]'
  LIMIT 4;

However, the Search method was not resetting the result index when it's called. This caused it to skip past results for later prefixes. For example, if the search of the first prefix returned 2 results, then the search of the second prefix would skip the first 2 results.

Epic: CRDB-42943
Release note: None

Release justification: Vector indexing is a business priority. These changes are all in the vecindex package, for a feature that is protected by a default-off feature flag.