### PR TITLE
release-24.1: explain: deflake TestMaximumMemoryUsage for good

### DIFF
--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -87,7 +87,6 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/treeprinter",
         "@com_github_cockroachdb_datadriven//:datadriven",
-        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
         "@in_gopkg_yaml_v2//:yaml_v2",

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilities"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
@@ -30,7 +31,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/datadriven"
-	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	yaml "gopkg.in/yaml.v2"
@@ -393,7 +393,21 @@ func TestMaximumMemoryUsage(t *testing.T) {
 	skip.UnderRace(t, "multinode cluster setup times out under race")
 
 	const numNodes = 3
-	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{})
+	tc := testcluster.StartTestCluster(t, numNodes, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Knobs: base.TestingKnobs{
+				SQLEvalContext: &eval.TestingKnobs{
+					// We disable the randomization of the batch sizes so that
+					// small number of gRPC calls is issued in the query below
+					// (with kv-batch-size=1 we would issue 10k of them which
+					// might result in dropping the ComponentStats proto that
+					// powers "maximum memory usage" from the trace, flaking the
+					// test).
+					ForceProductionValues: true,
+				},
+			},
+		},
+	})
 	ctx := context.Background()
 	defer tc.Stopper().Stop(ctx)
 
@@ -420,29 +434,19 @@ func TestMaximumMemoryUsage(t *testing.T) {
 		return err
 	})
 
-	// In rare cases (due to metamorphic randomization) we might drop the
-	// ComponentStats proto that powers "maximum memory usage" stat from the
-	// trace, so we add a retry loop around this.
-	testutils.SucceedsSoon(t, func() error {
-		rows := db.QueryStr(t, "EXPLAIN ANALYZE SELECT max(v) FROM t GROUP BY bucket;")
-		var output strings.Builder
-		maxMemoryRE := regexp.MustCompile(`maximum memory usage: ([\d\.]+) MiB`)
-		var maxMemoryUsage float64
-		for _, row := range rows {
-			output.WriteString(row[0])
-			output.WriteString("\n")
-			s := strings.TrimSpace(row[0])
-			if matches := maxMemoryRE.FindStringSubmatch(s); len(matches) > 0 {
-				var err error
-				maxMemoryUsage, err = strconv.ParseFloat(matches[1], 64)
-				if err != nil {
-					return err
-				}
-			}
+	rows := db.QueryStr(t, "EXPLAIN ANALYZE SELECT max(v) FROM t GROUP BY bucket;")
+	var output strings.Builder
+	maxMemoryRE := regexp.MustCompile(`maximum memory usage: ([\d\.]+) MiB`)
+	var maxMemoryUsage float64
+	for _, row := range rows {
+		output.WriteString(row[0])
+		output.WriteString("\n")
+		s := strings.TrimSpace(row[0])
+		if matches := maxMemoryRE.FindStringSubmatch(s); len(matches) > 0 {
+			var err error
+			maxMemoryUsage, err = strconv.ParseFloat(matches[1], 64)
+			require.NoError(t, err)
 		}
-		if maxMemoryUsage < 5.0 {
-			return errors.Newf("expected maximum memory usage to be at least 5 MiB, full output:\n\n%s", output.String())
-		}
-		return nil
-	})
+	}
+	require.Greaterf(t, maxMemoryUsage, 5.0, "expected maximum memory usage to be at least 5 MiB, full output:\n\n%s", output.String())
 }


### PR DESCRIPTION
Backport 1/1 commits from #146155 on behalf of @yuzefovich.

----

This commit reverts adeddb51ab96a542bd1c5d8c36fb37043fb58040 which attempted to deflake `TestMaximumMemoryUsage` which could fail under metamorphic randomization. Instead, this commit simply forces production values for the relevant batch sizes (I think `kv-batch-size` is the one to blame) because the previous attempt of introducing the retry loop could still flake.

Fixes: #146052.

Release note: None

----

Release justification: test-only change.