### PR TITLE
release-25.1: util/leaktest: ignore util/goschedstats.init goroutine

### DIFF
--- a/pkg/util/leaktest/leaktest.go
+++ b/pkg/util/leaktest/leaktest.go
@@ -69,6 +69,9 @@ func interestingGoroutines() map[int64]string {
 			// duration of the process.
 			strings.Contains(stack, "log.flushDaemon") ||
 			strings.Contains(stack, "log.signalFlusher") ||
+			// Ignore the goschedstats goroutine that lives for the duration of
+			// the process.
+			strings.Contains(stack, "util/goschedstats.init") ||
 			// Below are the stacks ignored by the upstream leaktest code.
 			strings.Contains(stack, "testing.Main(") ||
 			strings.Contains(stack, "testing.tRunner(") ||
@@ -171,7 +174,7 @@ func AfterTest(t T) func() {
 	}
 }
 
-// diffGoroutines compares the current goroutines with the base snapshort and
+// diffGoroutines compares the current goroutines with the base snapshot and
 // returns an error if they differ.
 func diffGoroutines(base map[int64]string) error {
 	var leaked []string
@@ -187,7 +190,7 @@ func diffGoroutines(base map[int64]string) error {
 	sort.Strings(leaked)
 	var b strings.Builder
 	for _, g := range leaked {
-		b.WriteString(fmt.Sprintf("Leaked goroutine: %v\n\n", g))
+		b.WriteString(fmt.Sprintf("\nLeaked goroutine: %v\n", g))
 	}
 	return errors.Newf("%s", b.String())
 }


### PR DESCRIPTION
Backport 1/1 commits from #146157 on behalf of @yuzefovich.

----

In `util/goschedstats.init` function we create a long-running goroutine that lives for the duration of the process and is never explicitly finished. Thus, this goroutine should be ignored by the leaktest.

Fixes: #124102.
Fixes: #146090.

Release note: None

----

Release justification: test-only change.