### PR TITLE
kvserver: remove UnregisterFromReplica callback

### DIFF
--- a/pkg/kv/kvserver/rangefeed/processor.go
+++ b/pkg/kv/kvserver/rangefeed/processor.go
@@ -104,11 +104,6 @@ type Config struct {
 	// for low-volume system ranges, since the worker pool is small (default 2).
 	// Only has an effect when Scheduler is used.
 	Priority bool
-
-	// UnregisterFromReplica is a callback provided from the
-	// replica that this processor can call when shutting down to
-	// remove itself from the replica.
-	UnregisterFromReplica func(Processor)
 }
 
 // SetDefaults initializes unset fields in Config to values
@@ -165,6 +160,9 @@ type Processor interface {
 	//
 	// It is not valid to restart a processor after it has been stopped.
 	StopWithErr(pErr *kvpb.Error)
+
+	// Returns true if a stop event has already been processed by this processor.
+	Stopping() bool
 
 	// Lifecycle of registrations.
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1089,6 +1089,9 @@ type Replica struct {
 		// Requires Replica.raftMu be held when providing logical ops and
 		//  informing the processor of closed timestamp updates. This properly
 		//  synchronizes updates that are linearized and driven by the Raft log.
+		//
+		// proc should only be accessed via getRangefeedProcessorAndFilter or
+		// getRangefeedProcessor in nearly all cases.
 		proc rangefeed.Processor
 		// opFilter is a best-effort filter that informs the raft processing
 		// goroutine of which logical operations the rangefeed processor is


### PR DESCRIPTION
The UnregisterFromReplica callback required obtaining the rangefeedMu mutex from inside the rangefeed scheduler worker. This is a problem because the current holder of the rangefeedMu (specifically (*ScheduledProcessor).Register) may require a response from the very same scheduler worker to make progress and release rangefeedMu.

Here, we solve that by removing this UnregisterFromReplica callback completely. This callback was responsible for removing the processor from the replica when the processor had been shut down.

But, nearly every code path that calls Stop() already removes the processor from the replica itself. The only case where this wasn't true is when the processor stops itself because it has no more active registrations.

Not removing the processor from the replica in that case has two consequences:

1. We may hold onto memory related to the ScheduledProcessor struct,

2. The replica does extra work because of the rangefeed processor is set.

Here, we choose to ignore (1) as a minor problem since a most ranges that have a rangefeed started once will have one started again in the future.

We solve (2) by making the `stopped` state variable accessible from outside the processor and consulting it before using the rangefeed processor on the replica. The assumption here is that the atomic load is cheap in comparison to the work we need to do when the processor is present.

Fixes #144828

Epic: none

Release note (bug fix): Fix a bug that could lead to a node stall.