### PR TITLE
vecindex: make fixes for vecbench workload

### DIFF
--- a/pkg/cmd/vecbench/main.go
+++ b/pkg/cmd/vecbench/main.go
@@ -31,7 +31,6 @@ import (
 )
 
 const defaultDataset = "unsplash-512-euclidean"
-const tempDir = "tmp"
 const minPartitionSize = 16
 const maxPartitionSize = 128
 
@@ -86,9 +85,9 @@ var flagDBConnStr = flag.String("db", "postgresql://root@localhost:26257",
 //	sift-128-euclidean (1M vectors, 128 dims)
 //	dbpedia-openai-100k-angular (100K vectors, 1536 dims)
 //
-// After download, the datasets are cached in a local tmp directory and a vector
-// index is created. The built vector index is also cached in the tmp directory
-// so that it can be rapidly reconstituted across benchmark runs.
+// After download, the datasets are cached in a local temp directory and a
+// vector index is created. The built vector index is also cached in the temp
+// directory so that it can be rapidly reconstituted across benchmark runs.
 //
 // The search benchmark runs over a set of test vectors that are not part of the
 // indexed vectors. It outputs average recall rates across the test vectors for

--- a/pkg/sql/vecindex/cspann/fixup_split.go
+++ b/pkg/sql/vecindex/cspann/fixup_split.go
@@ -131,14 +131,6 @@ func (fw *fixupWorker) splitPartition(
 		}
 	}
 
-	if metadata.Level != LeafLevel && partition.Count() == 0 {
-		if partitionKey != RootKey || metadata.StateDetails.State == ReadyState {
-			// Something's terribly wrong, abort and hope that merge can clean this up.
-			return errors.AssertionFailedf("non-leaf partition %d (state=%s) should not have 0 vectors",
-				partitionKey, metadata.StateDetails.State.String())
-		}
-	}
-
 	// Update partition's state to Splitting.
 	if metadata.StateDetails.State == ReadyState {
 		expected := metadata

--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -587,8 +587,7 @@ force-split partition-key=2 parent-partition-key=1
 ----
 • 1 (3, 6)
 │
-├───• 2 (3, 6) [DrainingForSplit:4,5]
-├───• 4 (5, 6) [Updating:2]
+├───• 5 (5, 6)
 │   │
 │   └───• 3 (5, 6)
 │       │
@@ -596,7 +595,7 @@ force-split partition-key=2 parent-partition-key=1
 │       ├───• vec3 (6, 8)
 │       └───• vec4 (6, 5)
 │
-└───• 5 (5, 6) [Updating:2]
+└───• 4 (5, 6)
     │
     └───• 3 (5, 6)
         │


### PR DESCRIPTION
#### cspann: remove spurious assert in splitPartition

In the past, it was illegal for an interior partition in the vector index
to be empty. It's now allowed, but an assert in splitPartition was never
updated to reflect the new rules. Remove this now spurious assert, which
was firing under high stress.

#### vecindex: cache index files in same dir as downloaded datasets

Previously, the cached index files used by the in-memory vecbench were
stored in a vecbench/tmp directory. Re-locate them to the same cache
directory used when downloading datasets for benchmarking, at
~/.cache/workload-datasets.