### PR TITLE
opt: optimize left join when no rows found on right input

### DIFF
--- a/pkg/sql/opt/memo/testdata/stats/join
+++ b/pkg/sql/opt/memo/testdata/stats/join
@@ -1042,160 +1042,367 @@ left-join (merge)
       └── y:2 > v:8 [type=bool, outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
 
 # Check that true filters are handled correctly for all join types.
-norm
+build
 SELECT * FROM (SELECT 1) JOIN (SELECT 1 WHERE false) ON true
 ----
-values
+inner-join (cross)
  ├── columns: "?column?":1(int!null) "?column?":2(int!null)
  ├── cardinality: [0 - 0]
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  ├── stats: [rows=0]
  ├── key: ()
- └── fd: ()-->(1,2)
+ ├── fd: ()-->(1,2)
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
 
-norm
+build
 SELECT * FROM (SELECT 1) LEFT JOIN (SELECT 1 WHERE false) ON true
 ----
 left-join (cross)
  ├── columns: "?column?":1(int!null) "?column?":2(int)
  ├── cardinality: [1 - 1]
- ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
  ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
- ├── values
+ ├── project
  │    ├── columns: "?column?":1(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
- │    └── (1,) [type=tuple{int}]
- ├── values
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
  │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [0 - 0]
  │    ├── stats: [rows=0]
  │    ├── key: ()
- │    └── fd: ()-->(2)
- └── filters (true)
+ │    ├── fd: ()-->(2)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
 
-norm
+build
 SELECT * FROM (SELECT 1) RIGHT JOIN (SELECT 1 WHERE false) ON true
 ----
-values
- ├── columns: "?column?":1(int!null) "?column?":2(int!null)
+right-join (cross)
+ ├── columns: "?column?":1(int) "?column?":2(int!null)
  ├── cardinality: [0 - 0]
  ├── stats: [rows=0]
  ├── key: ()
- └── fd: ()-->(1,2)
+ ├── fd: ()-->(1,2)
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
 
-norm
+build
 SELECT * FROM (SELECT 1) FULL JOIN (SELECT 1 WHERE false) ON true
+----
+full-join (cross)
+ ├── columns: "?column?":1(int) "?column?":2(int)
+ ├── cardinality: [1 - 1]
+ ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ ├── stats: [rows=1]
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
+
+build
+SELECT * FROM (SELECT 1 WHERE false) JOIN (SELECT 1) ON true
+----
+inner-join (cross)
+ ├── columns: "?column?":1(int!null) "?column?":2(int!null)
+ ├── cardinality: [0 - 0]
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── stats: [rows=0]
+ ├── key: ()
+ ├── fd: ()-->(1,2)
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
+ │    ├── columns: "?column?":2(int!null)
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
+
+build
+SELECT * FROM (SELECT 1 WHERE false) LEFT JOIN (SELECT 1) ON true
 ----
 left-join (cross)
  ├── columns: "?column?":1(int!null) "?column?":2(int)
- ├── cardinality: [1 - 1]
- ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
- ├── stats: [rows=1]
+ ├── cardinality: [0 - 0]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── stats: [rows=0]
  ├── key: ()
  ├── fd: ()-->(1,2)
- ├── values
+ ├── project
  │    ├── columns: "?column?":1(int!null)
- │    ├── cardinality: [1 - 1]
- │    ├── stats: [rows=1]
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
  │    ├── key: ()
  │    ├── fd: ()-->(1)
- │    └── (1,) [type=tuple{int}]
- ├── values
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
  │    ├── columns: "?column?":2(int!null)
- │    ├── cardinality: [0 - 0]
- │    ├── stats: [rows=0]
+ │    ├── cardinality: [1 - 1]
+ │    ├── stats: [rows=1]
  │    ├── key: ()
- │    └── fd: ()-->(2)
- └── filters (true)
+ │    ├── fd: ()-->(2)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
 
-norm
-SELECT * FROM (SELECT 1 WHERE false) JOIN (SELECT 1) ON true
-----
-values
- ├── columns: "?column?":1(int!null) "?column?":2(int!null)
- ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
- ├── key: ()
- └── fd: ()-->(1,2)
-
-norm
-SELECT * FROM (SELECT 1 WHERE false) LEFT JOIN (SELECT 1) ON true
-----
-values
- ├── columns: "?column?":1(int!null) "?column?":2(int!null)
- ├── cardinality: [0 - 0]
- ├── stats: [rows=0]
- ├── key: ()
- └── fd: ()-->(1,2)
-
-norm
+build
 SELECT * FROM (SELECT 1 WHERE false) RIGHT JOIN (SELECT 1) ON true
 ----
-left-join (cross)
+right-join (cross)
  ├── columns: "?column?":1(int) "?column?":2(int!null)
  ├── cardinality: [1 - 1]
- ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  ├── stats: [rows=1]
  ├── key: ()
  ├── fd: ()-->(1,2)
- ├── values
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
  │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(2)
- │    └── (1,) [type=tuple{int}]
- ├── values
- │    ├── columns: "?column?":1(int!null)
- │    ├── cardinality: [0 - 0]
- │    ├── stats: [rows=0]
- │    ├── key: ()
- │    └── fd: ()-->(1)
- └── filters (true)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
 
-norm
+build
 SELECT * FROM (SELECT 1 WHERE false) FULL JOIN (SELECT 1) ON true
 ----
-left-join (cross)
- ├── columns: "?column?":1(int) "?column?":2(int!null)
+full-join (cross)
+ ├── columns: "?column?":1(int) "?column?":2(int)
  ├── cardinality: [1 - 1]
  ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
  ├── stats: [rows=1]
- ├── key: ()
- ├── fd: ()-->(1,2)
- ├── values
+ ├── project
+ │    ├── columns: "?column?":1(int!null)
+ │    ├── cardinality: [0 - 0]
+ │    ├── stats: [rows=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    ├── select
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── stats: [rows=0]
+ │    │    ├── key: ()
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── filters
+ │    │         └── false [type=bool, constraints=(contradiction; tight)]
+ │    └── projections
+ │         └── 1 [as="?column?":1, type=int]
+ ├── project
  │    ├── columns: "?column?":2(int!null)
  │    ├── cardinality: [1 - 1]
  │    ├── stats: [rows=1]
  │    ├── key: ()
  │    ├── fd: ()-->(2)
- │    └── (1,) [type=tuple{int}]
- ├── values
- │    ├── columns: "?column?":1(int!null)
- │    ├── cardinality: [0 - 0]
- │    ├── stats: [rows=0]
- │    ├── key: ()
- │    └── fd: ()-->(1)
- └── filters (true)
+ │    ├── values
+ │    │    ├── cardinality: [1 - 1]
+ │    │    ├── stats: [rows=1]
+ │    │    ├── key: ()
+ │    │    └── () [type=tuple]
+ │    └── projections
+ │         └── 1 [as="?column?":2, type=int]
+ └── filters
+      └── true [type=bool]
 
-norm
+build
 SELECT * FROM (SELECT 1 UNION SELECT 2) FULL JOIN (VALUES (1), (2)) ON true
 ----
-inner-join (cross)
- ├── columns: "?column?":3(int!null) column1:4(int!null)
+full-join (cross)
+ ├── columns: "?column?":3(int) column1:4(int)
  ├── cardinality: [2 - 4]
- ├── multiplicity: left-rows(one-or-more), right-rows(one-or-more)
- ├── stats: [rows=4]
- ├── values
- │    ├── columns: column1:4(int!null)
- │    ├── cardinality: [2 - 2]
- │    ├── stats: [rows=2]
- │    ├── (1,) [type=tuple{int}]
- │    └── (2,) [type=tuple{int}]
+ ├── stats: [rows=2.66667]
  ├── union
  │    ├── columns: "?column?":3(int!null)
  │    ├── left columns: "?column?":1(int)
@@ -1203,21 +1410,40 @@ inner-join (cross)
  │    ├── cardinality: [1 - 2]
  │    ├── stats: [rows=2, distinct(3)=2, null(3)=0]
  │    ├── key: (3)
- │    ├── values
+ │    ├── project
  │    │    ├── columns: "?column?":1(int!null)
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
- │    │    └── (1,) [type=tuple{int}]
- │    └── values
+ │    │    ├── values
+ │    │    │    ├── cardinality: [1 - 1]
+ │    │    │    ├── stats: [rows=1]
+ │    │    │    ├── key: ()
+ │    │    │    └── () [type=tuple]
+ │    │    └── projections
+ │    │         └── 1 [as="?column?":1, type=int]
+ │    └── project
  │         ├── columns: "?column?":2(int!null)
  │         ├── cardinality: [1 - 1]
  │         ├── stats: [rows=1, distinct(2)=1, null(2)=0]
  │         ├── key: ()
  │         ├── fd: ()-->(2)
- │         └── (2,) [type=tuple{int}]
- └── filters (true)
+ │         ├── values
+ │         │    ├── cardinality: [1 - 1]
+ │         │    ├── stats: [rows=1]
+ │         │    ├── key: ()
+ │         │    └── () [type=tuple]
+ │         └── projections
+ │              └── 2 [as="?column?":2, type=int]
+ ├── values
+ │    ├── columns: column1:4(int!null)
+ │    ├── cardinality: [2 - 2]
+ │    ├── stats: [rows=2]
+ │    ├── (1,) [type=tuple{int}]
+ │    └── (2,) [type=tuple{int}]
+ └── filters
+      └── true [type=bool]
 
 exec-ddl
 CREATE TABLE table0 (
@@ -1235,7 +1461,7 @@ CREATE TABLE table1 (
 ----
 
 # Regression test for #38091.
-norm disable=EliminateJoinUnderProjectLeft
+norm disable=(EliminateJoinUnderProjectLeft,SimplifyLeftJoinWithZeroRowsRight)
 SELECT (
         SELECT 1
           FROM table1
@@ -1289,7 +1515,7 @@ project
  └── projections
       └── "?column?":23 [as="?column?":24, type=int, outer=(23)]
 
-norm colstat=1 colstat=2
+norm colstat=1 colstat=2 disable=SimplifyLeftJoinWithZeroRowsRight
 SELECT * FROM (SELECT 1) AS a(x) LEFT JOIN (SELECT 2) AS b(x) ON a.x = b.x
 ----
 left-join (cross)

--- a/pkg/sql/opt/memo/testdata/stats/select
+++ b/pkg/sql/opt/memo/testdata/stats/select
@@ -3244,7 +3244,7 @@ CREATE TABLE t84478 (
 )
 ----
 
-norm
+norm disable=SimplifyLeftJoinWithZeroRowsRight
 SELECT
   NULL, 1
 FROM

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -919,3 +919,17 @@ func getJoinKeyAndEquijoinCols(
 	}
 	return opt.ColSet{}, opt.ColList{}, opt.ColList{}, false
 }
+
+// MakeNullProjections creates a projection for each column in the right input,
+// producing NULL values for each column in the right input.
+func (c *CustomFuncs) MakeNullProjections(right memo.RelExpr) memo.ProjectionsExpr {
+	rightCols := right.Relational().OutputCols
+	projections := make(memo.ProjectionsExpr, 0, rightCols.Len())
+
+	for i, ok := rightCols.Next(0); ok; i, ok = rightCols.Next(i + 1) {
+		nullExpr := c.f.ConstructNull(c.mem.Metadata().ColumnMeta(i).Type)
+		projections = append(projections, c.f.ConstructProjectionsItem(nullExpr, i))
+	}
+
+	return projections
+}

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -324,6 +324,15 @@
 =>
 (ConstructNonLeftJoin (OpName) $left $right $on $private)
 
+# SimplifyLeftJoinWithZeroRowsRight replaces a LeftJoin with a Project when
+# the right input never returns any rows. The Project passes through columns
+# from the left input and produces NULL values for each column in the right
+# input.
+[SimplifyLeftJoinWithZeroRowsRight, Normalize]
+(LeftJoin $left:* $right:* & (HasZeroRows $right))
+=>
+(Project $left (MakeNullProjections $right) (OutputCols $left))
+
 # SimplifyRightJoin reduces a FullJoin operator to a LeftJoin operator when it's
 # known that every row in the join's right input will match at least one row in
 # the left input. This rule is symmetric with SimplifyLeftJoin; see that rule

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -267,21 +267,17 @@ inner-join (cross)
 norm expect=DetectJoinContradiction expect-not=SimplifyJoinFilters
 SELECT * FROM a LEFT JOIN b ON k<1 AND k>2
 ----
-left-join (cross)
+project
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:8 y:9
- ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── key: (1)
- ├── fd: (1)-->(2-5,8,9)
+ ├── fd: ()-->(8,9), (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- ├── values
- │    ├── columns: x:8!null y:9!null
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(8,9)
- └── filters (true)
+ └── projections
+      ├── CAST(NULL AS INT8) [as=x:8]
+      └── CAST(NULL AS INT8) [as=y:9]
 
 # --------------------------------------------------
 # DetectJoinContradiction
@@ -299,21 +295,17 @@ values
 norm expect=DetectJoinContradiction
 SELECT * FROM a LEFT JOIN b ON (k<1 AND k>2) OR (k<4 AND k>5)
 ----
-left-join (cross)
+project
  ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:8 y:9
- ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
  ├── key: (1)
- ├── fd: (1)-->(2-5,8,9)
+ ├── fd: ()-->(8,9), (1)-->(2-5)
  ├── scan a
  │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
  │    ├── key: (1)
  │    └── fd: (1)-->(2-5)
- ├── values
- │    ├── columns: x:8!null y:9!null
- │    ├── cardinality: [0 - 0]
- │    ├── key: ()
- │    └── fd: ()-->(8,9)
- └── filters (true)
+ └── projections
+      ├── CAST(NULL AS INT8) [as=x:8]
+      └── CAST(NULL AS INT8) [as=y:9]
 
 norm expect=DetectJoinContradiction
 SELECT * FROM a INNER JOIN xy ON NULL
@@ -2510,6 +2502,71 @@ left-join (hash)
  │    └── fd: (6)-->(7-10)
  └── filters
       └── y:2 = k:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+
+
+# --------------------------------------------------
+# SimplifyLeftJoinWithZeroRowsRight
+# --------------------------------------------------
+
+norm expect=SimplifyLeftJoinWithZeroRowsRight
+SELECT a.*, b_empty.* FROM a LEFT JOIN (SELECT * FROM b LIMIT 0) AS b_empty ON a.k = b_empty.x
+----
+project
+ ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:8 y:9
+ ├── key: (1)
+ ├── fd: ()-->(8,9), (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── projections
+      ├── CAST(NULL AS INT8) [as=x:8]
+      └── CAST(NULL AS INT8) [as=y:9]
+
+norm expect=SimplifyLeftJoinWithZeroRowsRight
+SELECT a.*, vals.* FROM a LEFT JOIN (VALUES (1, 2) LIMIT 0) AS vals(x, y) ON a.k = vals.x
+----
+project
+ ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:8 y:9
+ ├── key: (1)
+ ├── fd: ()-->(8,9), (1)-->(2-5)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ └── projections
+      ├── CAST(NULL AS INT8) [as=column1:8]
+      └── CAST(NULL AS INT8) [as=column2:9]
+
+# No-op case because the join is an inner-join.
+norm expect-not=SimplifyLeftJoinWithZeroRowsRight
+SELECT a.*, b_empty.* FROM a INNER JOIN (SELECT * FROM b LIMIT 0) AS b_empty ON a.k = b_empty.x
+----
+values
+ ├── columns: k:1!null i:2!null f:3!null s:4!null j:5!null x:8!null y:9!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(1-5,8,9)
+
+# No-op case because the right input does not have zero rows.
+norm expect-not=SimplifyLeftJoinWithZeroRowsRight
+SELECT a.*, b.* FROM a LEFT JOIN b ON a.k = b.x
+----
+left-join (hash)
+ ├── columns: k:1!null i:2 f:3!null s:4 j:5 x:8 y:9
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8,9), (8)-->(9)
+ ├── scan a
+ │    ├── columns: k:1!null i:2 f:3!null s:4 j:5
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2-5)
+ ├── scan b
+ │    ├── columns: x:8!null y:9
+ │    ├── key: (8)
+ │    └── fd: (8)-->(9)
+ └── filters
+      └── k:1 = x:8 [outer=(1,8), constraints=(/1: (/NULL - ]; /8: (/NULL - ]), fd=(1)==(8), (8)==(1)]
 
 # --------------------------------------------------
 # EliminateSemiJoin


### PR DESCRIPTION
#### opt: optimize left join when no rows found on right input

This commit adds a new norm rule 'SimplifyLeftJoinWithZeroRowsRight',
which matches a left join with zero rows in the right input and replaces
it with a project operator that passes left rows through and null-extends
them with the columns from the right input.

Fixes #132327

Release note: None