### PR TITLE
kvserver: Reduce replica mutex contention Phase 1

### DIFF
--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -604,7 +604,7 @@ func (r *Replica) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
 	return toClientClosedTsPolicy(closedTimestampPolicy(r.descRLocked(),
-		r.cachedClosedTimestampPolicy.Load()))
+		*r.cachedClosedTimestampPolicy.Load()))
 }
 
 // TripBreaker synchronously trips the breaker.

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -603,7 +603,8 @@ func (r *Replica) ReadCachedProtectedTS() (readAt, earliestProtectionTimestamp h
 func (r *Replica) ClosedTimestampPolicy() roachpb.RangeClosedTimestampPolicy {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return toClientClosedTsPolicy(r.closedTimestampPolicyRLocked())
+	return toClientClosedTsPolicy(closedTimestampPolicy(r.descRLocked(),
+		r.cachedClosedTimestampPolicy.Load()))
 }
 
 // TripBreaker synchronously trips the breaker.

--- a/pkg/kv/kvserver/replica_backpressure.go
+++ b/pkg/kv/kvserver/replica_backpressure.go
@@ -153,13 +153,16 @@ func (r *Replica) signallerForBatch(ba *kvpb.BatchRequest) signaller {
 // range's size is already larger than the absolute maximum we'll allow.
 func (r *Replica) shouldBackpressureWrites() bool {
 	r.mu.RLock()
-	defer r.mu.RUnlock()
+	size := r.shMu.state.Stats.Total()
+	rangeMaxBytes := r.mu.conf.RangeMaxBytes
+	largestPreviousMaxRangeSize := r.mu.largestPreviousMaxRangeSizeBytes
+	r.mu.RUnlock()
 
 	// Check if the current range's size is already over the absolute maximum
 	// we'll allow. Don't bother with any multipliers/byte tolerance calculations
 	// if it is.
 	rangeSizeHardCap := backpressureRangeHardCap.Get(&r.store.cfg.Settings.SV)
-	size := r.shMu.state.Stats.Total()
+
 	if size >= rangeSizeHardCap {
 		return true
 	}
@@ -170,7 +173,8 @@ func (r *Replica) shouldBackpressureWrites() bool {
 		return false
 	}
 
-	exceeded, bytesOver := r.exceedsMultipleOfSplitSizeRLocked(mult)
+	exceeded, bytesOver := exceedsMultipleOfSplitSize(mult, rangeMaxBytes,
+		largestPreviousMaxRangeSize, size)
 	if !exceeded {
 		return false
 	}

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -19,9 +19,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 )
 
-// getTargetByPolicy returns a range's closed timestamp policy and target
+// getTargetByPolicyRLocked returns a range's closed timestamp policy and target
 // timestamp.
-func (r *Replica) getTargetByPolicy(
+func (r *Replica) getTargetByPolicyRLocked(
 	targetByPolicy map[ctpb.RangeClosedTimestampPolicy]hlc.Timestamp,
 ) (ctpb.RangeClosedTimestampPolicy, hlc.Timestamp) {
 	policy := closedTimestampPolicy(r.descRLocked(), *r.cachedClosedTimestampPolicy.Load())
@@ -87,7 +87,7 @@ func (r *Replica) BumpSideTransportClosed(
 	}
 
 	lai := r.shMu.state.LeaseAppliedIndex
-	policy, target := r.getTargetByPolicy(targetByPolicy)
+	policy, target := r.getTargetByPolicyRLocked(targetByPolicy)
 	st := r.leaseStatusForRequestRLocked(ctx, now, hlc.Timestamp{} /* reqTS */)
 	// We need to own the lease but note that stasis (LeaseState_UNUSABLE) doesn't
 	// matter.

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -24,7 +24,7 @@ import (
 func (r *Replica) getTargetByPolicy(
 	targetByPolicy map[ctpb.RangeClosedTimestampPolicy]hlc.Timestamp,
 ) (ctpb.RangeClosedTimestampPolicy, hlc.Timestamp) {
-	policy := r.closedTimestampPolicyRLocked()
+	policy := closedTimestampPolicy(r.descRLocked(), r.cachedClosedTimestampPolicy.Load())
 	target, ok := targetByPolicy[policy]
 	if ok {
 		return policy, target
@@ -154,7 +154,7 @@ func (r *Replica) closedTimestampTargetRLocked() hlc.Timestamp {
 		closedts.TargetDuration.Get(&r.ClusterSettings().SV),
 		closedts.LeadForGlobalReadsOverride.Get(&r.ClusterSettings().SV),
 		closedts.SideTransportCloseInterval.Get(&r.ClusterSettings().SV),
-		r.closedTimestampPolicyRLocked(),
+		closedTimestampPolicy(r.descRLocked(), r.cachedClosedTimestampPolicy.Load()),
 	)
 }
 

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -24,7 +24,7 @@ import (
 func (r *Replica) getTargetByPolicy(
 	targetByPolicy map[ctpb.RangeClosedTimestampPolicy]hlc.Timestamp,
 ) (ctpb.RangeClosedTimestampPolicy, hlc.Timestamp) {
-	policy := closedTimestampPolicy(r.descRLocked(), r.cachedClosedTimestampPolicy.Load())
+	policy := closedTimestampPolicy(r.descRLocked(), *r.cachedClosedTimestampPolicy.Load())
 	target, ok := targetByPolicy[policy]
 	if ok {
 		return policy, target
@@ -154,7 +154,7 @@ func (r *Replica) closedTimestampTargetRLocked() hlc.Timestamp {
 		closedts.TargetDuration.Get(&r.ClusterSettings().SV),
 		closedts.LeadForGlobalReadsOverride.Get(&r.ClusterSettings().SV),
 		closedts.SideTransportCloseInterval.Get(&r.ClusterSettings().SV),
-		closedTimestampPolicy(r.descRLocked(), r.cachedClosedTimestampPolicy.Load()),
+		closedTimestampPolicy(r.descRLocked(), *r.cachedClosedTimestampPolicy.Load()),
 	)
 }
 

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -1231,9 +1231,9 @@ func TestRefreshPolicyWithVariousLatencies(t *testing.T) {
 // 4. Replica tries to use a latency-based policy but the policy map from step 1
 // doesn't include it yet.
 //
-// The logic in replica.getTargetByPolicy handles this race condition by falling
-// back to no-latency based policies if no-latency based policies were included
-// from the map provided by the side transport sender.
+// The logic in replica.getTargetByPolicyRLocked handles this race condition by
+// falling back to no-latency based policies if no-latency based policies were
+// included from the map provided by the side transport sender.
 //
 // This test simulates a race condition by using a testing knob to allow the
 // policy refresher to use latency based policies on replicas while the rest of

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/plan"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/tracker"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
@@ -146,6 +147,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		allocatorToken: &plan.AllocatorToken{},
 	}
 	r.sideTransportClosedTimestamp.init(store.cfg.ClosedTimestampReceiver, rangeID)
+	r.cachedClosedTimestampPolicy.Store(new(ctpb.RangeClosedTimestampPolicy))
 
 	r.mu.pendingLeaseRequest = makePendingLeaseRequest(r)
 	r.mu.stateLoader = stateloader.Make(rangeID)

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -125,7 +125,7 @@ func (r *Replica) Metrics(
 		paused:                   r.mu.pausedFollowers,
 		pendingRaftProposalCount: r.numPendingProposalsRLocked(),
 		slowRaftProposalCount:    r.mu.slowProposalCount,
-		closedTimestampPolicy:    ctpb.RangeClosedTimestampPolicy(r.cachedClosedTimestampPolicy.Load()),
+		closedTimestampPolicy:    *r.cachedClosedTimestampPolicy.Load(),
 	}
 
 	r.mu.RUnlock()

--- a/pkg/kv/kvserver/replica_metrics.go
+++ b/pkg/kv/kvserver/replica_metrics.go
@@ -383,7 +383,8 @@ func (r *Replica) LoadStats() load.ReplicaLoadStats {
 }
 
 func (r *Replica) needsSplitBySizeRLocked() bool {
-	exceeded, _ := r.exceedsMultipleOfSplitSizeRLocked(1)
+	exceeded, _ := exceedsMultipleOfSplitSize(1, r.mu.conf.RangeMaxBytes,
+		r.mu.largestPreviousMaxRangeSizeBytes, r.shMu.state.Stats.Total())
 	return exceeded
 }
 
@@ -408,18 +409,20 @@ func (r *Replica) needsRaftLogTruncationLocked() bool {
 	return checkRaftLog
 }
 
-// exceedsMultipleOfSplitSizeRLocked returns whether the current size of the
+// exceedsMultipleOfSplitSize returns whether the current size of the
 // range exceeds the max size times mult. If so, the bytes overage is also
 // returned. Note that the max size is determined by either the current maximum
 // size as dictated by the span config or a previous max size indicating that
 // the max size has changed relatively recently and thus we should not
 // backpressure for being over.
-func (r *Replica) exceedsMultipleOfSplitSizeRLocked(mult float64) (exceeded bool, bytesOver int64) {
-	maxBytes := r.mu.conf.RangeMaxBytes
-	if r.mu.largestPreviousMaxRangeSizeBytes > maxBytes {
-		maxBytes = r.mu.largestPreviousMaxRangeSizeBytes
+func exceedsMultipleOfSplitSize(
+	mult float64, rangeMaxBytes int64, largestPreviousMaxRangeSizeBytes int64, totalRangeSize int64,
+) (exceeded bool, bytesOver int64) {
+	maxBytes := rangeMaxBytes
+	if largestPreviousMaxRangeSizeBytes > maxBytes {
+		maxBytes = largestPreviousMaxRangeSizeBytes
 	}
-	size := r.shMu.state.Stats.Total()
+	size := totalRangeSize
 	maxSize := int64(float64(maxBytes)*mult) + 1
 	if maxBytes <= 0 || size <= maxSize {
 		return false, 0


### PR DESCRIPTION
This PR aims to reduce the replica mutex contention by limiting the scope that the mutex is taken in r.GetRangeInfo(), r.State(), r.shouldBackpressureWrites().

This PR reduces the replica mutex contention from `786.9ms` to `769.06ms` in my local machine using the following command:

```
rm -f /tmp/*.pb.gz && env GODEBUG=runtimecontentionstacks=1 go test ./pkg/sql/tests -run - -bench BenchmarkParallelSysbench/SQL/3node/oltp_read_write -v -test.benchtime=3000x -test.outputdir=/tmp -test.mutexprofile=mutex.pb.gz -test.mutexprofilefraction=100 -test.timeout 25s 2>&1
```

Before:
<img width="1728" alt="Screenshot 2025-05-06 at 6 04 48 PM" src="https://github.com/user-attachments/assets/e535434a-1d1e-4d34-9b6d-c4e05d54801d" />


After:
<img width="1724" alt="Screenshot 2025-05-06 at 6 16 17 PM" src="https://github.com/user-attachments/assets/15a812c5-963c-4d6f-9f53-9e70a96e47bd" />

References: #140235

Release note: None