### PR TITLE
kvcoord: fix the write buffer's adjustError

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -265,7 +265,7 @@ func (twb *txnWriteBuffer) SendLocked(
 
 	br, pErr := twb.wrapped.SendLocked(ctx, transformedBa)
 	if pErr != nil {
-		return nil, twb.adjustError(ctx, transformedBa, rr, pErr)
+		return nil, twb.adjustError(ctx, rr, pErr)
 	}
 
 	return twb.mergeResponseWithRequestRecords(ctx, rr, br)
@@ -442,7 +442,7 @@ func (twb *txnWriteBuffer) estimateSize(ba *kvpb.BatchRequest) int64 {
 // adjustError adjusts the provided error based on the transformations made by
 // the txnWriteBuffer to the batch request before sending it to KV.
 func (twb *txnWriteBuffer) adjustError(
-	ctx context.Context, ba *kvpb.BatchRequest, rr requestRecords, pErr *kvpb.Error,
+	ctx context.Context, rr requestRecords, pErr *kvpb.Error,
 ) *kvpb.Error {
 	// Fix the error index to hide the impact of any requests that were
 	// transformed.
@@ -452,39 +452,31 @@ func (twb *txnWriteBuffer) adjustError(
 		// therefore weren't sent to the KV layer. We can then adjust the error
 		// index accordingly.
 		numStripped := int32(0)
-		numOriginalRequests := len(ba.Requests) + len(rr)
 		baIdx := int32(0)
-		for i := range numOriginalRequests {
-			if len(rr) > 0 && rr[0].index == i {
-				curTs := rr[0]
-				rr = rr[1:]
-				if curTs.stripped {
-					numStripped++
-				} else {
-					// This is a transformed request (for example a LockingGet that was
-					// sent instead of a Del). In this case, the error might be a bit
-					// confusing to the client since the request that had an error isn't
-					// exactly the request the user sent.
-					//
-					// For now, we handle this by logging and removing the error index.
-					//
-					// [1] Get requests are always collected as transformations, but
-					// they're never transformed. Attributing an error to them shouldn't
-					// confuse the client.
-					if baIdx == pErr.Index.Index && curTs.origRequest.Method() != kvpb.Get {
-						log.Warningf(ctx, "error index %d is part of a transformed request", pErr.Index.Index)
-						pErr.Index = nil
-						return pErr
-					}
+		// Note that all requests in the batch are guaranteed to be in the list of
+		// request records.
+		for _, record := range rr {
+			if record.stripped {
+				numStripped++
+			} else {
+				// If this is a transformed request (for example a LockingGet that was
+				// sent instead of a Del), the error might be a bit confusing to the
+				// client since the request that had an error isn't exactly the request
+				// the user sent.
+				//
+				// For now, we handle this by logging and removing the error index.
+				//
+				// For requests that were not transformed, attributing an error to them
+				// shouldn't confuse the client.
+				if baIdx == pErr.Index.Index && record.transformed {
+					log.Warningf(ctx, "error index %d is part of a transformed request", pErr.Index.Index)
+					pErr.Index = nil
+					return pErr
+				} else if baIdx == pErr.Index.Index {
+					break
 				}
-				if curTs.origRequest.Method() != kvpb.Get {
-					continue
-				}
+				baIdx++
 			}
-			if baIdx == pErr.Index.Index {
-				break
-			}
-			baIdx++
 		}
 
 		pErr.Index.Index += numStripped
@@ -667,9 +659,8 @@ func (twb *txnWriteBuffer) applyTransformations(
 	baRemote := ba.ShallowCopy()
 	// TODO(arul): We could improve performance here by pre-allocating
 	// baRemote.Requests to the correct size by counting the number of Puts/Dels
-	// in ba.Requests. The same for the requestRecords slice. We could also
-	// allocate the right number of ResponseUnion, PutResponse, and DeleteResponse
-	// objects as well.
+	// in ba.Requests. We could also allocate the right number of ResponseUnion,
+	// PutResponse, and DeleteResponse objects as well.
 	baRemote.Requests = nil
 
 	rr := make(requestRecords, 0, len(ba.Requests))

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -1010,41 +1010,28 @@ func (twb *txnWriteBuffer) mergeResponseWithRequestRecords(
 		return br, nil
 	}
 
-	// Figure out the length of the merged responses slice.
-	mergedRespsLen := len(br.Responses)
-	for _, t := range rr {
-		if t.stripped {
-			mergedRespsLen++
-		}
-	}
-	mergedResps := make([]kvpb.ResponseUnion, mergedRespsLen)
-	for i := range mergedResps {
-		if len(rr) > 0 && rr[0].index == i {
-			if !rr[0].stripped {
-				// If the transformation wasn't stripped from the batch we sent to KV,
-				// we received a response for it, which then needs to be combined with
-				// what's in the write buffer.
-				resp := br.Responses[0]
-				mergedResps[i], pErr = rr[0].toResp(ctx, twb, resp, br.Txn)
-				if pErr != nil {
-					return nil, pErr
-				}
-				br.Responses = br.Responses[1:]
-			} else {
-				mergedResps[i], pErr = rr[0].toResp(ctx, twb, kvpb.ResponseUnion{}, br.Txn)
-				if pErr != nil {
-					return nil, pErr
-				}
+	// All original requests are guaranteed to be in the list of requestRecords,
+	// so the length of the merged responses is the same length as rr.
+	mergedResps := make([]kvpb.ResponseUnion, 0, len(rr))
+	for _, record := range rr {
+		brResp := kvpb.ResponseUnion{}
+		if !record.stripped {
+			if len(br.Responses) == 0 {
+				log.Fatal(ctx, "unexpectedly found a non-stripped request and no batch response")
 			}
-
-			rr = rr[1:]
-			continue
+			// If the request wasn't stripped from the batch we sent to KV, we
+			// received a response for it, which then needs to be combined with
+			// what's in the write buffer.
+			brResp = br.Responses[0]
+			br.Responses = br.Responses[1:]
 		}
-
-		// No transformation applies at this index. Copy over the response as is.
-		mergedResps[i] = br.Responses[0]
-		br.Responses = br.Responses[1:]
+		resp, pErr := record.toResp(ctx, twb, brResp, br.Txn)
+		if pErr != nil {
+			return nil, pErr
+		}
+		mergedResps = append(mergedResps, resp)
 	}
+
 	br.Responses = mergedResps
 	return br, nil
 }

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -408,17 +408,19 @@ func TestTxnWriteBufferCorrectlyAdjustsFlushErrors(t *testing.T) {
 // TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering ensures that the
 // txnWriteBuffer correctly adjusts the index of the errors returned when a part
 // of the batch is buffered on the client.
-//
-// TODO(arul): extend this test to transformations as well once we start
-// transforming read-write requests into separate bits.
 func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	for errIdx, resErrIdx := range map[int32]int32{
-		0: 1, // points to the GetB
-		1: 4, // points to the GetE
-		2: 5, // points to the GetF
+	for errIdx, resErrIdx := range map[int32]*kvpb.ErrPosition{
+		0: {Index: 1},  // points to the GetB
+		1: {Index: 4},  // points to the ScanE
+		2: {Index: 5},  // points to the RevScanF
+		3: nil,         // points to the CPutG
+		4: {Index: 7},  // points to the QueryLocks
+		5: {Index: 8},  // points to the LeaseInfo
+		6: nil,         // points to the CPutH
+		7: {Index: 11}, // points to the GetJ
 	} {
 		t.Run(fmt.Sprintf("errIdx=%d", errIdx), func(t *testing.T) {
 			ctx := context.Background()
@@ -426,8 +428,10 @@ func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
 
 			txn := makeTxnProto()
 			txn.Sequence = 1
-			keyA, keyB, keyC, keyD, keyE, keyF := roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c"),
-				roachpb.Key("d"), roachpb.Key("e"), roachpb.Key("f")
+			keyA, keyB, keyC, keyD, keyE, keyF, keyG, keyH, keyI, keyJ :=
+				roachpb.Key("a"), roachpb.Key("b"), roachpb.Key("c"), roachpb.Key("d"),
+				roachpb.Key("e"), roachpb.Key("f"), roachpb.Key("g"), roachpb.Key("h"),
+				roachpb.Key("i"), roachpb.Key("j")
 
 			// Construct a batch request where some of the requests will be buffered.
 			ba := &kvpb.BatchRequest{}
@@ -436,21 +440,38 @@ func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
 			getB := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyB}}
 			delC := delArgs(keyC, txn.Sequence)
 			putD := putArgs(keyD, "val2", txn.Sequence)
-			getE := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyE}}
-			getF := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyF}}
+			scanE := &kvpb.ScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyE}}
+			revScanF := &kvpb.ReverseScanRequest{RequestHeader: kvpb.RequestHeader{Key: keyF}}
+			cputG := &kvpb.ConditionalPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyG}}
+			queryLocks := &kvpb.QueryLocksRequest{}
+			leaseInfo := &kvpb.LeaseInfoRequest{}
+			cputH := &kvpb.ConditionalPutRequest{RequestHeader: kvpb.RequestHeader{Key: keyH}}
+			putI := putArgs(keyI, "val3", txn.Sequence)
+			getJ := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyJ}}
 
 			ba.Add(putA)
 			ba.Add(getB)
 			ba.Add(delC)
 			ba.Add(putD)
-			ba.Add(getE)
-			ba.Add(getF)
+			ba.Add(scanE)
+			ba.Add(revScanF)
+			ba.Add(cputG)
+			ba.Add(queryLocks)
+			ba.Add(leaseInfo)
+			ba.Add(cputH)
+			ba.Add(putI)
+			ba.Add(getJ)
 
 			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-				require.Len(t, ba.Requests, 3)
+				require.Len(t, ba.Requests, 8)
 				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
-				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[1].GetInner())
-				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[2].GetInner())
+				require.IsType(t, &kvpb.ScanRequest{}, ba.Requests[1].GetInner())
+				require.IsType(t, &kvpb.ReverseScanRequest{}, ba.Requests[2].GetInner())
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[3].GetInner())
+				require.IsType(t, &kvpb.QueryLocksRequest{}, ba.Requests[4].GetInner())
+				require.IsType(t, &kvpb.LeaseInfoRequest{}, ba.Requests[5].GetInner())
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[6].GetInner())
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[7].GetInner())
 
 				pErr := kvpb.NewErrorWithTxn(errors.New("boom"), &txn)
 				pErr.SetErrorIndex(errIdx)
@@ -461,9 +482,7 @@ func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
 			require.Nil(t, br)
 			require.NotNil(t, pErr)
 			require.Equal(t, &txn, pErr.GetTxn())
-
-			require.NotNil(t, pErr.Index)
-			require.Equal(t, resErrIdx, pErr.Index.Index)
+			require.Equal(t, resErrIdx, pErr.Index)
 
 			// The batch we sent encountered an error; nothing should have been
 			// buffered.


### PR DESCRIPTION
Previously, `adjustError` handled the cases of stripped requests (not sent to KV at all) and non-transformed requests (sent directly to KV), but didn't always handle the cases of transformed requests correctly.

This commit simplifies the logic in `adjustError` and adds additional testing.

Fixes: [#144694](https://github.com/cockroachdb/cockroach/issues/144694)

Release note: None