### PR TITLE
release-25.2: logictest: increase closed ts in buffered_writes further

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -404,7 +404,7 @@ SELECT count(*) FROM uvw
 user host-cluster-root
 
 statement ok
-SET CLUSTER SETTING kv.closed_timestamp.target_duration = '30s'
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '99999s'
 
 user root
 


### PR DESCRIPTION
Backport 1/1 commits from #146136 on behalf of @yuzefovich.

----

We still see a RETRY_SERIALIZABLE error on COMMIT of a txn that reads large blobs under race, so increase the closed ts interval even further (beyond the test timeout).

Fixes: #145891.
Fixes: #145963.
Fixes: #146092.

Release note: None

----

Release justification: test-only change.