### PR TITLE
tenanttokenbucket: improve redacted logging

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/tenanttokenbucket/tenant_token_bucket.go
@@ -197,7 +197,7 @@ func (s *State) Reconfigure(
 	s.clampToLimit()
 	log.Infof(
 		ctx, "token bucket for tenant %s reconfigured: available=%g refill-rate=%g burst-limit=%g",
-		tenantID.String(), s.TokenCurrent, s.TokenRefillRate, s.TokenBurstLimit,
+		tenantID, s.TokenCurrent, s.TokenRefillRate, s.TokenBurstLimit,
 	)
 }
 


### PR DESCRIPTION
Fixes:

```
token bucket for tenant ‹×› reconfigured: available=300000 refill-rate=30000 burst-limit=300000
```

Epic: none
