### PR TITLE
opt: remove unnecessary RLS allocation and refactor

### DIFF
--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -335,9 +335,11 @@ func (md *Metadata) CopyFrom(from *Metadata, copyScalarFn func(Expr) Expr) {
 	md.withBindings = nil
 
 	md.rlsMeta = from.rlsMeta
-	md.rlsMeta.PoliciesApplied = make(map[TableID]PoliciesApplied)
-	for id, policies := range from.rlsMeta.PoliciesApplied {
-		md.rlsMeta.PoliciesApplied[id] = policies.Copy()
+	if len(from.rlsMeta.PoliciesApplied) > 0 {
+		md.rlsMeta.PoliciesApplied = make(map[TableID]PoliciesApplied)
+		for id, policies := range from.rlsMeta.PoliciesApplied {
+			md.rlsMeta.PoliciesApplied[id] = policies.Copy()
+		}
 	}
 }
 

--- a/pkg/sql/opt/metadata.go
+++ b/pkg/sql/opt/metadata.go
@@ -334,13 +334,7 @@ func (md *Metadata) CopyFrom(from *Metadata, copyScalarFn func(Expr) Expr) {
 	// We cannot copy the bound expressions; they must be rebuilt in the new memo.
 	md.withBindings = nil
 
-	md.rlsMeta = from.rlsMeta
-	if len(from.rlsMeta.PoliciesApplied) > 0 {
-		md.rlsMeta.PoliciesApplied = make(map[TableID]PoliciesApplied)
-		for id, policies := range from.rlsMeta.PoliciesApplied {
-			md.rlsMeta.PoliciesApplied[id] = policies.Copy()
-		}
-	}
+	md.rlsMeta = from.rlsMeta.Copy()
 }
 
 // MDDepName stores either the unresolved DataSourceName or the StableID from

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -104,6 +104,23 @@ func (r *RowLevelSecurityMeta) RefreshNoPoliciesAppliedForTable(tableID TableID)
 	}
 }
 
+// Copy returns a deep copy of the RowLevelSecurityMeta.
+func (r *RowLevelSecurityMeta) Copy() RowLevelSecurityMeta {
+	cpy := RowLevelSecurityMeta{
+		IsInitialized:     r.IsInitialized,
+		User:              r.User,
+		HasAdminRole:      r.HasAdminRole,
+		NoPoliciesApplied: r.NoPoliciesApplied,
+	}
+	for id, policies := range r.PoliciesApplied {
+		if cpy.PoliciesApplied == nil {
+			cpy.PoliciesApplied = make(map[TableID]PoliciesApplied)
+		}
+		cpy.PoliciesApplied[id] = policies.Copy()
+	}
+	return cpy
+}
+
 // PoliciesApplied stores the set of policies that were applied to a table.
 type PoliciesApplied struct {
 	// NoForceExempt is true if the policies were exempt because they were the


### PR DESCRIPTION
#### opt: remove unnecessary RLS allocation

```
name                                                  old time/op    new time/op    delta
Phases/json-insert/Prepared/AssignPlaceholdersNoNorm    3.89µs ± 1%    3.72µs ± 1%  -4.45%

name                                                  old alloc/op   new alloc/op   delta
Phases/json-insert/Prepared/AssignPlaceholdersNoNorm    3.05kB ± 0%    3.00kB ± 0%  -1.57%

name                                                  old allocs/op  new allocs/op  delta
Phases/json-insert/Prepared/AssignPlaceholdersNoNorm      22.0 ± 0%      21.0 ± 0%  -4.55%
```

Release note: None

#### opt: add RowLevelSecurityMeta.Copy

Release note: None
