### PR TITLE
release-25.2: sql: fix internal failure with temp tables during ALTER operations

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1,6 +1,9 @@
 # knob-opt: sync-event-log
 # LogicTest: multiregion-9node-3region-3azs multiregion-9node-3region-3azs-tenant multiregion-9node-3region-3azs-no-los
 
+statement ok
+SET experimental_enable_temp_tables=true
+
 query TTTTT colnames,rowsort
 SHOW REGIONS
 ----
@@ -791,6 +794,14 @@ create database alter_survive_db
 statement ok
 use alter_survive_db
 
+# Including a type and a temp to repro issue #97975. Prior to fixing that, ADD
+# REGION would fail because it couldn't find a temp schema
+statement ok
+create type my_enum as enum ('value1', 'value2');
+
+statement ok
+CREATE TEMP TABLE tbl (a int)
+
 statement error database must have associated regions before a survival goal can be set
 alter database alter_survive_db survive region failure
 
@@ -805,6 +816,9 @@ alter database alter_survive_db add region "ap-southeast-2"
 
 statement ok
 alter database alter_survive_db add region "us-east-1"
+
+statement ok
+drop type my_enum;
 
 # Create some tables to validate that their zone configurations are adjusted appropriately.
 query TT

--- a/pkg/sql/database.go
+++ b/pkg/sql/database.go
@@ -106,7 +106,7 @@ func (p *planner) forEachMutableTableInDatabase(
 	dbDesc catalog.DatabaseDescriptor,
 	fn func(ctx context.Context, scName string, tbDesc *tabledesc.Mutable) error,
 ) error {
-	all, err := p.Descriptors().GetAllDescriptors(ctx, p.txn)
+	all, err := p.Descriptors().GetAll(ctx, p.txn)
 	if err != nil {
 		return err
 	}

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -481,3 +481,32 @@ statement ok
 DROP DATABASE database_108751 CASCADE
 
 subtest end
+
+# Test ALTER TYPE when a temp table exists.
+subtest alter_type
+
+statement ok
+USE defaultdb;
+
+statement ok
+SET experimental_enable_temp_tables=on
+
+statement ok
+create type my_enum as enum ('value1', 'value2');
+
+statement ok
+create temporary table tmp_table (id int primary key);
+
+statement ok
+insert into tmp_table values (1), (2), (3);
+
+statement ok
+ALTER TYPE my_enum ADD VALUE 'value3';
+
+statement ok
+DROP TYPE my_enum;
+
+statement ok
+DROP TABLE tmp_table;
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #145551.

/cc @cockroachdb/release

---

Certain operations—such as ALTER TYPE or ALTER DATABASE ... ADD REGION—could trigger an assertion failure if temporary tables were present. The failure occurred in planner.forEachMutableTableInDatabase, which used GetAllDescriptors. That method excludes temp schemas, so schema resolution for a temp table would fail.

The fix replaces GetAllDescriptors with GetAll, which includes temp schemas and avoids the failure.

Note: a broader catalog API issue around accessing temp objects across sessions (see issue #97822) remains unresolved.

Fixes #97975

Epic: none
Release note (bug fix): Fixed an internal assertion failure that could occur during operations like ALTER TYPE or ALTER DATABASE ... ADD REGION when temporary tables were present.

Release justification: trivial fix that has been hit a few times