### PR TITLE
cli: validate integrity of debug.zip file post generation

### DIFF
--- a/pkg/cli/cliflags/flags.go
+++ b/pkg/cli/cliflags/flags.go
@@ -1795,6 +1795,14 @@ Can be set to 1 to ensure only one node is polled for data at a time.
 `,
 	}
 
+	ZipValidateFile = FlagInfo{
+		Name: "validate-zip-file",
+		Description: `
+Validate debug zip file after generation. This is a quick check to validate
+whether the generated zip file is valid and not corrupted.
+`,
+	}
+
 	StmtDiagDeleteAll = FlagInfo{
 		Name:        "all",
 		Description: `Delete all bundles.`,

--- a/pkg/cli/context.go
+++ b/pkg/cli/context.go
@@ -372,6 +372,10 @@ type zipContext struct {
 
 	// The log/heap/etc files to include.
 	files fileSelection
+
+	// validateZipFile indicates whether the generated zip file should be validated
+	// post debug zip file generation.
+	validateZipFile bool
 }
 
 // setZipContextDefaults set the default values in zipCtx.  This
@@ -394,6 +398,7 @@ func setZipContextDefaults() {
 	zipCtx.includeRunningJobTraces = true
 	zipCtx.cpuProfDuration = 5 * time.Second
 	zipCtx.concurrency = 15
+	zipCtx.validateZipFile = true
 
 	// File selection covers the last 48 hours by default.
 	// We add 24 hours to now for the end timestamp to ensure

--- a/pkg/cli/flags.go
+++ b/pkg/cli/flags.go
@@ -764,6 +764,7 @@ func init() {
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRangeInfo, cliflags.ZipIncludeRangeInfo)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeStacks, cliflags.ZipIncludeGoroutineStacks)
 		cliflagcfg.BoolFlag(f, &zipCtx.includeRunningJobTraces, cliflags.ZipIncludeRunningJobTraces)
+		cliflagcfg.BoolFlag(f, &zipCtx.validateZipFile, cliflags.ZipValidateFile)
 	}
 	// List-files + Zip commands.
 	for _, cmd := range []*cobra.Command{debugZipCmd, debugListFilesCmd} {

--- a/pkg/cli/testdata/zip/partial1
+++ b/pkg/cli/testdata/zip/partial1
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=0s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=0s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/partial1_excluded
+++ b/pkg/cli/testdata/zip/partial1_excluded
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip /dev/null --concurrency=1 --exclude-nodes=2 --cpu-profile-duration=0
+debug zip /dev/null --concurrency=1 --exclude-nodes=2 --cpu-profile-duration=0 --validate-zip-file=false
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/partial2
+++ b/pkg/cli/testdata/zip/partial2
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=0 /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=0 --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip
+++ b/pkg/cli/testdata/zip/testzip
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_concurrent
+++ b/pkg/cli/testdata/zip/testzip_concurrent
@@ -212,4 +212,4 @@ zip
 [node ?] ? log files found
 [node ?] ? log files found
 [node ?] ? log files found
-debug zip --timeout=30s --cpu-profile-duration=0s /dev/null
+debug zip --timeout=30s --cpu-profile-duration=0s --validate-zip-file=false /dev/null

--- a/pkg/cli/testdata/zip/testzip_exclude_goroutine_stacks
+++ b/pkg/cli/testdata/zip/testzip_exclude_goroutine_stacks
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s --include-goroutine-stacks=false /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false --include-goroutine-stacks=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_exclude_range_info
+++ b/pkg/cli/testdata/zip/testzip_exclude_range_info
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info=false /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info=false --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_external_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_external_process_virtualization
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_fallback
+++ b/pkg/cli/testdata/zip/testzip_fallback
@@ -1,5 +1,5 @@
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...
@@ -44,7 +44,7 @@ debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
 [cluster] tenant hot range summary script... writing binary output: debug/hot-ranges-tenant.sh... done
 [cluster] capture debug zip flags... writing binary output: debug/debug_zip_command_flags.txt... done
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_include_goroutine_stacks
+++ b/pkg/cli/testdata/zip/testzip_include_goroutine_stacks
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_include_range_info
+++ b/pkg/cli/testdata/zip/testzip_include_range_info
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_redacted
+++ b/pkg/cli/testdata/zip/testzip_redacted
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s --redact /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --redact --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
+++ b/pkg/cli/testdata/zip/testzip_shared_process_virtualization_with_default_tenant
@@ -1,6 +1,6 @@
 zip
 ----
-debug zip --concurrency=1 --cpu-profile-duration=1s /dev/null
+debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false /dev/null
 [cluster] discovering virtual clusters... done
 [cluster] creating output file /dev/null... done
 [cluster] establishing RPC connection to ...

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -6,6 +6,7 @@
 package cli
 
 import (
+	"archive/zip"
 	"context"
 	"database/sql/driver"
 	"fmt"
@@ -179,6 +180,32 @@ func (zc *debugZipContext) getRedactedNodeDetails(
 
 type nodeLivenesses = map[roachpb.NodeID]livenesspb.NodeLivenessStatus
 
+// validateZipFile checks the integrity of the generated zip file.
+func validateZipFile(zipFilePath string, zr *zipReporter) error {
+	// skip validation if the user has not requested it.
+	if !zipCtx.validateZipFile {
+		return nil
+	}
+	// Open the zip file.
+	r, err := zip.OpenReader(zipFilePath)
+
+	defer func(r *zip.ReadCloser) {
+		if r != nil {
+			err := r.Close()
+			if err != nil {
+				zr.info("failed to close zip file: %v", err)
+			}
+		}
+	}(r)
+
+	if err != nil {
+		zr.info("The generated file %s is corrupt. Please retry debug zip generation. error: %v", zipFilePath, err)
+		return err
+	}
+
+	return nil
+}
+
 func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 	if err := zipCtx.files.validate(); err != nil {
 		return err
@@ -245,6 +272,9 @@ func runDebugZip(cmd *cobra.Command, args []string) (retErr error) {
 	z := newZipper(out)
 	defer func() {
 		cErr := z.close()
+		if err = validateZipFile(dirName, zr); err != nil {
+			retErr = errors.CombineErrors(retErr, err)
+		}
 		retErr = errors.CombineErrors(retErr, cErr)
 	}()
 	s.done()

--- a/pkg/cli/zip_tenant_test.go
+++ b/pkg/cli/zip_tenant_test.go
@@ -91,7 +91,7 @@ func TestTenantZip(t *testing.T) {
 				tenant.preZip(t, c)
 			}
 
-			out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s " + os.DevNull)
+			out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false " + os.DevNull)
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -165,7 +165,7 @@ func TestZip(t *testing.T) {
 	})
 	defer c.Cleanup()
 
-	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s " + os.DevNull)
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -211,7 +211,7 @@ func TestZipQueryFallback(t *testing.T) {
 	})
 	defer c.Cleanup()
 
-	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s " + os.DevNull)
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -242,7 +242,7 @@ func TestZipRedacted(t *testing.T) {
 	})
 	defer c.Cleanup()
 
-	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --redact " + os.DevNull)
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --redact --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -291,7 +291,7 @@ func TestZipIncludeGoroutineStacks(t *testing.T) {
 				}},
 			})
 			defer c.Cleanup()
-			cmd := "debug zip --concurrency=1 --cpu-profile-duration=1s "
+			cmd := "debug zip --concurrency=1 --cpu-profile-duration=1s --validate-zip-file=false "
 			if !tc.includeStacks {
 				cmd = cmd + "--include-goroutine-stacks=false "
 			}
@@ -332,7 +332,7 @@ func TestZipIncludeRangeInfo(t *testing.T) {
 	})
 	defer c.Cleanup()
 
-	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info " + os.DevNull)
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -367,7 +367,7 @@ func TestZipExcludeRangeInfo(t *testing.T) {
 	defer c.Cleanup()
 
 	out, err := c.RunWithCapture(
-		"debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info=false " + os.DevNull)
+		"debug zip --concurrency=1 --cpu-profile-duration=1s --include-range-info=false --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -420,7 +420,7 @@ func TestConcurrentZip(t *testing.T) {
 	defer func(prevStderr *os.File) { stderr = prevStderr }(stderr)
 	stderr = os.Stdout
 
-	out, err := c.RunWithCapture("debug zip --timeout=30s --cpu-profile-duration=0s " + os.DevNull)
+	out, err := c.RunWithCapture("debug zip --timeout=30s --cpu-profile-duration=0s --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -733,7 +733,7 @@ func TestPartialZip(t *testing.T) {
 	defer func(prevStderr *os.File) { stderr = prevStderr }(stderr)
 	stderr = os.Stdout
 
-	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=0s " + os.DevNull)
+	out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=0s --validate-zip-file=false " + os.DevNull)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -748,7 +748,8 @@ func TestPartialZip(t *testing.T) {
 		})
 
 	// Now do it again and exclude the down node explicitly.
-	out, err = c.RunWithCapture("debug zip " + os.DevNull + " --concurrency=1 --exclude-nodes=2 --cpu-profile-duration=0")
+	out, err = c.RunWithCapture("debug zip " + os.DevNull + " --concurrency=1 --exclude-nodes=2 --cpu-profile-duration=0" +
+		"  --validate-zip-file=false")
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -783,7 +784,7 @@ func TestPartialZip(t *testing.T) {
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "zip", "partial2"),
 		func(t *testing.T, td *datadriven.TestData) string {
 			f := func() string {
-				out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=0 " + os.DevNull)
+				out, err := c.RunWithCapture("debug zip --concurrency=1 --cpu-profile-duration=0  --validate-zip-file=false " + os.DevNull)
 				if err != nil {
 					t.Fatal(err)
 				}


### PR DESCRIPTION
Previously, we have received corrupt debug.zip files for analysing escalations. We have seen few incidents where debug.zip file is corrupt at the source. This patch adds additional quick validation to check integrity of generated debug.zip file. We are not iterating over all files of debug.zip to validate because it requires to read entire file and then calculate and compare checksum. We are failing debug zip command if the file is corrupt.

Epic: none
Part of: CRDB-48697
Release note (cli change): Introduced additional check for generated debug zip to ensure integrity of the file.

---
screenshot of output during failure case
![Screenshot 2025-05-06 at 7 08 27 PM](https://github.com/user-attachments/assets/8927cd44-2e91-457d-9365-effcecf6d2e6)

