### PR TITLE
kvserver,kvnemesis: dump raft logs on failure

### DIFF
--- a/pkg/kv/kvnemesis/BUILD.bazel
+++ b/pkg/kv/kvnemesis/BUILD.bazel
@@ -86,6 +86,7 @@ go_test(
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/kvserverpb",
+        "//pkg/kv/kvtestutils",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -6253,6 +6253,8 @@ func TestMergeReplicatesLocks(t *testing.T) {
 	scope := log.Scope(t)
 	defer scope.Close(t)
 
+	skip.UnderDuress(t, "too slow for testrace")
+
 	// Test Setup:
 	//
 	// txn1: holding lock on key k1

--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -6250,7 +6250,8 @@ func TestMergeDropsLocksIfLargerThanMax(t *testing.T) {
 
 func TestMergeReplicatesLocks(t *testing.T) {
 	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
+	scope := log.Scope(t)
+	defer scope.Close(t)
 
 	// Test Setup:
 	//
@@ -6288,9 +6289,25 @@ func TestMergeReplicatesLocks(t *testing.T) {
 					Settings: st,
 				},
 			})
+			defer tc.Stopper().Stop(ctx)
+
+			defer func() {
+				if !t.Failed() {
+					return
+				}
+				d := kvtestutils.RaftLogDumper{Dir: scope.GetDirectory()}
+				for _, srv := range tc.Servers {
+					require.NoError(t, srv.GetStores().(*kvserver.Stores).VisitStores(func(s *kvserver.Store) error {
+						s.VisitReplicas(func(replica *kvserver.Replica) (wantMore bool) {
+							d.Dump(t, s.LogEngine(), s.StoreID(), replica.RangeID)
+							return true // more
+						})
+						return nil
+					}))
+				}
+			}()
 
 			sql := tc.ServerConn(0)
-			defer tc.Stopper().Stop(ctx)
 			scratch := tc.ScratchRange(t)
 			mkKey := func(s string) roachpb.Key {
 				prefix := scratch.Clone()

--- a/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
+++ b/pkg/kv/kvserver/kvserverpb/proposer_kv.proto
@@ -299,6 +299,7 @@ message ReplicatedEvalResult {
 // can be distinguished from a zero-length batch, and so structs
 // containing pointers to it can be compared with the == operator.
 message WriteBatch {
+  option (gogoproto.goproto_getters) = true;
   bytes data = 1;
 }
 

--- a/pkg/kv/kvserver/logstore/logstore_test.go
+++ b/pkg/kv/kvserver/logstore/logstore_test.go
@@ -45,7 +45,7 @@ func TestRaftStorageWrites(t *testing.T) {
 		defer batch.Close()
 		prepare(batch)
 		wb := kvserverpb.WriteBatch{Data: batch.Repr()}
-		str, err := print.DecodeWriteBatch(&wb)
+		str, err := print.DecodeWriteBatch(wb.GetData())
 		require.NoError(t, err)
 		require.NoError(t, batch.Commit(true))
 		return str

--- a/pkg/kv/kvserver/print/BUILD.bazel
+++ b/pkg/kv/kvserver/print/BUILD.bazel
@@ -2,7 +2,10 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "print",
-    srcs = ["debug_print.go"],
+    srcs = [
+        "debug_print.go",
+        "dump_raft_log.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/print",
     visibility = ["//visibility:public"],
     deps = [
@@ -18,6 +21,7 @@ go_library(
         "//pkg/util/protoutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",
+        "@com_github_gogo_protobuf//proto",
     ],
 )
 

--- a/pkg/kv/kvserver/print/debug_print.go
+++ b/pkg/kv/kvserver/print/debug_print.go
@@ -232,7 +232,7 @@ func tryIntent(kv storage.MVCCKeyValue) (string, error) {
 	return s, nil
 }
 
-func DecodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
+func DecodeWriteBatch(writeBatch []byte) (string, error) {
 	// Ensure that we always update this function to consider any necessary
 	// updates when a new key kind is introduced. To do this, we assert
 	// pebble.KeyKindDeleteSized is the most recent key kind, ensuring that
@@ -244,7 +244,7 @@ func DecodeWriteBatch(writeBatch *kvserverpb.WriteBatch) (string, error) {
 		return "<nil>\n", nil
 	}
 
-	r, err := storage.NewBatchReader(writeBatch.Data)
+	r, err := storage.NewBatchReader(writeBatch)
 	if err != nil {
 		return "", err
 	}
@@ -381,7 +381,7 @@ func tryRaftLogEntry(kv storage.MVCCKeyValue) (string, error) {
 	e.Data = nil
 	cmd := e.Cmd
 
-	wbStr, err := DecodeWriteBatch(cmd.WriteBatch)
+	wbStr, err := DecodeWriteBatch(cmd.WriteBatch.GetData())
 	if err != nil {
 		wbStr = "failed to decode: " + err.Error() + "\nafter:\n" + wbStr
 	}

--- a/pkg/kv/kvserver/print/dump_raft_log.go
+++ b/pkg/kv/kvserver/print/dump_raft_log.go
@@ -31,11 +31,11 @@ func DumpRaftLog(w io.Writer, reader storage.Reader, rangeID roachpb.RangeID) er
 	return raftlog.Visit(ctx, reader, rangeID, 0, math.MaxUint64, func(ent raftpb.Entry) error {
 		put("****** index %d ******", ent.Index)
 		e, err := raftlog.NewEntry(ent)
-		defer e.Release()
 		if err != nil {
 			put("%s", err)
 			return nil // continue
 		}
+		defer e.Release()
 		wb := e.Cmd.WriteBatch
 		e.Cmd.WriteBatch = nil
 
@@ -49,7 +49,7 @@ func DumpRaftLog(w io.Writer, reader storage.Reader, rangeID roachpb.RangeID) er
 		s, err := DecodeWriteBatch(wb.GetData())
 		if err != nil {
 			put("%s", err)
-			// continue
+			return nil // continue
 		}
 		put("%s", strings.TrimSpace(s))
 		return nil

--- a/pkg/kv/kvserver/print/dump_raft_log.go
+++ b/pkg/kv/kvserver/print/dump_raft_log.go
@@ -1,0 +1,57 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package print
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"math"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
+	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/gogo/protobuf/proto"
+)
+
+// DumpRaftLog writes a debugging text representation of the raft log into the
+// provided writer.
+func DumpRaftLog(w io.Writer, reader storage.Reader, rangeID roachpb.RangeID) error {
+	ctx := context.Background()
+	put := func(format string, args ...interface{}) {
+		_, _ = fmt.Fprintf(w, format, args...)
+		_, _ = fmt.Fprintln(w)
+	}
+
+	return raftlog.Visit(ctx, reader, rangeID, 0, math.MaxUint64, func(ent raftpb.Entry) error {
+		put("****** index %d ******", ent.Index)
+		e, err := raftlog.NewEntry(ent)
+		defer e.Release()
+		if err != nil {
+			put("%s", err)
+			return nil // continue
+		}
+		wb := e.Cmd.WriteBatch
+		e.Cmd.WriteBatch = nil
+
+		// NB: I spent way too much time trying to find a way to output the
+		// struct recursively but while omitting zero values. This is the
+		// closest I got without putting in significant amounts of work (like
+		// adjusting dozens of gogoproto moretags or writing custom
+		// formatters).
+		put("RaftCommand: %+v", proto.CompactTextString(&e.Cmd))
+
+		s, err := DecodeWriteBatch(wb.GetData())
+		if err != nil {
+			put("%s", err)
+			// continue
+		}
+		put("%s", strings.TrimSpace(s))
+		return nil
+	})
+}

--- a/pkg/kv/kvtestutils/BUILD.bazel
+++ b/pkg/kv/kvtestutils/BUILD.bazel
@@ -7,6 +7,7 @@ go_library(
     # testonly = 1,
     srcs = [
         "consistency.go",
+        "dump_raft_logs.go",
         "test_utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvtestutils",
@@ -14,8 +15,10 @@ go_library(
     deps = [
         "//pkg/kv/kvbase",
         "//pkg/kv/kvpb",
+        "//pkg/kv/kvserver/print",
         "//pkg/roachpb",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/storage",
         "//pkg/util/tracing",
         "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/kv/kvtestutils/dump_raft_logs.go
+++ b/pkg/kv/kvtestutils/dump_raft_logs.go
@@ -1,0 +1,55 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvtestutils
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+)
+
+type RaftLogDumper struct {
+	Dir    string
+	logged bool
+}
+
+func (d *RaftLogDumper) Dump(
+	t interface {
+		Logf(format string, args ...interface{})
+	},
+	reader storage.Reader,
+	storeID roachpb.StoreID,
+	rangeID roachpb.RangeID,
+) {
+	if !d.logged {
+		t.Logf("dumping raft logs to %s", d.Dir)
+		d.logged = true
+	}
+	if err := d.dumpOne(reader, storeID, rangeID); err != nil {
+		t.Logf("error dumping s%dr%d: %s", storeID, rangeID, err)
+	}
+}
+
+func (d *RaftLogDumper) dumpOne(
+	reader storage.Reader, storeID roachpb.StoreID, rangeID roachpb.RangeID,
+) error {
+	if err := os.MkdirAll(d.Dir, 0755); err != nil {
+		return err
+	}
+	path := filepath.Join(d.Dir, "raftlog_s"+storeID.String()+"r"+rangeID.String()+".txt")
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	if err := print.DumpRaftLog(f, reader, rangeID); err != nil {
+		_, _ = fmt.Fprintf(f, "error on %s: %s", rangeID, err)
+	}
+	return f.Close()
+}


### PR DESCRIPTION
This helps diagnose failures such as #146043 and #143317.

```
$ go test [...]
somewhere.go:6207: dumping raft logs to [log-scope]/raftlog
```

```
$ ls [log-scope]/raftlog
r1.txt	r12.txt	r15.txt [...]
```

```
$ tail -n 10 r74.txt
****** index 25 ******
RaftCommand: proposer_lease_sequence:1 max_lease_index:20 closed_timestamp:<wall_time:1746450987106072000 > replicated_eval_result:<write_timestamp:<wall_time:1746450990105858000 > delta:<sys_bytes:147 > > logical_op_log:<>
Put: /Local/Lock/Local/Range/Table/72/RangeDescriptor 032e9bd313c26c4cb99422657288fdc2a8 (0x017a6b12016b12d000ff0172647363000100032e9bd313c26c4cb99422657288fdc2a812): 1746450990.105858000,0 txn={id=2e9bd313 key=/Local/Range/Table/72/RangeDescriptor iso=Serializable pri=0.00381679 epo=0 ts=1746450990.105858000,0 min=1746450990.105858000,0 seq=1} ts=1746450990.105858000,0 del=false klen=12 vlen=49 mergeTs=<nil> txnDidNotUpdateMeta=true
Put: 1746450990.105858000,0 /Local/Range/Table/72/RangeDescriptor (0x016b12d000017264736300183ca3ec22e38fd009): [/Table/72, /Table/Max)
	Raw:r74:/Table/{72-Max} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=5]
****** index 26 ******
RaftCommand: proposer_lease_sequence:1 max_lease_index:21 closed_timestamp:<wall_time:1746450987106175000 > replicated_eval_result:<write_timestamp:<wall_time:1746450990105858000 > delta:<sys_bytes:175 sys_count:1 > > logical_op_log:<>
Put: /Local/Lock/Local/Range/Table/Max/RangeDescriptor 032e9bd313c26c4cb99422657288fdc2a8 (0x017a6b12016b12fa00ff0172647363000100032e9bd313c26c4cb99422657288fdc2a812): 1746450990.105858000,0 txn={id=2e9bd313 key=/Local/Range/Table/72/RangeDescriptor iso=Serializable pri=0.00381679 epo=0 ts=1746450990.105858000,0 min=1746450990.105858000,0 seq=2} ts=1746450990.105858000,0 del=false klen=12 vlen=66 mergeTs=<nil> txnDidNotUpdateMeta=true
Put: 1746450990.105858000,0 /Local/Range/Table/Max/RangeDescriptor (0x016b12fa00017264736300183ca3ec22e38fd009): [/Table/Max, /Max)
	Raw:r75:/{Table/Max-Max} [(n1,s1):1, (n2,s2):2, (n3,s3):3, next=4, gen=5, sticky=9223372036.854775807,2147483647]
```

Closes https://github.com/cockroachdb/cockroach/issues/146043

Epic: none