### PR TITLE
goschedstats: change default of goschedstats.always_use_short_sample_…

### DIFF
--- a/pkg/util/goschedstats/runnable.go
+++ b/pkg/util/goschedstats/runnable.go
@@ -74,4 +74,4 @@ var alwaysUseShortSamplePeriodEnabled = settings.RegisterBoolSetting(
 	settings.SystemOnly,
 	"goschedstats.always_use_short_sample_period.enabled",
 	"when set to true, the system always does 1ms sampling of runnable queue lengths",
-	false)
+	true)

--- a/pkg/util/goschedstats/runnable_enabled.go
+++ b/pkg/util/goschedstats/runnable_enabled.go
@@ -43,7 +43,7 @@ func cumulativeNormalizedRunnableGoroutines() float64 {
 // The use of underloadedRunnablePerProcThreshold does not provide sufficient
 // protection against sluggish response in the admission control system, which
 // uses these samples to adjust concurrency of request processing. So
-// goschedstats.always_use_short_sample_period.enabled can be set to true to
+// goschedstats.always_use_short_sample_period.enabled now defaults to true to
 // force this responsiveness.
 const samplePeriodShort = time.Millisecond
 const samplePeriodLong = 250 * time.Millisecond


### PR DESCRIPTION
…period.enabled to true

The adaptive switching to a short period is not always responsive, based on observations from production clusters, including from https://github.com/cockroachlabs/support/issues/3292.

The only reason the adaptive switching was introduced was for idle serverless clusters, and those explicitly set this to false since https://github.com/cockroachlabs/rafa-production/pull/582.

Epic: none

Release note: None