### PR TITLE
changefeedccl: disable unsafe sql updates in nemeses test

### DIFF
--- a/pkg/internal/sqlsmith/sqlsmith.go
+++ b/pkg/internal/sqlsmith/sqlsmith.go
@@ -470,6 +470,17 @@ var InsUpdOnly = simpleOption("inserts and updates only", func(s *Smither) {
 	}
 })
 
+// InsUpdDelOnly causes the Smither to emit 80% INSERT, 10% UPDATE,
+// 10% DELETE statements.
+var InsUpdDelOnly = simpleOption("inserts updates and deletes only",
+	func(s *Smither) {
+		s.stmtWeights = []statementWeight{
+			{8, makeInsert},
+			{1, makeUpdate},
+			{1, makeDelete},
+		}
+	})
+
 // IgnoreFNs causes the Smither to ignore functions that match the regex.
 func IgnoreFNs(regex string) SmitherOption {
 	r := regexp.MustCompile(regex)


### PR DESCRIPTION
Some queries generated by sql smith can hang due to being unsafe (e.g., executing many self-joins). This PR enables the session setting `sql_safe_updates` in order to reject these kinds of queries, then redisables it for the remainder of the test. It also makes some minor improvements, such as only populating initial table state via sql smith if sql smit is enabled, logging to make it easy to reproduce the table's initial state before the changefeed is created, and only allowing normal sql mutations with sql smith.

Epic: none
Fixes: #140591

Release note: none