### PR TITLE
logictest: skip mixed_version_stats in 24.3 version

### DIFF
--- a/pkg/sql/logictest/logictestbase/logictestbase.go
+++ b/pkg/sql/logictest/logictestbase/logictestbase.go
@@ -649,6 +649,8 @@ var DefaultConfigSets = map[string]ConfigSet{
 
 	// Special alias for all testserver configs (for mixed-version testing).
 	"cockroach-go-testserver-configs": makeConfigSet(
+		// TODO(yuzefovich): when removing 24.3 version from here, ensure to
+		// use the alias in mixed_version_stats.
 		"cockroach-go-testserver-24.3",
 		"cockroach-go-testserver-25.1",
 	),

--- a/pkg/sql/logictest/testdata/logic_test/mixed_version_stats
+++ b/pkg/sql/logictest/testdata/logic_test/mixed_version_stats
@@ -1,4 +1,4 @@
-# LogicTest: cockroach-go-testserver-configs
+# LogicTest: cockroach-go-testserver-25.1
 
 # This is a regression test for #137386 which verifies the hyperloglog library
 # upgrade for the table stats. We want such a distributed table stats collection

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/BUILD.bazel
@@ -11,7 +11,7 @@ go_test(
         "//pkg/sql/logictest:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "heavy"},
-    shard_count = 11,
+    shard_count = 10,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/cockroach-go-testserver-24.3/generated_test.go
@@ -115,13 +115,6 @@ func TestLogic_mixed_version_plpgsql_srf(
 	runLogicTest(t, "mixed_version_plpgsql_srf")
 }
 
-func TestLogic_mixed_version_stats(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "mixed_version_stats")
-}
-
 func TestLogic_mixed_version_timeseries_range_already_exists(
 	t *testing.T,
 ) {


### PR DESCRIPTION
Recently merged commit jumped the gun on merging a change that is incompatible with 24.3. We haven't yet removed
`cockroach-go-testserver-24.3` config so we skip it for now for the mixed version stats test (the config isn't valid anymore but will be removed some time soon).

Fixes: #146132.

Release note: None