### PR TITLE
release-24.1: catalog/lease: clean up orphaned session based leases

### DIFF
--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -1669,7 +1669,7 @@ func (s *SQLServer) preStart(
 
 	// Delete all orphaned table leases created by a prior instance of this
 	// node. This also uses SQL.
-	s.leaseMgr.DeleteOrphanedLeases(ctx, orphanedLeasesTimeThresholdNanos)
+	s.leaseMgr.DeleteOrphanedLeases(ctx, orphanedLeasesTimeThresholdNanos, s.execCfg.Locality)
 
 	if err := s.statsRefresher.Start(ctx, stopper, stats.DefaultRefreshInterval); err != nil {
 		return err

--- a/pkg/server/server_sql.go
+++ b/pkg/server/server_sql.go
@@ -826,11 +826,12 @@ func newSQLServer(ctx context.Context, cfg sqlServerArgs) (*SQLServer, error) {
 		RowMetrics:         &rowMetrics,
 		InternalRowMetrics: &internalRowMetrics,
 
-		SQLLivenessReader: cfg.sqlLivenessProvider.CachedReader(),
-		JobRegistry:       jobRegistry,
-		Gossip:            cfg.gossip,
-		SQLInstanceDialer: cfg.sqlInstanceDialer,
-		LeaseManager:      leaseMgr,
+		SQLLivenessReader:         cfg.sqlLivenessProvider.CachedReader(),
+		BlockingSQLLivenessReader: cfg.sqlLivenessProvider.BlockingReader(),
+		JobRegistry:               jobRegistry,
+		Gossip:                    cfg.gossip,
+		SQLInstanceDialer:         cfg.sqlInstanceDialer,
+		LeaseManager:              leaseMgr,
 
 		ExternalStorage:        cfg.externalStorage,
 		ExternalStorageFromURI: cfg.externalStorageFromURI,

--- a/pkg/sql/catalog/lease/BUILD.bazel
+++ b/pkg/sql/catalog/lease/BUILD.bazel
@@ -135,6 +135,7 @@ go_test(
         "//pkg/sql/sqlliveness",
         "//pkg/sql/sqlliveness/slbase",
         "//pkg/sql/sqlliveness/slprovider",
+        "//pkg/sql/sqlliveness/slstorage",
         "//pkg/sql/stats",
         "//pkg/sql/types",
         "//pkg/storage",

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/regionliveness"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness"
 	kvstorage "github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -44,6 +45,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/metric"
 	"github.com/cockroachdb/cockroach/pkg/util/quotapool"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/startup"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil/singleflight"
@@ -1828,7 +1830,9 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, refreshAndPurgeAllDescr
 // DeleteOrphanedLeases releases all orphaned leases created by a prior
 // instance of this node. timeThreshold is a walltime lower than the
 // lowest hlc timestamp that the current instance of the node can use.
-func (m *Manager) DeleteOrphanedLeases(ctx context.Context, timeThreshold int64) {
+func (m *Manager) DeleteOrphanedLeases(
+	ctx context.Context, timeThreshold int64, locality roachpb.Locality,
+) {
 	if m.testingKnobs.DisableDeleteOrphanedLeases {
 		return
 	}
@@ -1844,6 +1848,7 @@ func (m *Manager) DeleteOrphanedLeases(ctx context.Context, timeThreshold int64)
 	// filled by AnnotateCtx.
 	newCtx = logtags.AddTags(newCtx, logtags.FromContext(ctx))
 	_ = m.stopper.RunAsyncTask(newCtx, "del-orphaned-leases", func(ctx context.Context) {
+		m.deleteOrphanedLeasesFromStaleSession(ctx, timeThreshold, locality)
 		// This could have been implemented using DELETE WHERE, but DELETE WHERE
 		// doesn't implement AS OF SYSTEM TIME.
 
@@ -2095,4 +2100,111 @@ func (m *Manager) TestingSetDisableRangeFeedCheckpointFn(disable bool) chan stru
 		m.testingKnobs.RangeFeedResetChannel = nil
 	}
 	return m.testingKnobs.RangeFeedResetChannel
+}
+
+// deleteOrphanedLeasesFromStaleSession deletes leases from sessions that are
+// no longer alive.
+func (m *Manager) deleteOrphanedLeasesFromStaleSession(
+	ctx context.Context, initialTimestamp int64, locality roachpb.Locality,
+) {
+	ex := m.storage.db.Executor()
+	row, err := ex.QueryRowEx(ctx, "check-system-db-multi-region", nil,
+		sessiondata.NodeUserSessionDataOverride,
+		"SELECT EXISTS (SELECT * FROM [SHOW REGIONS FROM DATABASE system])")
+	if err != nil {
+		log.Warningf(ctx, "unable to query if system database is multi-region: %v", err)
+		return
+	}
+	// For multi-region system databases, only focus on our own region; there is
+	// no need to incur cross-region hops.
+	region := string(enum.One)
+	multiRegionSystemDb := tree.MustBeDBool(row[0])
+	if !locality.Empty() && bool(multiRegionSystemDb) {
+		region = locality.Tiers[0].Value
+	}
+
+	retryOpts := base.DefaultRetryOptions()
+	retryOpts.MaxRetries = 10
+	var distinctSessions []tree.Datums
+	aostTime := hlc.Timestamp{WallTime: initialTimestamp}
+	distinctSessionQuery := `SELECT DISTINCT(session_id) FROM system.lease AS OF SYSTEM TIME %s WHERE crdb_region=$1 AND NOT crdb_internal.sql_liveness_is_alive(session_id, true) LIMIT $2`
+	syntheticDescriptors := catalog.Descriptors{systemschema.LeaseTable()}
+	const limit = 50
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		// Get a list of distinct, dead session IDs that exist in the system.lease
+		// table.
+		err = ex.WithSyntheticDescriptors(syntheticDescriptors, func() error {
+			distinctSessions, err = ex.QueryBufferedEx(ctx,
+				"query-lease-table-dead-sessions",
+				nil,
+				sessiondata.NodeUserSessionDataOverride,
+				fmt.Sprintf(distinctSessionQuery, aostTime.AsOfSystemTime()),
+				region,
+				limit,
+			)
+			return err
+		})
+		if err != nil {
+			if !startup.IsRetryableReplicaError(err) {
+				log.Warningf(ctx, "unable to read session IDs for orphaned leases: %v", err)
+				return
+			}
+		}
+
+		// Delete rows in our lease table with orphaned sessions.
+		for _, sessionRow := range distinctSessions {
+			sessionID := sqlliveness.SessionID(tree.MustBeDBytes(sessionRow[0]))
+			if err = deleteLeaseWithSessionIDWithBatch(ctx, ex, retryOpts, syntheticDescriptors, sessionID, region, limit); err != nil {
+				log.Warningf(ctx, "unable to delete orphaned leases: %v", err)
+				break
+			}
+		}
+
+		// No more dead sessions to clean up.
+		if len(distinctSessions) < limit {
+			return
+		}
+
+		// Advance our aostTime timstamp so that our query to detect leases with
+		// dead sessions is aware of new deletes and does not keep selecting the
+		// same leases.
+		aostTime = hlc.Timestamp{WallTime: m.storage.clock.Now().WallTime}
+	}
+}
+
+// deleteLeaseWithSessionIDWithBatch uses batchSize to batch deletes for leases
+// with the given sessionID in system.lease.
+func deleteLeaseWithSessionIDWithBatch(
+	ctx context.Context,
+	ex isql.Executor,
+	retryOpts retry.Options,
+	syntheticDescriptors catalog.Descriptors,
+	sessionID sqlliveness.SessionID,
+	region string,
+	batchSize int,
+) error {
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		var rowsDeleted int
+		deleteOrphanedQuery := `DELETE FROM system.lease WHERE session_id=$1 AND crdb_region=$2 LIMIT $3`
+		if err := ex.WithSyntheticDescriptors(syntheticDescriptors, func() error {
+			var err error
+			rowsDeleted, err = ex.ExecEx(ctx, "delete-orphaned-leases-by-session", nil,
+				sessiondata.NodeUserSessionDataOverride,
+				deleteOrphanedQuery,
+				sessionID.UnsafeBytes(),
+				region,
+				batchSize)
+			return err
+		}); err != nil {
+			if !startup.IsRetryableReplicaError(err) {
+				return err
+			}
+		}
+
+		// No more rows to clean up.
+		if rowsDeleted < batchSize {
+			break
+		}
+	}
+	return nil
 }

--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -1848,83 +1848,10 @@ func (m *Manager) DeleteOrphanedLeases(
 	// filled by AnnotateCtx.
 	newCtx = logtags.AddTags(newCtx, logtags.FromContext(ctx))
 	_ = m.stopper.RunAsyncTask(newCtx, "del-orphaned-leases", func(ctx context.Context) {
-		m.deleteOrphanedLeasesFromStaleSession(ctx, timeThreshold, locality)
-		// This could have been implemented using DELETE WHERE, but DELETE WHERE
-		// doesn't implement AS OF SYSTEM TIME.
-
-		// Read orphaned leases, and join against the internal session
-		// table in case we have dual written leases.
-		query := `
-SELECT COALESCE(l."descID", s."desc_id") as "descID", COALESCE(l.version, s.version), l.expiration, s."session_id", l.crdb_region, s.crdb_region FROM
-	 system.public.lease as l FULL OUTER JOIN "".crdb_internal.kv_session_based_leases as s ON l."nodeID"=s."sql_instance_id" AND
-	  l."descID"=s."desc_id" AND l.version=s.version
-		WHERE COALESCE(l."nodeID", s."sql_instance_id") =%d
-`
-		sqlQuery := fmt.Sprintf(query, instanceID)
-
-		var rows []tree.Datums
-		retryOptions := base.DefaultRetryOptions()
-		retryOptions.Closer = m.stopper.ShouldQuiesce()
-		// The retry is required because of errors caused by node restarts. Retry 30 times.
-		if err := retry.WithMaxAttempts(ctx, retryOptions, 30, func() error {
-			return m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-				if err := txn.KV().SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: timeThreshold}); err != nil {
-					return err
-				}
-				return txn.WithSyntheticDescriptors(catalog.Descriptors{systemschema.LeaseTable_V23_2()}, func() error {
-					var err error
-					rows, err = txn.QueryBuffered(
-						ctx, "read orphaned leases", txn.KV(), sqlQuery,
-					)
-					return err
-				})
-			})
-		}); err != nil {
-			log.Warningf(ctx, "unable to read orphaned leases: %+v", err)
-			return
-		}
-		var wg sync.WaitGroup
-		defer wg.Wait()
-		for i := range rows {
-			// Early exit?
-			row := rows[i]
-			wg.Add(1)
-			lease := &storedLease{
-				id:      descpb.ID(tree.MustBeDInt(row[0])),
-				version: int(tree.MustBeDInt(row[1])),
-			}
-			// Session based leases will not have a timestamp.
-			if row[2] != tree.DNull {
-				lease.expiration = tree.MustBeDTimestamp(row[2])
-			}
-			if row[3] != tree.DNull {
-				lease.sessionID = []byte(tree.MustBeDBytes(row[3]))
-			}
-			if ed, ok := row[4].(*tree.DEnum); ok {
-				lease.prefix = ed.PhysicalRep
-			} else if bd, ok := row[4].(*tree.DBytes); ok {
-				lease.prefix = []byte((*bd))
-			}
-			if len(row) >= 6 && lease.prefix == nil {
-				if bd, ok := row[5].(*tree.DBytes); ok {
-					lease.prefix = []byte((*bd))
-				}
-			}
-			if err := m.stopper.RunAsyncTaskEx(
-				ctx,
-				stop.TaskOpts{
-					TaskName:   fmt.Sprintf("release lease %+v", lease),
-					Sem:        m.sem,
-					WaitForSem: true,
-				},
-				func(ctx context.Context) {
-					m.storage.release(ctx, m.stopper, lease)
-					log.Infof(ctx, "released orphaned lease: %+v", lease)
-					wg.Done()
-				}); err != nil {
-				wg.Done()
-			}
-		}
+		retryOpts := base.DefaultRetryOptions()
+		retryOpts.MaxRetries = 10
+		m.deleteOrphanedLeasesFromStaleSession(ctx, retryOpts, timeThreshold, locality)
+		m.deleteOrphanedLeasesWithSameInstanceID(ctx, retryOpts, timeThreshold, instanceID)
 	})
 }
 
@@ -2105,7 +2032,7 @@ func (m *Manager) TestingSetDisableRangeFeedCheckpointFn(disable bool) chan stru
 // deleteOrphanedLeasesFromStaleSession deletes leases from sessions that are
 // no longer alive.
 func (m *Manager) deleteOrphanedLeasesFromStaleSession(
-	ctx context.Context, initialTimestamp int64, locality roachpb.Locality,
+	ctx context.Context, retryOpts retry.Options, initialTimestamp int64, locality roachpb.Locality,
 ) {
 	ex := m.storage.db.Executor()
 	row, err := ex.QueryRowEx(ctx, "check-system-db-multi-region", nil,
@@ -2123,8 +2050,6 @@ func (m *Manager) deleteOrphanedLeasesFromStaleSession(
 		region = locality.Tiers[0].Value
 	}
 
-	retryOpts := base.DefaultRetryOptions()
-	retryOpts.MaxRetries = 10
 	var distinctSessions []tree.Datums
 	aostTime := hlc.Timestamp{WallTime: initialTimestamp}
 	distinctSessionQuery := `SELECT DISTINCT(session_id) FROM system.lease AS OF SYSTEM TIME %s WHERE crdb_region=$1 AND NOT crdb_internal.sql_liveness_is_alive(session_id, true) LIMIT $2`
@@ -2207,4 +2132,87 @@ func deleteLeaseWithSessionIDWithBatch(
 		}
 	}
 	return nil
+}
+
+func (m *Manager) deleteOrphanedLeasesWithSameInstanceID(
+	ctx context.Context,
+	retryOptions retry.Options,
+	timeThreshold int64,
+	instanceID base.SQLInstanceID,
+) {
+	// This could have been implemented using DELETE WHERE, but DELETE WHERE
+	// doesn't implement AS OF SYSTEM TIME.
+
+	// Read orphaned leases, and join against the internal session
+	// table in case we have dual written leases.
+	query := `
+SELECT COALESCE(l."descID", s."desc_id") as "descID", COALESCE(l.version, s.version), l.expiration, s."session_id", l.crdb_region, s.crdb_region FROM
+	 system.public.lease as l FULL OUTER JOIN "".crdb_internal.kv_session_based_leases as s ON l."nodeID"=s."sql_instance_id" AND
+	  l."descID"=s."desc_id" AND l.version=s.version
+		WHERE COALESCE(l."nodeID", s."sql_instance_id") =%d
+`
+	sqlQuery := fmt.Sprintf(query, instanceID)
+
+	var rows []tree.Datums
+	// The retry is required because of errors caused by node restarts. Retry 30 times.
+	retryOptions.Closer = m.stopper.ShouldQuiesce()
+	if err := retry.WithMaxAttempts(ctx, retryOptions, 30, func() error {
+		return m.storage.db.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			if err := txn.KV().SetFixedTimestamp(ctx, hlc.Timestamp{WallTime: timeThreshold}); err != nil {
+				return err
+			}
+			return txn.WithSyntheticDescriptors(catalog.Descriptors{systemschema.LeaseTable_V23_2()}, func() error {
+				var err error
+				rows, err = txn.QueryBuffered(
+					ctx, "read orphaned leases", txn.KV(), sqlQuery,
+				)
+				return err
+			})
+		})
+	}); err != nil {
+		log.Warningf(ctx, "unable to read orphaned leases: %+v", err)
+		return
+	}
+	var wg sync.WaitGroup
+	defer wg.Wait()
+	for i := range rows {
+		// Early exit?
+		row := rows[i]
+		wg.Add(1)
+		lease := &storedLease{
+			id:      descpb.ID(tree.MustBeDInt(row[0])),
+			version: int(tree.MustBeDInt(row[1])),
+		}
+		// Session based leases will not have a timestamp.
+		if row[2] != tree.DNull {
+			lease.expiration = tree.MustBeDTimestamp(row[2])
+		}
+		if row[3] != tree.DNull {
+			lease.sessionID = []byte(tree.MustBeDBytes(row[3]))
+		}
+		if ed, ok := row[4].(*tree.DEnum); ok {
+			lease.prefix = ed.PhysicalRep
+		} else if bd, ok := row[4].(*tree.DBytes); ok {
+			lease.prefix = []byte((*bd))
+		}
+		if len(row) >= 6 && lease.prefix == nil {
+			if bd, ok := row[5].(*tree.DBytes); ok {
+				lease.prefix = []byte((*bd))
+			}
+		}
+		if err := m.stopper.RunAsyncTaskEx(
+			ctx,
+			stop.TaskOpts{
+				TaskName:   fmt.Sprintf("release lease %+v", lease),
+				Sem:        m.sem,
+				WaitForSem: true,
+			},
+			func(ctx context.Context) {
+				m.storage.release(ctx, m.stopper, lease)
+				log.Infof(ctx, "released orphaned lease: %+v", lease)
+				wg.Done()
+			}); err != nil {
+			wg.Done()
+		}
+	}
 }

--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -43,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/systemschema"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/enum"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
@@ -57,6 +58,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlinstance/instancestorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slprovider"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlliveness/slstorage"
 	"github.com/cockroachdb/cockroach/pkg/sql/stats"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
@@ -2145,6 +2147,71 @@ INSERT INTO t.kv VALUES ('c', 'd');
 	}
 }
 
+func TestDeleteOrphanedLeasesBySession(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	s, conn, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Locality: roachpb.Locality{
+			Tiers: []roachpb.Tier{{Key: "region", Value: "us-east1"}},
+		},
+	})
+	defer s.Stop(ctx)
+	idb := s.InternalDB().(*sql.InternalDB)
+	ie := idb.Executor()
+	// Validate only one session exists.
+	rows, err := ie.QueryBuffered(ctx,
+		"detect-existing-leases",
+		nil,
+		"SELECT DISTINCT(session_id) FROM system.lease")
+	require.NoError(t, err)
+	require.Lenf(t, rows, 1, "extra sessions were detected: %v", rows)
+	// Insert fake leases with dead sessions IDs.
+	for i := 0; i < 52; i++ {
+		fakeSessionID, err := slstorage.MakeSessionID(enum.One, uuid.MakeV4())
+		require.NoError(t, err)
+		_, err = ie.Exec(ctx, "insert-fake-lease", nil,
+			"INSERT INTO system.lease(desc_id, version, sql_instance_id, session_id, crdb_region) VALUES ($1, $2, $3, $4, $5)",
+			keys.SystemDatabaseID, 1, 32, fakeSessionID.UnsafeBytes(), enum.One)
+		require.NoError(t, err)
+	}
+	// Mock a fake lease with multiple leases to test that our DELETE batching
+	// works.
+	fakeSessionID, err := slstorage.MakeSessionID(enum.One, uuid.MakeV4())
+	require.NoError(t, err)
+	for i := 0; i < 52; i++ {
+		_, err = ie.Exec(ctx, "insert-fake-lease", nil,
+			"INSERT INTO system.lease(desc_id, version, sql_instance_id, session_id, crdb_region) VALUES ($1, $2, $3, $4, $5)",
+			i, 1, 32, fakeSessionID.UnsafeBytes(), enum.One)
+		require.NoError(t, err)
+	}
+	lm := s.LeaseManager().(*lease.Manager)
+	now := timeutil.Now().UnixNano()
+	db := sqlutils.MakeSQLRunner(conn)
+	// Insert a new lease for a valid session, since we are deleting
+	// before the current timestamp.
+	db.Exec(t, "CREATE TABLE t1(n int)")
+	db.Exec(t, "SELECT * FROM t1")
+	lm.DeleteOrphanedLeases(ctx, now, s.Locality())
+
+	// Confirm our leases from dead sessions are gone.
+	testutils.SucceedsSoon(t, func() error {
+		rows, err := ie.QueryBuffered(ctx,
+			"detect-existing-leases",
+			nil,
+			"SELECT DISTINCT(session_id) FROM system.lease")
+		if err != nil {
+			return err
+		}
+		if len(rows) != 1 {
+			return errors.AssertionFailedf("extra sessions were detected: %v", rows)
+		}
+		return nil
+	})
+
+}
+
 // Tests that DeleteOrphanedLeases() deletes only orphaned leases.
 func TestDeleteOrphanedLeases(testingT *testing.T) {
 	defer leaktest.AfterTest(testingT)()
@@ -2209,7 +2276,7 @@ CREATE TABLE t.after (k CHAR PRIMARY KEY, v CHAR);
 	t.expectLeases(afterDesc.GetID(), "/1/1")
 
 	// Call DeleteOrphanedLeases() with the server startup time.
-	t.node(1).DeleteOrphanedLeases(ctx, now)
+	t.node(1).DeleteOrphanedLeases(ctx, now, t.server.Locality())
 	// Orphaned lease is gone.
 	t.expectLeases(beforeDesc.GetID(), "")
 	t.expectLeases(afterDesc.GetID(), "/1/1")

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -351,6 +351,7 @@ func (ds *ServerImpl) setupFlow(
 			Regions:                   &faketreeeval.DummyRegionOperator{},
 			Txn:                       leafTxn,
 			SQLLivenessReader:         ds.ServerConfig.SQLLivenessReader,
+			BlockingSQLLivenessReader: ds.ServerConfig.BlockingSQLLivenessReader,
 			SQLStatsController:        ds.ServerConfig.SQLStatsController,
 			SchemaTelemetryController: ds.ServerConfig.SchemaTelemetryController,
 			IndexUsageStatsController: ds.ServerConfig.IndexUsageStatsController,

--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -128,6 +128,10 @@ type ServerConfig struct {
 
 	// SQLLivenessReader provides access to reading the liveness of sessions.
 	SQLLivenessReader sqlliveness.Reader
+	// BlockingSQLLivenessReader is a sqlliveness.Reader that synchronously
+	// blocks to determine the status of a session which it does not know about or
+	// thinks might be expired.
+	BlockingSQLLivenessReader sqlliveness.Reader
 
 	// JobRegistry manages jobs being used by this Server.
 	JobRegistry *jobs.Registry

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -19,6 +19,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
+        "//pkg/sql/sqlliveness",
         "//pkg/sql/types",
         "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/faketreeeval/BUILD.bazel
+++ b/pkg/sql/faketreeeval/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",
-        "//pkg/sql/sqlliveness",
         "//pkg/sql/types",
         "//pkg/util/duration",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -121,6 +121,7 @@ func (evalCtx *extendedEvalContext) copyFromExecCfg(execCfg *ExecutorConfig) {
 	evalCtx.Tracer = execCfg.AmbientCtx.Tracer
 	if execCfg.SQLLiveness != nil { // nil in some tests
 		evalCtx.SQLLivenessReader = execCfg.SQLLiveness.CachedReader()
+		evalCtx.BlockingSQLLivenessReader = execCfg.SQLLiveness.BlockingReader()
 	}
 	evalCtx.CompactEngineSpan = execCfg.CompactEngineSpanFunc
 	evalCtx.SetCompactionConcurrency = execCfg.CompactionConcurrencyFunc

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -6863,6 +6863,27 @@ Parameters:` + randgencfg.ConfigDoc,
 			Info:       "Checks if given sqlliveness session id is not expired",
 			Volatility: volatility.Stable,
 		},
+		tree.Overload{
+			Types: tree.ParamTypes{
+				{Name: "session_id", Typ: types.Bytes},
+				{Name: "is_sync", Typ: types.Bool},
+			},
+			ReturnType: tree.FixedReturnType(types.Bool),
+			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				sid := sqlliveness.SessionID(*(args[0].(*tree.DBytes)))
+				reader := evalCtx.SQLLivenessReader
+				if tree.MustBeDBool(args[1]) {
+					reader = evalCtx.BlockingSQLLivenessReader
+				}
+				live, err := reader.IsAlive(ctx, sid)
+				if err != nil {
+					return tree.MakeDBool(true), err
+				}
+				return tree.MakeDBool(tree.DBool(live)), nil
+			},
+			Info:       "Checks if given sqlliveness session id is not expired (sync if is_sync is specified)",
+			Volatility: volatility.Stable,
+		},
 	),
 
 	// Used to configure the tenant token bucket. See UpdateTenantResourceLimits.

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2569,6 +2569,7 @@ var builtinOidsArray = []string{
 	2606: `crdb_internal.protect_mvcc_history(timestamp: decimal, expiration_window: interval, description: string) -> int`,
 	2607: `crdb_internal.extend_mvcc_history_protection(job_id: int) -> void`,
 	2608: `crdb_internal.force_panic(msg: string, mode: string) -> int`,
+	2684: `crdb_internal.sql_liveness_is_alive(session_id: bytes, is_sync: bool) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -212,6 +212,11 @@ type Context struct {
 
 	SQLLivenessReader sqlliveness.Reader
 
+	// BlockingSQLLivenessReader is a sqlliveness.Reader that synchronously
+	// blocks to determine the status of a session which it does not know about or
+	// thinks might be expired.
+	BlockingSQLLivenessReader sqlliveness.Reader
+
 	SQLStatsController SQLStatsController
 
 	SchemaTelemetryController SchemaTelemetryController


### PR DESCRIPTION
Backport:
  * 3/3 commits from "catalog/lease: clean up orphaned session based leases " (#141429)
  * 1/1 commits from "distsql: initialize BlockingSQLLivenessReader for remote flows" (#142255)

Please see individual PRs for details.

/cc @cockroachdb/release

Release note (bug fix): Fixed a bug where orphaned leases were not
properly cleaned up.
Release justification: low risk fix that cleans up stale session based leases, which with accumulation can cause all schema change to hang