### PR TITLE
crosscluster/physical: ensure that set version fails on reader tenant

### DIFF
--- a/pkg/crosscluster/replicationtestutils/BUILD.bazel
+++ b/pkg/crosscluster/replicationtestutils/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/repstream/streampb",
         "//pkg/roachpb",
         "//pkg/security/username",
+        "//pkg/server",
         "//pkg/settings/cluster",
         "//pkg/spanconfig",
         "//pkg/spanconfig/spanconfigkvaccessor",

--- a/pkg/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/crosscluster/replicationtestutils/testutils.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -80,6 +81,7 @@ type TenantStreamingClustersArgs struct {
 	EnableReaderTenant             bool
 	TestingKnobs                   *sql.StreamingTestingKnobs
 	TenantCapabilitiesTestingKnobs *tenantcapabilities.TestingKnobs
+	ServerKnobs                    *server.TestingKnobs
 
 	MultitenantSingleClusterNumNodes    int
 	MultiTenantSingleClusterTestRegions []string
@@ -416,6 +418,10 @@ func CreateServerArgs(args TenantStreamingClustersArgs) base.TestServerArgs {
 			MaxRetries:     TestingMaxDistSQLRetries,
 		}
 	}
+	if args.ServerKnobs == nil {
+		// Prevents panics in cluster startup.
+		args.ServerKnobs = &server.TestingKnobs{}
+	}
 	return base.TestServerArgs{
 		DefaultTestTenant: base.TestControlsTenantsExplicitly,
 		Knobs: base.TestingKnobs{
@@ -430,6 +436,7 @@ func CreateServerArgs(args TenantStreamingClustersArgs) base.TestServerArgs {
 				// easy-to-predict IDs when we create a tenant after a drop.
 				EnableTenantIDReuse: true,
 			},
+			Server: args.ServerKnobs,
 		},
 		ExternalIODir: args.ExternalIODir,
 	}

--- a/pkg/upgrade/upgrademanager/BUILD.bazel
+++ b/pkg/upgrade/upgrademanager/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/multitenant/mtinfo",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/server/license",


### PR DESCRIPTION
Informs #143916

Release note (ops change): in a PCR deployment, it is not possible for the
destination system tenant or the reader tenant to upgrade the reader tenant by
setting the version setting. The user should follow these steps:
- upgrade the destination system tenant
- upgrade the source system tenant
- upgrade the source app tenant (these first 3 steps are already documented)
- wait for the replicated time to advanced past the time the source app tenant
  upgraded.
- shut down the reader tenant
- upgrade the dest host cluster
- re-initialize the reader tenant via
`ALTER VIRTUAL CLUSTER SET REPLICATION READ VIRTUAL CLUSTER`