### PR TITLE
changefeed: fix race in cloudstorage sink

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -66,13 +66,33 @@ func cloudStorageFormatTime(ts hlc.Timestamp) string {
 	return fmt.Sprintf(`%s%09d%010d`, t.Format(f), t.Nanosecond(), ts.Logical)
 }
 
+// byteBufferWithTrackedLength is a bytes.Buffer that also tracks its length
+// separately and atomically. This is useful for codecs that write to the buffer
+// asynchronously, such as pgzip/zstd, because we can't safely call `buf.Len()`
+// while the codec is open, because buf.Write() may be called after
+// codec.Write() returns.
+type byteBufferWithTrackedLength struct {
+	bytes.Buffer
+	len atomic.Int64
+}
+
+func (b *byteBufferWithTrackedLength) Write(p []byte) (n int, err error) {
+	n, err = b.Buffer.Write(p)
+	b.len.Add(int64(n))
+	return n, err
+}
+
+func (b *byteBufferWithTrackedLength) Len() int {
+	return int(b.len.Load())
+}
+
 type cloudStorageSinkFile struct {
 	cloudStorageSinkKey
 	created       time.Time
 	codec         io.WriteCloser
 	rawSize       int
 	numMessages   int
-	buf           bytes.Buffer
+	buf           byteBufferWithTrackedLength
 	alloc         kvevent.Alloc
 	oldestMVCC    hlc.Timestamp
 	parquetCodec  *parquetWriter

--- a/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage_test.go
@@ -37,7 +37,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -848,7 +847,6 @@ func (o explicitTimestampOracle) inclusiveLowerBoundTS() hlc.Timestamp {
 func TestCloudStorageSinkFastGzip(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderRace(t, "#130651")
 
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettings()

--- a/pkg/testutils/skip/skip.go
+++ b/pkg/testutils/skip/skip.go
@@ -86,6 +86,14 @@ func UnderRace(t SkippableTest, args ...interface{}) {
 	}
 }
 
+// UnlessUnderRace skips this test if the race detector is not enabled.
+func UnlessUnderRace(t SkippableTest, args ...interface{}) {
+	t.Helper()
+	if !util.RaceEnabled {
+		maybeSkip(t, "disabled unless under race", args...)
+	}
+}
+
 // UnderRaceWithIssue skips this test if the race detector is enabled,
 // logging the given issue ID as the reason.
 func UnderRaceWithIssue(t SkippableTest, githubIssueID int, args ...interface{}) {


### PR DESCRIPTION
When using zstd or "fast" gzip compression, the
cloudstorage sink was susceptible to a data race
on its buffered data. This was due to unexpected
asynchronousness in the compression writers.


Fixes: #130656
Fixes: #130651


Release note (bug fix): Fix a data race in the cloudstorage sink.