### PR TITLE
decommissionBench: add post process step

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/metric_utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/metric_utils.go
@@ -29,7 +29,7 @@ import (
 	"golang.org/x/exp/maps"
 )
 
-var openmetricsLineRegex = regexp.MustCompile(`^(\w+){([^}]*)} ([\d.e+-]+) ([\d.e+-]+)$`)
+var openmetricsLineRegex = regexp.MustCompile(`^([\w:]+){([^}]*)} ([\d.e+-]+) ([\d.e+-]+)$`)
 
 // AggregatedPerfMetrics is the output of PostProcessPerfMetrics function in individual test
 type AggregatedPerfMetrics []*AggregatedMetric

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2074,7 +2074,7 @@ func (m *perfMetricsCollector) collectFromNodes(
 			continue
 		}
 		m.perfNodes = append(m.perfNodes, node)
-		if err := m.processFiles(files); err != nil {
+		if err := m.processFiles(files, log); err != nil {
 			return errors.Wrapf(err, "error while processing files")
 		}
 	}
@@ -2095,7 +2095,7 @@ func (m *perfMetricsCollector) findMetricsFiles(dirPath string) ([]string, error
 	return files, err
 }
 
-func (m *perfMetricsCollector) processFiles(files []string) error {
+func (m *perfMetricsCollector) processFiles(files []string, log *logger.Logger) error {
 	for _, file := range files {
 		fileBytes, err := os.ReadFile(file)
 		if err != nil {
@@ -2104,7 +2104,9 @@ func (m *perfMetricsCollector) processFiles(files []string) error {
 
 		histograms, labels, err := roachtestutil.GetHistogramMetrics(bytes.NewBuffer(fileBytes))
 		if err != nil {
-			return errors.Wrapf(err, "getting histogram metrics")
+			// This file didn't have valid histograms, continue with other files
+			log.Errorf("error getting histogram metrics for file %s: %v", file, err)
+			continue
 		}
 
 		m.histogramMetrics.Summaries = append(m.histogramMetrics.Summaries, histograms.Summaries...)


### PR DESCRIPTION
1. Removes metrics duplication on pinnedNode and only use workloadNode
for metrics
2. Create a new file for decommission metrics rather than
appending to stats file
3. Adds post process step for decommission Bench
metrics

Epic: none

Release note: None