### PR TITLE
kvserver: Reduce replica mutex contention Phase 2

### DIFF
--- a/pkg/kv/kvserver/client_replica_test.go
+++ b/pkg/kv/kvserver/client_replica_test.go
@@ -1975,7 +1975,7 @@ func TestLeaseExpirationBelowFutureTimeRequest(t *testing.T) {
 		now := l.tc.Servers[1].Clock().Now()
 
 		// Construct a future-time request timestamp past the current lease's
-		// expiration. See Replica.checkRequestTimeRLocked for the determination
+		// expiration. See Replica.checkRequestTime for the determination
 		// of whether a request timestamp is too far in the future or not.
 		leaseRenewal := l.tc.Servers[1].RaftConfig().RangeLeaseRenewalDuration()
 		leaseRenewalMinusStasis := leaseRenewal - l.tc.Servers[1].Clock().MaxOffset()

--- a/pkg/kv/kvserver/helpers_test.go
+++ b/pkg/kv/kvserver/helpers_test.go
@@ -702,10 +702,9 @@ func NewRangefeedTxnPusher(
 	}
 }
 
-// SupportFromEnabled exports (replicaRLockedStoreLiveness).SupportFromEnabled
-// for testing purposes.
-func (r *Replica) SupportFromEnabled() bool {
-	return (*replicaRLockedStoreLiveness)(r).SupportFromEnabled()
+// descRLocked exports (*Replica).descRLocked() for testing purposes.
+func (r *Replica) DescRLocked() *roachpb.RangeDescriptor {
+	return r.descRLocked()
 }
 
 // RaftFortificationEnabledForRangeID exports raftFortificationEnabledForRangeID

--- a/pkg/kv/kvserver/kvserverpb/state.proto
+++ b/pkg/kv/kvserver/kvserverpb/state.proto
@@ -42,6 +42,8 @@ message ReplicaState {
   // (*Replica).setDesc* methods.
   roachpb.RangeDescriptor desc = 3;
   // The latest range lease.
+  // The pointer may change, but the referenced Lease struct itself must be
+  // treated as immutable; it is leaked out of the lock.
   //
   // Note that this message is both sent over the network and used to model
   // replica state in memory. In memory (Replica.mu.state), the lease is never

--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -435,7 +435,7 @@ func TestUpdateLastUpdateTimesUsingStoreLiveness(t *testing.T) {
 			// Also see updateLastUpdateTimesUsingStoreLivenessRLocked which is the
 			// method being tested here.
 			DisableUpdateLastUpdateTimesMapOnRaftGroupStep: func(r *kvserver.Replica) bool {
-				return r.SupportFromEnabled()
+				return r.SupportFromEnabled(r.DescRLocked())
 			},
 		},
 	}

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1524,38 +1524,41 @@ func (r *Replica) GetGCHint() roachpb.GCHint {
 func (r *Replica) ExcludeDataFromBackup(ctx context.Context, sp roachpb.Span) (bool, error) {
 	r.mu.RLock()
 	defer r.mu.RUnlock()
-	return r.entireSpanExcludedFromBackupRLocked(ctx, sp)
+	return entireSpanExcludedFromBackup(ctx, sp, r.mu.conf.ExcludeDataFromBackup, r.mu.confSpan)
 }
 
-func (r *Replica) excludeReplicaFromBackupRLocked(ctx context.Context, rspan roachpb.RSpan) bool {
+func excludeReplicaFromBackup(
+	ctx context.Context, rspan roachpb.RSpan, excludeDataFromBackup bool, confSpan roachpb.Span,
+) bool {
 	// We ignore the error here to avoid failing requests that
 	// don't need to fail.
-	excluded, _ := r.entireSpanExcludedFromBackupRLocked(ctx, rspan.AsRawSpanWithNoLocals())
+	excluded, _ := entireSpanExcludedFromBackup(ctx, rspan.AsRawSpanWithNoLocals(),
+		excludeDataFromBackup, confSpan)
 	return excluded
 }
 
-// entireSpanExcludedFromBackupRLocked returns true if this replica
+// entireSpanExcludedFromBackup returns true if this replica
 // has ExcludeDataFromBackup set in its span configuration and that
 // span configuration covers the entire given span.
-func (r *Replica) entireSpanExcludedFromBackupRLocked(
-	ctx context.Context, sp roachpb.Span,
+func entireSpanExcludedFromBackup(
+	ctx context.Context, sp roachpb.Span, excludeDataFromBackup bool, confSpan roachpb.Span,
 ) (bool, error) {
-	if r.mu.conf.ExcludeDataFromBackup {
+	if excludeDataFromBackup {
 		// If ExcludeDataFromBackup is set, we also want to ensure that
 		// we only elide data if the span configuration we currently
 		// have actually contains the requested span.
-		if r.mu.confSpan.Equal(roachpb.Span{}) {
+		if confSpan.Equal(roachpb.Span{}) {
 			return false, errors.Newf("replica's span configuration bounds not set")
 		}
-		if !r.mu.confSpan.Contains(sp) {
+		if !confSpan.Contains(sp) {
 			log.Warningf(ctx, "ExcludeDataFromBackup set but span %q not containd by span config bounds %q",
 				sp,
-				r.mu.confSpan)
+				confSpan)
 
 			return false, nil
 		}
 	}
-	return r.mu.conf.ExcludeDataFromBackup, nil
+	return excludeDataFromBackup, nil
 }
 
 // Version returns the replica version.
@@ -1614,19 +1617,25 @@ func (r *Replica) GetRangeInfo(ctx context.Context) roachpb.RangeInfo {
 	}
 }
 
-// getImpliedGCThresholdRLocked returns the gc threshold of the replica which
+// getImpliedGCThreshold returns the gc threshold of the replica which
 // should be used to determine the validity of commands. The returned timestamp
 // may be newer than the replica's true GC threshold if strict enforcement
 // is enabled and the TTL has passed. If this is an admin command or this range
 // opts out of strict GC enforcement (typically data outside the user keyspace),
 // we return the true GC threshold.
-func (r *Replica) getImpliedGCThresholdRLocked(
-	st kvserverpb.LeaseStatus, isAdmin bool,
+func (r *Replica) getImpliedGCThreshold(
+	st kvserverpb.LeaseStatus,
+	isAdmin bool,
+	spanConfigExplicitlySet bool,
+	ignoreStrictEnforcement bool,
+	gcThreshold hlc.Timestamp,
+	cachedProtectedTS cachedProtectedTimestampState,
+	confTTL time.Duration,
 ) hlc.Timestamp {
 	// The GC threshold is the oldest value we can return here.
 	if isAdmin || !StrictGCEnforcement.Get(&r.store.ClusterSettings().SV) ||
-		r.shouldIgnoreStrictGCEnforcementRLocked() {
-		return *r.shMu.state.GCThreshold
+		r.shouldIgnoreStrictGCEnforcement(spanConfigExplicitlySet, ignoreStrictEnforcement) {
+		return gcThreshold
 	}
 
 	// In order to make this check inexpensive, we keep a copy of the reading of
@@ -1637,26 +1646,26 @@ func (r *Replica) getImpliedGCThresholdRLocked(
 	// has technically expired. Fortunately this strict enforcement is merely a
 	// user experience win; it's always safe to allow reads to continue so long
 	// as they are after the GC threshold.
-	c := r.mu.cachedProtectedTS
-	if st.State != kvserverpb.LeaseState_VALID || c.readAt.Less(st.Lease.Start.ToTimestamp()) {
-		return *r.shMu.state.GCThreshold
+	if st.State != kvserverpb.LeaseState_VALID ||
+		cachedProtectedTS.readAt.Less(st.Lease.Start.ToTimestamp()) {
+		return gcThreshold
 	}
 
-	gcTTL := r.mu.conf.TTL()
-	gcThreshold := gc.CalculateThreshold(c.readAt, gcTTL)
-	if !c.earliestProtectionTimestamp.IsEmpty() {
+	gcTTL := confTTL
+	newGCThreshold := gc.CalculateThreshold(cachedProtectedTS.readAt, gcTTL)
+	if !cachedProtectedTS.earliestProtectionTimestamp.IsEmpty() {
 		// We want to allow GC up to the timestamp preceding the earliest valid
 		// protection timestamp.
-		impliedGCThreshold := c.earliestProtectionTimestamp.Prev()
+		impliedGCThreshold := cachedProtectedTS.earliestProtectionTimestamp.Prev()
 		// If we have a protected timestamp record which precedes the gcThreshold,
 		// use the threshold it implies instead.
-		if impliedGCThreshold.Less(gcThreshold) {
-			gcThreshold = impliedGCThreshold
+		if impliedGCThreshold.Less(newGCThreshold) {
+			newGCThreshold = impliedGCThreshold
 		}
 	}
-	gcThreshold.Forward(*r.shMu.state.GCThreshold)
+	newGCThreshold.Forward(gcThreshold)
 
-	return gcThreshold
+	return newGCThreshold
 }
 
 func (r *Replica) isRangefeedEnabled() (ret bool) {
@@ -1673,8 +1682,10 @@ func (r *Replica) isRangefeedEnabledRLocked() (ret bool) {
 	return r.mu.conf.RangefeedEnabled
 }
 
-func (r *Replica) shouldIgnoreStrictGCEnforcementRLocked() (ret bool) {
-	if !r.mu.spanConfigExplicitlySet {
+func (r *Replica) shouldIgnoreStrictGCEnforcement(
+	spanConfigExplicitlySet bool, ignoreStrictEnforcement bool,
+) (ret bool) {
+	if !spanConfigExplicitlySet {
 		return true
 	}
 
@@ -1682,7 +1693,7 @@ func (r *Replica) shouldIgnoreStrictGCEnforcementRLocked() (ret bool) {
 		return true
 	}
 
-	return r.mu.conf.GCPolicy.IgnoreStrictEnforcement
+	return ignoreStrictEnforcement
 }
 
 // maxReplicaIDOfAny returns the maximum ReplicaID of any replica, including
@@ -2211,7 +2222,16 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 	}
 
 	r.mu.RLock()
-	defer r.mu.RUnlock()
+	lease := r.shMu.state.Lease
+	spanConfExplicitlySet := r.mu.spanConfigExplicitlySet
+	ignoreStrictEnforcement := r.mu.conf.GCPolicy.IgnoreStrictEnforcement
+	gcThreshold := *r.shMu.state.GCThreshold
+	cachedProtectedTS := r.mu.cachedProtectedTS
+	confTTL := r.mu.conf.TTL()
+	desc := r.descRLocked()
+	confSpan := r.mu.confSpan
+	excludeDataFromBackup := r.mu.conf.ExcludeDataFromBackup
+	r.mu.RUnlock()
 
 	// Ensure the request is entirely contained within the range's key bounds
 	// (even) after the storage engine has been pinned by the iterator. Given we
@@ -2219,8 +2239,8 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 	// meaningful in the context of follower reads. This is because latches on
 	// followers don't provide the synchronization with concurrent splits like
 	// they do on leaseholders.
-	if err := checkSpanInRange(ctx, rSpan, r.descRLocked(), r.shMu.state.Lease,
-		*r.cachedClosedTimestampPolicy.Load()); err != nil {
+	cachedClosedTimestampPolicy := *r.cachedClosedTimestampPolicy.Load()
+	if err := checkSpanInRange(ctx, rSpan, desc, lease, cachedClosedTimestampPolicy); err != nil {
 		return err
 	}
 
@@ -2237,7 +2257,9 @@ func (r *Replica) checkExecutionCanProceedAfterStorageSnapshot(
 	// TODO(aayush): The above description intentionally omits some details, as
 	// they are going to be changed as part of
 	// https://github.com/cockroachdb/cockroach/issues/55293.
-	return r.checkTSAboveGCThresholdRLocked(ctx, ba.EarliestActiveTimestamp(), st, ba.IsAdmin(), rSpan)
+	return r.checkTSAboveGCThreshold(ctx, ba.EarliestActiveTimestamp(), st, ba.IsAdmin(), rSpan,
+		spanConfExplicitlySet, ignoreStrictEnforcement, gcThreshold, cachedProtectedTS, confTTL,
+		desc, confSpan, excludeDataFromBackup)
 }
 
 // checkExecutionCanProceedRWOrAdmin returns an error if a batch request going
@@ -2330,7 +2352,10 @@ func (r *Replica) checkExecutionCanProceedForRangeFeed(
 	} else if !r.isRangefeedEnabledRLocked() && !RangefeedEnabled.Get(&r.store.cfg.Settings.SV) {
 		return errors.Errorf("[r%d] rangefeeds require the kv.rangefeed.enabled setting. See %s",
 			r.RangeID, docs.URL(`change-data-capture.html#enable-rangefeeds-to-reduce-latency`))
-	} else if err := r.checkTSAboveGCThresholdRLocked(ctx, ts, status, false /* isAdmin */, rSpan); err != nil {
+	} else if err := r.checkTSAboveGCThreshold(ctx, ts, status, false /* isAdmin */, rSpan,
+		r.mu.spanConfigExplicitlySet, r.mu.conf.GCPolicy.IgnoreStrictEnforcement,
+		*r.shMu.state.GCThreshold, r.mu.cachedProtectedTS, r.mu.conf.TTL(), r.descRLocked(),
+		r.mu.confSpan, r.mu.conf.ExcludeDataFromBackup); err != nil {
 		return err
 	}
 	return nil
@@ -2354,24 +2379,32 @@ func checkSpanInRange(
 			desc, cachedClosedTimestampPolicy)))
 }
 
-// checkTSAboveGCThresholdRLocked returns an error if a request (identified by
+// checkTSAboveGCThreshold returns an error if a request (identified by
 // its read timestamp) wants to read below the range's GC threshold.
-func (r *Replica) checkTSAboveGCThresholdRLocked(
+func (r *Replica) checkTSAboveGCThreshold(
 	ctx context.Context,
 	ts hlc.Timestamp,
 	st kvserverpb.LeaseStatus,
 	isAdmin bool,
 	rspan roachpb.RSpan,
+	spanConfigExplicitlySet bool,
+	ignoreStrictEnforcement bool,
+	gcThreshold hlc.Timestamp,
+	cachedProtectedTS cachedProtectedTimestampState,
+	confTTL time.Duration,
+	desc *roachpb.RangeDescriptor,
+	confSpan roachpb.Span,
+	excludeDataFromBackup bool,
 ) error {
-	threshold := r.getImpliedGCThresholdRLocked(st, isAdmin)
+	threshold := r.getImpliedGCThreshold(st, isAdmin, spanConfigExplicitlySet,
+		ignoreStrictEnforcement, gcThreshold, cachedProtectedTS, confTTL)
 	if threshold.Less(ts) {
 		return nil
 	}
-	desc := r.descRLocked()
 	return &kvpb.BatchTimestampBeforeGCError{
 		Timestamp:              ts,
 		Threshold:              threshold,
-		DataExcludedFromBackup: r.excludeReplicaFromBackupRLocked(ctx, rspan),
+		DataExcludedFromBackup: excludeReplicaFromBackup(ctx, rspan, excludeDataFromBackup, confSpan),
 		RangeID:                desc.RangeID,
 		StartKey:               desc.StartKey.AsRawKey(),
 		EndKey:                 desc.EndKey.AsRawKey(),

--- a/pkg/kv/kvserver/replica_circuit_breaker.go
+++ b/pkg/kv/kvserver/replica_circuit_breaker.go
@@ -284,7 +284,9 @@ func (r *Replica) replicaUnavailableErrorRLocked(err error) error {
 	replDesc, _ := desc.GetReplicaDescriptor(r.store.StoreID())
 
 	isLiveMap, _ := r.store.livenessMap.Load().(livenesspb.IsLiveMap)
-	ct := r.getCurrentClosedTimestampLocked(context.Background(), hlc.Timestamp{} /* sufficient */)
+	ct := r.getCurrentClosedTimestamp(context.Background(), hlc.Timestamp{}, /* sufficient */
+		r.shMu.state.LeaseAppliedIndex, r.shMu.state.Lease.Replica.NodeID,
+		r.shMu.state.RaftClosedTimestamp)
 
 	return replicaUnavailableError(err, desc, replDesc, isLiveMap, r.raftStatusRLocked(), ct)
 }

--- a/pkg/kv/kvserver/replica_closedts.go
+++ b/pkg/kv/kvserver/replica_closedts.go
@@ -88,7 +88,8 @@ func (r *Replica) BumpSideTransportClosed(
 
 	lai := r.shMu.state.LeaseAppliedIndex
 	policy, target := r.getTargetByPolicyRLocked(targetByPolicy)
-	st := r.leaseStatusForRequestRLocked(ctx, now, hlc.Timestamp{} /* reqTS */)
+	st := r.leaseStatusForRequest(ctx, now, hlc.Timestamp{} /* reqTS */, r.mu.minLeaseProposedTS,
+		r.mu.minValidObservedTimestamp, r.shMu.state.Lease, r.raftBasicStatusRLocked())
 	// We need to own the lease but note that stasis (LeaseState_UNUSABLE) doesn't
 	// matter.
 	valid := st.IsValid() || st.State == kvserverpb.LeaseState_UNUSABLE

--- a/pkg/kv/kvserver/replica_closedts_internal_test.go
+++ b/pkg/kv/kvserver/replica_closedts_internal_test.go
@@ -569,7 +569,9 @@ func TestReplicaClosedTimestamp(t *testing.T) {
 			// NB: don't release the mutex to make this test a bit more resilient to
 			// problems that could arise should something propose a command to this
 			// replica whose LeaseAppliedIndex we've mutated.
-			require.Equal(t, test.expClosed, tc.repl.getCurrentClosedTimestampLocked(ctx, hlc.Timestamp{} /* sufficient */))
+			require.Equal(t, test.expClosed, tc.repl.getCurrentClosedTimestamp(ctx,
+				hlc.Timestamp{} /* sufficient */, tc.repl.shMu.state.LeaseAppliedIndex,
+				tc.repl.shMu.state.Lease.Replica.NodeID, tc.repl.shMu.state.RaftClosedTimestamp))
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_closedts_test.go
+++ b/pkg/kv/kvserver/replica_closedts_test.go
@@ -691,7 +691,7 @@ func TestRejectedLeaseDoesntDictateClosedTimestamp(t *testing.T) {
 // TODO(nvanbenschoten,andrei): Currently, the benchmark indicates that a call
 // takes about 130ns. This exceeds the latency budget we've allocated to the
 // call. However, it looks like there is some low-hanging fruit. 70% of the time
-// is spent in leaseStatusForRequestRLocked, within which 24% of the total time
+// is spent in leaseStatusForRequest, within which 24% of the total time
 // is spent zeroing and copying memory and 30% of the total time is spent in
 // (*NodeLiveness).GetLiveness, grabbing the current node's liveness record. If
 // we eliminate some memory copying and pass the node liveness record in to the

--- a/pkg/kv/kvserver/replica_follower_read_test.go
+++ b/pkg/kv/kvserver/replica_follower_read_test.go
@@ -94,7 +94,9 @@ func TestCanServeFollowerRead(t *testing.T) {
 			r := tc.repl
 			r.mu.RLock()
 			defer r.mu.RUnlock()
-			require.Equal(t, test.expCanServeFollowerRead, r.canServeFollowerReadRLocked(ctx, ba))
+			require.Equal(t, test.expCanServeFollowerRead, r.canServeFollowerRead(ctx, ba,
+				r.shMu.state.Desc, r.shMu.state.LeaseAppliedIndex, r.shMu.state.Lease.Replica.NodeID,
+				r.shMu.state.RaftClosedTimestamp))
 		})
 	}
 }

--- a/pkg/kv/kvserver/replica_proposal.go
+++ b/pkg/kv/kvserver/replica_proposal.go
@@ -484,7 +484,7 @@ func (r *Replica) leasePostApplyLocked(
 
 	st := r.leaseStatusAtRLocked(ctx, now)
 	if leaseChangingHands && newLease.Type() == roachpb.LeaseExpiration &&
-		r.ownsValidLeaseRLocked(ctx, now) && !r.shouldUseExpirationLeaseRLocked() {
+		r.ownsValidLeaseRLocked(ctx, now) && !r.shouldUseExpirationLease(r.descRLocked()) {
 		// We've received and applied an expiration lease for a range that shouldn't
 		// keep using it, most likely as part of a lease transfer (which is always
 		// expiration-based). The lease is also still valid. Upgrade this lease to

--- a/pkg/kv/kvserver/replica_proposal_buf.go
+++ b/pkg/kv/kvserver/replica_proposal_buf.go
@@ -1278,7 +1278,7 @@ func (rp *replicaProposer) verifyLeaseRequestSafetyRLocked(
 		PrevLeaseExpired:   !r.ownsValidLeaseRLocked(ctx, r.Clock().NowAsClockTimestamp()),
 		NextLeaseHolder:    nextLease.Replica,
 		BypassSafetyChecks: bypassSafetyChecks,
-		DesiredLeaseType:   r.desiredLeaseTypeRLocked(),
+		DesiredLeaseType:   r.desiredLeaseType(r.descRLocked()),
 	}
 	if err := leases.Verify(ctx, st, in); err != nil {
 		if in.Transfer() {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2386,7 +2386,7 @@ func (r *Replica) maybeCampaignOnWakeLocked(ctx context.Context) {
 	raftStatus := r.mu.internalRaftGroup.BasicStatus()
 	livenessMap, _ := r.store.livenessMap.Load().(livenesspb.IsLiveMap)
 	if shouldCampaignOnWake(leaseStatus, r.store.StoreID(), raftStatus, livenessMap, r.descRLocked(),
-		r.requiresExpirationLeaseRLocked(), now.ToTimestamp()) {
+		r.requiresExpirationLease(r.descRLocked()), now.ToTimestamp()) {
 		r.campaignLocked(ctx)
 	}
 }

--- a/pkg/kv/kvserver/replica_store_liveness_test.go
+++ b/pkg/kv/kvserver/replica_store_liveness_test.go
@@ -161,9 +161,9 @@ func TestRaftFortificationDisabledForExpirationBasedLeases(t *testing.T) {
 		for _, test := range testCases {
 			repl := tc.GetFirstStoreFromServer(t, 0).LookupReplica(roachpb.RKey(test.key))
 			if useExpirationBasedLeases {
-				require.False(t, repl.SupportFromEnabled())
+				require.False(t, repl.SupportFromEnabled(repl.Desc()))
 			} else {
-				require.Equal(t, test.exp, repl.SupportFromEnabled())
+				require.Equal(t, test.exp, repl.SupportFromEnabled(repl.Desc()))
 			}
 		}
 	})

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -2361,7 +2361,7 @@ func (s *Store) Start(ctx context.Context, stopper *stop.Stopper) error {
 		// acquiring the new lease, which will wake them up.
 		//
 		// NB: cluster settings haven't propagated yet, so we have to check the last
-		// known lease instead of desiredLeaseTypeRLocked. We also check Sequence >
+		// known lease instead of desiredLeaseType. We also check Sequence >
 		// 0 to omit ranges that haven't seen a lease yet.
 		if l, _ := rep.GetLease(); !l.SupportsQuiescence() && l.Sequence > 0 {
 			rep.maybeUnquiesce(ctx, true /* wakeLeader */, true /* mayCampaign */)

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1194,7 +1194,7 @@ func (n *Node) startPeriodicLivenessCompaction(
 
 // updateNodeRangeCount updates the internal counter of the total ranges across
 // all stores. This value is used to make a decision on whether the node should
-// use expiration leases (see Replica.shouldUseExpirationLeaseRLocked).
+// use expiration leases (see Replica.shouldUseExpirationLease).
 func (n *Node) updateNodeRangeCount() {
 	var count int64
 	_ = n.stores.VisitStores(func(store *kvserver.Store) error {

--- a/pkg/sql/catalog/lease/storage.go
+++ b/pkg/sql/catalog/lease/storage.go
@@ -338,7 +338,7 @@ func (s storage) release(
 // a version of the descriptor. A descriptorVersionState with the
 // expiration time set to expiration is returned.
 //
-// This returns an error when Replica.checkTSAboveGCThresholdRLocked()
+// This returns an error when Replica.checkTSAboveGCThreshold()
 // returns an error when the expiration timestamp is less than the storage
 // layer GC threshold.
 func (s storage) getForExpiration(


### PR DESCRIPTION
The first 2 commits are based on https://github.com/cockroachdb/cockroach/pull/146085

This PR reduces the replica mutex contention for both checkExecutionCanProceedBeforeStorageSnapshot and checkExecutionCanProceedAfterStorageSnapshot by making each of the two methods only briefly take the mutex and release it after it copies everything it needs.

Running this microbenchmark:

```
rm -f /tmp/*.pb.gz && env GODEBUG=runtimecontentionstacks=1 go test ./pkg/sql/tests -run - -bench BenchmarkParallelSysbench/SQL/3node/oltp_read_write -v -test.benchtime=3000x -test.outputdir=/tmp -test.mutexprofile=mutex.pb.gz -test.mutexprofilefraction=100 -test.timeout 25s 2>&1
```

shows that the ReplicaMutex contention goes from `786.9ms` to `614.3ms`.

Before:
<img width="1728" alt="Screenshot 2025-05-06 at 6 04 48 PM" src="https://github.com/user-attachments/assets/1438d395-5edd-4370-a683-dceaee808cee" />

After:
<img width="1725" alt="Screenshot 2025-05-06 at 6 04 35 PM" src="https://github.com/user-attachments/assets/85aa2c19-ac14-48fa-91a0-ad45b2979fe4" />


Running benchdiff command:
```
rm -f /tmp/*.pb.gz && env GODEBUG=runtimecontentionstacks=1 benchdiff -b --old 6cbfc38325b68a2547165ef194699c781b15f476 -c 20 ./pkg/sql/tests -r BenchmarkParallelSysbench/SQL/3node/oltp_read_write --mutexprofile -d=3000x
```

Shows the resutls:

```
name                                           old time/op    new time/op    delta
ParallelSysbench/SQL/3node/oltp_read_write-24    1.39ms ± 4%    1.39ms ± 3%   ~     (p=0.912 n=10+10)

name                                           old errs/op    new errs/op    delta
ParallelSysbench/SQL/3node/oltp_read_write-24      0.01 ±57%      0.01 ±27%   ~     (p=0.092 n=10+10)

name                                           old alloc/op   new alloc/op   delta
ParallelSysbench/SQL/3node/oltp_read_write-24    2.07MB ± 1%    2.07MB ± 1%   ~     (p=0.912 n=10+10)

name                                           old allocs/op  new allocs/op  delta
ParallelSysbench/SQL/3node/oltp_read_write-24     8.29k ± 1%     8.30k ± 1%   ~     (p=0.684 n=10+10)
```


References: #140235

Release note: None