### PR TITLE
kvserver: introduce setting to periodically reset split samples

### DIFF
--- a/pkg/kv/kvserver/asim/state/split_decider.go
+++ b/pkg/kv/kvserver/asim/state/split_decider.go
@@ -58,6 +58,12 @@ func (lsc loadSplitConfig) StatThreshold(_ split.SplitObjective) float64 {
 	return lsc.settings.SplitQPSThreshold
 }
 
+// SampleResetDuration returns the duration that any sampling structure should
+// retain data for before resetting.
+func (lsc loadSplitConfig) SampleResetDuration() time.Duration {
+	return 0 /* disabled */
+}
+
 // SplitDecider implements the LoadSplitter interface.
 type SplitDecider struct {
 	deciders    map[RangeID]*split.Decider

--- a/pkg/kv/kvserver/split/decider.go
+++ b/pkg/kv/kvserver/split/decider.go
@@ -75,6 +75,9 @@ type LoadSplitConfig interface {
 	// StatThreshold returns the threshold for load above which the range
 	// should be considered split.
 	StatThreshold(SplitObjective) float64
+	// SampleResetDuration returns the duration that any sampling structure
+	// should retain data for before resetting.
+	SampleResetDuration() time.Duration
 }
 
 type RandSource interface {
@@ -167,6 +170,7 @@ type Decider struct {
 
 		// Fields tracking split key suggestions.
 		splitFinder         LoadBasedSplitter // populated when engaged or decided
+		splitFinderInitAt   time.Time         // when the split finder was initialized
 		lastSplitSuggestion time.Time         // last stipulation to client to carry out split
 		suggestionsMade     int               // suggestions made since last reset
 
@@ -252,6 +256,7 @@ func (d *Decider) recordLocked(
 		if d.mu.lastStatVal >= d.config.StatThreshold(d.mu.objective) {
 			if d.mu.splitFinder == nil {
 				d.mu.splitFinder = d.config.NewLoadBasedSplitter(now, d.mu.objective)
+				d.mu.splitFinderInitAt = now
 			}
 		} else {
 			d.mu.splitFinder = nil
@@ -296,6 +301,15 @@ func (d *Decider) recordLocked(
 					}
 				}
 			}
+		}
+		// If the split finder has been initialized for longer than the sample
+		// reset duration, then we discard the split finder and start over. This is
+		// to prevent the split finder from being stuck in a state where it is not
+		// finding a split key based on earlier sampled keys, but could find one if
+		// it were to sample new keys with higher probability.
+		if sampleResetDuration := d.config.SampleResetDuration(); sampleResetDuration != 0 &&
+			now.Sub(d.mu.splitFinderInitAt) >= sampleResetDuration {
+			d.mu.splitFinder = nil
 		}
 	}
 	return false
@@ -402,6 +416,7 @@ func (d *Decider) resetLocked(now time.Time) {
 	d.mu.lastStatVal = 0
 	d.mu.count = 0
 	d.mu.maxStat.reset(now, d.config.StatRetention())
+	d.mu.splitFinderInitAt = time.Time{}
 	d.mu.splitFinder = nil
 	d.mu.suggestionsMade = 0
 	d.mu.lastSplitSuggestion = time.Time{}


### PR DESCRIPTION
Introduce a cluster setting `kv.range_split.load_reset_duration` which resets the load based splitter sampling after the set duration. When the set duration is zero, the load based splitter continues to only be reset when the per-second load falls below the load split threshold.

This setting may be useful when a range services a non-stationary load distribution, such that the initially sampled set of split keys are unsuitable to determine a split key from (e.g., all the same key) but a later sample set is suitable.

Informs: #144407
Release note: None