### PR TITLE
hlc/logger,fmtsafe: add logLogger methods to fmtsafe

### DIFF
--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -44,6 +44,9 @@ var requireConstFmt = map[string]bool{
 	"(*log.Logger).Panicf": true,
 	"(*log.Logger).Printf": true,
 
+	"(*github.com/cockroachdb/cockroach/pkg/util/hlc/logger.logLogger).Fatalf":   true,
+	"(*github.com/cockroachdb/cockroach/pkg/util/hlc/logger.logLogger).Warningf": true,
+
 	"github.com/cockroachdb/cockroach/pkg/util/log.Shoutf":          true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.Eventf":          true,
 	"github.com/cockroachdb/cockroach/pkg/util/log.vEventf":         true,

--- a/pkg/util/hlc/logger/logger.go
+++ b/pkg/util/hlc/logger/logger.go
@@ -19,10 +19,10 @@ var CRDBLogger = &logLogger{}
 type logLogger struct{}
 
 func (*logLogger) Fatalf(ctx context.Context, format string, args ...interface{}) {
-	log.Fatalf(ctx, format, args...) // nolint:fmtsafe
+	log.Fatalf(ctx, format, args...)
 }
 func (*logLogger) Warningf(ctx context.Context, format string, args ...interface{}) {
-	log.Warningf(ctx, format, args...) // nolint:fmtsafe
+	log.Warningf(ctx, format, args...)
 }
 
 type Logfer interface {


### PR DESCRIPTION
The `Fatalf` and `WarningF` methods of `logLogger` are now linted by
`fmtsafe` to ensure that the `format string` argument is always a
constant string at call sites. The `// nolint:fmtsafe` comments have
been removed (they shouldn't have been allowed, but they are due to a
bug in the interaction of `fmtsafe` and `rules_go` and I plan to fix
this soon).

Release note: None
