### PR TITLE
release-25.2: ttljob: add cluster setting to control concurrency

### DIFF
--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -174,7 +174,7 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 
 	group := ctxgroup.WithContext(ctx)
 	processorSpanCount := int64(len(ttlSpec.Spans))
-	processorConcurrency := int64(runtime.GOMAXPROCS(0))
+	processorConcurrency := ttlbase.GetProcessorConcurrency(&flowCtx.Cfg.Settings.SV, int64(runtime.GOMAXPROCS(0)))
 	if processorSpanCount < processorConcurrency {
 		processorConcurrency = processorSpanCount
 	}


### PR DESCRIPTION
Backport 1/1 commits from #145578 on behalf of @rafiss.

----

Each processor of the TTL job creates a number of goroutines that operate concurrently to scan for expired rows and delete them.

Previously, the concurrency was always equal to GOMAXPROCS. This new setting allows it to be overriden.

Once this is merged, we should update support runbooks to discuss this setting.

Informs: https://github.com/cockroachlabs/support/issues/3284
Epic: None
Release note: None

----

Release justification: adds a new non-public opt-in setting