### PR TITLE
release-25.2: vecindex: bump test size under `race`

### DIFF
--- a/pkg/sql/vecindex/BUILD.bazel
+++ b/pkg/sql/vecindex/BUILD.bazel
@@ -50,6 +50,10 @@ go_test(
     ],
     data = ["//pkg/sql/vecindex/cspann:features_10000"],
     embed = [":vecindex"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Backport 1/1 commits from #145373 on behalf of @rickystewart.

----

Closes #145299

Epic: none
Release note: None

----

Release justification: test-only change.