### PR TITLE
sql: prevent overflow of field position in split_part

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -493,6 +493,18 @@ SELECT split_part('joeuser@mydatabase', '?', -2)
 ----
 ·
 
+# Verify min value for field
+query T
+SELECT split_part('joeuser@mydatabase', '@', -9223372036854775808);
+----
+·
+
+# Verify max value for field
+query T
+SELECT split_part('joeuser@mydatabase', '@', 9223372036854775807);
+----
+·
+
 query T
 SELECT repeat('Pg', 4)
 ----

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -1189,7 +1189,7 @@ var regularBuiltins = map[string]builtinDefinition{
 				}
 
 				splits := strings.Split(text, sep)
-				if field > len(splits) || -1*field > len(splits) {
+				if field > len(splits) || (field < 0 && field < -len(splits)) {
 					return tree.NewDString(""), nil
 				}
 


### PR DESCRIPTION
Previously, the field position argument to `split_part` could cause an integer overflow when passed a value of math.MinInt64. This happened because we attempted to negate the value with `-1 * field`, which fails for MinInt64 since its negation cannot be represented in a signed 64-bit integer.

This change updates the bounds check to properly handle this edge case without overflowing.

Fixes #145888

Epic: none
Release note (bug fix): Fixed an integer overflow in the split_part function when using extremely negative field positions like math.MinInt64.