### PR TITLE
catalog: gracefully handle invalid entries in system.comments

### DIFF
--- a/pkg/sql/catalog/catalogkeys/keys.go
+++ b/pkg/sql/catalog/catalogkeys/keys.go
@@ -120,6 +120,14 @@ func MakeCommentKey(objID uint32, subID uint32, cmtType CommentType) CommentKey 
 	}
 }
 
+// Validate returns if a comment key is valid.
+func (k CommentKey) Validate() error {
+	if !IsValidCommentType(k.CommentType) {
+		return errors.Errorf("invalid comment type: %d on object ID: %d", k.CommentType, k.ObjectID)
+	}
+	return nil
+}
+
 // IndexColumnEncodingDirection converts a direction from the proto to an
 // encoding.Direction.
 func IndexColumnEncodingDirection(dir catenumpb.IndexColumn_Direction) (encoding.Direction, error) {

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -495,6 +495,11 @@ func (tc *Collection) WriteCommentToBatch(
 		}
 	}
 
+	// Validate the values being used when updating the table.
+	if !catalogkeys.IsValidCommentType(key.CommentType) {
+		return errors.AssertionFailedf("invalid comment type %d", key.CommentType)
+	}
+
 	var err error
 	if expValues == nil {
 		err = cmtWriter.Insert(ctx, b, kvTrace, values...)

--- a/pkg/sql/catalog/internal/catkv/catalog_query.go
+++ b/pkg/sql/catalog/internal/catkv/catalog_query.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 )
 
@@ -70,6 +71,12 @@ func (cq catalogQuery) query(
 				err = cq.processDescriptorResultRow(row, out)
 			case keys.CommentsTableID:
 				err = cq.processCommentsResultRow(row, out)
+				// Any errors processing comments can be ignored these are not fatal.
+				if err != nil {
+					log.VInfof(ctx, 2, "unable to process a comment : %v", err)
+					err = nil
+					continue
+				}
 			case keys.ZonesTableID:
 				err = cq.processZonesResultRow(row, out)
 			default:

--- a/pkg/sql/catalog/nstree/catalog_mutable.go
+++ b/pkg/sql/catalog/nstree/catalog_mutable.go
@@ -13,7 +13,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/internal/validate"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/zone"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
-	"github.com/cockroachdb/errors"
 )
 
 // MutableCatalog is like Catalog but mutable.
@@ -144,8 +143,8 @@ func (mc *MutableCatalog) UpsertDescriptor(desc catalog.Descriptor) {
 // UpsertComment upserts a ((ObjectID, SubID, CommentType) -> Comment) mapping
 // into the catalog.
 func (mc *MutableCatalog) UpsertComment(key catalogkeys.CommentKey, cmt string) error {
-	if !catalogkeys.IsValidCommentType(key.CommentType) {
-		return errors.AssertionFailedf("invalid comment type %d", key.CommentType)
+	if err := key.Validate(); err != nil {
+		return err
 	}
 	e := mc.ensureForID(descpb.ID(key.ObjectID))
 	mc.byteSize -= e.ByteSize()

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6391,7 +6391,7 @@ CREATE TABLE crdb_internal.invalid_objects (
 )`,
 	populate: func(
 		ctx context.Context, p *planner, dbContext catalog.DatabaseDescriptor, addRow func(...tree.Datum) error,
-	) error {
+	) (retError error) {
 		// The internalLookupContext will only have descriptors in the current
 		// database. To deal with this, we fall through.
 		c, err := p.Descriptors().GetAllFromStorageUnvalidated(ctx, p.txn)
@@ -6537,6 +6537,54 @@ CREATE TABLE crdb_internal.invalid_objects (
 				return doDescriptorValidationErrors(ctx, desc, lCtx)
 			}); err != nil {
 				return err
+			}
+
+			// Validate the system.comments table.
+			txn := p.InternalSQLTxn()
+			rows, err := txn.QueryIterator(ctx, "scan-comments-table",
+				txn.KV(), "SELECT type, object_id, sub_id FROM system.comments")
+			if err != nil {
+				return err
+			}
+			defer func() {
+				if err := rows.Close(); err != nil {
+					retError = errors.CombineErrors(retError, err)
+				}
+			}()
+			for {
+				hasMore, err := rows.Next(ctx)
+				if err != nil {
+					return err
+				}
+				if !hasMore {
+					break
+				}
+				datums := rows.Cur()
+				commentType := tree.MustBeDInt(datums[0])
+				objectID := tree.MustBeDInt(datums[1])
+				subID := tree.MustBeDInt(datums[2])
+				cmtKey := catalogkeys.MakeCommentKey(uint32(objectID), uint32(subID), catalogkeys.CommentType(commentType))
+				// Validate the objects exist for the comments.
+				desc := c.LookupDescriptor(descpb.ID(objectID))
+				if desc == nil {
+					missingDescErr := errors.AssertionFailedf("comment exists for non-existent descriptor %d", objectID)
+					if err := addRow(
+						tree.NewDInt(objectID),
+						tree.NewDString(""),
+						tree.NewDString(""),
+						tree.NewDString(""),
+						tree.NewDString(missingDescErr.Error()),
+						tree.NewDString(missingDescErr.Error())); err != nil {
+						return err
+					}
+					continue
+				}
+				// Validate the comment key is sane.
+				if validationErr := cmtKey.Validate(); validationErr != nil {
+					if err := addValidationErrorRow(desc, validationErr, lCtx); err != nil {
+						return err
+					}
+				}
 			}
 
 			return c.ForEachNamespaceEntry(func(ne nstree.NamespaceEntry) error {

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -296,8 +296,15 @@ CREATE TABLE t_99316(a INT);
 statement ok
 INSERT INTO system.comments VALUES (4294967122, 't_99316'::regclass::OID, 0, 'bar');
 
-statement error pgcode XX000 internal error: invalid comment type 4294967122
+# Invalid comments will be ignored
+statement ok
 SELECT * FROM pg_catalog.pg_description WHERE objoid = 't'::regclass::OID;
+
+# Validation errors will be generated for them in invalid_objects.
+query ITTTT
+SELECT * FROM crdb_internal.invalid_objects ORDER BY id;
+----
+111  test  public  t_99316  invalid comment type: 4294967122 on object ID: 111
 
 statement ok
 DELETE FROM system.comments WHERE type = 4294967122
@@ -368,3 +375,30 @@ SELECT * FROM SYSTEM.COMMENTS;
 ----
 type  object_id  sub_id  comment
 4     109        0       Database_Schema
+
+# Test what happens if a user intentionally adds invalid comments.
+subtest validate_invalid_comments
+
+statement ok
+INSERT INTO system.comments VALUES (32, 11111, 0, 'abc');
+INSERT INTO system.comments VALUES (32, 1, 0, 'abc');
+
+# Validate we can scan pg_description fine even if an invalid
+# comment exists.
+statement ok
+SELECT count(*) FROM pg_catalog.pg_description
+
+query ITTTT
+SELECT * FROM crdb_internal.invalid_objects ORDER BY id;
+----
+1      system  ·  ·  invalid comment type: 32 on object ID: 1
+11111  ·       ·  ·  comment exists for non-existent descriptor 11111
+
+statement ok
+DELETE FROM system.comments WHERE type=32;
+
+query ITTTT
+SELECT * FROM crdb_internal.invalid_objects ORDER BY id;
+----
+
+subtest end


### PR DESCRIPTION
Previously, an invalid comment in system.comments would cause errors when reading the referenced descriptor. This was problematic because a bad comment referencing a descriptor could make it unreadable. This issue became more significant when descriptor collections started reading metadata along with descriptors.

This patch addresses this by:
- Logging such validation errors only if verbose logging is enabled.
- Detecting invalid comments in the crdb_internal.invalid_objects table.

Fixes: #145933

Release note (bug fix): An invalid comment in the system.comment table for a schema object can make it inacessible.