### PR TITLE
storeliveness: increase pool size under `race`

### DIFF
--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -55,6 +55,10 @@ go_test(
     ],
     data = glob(["testdata/**"]),
     embed = [":storeliveness"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/gossip",


### PR DESCRIPTION
This OOM'ed in #146093.

Closes #146093.

Epic: none
Release note: None