### PR TITLE
kvserver: revert add NoReplicasMoved to AdminScatterResponse

### DIFF
--- a/pkg/backup/generative_split_and_scatter_processor.go
+++ b/pkg/backup/generative_split_and_scatter_processor.go
@@ -212,26 +212,11 @@ func (s dbSplitAndScatterer) scatter(
 			// throughput.
 			log.Errorf(ctx, "failed to scatter span [%s,%s): %+v",
 				newScatterKey, newScatterKey.Next(), pErr.GoError())
-		} else {
-			// Log at INFO level when scatter request is rejected because the range is
-			// non-empty (range size exceeds req.MaxSize). This is expected during
-			// RESTORE resume.
-			log.Infof(ctx, "failed to scatter span [%s,%s): %+v",
-				newScatterKey, newScatterKey.Next(), pErr.GoError())
 		}
 		return 0, nil
 	}
 
-	scatteredResp, ok := res.(*kvpb.AdminScatterResponse)
-	if !ok {
-		log.Fatalf(ctx, "expected AdminScatterResponse, got %T", res)
-	}
-	if scatteredResp.NoReplicasMoved {
-		// TODO(#144856): DR should consider retrying the scatter if no replicas
-		// were moved.
-		log.Warningf(ctx, "no replicas moved during scatter")
-	}
-	return s.findDestination(scatteredResp), nil
+	return s.findDestination(res.(*kvpb.AdminScatterResponse)), nil
 }
 
 // findDestination returns the node ID of the node of the destination of the

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -626,7 +626,6 @@ func (r *AdminScatterResponse) combine(_ context.Context, c combinable, _ *Batch
 		r.RangeInfos = append(r.RangeInfos, otherR.RangeInfos...)
 		r.MVCCStats.Add(otherR.MVCCStats)
 		r.ReplicasScatteredBytes += otherR.ReplicasScatteredBytes
-		r.NoReplicasMoved = r.NoReplicasMoved && otherR.NoReplicasMoved
 	}
 	return nil
 }

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -1974,13 +1974,6 @@ message AdminScatterResponse {
   // scattered
   int64 replicas_scattered_bytes = 5;
 
-  // NoReplicasMoved indicates whether no replicas were moved during the scatter
-  // operation. NB: this needs to be a separate field, since we can't reliably
-  // infer "no replica moved" from ReplicasScatteredBytes == 0. Empty ranges
-  // have stats.Total() == 0 and ReplicasScatteredBytes will be 0 regardless of
-  // whether any replicas were moved.
-  bool no_replicas_moved = 6;
-
   // NB: if you add a field here, don't forget to update combine().
 }
 

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -4266,11 +4266,6 @@ func (r *Replica) adminScatter(
 		// that were moved so the value may not be entirely accurate, but it is
 		// adequate.
 		ReplicasScatteredBytes: stats.Total() * int64(numReplicasMoved),
-		// NB: this needs to be a separate field, since we can't reliably infer
-		// "no replica moved" from ReplicasScatteredBytes == 0. Empty ranges have
-		// stats.Total() == 0 and ReplicasScatteredBytes will be 0 regardless of
-		// whether any replicas were moved.
-		NoReplicasMoved: numReplicasMoved == 0,
 	}, nil
 }
 


### PR DESCRIPTION
**Revert "backup: add warning when no replica moved from AdminScatter"**

This commit reverts 519f22c6a8e5030fcd73fba5618a82632561c3d6.

We found that the number of replicas moved is not a reliable criterion for DR to
rely on for retries. We're exploring alternative responses. As a simple example,
in a 3-node single-store cluster with RF=3, it is expected for AdminScatter to
move zero replicas. DR should not retry just because numnber of replicas moved
is zero.

Epic: none
Release note: none

---

**Revert "kvpb: add NoReplicasMoved to AdminScatterResponse"**

This commit reverts 8f00544fbc87b428671f90f348dadfdd519d8883.

We found that the number of replicas moved is not a reliable criterion for DR to
rely on for retries. We're exploring alternative responses. As a simple example,
in a 3-node single-store cluster with RF=3, it is expected for AdminScatter to
move zero replicas. DR should not retry just because numnber of replicas moved
is zero.

Epic: none
Release note: none


