### PR TITLE
drt: add create sequence operations

### DIFF
--- a/pkg/cmd/roachtest/operations/sql_objects.go
+++ b/pkg/cmd/roachtest/operations/sql_objects.go
@@ -110,6 +110,14 @@ func registerCreateSQLOperations(r registry.Registry) {
 				return fmt.Sprintf("CREATE TABLE %s (id INT PRIMARY KEY, val STRING)", name)
 			},
 		},
+		{
+			name:       "create-sequence",
+			objectType: "SEQUENCE",
+			prefix:     "roachtest_sequence",
+			createSQL: func(name string) string {
+				return fmt.Sprintf("CREATE SEQUENCE %s", name)
+			},
+		},
 	}
 
 	for _, obj := range objs {


### PR DESCRIPTION
This PR adds a `CREATE SEQUENCE` operation using the generic SQL operation interface

Epic: none
Fixes: #138439
Release note: None