### PR TITLE
changefeedccl: turn on verbose logging for TestChangefeedCursor

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1005,6 +1005,7 @@ func TestChangefeedMultiTable(t *testing.T) {
 func TestChangefeedCursor(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	require.NoError(t, log.SetVModule("event_processing=3,blocking_buffer=2"))
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)


### PR DESCRIPTION
For test failure on master, issue https://github.com/cockroachdb/cockroach/issues/146179, we saw missing
updates. To be able to better debug, we add these logs.

Informs: https://github.com/cockroachdb/cockroach/issues/146179