### PR TITLE
ui: always show network page for virtual clusters

### DIFF
--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -826,7 +826,7 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 		serverpb.FeatureFlags{
 			CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID) ||
 				s.sqlServer.serviceMode == mtinfopb.ServiceModeShared,
-			DisableKvLevelAdvancedDebug: true,
+			DisableKvLevelAdvancedDebug: s.sqlServer.serviceMode != mtinfopb.ServiceModeShared,
 		},
 	); err != nil {
 		return err


### PR DESCRIPTION
This page is gated behind the "advanced debug" feature flag. Instead of always disabling this for tenants, we compute the value based on the tenant mode. If the tenant is a shared-process one we allow this capability by default.

The backend endpoint is already permitted because shared process tenants are automatically authorized.

Resolves: #142378

Release note: None