### PR TITLE
crosscluster/physical: test that set version fails on reader tenant

### DIFF
--- a/pkg/crosscluster/physical/replication_stream_e2e_test.go
+++ b/pkg/crosscluster/physical/replication_stream_e2e_test.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	_ "github.com/cockroachdb/cockroach/pkg/cloud/impl"
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationtestutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/replicationutils"
 	"github.com/cockroachdb/cockroach/pkg/crosscluster/streamclient"
@@ -28,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
@@ -1572,4 +1574,52 @@ FROM [SHOW VIRTUAL CLUSTER '%s' WITH REPLICATION STATUS]
 
 	require.Equal(t, expectedReaderTenantName, name)
 	require.Equal(t, "ready", status)
+}
+
+// TestReaderTenantUpgrade ensures the reader tenant cannot upgrade itself or
+// via the system tenant, rather the user needs to upgrade the host cluster, and
+// then recreate the reader tenant.
+func TestReaderTenantUpgrade(t *testing.T) {
+
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	args := replicationtestutils.DefaultTenantStreamingClustersArgs
+	args.EnableReaderTenant = true
+	args.InitSettings = cluster.MakeTestingClusterSettingsWithVersions(
+		clusterversion.MinSupported.Version(),
+		clusterversion.MinSupported.Version(),
+		true, /* initializeVersion */
+	)
+	c, cleanup := replicationtestutils.CreateTenantStreamingClusters(ctx, t, args)
+	defer cleanup()
+
+	producerJobID, ingestionJobID := c.StartStreamReplication(ctx)
+
+	jobutils.WaitForJobToRun(c.T, c.SrcSysSQL, jobspb.JobID(producerJobID))
+	jobutils.WaitForJobToRun(c.T, c.DestSysSQL, jobspb.JobID(ingestionJobID))
+
+	srcTime := c.SrcCluster.Server(0).Clock().Now()
+	c.WaitUntilReplicatedTime(srcTime, jobspb.JobID(ingestionJobID))
+
+	stats := replicationtestutils.TestingGetStreamIngestionStatsFromReplicationJob(t, ctx, c.DestSysSQL, ingestionJobID)
+	readerTenantID := stats.IngestionDetails.ReadTenantID
+
+	readerTenantName := fmt.Sprintf("%s-readonly", args.DestTenantName)
+	c.ConnectToReaderTenant(ctx, readerTenantID, readerTenantName)
+
+	latestVersion := clusterversion.PreviousRelease.Version().String()
+
+	c.ReaderTenantSQL.ExpectErr(t, "cannot execute SET CLUSTER SETTING in a read-only transaction", fmt.Sprintf("SET CLUSTER SETTING version = '%s'", latestVersion))
+
+	// Ensure the reader tenant cannot upgrade itself even if we allow it to write.
+	c.ReaderTenantSQL.Exec(t, "SET SESSION bypass_pcr_reader_catalog_aost ='true'")
+	c.ReaderTenantSQL.ExpectErr(t, "reader virtual clusters cannot be upgraded", fmt.Sprintf("SET CLUSTER SETTING version = '%s'", latestVersion))
+
+	c.DestSysSQL.ExpectErr(t, "cannot set 'version' for tenants", fmt.Sprintf("ALTER TENANT '%s' SET CLUSTER SETTING version = '%s'", readerTenantName, latestVersion))
+
+	c.DestSysSQL.Exec(t, fmt.Sprintf("SET CLUSTER SETTING version = '%s'", latestVersion))
+	c.DestSysSQL.Exec(t, fmt.Sprintf("DROP VIRTUAL CLUSTER %s", readerTenantName))
+	c.DestSysSQL.Exec(t, fmt.Sprintf("ALTER VIRTUAL CLUSTER %s SET REPLICATION READ VIRTUAL CLUSTER", args.DestTenantName))
 }

--- a/pkg/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/crosscluster/replicationtestutils/testutils.go
@@ -88,6 +88,11 @@ type TenantStreamingClustersArgs struct {
 	ExternalIODir                   string
 
 	RoutingMode streamclient.RoutingMode
+
+	// If set, the host virtual cluster will be initialized with these, unlike
+	// DestClusterSettings and SrcClusterSettings, which are set after the cluster
+	// spins up.
+	InitSettings *cluster.Settings
 }
 
 var DefaultTenantStreamingClustersArgs = TenantStreamingClustersArgs{
@@ -432,6 +437,7 @@ func CreateServerArgs(args TenantStreamingClustersArgs) base.TestServerArgs {
 			},
 		},
 		ExternalIODir: args.ExternalIODir,
+		Settings:      args.InitSettings,
 	}
 }
 

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/multitenant/mtinfo",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/server/license",


### PR DESCRIPTION
Informs #143916

Release note (ops change): in a PCR deployment, it is not possible for the destination
system tenant or the reader tenant to upgrade the reader tenant by setting the
version setting. The user should instead shutdown the reader tenant, upgrade
the dest host cluster, and re-initialize the reader tenant via `ALTER VIRTUAL
CLUSTER SET REPLICATION READ VIRTUAL CLUSTER`