### PR TITLE
tsdump: better error message for virtual cluster

### DIFF
--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -160,7 +160,7 @@ will then convert it to the --format requested in the current invocation.
 			if debugTimeSeriesDumpOpts.format == tsDumpRaw {
 				stream, err := tsClient.DumpRaw(context.Background(), req)
 				if err != nil {
-					return err
+					return errors.Wrapf(err, "connecting to %s", conn.Target())
 				}
 
 				// Buffer the writes to os.Stdout since we're going to
@@ -190,7 +190,7 @@ will then convert it to the --format requested in the current invocation.
 			}
 			stream, err := tsClient.Dump(context.Background(), req)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "connecting to %s", conn.Target())
 			}
 			recv = stream.Recv
 		} else {
@@ -245,7 +245,7 @@ will then convert it to the --format requested in the current invocation.
 				return w.Flush()
 			}
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "connecting to %s", serverCfg.AdvertiseAddr)
 			}
 			if err := w.Emit(data); err != nil {
 				return err

--- a/pkg/ts/server.go
+++ b/pkg/ts/server.go
@@ -388,6 +388,20 @@ func (s *Server) DumpRaw(req *tspb.DumpRequest, stream tspb.TimeSeries_DumpRawSe
 	return dumpImpl(stream.Context(), s.db.db, req, d)
 }
 
+func (s *TenantServer) DumpRaw(_ *tspb.DumpRequest, _ tspb.TimeSeries_DumpRawServer) error {
+	return status.Errorf(codes.Unimplemented, "DumpRaw is not implemented for virtual clusters. "+
+		"If you are attempting to take a tsdump, please connect to the system virtual cluster, "+
+		"not an application virtual cluster. System virtual clusters will dump all persisted "+
+		"metrics from all virtual clusters.")
+}
+
+func (s *TenantServer) Dump(_ *tspb.DumpRequest, _ tspb.TimeSeries_DumpServer) error {
+	return status.Errorf(codes.Unimplemented, "Dump is not implemented for virtual clusters. "+
+		"If you are attempting to take a tsdump, please connect to the system virtual cluster, "+
+		"not an application virtual cluster. System virtual clusters will dump all persisted "+
+		"metrics from all virtual clusters.")
+}
+
 func dumpImpl(
 	ctx context.Context, db *kv.DB, req *tspb.DumpRequest, d func(*roachpb.KeyValue) error,
 ) error {


### PR DESCRIPTION
Wrap gRPC errors in `tsdump` with info about which host they're connecting to.

Add custom unimplemented error messages for tenant dump commands which instruct the user to connect to the "system virtual cluster".

Resolves: #142823

Release note: None