### PR TITLE
metric: make new metadata fields optional

### DIFF
--- a/pkg/util/metric/metric.proto
+++ b/pkg/util/metric/metric.proto
@@ -68,7 +68,7 @@ message Metadata {
   repeated LabelPair static_labels = 7;
   // if a labeled_name is provided, it will be output in the /metrics endpoint
   // with the corresponding static labels.
-  required string labeled_name = 8 [(gogoproto.nullable) = false];
+  optional string labeled_name = 8 [(gogoproto.nullable) = false];
 
   enum Category {
     UNSET = 0;
@@ -92,11 +92,11 @@ message Metadata {
   // if essential is true, the metric is required to be included in
   // a DB Console dashboard, in our public docs, and in all tsdump
   // exports.
-  required bool essential = 9 [(gogoproto.nullable) = false];
+  optional bool essential = 9 [(gogoproto.nullable) = false];
   // category is the dashboard category of this metric. This is
   // required if `essential` is true.
-  required Category category = 11 [(gogoproto.nullable) = false];
+  optional Category category = 11 [(gogoproto.nullable) = false];
   // how_to_use is an extended description of how to use this metric
   // with a running cluster. This is required if `essential` is true.
-  required string how_to_use = 12 [(gogoproto.nullable) = false];
+  optional string how_to_use = 12 [(gogoproto.nullable) = false];
 }


### PR DESCRIPTION
Marking these new fields optional reflects their nature more correctly.

Release note: None