### PR TITLE
gssapiccl: link with `keyutils` on `s390x`

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -413,6 +413,16 @@ config_setting(
     },
 )
 
+config_setting(
+    name = "is_dev_s390x",
+    constraint_values = [
+        "@platforms//cpu:s390x",
+    ],
+    flag_values = {
+        ":dev_flag": "true",
+    },
+)
+
 bool_flag(
     name = "force_build_cdeps_flag",
     build_setting_default = False,

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         # NB: On Ubuntu, res_nsearch is found in the resolv_wrapper library,
         # found in the libresolv-wrapper package.
         "//build/toolchains:is_dev_linux": ["-ldl -lresolv -lresolv_wrapper"],
+        "//build/toolchains:is_dev_s390x": ["-ldl -lresolv -lresolv_wrapper -lkeyutils"],
         "@io_bazel_rules_go//go/platform:linux": ["-ldl -lresolv"],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
This only needs to be done in non-`cross` mode.

Epic: CRDB-21133

Release note: None