### PR TITLE
release-25.2: sql/rls: apply SELECT policies only if RETURNING references columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -707,6 +707,15 @@ statement ok
 CREATE USER ins;
 
 statement ok
+CREATE TABLE other (k INT PRIMARY KEY);
+
+statement ok
+INSERT INTO other VALUES (99);
+
+statement ok
+GRANT ALL ON other TO ins;
+
+statement ok
 ALTER TABLE ins OWNER TO ins;
 
 statement ok
@@ -726,9 +735,30 @@ statement ok
 INSERT INTO ins VALUES (1),(2),(3),(4);
 
 # Verify that the same statement with RETURNING will fail because it enforces
-# the SELECT policy.
+# the SELECT policy. Unless the RETURNING clause doesn't reference any columns.
 statement error pq: new row violates row-level security policy for table "ins"
 INSERT INTO ins VALUES (1),(2),(3),(4) RETURNING c1;
+
+statement error pq: new row violates row-level security policy for table "ins"
+INSERT INTO ins VALUES (5) RETURNING *;
+
+statement error pq: new row violates row-level security policy for table "ins"
+INSERT INTO ins VALUES (7) RETURNING (select ins.c1);
+
+query T
+INSERT INTO ins VALUES (9) RETURNING 'foo';
+----
+foo
+
+query I
+INSERT INTO ins VALUES (11) RETURNING (select 1);
+----
+1
+
+query I
+INSERT INTO ins VALUES (13) RETURNING (SELECT k FROM other);
+----
+99
 
 # Verify that only rows that pass the USING expression are allowed (even numbers).
 statement ok
@@ -743,6 +773,9 @@ SET ROLE root;
 
 statement ok
 DROP TABLE ins;
+
+statement ok
+DROP TABLE other;
 
 statement ok
 DROP USER ins;
@@ -4441,13 +4474,59 @@ UPDATE t SET a = 0 WHERE k = 1;
 statement error pq: new row violates row-level security policy for table "t"
 UPDATE t SET a = 0 WHERE true RETURNING k;
 
-# TODO(144951): the RETURNING clause doesn't reference a column, so the SELECT
-# policy shouldn't apply.
 statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE true RETURNING k + 1;
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE true RETURNING (select t.a);
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE true RETURNING *;
+
+statement error pq: new row violates row-level security policy for table "t"
+UPDATE t SET a = 0 WHERE true RETURNING t.*;
+
+query T
 UPDATE t SET a = 0 WHERE true RETURNING 'foo';
+----
+foo
+
+statement ok
+SET ROLE bob;
+
+# Reset the row.
+statement ok
+UPDATE t SET k = 1, a = 10 WHERE true;
+
+statement ok
+SET ROLE alice;
+
+query I
+UPDATE t SET a = 0 WHERE true RETURNING (select 1);
+----
+1
+
+statement ok
+SET ROLE bob;
+
+# Reset the row.
+statement ok
+UPDATE t SET k = 1, a = 10 WHERE true;
+
+statement ok
+SET ROLE alice;
+
+query IIT
+UPDATE t SET a = 0 WHERE true RETURNING 1 + 1, 2, 'three'
+----
+2 2 three
 
 statement ok
 SET ROLE root;
+
+# Reset the row.
+statement ok
+UPDATE t SET k = 1, a = 10 WHERE true;
 
 # Create another table to test UPDATE .. FROM. Confirm that SELECT policies on 't'
 # are not applied, even if the UPDATE references columns from this table.
@@ -4472,10 +4551,27 @@ UPDATE t SET a = other.a FROM other WHERE true;
 statement ok
 SET ROLE root;
 
+# Reset the row.
+statement ok
+UPDATE t SET k = 1, a = 10 WHERE true;
+
+statement ok
+SET ROLE alice;
+
+# Ensure SELECT policies on 't' are not applied when the RETURNING clause
+# only references a column from the 'other' table.
+query I
+UPDATE t SET a = -3 FROM other WHERE true RETURNING other.k;
+----
+1
+
+statement ok
+SET ROLE root;
+
 query I
 SELECT a FROM t;
 ----
--1
+-3
 
 # Reset the row.
 statement ok

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -237,6 +237,29 @@ INSERT INTO writer VALUES (3, 'three');
   size: 3 columns, 1 row
   policies: p_insert
 
+# The next two show that the SELECT policy is applied when using the RETURNING
+# clause, but only if it references the columns in the table.
+
+plan
+INSERT INTO writer VALUES (4, 'four') RETURNING *;
+----
+• insert fast path
+  into: writer(key, value)
+  auto commit
+  size: 3 columns, 1 row
+  policies: p_select, p_insert
+
+plan
+INSERT INTO writer VALUES (4, 'four') RETURNING 'foo'
+----
+• render
+│
+└── • insert fast path
+      into: writer(key, value)
+      auto commit
+      size: 3 columns, 1 row
+      policies: p_insert
+
 exec-ddl
 CREATE TABLE populator (key int not null primary key, value text);
 ----

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -760,9 +760,28 @@ func (mb *mutationBuilder) buildInsert(
 	// check constraint, refer to the correct columns.
 	mb.disambiguateColumns()
 
+	// Apply SELECT policies if:
+	// - There is an ON CONFLICT clause, which always requires SELECT policies
+	//   due to the conflict scan accessing existing data.
+	// - The RETURNING clause references any columns, which also necessitates
+	//   SELECT policies.
+	includeSelectPolicies := hasOnConflict
+	if mb.tab.IsRowLevelSecurityEnabled() && !includeSelectPolicies && returning != nil {
+		// RETURNING is constructed last and depends on the final scope, so we can’t
+		// build it early or move it. However, we can build temporary scopes to
+		// gather referenced columns (colRefs) just to determine if SELECT policies
+		// are needed. If policies are already required or RLS is not enabled, we skip
+		// this work.
+		var colRefs opt.ColSet
+		_, _ = mb.maybeBuildReturningScopes(returning, &colRefs)
+		// For INSERT, the RETURNING clause can only reference columns from the target table.
+		// So, it's sufficient to check whether any columns are referenced, rather than
+		// verifying if each one belongs to the table.
+		includeSelectPolicies = !colRefs.Empty()
+	}
+
 	// Add any check constraint boolean columns to the input.
-	mb.addCheckConstraintCols(false, /* isUpdate */
-		cat.PolicyScopeInsert, returning != nil || hasOnConflict /* includeSelectPolicies */)
+	mb.addCheckConstraintCols(false /* isUpdate */, cat.PolicyScopeInsert, includeSelectPolicies)
 
 	// Project partial index PUT boolean columns.
 	mb.projectPartialIndexPutCols()

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -195,10 +195,12 @@ func (b *Builder) analyzeSelectList(
 // expressions in projectionsScope.
 //
 // See Builder.buildStmt for a description of the remaining input values.
-func (b *Builder) buildProjectionList(inScope *scope, projectionsScope *scope) {
+func (b *Builder) buildProjectionList(
+	inScope *scope, projectionsScope *scope, colRefs *opt.ColSet,
+) {
 	for i := range projectionsScope.cols {
 		col := &projectionsScope.cols[i]
-		b.buildScalar(col.getExpr(), inScope, projectionsScope, col, nil)
+		b.buildScalar(col.getExpr(), inScope, projectionsScope, col, colRefs)
 	}
 }
 

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1250,7 +1250,7 @@ func (b *Builder) buildSelectClause(
 		having = b.buildHaving(havingExpr, fromScope)
 	}
 
-	b.buildProjectionList(fromScope, projectionsScope)
+	b.buildProjectionList(fromScope, projectionsScope, nil /* colRefs */)
 	b.buildOrderBy(fromScope, projectionsScope, orderByScope)
 	b.buildDistinctOnArgs(fromScope, projectionsScope, distinctOnScope)
 	b.buildLockArgs(fromScope, projectionsScope, lockScope)

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -192,7 +192,7 @@ build
 UPDATE T1 SET c1 = 2 WHERE true RETURNING 'foo';
 ----
 project
- ├── columns: "?column?":15!null
+ ├── columns: "?column?":14!null
  ├── update t1
  │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null
  │    ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
@@ -203,9 +203,9 @@ project
  │    │    ├── c2:8 => c2:2
  │    │    ├── c3:9 => c3:3
  │    │    └── rowid:10 => rowid:4
- │    ├── check columns: rls:14
+ │    ├── check columns: rls:15
  │    └── project
- │         ├── columns: rls:14!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
+ │         ├── columns: rls:15!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13!null
  │         ├── project
  │         │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
  │         │    ├── select
@@ -222,9 +222,9 @@ project
  │         │    └── projections
  │         │         └── 2 [as=c1_new:13]
  │         └── projections
- │              └── ((c1_new:13 % 2) = 0) AND (c1_new:13 < 100) [as=rls:14]
+ │              └── c1_new:13 < 100 [as=rls:15]
  └── projections
-      └── 'foo' [as="?column?":15]
+      └── 'foo' [as="?column?":14]
 
 build
 UPDATE T1 SET c1 = c1 + 1 WHERE true;
@@ -437,6 +437,68 @@ update t1
       │         └── -2 [as=c1_new:17]
       └── projections
            └── c1_new:17 < 100 [as=rls:18]
+
+# Ensure that column references to the 'other' table in the RETURNING clause
+# do not result in the SELECT policy being applied.
+build
+UPDATE T1 SET c1 = -20 FROM other RETURNING other.k;
+----
+project
+ ├── columns: k:13
+ └── update t1
+      ├── columns: c1:1!null c2:2 c3:3 rowid:4!null k:13 a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
+      ├── passthrough columns: k:13 a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+      ├── update-mapping:
+      │    └── c1_new:17 => c1:1
+      ├── return-mapping:
+      │    ├── c1_new:17 => c1:1
+      │    ├── c2:8 => c2:2
+      │    ├── c3:9 => c3:3
+      │    └── rowid:10 => rowid:4
+      ├── check columns: rls:18
+      └── project
+           ├── columns: rls:18!null c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16 c1_new:17!null
+           ├── project
+           │    ├── columns: c1_new:17!null c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+           │    ├── distinct-on
+           │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+           │    │    ├── grouping columns: rowid:10!null
+           │    │    ├── inner-join (cross)
+           │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+           │    │    │    ├── select
+           │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+           │    │    │    │    ├── scan t1
+           │    │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+           │    │    │    │    │    └── flags: avoid-full-scan
+           │    │    │    │    └── filters
+           │    │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+           │    │    │    ├── scan other
+           │    │    │    │    └── columns: k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
+           │    │    │    └── filters (true)
+           │    │    └── aggregations
+           │    │         ├── first-agg [as=c1:7]
+           │    │         │    └── c1:7
+           │    │         ├── first-agg [as=c2:8]
+           │    │         │    └── c2:8
+           │    │         ├── first-agg [as=c3:9]
+           │    │         │    └── c3:9
+           │    │         ├── first-agg [as=t1.crdb_internal_mvcc_timestamp:11]
+           │    │         │    └── t1.crdb_internal_mvcc_timestamp:11
+           │    │         ├── first-agg [as=t1.tableoid:12]
+           │    │         │    └── t1.tableoid:12
+           │    │         ├── first-agg [as=k:13]
+           │    │         │    └── k:13
+           │    │         ├── first-agg [as=a:14]
+           │    │         │    └── a:14
+           │    │         ├── first-agg [as=other.crdb_internal_mvcc_timestamp:15]
+           │    │         │    └── other.crdb_internal_mvcc_timestamp:15
+           │    │         └── first-agg [as=other.tableoid:16]
+           │    │              └── other.tableoid:16
+           │    └── projections
+           │         └── -20 [as=c1_new:17]
+           └── projections
+                └── c1_new:17 < 100 [as=rls:18]
 
 # Verify a DELETE won't use policies for UPDATE.
 
@@ -768,9 +830,11 @@ insert t1
       └── projections
            └── char_length(c2:8) < 10 [as=rls:14]
 
-# Apply SELECT policies on inserted rows if a RETURNING clause is present.
-# The first case handles inserts without RETURNING; the second handles inserts
-# with RETURNING.
+# Apply SELECT policies on inserted rows if the RETURNING clause exists and
+# references any columns.
+# - Case 1: No RETURNING clause — SELECT policies are not needed.
+# - Case 2: RETURNING clause references columns — SELECT policies are required.
+# - Case 3: RETURNING clause does not reference columns — SELECT policies are not needed.
 
 build
 INSERT INTO t1(c1) VALUES (10);
@@ -828,6 +892,48 @@ project
            │         └── unique_rowid() [as=rowid_default:10]
            └── projections
                 └── (c3_default:9 IN ('2013-06-02', '1988-07-01')) AND (char_length(c2_default:8) < 10) [as=rls:11]
+
+build
+INSERT INTO t1(c1) VALUES (10) RETURNING (select 1);
+----
+project
+ ├── columns: "?column?":15
+ ├── insert t1
+ │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null
+ │    ├── insert-mapping:
+ │    │    ├── column1:7 => c1:1
+ │    │    ├── c2_default:8 => c2:2
+ │    │    ├── c3_default:9 => c3:3
+ │    │    └── rowid_default:10 => rowid:4
+ │    ├── return-mapping:
+ │    │    ├── column1:7 => c1:1
+ │    │    ├── c2_default:8 => c2:2
+ │    │    ├── c3_default:9 => c3:3
+ │    │    └── rowid_default:10 => rowid:4
+ │    ├── check columns: rls:13
+ │    └── project
+ │         ├── columns: rls:13 column1:7!null c2_default:8 c3_default:9 rowid_default:10
+ │         ├── project
+ │         │    ├── columns: c2_default:8 c3_default:9 rowid_default:10 column1:7!null
+ │         │    ├── values
+ │         │    │    ├── columns: column1:7!null
+ │         │    │    └── (10,)
+ │         │    └── projections
+ │         │         ├── NULL::STRING [as=c2_default:8]
+ │         │         ├── NULL::DATE [as=c3_default:9]
+ │         │         └── unique_rowid() [as=rowid_default:10]
+ │         └── projections
+ │              └── char_length(c2_default:8) < 10 [as=rls:13]
+ └── projections
+      └── subquery [as="?column?":15]
+           └── max1-row
+                ├── columns: "?column?":14!null
+                └── project
+                     ├── columns: "?column?":14!null
+                     ├── values
+                     │    └── ()
+                     └── projections
+                          └── 1 [as="?column?":14]
 
 exec-ddl
 DROP POLICY p_select on t1;

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -732,9 +732,9 @@ with &1 (update_last_trade)
                      ├── key: (141)
                      ├── fd: (141)-->(142-144)
                      ├── project
-                     │    ├── columns: "?column?":140
+                     │    ├── columns: "?column?":130
                      │    ├── volatile, mutations
-                     │    ├── fd: ()-->(140)
+                     │    ├── fd: ()-->(130)
                      │    ├── update trade
                      │    │    ├── columns: t_id:88!null
                      │    │    ├── fetch columns: t_id:105 t_dts:106 trade.t_st_id:107 t_tt_id:108 t_is_cash:109 t_s_symb:110 t_qty:111 t_bid_price:112 t_ca_id:113 t_exec_name:114 t_trade_price:115 t_chrg:116 t_comm:117 t_lifo:119
@@ -772,18 +772,18 @@ with &1 (update_last_trade)
                      │    │    └── f-k-checks
                      │    │         └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
                      │    │              └── anti-join (lookup status_type)
-                     │    │                   ├── columns: t_st_id:135!null
-                     │    │                   ├── key columns: [135] = [136]
+                     │    │                   ├── columns: t_st_id:136!null
+                     │    │                   ├── key columns: [136] = [137]
                      │    │                   ├── lookup columns are key
-                     │    │                   ├── fd: ()-->(135)
+                     │    │                   ├── fd: ()-->(136)
                      │    │                   ├── with-scan &6
-                     │    │                   │    ├── columns: t_st_id:135!null
+                     │    │                   │    ├── columns: t_st_id:136!null
                      │    │                   │    ├── mapping:
-                     │    │                   │    │    └──  t_st_id_cast:129 => t_st_id:135
-                     │    │                   │    └── fd: ()-->(135)
+                     │    │                   │    │    └──  t_st_id_cast:129 => t_st_id:136
+                     │    │                   │    └── fd: ()-->(136)
                      │    │                   └── filters (true)
                      │    └── projections
-                     │         └── NULL [as="?column?":140]
+                     │         └── NULL [as="?column?":130]
                      └── with-scan &2 (request_list)
                           ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                           ├── mapping:
@@ -3960,11 +3960,11 @@ opt
 RETURNING t_tax::FLOAT8;
 ----
 project
- ├── columns: t_tax:53!null
+ ├── columns: t_tax:48!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(53)
+ ├── fd: ()-->(48)
  ├── update trade
  │    ├── columns: t_id:1!null trade.t_tax:14!null
  │    ├── fetch columns: t_id:18 trade.t_tax:31
@@ -3973,17 +3973,17 @@ project
  │    ├── return-mapping:
  │    │    ├── t_id:18 => t_id:1
  │    │    └── t_tax_cast:47 => trade.t_tax:14
- │    ├── check columns: check5:52
+ │    ├── check columns: check5:53
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1,14)
  │    └── project
- │         ├── columns: check5:52 t_id:18!null trade.t_tax:31!null t_tax_cast:47
+ │         ├── columns: check5:53 t_id:18!null trade.t_tax:31!null t_tax_cast:47
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(18,31,47,52)
+ │         ├── fd: ()-->(18,31,47,53)
  │         ├── project
  │         │    ├── columns: t_tax_cast:47 t_id:18!null trade.t_tax:31!null
  │         │    ├── cardinality: [0 - 1]
@@ -4023,9 +4023,9 @@ project
  │         │                   │                   └── tx_rate:37
  │         │                   └── 2E+1
  │         └── projections
- │              └── t_tax_cast:47 >= 0 [as=check5:52, outer=(47), immutable]
+ │              └── t_tax_cast:47 >= 0 [as=check5:53, outer=(47), immutable]
  └── projections
-      └── trade.t_tax:14::FLOAT8 [as=t_tax:53, outer=(14), immutable]
+      └── trade.t_tax:14::FLOAT8 [as=t_tax:48, outer=(14), immutable]
 
 # Q13
 opt
@@ -4192,11 +4192,11 @@ with &2 (update_trade_commission)
  ├── key: ()
  ├── fd: ()-->(104)
  ├── project
- │    ├── columns: "?column?":52!null
+ │    ├── columns: "?column?":42!null
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(52)
+ │    ├── fd: ()-->(42)
  │    ├── update trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── fetch columns: t_id:18 t_dts:19 trade.t_st_id:20 t_tt_id:21 t_is_cash:22 t_s_symb:23 t_qty:24 t_bid_price:25 t_ca_id:26 t_exec_name:27 t_trade_price:28 t_chrg:29 t_comm:30 t_lifo:32
@@ -4207,17 +4207,17 @@ with &2 (update_trade_commission)
  │    │    │    └── t_comm_cast:41 => t_comm:13
  │    │    ├── return-mapping:
  │    │    │    └── t_id:18 => t_id:1
- │    │    ├── check columns: check4:45
+ │    │    ├── check columns: check4:46
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── project
- │    │    │    ├── columns: check4:45!null t_comm_cast:41!null t_st_id_cast:39!null t_trade_price_cast:40!null t_dts_new:36!null t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
+ │    │    │    ├── columns: check4:46!null t_comm_cast:41!null t_st_id_cast:39!null t_trade_price_cast:40!null t_dts_new:36!null t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18-30,32,36,39-41,45)
+ │    │    │    ├── fd: ()-->(18-30,32,36,39-41,46)
  │    │    │    ├── scan trade
  │    │    │    │    ├── columns: t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    │    │    ├── constraint: /18: [/0 - /0]
@@ -4226,7 +4226,7 @@ with &2 (update_trade_commission)
  │    │    │    │    ├── key: ()
  │    │    │    │    └── fd: ()-->(18-30,32)
  │    │    │    └── projections
- │    │    │         ├── true [as=check4:45]
+ │    │    │         ├── true [as=check4:46]
  │    │    │         ├── 50.00 [as=t_comm_cast:41]
  │    │    │         ├── 'ACTV' [as=t_st_id_cast:39]
  │    │    │         ├── 100.00 [as=t_trade_price_cast:40]
@@ -4234,22 +4234,22 @@ with &2 (update_trade_commission)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │              └── anti-join (lookup status_type)
- │    │                   ├── columns: t_st_id:47!null
- │    │                   ├── key columns: [47] = [48]
+ │    │                   ├── columns: t_st_id:48!null
+ │    │                   ├── key columns: [48] = [49]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(47)
+ │    │                   ├── fd: ()-->(48)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_st_id:47!null
+ │    │                   │    ├── columns: t_st_id:48!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  t_st_id_cast:39 => t_st_id:47
+ │    │                   │    │    └──  t_st_id_cast:39 => t_st_id:48
  │    │                   │    ├── cardinality: [0 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(47)
+ │    │                   │    └── fd: ()-->(48)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":52]
+ │         └── 1 [as="?column?":42]
  └── with &3 (update_broker_commission)
       ├── columns: "?column?":104!null
       ├── cardinality: [1 - 1]
@@ -4394,11 +4394,11 @@ WHERE ca_id = 0
 RETURNING ca_bal::FLOAT8;
 ----
 with &2 (insert_settlement)
- ├── columns: ca_bal:82!null
+ ├── columns: ca_bal:81!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(82)
+ ├── fd: ()-->(81)
  ├── project
  │    ├── columns: "?column?":31!null
  │    ├── cardinality: [1 - 1]
@@ -4445,11 +4445,11 @@ with &2 (insert_settlement)
  │    └── projections
  │         └── 1 [as="?column?":31]
  └── with &4 (insert_cash_transaction)
-      ├── columns: ca_bal:82!null
+      ├── columns: ca_bal:81!null
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
-      ├── fd: ()-->(82)
+      ├── fd: ()-->(81)
       ├── project
       │    ├── columns: "?column?":62!null
       │    ├── cardinality: [1 - 1]
@@ -4496,11 +4496,11 @@ with &2 (insert_settlement)
       │    └── projections
       │         └── 1 [as="?column?":62]
       └── project
-           ├── columns: ca_bal:82!null
+           ├── columns: ca_bal:81!null
            ├── cardinality: [0 - 1]
            ├── volatile, mutations
            ├── key: ()
-           ├── fd: ()-->(82)
+           ├── fd: ()-->(81)
            ├── update customer_account
            │    ├── columns: ca_id:63!null customer_account.ca_bal:68!null
            │    ├── fetch columns: ca_id:71 ca_b_id:72 ca_c_id:73 ca_name:74 ca_tax_st:75 customer_account.ca_bal:76
@@ -4530,7 +4530,7 @@ with &2 (insert_settlement)
            │              └── assignment-cast: DECIMAL(12,2) [as=ca_bal_cast:80, outer=(76), immutable]
            │                   └── customer_account.ca_bal:76 + 1E+2
            └── projections
-                └── customer_account.ca_bal:68::FLOAT8 [as=ca_bal:82, outer=(68), immutable]
+                └── customer_account.ca_bal:68::FLOAT8 [as=ca_bal:81, outer=(68), immutable]
 
 # Q16
 opt

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -750,9 +750,9 @@ with &1 (update_last_trade)
                      ├── key: (141)
                      ├── fd: (141)-->(142-144)
                      ├── project
-                     │    ├── columns: "?column?":140
+                     │    ├── columns: "?column?":130
                      │    ├── volatile, mutations
-                     │    ├── fd: ()-->(140)
+                     │    ├── fd: ()-->(130)
                      │    ├── update trade
                      │    │    ├── columns: t_id:88!null
                      │    │    ├── fetch columns: t_id:105 t_dts:106 trade.t_st_id:107 t_tt_id:108 t_is_cash:109 t_s_symb:110 t_qty:111 t_bid_price:112 t_ca_id:113 t_exec_name:114 t_trade_price:115 t_chrg:116 t_comm:117 t_lifo:119
@@ -790,18 +790,18 @@ with &1 (update_last_trade)
                      │    │    └── f-k-checks
                      │    │         └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
                      │    │              └── anti-join (lookup status_type)
-                     │    │                   ├── columns: t_st_id:135!null
-                     │    │                   ├── key columns: [135] = [136]
+                     │    │                   ├── columns: t_st_id:136!null
+                     │    │                   ├── key columns: [136] = [137]
                      │    │                   ├── lookup columns are key
-                     │    │                   ├── fd: ()-->(135)
+                     │    │                   ├── fd: ()-->(136)
                      │    │                   ├── with-scan &6
-                     │    │                   │    ├── columns: t_st_id:135!null
+                     │    │                   │    ├── columns: t_st_id:136!null
                      │    │                   │    ├── mapping:
-                     │    │                   │    │    └──  t_st_id_cast:129 => t_st_id:135
-                     │    │                   │    └── fd: ()-->(135)
+                     │    │                   │    │    └──  t_st_id_cast:129 => t_st_id:136
+                     │    │                   │    └── fd: ()-->(136)
                      │    │                   └── filters (true)
                      │    └── projections
-                     │         └── NULL [as="?column?":140]
+                     │         └── NULL [as="?column?":130]
                      └── with-scan &2 (request_list)
                           ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                           ├── mapping:
@@ -3980,11 +3980,11 @@ opt
 RETURNING t_tax::FLOAT8;
 ----
 project
- ├── columns: t_tax:53!null
+ ├── columns: t_tax:48!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(53)
+ ├── fd: ()-->(48)
  ├── update trade
  │    ├── columns: t_id:1!null trade.t_tax:14!null
  │    ├── fetch columns: t_id:18 trade.t_tax:31
@@ -3993,17 +3993,17 @@ project
  │    ├── return-mapping:
  │    │    ├── t_id:18 => t_id:1
  │    │    └── t_tax_cast:47 => trade.t_tax:14
- │    ├── check columns: check5:52
+ │    ├── check columns: check5:53
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
  │    ├── fd: ()-->(1,14)
  │    └── project
- │         ├── columns: check5:52 t_id:18!null trade.t_tax:31!null t_tax_cast:47
+ │         ├── columns: check5:53 t_id:18!null trade.t_tax:31!null t_tax_cast:47
  │         ├── cardinality: [0 - 1]
  │         ├── immutable
  │         ├── key: ()
- │         ├── fd: ()-->(18,31,47,52)
+ │         ├── fd: ()-->(18,31,47,53)
  │         ├── project
  │         │    ├── columns: t_tax_cast:47 t_id:18!null trade.t_tax:31!null
  │         │    ├── cardinality: [0 - 1]
@@ -4043,9 +4043,9 @@ project
  │         │                   │                   └── tx_rate:37
  │         │                   └── 2E+1
  │         └── projections
- │              └── t_tax_cast:47 >= 0 [as=check5:52, outer=(47), immutable]
+ │              └── t_tax_cast:47 >= 0 [as=check5:53, outer=(47), immutable]
  └── projections
-      └── trade.t_tax:14::FLOAT8 [as=t_tax:53, outer=(14), immutable]
+      └── trade.t_tax:14::FLOAT8 [as=t_tax:48, outer=(14), immutable]
 
 # Q13
 opt
@@ -4212,11 +4212,11 @@ with &2 (update_trade_commission)
  ├── key: ()
  ├── fd: ()-->(104)
  ├── project
- │    ├── columns: "?column?":52!null
+ │    ├── columns: "?column?":42!null
  │    ├── cardinality: [0 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(52)
+ │    ├── fd: ()-->(42)
  │    ├── update trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── fetch columns: t_id:18 t_dts:19 trade.t_st_id:20 t_tt_id:21 t_is_cash:22 t_s_symb:23 t_qty:24 t_bid_price:25 t_ca_id:26 t_exec_name:27 t_trade_price:28 t_chrg:29 t_comm:30 t_lifo:32
@@ -4227,17 +4227,17 @@ with &2 (update_trade_commission)
  │    │    │    └── t_comm_cast:41 => t_comm:13
  │    │    ├── return-mapping:
  │    │    │    └── t_id:18 => t_id:1
- │    │    ├── check columns: check4:45
+ │    │    ├── check columns: check4:46
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [0 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── project
- │    │    │    ├── columns: check4:45!null t_comm_cast:41!null t_st_id_cast:39!null t_trade_price_cast:40!null t_dts_new:36!null t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
+ │    │    │    ├── columns: check4:46!null t_comm_cast:41!null t_st_id_cast:39!null t_trade_price_cast:40!null t_dts_new:36!null t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    │    ├── cardinality: [0 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18-30,32,36,39-41,45)
+ │    │    │    ├── fd: ()-->(18-30,32,36,39-41,46)
  │    │    │    ├── scan trade
  │    │    │    │    ├── columns: t_id:18!null t_dts:19!null trade.t_st_id:20!null t_tt_id:21!null t_is_cash:22!null t_s_symb:23!null t_qty:24!null t_bid_price:25!null t_ca_id:26!null t_exec_name:27!null t_trade_price:28 t_chrg:29!null t_comm:30!null t_lifo:32!null
  │    │    │    │    ├── constraint: /18: [/0 - /0]
@@ -4246,7 +4246,7 @@ with &2 (update_trade_commission)
  │    │    │    │    ├── key: ()
  │    │    │    │    └── fd: ()-->(18-30,32)
  │    │    │    └── projections
- │    │    │         ├── true [as=check4:45]
+ │    │    │         ├── true [as=check4:46]
  │    │    │         ├── 50.00 [as=t_comm_cast:41]
  │    │    │         ├── 'ACTV' [as=t_st_id_cast:39]
  │    │    │         ├── 100.00 [as=t_trade_price_cast:40]
@@ -4254,22 +4254,22 @@ with &2 (update_trade_commission)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │              └── anti-join (lookup status_type)
- │    │                   ├── columns: t_st_id:47!null
- │    │                   ├── key columns: [47] = [48]
+ │    │                   ├── columns: t_st_id:48!null
+ │    │                   ├── key columns: [48] = [49]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(47)
+ │    │                   ├── fd: ()-->(48)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_st_id:47!null
+ │    │                   │    ├── columns: t_st_id:48!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  t_st_id_cast:39 => t_st_id:47
+ │    │                   │    │    └──  t_st_id_cast:39 => t_st_id:48
  │    │                   │    ├── cardinality: [0 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(47)
+ │    │                   │    └── fd: ()-->(48)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":52]
+ │         └── 1 [as="?column?":42]
  └── with &3 (update_broker_commission)
       ├── columns: "?column?":104!null
       ├── cardinality: [1 - 1]
@@ -4414,11 +4414,11 @@ WHERE ca_id = 0
 RETURNING ca_bal::FLOAT8;
 ----
 with &2 (insert_settlement)
- ├── columns: ca_bal:82!null
+ ├── columns: ca_bal:81!null
  ├── cardinality: [0 - 1]
  ├── volatile, mutations
  ├── key: ()
- ├── fd: ()-->(82)
+ ├── fd: ()-->(81)
  ├── project
  │    ├── columns: "?column?":31!null
  │    ├── cardinality: [1 - 1]
@@ -4465,11 +4465,11 @@ with &2 (insert_settlement)
  │    └── projections
  │         └── 1 [as="?column?":31]
  └── with &4 (insert_cash_transaction)
-      ├── columns: ca_bal:82!null
+      ├── columns: ca_bal:81!null
       ├── cardinality: [0 - 1]
       ├── volatile, mutations
       ├── key: ()
-      ├── fd: ()-->(82)
+      ├── fd: ()-->(81)
       ├── project
       │    ├── columns: "?column?":62!null
       │    ├── cardinality: [1 - 1]
@@ -4516,11 +4516,11 @@ with &2 (insert_settlement)
       │    └── projections
       │         └── 1 [as="?column?":62]
       └── project
-           ├── columns: ca_bal:82!null
+           ├── columns: ca_bal:81!null
            ├── cardinality: [0 - 1]
            ├── volatile, mutations
            ├── key: ()
-           ├── fd: ()-->(82)
+           ├── fd: ()-->(81)
            ├── update customer_account
            │    ├── columns: ca_id:63!null customer_account.ca_bal:68!null
            │    ├── fetch columns: ca_id:71 ca_b_id:72 ca_c_id:73 ca_name:74 ca_tax_st:75 customer_account.ca_bal:76
@@ -4550,7 +4550,7 @@ with &2 (insert_settlement)
            │              └── assignment-cast: DECIMAL(12,2) [as=ca_bal_cast:80, outer=(76), immutable]
            │                   └── customer_account.ca_bal:76 + 1E+2
            └── projections
-                └── customer_account.ca_bal:68::FLOAT8 [as=ca_bal:82, outer=(68), immutable]
+                └── customer_account.ca_bal:68::FLOAT8 [as=ca_bal:81, outer=(68), immutable]
 
 # Q16
 opt


### PR DESCRIPTION
Backport 1/1 commits from #145890 on behalf of @spilchen.

----

Previously, SELECT policies were always applied when a RETURNING clause was used in an INSERT or UPDATE statement. This behavior was overly restrictive, as the SELECT policies should only be enforced when the RETURNING clause actually references one or more columns from the table.

This change modifies the logic to inspect the RETURNING clause and apply SELECT policies only when column references are present.

Fixes #144951

Epic: CRDB-11724

Release note (bug fix): Fixed incorrect application of SELECT policies
to RETURNING clauses in INSERT and UPDATE when no table columns were
referenced.


----

Release justification: bug fix for RLS that was initially released in 25.2