### PR TITLE
release-25.2: roachtest: fix tenant auto upgrade scheduling user hooks during setup

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -938,10 +938,12 @@ func (p *testPlanner) finalizeUpgradeSteps(
 		// auto-upgrading after resetting a cluster setting, we need to
 		// "manually" run the migrations at this point.
 		if toVersion.AtLeast(tenantSupportsAutoUpgradeVersion) {
-			steps = append(
-				steps,
-				p.concurrently(mixedVersionLabel, p.hooks.MixedVersionSteps(p.currentContext, p.prng))...,
-			)
+			if scheduleHooks {
+				steps = append(
+					steps,
+					p.concurrently(mixedVersionLabel, p.hooks.MixedVersionSteps(p.currentContext, p.prng))...,
+				)
+			}
 		} else {
 			runStepsWithTenantMigrations()
 		}


### PR DESCRIPTION
Backport 1/1 commits from #146115.

/cc @cockroachdb/release

---

The mixed version planner splits up a plan into two partitions, setup steps and test steps. The latter will have user hooks scheduled while the former will omit them.

The scheduling of user hooks is gated by the scheduleHooks boolean. However, there was one edge case which omitted this check and allowed for user hooks to be scheduled during version finalization of a tenant.

Fixes: #145951
Release note: none

Release Justification: test only change