### PR TITLE
drtprod: refactor PUA configuration to use env variables

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_pua_9.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_9.yaml
@@ -26,6 +26,9 @@ environment:
   RUN_DURATION: 12h
   MAX_CONN_LIFETIME: 3m
 
+  # GCP Cloud Storage bucket for storing backups
+  BUCKET_US_EAST_1: cockroach-drt-backup-us-east1
+
 dependent_file_locations:
   - artifacts/roachprod
   - artifacts/roachtest
@@ -244,7 +247,7 @@ targets:
           - --
           - -e
           - |
-            BACKUP INTO 'gs://cockroach-drt-backup-us-east1/drt-pua-9?AUTH=implicit'
+            BACKUP INTO 'gs://$BUCKET_US_EAST_1/$CLUSTER?AUTH=implicit'
             WITH OPTIONS (revision_history = true, detached)
         wait: 1800
       - command: sql # create changefeed without initial scan

--- a/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
@@ -33,6 +33,11 @@ environment:
   MAX_RATE: 500
   MAX_CONN_LIFETIME: 3m
 
+  # GCP Cloud Storage bucket for storing locality-aware backups
+  BUCKET_NORTH_AMERICA: cockroach-drt-backup-northamerica-northeast2
+  BUCKET_US_EAST_5: cockroach-drt-backup-us-east5
+  BUCKET_US_EAST_1: cockroach-drt-backup-us-east1
+
 dependent_file_locations:
   - artifacts/roachprod
   - artifacts/roachtest
@@ -248,9 +253,9 @@ targets:
           - --
           - -e
           - |
-            BACKUP INTO ('gs://cockroach-drt-backup-northamerica-northeast2/drt-pua-15?AUTH=implicit&COCKROACH_LOCALITY=default',
-                            'gs://cockroach-drt-backup-us-east5/drt-pua-15?AUTH=implicit&COCKROACH_LOCALITY=region%3Dus-east5',
-                            'gs://cockroach-drt-backup-us-east1/drt-pua-15?AUTH=implicit&COCKROACH_LOCALITY=region%3Dus-east1')
+            BACKUP INTO ('gs://$BUCKET_NORTH_AMERICA/$CLUSTER?AUTH=implicit&COCKROACH_LOCALITY=default',
+                            'gs://$BUCKET_US_EAST_5/$CLUSTER?AUTH=implicit&COCKROACH_LOCALITY=region%3Dus-east5',
+                            'gs://$BUCKET_US_EAST_1/$CLUSTER?AUTH=implicit&COCKROACH_LOCALITY=region%3Dus-east1')
             WITH OPTIONS (revision_history = true, detached)
         wait: 1500
       - command: sql # create changefeed without initial scan


### PR DESCRIPTION
- Replace hardcoded bucket names with configurable environment variables.
- Introduce descriptive environment variables (e.g., BUCKET_US_EAST_1, BUCKET_NORTH_AMERICA) to support region-specific backups.