### PR TITLE
release-25.2: colenc: harden TestEncoderEqualityRand

### DIFF
--- a/pkg/sql/colenc/encode_test.go
+++ b/pkg/sql/colenc/encode_test.go
@@ -259,6 +259,10 @@ func TestEncoderEqualityRand(t *testing.T) {
 	ctx := context.Background()
 	s, db, kvdb := serverutils.StartServer(t, base.TestServerArgs{})
 	defer s.Stopper().Stop(ctx)
+	// Increase the span config limit in case we're running with multiple
+	// tenants since the loop below might create more spans than the default
+	// limit of 5k.
+	s.SQLConn(t).QueryRow("SET CLUSTER SETTING spanconfig.tenant_limit = 50000")
 	codec, sv := s.ApplicationLayer().Codec(), &s.ApplicationLayer().ClusterSettings().SV
 	rng, _ := randutil.NewTestRand()
 	for i := 0; i < 100; i++ {


### PR DESCRIPTION
Backport 1/1 commits from #146254 on behalf of @yuzefovich.

----

We just saw a failure in this test due to hitting `spanconfig.tenant_limit` (5k by default) since the test creates 100 tables without dropping them, and some of those tables might have partitions. This commit simply increases the limit by 10x (similar to what we do in mixed-version roachtest framework).

Fixes: #146057.

Release note: None

----

Release justification: test-only change.