### PR TITLE
workload: make literal-implementation a runtime-only flag

### DIFF
--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -279,6 +279,7 @@ var tpccMeta = workload.Meta{
 			`fake-time`:                {RuntimeOnly: true},
 			`txn-preamble-file`:        {RuntimeOnly: true},
 			`aost`:                     {RuntimeOnly: true, CheckConsistencyOnly: true},
+			`literal-implementation`:   {RuntimeOnly: true},
 		}
 
 		g.flags.IntVar(&g.warehouses, `warehouses`, 1, `Number of warehouses for loading`)


### PR DESCRIPTION
The recently merged #145257 added a literal-implementation flag to the tpcc kit but didn't mark the flag as runtime only. This PR adds the runtime-only designation for the flag.

Epic: None
Fixes: #136773
Fixes: #146049
Fixes: #144296
Release note: None