### PR TITLE
kvcoord: add debugging for TestDistSenderReplicaStall

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -218,6 +218,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/allstacks",
         "//pkg/util/caller",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",

--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
+	"github.com/cockroachdb/cockroach/pkg/util/allstacks"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
@@ -50,6 +51,9 @@ func TestDistSenderReplicaStall(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "clientTimeout", func(t *testing.T, clientTimeout bool) {
 		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer time.AfterFunc(29*time.Second, func() {
+			log.Errorf(ctx, "about to time out, all stacks:\n\n%s", allstacks.Get())
+		}).Stop()
 		defer cancel()
 
 		// The lease won't move unless we use expiration-based leases. We also


### PR DESCRIPTION
Dump the stacks if the test is about to time out. This will help with investigations such as the below, which we close to wait for a repro under this PR.

Closes https://github.com/cockroachdb/cockroach/issues/140957
Closes https://github.com/cockroachdb/cockroach/issues/146054

Epic: none