### PR TITLE
release-24.3: sql: fix DROP REGION error messages

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -439,16 +439,25 @@ func (p *planner) AlterDatabaseDropRegion(
 			)
 		}
 
+		// The system database, once it's been made multi-region, must not be
+		// allowed to go back.
 		isSystemDatabase := dbDesc.ID == keys.SystemDatabaseID
-		if allowDrop := allowDropFinalRegion.Get(&p.execCfg.Settings.SV); !allowDrop ||
-			// The system database, once it's been made multi-region, must not be
-			// allowed to go back.
-			isSystemDatabase {
+		if isSystemDatabase {
 			return nil, pgerror.Newf(
 				pgcode.InvalidDatabaseDefinition,
-				"databases in this cluster must have at least 1 region",
+				"cannot drop %s; system database must have at least 1 region",
 				n.Region,
-				sqlclustersettings.DefaultPrimaryRegionClusterSettingName,
+			)
+		}
+		if allowDrop := allowDropFinalRegion.Get(&p.execCfg.Settings.SV); !allowDrop {
+			return nil, errors.WithHintf(
+				pgerror.Newf(
+					pgcode.InvalidDatabaseDefinition,
+					"cannot drop %s; databases in this cluster must have at least 1 region",
+					n.Region,
+				),
+				"Try enabling the %s cluster setting.",
+				allowDropFinalRegion.Name(),
 			)
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #146135 on behalf of @rafiss.

----

The format arguments were not correct, and the error was misleading for the system database.

Epic: None
Release note: None

----

Release justification: fix to error message 