### PR TITLE
sql: improve routine dependency tracking

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4190,6 +4190,10 @@ func (m *sessionDataMutator) SetInitialRetryBackoffForReadCommitted(val time.Dur
 	m.data.InitialRetryBackoffForReadCommitted = val
 }
 
+func (m *sessionDataMutator) SetUseImprovedRoutineDependencyTracking(val bool) {
+	m.data.UseImprovedRoutineDependencyTracking = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -563,20 +563,6 @@ CREATE TABLE tab_145100 (
 )
 
 statement ok
-CREATE PROCEDURE proc_insert_145100(in_id UUID, in_i INT) LANGUAGE SQL AS $$
-  INSERT INTO tab_145100 (id, i) VALUES (in_id, in_i);
-$$;
-
-# Note: Due to https://github.com/cockroachdb/cockroach/issues/145098, the
-# procedure has a dependency on the shard column. When that issue is resolved,
-# this DROP statement should succeed.
-statement error cannot drop column "crdb_internal_i_shard_16" because function "proc_insert_145100" depends on it
-DROP INDEX tab_145100@tab_145100_i_idx
-
-statement ok
-DROP PROCEDURE proc_insert_145100
-
-statement ok
 CREATE PROCEDURE proc_select_145100() LANGUAGE SQL AS $$
   SELECT *, crdb_internal_i_shard_16 FROM tab_145100;
 $$;
@@ -585,7 +571,18 @@ statement error cannot drop column "crdb_internal_i_shard_16" because function "
 DROP INDEX tab_145100@tab_145100_i_idx
 
 statement ok
-DROP INDEX tab_145100@tab_145100_i_idx CASCADE
+DROP PROCEDURE proc_select_145100
+
+statement ok
+CREATE PROCEDURE proc_insert_145100(in_id UUID, in_i INT) LANGUAGE SQL AS $$
+  INSERT INTO tab_145100 (id, i) VALUES (in_id, in_i);
+$$;
+
+statement ok
+DROP INDEX tab_145100@tab_145100_i_idx
+
+statement ok
+DROP PROCEDURE proc_insert_145100
 
 skipif config local-schema-locked
 query T

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -574,15 +574,9 @@ statement ok
 DROP PROCEDURE proc_select_145100
 
 statement ok
-SET use_improved_routine_dependency_tracking = true;
-
-statement ok
 CREATE PROCEDURE proc_insert_145100(in_id UUID, in_i INT) LANGUAGE SQL AS $$
   INSERT INTO tab_145100 (id, i) VALUES (in_id, in_i);
 $$;
-
-statement ok
-RESET use_improved_routine_dependency_tracking;
 
 statement ok
 DROP INDEX tab_145100@tab_145100_i_idx

--- a/pkg/sql/logictest/testdata/logic_test/drop_index
+++ b/pkg/sql/logictest/testdata/logic_test/drop_index
@@ -574,9 +574,15 @@ statement ok
 DROP PROCEDURE proc_select_145100
 
 statement ok
+SET use_improved_routine_dependency_tracking = true;
+
+statement ok
 CREATE PROCEDURE proc_insert_145100(in_id UUID, in_i INT) LANGUAGE SQL AS $$
   INSERT INTO tab_145100 (id, i) VALUES (in_id, in_i);
 $$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
 
 statement ok
 DROP INDEX tab_145100@tab_145100_i_idx

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4133,6 +4133,7 @@ unbounded_parallel_scans                                   off
 unconstrained_non_covering_index_scan_enabled              off
 unsafe_allow_triggers_modifying_cascades                   off
 use_cputs_on_non_unique_indexes                            off
+use_improved_routine_dependency_tracking                   off
 use_pre_25_2_variadic_builtins                             off
 variable_inequality_lookup_join_enabled                    on
 vector_search_beam_size                                    32

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4133,7 +4133,7 @@ unbounded_parallel_scans                                   off
 unconstrained_non_covering_index_scan_enabled              off
 unsafe_allow_triggers_modifying_cascades                   off
 use_cputs_on_non_unique_indexes                            off
-use_improved_routine_dependency_tracking                   off
+use_improved_routine_dependency_tracking                   on
 use_pre_25_2_variadic_builtins                             off
 variable_inequality_lookup_join_enabled                    on
 vector_search_beam_size                                    32

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3128,6 +3128,7 @@ unconstrained_non_covering_index_scan_enabled              off                 N
 unsafe_allow_triggers_modifying_cascades                   off                 NULL      NULL        NULL        string
 use_cputs_on_non_unique_indexes                            off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                             on                  NULL      NULL        NULL        string
+use_improved_routine_dependency_tracking                   off                 NULL      NULL        NULL        string
 use_pre_25_2_variadic_builtins                             off                 NULL      NULL        NULL        string
 variable_inequality_lookup_join_enabled                    on                  NULL      NULL        NULL        string
 vector_search_beam_size                                    32                  NULL      NULL        NULL        string
@@ -3359,6 +3360,7 @@ unconstrained_non_covering_index_scan_enabled              off                 N
 unsafe_allow_triggers_modifying_cascades                   off                 NULL  user     NULL      off                 off
 use_cputs_on_non_unique_indexes                            off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                             on                  NULL  user     NULL      on                  on
+use_improved_routine_dependency_tracking                   off                 NULL  user     NULL      off                 off
 use_pre_25_2_variadic_builtins                             off                 NULL  user     NULL      off                 off
 variable_inequality_lookup_join_enabled                    on                  NULL  user     NULL      on                  on
 vector_search_beam_size                                    32                  NULL  user     NULL      32                  32
@@ -3582,6 +3584,7 @@ unconstrained_non_covering_index_scan_enabled              NULL    NULL     NULL
 unsafe_allow_triggers_modifying_cascades                   NULL    NULL     NULL     NULL        NULL
 use_cputs_on_non_unique_indexes                            NULL    NULL     NULL     NULL        NULL
 use_declarative_schema_changer                             NULL    NULL     NULL     NULL        NULL
+use_improved_routine_dependency_tracking                   NULL    NULL     NULL     NULL        NULL
 use_pre_25_2_variadic_builtins                             NULL    NULL     NULL     NULL        NULL
 variable_inequality_lookup_join_enabled                    NULL    NULL     NULL     NULL        NULL
 vector_search_beam_size                                    NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3128,7 +3128,7 @@ unconstrained_non_covering_index_scan_enabled              off                 N
 unsafe_allow_triggers_modifying_cascades                   off                 NULL      NULL        NULL        string
 use_cputs_on_non_unique_indexes                            off                 NULL      NULL        NULL        string
 use_declarative_schema_changer                             on                  NULL      NULL        NULL        string
-use_improved_routine_dependency_tracking                   off                 NULL      NULL        NULL        string
+use_improved_routine_dependency_tracking                   on                  NULL      NULL        NULL        string
 use_pre_25_2_variadic_builtins                             off                 NULL      NULL        NULL        string
 variable_inequality_lookup_join_enabled                    on                  NULL      NULL        NULL        string
 vector_search_beam_size                                    32                  NULL      NULL        NULL        string
@@ -3360,7 +3360,7 @@ unconstrained_non_covering_index_scan_enabled              off                 N
 unsafe_allow_triggers_modifying_cascades                   off                 NULL  user     NULL      off                 off
 use_cputs_on_non_unique_indexes                            off                 NULL  user     NULL      off                 off
 use_declarative_schema_changer                             on                  NULL  user     NULL      on                  on
-use_improved_routine_dependency_tracking                   off                 NULL  user     NULL      off                 off
+use_improved_routine_dependency_tracking                   on                  NULL  user     NULL      on                  on
 use_pre_25_2_variadic_builtins                             off                 NULL  user     NULL      off                 off
 variable_inequality_lookup_join_enabled                    on                  NULL  user     NULL      on                  on
 vector_search_beam_size                                    32                  NULL  user     NULL      32                  32

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -242,6 +242,7 @@ unconstrained_non_covering_index_scan_enabled              off
 unsafe_allow_triggers_modifying_cascades                   off
 use_cputs_on_non_unique_indexes                            off
 use_declarative_schema_changer                             on
+use_improved_routine_dependency_tracking                   off
 use_pre_25_2_variadic_builtins                             off
 variable_inequality_lookup_join_enabled                    on
 vector_search_beam_size                                    32

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -242,7 +242,7 @@ unconstrained_non_covering_index_scan_enabled              off
 unsafe_allow_triggers_modifying_cascades                   off
 use_cputs_on_non_unique_indexes                            off
 use_declarative_schema_changer                             on
-use_improved_routine_dependency_tracking                   off
+use_improved_routine_dependency_tracking                   on
 use_pre_25_2_variadic_builtins                             off
 variable_inequality_lookup_join_enabled                    on
 vector_search_beam_size                                    32

--- a/pkg/sql/logictest/testdata/logic_test/udf_delete
+++ b/pkg/sql/logictest/testdata/logic_test/udf_delete
@@ -312,10 +312,16 @@ CREATE TABLE t146414 (
 )
 
 statement ok
+SET use_improved_routine_dependency_tracking = true;
+
+statement ok
 CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
   DELETE FROM t146414 WHERE a = 1 RETURNING b;
   SELECT 1;
 $$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
 
 statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
 ALTER TABLE t146414 DROP COLUMN b;

--- a/pkg/sql/logictest/testdata/logic_test/udf_delete
+++ b/pkg/sql/logictest/testdata/logic_test/udf_delete
@@ -312,16 +312,10 @@ CREATE TABLE t146414 (
 )
 
 statement ok
-SET use_improved_routine_dependency_tracking = true;
-
-statement ok
 CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
   DELETE FROM t146414 WHERE a = 1 RETURNING b;
   SELECT 1;
 $$;
-
-statement ok
-RESET use_improved_routine_dependency_tracking;
 
 statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
 ALTER TABLE t146414 DROP COLUMN b;

--- a/pkg/sql/logictest/testdata/logic_test/udf_delete
+++ b/pkg/sql/logictest/testdata/logic_test/udf_delete
@@ -302,3 +302,25 @@ SELECT * FROM u_a;
 2  b  20
 
 subtest end
+
+subtest regression_146414
+
+statement ok
+CREATE TABLE t146414 (
+  a INT NOT NULL,
+  b INT AS (a + 1) VIRTUAL
+)
+
+statement ok
+CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
+  DELETE FROM t146414 WHERE a = 1 RETURNING b;
+  SELECT 1;
+$$;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
+ALTER TABLE t146414 DROP COLUMN b;
+
+statement ok
+SELECT f146414()
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_delete
+++ b/pkg/sql/logictest/testdata/logic_test/udf_delete
@@ -324,3 +324,40 @@ statement ok
 SELECT f146414()
 
 subtest end
+
+# Make sure that the routine does not add unnecessary columns as dependencies.
+subtest drop_column
+
+statement ok
+CREATE TABLE table_drop (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  d INT AS (a + b) STORED,
+  -- Hash-sharded indexes generate a hidden computed column.
+  INDEX i (b ASC) USING HASH
+);
+INSERT INTO table_drop VALUES (1,2,3), (4,5,6), (7,8,9);
+
+statement ok
+CREATE FUNCTION f_delete() RETURNS INT LANGUAGE SQL AS $$
+  DELETE FROM table_drop WHERE a = b - 1;
+  SELECT 1;
+$$;
+
+statement ok
+DROP INDEX i;
+
+statement ok
+ALTER TABLE table_drop DROP COLUMN d;
+
+statement ok
+ALTER TABLE table_drop DROP COLUMN c;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f_delete" depends on it
+ALTER TABLE table_drop DROP COLUMN b;
+
+statement error pgcode 2BP01 pq: cannot drop column "a" because function "f_delete" depends on it
+ALTER TABLE table_drop DROP COLUMN a;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_insert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_insert
@@ -297,11 +297,19 @@ CREATE TABLE t_computed (
   INDEX i (a ASC) USING HASH
 )
 
+# An insert routine created with use_improved_routine_dependency_tracking = true
+# should not depend on columns other than the target column "a".
+statement ok
+SET use_improved_routine_dependency_tracking = true;
+
 statement ok
 CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
   INSERT INTO t_computed VALUES (100);
   SELECT 1;
 $$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
 
 statement ok
 SELECT f145098();
@@ -361,6 +369,43 @@ DROP FUNCTION f145098;
 statement ok
 DROP TABLE t_computed;
 
+statement ok
+CREATE TABLE t_computed (
+  a INT NOT NULL,
+  b INT AS (a + 1) STORED,
+  c INT AS (a * 2) VIRTUAL,
+  INDEX i (a ASC) USING HASH
+)
+
+# With use_improved_routine_dependency_tracking = false, the insert routine
+# will depend on all columns in the table.
+statement ok
+SET use_improved_routine_dependency_tracking = false;
+
+statement ok
+CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
+  INSERT INTO t_computed VALUES (100);
+  SELECT 1;
+$$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
+
+statement error pgcode 2BP01 pq: cannot drop column "crdb_internal_a_shard_16" because function "f145098" depends on it
+DROP INDEX i;
+
+statement error pgcode 2BP01 pq: cannot drop column "c" because function "f145098" depends on it
+ALTER TABLE t_computed DROP COLUMN c;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f145098" depends on it
+ALTER TABLE t_computed DROP COLUMN b;
+
+statement ok
+DROP FUNCTION f145098;
+
+statement ok
+DROP TABLE t_computed;
+
 # Case where the INSERT statement has a RETURNING clause that references the
 # hash-sharded index column. In this case, a dependency *should* be added.
 statement ok
@@ -370,10 +415,16 @@ CREATE TABLE t_hash_sharded (
 )
 
 statement ok
+SET use_improved_routine_dependency_tracking = true;
+
+statement ok
 CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
   INSERT INTO t_hash_sharded VALUES (100) RETURNING crdb_internal_a_shard_16;
   SELECT 1;
 $$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
 
 statement error pgcode 2BP01 pq: cannot drop column "crdb_internal_a_shard_16" because function "f145098" depends on it
 DROP INDEX i;

--- a/pkg/sql/logictest/testdata/logic_test/udf_insert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_insert
@@ -286,3 +286,105 @@ statement ok
 SELECT f146414()
 
 subtest end
+
+subtest regression_145098
+
+statement ok
+CREATE TABLE t_computed (
+  a INT NOT NULL,
+  b INT AS (a + 1) STORED,
+  c INT AS (a * 2) VIRTUAL,
+  INDEX i (a ASC) USING HASH
+)
+
+statement ok
+CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
+  INSERT INTO t_computed VALUES (100);
+  SELECT 1;
+$$;
+
+statement ok
+SELECT f145098();
+
+query III
+SELECT * FROM t_computed;
+----
+100  101  200
+
+# The internal computed column used by the hash-sharded index should not be
+# included in the routine's dependencies, and the drop should succeed.
+statement ok
+DROP INDEX i;
+
+statement ok
+SELECT f145098();
+
+query III
+SELECT * FROM t_computed;
+----
+100  101  200
+100  101  200
+
+statement ok
+ALTER TABLE t_computed DROP COLUMN c;
+
+statement ok
+SELECT f145098();
+
+query II
+SELECT * FROM t_computed;
+----
+100  101
+100  101
+100  101
+
+statement ok
+ALTER TABLE t_computed DROP COLUMN b;
+
+statement ok
+SELECT f145098();
+
+query I
+SELECT * FROM t_computed;
+----
+100
+100
+100
+100
+
+statement error pgcode 2BP01 pq: cannot drop column "a" because function "f145098" depends on it
+ALTER TABLE t_computed DROP COLUMN a;
+
+statement ok
+DROP FUNCTION f145098;
+
+statement ok
+DROP TABLE t_computed;
+
+# Case where the INSERT statement has a RETURNING clause that references the
+# hash-sharded index column. In this case, a dependency *should* be added.
+statement ok
+CREATE TABLE t_hash_sharded (
+  a INT NOT NULL,
+  INDEX i (a ASC) USING HASH
+)
+
+statement ok
+CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
+  INSERT INTO t_hash_sharded VALUES (100) RETURNING crdb_internal_a_shard_16;
+  SELECT 1;
+$$;
+
+statement error pgcode 2BP01 pq: cannot drop column "crdb_internal_a_shard_16" because function "f145098" depends on it
+DROP INDEX i;
+
+statement ok
+SELECT f145098();
+
+statement ok
+DROP FUNCTION f145098;
+
+statement ok
+DROP TABLE t_hash_sharded;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_insert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_insert
@@ -298,18 +298,12 @@ CREATE TABLE t_computed (
 )
 
 # An insert routine created with use_improved_routine_dependency_tracking = true
-# should not depend on columns other than the target column "a".
-statement ok
-SET use_improved_routine_dependency_tracking = true;
-
+# (the default) should not depend on columns other than the target column "a".
 statement ok
 CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
   INSERT INTO t_computed VALUES (100);
   SELECT 1;
 $$;
-
-statement ok
-RESET use_improved_routine_dependency_tracking;
 
 statement ok
 SELECT f145098();
@@ -415,16 +409,10 @@ CREATE TABLE t_hash_sharded (
 )
 
 statement ok
-SET use_improved_routine_dependency_tracking = true;
-
-statement ok
 CREATE FUNCTION f145098() RETURNS INT LANGUAGE SQL AS $$
   INSERT INTO t_hash_sharded VALUES (100) RETURNING crdb_internal_a_shard_16;
   SELECT 1;
 $$;
-
-statement ok
-RESET use_improved_routine_dependency_tracking;
 
 statement error pgcode 2BP01 pq: cannot drop column "crdb_internal_a_shard_16" because function "f145098" depends on it
 DROP INDEX i;

--- a/pkg/sql/logictest/testdata/logic_test/udf_insert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_insert
@@ -264,3 +264,25 @@ statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(b > 1:::IN
 SELECT f_checkb();
 
 subtest end
+
+subtest regression_146414
+
+statement ok
+CREATE TABLE t146414 (
+  a INT NOT NULL,
+  b INT AS (a + 1) VIRTUAL
+)
+
+statement ok
+CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
+  INSERT INTO t146414 (a) VALUES (100) RETURNING b;
+  SELECT 1;
+$$;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
+ALTER TABLE t146414 DROP COLUMN b;
+
+statement ok
+SELECT f146414()
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -336,16 +336,10 @@ CREATE TABLE t146414 (
 )
 
 statement ok
-SET use_improved_routine_dependency_tracking = true;
-
-statement ok
 CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
   UPDATE t146414 SET a = a + 1 WHERE a = 1 RETURNING b;
   SELECT 1;
 $$;
-
-statement ok
-RESET use_improved_routine_dependency_tracking;
 
 statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
 ALTER TABLE t146414 DROP COLUMN b;

--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -336,10 +336,16 @@ CREATE TABLE t146414 (
 )
 
 statement ok
+SET use_improved_routine_dependency_tracking = true;
+
+statement ok
 CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
   UPDATE t146414 SET a = a + 1 WHERE a = 1 RETURNING b;
   SELECT 1;
 $$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
 
 statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
 ALTER TABLE t146414 DROP COLUMN b;

--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -348,3 +348,41 @@ statement ok
 SELECT f146414()
 
 subtest end
+
+# Make sure that the routine does not add unnecessary columns as dependencies.
+subtest drop_column
+
+statement ok
+CREATE TABLE table_drop (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  d INT AS (a + b) STORED,
+  -- Hash-sharded indexes generate a hidden computed column.
+  INDEX i (b ASC) USING HASH
+);
+INSERT INTO table_drop VALUES (1,2,3), (4,5,6), (7,8,9);
+
+statement ok
+DROP FUNCTION f_update;
+CREATE FUNCTION f_update() RETURNS INT LANGUAGE SQL AS $$
+  UPDATE table_drop SET b = b + 1 WHERE a = 1;
+  SELECT 1;
+$$;
+
+statement ok
+DROP INDEX i;
+
+statement ok
+ALTER TABLE table_drop DROP COLUMN d;
+
+statement ok
+ALTER TABLE table_drop DROP COLUMN c;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f_update" depends on it
+ALTER TABLE table_drop DROP COLUMN b;
+
+statement error pgcode 2BP01 pq: cannot drop column "a" because function "f_update" depends on it
+ALTER TABLE table_drop DROP COLUMN a;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_update
+++ b/pkg/sql/logictest/testdata/logic_test/udf_update
@@ -326,3 +326,25 @@ SELECT * FROM kv;
 5 5
 
 subtest end
+
+subtest regression_146414
+
+statement ok
+CREATE TABLE t146414 (
+  a INT NOT NULL,
+  b INT AS (a + 1) VIRTUAL
+)
+
+statement ok
+CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
+  UPDATE t146414 SET a = a + 1 WHERE a = 1 RETURNING b;
+  SELECT 1;
+$$;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
+ALTER TABLE t146414 DROP COLUMN b;
+
+statement ok
+SELECT f146414()
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_upsert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_upsert
@@ -275,20 +275,12 @@ CREATE TABLE table_drop (
 );
 INSERT INTO table_drop VALUES (1,2,3), (4,5,6), (7,8,9);
 
-# An insert routine created with use_improved_routine_dependency_tracking = true
-# should not depend on columns other than the target column "a". 
-statement ok
-SET use_improved_routine_dependency_tracking = true;
-
 statement ok
 DROP FUNCTION f_upsert;
 CREATE FUNCTION f_upsert() RETURNS INT LANGUAGE SQL AS $$
   UPSERT INTO table_drop (a, b) VALUES (100, 200);
   SELECT 1;
 $$;
-
-statement ok
-RESET use_improved_routine_dependency_tracking;
 
 statement ok
 DROP INDEX i;

--- a/pkg/sql/logictest/testdata/logic_test/udf_upsert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_upsert
@@ -260,3 +260,41 @@ statement ok
 SELECT f146414()
 
 subtest end
+
+# Make sure that the routine does not add unnecessary columns as dependencies.
+subtest drop_column
+
+statement ok
+CREATE TABLE table_drop (
+  a INT NOT NULL,
+  b INT NOT NULL,
+  c INT NOT NULL,
+  d INT AS (a + b) STORED,
+  -- Hash-sharded indexes generate a hidden computed column.
+  INDEX i (b ASC) USING HASH
+);
+INSERT INTO table_drop VALUES (1,2,3), (4,5,6), (7,8,9);
+
+statement ok
+DROP FUNCTION f_upsert;
+CREATE FUNCTION f_upsert() RETURNS INT LANGUAGE SQL AS $$
+  UPSERT INTO table_drop (a, b) VALUES (100, 200);
+  SELECT 1;
+$$;
+
+statement ok
+DROP INDEX i;
+
+statement ok
+ALTER TABLE table_drop DROP COLUMN d;
+
+statement ok
+ALTER TABLE table_drop DROP COLUMN c;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f_upsert" depends on it
+ALTER TABLE table_drop DROP COLUMN b;
+
+statement error pgcode 2BP01 pq: cannot drop column "a" because function "f_upsert" depends on it
+ALTER TABLE table_drop DROP COLUMN a;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_upsert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_upsert
@@ -275,12 +275,20 @@ CREATE TABLE table_drop (
 );
 INSERT INTO table_drop VALUES (1,2,3), (4,5,6), (7,8,9);
 
+# An insert routine created with use_improved_routine_dependency_tracking = true
+# should not depend on columns other than the target column "a". 
+statement ok
+SET use_improved_routine_dependency_tracking = true;
+
 statement ok
 DROP FUNCTION f_upsert;
 CREATE FUNCTION f_upsert() RETURNS INT LANGUAGE SQL AS $$
   UPSERT INTO table_drop (a, b) VALUES (100, 200);
   SELECT 1;
 $$;
+
+statement ok
+RESET use_improved_routine_dependency_tracking;
 
 statement ok
 DROP INDEX i;

--- a/pkg/sql/logictest/testdata/logic_test/udf_upsert
+++ b/pkg/sql/logictest/testdata/logic_test/udf_upsert
@@ -238,3 +238,25 @@ statement error pgcode 22001 value too long for type CHAR\(3\)
 SELECT f_check_colerr_vals(NULL, 'abcd')
 
 subtest end
+
+subtest regression_146414
+
+statement ok
+CREATE TABLE t146414 (
+  a INT NOT NULL,
+  b INT AS (a + 1) VIRTUAL
+)
+
+statement ok
+CREATE FUNCTION f146414() RETURNS INT LANGUAGE SQL AS $$
+  UPSERT INTO t146414 (a) VALUES (100) RETURNING b;
+  SELECT 1;
+$$;
+
+statement error pgcode 2BP01 pq: cannot drop column "b" because function "f146414" depends on it
+ALTER TABLE t146414 DROP COLUMN b;
+
+statement ok
+SELECT f146414()
+
+subtest end

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -849,7 +849,7 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList
 		colIDs[i] = newCol
 
 		// Track columns that were not explicitly set in the insert statement.
-		if mb.b.trackSchemaDeps {
+		if mb.b.trackSchemaDeps && mb.b.evalCtx.SessionData().UseImprovedRoutineDependencyTracking {
 			mb.implicitInsertCols.Add(newCol)
 		}
 

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -848,6 +848,11 @@ func (mb *mutationBuilder) addSynthesizedComputedCols(colIDs opt.OptionalColList
 		// Remember id of newly synthesized column.
 		colIDs[i] = newCol
 
+		// Track columns that were not explicitly set in the insert statement.
+		if mb.b.trackSchemaDeps {
+			mb.implicitInsertCols.Add(newCol)
+		}
+
 		// Add corresponding target column.
 		mb.targetColList = append(mb.targetColList, tabColID)
 		mb.targetColSet.Add(tabColID)

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1702,7 +1702,7 @@ func (mb *mutationBuilder) buildReturningScopes(
 	//   4. Project columns in same order as defined in table schema.
 	//
 	inScope = mb.outScope.replace()
-	inScope.appendOrdinaryColumnsFromTable(mb.md.TableMeta(mb.tabID), &mb.alias)
+	mb.b.appendOrdinaryColumnsFromTable(inScope, mb.md.TableMeta(mb.tabID), &mb.alias)
 
 	// extraAccessibleCols contains all the columns that the RETURNING
 	// clause can refer to in addition to the table columns. This is useful for

--- a/pkg/sql/opt/optbuilder/partial_index.go
+++ b/pkg/sql/opt/optbuilder/partial_index.go
@@ -57,7 +57,7 @@ func (b *Builder) addPartialIndexPredicatesForTable(tabMeta *opt.TableMeta, scan
 	// Construct a scan as the tableScope expr so that logical properties of the
 	// scan can be used to fully normalize the index predicate.
 	tableScope := b.allocScope()
-	tableScope.appendOrdinaryColumnsFromTable(tabMeta, &tabMeta.Alias)
+	b.appendOrdinaryColumnsFromTable(tableScope, tabMeta, &tabMeta.Alias)
 
 	// If the optional scan argument was provided and it outputs all of the
 	// ordinary table columns, we use it as tableScope.expr. Otherwise, we must

--- a/pkg/sql/opt/optbuilder/scope.go
+++ b/pkg/sql/opt/optbuilder/scope.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
-	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
@@ -227,28 +226,6 @@ func (s *scope) appendColumnsFromScope(src *scope) {
 	// the new scope.
 	for i := l; i < len(s.cols); i++ {
 		s.cols[i].scalar = nil
-	}
-}
-
-// appendOrdinaryColumnsFromTable adds all non-mutation and non-system columns from the
-// given table metadata to this scope.
-func (s *scope) appendOrdinaryColumnsFromTable(tabMeta *opt.TableMeta, alias *tree.TableName) {
-	tab := tabMeta.Table
-	if s.cols == nil {
-		s.cols = make([]scopeColumn, 0, tab.ColumnCount())
-	}
-	for i, n := 0, tab.ColumnCount(); i < n; i++ {
-		tabCol := tab.Column(i)
-		if tabCol.Kind() != cat.Ordinary {
-			continue
-		}
-		s.cols = append(s.cols, scopeColumn{
-			name:       scopeColName(tabCol.ColName()),
-			table:      *alias,
-			typ:        tabCol.DatumType(),
-			id:         tabMeta.MetaID.ColumnID(i),
-			visibility: columnVisibility(tabCol.Visibility()),
-		})
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -828,7 +828,7 @@ func (b *Builder) addCheckConstraintsForTable(tabMeta *opt.TableMeta) {
 
 	// Create a scope that can be used for building the scalar expressions.
 	tableScope := b.allocScope()
-	tableScope.appendOrdinaryColumnsFromTable(tabMeta, &tabMeta.Alias)
+	b.appendOrdinaryColumnsFromTable(tableScope, tabMeta, &tabMeta.Alias)
 	// Synthesized CHECK expressions, e.g., for columns of ENUM types, may
 	// reference inaccessible columns. This can happen when the type of an
 	// indexed expression is an ENUM. We make these columns visible so that they
@@ -925,7 +925,7 @@ func (b *Builder) addComputedColsForTable(
 
 		if tableScope == nil {
 			tableScope = b.allocScope()
-			tableScope.appendOrdinaryColumnsFromTable(tabMeta, &tabMeta.Alias)
+			b.appendOrdinaryColumnsFromTable(tableScope, tabMeta, &tabMeta.Alias)
 		}
 
 		colType := tabCol.DatumType()

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -851,3 +851,41 @@ func (b *Builder) makePLpgSQLRaiseFn(args memo.ScalarListExpr) opt.ScalarExpr {
 		},
 	)
 }
+
+// appendOrdinaryColumnsFromTable adds all non-mutation and non-system columns
+// from the given table metadata to the given scope. References to these columns
+// will be tracked in the schema dependencies, if trackSchemaDeps is set.
+func (b *Builder) appendOrdinaryColumnsFromTable(
+	s *scope, tabMeta *opt.TableMeta, alias *tree.TableName,
+) {
+	tab := tabMeta.Table
+	if s.cols == nil {
+		s.cols = make([]scopeColumn, 0, tab.ColumnCount())
+	}
+	for i, n := 0, tab.ColumnCount(); i < n; i++ {
+		tabCol := tab.Column(i)
+		if tabCol.Kind() != cat.Ordinary {
+			continue
+		}
+		s.cols = append(s.cols, scopeColumn{
+			name:       scopeColName(tabCol.ColName()),
+			table:      *alias,
+			typ:        tabCol.DatumType(),
+			id:         tabMeta.MetaID.ColumnID(i),
+			visibility: columnVisibility(tabCol.Visibility()),
+		})
+	}
+	if b.trackSchemaDeps {
+		dep := opt.SchemaDep{DataSource: tab}
+		for i, n := 0, tab.ColumnCount(); i < n; i++ {
+			if tab.Column(i).Kind() != cat.Ordinary {
+				continue
+			}
+			if dep.ColumnIDToOrd == nil {
+				dep.ColumnIDToOrd = make(map[opt.ColumnID]int)
+			}
+			dep.ColumnIDToOrd[tabMeta.MetaID.ColumnID(i)] = i
+		}
+		b.schemaDeps = append(b.schemaDeps, dep)
+	}
+}

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -875,7 +875,7 @@ func (b *Builder) appendOrdinaryColumnsFromTable(
 			visibility: columnVisibility(tabCol.Visibility()),
 		})
 	}
-	if b.trackSchemaDeps {
+	if b.trackSchemaDeps && b.evalCtx.SessionData().UseImprovedRoutineDependencyTracking {
 		dep := opt.SchemaDep{DataSource: tab}
 		for i, n := 0, tab.ColumnCount(); i < n; i++ {
 			if tab.Column(i).Kind() != cat.Ordinary {

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -674,6 +674,11 @@ message LocalOnlySessionData {
   // duration for automatic retries of statements in explicit READ COMMITTED
   // transactions that see a transaction retry error. 0 disables backoff.
   int64 initial_retry_backoff_for_read_committed = 171 [(gogoproto.casttype) = "time.Duration"];
+  // UseImprovedRoutineDependencyTracking, when true, causes newly-created
+  // routines to only consider user-specified target columns when determining the
+  // dependencies of an INSERT statement in a routine.
+  bool use_improved_routine_dependency_tracking = 172;
+
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4078,7 +4078,7 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return formatBoolAsPostgresSetting(evalCtx.SessionData().UseImprovedRoutineDependencyTracking), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4063,6 +4063,23 @@ var varGen = map[string]sessionVar{
 			return "2ms"
 		},
 	},
+
+	// CockroachDB extension.
+	`use_improved_routine_dependency_tracking`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`use_improved_routine_dependency_tracking`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("use_improved_routine_dependency_tracking", s)
+			if err != nil {
+				return err
+			}
+			m.SetUseImprovedRoutineDependencyTracking(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().UseImprovedRoutineDependencyTracking), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
#### sql: track routine dependencies on columns in RETURNING clause

Previously, while building a routine, we did not explicitly add dependencies
to columns referenced in the RETURNING clause of mutations within the body
statements. This was not a problem for INSERT or UPSERT due to #145098, but
could cause a routine with UPDATE or DELETE statements to be broken after
a referenced column was dropped. This commit fixes the bug by tracking
column references in the RETURNING clause.

Fixes #146414

Release note (bug fix): Fixed a bug that allowed a column to be dropped
from a table even if it was referenced in the RETURNING clause of an UPDATE
or DELETE statement in a routine. In releases prior to v25.3, the fix will
be off by default, and can be enabled by setting the session variable
`use_improved_routine_dependency_tracking`.

#### opt: do not add unnecessary columns to routine deps

Previously, computed columns would be added to the depended-on columns
list for a routine that performs an INSERT. This is unnecessary, since
values for computed columns are automatically generated when the routine
is invoked depending on the table schema at the time of invocation.
Because of this behavior, a routine with an INSERT statement previously
prevented dropping computed columns from the target table, including the
implicit column used for hash-sharded indexes.

This commit skips computed columns when adding insert target columns to
the routine's dependency list. Note that there was already logic to do
this for columns with default values. This commit also adds a session
variable `use_improved_routine_dependency_tracking` to control the new
behavior, default off for backports. The follow-up will flip the variable
on for master.

Fixes #145098

Release note (sql change): Fixed a bug that caused a routine with an
INSERT statement to unnecessarily block dropping a hash-sharded index
or computed column on the target table. Note that the fix applies only
to newly-created routines. In releases prior to v25.3, the fix will
be off by default, and can be enabled by setting the session variable
`use_improved_routine_dependency_tracking`.

#### sql: add session setting for routine dependency improvements

This commit adds a session var `use_improved_routine_dependency_tracking`
which enables the improvements in the previous two commits (do not add
dependencies on unnecessary columns, and track dependencies in the
RETURNING clause). The var is off by default in this commit for backports.

Informs #145098
Informs #146414

Release note: None

#### opt: enable improved routine dependency tracking

This commit flips `use_improved_routine_dependency_tracking` to on by
default. This means that newly-created routines will not add unnecessary
implicit insert columns to the list of dependencies, and will correctly
track dependencies in the RETURNING clause of UPDATE and DELETE statements.

Informs #145098
Informs #146414

Release note: None