### PR TITLE
security: update TestTLSCipherRestrict test setup

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -93,7 +93,6 @@ go_test(
         "//pkg/server",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
-        "//pkg/testutils/skip",
         "//pkg/util/envutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -359,6 +359,12 @@ type ApplicationLayerInterface interface {
 	// with verbose method name.
 	GetUnauthenticatedHTTPClient() (http.Client, error)
 
+	// GetUnauthenticatedHTTPClientWithTransport returns an http client and its
+	// corresponding transport configured with the client TLS config required by
+	// the TestServer's configuration. Discourages implementer from using
+	// unauthenticated http connections with verbose method name.
+	GetUnauthenticatedHTTPClientWithTransport() (http.Client, *http.Transport, error)
+
 	// GetAdminHTTPClient returns an http client which has been
 	// authenticated to access Admin API methods (via a cookie).
 	// The user has admin privileges.


### PR DESCRIPTION
Current test setup starts the test server only once and runs various tls cipher
configurations but this seems to fail the test as final cipher configuration set
by previous run of the test may not be overridden by current run, and we have
stale ciphers configured for the subtest. Another issue is the timout being set
is 2s which may fail and increasing it is not possible as the test may timeout
before that leading to leaky goroutines. Hence, handling the http client
response timeouts as a flake. Waitgroups are added for all client calls to
ensure there are no open connections during test breakdown.

fixes #145812
fixes #145527
fixes #145459
fixes #145313

Release Note: None