### PR TITLE
opt: add rule to pull filters out of EXISTS condition

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4124,6 +4124,10 @@ func (m *sessionDataMutator) SetPropagateAdmissionHeaderToLeafTransactions(val b
 	m.data.PropagateAdmissionHeaderToLeafTransactions = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseExistsFilterHoistRule(val bool) {
+	m.data.OptimizerUseExistsFilterHoistRule = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4034,6 +4034,7 @@ optimizer_push_limit_into_project_filtered_scan            on
 optimizer_push_offset_into_index_join                      on
 optimizer_use_conditional_hoist_fix                        on
 optimizer_use_delete_range_fast_path                       on
+optimizer_use_exists_filter_hoist_rule                     off
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4034,7 +4034,7 @@ optimizer_push_limit_into_project_filtered_scan            on
 optimizer_push_offset_into_index_join                      on
 optimizer_use_conditional_hoist_fix                        on
 optimizer_use_delete_range_fast_path                       on
-optimizer_use_exists_filter_hoist_rule                     off
+optimizer_use_exists_filter_hoist_rule                     on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3047,6 +3047,7 @@ optimizer_push_limit_into_project_filtered_scan            on                  N
 optimizer_push_offset_into_index_join                      on                  NULL      NULL        NULL        string
 optimizer_use_conditional_hoist_fix                        on                  NULL      NULL        NULL        string
 optimizer_use_delete_range_fast_path                       on                  NULL      NULL        NULL        string
+optimizer_use_exists_filter_hoist_rule                     off                 NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL      NULL        NULL        string
@@ -3276,6 +3277,7 @@ optimizer_push_limit_into_project_filtered_scan            on                  N
 optimizer_push_offset_into_index_join                      on                  NULL  user     NULL      on                  on
 optimizer_use_conditional_hoist_fix                        on                  NULL  user     NULL      on                  on
 optimizer_use_delete_range_fast_path                       on                  NULL  user     NULL      on                  on
+optimizer_use_exists_filter_hoist_rule                     off                 NULL  user     NULL      off                 off
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL  user     NULL      on                  on
@@ -3496,6 +3498,7 @@ optimizer_push_limit_into_project_filtered_scan            NULL    NULL     NULL
 optimizer_push_offset_into_index_join                      NULL    NULL     NULL     NULL        NULL
 optimizer_use_conditional_hoist_fix                        NULL    NULL     NULL     NULL        NULL
 optimizer_use_delete_range_fast_path                       NULL    NULL     NULL     NULL        NULL
+optimizer_use_exists_filter_hoist_rule                     NULL    NULL     NULL     NULL        NULL
 optimizer_use_forecasts                                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_histograms                                   NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_computed_column_filters_derivation  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3047,7 +3047,7 @@ optimizer_push_limit_into_project_filtered_scan            on                  N
 optimizer_push_offset_into_index_join                      on                  NULL      NULL        NULL        string
 optimizer_use_conditional_hoist_fix                        on                  NULL      NULL        NULL        string
 optimizer_use_delete_range_fast_path                       on                  NULL      NULL        NULL        string
-optimizer_use_exists_filter_hoist_rule                     off                 NULL      NULL        NULL        string
+optimizer_use_exists_filter_hoist_rule                     on                  NULL      NULL        NULL        string
 optimizer_use_forecasts                                    on                  NULL      NULL        NULL        string
 optimizer_use_histograms                                   on                  NULL      NULL        NULL        string
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL      NULL        NULL        string
@@ -3277,7 +3277,7 @@ optimizer_push_limit_into_project_filtered_scan            on                  N
 optimizer_push_offset_into_index_join                      on                  NULL  user     NULL      on                  on
 optimizer_use_conditional_hoist_fix                        on                  NULL  user     NULL      on                  on
 optimizer_use_delete_range_fast_path                       on                  NULL  user     NULL      on                  on
-optimizer_use_exists_filter_hoist_rule                     off                 NULL  user     NULL      off                 off
+optimizer_use_exists_filter_hoist_rule                     on                  NULL  user     NULL      on                  on
 optimizer_use_forecasts                                    on                  NULL  user     NULL      on                  on
 optimizer_use_histograms                                   on                  NULL  user     NULL      on                  on
 optimizer_use_improved_computed_column_filters_derivation  on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -161,6 +161,7 @@ optimizer_push_limit_into_project_filtered_scan            on
 optimizer_push_offset_into_index_join                      on
 optimizer_use_conditional_hoist_fix                        on
 optimizer_use_delete_range_fast_path                       on
+optimizer_use_exists_filter_hoist_rule                     off
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -161,7 +161,7 @@ optimizer_push_limit_into_project_filtered_scan            on
 optimizer_push_offset_into_index_join                      on
 optimizer_use_conditional_hoist_fix                        on
 optimizer_use_delete_range_fast_path                       on
-optimizer_use_exists_filter_hoist_rule                     off
+optimizer_use_exists_filter_hoist_rule                     on
 optimizer_use_forecasts                                    on
 optimizer_use_histograms                                   on
 optimizer_use_improved_computed_column_filters_derivation  on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -206,6 +206,7 @@ type Memo struct {
 	useInsertFastPath                          bool
 	internal                                   bool
 	usePre_25_2VariadicBuiltins                bool
+	useExistsFilterHoistRule                   bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -309,6 +310,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		useInsertFastPath:                          evalCtx.SessionData().InsertFastPath,
 		internal:                                   evalCtx.SessionData().Internal,
 		usePre_25_2VariadicBuiltins:                evalCtx.SessionData().UsePre_25_2VariadicBuiltins,
+		useExistsFilterHoistRule:                   evalCtx.SessionData().OptimizerUseExistsFilterHoistRule,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -485,6 +487,7 @@ func (m *Memo) IsStale(
 		m.useInsertFastPath != evalCtx.SessionData().InsertFastPath ||
 		m.internal != evalCtx.SessionData().Internal ||
 		m.usePre_25_2VariadicBuiltins != evalCtx.SessionData().UsePre_25_2VariadicBuiltins ||
+		m.useExistsFilterHoistRule != evalCtx.SessionData().OptimizerUseExistsFilterHoistRule ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -574,6 +574,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().UsePre_25_2VariadicBuiltins = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerUseExistsFilterHoistRule = true
+	stale()
+	evalCtx.SessionData().OptimizerUseExistsFilterHoistRule = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -996,39 +996,38 @@ project
 opt
 SELECT * FROM (SELECT count(*) cnt FROM xysd) WHERE EXISTS(SELECT * FROM uv WHERE cnt=1)
 ----
-project
+select
  ├── columns: cnt:7(int!null)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(7)
- └── inner-join (cross)
-      ├── columns: count_rows:7(int!null)
-      ├── cardinality: [0 - 1]
-      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
-      ├── key: ()
-      ├── fd: ()-->(7)
-      ├── select
-      │    ├── columns: count_rows:7(int!null)
-      │    ├── cardinality: [0 - 1]
-      │    ├── key: ()
-      │    ├── fd: ()-->(7)
-      │    ├── scalar-group-by
-      │    │    ├── columns: count_rows:7(int!null)
-      │    │    ├── cardinality: [1 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(7)
-      │    │    ├── prune: (7)
-      │    │    ├── scan xysd@xysd_s_d_key
-      │    │    └── aggregations
-      │    │         └── count-rows [as=count_rows:7, type=int]
-      │    └── filters
-      │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
-      │              ├── variable: count_rows:7 [type=int]
-      │              └── const: 1 [type=int]
-      ├── scan uv
-      │    ├── limit: 1
-      │    └── key: ()
-      └── filters (true)
+ ├── scalar-group-by
+ │    ├── columns: count_rows:7(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(7)
+ │    ├── prune: (7)
+ │    ├── scan xysd@xysd_s_d_key
+ │    └── aggregations
+ │         └── count-rows [as=count_rows:7, type=int]
+ └── filters
+      ├── coalesce [type=bool, subquery]
+      │    ├── subquery [type=bool]
+      │    │    └── project
+      │    │         ├── columns: column14:14(bool!null)
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(14)
+      │    │         ├── prune: (14)
+      │    │         ├── scan uv
+      │    │         │    ├── limit: 1
+      │    │         │    └── key: ()
+      │    │         └── projections
+      │    │              └── true [as=column14:14, type=bool]
+      │    └── false [type=bool]
+      └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+           ├── variable: count_rows:7 [type=int]
+           └── const: 1 [type=int]
 
 # Maximum cardinality of the right input is propagated to the SemiJoin when
 # right rows are guaranteed at most one match each over the join filters.

--- a/pkg/sql/opt/memo/testdata/logprops/join
+++ b/pkg/sql/opt/memo/testdata/logprops/join
@@ -996,38 +996,39 @@ project
 opt
 SELECT * FROM (SELECT count(*) cnt FROM xysd) WHERE EXISTS(SELECT * FROM uv WHERE cnt=1)
 ----
-select
+project
  ├── columns: cnt:7(int!null)
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(7)
- ├── scalar-group-by
- │    ├── columns: count_rows:7(int!null)
- │    ├── cardinality: [1 - 1]
- │    ├── key: ()
- │    ├── fd: ()-->(7)
- │    ├── prune: (7)
- │    ├── scan xysd@xysd_s_d_key
- │    └── aggregations
- │         └── count-rows [as=count_rows:7, type=int]
- └── filters
-      ├── coalesce [type=bool, subquery]
-      │    ├── subquery [type=bool]
-      │    │    └── project
-      │    │         ├── columns: column14:14(bool!null)
-      │    │         ├── cardinality: [0 - 1]
-      │    │         ├── key: ()
-      │    │         ├── fd: ()-->(14)
-      │    │         ├── prune: (14)
-      │    │         ├── scan uv
-      │    │         │    ├── limit: 1
-      │    │         │    └── key: ()
-      │    │         └── projections
-      │    │              └── true [as=column14:14, type=bool]
-      │    └── false [type=bool]
-      └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
-           ├── variable: count_rows:7 [type=int]
-           └── const: 1 [type=int]
+ └── inner-join (cross)
+      ├── columns: count_rows:7(int!null)
+      ├── cardinality: [0 - 1]
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      ├── key: ()
+      ├── fd: ()-->(7)
+      ├── select
+      │    ├── columns: count_rows:7(int!null)
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(7)
+      │    ├── scalar-group-by
+      │    │    ├── columns: count_rows:7(int!null)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(7)
+      │    │    ├── prune: (7)
+      │    │    ├── scan xysd@xysd_s_d_key
+      │    │    └── aggregations
+      │    │         └── count-rows [as=count_rows:7, type=int]
+      │    └── filters
+      │         └── eq [type=bool, outer=(7), constraints=(/7: [/1 - /1]; tight), fd=()-->(7)]
+      │              ├── variable: count_rows:7 [type=int]
+      │              └── const: 1 [type=int]
+      ├── scan uv
+      │    ├── limit: 1
+      │    └── key: ()
+      └── filters (true)
 
 # Maximum cardinality of the right input is propagated to the SemiJoin when
 # right rows are guaranteed at most one match each over the join filters.

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -247,83 +247,83 @@ WHERE t1.b IN (
 )
 ORDER BY t1.a ASC;
 ----
-sort
- ├── columns: "?column?":23(int!null)  [hidden: t1.a:1(int!null)]
+project
+ ├── columns: "?column?":24(int!null)  [hidden: t1.a:1(int!null)]
  ├── key: (1)
- ├── fd: ()-->(23)
- ├── ordering: +1 opt(23) [actual: +1]
- ├── prune: (1,23)
- ├── interesting orderings: (+1 opt(23))
- └── project
-      ├── columns: "?column?":23(int!null) t1.a:1(int!null)
-      ├── key: (1)
-      ├── fd: ()-->(23)
-      ├── prune: (1,23)
-      ├── interesting orderings: (+1 opt(23))
-      ├── semi-join (cross)
-      │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
-      │    ├── key: (1)
-      │    ├── fd: ()-->(2)
-      │    ├── prune: (1)
-      │    ├── interesting orderings: (+1 opt(2))
-      │    ├── select
-      │    │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
-      │    │    ├── key: (1)
-      │    │    ├── fd: ()-->(2)
-      │    │    ├── prune: (1)
-      │    │    ├── interesting orderings: (+1 opt(2))
-      │    │    ├── scan t65038 [as=t1]
-      │    │    │    ├── columns: t1.a:1(int!null) t1.b:2(int)
-      │    │    │    ├── key: (1)
-      │    │    │    ├── fd: (1)-->(2)
-      │    │    │    ├── prune: (1,2)
-      │    │    │    └── interesting orderings: (+1)
-      │    │    └── filters
-      │    │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
-      │    │              ├── variable: t1.b:2 [type=int]
-      │    │              └── const: 1 [type=int]
-      │    ├── top-k
-      │    │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
-      │    │    ├── internal-ordering: +(12|17)
-      │    │    ├── k: 1
-      │    │    ├── cardinality: [0 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(11-13,16-18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
-      │    │    ├── interesting orderings: (+(12|17))
-      │    │    └── inner-join (cross)
-      │    │         ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
-      │    │         ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
-      │    │         ├── interesting orderings: (+11) (+16)
-      │    │         ├── scan t65038
-      │    │         │    └── unfiltered-cols: (6-10)
-      │    │         ├── inner-join (merge)
-      │    │         │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
-      │    │         │    ├── left ordering: +11,+12,+13
-      │    │         │    ├── right ordering: +16,+17,+18
-      │    │         │    ├── key: (16)
-      │    │         │    ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
-      │    │         │    ├── interesting orderings: (+11) (+16)
-      │    │         │    ├── scan t65038 [as=t2]
-      │    │         │    │    ├── columns: t2.a:11(int!null) t2.b:12(int) t2.c:13(int)
-      │    │         │    │    ├── key: (11)
-      │    │         │    │    ├── fd: (11)-->(12,13)
-      │    │         │    │    ├── ordering: +11
-      │    │         │    │    ├── prune: (11-13)
-      │    │         │    │    ├── interesting orderings: (+11)
-      │    │         │    │    └── unfiltered-cols: (11-15)
-      │    │         │    ├── scan t65038 [as=t3]
-      │    │         │    │    ├── columns: t3.a:16(int!null) t3.b:17(int) t3.c:18(int)
-      │    │         │    │    ├── key: (16)
-      │    │         │    │    ├── fd: (16)-->(17,18)
-      │    │         │    │    ├── ordering: +16
-      │    │         │    │    ├── prune: (16-18)
-      │    │         │    │    ├── interesting orderings: (+16)
-      │    │         │    │    └── unfiltered-cols: (16-20)
-      │    │         │    └── filters (true)
-      │    │         └── filters (true)
-      │    └── filters (true)
-      └── projections
-           └── const: 1 [as="?column?":23, type=int]
+ ├── fd: ()-->(24)
+ ├── ordering: +1 opt(24) [actual: +1]
+ ├── prune: (1,24)
+ ├── interesting orderings: (+1 opt(24))
+ ├── select
+ │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2)
+ │    ├── ordering: +1 opt(2) [actual: +1]
+ │    ├── prune: (1)
+ │    ├── interesting orderings: (+1 opt(2))
+ │    ├── scan t65038 [as=t1]
+ │    │    ├── columns: t1.a:1(int!null) t1.b:2(int)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── ordering: +1
+ │    │    ├── prune: (1,2)
+ │    │    └── interesting orderings: (+1)
+ │    └── filters
+ │         ├── coalesce [type=bool, subquery]
+ │         │    ├── subquery [type=bool]
+ │         │    │    └── project
+ │         │    │         ├── columns: column23:23(bool!null)
+ │         │    │         ├── cardinality: [0 - 1]
+ │         │    │         ├── key: ()
+ │         │    │         ├── fd: ()-->(23)
+ │         │    │         ├── prune: (23)
+ │         │    │         ├── top-k
+ │         │    │         │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
+ │         │    │         │    ├── internal-ordering: +(12|17)
+ │         │    │         │    ├── k: 1
+ │         │    │         │    ├── cardinality: [0 - 1]
+ │         │    │         │    ├── key: ()
+ │         │    │         │    ├── fd: ()-->(11-13,16-18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
+ │         │    │         │    ├── interesting orderings: (+(12|17))
+ │         │    │         │    └── inner-join (cross)
+ │         │    │         │         ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
+ │         │    │         │         ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
+ │         │    │         │         ├── interesting orderings: (+11) (+16)
+ │         │    │         │         ├── scan t65038
+ │         │    │         │         │    └── unfiltered-cols: (6-10)
+ │         │    │         │         ├── inner-join (merge)
+ │         │    │         │         │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
+ │         │    │         │         │    ├── left ordering: +11,+12,+13
+ │         │    │         │         │    ├── right ordering: +16,+17,+18
+ │         │    │         │         │    ├── key: (16)
+ │         │    │         │         │    ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
+ │         │    │         │         │    ├── interesting orderings: (+11) (+16)
+ │         │    │         │         │    ├── scan t65038 [as=t2]
+ │         │    │         │         │    │    ├── columns: t2.a:11(int!null) t2.b:12(int) t2.c:13(int)
+ │         │    │         │         │    │    ├── key: (11)
+ │         │    │         │         │    │    ├── fd: (11)-->(12,13)
+ │         │    │         │         │    │    ├── ordering: +11
+ │         │    │         │         │    │    ├── prune: (11-13)
+ │         │    │         │         │    │    ├── interesting orderings: (+11)
+ │         │    │         │         │    │    └── unfiltered-cols: (11-15)
+ │         │    │         │         │    ├── scan t65038 [as=t3]
+ │         │    │         │         │    │    ├── columns: t3.a:16(int!null) t3.b:17(int) t3.c:18(int)
+ │         │    │         │         │    │    ├── key: (16)
+ │         │    │         │         │    │    ├── fd: (16)-->(17,18)
+ │         │    │         │         │    │    ├── ordering: +16
+ │         │    │         │         │    │    ├── prune: (16-18)
+ │         │    │         │         │    │    ├── interesting orderings: (+16)
+ │         │    │         │         │    │    └── unfiltered-cols: (16-20)
+ │         │    │         │         │    └── filters (true)
+ │         │    │         │         └── filters (true)
+ │         │    │         └── projections
+ │         │    │              └── true [as=column23:23, type=bool]
+ │         │    └── false [type=bool]
+ │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+ │              ├── variable: t1.b:2 [type=int]
+ │              └── const: 1 [type=int]
+ └── projections
+      └── const: 1 [as="?column?":24, type=int]
 
 opt
 SELECT * FROM xyzs ORDER BY y DESC LIMIT 10

--- a/pkg/sql/opt/memo/testdata/logprops/limit
+++ b/pkg/sql/opt/memo/testdata/logprops/limit
@@ -247,83 +247,83 @@ WHERE t1.b IN (
 )
 ORDER BY t1.a ASC;
 ----
-project
- ├── columns: "?column?":24(int!null)  [hidden: t1.a:1(int!null)]
+sort
+ ├── columns: "?column?":23(int!null)  [hidden: t1.a:1(int!null)]
  ├── key: (1)
- ├── fd: ()-->(24)
- ├── ordering: +1 opt(24) [actual: +1]
- ├── prune: (1,24)
- ├── interesting orderings: (+1 opt(24))
- ├── select
- │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
- │    ├── key: (1)
- │    ├── fd: ()-->(2)
- │    ├── ordering: +1 opt(2) [actual: +1]
- │    ├── prune: (1)
- │    ├── interesting orderings: (+1 opt(2))
- │    ├── scan t65038 [as=t1]
- │    │    ├── columns: t1.a:1(int!null) t1.b:2(int)
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    ├── ordering: +1
- │    │    ├── prune: (1,2)
- │    │    └── interesting orderings: (+1)
- │    └── filters
- │         ├── coalesce [type=bool, subquery]
- │         │    ├── subquery [type=bool]
- │         │    │    └── project
- │         │    │         ├── columns: column23:23(bool!null)
- │         │    │         ├── cardinality: [0 - 1]
- │         │    │         ├── key: ()
- │         │    │         ├── fd: ()-->(23)
- │         │    │         ├── prune: (23)
- │         │    │         ├── top-k
- │         │    │         │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
- │         │    │         │    ├── internal-ordering: +(12|17)
- │         │    │         │    ├── k: 1
- │         │    │         │    ├── cardinality: [0 - 1]
- │         │    │         │    ├── key: ()
- │         │    │         │    ├── fd: ()-->(11-13,16-18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
- │         │    │         │    ├── interesting orderings: (+(12|17))
- │         │    │         │    └── inner-join (cross)
- │         │    │         │         ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
- │         │    │         │         ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
- │         │    │         │         ├── interesting orderings: (+11) (+16)
- │         │    │         │         ├── scan t65038
- │         │    │         │         │    └── unfiltered-cols: (6-10)
- │         │    │         │         ├── inner-join (merge)
- │         │    │         │         │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
- │         │    │         │         │    ├── left ordering: +11,+12,+13
- │         │    │         │         │    ├── right ordering: +16,+17,+18
- │         │    │         │         │    ├── key: (16)
- │         │    │         │         │    ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
- │         │    │         │         │    ├── interesting orderings: (+11) (+16)
- │         │    │         │         │    ├── scan t65038 [as=t2]
- │         │    │         │         │    │    ├── columns: t2.a:11(int!null) t2.b:12(int) t2.c:13(int)
- │         │    │         │         │    │    ├── key: (11)
- │         │    │         │         │    │    ├── fd: (11)-->(12,13)
- │         │    │         │         │    │    ├── ordering: +11
- │         │    │         │         │    │    ├── prune: (11-13)
- │         │    │         │         │    │    ├── interesting orderings: (+11)
- │         │    │         │         │    │    └── unfiltered-cols: (11-15)
- │         │    │         │         │    ├── scan t65038 [as=t3]
- │         │    │         │         │    │    ├── columns: t3.a:16(int!null) t3.b:17(int) t3.c:18(int)
- │         │    │         │         │    │    ├── key: (16)
- │         │    │         │         │    │    ├── fd: (16)-->(17,18)
- │         │    │         │         │    │    ├── ordering: +16
- │         │    │         │         │    │    ├── prune: (16-18)
- │         │    │         │         │    │    ├── interesting orderings: (+16)
- │         │    │         │         │    │    └── unfiltered-cols: (16-20)
- │         │    │         │         │    └── filters (true)
- │         │    │         │         └── filters (true)
- │         │    │         └── projections
- │         │    │              └── true [as=column23:23, type=bool]
- │         │    └── false [type=bool]
- │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
- │              ├── variable: t1.b:2 [type=int]
- │              └── const: 1 [type=int]
- └── projections
-      └── const: 1 [as="?column?":24, type=int]
+ ├── fd: ()-->(23)
+ ├── ordering: +1 opt(23) [actual: +1]
+ ├── prune: (1,23)
+ ├── interesting orderings: (+1 opt(23))
+ └── project
+      ├── columns: "?column?":23(int!null) t1.a:1(int!null)
+      ├── key: (1)
+      ├── fd: ()-->(23)
+      ├── prune: (1,23)
+      ├── interesting orderings: (+1 opt(23))
+      ├── semi-join (cross)
+      │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── prune: (1)
+      │    ├── interesting orderings: (+1 opt(2))
+      │    ├── select
+      │    │    ├── columns: t1.a:1(int!null) t1.b:2(int!null)
+      │    │    ├── key: (1)
+      │    │    ├── fd: ()-->(2)
+      │    │    ├── prune: (1)
+      │    │    ├── interesting orderings: (+1 opt(2))
+      │    │    ├── scan t65038 [as=t1]
+      │    │    │    ├── columns: t1.a:1(int!null) t1.b:2(int)
+      │    │    │    ├── key: (1)
+      │    │    │    ├── fd: (1)-->(2)
+      │    │    │    ├── prune: (1,2)
+      │    │    │    └── interesting orderings: (+1)
+      │    │    └── filters
+      │    │         └── eq [type=bool, outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │    │              ├── variable: t1.b:2 [type=int]
+      │    │              └── const: 1 [type=int]
+      │    ├── top-k
+      │    │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
+      │    │    ├── internal-ordering: +(12|17)
+      │    │    ├── k: 1
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(11-13,16-18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
+      │    │    ├── interesting orderings: (+(12|17))
+      │    │    └── inner-join (cross)
+      │    │         ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
+      │    │         ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
+      │    │         ├── interesting orderings: (+11) (+16)
+      │    │         ├── scan t65038
+      │    │         │    └── unfiltered-cols: (6-10)
+      │    │         ├── inner-join (merge)
+      │    │         │    ├── columns: t2.a:11(int!null) t2.b:12(int!null) t2.c:13(int!null) t3.a:16(int!null) t3.b:17(int!null) t3.c:18(int!null)
+      │    │         │    ├── left ordering: +11,+12,+13
+      │    │         │    ├── right ordering: +16,+17,+18
+      │    │         │    ├── key: (16)
+      │    │         │    ├── fd: (11)-->(12,13), (16)-->(17,18), (11)==(16), (16)==(11), (13)==(18), (18)==(13), (12)==(17), (17)==(12)
+      │    │         │    ├── interesting orderings: (+11) (+16)
+      │    │         │    ├── scan t65038 [as=t2]
+      │    │         │    │    ├── columns: t2.a:11(int!null) t2.b:12(int) t2.c:13(int)
+      │    │         │    │    ├── key: (11)
+      │    │         │    │    ├── fd: (11)-->(12,13)
+      │    │         │    │    ├── ordering: +11
+      │    │         │    │    ├── prune: (11-13)
+      │    │         │    │    ├── interesting orderings: (+11)
+      │    │         │    │    └── unfiltered-cols: (11-15)
+      │    │         │    ├── scan t65038 [as=t3]
+      │    │         │    │    ├── columns: t3.a:16(int!null) t3.b:17(int) t3.c:18(int)
+      │    │         │    │    ├── key: (16)
+      │    │         │    │    ├── fd: (16)-->(17,18)
+      │    │         │    │    ├── ordering: +16
+      │    │         │    │    ├── prune: (16-18)
+      │    │         │    │    ├── interesting orderings: (+16)
+      │    │         │    │    └── unfiltered-cols: (16-20)
+      │    │         │    └── filters (true)
+      │    │         └── filters (true)
+      │    └── filters (true)
+      └── projections
+           └── const: 1 [as="?column?":23, type=int]
 
 opt
 SELECT * FROM xyzs ORDER BY y DESC LIMIT 10

--- a/pkg/sql/opt/memo/testdata/stats/project
+++ b/pkg/sql/opt/memo/testdata/stats/project
@@ -302,7 +302,7 @@ exec-ddl
 CREATE TABLE t124831 (a INT, b INT);
 ----
 
-norm disable=(SimplifyZeroCardinalityGroup,EliminateExistsZeroRows,SimplifyZeroCardinalitySemiJoin,PushFilterIntoJoinLeft)
+norm disable=(SimplifyZeroCardinalityGroup,EliminateExistsZeroRows,SimplifyZeroCardinalitySemiJoin,PushFilterIntoJoinLeft,HoistUnboundFilterFromExistsSubquery)
 SELECT a FROM t124831 WHERE NULL::INT IN (SELECT 1 LIMIT b);
 ----
 project

--- a/pkg/sql/opt/norm/decorrelate_funcs.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs.go
@@ -1566,3 +1566,9 @@ func (c *CustomFuncs) MakeAnyNotNullScalarGroupBy(input memo.RelExpr) memo.RelEx
 		memo.EmptyGroupingPrivate,
 	)
 }
+
+// CanHoistUnboundFilterFromExistsSubquery returns true if the
+// HoistUnboundFilterFromExistsSubquery rule is enabled by session-setting.
+func (c *CustomFuncs) CanHoistUnboundFilterFromExistsSubquery() bool {
+	return c.f.evalCtx.SessionData().OptimizerUseExistsFilterHoistRule
+}

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -769,6 +769,17 @@ func (c *CustomFuncs) RemoveFiltersItem(
 	return filters.RemoveFiltersItem(search)
 }
 
+// AppendFiltersItem returns a new list that is a copy of the given list, except
+// that the given item has been appended to the end of the list.
+func (c *CustomFuncs) AppendFiltersItem(
+	filters memo.FiltersExpr, toAppend opt.ScalarExpr,
+) memo.FiltersExpr {
+	newFilters := make(memo.FiltersExpr, len(filters)+1)
+	copy(newFilters, filters)
+	newFilters[len(filters)] = c.f.ConstructFiltersItem(toAppend)
+	return newFilters
+}
+
 // ReplaceFiltersItem returns a new list that is a copy of the given list,
 // except that the given search item has been replaced by the given replace
 // item. If the list contains the search item multiple times, then only the

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -911,6 +911,54 @@
     (OutputCols2 $left $right)
 )
 
+# HoistUnboundFilterFromExistsSubquery pulls a filter condition out of an
+# Exists subquery if the filter condition only depends on columns from the
+# outer query. This is useful because it allows other optimization rules to
+# apply to the filter which was previously hidden inside the subquery.
+[HoistUnboundFilterFromExistsSubquery, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Exists
+                (Select
+                    $innerInput:*
+                    $innerFilters:[
+                        ...
+                        $innerItem:(FiltersItem $unboundCond:*) &
+                            (IsBoundBy
+                                $innerItem
+                                $inputCols:(OutputCols $input)
+                            )
+                        ...
+                    ]
+                )
+                $existsPrivate:*
+            )
+        )
+        ...
+    ]
+)
+=>
+(Select
+    $input
+    (AppendFiltersItem
+        (ReplaceFiltersItem
+            $filters
+            $item
+            (Exists
+                (Select
+                    $innerInput
+                    (RemoveFiltersItem $innerFilters $innerItem)
+                )
+                $existsPrivate
+            )
+        )
+        $unboundCond
+    )
+)
+
 # HoistSelectExists extracts existential subqueries from Select filters,
 # turning them into semi-joins. This eliminates the subquery, which is often
 # expensive to execute and restricts the optimizer's plan choices.

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -959,6 +959,57 @@
     )
 )
 
+# HoistUnboundJoinFilterFromExistsSubquery is similar to
+# HoistUnboundFilterFromExistsSubquery, but it applies to a join filter.
+[HoistUnboundJoinFilterFromExistsSubquery, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Exists
+                $join:(InnerJoin | InnerJoinApply | SemiJoin
+                        | SemiJoinApply
+                    $left:*
+                    $right:*
+                    $joinFilters:[
+                        ...
+                        $innerItem:(FiltersItem $unboundCond:*) &
+                            (IsBoundBy
+                                $innerItem
+                                $inputCols:(OutputCols $input)
+                            )
+                        ...
+                    ]
+                    $joinPrivate:*
+                )
+                $existsPrivate:*
+            )
+        )
+        ...
+    ]
+)
+=>
+(Select
+    $input
+    (AppendFiltersItem
+        (ReplaceFiltersItem
+            $filters
+            $item
+            (Exists
+                ((OpName $join)
+                    $left
+                    $right
+                    (RemoveFiltersItem $joinFilters $innerItem)
+                    $joinPrivate
+                )
+                $existsPrivate
+            )
+        )
+        $unboundCond
+    )
+)
+
 # HoistSelectExists extracts existential subqueries from Select filters,
 # turning them into semi-joins. This eliminates the subquery, which is often
 # expensive to execute and restricts the optimizer's plan choices.

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -917,7 +917,7 @@
 # apply to the filter which was previously hidden inside the subquery.
 [HoistUnboundFilterFromExistsSubquery, Normalize]
 (Select
-    $input:*
+    $input:* & (CanHoistUnboundFilterFromExistsSubquery)
     $filters:[
         ...
         $item:(FiltersItem
@@ -963,7 +963,7 @@
 # HoistUnboundFilterFromExistsSubquery, but it applies to a join filter.
 [HoistUnboundJoinFilterFromExistsSubquery, Normalize]
 (Select
-    $input:*
+    $input:* & (CanHoistUnboundFilterFromExistsSubquery)
     $filters:[
         ...
         $item:(FiltersItem

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -8458,3 +8458,294 @@ project
       │    └── key: (8)
       └── filters
            └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# --------------------------------------------------
+# HoistUnboundJoinFilterFromExistsSubquery
+# --------------------------------------------------
+
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy INNER JOIN uv ON x = u AND a.i = 100
+);
+----
+select
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      ├── coalesce [subquery]
+      │    ├── subquery
+      │    │    └── project
+      │    │         ├── columns: column17:17!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(17)
+      │    │         ├── limit
+      │    │         │    ├── columns: x:8!null u:12!null
+      │    │         │    ├── cardinality: [0 - 1]
+      │    │         │    ├── key: ()
+      │    │         │    ├── fd: ()-->(8,12), (8)==(12), (12)==(8)
+      │    │         │    ├── inner-join (hash)
+      │    │         │    │    ├── columns: x:8!null u:12!null
+      │    │         │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      │    │         │    │    ├── key: (12)
+      │    │         │    │    ├── fd: (8)==(12), (12)==(8)
+      │    │         │    │    ├── limit hint: 1.00
+      │    │         │    │    ├── scan xy
+      │    │         │    │    │    ├── columns: x:8!null
+      │    │         │    │    │    └── key: (8)
+      │    │         │    │    ├── scan uv
+      │    │         │    │    │    ├── columns: u:12!null
+      │    │         │    │    │    └── key: (12)
+      │    │         │    │    └── filters
+      │    │         │    │         └── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
+      │    │         │    └── 1
+      │    │         └── projections
+      │    │              └── true [as=column17:17]
+      │    └── false
+      └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy INNER JOIN LATERAL (
+    WITH foo(u, v) AS MATERIALIZED (SELECT * FROM uv WHERE y > 5) SELECT * FROM foo
+  ) ON x = u AND a.i = 100
+);
+----
+select
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      ├── coalesce [subquery]
+      │    ├── subquery
+      │    │    └── project
+      │    │         ├── columns: column19:19!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(19)
+      │    │         ├── limit
+      │    │         │    ├── columns: x:8!null y:9 u:16!null
+      │    │         │    ├── cardinality: [0 - 1]
+      │    │         │    ├── key: ()
+      │    │         │    ├── fd: ()-->(8,9,16), (8)==(16), (16)==(8)
+      │    │         │    ├── inner-join-apply
+      │    │         │    │    ├── columns: x:8!null y:9 u:16!null
+      │    │         │    │    ├── key: (16)
+      │    │         │    │    ├── fd: (8)-->(9), (8)==(16), (16)==(8)
+      │    │         │    │    ├── limit hint: 1.00
+      │    │         │    │    ├── scan xy
+      │    │         │    │    │    ├── columns: x:8!null y:9
+      │    │         │    │    │    ├── key: (8)
+      │    │         │    │    │    └── fd: (8)-->(9)
+      │    │         │    │    ├── with &1 (foo)
+      │    │         │    │    │    ├── columns: u:16!null
+      │    │         │    │    │    ├── materialized
+      │    │         │    │    │    ├── outer: (9)
+      │    │         │    │    │    ├── key: (16)
+      │    │         │    │    │    ├── select
+      │    │         │    │    │    │    ├── columns: uv.u:12!null uv.v:13
+      │    │         │    │    │    │    ├── outer: (9)
+      │    │         │    │    │    │    ├── key: (12)
+      │    │         │    │    │    │    ├── fd: (12)-->(13)
+      │    │         │    │    │    │    ├── scan uv
+      │    │         │    │    │    │    │    ├── columns: uv.u:12!null uv.v:13
+      │    │         │    │    │    │    │    ├── key: (12)
+      │    │         │    │    │    │    │    └── fd: (12)-->(13)
+      │    │         │    │    │    │    └── filters
+      │    │         │    │    │    │         └── y:9 > 5 [outer=(9), constraints=(/9: [/6 - ]; tight)]
+      │    │         │    │    │    └── with-scan &1 (foo)
+      │    │         │    │    │         ├── columns: u:16!null
+      │    │         │    │    │         ├── mapping:
+      │    │         │    │    │         │    └──  uv.u:12 => u:16
+      │    │         │    │    │         └── key: (16)
+      │    │         │    │    └── filters
+      │    │         │    │         └── x:8 = u:16 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+      │    │         │    └── 1
+      │    │         └── projections
+      │    │              └── true [as=column19:19]
+      │    └── false
+      └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy WHERE EXISTS (
+    SELECT * FROM uv WHERE x = u AND a.i = 100
+  )
+);
+----
+select
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      ├── coalesce [subquery]
+      │    ├── subquery
+      │    │    └── project
+      │    │         ├── columns: column18:18!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(18)
+      │    │         ├── limit
+      │    │         │    ├── columns: x:8!null
+      │    │         │    ├── cardinality: [0 - 1]
+      │    │         │    ├── key: ()
+      │    │         │    ├── fd: ()-->(8)
+      │    │         │    ├── semi-join (hash)
+      │    │         │    │    ├── columns: x:8!null
+      │    │         │    │    ├── key: (8)
+      │    │         │    │    ├── limit hint: 1.00
+      │    │         │    │    ├── scan xy
+      │    │         │    │    │    ├── columns: x:8!null
+      │    │         │    │    │    └── key: (8)
+      │    │         │    │    ├── scan uv
+      │    │         │    │    │    ├── columns: u:12!null
+      │    │         │    │    │    └── key: (12)
+      │    │         │    │    └── filters
+      │    │         │    │         └── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
+      │    │         │    └── 1
+      │    │         └── projections
+      │    │              └── true [as=column18:18]
+      │    └── false
+      └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy WHERE EXISTS (
+    SELECT * FROM (
+      WITH foo(u, v) AS MATERIALIZED (SELECT * FROM uv WHERE y > 5) SELECT * FROM foo
+    ) WHERE x = u AND a.i = 100
+  )
+);
+----
+select
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      ├── coalesce [subquery]
+      │    ├── subquery
+      │    │    └── project
+      │    │         ├── columns: column20:20!null
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         ├── fd: ()-->(20)
+      │    │         ├── limit
+      │    │         │    ├── columns: x:8!null y:9
+      │    │         │    ├── cardinality: [0 - 1]
+      │    │         │    ├── key: ()
+      │    │         │    ├── fd: ()-->(8,9)
+      │    │         │    ├── semi-join-apply
+      │    │         │    │    ├── columns: x:8!null y:9
+      │    │         │    │    ├── key: (8)
+      │    │         │    │    ├── fd: (8)-->(9)
+      │    │         │    │    ├── limit hint: 1.00
+      │    │         │    │    ├── scan xy
+      │    │         │    │    │    ├── columns: x:8!null y:9
+      │    │         │    │    │    ├── key: (8)
+      │    │         │    │    │    └── fd: (8)-->(9)
+      │    │         │    │    ├── with &1 (foo)
+      │    │         │    │    │    ├── columns: u:16!null
+      │    │         │    │    │    ├── materialized
+      │    │         │    │    │    ├── outer: (9)
+      │    │         │    │    │    ├── key: (16)
+      │    │         │    │    │    ├── select
+      │    │         │    │    │    │    ├── columns: uv.u:12!null uv.v:13
+      │    │         │    │    │    │    ├── outer: (9)
+      │    │         │    │    │    │    ├── key: (12)
+      │    │         │    │    │    │    ├── fd: (12)-->(13)
+      │    │         │    │    │    │    ├── scan uv
+      │    │         │    │    │    │    │    ├── columns: uv.u:12!null uv.v:13
+      │    │         │    │    │    │    │    ├── key: (12)
+      │    │         │    │    │    │    │    └── fd: (12)-->(13)
+      │    │         │    │    │    │    └── filters
+      │    │         │    │    │    │         └── y:9 > 5 [outer=(9), constraints=(/9: [/6 - ]; tight)]
+      │    │         │    │    │    └── with-scan &1 (foo)
+      │    │         │    │    │         ├── columns: u:16!null
+      │    │         │    │    │         ├── mapping:
+      │    │         │    │    │         │    └──  uv.u:12 => u:16
+      │    │         │    │    │         └── key: (16)
+      │    │         │    │    └── filters
+      │    │         │    │         └── x:8 = u:16 [outer=(8,16), constraints=(/8: (/NULL - ]; /16: (/NULL - ]), fd=(8)==(16), (16)==(8)]
+      │    │         │    └── 1
+      │    │         └── projections
+      │    │              └── true [as=column20:20]
+      │    └── false
+      └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+
+# No-op because of the left-join.
+norm expect-not=HoistUnboundJoinFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy LEFT JOIN uv ON x = u AND a.i = 100
+);
+----
+semi-join-apply
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── left-join (hash)
+ │    ├── columns: x:8!null u:12
+ │    ├── outer: (2)
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(12)
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null
+ │    │    └── key: (8)
+ │    ├── scan uv
+ │    │    ├── columns: u:12!null
+ │    │    └── key: (12)
+ │    └── filters
+ │         ├── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
+ │         └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+ └── filters (true)
+
+# No-op because of the full-join.
+norm expect-not=HoistUnboundJoinFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy FULL JOIN uv ON x = u AND a.i = 100
+);
+----
+semi-join-apply
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── full-join (hash)
+ │    ├── columns: x:8 u:12
+ │    ├── outer: (2)
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    ├── key: (8,12)
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null
+ │    │    └── key: (8)
+ │    ├── scan uv
+ │    │    ├── columns: u:12!null
+ │    │    └── key: (12)
+ │    └── filters
+ │         ├── x:8 = u:12 [outer=(8,12), constraints=(/8: (/NULL - ]; /12: (/NULL - ]), fd=(8)==(12), (12)==(8)]
+ │         └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+ └── filters (true)

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -8137,7 +8137,7 @@ project
 # HoistUnboundFilterFromExistsSubquery
 # --------------------------------------------------
 
-norm expect=HoistUnboundFilterFromExistsSubquery
+norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8163,7 +8163,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with a projection.
-norm expect=HoistUnboundFilterFromExistsSubquery
+norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT true FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8189,7 +8189,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with multiple filters.
-norm expect=HoistUnboundFilterFromExistsSubquery
+norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy
   WHERE xy.x = a.k
@@ -8230,7 +8230,7 @@ semi-join (hash)
 
 # Case where hoisting the filter "a.k = 1000" allows the optimizer to infer
 # a filter on "uv.u".
-norm expect=HoistUnboundFilterFromExistsSubquery
+norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a LEFT JOIN uv ON a.k = uv.u WHERE EXISTS (
   SELECT * FROM xy WHERE xy.y = a.i AND a.k = 1000
 );
@@ -8276,7 +8276,7 @@ left-join (hash)
       └── k:1 = u:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with an ANY filter that gets normalized to EXISTS.
-norm expect=HoistUnboundFilterFromExistsSubquery
+norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE a.k = ANY (
   SELECT xy.x FROM xy WHERE a.i = 100
 );
@@ -8302,7 +8302,7 @@ semi-join (hash)
       └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with an IN filter that gets normalized to EXISTS.
-norm expect=HoistUnboundFilterFromExistsSubquery
+norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE a.k IN (
   SELECT xy.x FROM xy WHERE a.i = 100
 );
@@ -8327,8 +8327,34 @@ semi-join (hash)
  └── filters
       └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
+# No-op because the rule is disabled.
+norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=false
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── select
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
+ ├── scan xy
+ │    ├── columns: x:8!null
+ │    └── key: (8)
+ └── filters
+      └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
 # No-op with no filters.
-norm expect-not=HoistUnboundFilterFromExistsSubquery
+norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (SELECT * FROM xy);
 ----
 select
@@ -8358,7 +8384,7 @@ select
            └── false
 
 # No-op because all filters reference xy.
-norm expect-not=HoistUnboundFilterFromExistsSubquery
+norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND xy.y = 1000
 );
@@ -8385,7 +8411,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # No-op because all filters reference xy.
-norm expect-not=HoistUnboundFilterFromExistsSubquery
+norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND xy.y + a.i = 1000
 );
@@ -8408,7 +8434,7 @@ semi-join (hash)
       └── (y:9 + i:2) = 1000 [outer=(2,9), immutable]
 
 # No-op case with NOT EXISTS.
-norm expect-not=HoistUnboundFilterFromExistsSubquery
+norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE NOT EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8429,7 +8455,7 @@ anti-join (hash)
       └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
 
 # No-op because the top expression in the subquery isn't a Select.
-norm expect-not=HoistUnboundFilterFromExistsSubquery
+norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT sum(xy.y) OVER () FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8463,7 +8489,7 @@ project
 # HoistUnboundJoinFilterFromExistsSubquery
 # --------------------------------------------------
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery
+norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy INNER JOIN uv ON x = u AND a.i = 100
 );
@@ -8509,7 +8535,7 @@ select
       │    └── false
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery
+norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy INNER JOIN LATERAL (
     WITH foo(u, v) AS MATERIALIZED (SELECT * FROM uv WHERE y > 5) SELECT * FROM foo
@@ -8575,7 +8601,7 @@ select
       │    └── false
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery
+norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE EXISTS (
     SELECT * FROM uv WHERE x = u AND a.i = 100
@@ -8621,7 +8647,7 @@ select
       │    └── false
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery
+norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE EXISTS (
     SELECT * FROM (
@@ -8690,7 +8716,7 @@ select
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
 # No-op because of the left-join.
-norm expect-not=HoistUnboundJoinFilterFromExistsSubquery
+norm expect-not=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy LEFT JOIN uv ON x = u AND a.i = 100
 );
@@ -8721,7 +8747,7 @@ semi-join-apply
  └── filters (true)
 
 # No-op because of the full-join.
-norm expect-not=HoistUnboundJoinFilterFromExistsSubquery
+norm expect-not=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy FULL JOIN uv ON x = u AND a.i = 100
 );

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -8132,3 +8132,329 @@ project
  │              └── j:5
  └── projections
       └── CASE WHEN canary_agg:22 IS NOT NULL THEN 1 ELSE 0 END [as=case:20]
+
+# --------------------------------------------------
+# HoistUnboundFilterFromExistsSubquery
+# --------------------------------------------------
+
+norm expect=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── select
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
+ ├── scan xy
+ │    ├── columns: x:8!null
+ │    └── key: (8)
+ └── filters
+      └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Case with a projection.
+norm expect=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT true FROM xy WHERE xy.x = a.k AND a.i = 1000
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── select
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
+ ├── scan xy
+ │    ├── columns: x:8!null
+ │    └── key: (8)
+ └── filters
+      └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Case with multiple filters.
+norm expect=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy
+  WHERE xy.x = a.k
+  AND xy.y = 5
+  AND a.s LIKE '%foo%'
+  AND a.i + a.f::INT > 200
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── select
+ │    ├── columns: k:1!null i:2 f:3 s:4!null j:5
+ │    ├── immutable
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         ├── s:4 LIKE '%foo%' [outer=(4), constraints=(/4: (/NULL - ])]
+ │         └── (i:2 + f:3::INT8) > 200 [outer=(2,3), immutable]
+ ├── select
+ │    ├── columns: x:8!null y:9!null
+ │    ├── key: (8)
+ │    ├── fd: ()-->(9)
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── y:9 = 5 [outer=(9), constraints=(/9: [/5 - /5]; tight), fd=()-->(9)]
+ └── filters
+      └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Case where hoisting the filter "a.k = 1000" allows the optimizer to infer
+# a filter on "uv.u".
+norm expect=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a LEFT JOIN uv ON a.k = uv.u WHERE EXISTS (
+  SELECT * FROM xy WHERE xy.y = a.i AND a.k = 1000
+);
+----
+left-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 u:8 v:9
+ ├── cardinality: [0 - 1]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── key: ()
+ ├── fd: ()-->(1-5,8,9)
+ ├── semi-join (hash)
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1-5)
+ │    ├── select
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1-5)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2-5)
+ │    │    └── filters
+ │    │         └── k:1 = 1000 [outer=(1), constraints=(/1: [/1000 - /1000]; tight), fd=()-->(1)]
+ │    ├── scan xy
+ │    │    └── columns: y:13
+ │    └── filters
+ │         └── y:13 = i:2 [outer=(2,13), constraints=(/2: (/NULL - ]; /13: (/NULL - ]), fd=(2)==(13), (13)==(2)]
+ ├── select
+ │    ├── columns: u:8!null v:9
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(8,9)
+ │    ├── scan uv
+ │    │    ├── columns: u:8!null v:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── u:8 = 1000 [outer=(8), constraints=(/8: [/1000 - /1000]; tight), fd=()-->(8)]
+ └── filters
+      └── k:1 = u:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Case with an ANY filter that gets normalized to EXISTS.
+norm expect=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE a.k = ANY (
+  SELECT xy.x FROM xy WHERE a.i = 100
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── select
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+ ├── scan xy
+ │    ├── columns: x:8!null
+ │    └── key: (8)
+ └── filters
+      └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# Case with an IN filter that gets normalized to EXISTS.
+norm expect=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE a.k IN (
+  SELECT xy.x FROM xy WHERE a.i = 100
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ ├── select
+ │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2), (1)-->(3-5)
+ │    ├── scan a
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2-5)
+ │    └── filters
+ │         └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
+ ├── scan xy
+ │    ├── columns: x:8!null
+ │    └── key: (8)
+ └── filters
+      └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# No-op with no filters.
+norm expect-not=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (SELECT * FROM xy);
+----
+select
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── filters
+      └── coalesce [subquery]
+           ├── subquery
+           │    └── project
+           │         ├── columns: column13:13!null
+           │         ├── cardinality: [0 - 1]
+           │         ├── key: ()
+           │         ├── fd: ()-->(13)
+           │         ├── limit
+           │         │    ├── cardinality: [0 - 1]
+           │         │    ├── key: ()
+           │         │    ├── scan xy
+           │         │    │    └── limit hint: 1.00
+           │         │    └── 1
+           │         └── projections
+           │              └── true [as=column13:13]
+           └── false
+
+# No-op because all filters reference xy.
+norm expect-not=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy WHERE xy.x = a.k AND xy.y = 1000
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── select
+ │    ├── columns: x:8!null y:9!null
+ │    ├── key: (8)
+ │    ├── fd: ()-->(9)
+ │    ├── scan xy
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── y:9 = 1000 [outer=(9), constraints=(/9: [/1000 - /1000]; tight), fd=()-->(9)]
+ └── filters
+      └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+
+# No-op because all filters reference xy.
+norm expect-not=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT * FROM xy WHERE xy.x = a.k AND xy.y + a.i = 1000
+);
+----
+semi-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan xy
+ │    ├── columns: x:8!null y:9
+ │    ├── key: (8)
+ │    └── fd: (8)-->(9)
+ └── filters
+      ├── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      └── (y:9 + i:2) = 1000 [outer=(2,9), immutable]
+
+# No-op case with NOT EXISTS.
+norm expect-not=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE NOT EXISTS (
+  SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
+);
+----
+anti-join (hash)
+ ├── columns: k:1!null i:2 f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan xy
+ │    ├── columns: x:8!null
+ │    └── key: (8)
+ └── filters
+      ├── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
+      └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
+
+# No-op because the top expression in the subquery isn't a Select.
+norm expect-not=HoistUnboundFilterFromExistsSubquery
+SELECT * FROM a WHERE EXISTS (
+  SELECT sum(xy.y) OVER () FROM xy WHERE xy.x = a.k AND a.i = 1000
+);
+----
+project
+ ├── columns: k:1!null i:2!null f:3 s:4 j:5
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3-5)
+ └── inner-join (hash)
+      ├── columns: k:1!null i:2!null f:3 s:4 j:5 x:8!null
+      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+      ├── key: (8)
+      ├── fd: ()-->(2), (1)-->(3-5), (1)==(8), (8)==(1)
+      ├── select
+      │    ├── columns: k:1!null i:2!null f:3 s:4 j:5
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2), (1)-->(3-5)
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2-5)
+      │    └── filters
+      │         └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
+      ├── scan xy
+      │    ├── columns: x:8!null
+      │    └── key: (8)
+      └── filters
+           └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]

--- a/pkg/sql/opt/norm/testdata/rules/decorrelate
+++ b/pkg/sql/opt/norm/testdata/rules/decorrelate
@@ -8137,7 +8137,7 @@ project
 # HoistUnboundFilterFromExistsSubquery
 # --------------------------------------------------
 
-norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8163,7 +8163,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with a projection.
-norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT true FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8189,7 +8189,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with multiple filters.
-norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy
   WHERE xy.x = a.k
@@ -8230,7 +8230,7 @@ semi-join (hash)
 
 # Case where hoisting the filter "a.k = 1000" allows the optimizer to infer
 # a filter on "uv.u".
-norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a LEFT JOIN uv ON a.k = uv.u WHERE EXISTS (
   SELECT * FROM xy WHERE xy.y = a.i AND a.k = 1000
 );
@@ -8276,7 +8276,7 @@ left-join (hash)
       └── k:1 = u:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with an ANY filter that gets normalized to EXISTS.
-norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE a.k = ANY (
   SELECT xy.x FROM xy WHERE a.i = 100
 );
@@ -8302,7 +8302,7 @@ semi-join (hash)
       └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # Case with an IN filter that gets normalized to EXISTS.
-norm expect=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE a.k IN (
   SELECT xy.x FROM xy WHERE a.i = 100
 );
@@ -8354,7 +8354,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # No-op with no filters.
-norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (SELECT * FROM xy);
 ----
 select
@@ -8384,7 +8384,7 @@ select
            └── false
 
 # No-op because all filters reference xy.
-norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND xy.y = 1000
 );
@@ -8411,7 +8411,7 @@ semi-join (hash)
       └── x:8 = k:1 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # No-op because all filters reference xy.
-norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND xy.y + a.i = 1000
 );
@@ -8434,7 +8434,7 @@ semi-join (hash)
       └── (y:9 + i:2) = 1000 [outer=(2,9), immutable]
 
 # No-op case with NOT EXISTS.
-norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE NOT EXISTS (
   SELECT * FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8455,7 +8455,7 @@ anti-join (hash)
       └── i:2 = 1000 [outer=(2), constraints=(/2: [/1000 - /1000]; tight), fd=()-->(2)]
 
 # No-op because the top expression in the subquery isn't a Select.
-norm expect-not=HoistUnboundFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT sum(xy.y) OVER () FROM xy WHERE xy.x = a.k AND a.i = 1000
 );
@@ -8489,7 +8489,7 @@ project
 # HoistUnboundJoinFilterFromExistsSubquery
 # --------------------------------------------------
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy INNER JOIN uv ON x = u AND a.i = 100
 );
@@ -8535,7 +8535,7 @@ select
       │    └── false
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy INNER JOIN LATERAL (
     WITH foo(u, v) AS MATERIALIZED (SELECT * FROM uv WHERE y > 5) SELECT * FROM foo
@@ -8601,7 +8601,7 @@ select
       │    └── false
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE EXISTS (
     SELECT * FROM uv WHERE x = u AND a.i = 100
@@ -8647,7 +8647,7 @@ select
       │    └── false
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
-norm expect=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect=HoistUnboundJoinFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy WHERE EXISTS (
     SELECT * FROM (
@@ -8716,7 +8716,7 @@ select
       └── i:2 = 100 [outer=(2), constraints=(/2: [/100 - /100]; tight), fd=()-->(2)]
 
 # No-op because of the left-join.
-norm expect-not=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundJoinFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy LEFT JOIN uv ON x = u AND a.i = 100
 );
@@ -8747,7 +8747,7 @@ semi-join-apply
  └── filters (true)
 
 # No-op because of the full-join.
-norm expect-not=HoistUnboundJoinFilterFromExistsSubquery set=optimizer_use_exists_filter_hoist_rule=true
+norm expect-not=HoistUnboundJoinFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS (
   SELECT * FROM xy FULL JOIN uv ON x = u AND a.i = 100
 );

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -392,7 +392,7 @@ left-join (hash)
       └── i:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
 
 # Semi-join case.
-norm expect=PushFilterIntoJoinLeft
+norm expect=PushFilterIntoJoinLeft disable=HoistUnboundFilterFromExistsSubquery
 SELECT * FROM a WHERE EXISTS(SELECT * FROM b WHERE x=k AND s='foo')
 ----
 semi-join (hash)

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -1201,7 +1201,7 @@ inner-join (cross)
 
 # Regression for issue 28818. Try to trigger undetectable cycle between the
 # PushFilterIntoJoinLeftAndRight and TryDecorrelateSelect rules.
-norm
+norm disable=HoistUnboundJoinFilterFromExistsSubquery
 SELECT 1
 FROM a
 WHERE EXISTS (

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -676,9 +676,9 @@ semi-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
- │         ├── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
  │         ├── f:3 > 1.0 [outer=(3), constraints=(/3: [/1.0000000000000002 - ]; tight)]
- │         └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ │         ├── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+ │         └── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
  ├── scan xy
  │    ├── columns: x:8!null
  │    └── key: (8)

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -676,9 +676,9 @@ semi-join (hash)
  │    │    ├── key: (1)
  │    │    └── fd: (1)-->(2-5)
  │    └── filters
+ │         ├── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
  │         ├── f:3 > 1.0 [outer=(3), constraints=(/3: [/1.0000000000000002 - ]; tight)]
- │         ├── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
- │         └── i:2 = 2 [outer=(2), constraints=(/2: [/2 - /2]; tight), fd=()-->(2)]
+ │         └── s:4 = 'foo' [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
  ├── scan xy
  │    ├── columns: x:8!null
  │    └── key: (8)

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -2715,46 +2715,68 @@ opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3,c.* FROM a,c
        WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = a2) AND (a1 = c1 OR c1 = c2))
 ----
-project
+inner-join (hash)
  ├── columns: a1:1!null a2:2!null a3:3!null c1:7!null c2:8!null c3:9 c4:10
  ├── fd: (2)==(8), (8)==(2)
- └── group-by (hash)
-      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
-      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
-      ├── key: (1,3,4,11)
-      ├── fd: (11)-->(7-10), (1,3,4,11)-->(2,7-10), (2)==(8), (8)==(2)
-      ├── inner-join (cross)
-      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null b1:14
-      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
-      │    ├── scan b
-      │    │    └── columns: b1:14
-      │    ├── inner-join (hash)
-      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
-      │    │    ├── key: (1,3,4,11)
-      │    │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
-      │    │    ├── scan a
-      │    │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      │    │    │    └── key: (1-4)
-      │    │    ├── scan c
-      │    │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
-      │    │    │    ├── key: (11)
-      │    │    │    └── fd: (11)-->(7-10)
-      │    │    └── filters
-      │    │         ├── (a1:1 = c1:7) OR (c1:7 = c2:8) [outer=(1,7,8), constraints=(/7: (/NULL - ])]
-      │    │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
-      │    └── filters
-      │         └── (a1:1 = b1:14) OR (a1:1 = a2:2) [outer=(1,2,14), constraints=(/1: (/NULL - ])]
-      └── aggregations
-           ├── const-agg [as=c1:7, outer=(7)]
-           │    └── c1:7
-           ├── const-agg [as=c2:8, outer=(8)]
-           │    └── c2:8
-           ├── const-agg [as=c3:9, outer=(9)]
-           │    └── c3:9
-           ├── const-agg [as=c4:10, outer=(10)]
-           │    └── c4:10
-           └── const-agg [as=a2:2, outer=(2)]
-                └── a2:2
+ ├── project
+ │    ├── columns: a1:1!null a2:2!null a3:3!null
+ │    └── distinct-on
+ │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │         ├── key: (1-4)
+ │         └── union-all
+ │              ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+ │              ├── left columns: a1:22 a2:23 a3:24 a4:25
+ │              ├── right columns: a1:35 a2:36 a3:37 a4:38
+ │              ├── project
+ │              │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
+ │              │    ├── key: (22-25)
+ │              │    └── inner-join (merge)
+ │              │         ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null
+ │              │         ├── left ordering: +22
+ │              │         ├── right ordering: +28
+ │              │         ├── key: (23-25,28)
+ │              │         ├── fd: (22)==(28), (28)==(22)
+ │              │         ├── scan a
+ │              │         │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
+ │              │         │    ├── key: (22-25)
+ │              │         │    └── ordering: +22
+ │              │         ├── distinct-on
+ │              │         │    ├── columns: b1:28
+ │              │         │    ├── grouping columns: b1:28
+ │              │         │    ├── key: (28)
+ │              │         │    ├── ordering: +28
+ │              │         │    └── scan b@b_b1_b2_idx
+ │              │         │         ├── columns: b1:28
+ │              │         │         └── ordering: +28
+ │              │         └── filters (true)
+ │              └── project
+ │                   ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+ │                   ├── key: (36-38)
+ │                   ├── fd: (35)==(36), (36)==(35)
+ │                   └── inner-join (cross)
+ │                        ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+ │                        ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │                        ├── key: (36-38)
+ │                        ├── fd: (35)==(36), (36)==(35)
+ │                        ├── select
+ │                        │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+ │                        │    ├── key: (36-38)
+ │                        │    ├── fd: (35)==(36), (36)==(35)
+ │                        │    ├── scan a
+ │                        │    │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
+ │                        │    │    └── key: (35-38)
+ │                        │    └── filters
+ │                        │         └── a1:35 = a2:36 [outer=(35,36), constraints=(/35: (/NULL - ]; /36: (/NULL - ]), fd=(35)==(36), (36)==(35)]
+ │                        ├── scan b
+ │                        │    ├── limit: 1
+ │                        │    └── key: ()
+ │                        └── filters (true)
+ ├── scan c
+ │    └── columns: c1:7 c2:8 c3:9 c4:10
+ └── filters
+      ├── (a1:1 = c1:7) OR (c1:7 = c2:8) [outer=(1,7,8), constraints=(/7: (/NULL - ])]
+      └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3,c.* FROM a,c
@@ -2842,46 +2864,23 @@ opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3,c.* FROM a,c
        WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = b3) AND (a1 = c1 OR a1 = c3))
 ----
-project
+semi-join (cross)
  ├── columns: a1:1!null a2:2!null a3:3!null c1:7 c2:8!null c3:9 c4:10
  ├── fd: (2)==(8), (8)==(2)
- └── group-by (hash)
-      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null
-      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
-      ├── key: (1,3,4,11)
-      ├── fd: (11)-->(7-10), (1,3,4,11)-->(2,7-10), (2)==(8), (8)==(2)
-      ├── inner-join (cross)
-      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null b1:14 b3:16
-      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
-      │    ├── scan b
-      │    │    └── columns: b1:14 b3:16
-      │    ├── inner-join (hash)
-      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null
-      │    │    ├── key: (1,3,4,11)
-      │    │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
-      │    │    ├── scan a
-      │    │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
-      │    │    │    └── key: (1-4)
-      │    │    ├── scan c
-      │    │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
-      │    │    │    ├── key: (11)
-      │    │    │    └── fd: (11)-->(7-10)
-      │    │    └── filters
-      │    │         ├── (a1:1 = c1:7) OR (a1:1 = c3:9) [outer=(1,7,9), constraints=(/1: (/NULL - ])]
-      │    │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
-      │    └── filters
-      │         └── (a1:1 = b1:14) OR (a1:1 = b3:16) [outer=(1,14,16), constraints=(/1: (/NULL - ])]
-      └── aggregations
-           ├── const-agg [as=c1:7, outer=(7)]
-           │    └── c1:7
-           ├── const-agg [as=c2:8, outer=(8)]
-           │    └── c2:8
-           ├── const-agg [as=c3:9, outer=(9)]
-           │    └── c3:9
-           ├── const-agg [as=c4:10, outer=(10)]
-           │    └── c4:10
-           └── const-agg [as=a2:2, outer=(2)]
-                └── a2:2
+ ├── inner-join (hash)
+ │    ├── columns: a1:1!null a2:2!null a3:3!null c1:7 c2:8!null c3:9 c4:10
+ │    ├── fd: (2)==(8), (8)==(2)
+ │    ├── scan a
+ │    │    └── columns: a1:1!null a2:2!null a3:3!null
+ │    ├── scan c
+ │    │    └── columns: c1:7 c2:8 c3:9 c4:10
+ │    └── filters
+ │         ├── (a1:1 = c1:7) OR (a1:1 = c3:9) [outer=(1,7,9), constraints=(/1: (/NULL - ])]
+ │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ ├── scan b
+ │    └── columns: b1:14 b3:16
+ └── filters
+      └── (a1:1 = b1:14) OR (a1:1 = b3:16) [outer=(1,14,16), constraints=(/1: (/NULL - ])]
 
 # Nested EXISTS
 opt expect=SplitDisjunctionOfJoinTerms

--- a/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
+++ b/pkg/sql/opt/xform/testdata/rules/disjunction_in_join
@@ -2715,68 +2715,46 @@ opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3,c.* FROM a,c
        WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = a2) AND (a1 = c1 OR c1 = c2))
 ----
-inner-join (hash)
+project
  ├── columns: a1:1!null a2:2!null a3:3!null c1:7!null c2:8!null c3:9 c4:10
  ├── fd: (2)==(8), (8)==(2)
- ├── project
- │    ├── columns: a1:1!null a2:2!null a3:3!null
- │    └── distinct-on
- │         ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
- │         ├── grouping columns: a1:1!null a2:2!null a3:3!null a4:4!null
- │         ├── key: (1-4)
- │         └── union-all
- │              ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
- │              ├── left columns: a1:22 a2:23 a3:24 a4:25
- │              ├── right columns: a1:35 a2:36 a3:37 a4:38
- │              ├── project
- │              │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
- │              │    ├── key: (22-25)
- │              │    └── inner-join (merge)
- │              │         ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null b1:28!null
- │              │         ├── left ordering: +22
- │              │         ├── right ordering: +28
- │              │         ├── key: (23-25,28)
- │              │         ├── fd: (22)==(28), (28)==(22)
- │              │         ├── scan a
- │              │         │    ├── columns: a1:22!null a2:23!null a3:24!null a4:25!null
- │              │         │    ├── key: (22-25)
- │              │         │    └── ordering: +22
- │              │         ├── distinct-on
- │              │         │    ├── columns: b1:28
- │              │         │    ├── grouping columns: b1:28
- │              │         │    ├── key: (28)
- │              │         │    ├── ordering: +28
- │              │         │    └── scan b@b_b1_b2_idx
- │              │         │         ├── columns: b1:28
- │              │         │         └── ordering: +28
- │              │         └── filters (true)
- │              └── project
- │                   ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
- │                   ├── key: (36-38)
- │                   ├── fd: (35)==(36), (36)==(35)
- │                   └── inner-join (cross)
- │                        ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
- │                        ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
- │                        ├── key: (36-38)
- │                        ├── fd: (35)==(36), (36)==(35)
- │                        ├── select
- │                        │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
- │                        │    ├── key: (36-38)
- │                        │    ├── fd: (35)==(36), (36)==(35)
- │                        │    ├── scan a
- │                        │    │    ├── columns: a1:35!null a2:36!null a3:37!null a4:38!null
- │                        │    │    └── key: (35-38)
- │                        │    └── filters
- │                        │         └── a1:35 = a2:36 [outer=(35,36), constraints=(/35: (/NULL - ]; /36: (/NULL - ]), fd=(35)==(36), (36)==(35)]
- │                        ├── scan b
- │                        │    ├── limit: 1
- │                        │    └── key: ()
- │                        └── filters (true)
- ├── scan c
- │    └── columns: c1:7 c2:8 c3:9 c4:10
- └── filters
-      ├── (a1:1 = c1:7) OR (c1:7 = c2:8) [outer=(1,7,8), constraints=(/7: (/NULL - ])]
-      └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── group-by (hash)
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
+      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
+      ├── key: (1,3,4,11)
+      ├── fd: (11)-->(7-10), (1,3,4,11)-->(2,7-10), (2)==(8), (8)==(2)
+      ├── inner-join (cross)
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null b1:14
+      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    ├── scan b
+      │    │    └── columns: b1:14
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7!null c2:8!null c3:9 c4:10 c.rowid:11!null
+      │    │    ├── key: (1,3,4,11)
+      │    │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    │    ├── scan a
+      │    │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    │    │    └── key: (1-4)
+      │    │    ├── scan c
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
+      │    │    │    ├── key: (11)
+      │    │    │    └── fd: (11)-->(7-10)
+      │    │    └── filters
+      │    │         ├── (a1:1 = c1:7) OR (c1:7 = c2:8) [outer=(1,7,8), constraints=(/7: (/NULL - ])]
+      │    │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    └── filters
+      │         └── (a1:1 = b1:14) OR (a1:1 = a2:2) [outer=(1,2,14), constraints=(/1: (/NULL - ])]
+      └── aggregations
+           ├── const-agg [as=c1:7, outer=(7)]
+           │    └── c1:7
+           ├── const-agg [as=c2:8, outer=(8)]
+           │    └── c2:8
+           ├── const-agg [as=c3:9, outer=(9)]
+           │    └── c3:9
+           ├── const-agg [as=c4:10, outer=(10)]
+           │    └── c4:10
+           └── const-agg [as=a2:2, outer=(2)]
+                └── a2:2
 
 opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3,c.* FROM a,c
@@ -2864,23 +2842,46 @@ opt expect=SplitDisjunctionOfJoinTerms
 SELECT a1,a2,a3,c.* FROM a,c
        WHERE a2 = c2 AND EXISTS (SELECT * FROM b WHERE (a1 = b1 OR a1 = b3) AND (a1 = c1 OR a1 = c3))
 ----
-semi-join (cross)
+project
  ├── columns: a1:1!null a2:2!null a3:3!null c1:7 c2:8!null c3:9 c4:10
  ├── fd: (2)==(8), (8)==(2)
- ├── inner-join (hash)
- │    ├── columns: a1:1!null a2:2!null a3:3!null c1:7 c2:8!null c3:9 c4:10
- │    ├── fd: (2)==(8), (8)==(2)
- │    ├── scan a
- │    │    └── columns: a1:1!null a2:2!null a3:3!null
- │    ├── scan c
- │    │    └── columns: c1:7 c2:8 c3:9 c4:10
- │    └── filters
- │         ├── (a1:1 = c1:7) OR (a1:1 = c3:9) [outer=(1,7,9), constraints=(/1: (/NULL - ])]
- │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
- ├── scan b
- │    └── columns: b1:14 b3:16
- └── filters
-      └── (a1:1 = b1:14) OR (a1:1 = b3:16) [outer=(1,14,16), constraints=(/1: (/NULL - ])]
+ └── group-by (hash)
+      ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null
+      ├── grouping columns: a1:1!null a3:3!null a4:4!null c.rowid:11!null
+      ├── key: (1,3,4,11)
+      ├── fd: (11)-->(7-10), (1,3,4,11)-->(2,7-10), (2)==(8), (8)==(2)
+      ├── inner-join (cross)
+      │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null b1:14 b3:16
+      │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    ├── scan b
+      │    │    └── columns: b1:14 b3:16
+      │    ├── inner-join (hash)
+      │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null c1:7 c2:8!null c3:9 c4:10 c.rowid:11!null
+      │    │    ├── key: (1,3,4,11)
+      │    │    ├── fd: (11)-->(7-10), (2)==(8), (8)==(2)
+      │    │    ├── scan a
+      │    │    │    ├── columns: a1:1!null a2:2!null a3:3!null a4:4!null
+      │    │    │    └── key: (1-4)
+      │    │    ├── scan c
+      │    │    │    ├── columns: c1:7 c2:8 c3:9 c4:10 c.rowid:11!null
+      │    │    │    ├── key: (11)
+      │    │    │    └── fd: (11)-->(7-10)
+      │    │    └── filters
+      │    │         ├── (a1:1 = c1:7) OR (a1:1 = c3:9) [outer=(1,7,9), constraints=(/1: (/NULL - ])]
+      │    │         └── a2:2 = c2:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    └── filters
+      │         └── (a1:1 = b1:14) OR (a1:1 = b3:16) [outer=(1,14,16), constraints=(/1: (/NULL - ])]
+      └── aggregations
+           ├── const-agg [as=c1:7, outer=(7)]
+           │    └── c1:7
+           ├── const-agg [as=c2:8, outer=(8)]
+           │    └── c2:8
+           ├── const-agg [as=c3:9, outer=(9)]
+           │    └── c3:9
+           ├── const-agg [as=c4:10, outer=(10)]
+           │    └── c4:10
+           └── const-agg [as=a2:2, outer=(2)]
+                └── a2:2
 
 # Nested EXISTS
 opt expect=SplitDisjunctionOfJoinTerms

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4076,46 +4076,63 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── semi-join (cross)
+ └── select
       ├── columns: pk:1!null col0:2!null col2:4!null col4:5!null
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1,2,4,5)
-      ├── select
-      │    ├── columns: pk:1!null col0:2!null col2:4!null col4:5!null
+      ├── index-join t
+      │    ├── columns: pk:1!null col0:2 col2:4 col4:5
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1,2,4,5)
-      │    ├── index-join t
-      │    │    ├── columns: pk:1!null col0:2 col2:4 col4:5
-      │    │    ├── cardinality: [0 - 1]
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(1,2,4,5)
-      │    │    └── scan t@t_col2_key
-      │    │         ├── columns: pk:1!null col2:4!null
-      │    │         ├── constraint: /4: [/1 - /1]
-      │    │         ├── cardinality: [0 - 1]
-      │    │         ├── key: ()
-      │    │         └── fd: ()-->(1,4)
-      │    └── filters
-      │         ├── col4:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
-      │         └── col0:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
-      ├── select
-      │    ├── columns: col0:9!null col2:11
-      │    ├── lax-key: (11)
-      │    ├── fd: ()-->(9,11)
-      │    ├── index-join t
-      │    │    ├── columns: col0:9 col2:11
-      │    │    ├── lax-key: (9,11)
-      │    │    ├── fd: ()-->(11), (11)~~>(9)
-      │    │    └── scan t@t_col2_key
-      │    │         ├── columns: pk:8!null col2:11
-      │    │         ├── constraint: /11: [/NULL - /NULL]
-      │    │         ├── key: (8)
-      │    │         └── fd: ()-->(11), (11)~~>(8)
-      │    └── filters
-      │         └── col0:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
-      └── filters (true)
+      │    └── select
+      │         ├── columns: pk:1!null col2:4!null
+      │         ├── cardinality: [0 - 1]
+      │         ├── key: ()
+      │         ├── fd: ()-->(1,4)
+      │         ├── scan t@t_col2_key
+      │         │    ├── columns: pk:1!null col2:4!null
+      │         │    ├── constraint: /4: [/1 - /1]
+      │         │    ├── cardinality: [0 - 1]
+      │         │    ├── key: ()
+      │         │    └── fd: ()-->(1,4)
+      │         └── filters
+      │              └── coalesce [subquery]
+      │                   ├── subquery
+      │                   │    └── project
+      │                   │         ├── columns: column16:16!null
+      │                   │         ├── cardinality: [0 - 1]
+      │                   │         ├── key: ()
+      │                   │         ├── fd: ()-->(16)
+      │                   │         ├── limit
+      │                   │         │    ├── columns: col0:9!null col2:11
+      │                   │         │    ├── cardinality: [0 - 1]
+      │                   │         │    ├── key: ()
+      │                   │         │    ├── fd: ()-->(9,11)
+      │                   │         │    ├── select
+      │                   │         │    │    ├── columns: col0:9!null col2:11
+      │                   │         │    │    ├── lax-key: (11)
+      │                   │         │    │    ├── fd: ()-->(9,11)
+      │                   │         │    │    ├── limit hint: 1.00
+      │                   │         │    │    ├── index-join t
+      │                   │         │    │    │    ├── columns: col0:9 col2:11
+      │                   │         │    │    │    ├── lax-key: (9,11)
+      │                   │         │    │    │    ├── fd: ()-->(11), (11)~~>(9)
+      │                   │         │    │    │    └── scan t@t_col2_key
+      │                   │         │    │    │         ├── columns: pk:8!null col2:11
+      │                   │         │    │    │         ├── constraint: /11: [/NULL - /NULL]
+      │                   │         │    │    │         ├── key: (8)
+      │                   │         │    │    │         └── fd: ()-->(11), (11)~~>(8)
+      │                   │         │    │    └── filters
+      │                   │         │    │         └── col0:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
+      │                   │         │    └── 1
+      │                   │         └── projections
+      │                   │              └── true [as=column16:16]
+      │                   └── false
+      └── filters
+           ├── col4:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+           └── col0:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
 
 # Lookup semi-join with covering index.
 opt expect=GenerateLookupJoinsWithFilter

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -4076,63 +4076,46 @@ project
  ├── cardinality: [0 - 1]
  ├── key: ()
  ├── fd: ()-->(1)
- └── select
+ └── semi-join (cross)
       ├── columns: pk:1!null col0:2!null col2:4!null col4:5!null
       ├── cardinality: [0 - 1]
       ├── key: ()
       ├── fd: ()-->(1,2,4,5)
-      ├── index-join t
-      │    ├── columns: pk:1!null col0:2 col2:4 col4:5
+      ├── select
+      │    ├── columns: pk:1!null col0:2!null col2:4!null col4:5!null
       │    ├── cardinality: [0 - 1]
       │    ├── key: ()
       │    ├── fd: ()-->(1,2,4,5)
-      │    └── select
-      │         ├── columns: pk:1!null col2:4!null
-      │         ├── cardinality: [0 - 1]
-      │         ├── key: ()
-      │         ├── fd: ()-->(1,4)
-      │         ├── scan t@t_col2_key
-      │         │    ├── columns: pk:1!null col2:4!null
-      │         │    ├── constraint: /4: [/1 - /1]
-      │         │    ├── cardinality: [0 - 1]
-      │         │    ├── key: ()
-      │         │    └── fd: ()-->(1,4)
-      │         └── filters
-      │              └── coalesce [subquery]
-      │                   ├── subquery
-      │                   │    └── project
-      │                   │         ├── columns: column16:16!null
-      │                   │         ├── cardinality: [0 - 1]
-      │                   │         ├── key: ()
-      │                   │         ├── fd: ()-->(16)
-      │                   │         ├── limit
-      │                   │         │    ├── columns: col0:9!null col2:11
-      │                   │         │    ├── cardinality: [0 - 1]
-      │                   │         │    ├── key: ()
-      │                   │         │    ├── fd: ()-->(9,11)
-      │                   │         │    ├── select
-      │                   │         │    │    ├── columns: col0:9!null col2:11
-      │                   │         │    │    ├── lax-key: (11)
-      │                   │         │    │    ├── fd: ()-->(9,11)
-      │                   │         │    │    ├── limit hint: 1.00
-      │                   │         │    │    ├── index-join t
-      │                   │         │    │    │    ├── columns: col0:9 col2:11
-      │                   │         │    │    │    ├── lax-key: (9,11)
-      │                   │         │    │    │    ├── fd: ()-->(11), (11)~~>(9)
-      │                   │         │    │    │    └── scan t@t_col2_key
-      │                   │         │    │    │         ├── columns: pk:8!null col2:11
-      │                   │         │    │    │         ├── constraint: /11: [/NULL - /NULL]
-      │                   │         │    │    │         ├── key: (8)
-      │                   │         │    │    │         └── fd: ()-->(11), (11)~~>(8)
-      │                   │         │    │    └── filters
-      │                   │         │    │         └── col0:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
-      │                   │         │    └── 1
-      │                   │         └── projections
-      │                   │              └── true [as=column16:16]
-      │                   └── false
-      └── filters
-           ├── col4:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
-           └── col0:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      │    ├── index-join t
+      │    │    ├── columns: pk:1!null col0:2 col2:4 col4:5
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1,2,4,5)
+      │    │    └── scan t@t_col2_key
+      │    │         ├── columns: pk:1!null col2:4!null
+      │    │         ├── constraint: /4: [/1 - /1]
+      │    │         ├── cardinality: [0 - 1]
+      │    │         ├── key: ()
+      │    │         └── fd: ()-->(1,4)
+      │    └── filters
+      │         ├── col4:5 = 1 [outer=(5), constraints=(/5: [/1 - /1]; tight), fd=()-->(5)]
+      │         └── col0:2 = 1 [outer=(2), constraints=(/2: [/1 - /1]; tight), fd=()-->(2)]
+      ├── select
+      │    ├── columns: col0:9!null col2:11
+      │    ├── lax-key: (11)
+      │    ├── fd: ()-->(9,11)
+      │    ├── index-join t
+      │    │    ├── columns: col0:9 col2:11
+      │    │    ├── lax-key: (9,11)
+      │    │    ├── fd: ()-->(11), (11)~~>(9)
+      │    │    └── scan t@t_col2_key
+      │    │         ├── columns: pk:8!null col2:11
+      │    │         ├── constraint: /11: [/NULL - /NULL]
+      │    │         ├── key: (8)
+      │    │         └── fd: ()-->(11), (11)~~>(8)
+      │    └── filters
+      │         └── col0:9 = 1 [outer=(9), constraints=(/9: [/1 - /1]; tight), fd=()-->(9)]
+      └── filters (true)
 
 # Lookup semi-join with covering index.
 opt expect=GenerateLookupJoinsWithFilter

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -667,6 +667,9 @@ message LocalOnlySessionData {
   // PropagateAdmissionHeaderToLeafTransactions, when true, causes leaf
   // transactions to inherit the admission header from the root transaction.
   bool propagate_admission_header_to_leaf_transactions = 169;
+  // OptimizerUseExistsFilterHoistRule, when true, causes the optimizer to apply
+  // the HoistUnboundFilterFromExistsSubquery rule to EXISTS conditions.
+  bool optimizer_use_exists_filter_hoist_rule = 170;
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4017,6 +4017,23 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_exists_filter_hoist_rule`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_exists_filter_hoist_rule`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_exists_filter_hoist_rule", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseExistsFilterHoistRule(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseExistsFilterHoistRule), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4032,7 +4032,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().OptimizerUseExistsFilterHoistRule), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 


### PR DESCRIPTION
#### opt: add rule to pull filters out of EXISTS condition

This commit adds a new norm rule `HoistUnboundFilterFromExistsSubquery`
that pulls a filter out of an EXISTS filter if the inner filter only
references columns from the outer query. This gives other optimizations
a chance to apply before filter push-down rules move the EXISTS subquery
and everything in it below joins and other operators.

Fixes #146000

Release note: None

#### opt: add rule to pull filters out of EXISTS join condition

This commit adds a new norm rule `HoistUnboundJoinFilterFromExistsSubquery`
that pulls a filter from a join in an `EXISTS` subquery if the join filter
only references columns from the outer query. This gives other optimizations
a chance to apply before filter push-down rules move the EXISTS subquery
and everything in it below joins and other operators in the outer query.

Fixes #146000

Release note: None

#### opt: add session setting to control new norm rule

This commit adds a session setting `optimizer_use_exists_filter_hoist_rule`
to toggle the new optimizer rule `HoistUnboundFilterFromExistsSubquery`.
It if off by default in this commit, while the next will switch it on
only on master.

Informs #146000

Release note: None

#### opt: flip new session setting on

This commit sets `optimizer_use_exists_filter_hoist_rule` to true
by default. This commit will not be backported, so that the changes
in previous commits are opt-in.

Informs #146000

Release note: None