### PR TITLE
structlogging: hot ranges log modify interval loop check to be 1m

### DIFF
--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -29,7 +29,7 @@ var ReportTopHottestRanges int32 = 5
 
 // CheckInterval is the interval at which the system checks
 // whether or not to log the hot ranges.
-var CheckInterval = time.Second
+var CheckInterval = time.Minute
 
 // TestLoopChannel triggers the hot ranges logging loop to start again.
 // It's useful in the context of a test, where we don't want to wait


### PR DESCRIPTION
structlogging: hot ranges log modify interval loop check to be 1m

It seems like the interval loop checker for hot ranges was set to 1s for testing, and accidentally committed. This change reverts the original change.

Fixes: #138767
Epic: CRDB-43150

Release note: None