### PR TITLE
logictest: skip testserver upgrade tests on `s390x`

### DIFF
--- a/pkg/sql/logictest/logic.go
+++ b/pkg/sql/logictest/logic.go
@@ -2002,6 +2002,9 @@ func (t *logicTest) setup(
 		if !bazel.BuiltWithBazel() {
 			skip.IgnoreLint(t.t(), "cockroach-go/testserver can only be uzed in bazel builds")
 		}
+		if runtime.GOARCH == "s390x" {
+			skip.IgnoreLint(t.t(), "cockroach-go/testserver is not operational on s390x")
+		}
 		if cfg.NumNodes != 3 {
 			t.Fatal("cockroach-go testserver tests must use 3 nodes")
 		}


### PR DESCRIPTION
These tests do not make sense on `s390x` as there are no `s390x` releases right now.

Epic: CRDB-21133
Release note: None