### PR TITLE
vecindex: add more logic tests for vector indexes

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -1364,7 +1364,6 @@ SELECT * FROM prune@idx WHERE c > 0
 1  2  3  7
 
 # Vector partial indexes.
-# TODO(andyk): Need more tests once insertion is possible.
 subtest vector
 
 statement ok
@@ -1397,6 +1396,142 @@ statement ok
 CREATE TABLE vec (id INT PRIMARY KEY, s STRING, v VECTOR(3));
 CREATE VECTOR INDEX ON vec (v) WHERE s IN ('foo', 'bar');
 DROP TABLE vec;
+
+statement ok
+CREATE TABLE vec (k INT PRIMARY KEY, v VECTOR(2), s STRING);
+CREATE VECTOR INDEX i ON vec (s, v) WHERE s IN ('foo', 'bar');
+
+statement ok
+INSERT INTO vec VALUES
+    (1, '[1,2]', 'foo'),
+    (2, '[3,4]', 'foo'),
+    (3, '[5,6]', 'baz'),
+    (4, '[5,6]', 'bar')
+
+# Only consider foo rows.
+query ITT
+SELECT * FROM vec@i WHERE s = 'foo' ORDER BY v <-> '[5,5]' LIMIT 1
+----
+2  [3,4]  foo
+
+# Consider both foo and bar rows.
+query ITT
+SELECT * FROM vec@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 1
+----
+4  [5,6]  bar
+
+# Delete bar row and ensure it is not returned.
+statement ok
+DELETE FROM vec WHERE k = 4
+
+query ITT
+SELECT * FROM vec@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 1
+----
+2  [3,4]  foo
+
+# Update vector and ensure it is now returned.
+statement ok
+UPDATE vec SET v = '[6,6]' WHERE k = 1
+
+query ITT
+SELECT * FROM vec@i WHERE s = 'foo' ORDER BY v <-> '[5,5]' LIMIT 1
+----
+1  [6,6]  foo
+
+# Update primary key and move row into partial index (baz => bar).
+statement ok
+UPDATE vec SET k = 10 WHERE k = 1
+
+statement ok
+UPDATE vec SET s = 'bar' WHERE k = 3
+
+query ITT
+SELECT * FROM vec@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 3
+----
+3   [5,6]  bar
+10  [6,6]  foo
+2   [3,4]  foo
+
+# Move row out of partial index (foo => baz).
+statement ok
+UPDATE vec SET s = 'baz' WHERE k = 10
+
+query ITT
+SELECT * FROM vec@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 3
+----
+3  [5,6]  bar
+2  [3,4]  foo
+
+# Overwrite value of row in partial index.
+statement ok
+UPSERT INTO vec VALUES (3, '[7, 8]', 'bar')
+
+query ITT
+SELECT * FROM vec@i WHERE s = 'bar' ORDER BY v <-> '[5,5]' LIMIT 3
+----
+3  [7,8]  bar
+
+statement error index "i" is a partial index that does not contain all the rows needed to execute this query
+SELECT * FROM vec@i WHERE s = 'baz' ORDER BY v <-> '[5,5]' LIMIT 3
+
+statement ok
+DROP TABLE vec
+
+# Backfill a partial vector index.
+statement ok
+CREATE TABLE vec_b (k INT PRIMARY KEY, v VECTOR(2), s STRING)
+
+statement ok
+INSERT INTO vec_b VALUES
+    (1, '[1,2]', 'foo'),
+    (2, '[3,4]', 'foo'),
+    (3, '[5,6]', 'baz'),
+    (4, '[5,6]', 'bar')
+
+statement ok
+CREATE VECTOR INDEX i ON vec_b (s, v) WHERE s IN ('foo', 'bar')
+
+query ITT
+SELECT * FROM vec_b@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 3
+----
+4  [5,6]  bar
+2  [3,4]  foo
+1  [1,2]  foo
+
+statement ok
+DROP TABLE vec_b
+
+# Backfill a partial vector index when a new table is created in the same
+# transaction.
+
+statement ok
+BEGIN
+
+statement ok
+CREATE TABLE vec_c (k INT PRIMARY KEY, v VECTOR(2), s STRING)
+
+statement ok
+INSERT INTO vec_c VALUES
+    (1, '[1,2]', 'foo'),
+    (2, '[3,4]', 'foo'),
+    (3, '[5,6]', 'baz'),
+    (4, '[5,6]', 'bar')
+
+statement ok
+CREATE VECTOR INDEX i ON vec_c (s, v) WHERE s IN ('foo', 'bar')
+
+query ITT
+SELECT * FROM vec_c@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 3
+----
+4  [5,6]  bar
+2  [3,4]  foo
+1  [1,2]  foo
+
+statement ok
+COMMIT
+
+statement ok
+DROP TABLE vec_c
 
 # Tests for partial indexes with predicates that reference virtual computed
 # columns.

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -391,7 +391,8 @@ CREATE TABLE exec_test (
   b INT,
   vec1 VECTOR(3),
   VECTOR INDEX idx1 (vec1) WITH (min_partition_size=1, max_partition_size=4),
-  VECTOR INDEX idx2 (b, vec1) WITH (min_partition_size=1, max_partition_size=4)
+  VECTOR INDEX idx2 (b, vec1) WITH (min_partition_size=1, max_partition_size=4),
+  FAMILY (a, b, vec1)
 )
 
 statement ok
@@ -402,7 +403,21 @@ INSERT INTO exec_test (a, b, vec1) VALUES
   (4, 2, '[10, 11, 12]'),
   (5, 2, '[13, 14, 15]'),
   (6, NULL, '[16, 17, 18]'),
-  (7, NULL, '[1, 1, 1]');
+  (7, NULL, '[1, 1, 1]'),
+  (8, NULL, NULL),
+  (9, 3, NULL);
+
+# Get all rows that do not have NULL vector values.
+query IT rowsort
+SELECT a, vec1 FROM exec_test@idx1 ORDER BY vec1 <-> '[1, 1, 2]' LIMIT 10;
+----
+7  [1,1,1]
+1  [1,2,3]
+2  [4,5,6]
+3  [7,8,9]
+4  [10,11,12]
+5  [13,14,15]
+6  [16,17,18]
 
 # Search index with no prefix.
 query IT rowsort
@@ -440,6 +455,26 @@ SELECT a, b, vec1 FROM exec_test WHERE b IN (1, 2) ORDER BY vec1 <-> '[1, 1, 2]'
 2  1  [4,5,6]
 3  2  [7,8,9]
 4  2  [10,11,12]
+
+# Get all rows that do not have NULL vector values.
+query IT rowsort
+SELECT a, vec1 FROM exec_test@idx1 ORDER BY vec1 <-> '[5, 5, 5]' LIMIT 10;
+----
+2  [4,5,6]
+3  [7,8,9]
+1  [1,2,3]
+7  [1,1,1]
+4  [10,11,12]
+5  [13,14,15]
+6  [16,17,18]
+
+# Search again, but with smaller limit.
+query IT rowsort
+SELECT a, vec1 FROM exec_test@idx1 ORDER BY vec1 <-> '[5, 5, 5]' LIMIT 3;
+----
+2  [4,5,6]
+3  [7,8,9]
+1  [1,2,3]
 
 statement ok
 DROP TABLE exec_test

--- a/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/not_visible_index
@@ -615,7 +615,7 @@ CREATE VECTOR INDEX idx_partial_invisible ON t1 (a, v) WHERE a > 10 NOT VISIBLE
 
 # Check invisible vector partial index: ignored idx_partial_invisible.
 query T
-EXPLAIN SELECT * FROM t1 WHERE a > 10 ORDER BY v <-> '[3,1,2]' LIMIT 5;
+EXPLAIN SELECT * FROM t1 WHERE a IN (10, 20) ORDER BY v <-> '[3,1,2]' LIMIT 5;
 ----
 distribution: local
 vectorized: true
@@ -627,12 +627,38 @@ vectorized: true
 └── • render
     │
     └── • filter
-        │ filter: a > 10
+        │ filter: a IN (10, 20)
         │
         └── • scan
               missing stats
               table: t1@t1_pkey
               spans: FULL SCAN
+
+statement ok
+ALTER INDEX idx_partial_invisible VISIBLE
+
+# Partial index is now visible, so it should be chosen.
+query T
+EXPLAIN SELECT * FROM t1 WHERE a IN (20, 30) ORDER BY v <-> '[3,1,2]' LIMIT 5;
+----
+distribution: local
+vectorized: true
+·
+• top-k
+│ order: +column9
+│ k: 5
+│
+└── • render
+    │
+    └── • lookup join
+        │ table: t1@t1_pkey
+        │ equality: (rowid) = (rowid)
+        │ equality cols are key
+        │
+        └── • vector search
+              table: t1@idx_partial_invisible (partial index)
+              target count: 5
+              prefix spans: [/20 - /20] [/30 - /30]
 
 statement ok
 DROP TABLE t1

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -18,6 +18,15 @@ CREATE TABLE inv (
     FAMILY (a, b, c)
 )
 
+statement ok
+CREATE TABLE vec (
+    a INT PRIMARY KEY,
+    b VECTOR(2),
+    c STRING,
+    VECTOR INDEX i (c, b) WHERE c IN ('foo', 'bar'),
+    FAMILY (a, b, c)
+)
+
 # ---------------------------------------------------------
 # EXPLAIN
 # ---------------------------------------------------------
@@ -203,13 +212,13 @@ CREATE TABLE u (
 query T kvtrace
 SELECT a FROM t WHERE a > b AND c = 'foo'
 ----
-Scan /Table/20/1/11{2-3}
-Scan /Table/112/4/"foo"{-/PrefixEnd}
+Scan /Table/20/1/11{3-4}
+Scan /Table/113/4/"foo"{-/PrefixEnd}
 
 query T kvtrace
 SELECT a FROM t@c_partial WHERE a > b AND c = 'foo'
 ----
-Scan /Table/112/4/"foo"{-/PrefixEnd}
+Scan /Table/113/4/"foo"{-/PrefixEnd}
 
 statement error index "c_partial" is a partial index that does not contain all the rows needed to execute this query
 SELECT a FROM t@c_partial WHERE a > b AND c = 'bar'
@@ -222,40 +231,40 @@ SELECT a FROM t@c_partial WHERE a > b AND c = 'bar'
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar')
 ----
-CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
-Put /Table/112/2/4/5/0 -> /BYTES/
+CPut /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+Put /Table/113/2/4/5/0 -> /BYTES/
 
 # Inserted row matches the first partial index.
 query T kvtrace
 INSERT INTO t VALUES (6, 11, 'bar')
 ----
-CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Put /Table/112/2/11/6/0 -> /BYTES/
-Put /Table/112/3/11/6/0 -> /BYTES/
+CPut /Table/113/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Put /Table/113/2/11/6/0 -> /BYTES/
+Put /Table/113/3/11/6/0 -> /BYTES/
 
 # Inserted row matches both partial indexes.
 query T kvtrace
 INSERT INTO t VALUES (12, 11, 'foo')
 ----
-CPut /Table/112/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
-Put /Table/112/2/11/12/0 -> /BYTES/
-Put /Table/112/3/11/12/0 -> /BYTES/
-Put /Table/112/4/"foo"/12/0 -> /BYTES/
+CPut /Table/113/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+Put /Table/113/2/11/12/0 -> /BYTES/
+Put /Table/113/3/11/12/0 -> /BYTES/
+Put /Table/113/4/"foo"/12/0 -> /BYTES/
 
 # Inserted row does not match partial index with predicate column that is not
 # indexed.
 query T kvtrace
 INSERT INTO u VALUES (1, 2, 3)
 ----
-Scan /Table/20/1/11{3-4}
-CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+Scan /Table/20/1/11{4-5}
+CPut /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Inserted row matches partial index with predicate column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11)
 ----
-CPut /Table/113/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
-Put /Table/113/2/3/2/0 -> /BYTES/
+CPut /Table/114/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+Put /Table/114/2/3/2/0 -> /BYTES/
 
 # ---------------------------------------------------------
 # DELETE
@@ -265,45 +274,45 @@ Put /Table/113/2/3/2/0 -> /BYTES/
 query T kvtrace
 DELETE FROM t WHERE a = 5
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/5/0
-Del /Table/112/1/5/0
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/4/5/0
+Del /Table/113/1/5/0
 
 # Deleted row matches the first partial index.
 query T kvtrace
 DELETE FROM t WHERE a = 6
 ----
-Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/6/0
-Del /Table/112/3/11/6/0
-Del /Table/112/1/6/0
+Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/11/6/0
+Del /Table/113/3/11/6/0
+Del /Table/113/1/6/0
 
 # Deleted row matches both partial indexes.
 query T kvtrace
 DELETE FROM t WHERE a = 12
 ----
-Scan /Table/112/1/12/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/12/0
-Del /Table/112/3/11/12/0
-Del /Table/112/4/"foo"/12/0
-Del /Table/112/1/12/0
+Scan /Table/113/1/12/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/11/12/0
+Del /Table/113/3/11/12/0
+Del /Table/113/4/"foo"/12/0
+Del /Table/113/1/12/0
 
 # Deleted row does not match partial index with predicate column that is not
 # indexed.
 query T kvtrace
 DELETE FROM u WHERE k = 1
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/1/1/0
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/114/1/1/0
 
 # Deleted row matches partial index with predicate column that is not
 # indexed.
 query T kvtrace
 DELETE FROM u WHERE k = 2
 ----
-Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/2/3/2/0
-Del /Table/113/1/2/0
+Scan /Table/114/1/2/0 lock Exclusive (Block, Unreplicated)
+Del /Table/114/2/3/2/0
+Del /Table/114/1/2/0
 
 # ---------------------------------------------------------
 # UPDATE
@@ -332,75 +341,75 @@ INSERT INTO t VALUES(13, 11, 'foo')
 query T kvtrace
 UPDATE t SET c = 'baz' WHERE a = 5
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/baz
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/baz
 
 # Update a row that matches no partial indexes before the update, but does match
 # after the update.
 query T kvtrace
 UPDATE t SET b = 11 WHERE a = 5
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
-Del /Table/112/2/4/5/0
-Put /Table/112/2/11/5/0 -> /BYTES/
-Put /Table/112/3/11/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+Del /Table/113/2/4/5/0
+Put /Table/113/2/11/5/0 -> /BYTES/
+Put /Table/113/3/11/5/0 -> /BYTES/
 
 # Update a row that matches the first partial index before and after the update
 # and the index entry does not change.
 query T kvtrace
 UPDATE t SET c = 'baz' WHERE a = 6
 ----
-Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
 
 # Update a row that matches the first partial index before and after the update
 # and the index entry changes.
 query T kvtrace
 UPDATE t SET b = 12 WHERE a = 6
 ----
-Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
-Del /Table/112/2/11/6/0
-Put /Table/112/2/12/6/0 -> /BYTES/
-Del /Table/112/3/11/6/0
-Put /Table/112/3/12/6/0 -> /BYTES/
+Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/6/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
+Del /Table/113/2/11/6/0
+Put /Table/113/2/12/6/0 -> /BYTES/
+Del /Table/113/3/11/6/0
+Put /Table/113/3/12/6/0 -> /BYTES/
 
 # Update a row that matches the first partial index before the update, but does
 # not match after the update.
 query T kvtrace
 UPDATE t SET b = 9 WHERE a = 6
 ----
-Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
-Del /Table/112/2/12/6/0
-Put /Table/112/2/9/6/0 -> /BYTES/
-Del /Table/112/3/12/6/0
+Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/6/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/baz
+Del /Table/113/2/12/6/0
+Put /Table/113/2/9/6/0 -> /BYTES/
+Del /Table/113/3/12/6/0
 
 # Update a row that matches both partial indexes before the update, the first
 # partial index entry needs to be updated, and the second needs to be deleted.
 query T kvtrace
 UPDATE t SET c = 'baz', b = 12 WHERE a = 13
 ----
-Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
-Del /Table/112/2/11/13/0
-Put /Table/112/2/12/13/0 -> /BYTES/
-Del /Table/112/3/11/13/0
-Put /Table/112/3/12/13/0 -> /BYTES/
-Del /Table/112/4/"foo"/13/0
+Scan /Table/113/1/13/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/13/0 -> /TUPLE/2:2:Int/12/1:3:Bytes/baz
+Del /Table/113/2/11/13/0
+Put /Table/113/2/12/13/0 -> /BYTES/
+Del /Table/113/3/11/13/0
+Put /Table/113/3/12/13/0 -> /BYTES/
+Del /Table/113/4/"foo"/13/0
 
 # Reversing the previous update should reverse the partial index changes.
 query T kvtrace
 UPDATE t SET c = 'foo', b = 11 WHERE a = 13
 ----
-Scan /Table/112/1/13/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
-Del /Table/112/2/12/13/0
-Put /Table/112/2/11/13/0 -> /BYTES/
-Del /Table/112/3/12/13/0
-Put /Table/112/3/11/13/0 -> /BYTES/
-Put /Table/112/4/"foo"/13/0 -> /BYTES/
+Scan /Table/113/1/13/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/13/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+Del /Table/113/2/12/13/0
+Put /Table/113/2/11/13/0 -> /BYTES/
+Del /Table/113/3/12/13/0
+Put /Table/113/3/11/13/0 -> /BYTES/
+Put /Table/113/4/"foo"/13/0 -> /BYTES/
 
 # Update a row to match a partial index that does not index the column
 # referenced in predicate.
@@ -410,18 +419,18 @@ INSERT INTO u VALUES (1, 2, 3)
 query T kvtrace
 UPDATE u SET v = 11 WHERE k = 1
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/11
-Put /Table/113/2/2/1/0 -> /BYTES/
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/11
+Put /Table/114/2/2/1/0 -> /BYTES/
 
 # Update a row to no longer match a partial index that does not index the column
 # referenced in predicate.
 query T kvtrace
 UPDATE u SET v = 3 WHERE k = 1
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
-Del /Table/113/2/2/1/0
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+Del /Table/114/2/2/1/0
 
 # ---------------------------------------------------------
 # UPDATE primary key
@@ -436,13 +445,13 @@ INSERT INTO t VALUES(20, 11, 'bar')
 query T kvtrace
 UPDATE t SET a = 21 WHERE a = 20
 ----
-Scan /Table/112/1/20/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/20/0
-Del /Table/112/3/11/20/0
-Del /Table/112/1/20/0
-CPut /Table/112/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Put /Table/112/2/11/21/0 -> /BYTES/
-Put /Table/112/3/11/21/0 -> /BYTES/
+Scan /Table/113/1/20/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/11/20/0
+Del /Table/113/3/11/20/0
+Del /Table/113/1/20/0
+CPut /Table/113/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Put /Table/113/2/11/21/0 -> /BYTES/
+Put /Table/113/3/11/21/0 -> /BYTES/
 
 # Update the primary key of a row that currently matches the first partial
 # index. Also update the row so that the row no longer matches the first partial
@@ -450,13 +459,13 @@ Put /Table/112/3/11/21/0 -> /BYTES/
 query T kvtrace
 UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
 ----
-Scan /Table/112/1/21/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/21/0
-Del /Table/112/3/11/21/0
-Del /Table/112/1/21/0
-CPut /Table/112/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
-Put /Table/112/2/9/22/0 -> /BYTES/
-Put /Table/112/4/"foo"/22/0 -> /BYTES/
+Scan /Table/113/1/21/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/11/21/0
+Del /Table/113/3/11/21/0
+Del /Table/113/1/21/0
+CPut /Table/113/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
+Put /Table/113/2/9/22/0 -> /BYTES/
+Put /Table/113/4/"foo"/22/0 -> /BYTES/
 
 # ---------------------------------------------------------
 # INSERT ON CONFLICT DO NOTHING
@@ -473,77 +482,77 @@ DELETE FROM u
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT DO NOTHING
 ----
-Scan /Table/112/1/5/0
-CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
-Put /Table/112/2/4/5/0 -> /BYTES/
+Scan /Table/113/1/5/0
+CPut /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+Put /Table/113/2/4/5/0 -> /BYTES/
 
 # Insert a conflicting row that matches no partial index.
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT DO NOTHING
 ----
-Scan /Table/112/1/5/0
+Scan /Table/113/1/5/0
 
 # Insert a row that matches the first partial index.
 query T kvtrace
 INSERT INTO t VALUES (6, 11, 'bar') ON CONFLICT DO NOTHING
 ----
-Scan /Table/112/1/6/0
-CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Put /Table/112/2/11/6/0 -> /BYTES/
-Put /Table/112/3/11/6/0 -> /BYTES/
+Scan /Table/113/1/6/0
+CPut /Table/113/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Put /Table/113/2/11/6/0 -> /BYTES/
+Put /Table/113/3/11/6/0 -> /BYTES/
 
 # Insert a conflicting row that matches the first partial index.
 query T kvtrace
 INSERT INTO t VALUES (6, 11, 'bar') ON CONFLICT DO NOTHING
 ----
-Scan /Table/112/1/6/0
+Scan /Table/113/1/6/0
 
 # Insert a row that matches both partial indexes.
 query T kvtrace
 INSERT INTO t VALUES (12, 11, 'foo') ON CONFLICT DO NOTHING
 ----
-Scan /Table/112/1/12/0
-CPut /Table/112/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
-Put /Table/112/2/11/12/0 -> /BYTES/
-Put /Table/112/3/11/12/0 -> /BYTES/
-Put /Table/112/4/"foo"/12/0 -> /BYTES/
+Scan /Table/113/1/12/0
+CPut /Table/113/1/12/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+Put /Table/113/2/11/12/0 -> /BYTES/
+Put /Table/113/3/11/12/0 -> /BYTES/
+Put /Table/113/4/"foo"/12/0 -> /BYTES/
 
 # Insert a conflicting row that matches both partial indexes.
 query T kvtrace
 INSERT INTO t VALUES (12, 11, 'foo') ON CONFLICT DO NOTHING
 ----
-Scan /Table/112/1/12/0
+Scan /Table/113/1/12/0
 
 # Insert a non-conflicting row that does not match the partial index with
 # predicate column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (1, 2, 3) ON CONFLICT DO NOTHING
 ----
-Scan /Table/113/1/1/0
-CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+Scan /Table/114/1/1/0
+CPut /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Insert a conflicting row that does not match the partial index with predicate
 # column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (1, 4, 6) ON CONFLICT DO NOTHING
 ----
-Scan /Table/113/1/1/0
+Scan /Table/114/1/1/0
 
 # Insert a non-conflicting row that matches the partial index with predicate
 # column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11) ON CONFLICT DO NOTHING
 ----
-Scan /Table/113/1/2/0
-CPut /Table/113/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
-Put /Table/113/2/3/2/0 -> /BYTES/
+Scan /Table/114/1/2/0
+CPut /Table/114/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+Put /Table/114/2/3/2/0 -> /BYTES/
 
 # Insert a conflicting row that matches the partial index with predicate column
 # that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11) ON CONFLICT DO NOTHING
 ----
-Scan /Table/113/1/2/0
+Scan /Table/114/1/2/0
 
 # ---------------------------------------------------------
 # INSERT ON CONFLICT DO UPDATE
@@ -560,30 +569,30 @@ DELETE FROM u
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
-Put /Table/112/2/4/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+Put /Table/113/2/4/5/0 -> /BYTES/
 
 # Insert a conflicting row that matches no partial indexes before or after
 # the update.
 query T kvtrace
 INSERT INTO t VALUES (5, 3, 'foo') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
-Del /Table/112/2/4/5/0
-Put /Table/112/2/3/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
+Del /Table/113/2/4/5/0
+Put /Table/113/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that does not match the first partial index
 # before the update, but does match after the update.
 query T kvtrace
 INSERT INTO t VALUES (5, 7, 'foo') ON CONFLICT (a) DO UPDATE SET b = 11
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Del /Table/112/2/3/5/0
-Put /Table/112/2/11/5/0 -> /BYTES/
-Put /Table/112/3/11/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Del /Table/113/2/3/5/0
+Put /Table/113/2/11/5/0 -> /BYTES/
+Put /Table/113/3/11/5/0 -> /BYTES/
 
 # Insert a conflicting row that currently matches the first partial index before
 # the update. Update the row so that the row no longer matches the first partial
@@ -591,76 +600,76 @@ Put /Table/112/3/11/5/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 4, c = 'foo'
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Del /Table/112/2/11/5/0
-Put /Table/112/2/4/5/0 -> /BYTES/
-Del /Table/112/3/11/5/0
-Put /Table/112/4/"foo"/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
+Del /Table/113/2/11/5/0
+Put /Table/113/2/4/5/0 -> /BYTES/
+Del /Table/113/3/11/5/0
+Put /Table/113/4/"foo"/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
 # after the update and the index entry does not change.
 query T kvtrace
 INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
-Del /Table/112/2/4/5/0
-Put /Table/112/2/3/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
+Del /Table/113/2/4/5/0
+Put /Table/113/2/3/5/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the second partial index before and
 # after the update and the index entry changes.
 query T kvtrace
 INSERT INTO t VALUES (5, 11, 'bar') ON CONFLICT (a) DO UPDATE SET c = 'foobar'
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
-Del /Table/112/4/"foo"/5/0
-Put /Table/112/4/"foobar"/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foobar
+Del /Table/113/4/"foo"/5/0
+Put /Table/113/4/"foobar"/5/0 -> /BYTES/
 
 # Insert a non-conflicting row that matches the first partial index.
 query T kvtrace
 INSERT INTO t VALUES (6, 11, 'baz') ON CONFLICT (a) DO UPDATE SET b = 3
 ----
-Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
-Put /Table/112/2/11/6/0 -> /BYTES/
-Put /Table/112/3/11/6/0 -> /BYTES/
+Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/113/1/6/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+Put /Table/113/2/11/6/0 -> /BYTES/
+Put /Table/113/3/11/6/0 -> /BYTES/
 
 # Insert a non-conflicting row that does not match the partial index with
 # predicate column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (1, 2, 3) ON CONFLICT (k) DO UPDATE SET u = 5
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Insert a conflicting row that does not match the partial index with predicate
 # column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (1, 4, 6) ON CONFLICT (k) DO UPDATE SET v = 8
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/8
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/8
 
 # Insert a non-conflicting row that matches the partial index with predicate
 # column that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 5
 ----
-Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/113/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
-Put /Table/113/2/3/2/0 -> /BYTES/
+Scan /Table/114/1/2/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/114/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+Put /Table/114/2/3/2/0 -> /BYTES/
 
 # Insert a conflicting row that matches the partial index with predicate column
 # that is not indexed.
 query T kvtrace
 INSERT INTO u VALUES (2, 3, 11) ON CONFLICT (k) DO UPDATE SET u = 4, v = 12
 ----
-Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
-Del /Table/113/2/3/2/0
-Put /Table/113/2/4/2/0 -> /BYTES/
+Scan /Table/114/1/2/0 lock Exclusive (Block, Unreplicated)
+Put /Table/114/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
+Del /Table/114/2/3/2/0
+Put /Table/114/2/4/2/0 -> /BYTES/
 
 # ---------------------------------------------------------
 # INSERT ON CONFLICT DO UPDATE primary key
@@ -677,32 +686,32 @@ DELETE FROM u
 query T kvtrace
 INSERT INTO t VALUES (5, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 5
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
-Put /Table/112/2/4/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+Put /Table/113/2/4/5/0 -> /BYTES/
 
 # Insert a conflicting row that matches no partial indexes before or after
 # the update.
 query T kvtrace
 INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/5/0
-Del /Table/112/1/5/0
-CPut /Table/112/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
-Put /Table/112/2/4/6/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/4/5/0
+Del /Table/113/1/5/0
+CPut /Table/113/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+Put /Table/113/2/4/6/0 -> /BYTES/
 
 # Insert a conflicting row that currently does not match the second partial
 # index before the update, but does match after the update.
 query T kvtrace
 INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo'
 ----
-Scan /Table/112/1/6/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/6/0
-Del /Table/112/1/6/0
-CPut /Table/112/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Put /Table/112/2/4/7/0 -> /BYTES/
-Put /Table/112/4/"foo"/7/0 -> /BYTES/
+Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/4/6/0
+Del /Table/113/1/6/0
+CPut /Table/113/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
+Put /Table/113/2/4/7/0 -> /BYTES/
+Put /Table/113/4/"foo"/7/0 -> /BYTES/
 
 # Insert a conflicting row that currently matches the second partial index
 # before the update. Update the row so that the row no longer matches the second
@@ -710,26 +719,26 @@ Put /Table/112/4/"foo"/7/0 -> /BYTES/
 query T kvtrace
 INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
 ----
-Scan /Table/112/1/7/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/4/7/0
-Del /Table/112/4/"foo"/7/0
-Del /Table/112/1/7/0
-CPut /Table/112/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
-Put /Table/112/2/11/8/0 -> /BYTES/
-Put /Table/112/3/11/8/0 -> /BYTES/
+Scan /Table/113/1/7/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/4/7/0
+Del /Table/113/4/"foo"/7/0
+Del /Table/113/1/7/0
+CPut /Table/113/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
+Put /Table/113/2/11/8/0 -> /BYTES/
+Put /Table/113/3/11/8/0 -> /BYTES/
 
 # Insert a conflicting row that that matches the first partial index before and
 # after the update and the index entry changes.
 query T kvtrace
 INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foobar'
 ----
-Scan /Table/112/1/8/0 lock Exclusive (Block, Unreplicated)
-Del /Table/112/2/11/8/0
-Del /Table/112/3/11/8/0
-Del /Table/112/1/8/0
-CPut /Table/112/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
-Put /Table/112/2/11/9/0 -> /BYTES/
-Put /Table/112/3/11/9/0 -> /BYTES/
+Scan /Table/113/1/8/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/2/11/8/0
+Del /Table/113/3/11/8/0
+Del /Table/113/1/8/0
+CPut /Table/113/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
+Put /Table/113/2/11/9/0 -> /BYTES/
+Put /Table/113/3/11/9/0 -> /BYTES/
 
 # ---------------------------------------------------------
 # UPSERT
@@ -746,30 +755,30 @@ DELETE FROM u
 query T kvtrace
 UPSERT INTO t VALUES (5, 4, 'bar')
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
-Put /Table/112/2/4/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
+Put /Table/113/2/4/5/0 -> /BYTES/
 
 # Upsert a conflicting row that matches no partial indexes before or after
 # the update.
 query T kvtrace
 UPSERT INTO t VALUES (5, 3, 'bar')
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
-Del /Table/112/2/4/5/0
-Put /Table/112/2/3/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/bar
+Del /Table/113/2/4/5/0
+Put /Table/113/2/3/5/0 -> /BYTES/
 
 # Upsert a conflicting row that does not match the first partial index before
 # the update, but does match after the update.
 query T kvtrace
 UPSERT INTO t VALUES (5, 11, 'bar')
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
-Del /Table/112/2/3/5/0
-Put /Table/112/2/11/5/0 -> /BYTES/
-Put /Table/112/3/11/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
+Del /Table/113/2/3/5/0
+Put /Table/113/2/11/5/0 -> /BYTES/
+Put /Table/113/3/11/5/0 -> /BYTES/
 
 # Upsert a conflicting row that currently matches the first partial index before
 # the update. Update the row so that the row no longer matches the first partial
@@ -777,76 +786,76 @@ Put /Table/112/3/11/5/0 -> /BYTES/
 query T kvtrace
 UPSERT INTO t VALUES (5, 3, 'foo')
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
-Del /Table/112/2/11/5/0
-Put /Table/112/2/3/5/0 -> /BYTES/
-Del /Table/112/3/11/5/0
-Put /Table/112/4/"foo"/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/3/1:3:Bytes/foo
+Del /Table/113/2/11/5/0
+Put /Table/113/2/3/5/0 -> /BYTES/
+Del /Table/113/3/11/5/0
+Put /Table/113/4/"foo"/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
 # after the update and the index entry does not change.
 query T kvtrace
 UPSERT INTO t VALUES (5, 4, 'foo')
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
-Del /Table/112/2/3/5/0
-Put /Table/112/2/4/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
+Del /Table/113/2/3/5/0
+Put /Table/113/2/4/5/0 -> /BYTES/
 
 # Upsert a conflicting row that that matches the second partial index before and
 # after the update and the index entry changes.
 query T kvtrace
 UPSERT INTO t VALUES (5, 4, 'foobar')
 ----
-Scan /Table/112/1/5/0 lock Exclusive (Block, Unreplicated)
-Put /Table/112/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
-Del /Table/112/4/"foo"/5/0
-Put /Table/112/4/"foobar"/5/0 -> /BYTES/
+Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
+Put /Table/113/1/5/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foobar
+Del /Table/113/4/"foo"/5/0
+Put /Table/113/4/"foobar"/5/0 -> /BYTES/
 
 # Upsert a non-conflicting row that matches the first partial index.
 query T kvtrace
 UPSERT INTO t VALUES (9, 11, 'baz')
 ----
-Scan /Table/112/1/9/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/112/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
-Put /Table/112/2/11/9/0 -> /BYTES/
-Put /Table/112/3/11/9/0 -> /BYTES/
+Scan /Table/113/1/9/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/113/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/baz
+Put /Table/113/2/11/9/0 -> /BYTES/
+Put /Table/113/3/11/9/0 -> /BYTES/
 
 # Upsert a non-conflicting row that does not match the partial index with
 # predicate column that is not indexed.
 query T kvtrace
 UPSERT INTO u VALUES (1, 2, 3)
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/113/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/114/1/1/0 -> /TUPLE/2:2:Int/2/1:3:Int/3
 
 # Upsert a conflicting row that does not match the partial index with predicate
 # column that is not indexed.
 query T kvtrace
 UPSERT INTO u VALUES (1, 4, 6)
 ----
-Scan /Table/113/1/1/0 lock Exclusive (Block, Unreplicated)
-Put /Table/113/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/6
+Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Put /Table/114/1/1/0 -> /TUPLE/2:2:Int/4/1:3:Int/6
 
 # Upsert a non-conflicting row that matches the partial index with predicate
 # column that is not indexed.
 query T kvtrace
 UPSERT INTO u VALUES (2, 3, 11)
 ----
-Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-CPut /Table/113/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
-Put /Table/113/2/3/2/0 -> /BYTES/
+Scan /Table/114/1/2/0 lock Exclusive (Block, Unreplicated)
+CPut /Table/114/1/2/0 -> /TUPLE/2:2:Int/3/1:3:Int/11
+Put /Table/114/2/3/2/0 -> /BYTES/
 
 # Upsert a conflicting row that matches the partial index with predicate column
 # that is not indexed.
 query T kvtrace
 UPSERT INTO u VALUES (2, 4, 12)
 ----
-Scan /Table/113/1/2/0 lock Exclusive (Block, Unreplicated)
-Put /Table/113/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
-Del /Table/113/2/3/2/0
-Put /Table/113/2/4/2/0 -> /BYTES/
+Scan /Table/114/1/2/0 lock Exclusive (Block, Unreplicated)
+Put /Table/114/1/2/0 -> /TUPLE/2:2:Int/4/1:3:Int/12
+Del /Table/114/2/3/2/0
+Put /Table/114/2/4/2/0 -> /BYTES/
 
 # Tests for partial inverted indexes.
 
@@ -1072,8 +1081,272 @@ INSERT INTO t57085_c VALUES (10, 1, true), (20, 1, false), (30, 2, true);
 query T kvtrace
 DELETE FROM t57085_p WHERE p = 1;
 ----
-Del (locking) /Table/114/1/1/0
-Scan /Table/115/{1-2}
-Del /Table/115/2/1/10/0
-Del (locking) /Table/115/1/10/0
-Del (locking) /Table/115/1/20/0
+Del (locking) /Table/115/1/1/0
+Scan /Table/116/{1-2}
+Del /Table/116/2/1/10/0
+Del (locking) /Table/116/1/10/0
+Del (locking) /Table/116/1/20/0
+
+# Tests for partial vector indexes.
+
+# ---------------------------------------------------------
+# SELECT from partial vector index
+# ---------------------------------------------------------
+
+query T
+EXPLAIN SELECT a FROM vec@i WHERE c IN ('foo', 'bar') ORDER BY b <-> '[1,2]' LIMIT 10
+----
+distribution: local
+vectorized: true
+·
+• top-k
+│ order: +column8
+│ k: 10
+│
+└── • render
+    │
+    └── • lookup join
+        │ table: vec@vec_pkey
+        │ equality: (a) = (a)
+        │ equality cols are key
+        │
+        └── • vector search
+              table: vec@i (partial index)
+              target count: 10
+              prefix spans: [/'bar' - /'bar'] [/'foo' - /'foo']
+
+query T kvtrace
+SELECT a FROM vec@i WHERE c IN ('foo', 'bar') ORDER BY b <-> '[1,2]' LIMIT 10
+----
+Scan /Table/108/2/"bar"/{1/1-2}
+Scan /Table/108/2/"foo"/{1/1-2}
+
+query T kvtrace
+SELECT a FROM vec@i WHERE c = 'foo' ORDER BY b <-> '[1,2]' LIMIT 10
+----
+Scan /Table/108/2/"foo"/{1/1-2}
+
+statement error index "i" is a partial index that does not contain all the rows needed to execute this query
+SELECT a FROM vec@i WHERE c = 'baz' ORDER BY b <-> '[1,2]' LIMIT 10
+
+# ---------------------------------------------------------
+# INSERT into partial vector index
+# ---------------------------------------------------------
+
+# Key format:
+# /Table/TableID/IndexID/PrefixCol/PartitionKey/Level/PrimaryKey/FamilyID
+query T kvtrace(redactbytes)
+INSERT INTO vec VALUES (10, '[1, 2]', 'foo')
+----
+Scan /Table/108/2/"foo"/{1/2-2}
+CPut /Table/108/1/10/0 -> /TUPLE/
+Put /Table/108/2/"foo"/1/1/10/0 -> /BYTES/:redacted:
+
+query T kvtrace
+INSERT INTO vec VALUES (20, '[1, 2]', 'baz')
+----
+Scan /Table/108/2/"baz"/{1/2-2}
+CPut /Table/108/1/20/0 -> /TUPLE/
+
+# ---------------------------------------------------------
+# DELETE partial vector index
+# ---------------------------------------------------------
+
+query T kvtrace
+DELETE FROM vec WHERE a = 10
+----
+Scan /Table/108/1/10/0
+Scan /Table/108/2/"foo"/{1/1-2}
+Del /Table/108/2/"foo"/1/1/10/0
+Del (locking) /Table/108/1/10/0
+
+query T kvtrace
+DELETE FROM vec WHERE a = 20
+----
+Scan /Table/108/1/20/0
+Scan /Table/108/2/"baz"/{1/1-2}
+Del (locking) /Table/108/1/20/0
+
+# ---------------------------------------------------------
+# UPDATE partial vector index
+# ---------------------------------------------------------
+
+statement ok
+INSERT INTO vec VALUES (10, '[1, 2]', 'foo');
+INSERT INTO vec VALUES (20, '[3, 4]', 'baz')
+
+# Update a non-vector column so that the row remains in the partial index.
+query T kvtrace(redactbytes)
+UPDATE vec SET c = 'bar' WHERE a = 10
+----
+Scan /Table/108/1/10/0
+Scan /Table/108/2/"foo"/{1/1-2}
+Scan /Table/108/2/"bar"/{1/2-2}
+Put (locking) /Table/108/1/10/0 -> /TUPLE/
+Del /Table/108/2/"foo"/1/1/10/0
+Put /Table/108/2/"bar"/1/1/10/0 -> /BYTES/:redacted:
+
+# Update the vector of a row in the partial index.
+query T kvtrace(redactbytes)
+UPDATE vec SET b = '[5, 6]' WHERE a = 10
+----
+Scan /Table/108/1/10/0
+Scan /Table/108/2/"bar"/{1/1-2}
+Scan /Table/108/2/"bar"/{1/2-2}
+Put (locking) /Table/108/1/10/0 -> /TUPLE/
+Del /Table/108/2/"bar"/1/1/10/0
+Put /Table/108/2/"bar"/1/1/10/0 -> /BYTES/:redacted:
+
+# Update a non-vector column so that the row is removed from the partial index.
+query T kvtrace
+UPDATE vec SET c = 'fud' WHERE a = 10
+----
+Scan /Table/108/1/10/0
+Scan /Table/108/2/"bar"/{1/1-2}
+Scan /Table/108/2/"fud"/{1/2-2}
+Put (locking) /Table/108/1/10/0 -> /TUPLE/
+Del /Table/108/2/"bar"/1/1/10/0
+
+# Update a non-vector column so that the row remains not in the partial index.
+query T kvtrace
+UPDATE vec SET c = 'boo' WHERE a = 20
+----
+Scan /Table/108/1/20/0
+Scan /Table/108/2/"baz"/{1/1-2}
+Scan /Table/108/2/"boo"/{1/2-2}
+Put (locking) /Table/108/1/20/0 -> /TUPLE/
+
+# Update the vector column of a row not in the partial index.
+query T kvtrace
+UPDATE vec SET b = '[7,8]' WHERE a = 20
+----
+Scan /Table/108/1/20/0
+Scan /Table/108/2/"boo"/{1/1-2}
+Scan /Table/108/2/"boo"/{1/2-2}
+Put (locking) /Table/108/1/20/0 -> /TUPLE/
+
+# Update a non-vector column so that the row is added to the partial index.
+query T kvtrace(redactbytes)
+UPDATE vec SET c = 'bar' WHERE a = 20
+----
+Scan /Table/108/1/20/0
+Scan /Table/108/2/"boo"/{1/1-2}
+Scan /Table/108/2/"bar"/{1/2-2}
+Put (locking) /Table/108/1/20/0 -> /TUPLE/
+Put /Table/108/2/"bar"/1/1/20/0 -> /BYTES/:redacted:
+
+# Update the primary key of a row in the partial index.
+query T kvtrace(redactbytes)
+UPDATE vec SET a = 40 WHERE a = 20
+----
+Scan /Table/108/1/20/0
+Scan /Table/108/2/"bar"/{1/1-2}
+Scan /Table/108/2/"bar"/{1/2-2}
+Del /Table/108/2/"bar"/1/1/20/0
+Del (locking) /Table/108/1/20/0
+CPut /Table/108/1/40/0 -> /TUPLE/
+Put /Table/108/2/"bar"/1/1/40/0 -> /BYTES/:redacted:
+
+# Update the primary key of a row not in the partial index.
+query T kvtrace
+UPDATE vec SET a = 30 WHERE a = 10
+----
+Scan /Table/108/1/10/0
+Scan /Table/108/2/"fud"/{1/1-2}
+Scan /Table/108/2/"fud"/{1/2-2}
+Del (locking) /Table/108/1/10/0
+CPut /Table/108/1/30/0 -> /TUPLE/
+
+# Update to multiple rows (one in and one not in the partial index) so that both
+# are in the partial index.
+statement ok
+INSERT INTO vec VALUES (100, '[9,10]', 'foo'), (110, '[11,12]', 'baz')
+
+query T kvtrace(redactbytes)
+UPDATE vec SET c = 'foo' WHERE a IN (100, 110)
+----
+Scan /Table/108/1/100/0, /Table/108/1/110/0
+Scan /Table/108/2/"foo"/{1/1-2}
+Scan /Table/108/2/"foo"/{1/2-2}
+Put (locking) /Table/108/1/100/0 -> /TUPLE/
+Del /Table/108/2/"foo"/1/1/100/0
+Put /Table/108/2/"foo"/1/1/100/0 -> /BYTES/:redacted:
+Scan /Table/108/2/"baz"/{1/1-2}
+Scan /Table/108/2/"foo"/{1/2-2}
+Put (locking) /Table/108/1/110/0 -> /TUPLE/
+Put /Table/108/2/"foo"/1/1/110/0 -> /BYTES/:redacted:
+
+# Update to multiple rows (one in and one not in the partial index) so that both
+# are not in the partial index.
+statement ok
+INSERT INTO vec VALUES (50, '[11,12]', 'foo'), (60, '[13,14]', 'baz')
+
+query T kvtrace
+UPDATE vec SET c = 'fud' WHERE a IN (50, 60)
+----
+Scan /Table/108/1/50/0, /Table/108/1/60/0
+Scan /Table/108/2/"foo"/{1/1-2}
+Scan /Table/108/2/"fud"/{1/2-2}
+Put (locking) /Table/108/1/50/0 -> /TUPLE/
+Del /Table/108/2/"foo"/1/1/50/0
+Scan /Table/108/2/"baz"/{1/1-2}
+Scan /Table/108/2/"fud"/{1/2-2}
+Put (locking) /Table/108/1/60/0 -> /TUPLE/
+
+# ---------------------------------------------------------
+# UPSERT partial vector index
+# ---------------------------------------------------------
+
+# Upsert a conflicting row with the same vector as the existing row in the
+# partial index so that it remains in the partial index.
+query T kvtrace(redactbytes)
+UPSERT INTO vec VALUES (40, '[15,16]', 'foo')
+----
+Scan /Table/108/1/40/0
+Scan /Table/108/2/"bar"/{1/1-2}
+Scan /Table/108/2/"foo"/{1/2-2}
+Put (locking) /Table/108/1/40/0 -> /TUPLE/
+Del /Table/108/2/"bar"/1/1/40/0
+Put /Table/108/2/"foo"/1/1/40/0 -> /BYTES/:redacted:
+
+# Upsert a conflicting row with different vector from the existing row in the
+# partial index.
+query T kvtrace(redactbytes)
+UPSERT INTO vec VALUES (40, '[17,18]', 'foo')
+----
+Scan /Table/108/1/40/0
+Scan /Table/108/2/"foo"/{1/1-2}
+Scan /Table/108/2/"foo"/{1/2-2}
+Put (locking) /Table/108/1/40/0 -> /TUPLE/
+Del /Table/108/2/"foo"/1/1/40/0
+Put /Table/108/2/"foo"/1/1/40/0 -> /BYTES/:redacted:
+
+# Upsert a conflicting row so that it is removed from the partial index.
+query T kvtrace
+UPSERT INTO vec VALUES (40, '[19,20]', 'fud')
+----
+Scan /Table/108/1/40/0
+Scan /Table/108/2/"foo"/{1/1-2}
+Scan /Table/108/2/"fud"/{1/2-2}
+Put (locking) /Table/108/1/40/0 -> /TUPLE/
+Del /Table/108/2/"foo"/1/1/40/0
+
+# Upsert a non-conflicting row that is added to the partial index.
+query T kvtrace(redactbytes)
+UPSERT INTO vec VALUES (5, '[21,22]', 'bar')
+----
+Scan /Table/108/1/5/0
+Scan /Table/108/2/"bar"/{1/2-2}
+CPut /Table/108/1/5/0 -> /TUPLE/
+Put /Table/108/2/"bar"/1/1/5/0 -> /BYTES/:redacted:
+
+# Upsert a non-conflicting row that is not added to the partial index.
+query T kvtrace
+UPSERT INTO vec VALUES (6, '[23,24]', 'baz')
+----
+Scan /Table/108/1/6/0
+Scan /Table/108/2/"baz"/{1/2-2}
+CPut /Table/108/1/6/0 -> /TUPLE/
+
+statement ok
+DROP TABLE vec

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
@@ -18,10 +18,19 @@ CREATE INDEX ON exec_test (user_id) WHERE user_id >= 10 AND user_id <= 20
 query T kvtrace(redactbytes)
 INSERT INTO exec_test VALUES (1, 1, 'foo', '[1, 2, 3]'), (2, 10, 'bar', '[4, 5, 6]'), (3, 15, 'baz', '[7, 8, 9]')
 ----
+Scan /Table/106/2/{1/2-2}
+Scan /Table/106/3/1/{1/2-2}
+Scan /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/{1/2-2}
 CPut /Table/106/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo/
 Put /Table/106/2/1/1/1/0 -> /BYTES/:redacted:
 Put /Table/106/3/1/1/1/1/0 -> /BYTES/:redacted:
 Put /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/1/1/1/0 -> /BYTES/:redacted:
+Scan /Table/106/2/{1/2-2}
+Scan /Table/106/2/{1/2-2}
+Scan /Table/106/3/10/{1/2-2}
+Scan /Table/106/3/15/{1/2-2}
+Scan /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/{1/2-2}
+Scan /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/{1/2-2}
 CPut /Table/106/1/2/0 -> /TUPLE/2:2:Int/10/1:3:Bytes/bar/
 Put /Table/106/2/1/1/2/0 -> /BYTES/:redacted:
 Put /Table/106/3/10/1/1/2/0 -> /BYTES/:redacted:
@@ -37,6 +46,12 @@ query T kvtrace(redactbytes)
 UPSERT INTO exec_test VALUES (2, 10, 'bar', '[6, 5, 4]'), (4, 20, 'qux', '[10, 11, 12]')
 ----
 Scan /Table/106/1/2/0, /Table/106/1/4/0
+Scan /Table/106/2/{1/1-2}
+Scan /Table/106/2/{1/2-2}
+Scan /Table/106/3/10/{1/1-2}
+Scan /Table/106/3/10/{1/2-2}
+Scan /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/{1/1-2}
+Scan /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/{1/2-2}
 Put (locking) /Table/106/1/2/0 -> /TUPLE/2:2:Int/10/1:3:Bytes/bar/
 Del /Table/106/2/1/1/2/0
 Put /Table/106/2/1/1/2/0 -> /BYTES/:redacted:
@@ -44,6 +59,9 @@ Del /Table/106/3/10/1/1/2/0
 Put /Table/106/3/10/1/1/2/0 -> /BYTES/:redacted:
 Del /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0
 Put /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0 -> /BYTES/:redacted:
+Scan /Table/106/2/{1/2-2}
+Scan /Table/106/3/20/{1/2-2}
+Scan /Table/106/4/"\x17\xab\x186\x18{\x00\x00\x00 \x00 \x00 "/{1/2-2}
 CPut /Table/106/1/4/0 -> /TUPLE/2:2:Int/20/1:3:Bytes/qux/
 Put /Table/106/2/1/1/4/0 -> /BYTES/:redacted:
 Put /Table/106/3/20/1/1/4/0 -> /BYTES/:redacted:
@@ -54,6 +72,12 @@ query T kvtrace(redactbytes)
 UPDATE exec_test SET encoding = '[3, 2, 1]' WHERE id = 1
 ----
 Scan /Table/106/1/1/0
+Scan /Table/106/2/{1/1-2}
+Scan /Table/106/2/{1/2-2}
+Scan /Table/106/3/1/{1/1-2}
+Scan /Table/106/3/1/{1/2-2}
+Scan /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/{1/1-2}
+Scan /Table/106/4/"\x16\x84\x17q\x17q\x00\x00\x00 \x00 \x00 "/{1/2-2}
 Put (locking) /Table/106/1/1/0 -> /TUPLE/2:2:Int/1/1:3:Bytes/foo/
 Del /Table/106/2/1/1/1/0
 Put /Table/106/2/1/1/1/0 -> /BYTES/:redacted:
@@ -67,6 +91,8 @@ UPDATE exec_test SET data = 'fooo' WHERE user_id = 15;
 ----
 Scan /Table/106/5/1{5-6}
 Scan /Table/106/1/3/0
+Scan /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/{1/1-2}
+Scan /Table/106/4/"\x16\x84\x17q\x17q\x17q\x00\x00\x00 \x00 \x00 \x00 "/{1/2-2}
 Put (locking) /Table/106/1/3/0 -> /TUPLE/2:2:Int/15/1:3:Bytes/fooo/
 Del /Table/106/4/"\x16\x05\x15\xef\x18\x95\x00\x00\x00 \x00 \x00 "/1/1/3/0
 Put /Table/106/4/"\x16\x84\x17q\x17q\x17q\x00\x00\x00 \x00 \x00 \x00 "/1/1/3/0 -> /BYTES/:redacted:
@@ -76,6 +102,9 @@ DELETE FROM exec_test WHERE user_id = 10
 ----
 Scan /Table/106/5/1{0-1}
 Scan /Table/106/1/2/0
+Scan /Table/106/2/{1/1-2}
+Scan /Table/106/3/10/{1/1-2}
+Scan /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/{1/1-2}
 Del /Table/106/2/1/1/2/0
 Del /Table/106/3/10/1/1/2/0
 Del /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0

--- a/pkg/sql/vecindex/cspann/fixup_processor.go
+++ b/pkg/sql/vecindex/cspann/fixup_processor.go
@@ -216,6 +216,12 @@ func (fp *FixupProcessor) Init(
 
 	fp.mu.pendingFixups = make(map[fixupKey]bool, maxFixups)
 	fp.mu.waitForFixups.L = &fp.mu
+
+	if index.options.IsDeterministic {
+		// A deterministic index should be suspended until an explicit call to
+		// Process is called.
+		fp.Suspend()
+	}
 }
 
 // OnSuccessfulSplit sets a callback function that's invoked when a partition is

--- a/pkg/sql/vecindex/cspann/fixup_processor_test.go
+++ b/pkg/sql/vecindex/cspann/fixup_processor_test.go
@@ -27,7 +27,8 @@ func TestDelayInsertOrDelete(t *testing.T) {
 	// Set up the fixup processor with a minimum delay and allowed ops/sec = 1.
 	var fp FixupProcessor
 	fp.minDelay = time.Hour
-	fp.Init(ctx, stopper, nil /* index */, 42 /* seed */)
+	var index Index
+	fp.Init(ctx, stopper, &index, 42 /* seed */)
 	fp.mu.pacer.Init(1, 0, fp.mu.pacer.monoNow)
 
 	// Cancel the context and verify that DelayInsertOrDelete immediately

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -535,12 +535,6 @@ func (vi *Index) SearchForDelete(
 	return vi.searchForUpdateHelper(ctx, idxCtx, removeFunc, key, vi.options.MaxDeleteAttempts)
 }
 
-// SuspendFixups suspends background fixup processing until ProcessFixups is
-// explicitly called. It is used for testing.
-func (vi *Index) SuspendFixups() {
-	vi.fixups.Suspend()
-}
-
 // DiscardFixups drops all pending fixups. It is used for testing.
 func (vi *Index) DiscardFixups() {
 	vi.fixups.Process(true /* discard */)

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -667,10 +667,6 @@ func (s *testState) makeNewIndex(d *datadriven.TestData) {
 
 	s.Index.Fixups().OnSuccessfulSplit(func() { s.SuccessfulSplits++ })
 	s.Index.Fixups().OnPendingSplitsMerges(func(count int) { s.PendingSplitsMerges = count })
-
-	// Suspend background fixups until ProcessFixups is explicitly called, so
-	// that vector index operations can be deterministic.
-	s.Index.SuspendFixups()
 }
 
 func (s *testState) processFixups() {

--- a/pkg/sql/vecindex/manager_test.go
+++ b/pkg/sql/vecindex/manager_test.go
@@ -81,6 +81,7 @@ func buildTestTable(tableID catid.DescID, tableName string) catalog.MutableTable
 					MinPartitionSize: 2,
 					MaxPartitionSize: 8,
 					BuildBeamSize:    4,
+					IsDeterministic:  true,
 				},
 			},
 		},
@@ -154,7 +155,6 @@ func TestVectorManager(t *testing.T) {
 	t.Run("test metrics", func(t *testing.T) {
 		idx, err := vectorMgr.Get(ctx, catid.DescID(140), 2)
 		require.NoError(t, err)
-		idx.SuspendFixups()
 		idx.ForceSplit(ctx, nil, 0, cspann.RootKey, false /* singleStep */)
 
 		metrics := vectorMgr.Metrics().(*vecindex.Metrics)


### PR DESCRIPTION
Add more logic tests for vector indexes, in order to expand our testing coverage, particularly when it comes to partial indexes.

Fix a buglet where fixups in a deterministic index weren't being suspended. Make it so that a deterministic index always automatically suspends its fixups, without needing the caller to do so.

Epic: CRDB-42943
Release note: None