### PR TITLE
kvclient/rangefeed: release resource properly for restartActiveRangeFeeds

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -529,8 +529,12 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 func (m *rangefeedMuxer) restartActiveRangeFeeds(
 	ctx context.Context, reason error, toRestart []*activeMuxRangeFeed,
 ) error {
-	for _, active := range toRestart {
+	for i, active := range toRestart {
 		if err := m.restartActiveRangeFeed(ctx, active, reason); err != nil {
+			// Release all remaining rangefeeds that we won't restart.
+			for _, remaining := range toRestart[i+1:] {
+				remaining.release()
+			}
 			return err
 		}
 	}


### PR DESCRIPTION
Previously, resources were not properly released when restartActiveRangeFeeds
returned early due to an error, without calling restartActiveRangeFeed on each
toRestart rangefeed. This commit fixes the resource leak.

Fixes: https://github.com/cockroachdb/cockroach/issues/129486
Release note: none