### PR TITLE
release-24.3: storage/disk: improve logging of device IDs

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -815,6 +815,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			if err != nil {
 				return Engines{}, errors.Wrap(err, "creating disk monitor")
 			}
+			detail(redact.Sprintf("store %d: disk deviceID: %s", i, monitor.DeviceID()))
 
 			statsCollector, err := cfg.DiskWriteStats.GetOrCreateCollector(spec.Path)
 			if err != nil {

--- a/pkg/storage/disk/BUILD.bazel
+++ b/pkg/storage/disk/BUILD.bazel
@@ -16,10 +16,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/envutil",
+        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_cockroachdb_redact//:redact",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/util/sysutil",
@@ -57,5 +59,13 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/util/timeutil",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/util/timeutil",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/storage/disk/linux_parse.go
+++ b/pkg/storage/disk/linux_parse.go
@@ -45,7 +45,9 @@ import (
 //	12  I/Os currently in progress
 //	13  time spent doing I/Os (ms)
 //	14  weighted time spent doing I/Os (ms)
-func parseDiskStats(contents []byte, disks []*monitoredDisk, measuredAt time.Time) error {
+func parseDiskStats(
+	contents []byte, disks []*monitoredDisk, measuredAt time.Time,
+) (countCollected int, err error) {
 	for lineNum := 0; len(contents) > 0; lineNum++ {
 		lineBytes, rest := splitLine(contents)
 		line := unsafe.String(&lineBytes[0], len(lineBytes))
@@ -55,13 +57,13 @@ func parseDiskStats(contents []byte, disks []*monitoredDisk, measuredAt time.Tim
 
 		var deviceID DeviceID
 		if devMajor, rest, err := mustParseUint(line, 32, "deviceID.major"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else {
 			line = rest
 			deviceID.major = uint32(devMajor)
 		}
 		if devMinor, rest, err := mustParseUint(line, 32, "deviceID.minor"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else {
 			line = rest
 			deviceID.minor = uint32(devMinor)
@@ -79,46 +81,46 @@ func parseDiskStats(contents []byte, disks []*monitoredDisk, measuredAt time.Tim
 		var err error
 		stats.DeviceName, line = splitFieldDelim(line)
 		if stats.ReadsCount, line, err = mustParseUint(line, 64, "reads count"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if stats.ReadsMerged, line, err = mustParseUint(line, 64, "reads merged"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if stats.ReadsSectors, line, err = mustParseUint(line, 64, "reads sectors"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if millis, rest, err := mustParseUint(line, 64, "reads duration"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else {
 			line = rest
 			stats.ReadsDuration = time.Duration(millis) * time.Millisecond
 		}
 		if stats.WritesCount, line, err = mustParseUint(line, 64, "writes count"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if stats.WritesMerged, line, err = mustParseUint(line, 64, "writes merged"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if stats.WritesSectors, line, err = mustParseUint(line, 64, "writes sectors"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if millis, rest, err := mustParseUint(line, 64, "writes duration"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else {
 			line = rest
 			stats.WritesDuration = time.Duration(millis) * time.Millisecond
 		}
 		if stats.InProgressCount, line, err = mustParseUint(line, 64, "inprogress iops"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if millis, rest, err := mustParseUint(line, 64, "time doing IO"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else {
 			line = rest
 			stats.CumulativeDuration = time.Duration(millis) * time.Millisecond
 		}
 		if millis, rest, err := mustParseUint(line, 64, "weighted IO duration"); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else {
 			line = rest
 			stats.WeightedIODuration = time.Duration(millis) * time.Millisecond
@@ -126,31 +128,32 @@ func parseDiskStats(contents []byte, disks []*monitoredDisk, measuredAt time.Tim
 
 		// The below fields are optional.
 		if stats.DiscardsCount, _, line, err = tryParseUint(line, 64); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if stats.DiscardsMerged, _, line, err = tryParseUint(line, 64); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if stats.DiscardsSectors, _, line, err = tryParseUint(line, 64); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if millis, ok, rest, err := tryParseUint(line, 64); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else if ok {
 			line = rest
 			stats.DiscardsDuration = time.Duration(millis) * time.Millisecond
 		}
 		if stats.FlushesCount, _, line, err = tryParseUint(line, 64); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		}
 		if millis, ok, _, err := tryParseUint(line, 64); err != nil {
-			return errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
+			return 0, errors.Wrapf(err, "/proc/diskstats:%d: %q", lineNum, err)
 		} else if ok {
 			stats.FlushesDuration = time.Duration(millis) * time.Millisecond
 		}
 		disks[diskIdx].recordStats(measuredAt, stats)
+		countCollected++
 	}
-	return nil
+	return countCollected, nil
 }
 
 func splitLine(b []byte) (line, rest []byte) {

--- a/pkg/storage/disk/linux_parse_test.go
+++ b/pkg/storage/disk/linux_parse_test.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -60,7 +61,7 @@ func TestLinux_CollectDiskStats(t *testing.T) {
 				// resizing logic.
 				buf: make([]byte, 16),
 			}
-			err := s.collect(disks)
+			_, err := s.collect(disks, timeutil.Now())
 			if err != nil {
 				return err.Error()
 			}

--- a/pkg/storage/disk/monitor.go
+++ b/pkg/storage/disk/monitor.go
@@ -6,15 +6,17 @@
 package disk
 
 import (
-	"fmt"
+	"context"
 	"slices"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 )
 
 var DefaultDiskStatsPollingInterval = envutil.EnvOrDefaultDuration("COCKROACH_DISK_STATS_POLLING_INTERVAL", 100*time.Millisecond)
@@ -28,7 +30,12 @@ type DeviceID struct {
 
 // String returns the string representation of the device ID.
 func (d DeviceID) String() string {
-	return fmt.Sprintf("%d:%d", d.major, d.minor)
+	return redact.StringWithoutMarkers(d)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (d DeviceID) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%d:%d", d.major, d.minor)
 }
 
 // MonitorManager provides observability into a pool of disks by sampling disk stats
@@ -128,7 +135,7 @@ func (m *MonitorManager) unrefDisk(disk *monitoredDisk) {
 }
 
 type statsCollector interface {
-	collect(disks []*monitoredDisk) error
+	collect(disks []*monitoredDisk, now time.Time) (countCollected int, err error)
 }
 
 // monitorDisks runs a loop collecting disk stats for all monitored disks.
@@ -137,9 +144,13 @@ type statsCollector interface {
 // race where the MonitorManager creates a new stop channel after unrefDisk sends a message
 // across the old stop channel.
 func (m *MonitorManager) monitorDisks(collector statsCollector, stop chan struct{}) {
+	// TODO(jackson): Should we propagate a context here to replace the stop
+	// channel?
+	ctx := context.TODO()
 	ticker := time.NewTicker(DefaultDiskStatsPollingInterval)
 	defer ticker.Stop()
 
+	every := log.Every(5 * time.Minute)
 	for {
 		select {
 		case <-stop:
@@ -150,13 +161,25 @@ func (m *MonitorManager) monitorDisks(collector statsCollector, stop chan struct
 			disks := m.mu.disks
 			m.mu.Unlock()
 
-			if err := collector.collect(disks); err != nil {
+			now := timeutil.Now()
+			countCollected, err := collector.collect(disks, now)
+			if err != nil {
 				for i := range disks {
 					disks[i].tracer.RecordEvent(traceEvent{
 						time:  timeutil.Now(),
 						stats: Stats{},
 						err:   err,
 					})
+				}
+			} else if countCollected != len(disks) && every.ShouldLog() {
+				// Log a warning if we collected fewer disk stats than expected.
+				log.Warningf(ctx, "collected %d disk stats, expected %d", countCollected, len(disks))
+				cutoff := now.Add(-10 * DefaultDiskStatsPollingInterval)
+				for i := range disks {
+					if disks[i].tracer.LastEventTime().Before(cutoff) {
+						log.Warningf(ctx, "disk %s has not recorded any stats for the past %s",
+							disks[i].deviceID, DefaultDiskStatsPollingInterval)
+					}
 				}
 			}
 		}
@@ -225,6 +248,11 @@ type Monitor struct {
 		// Tracks the time of the last invocation of IncrementalStats.
 		lastIncrementedAt time.Time
 	}
+}
+
+// DeviceID returns the device ID of the disk being monitored.
+func (m *Monitor) DeviceID() DeviceID {
+	return m.deviceID
 }
 
 // CumulativeStats returns the most-recent stats observed.

--- a/pkg/storage/disk/monitor_test.go
+++ b/pkg/storage/disk/monitor_test.go
@@ -17,12 +17,14 @@ import (
 )
 
 type spyCollector struct {
-	collectCount int
+	collectCallCount int
 }
 
-func (s *spyCollector) collect(disks []*monitoredDisk) error {
-	s.collectCount++
-	return nil
+func (s *spyCollector) collect(
+	disks []*monitoredDisk, now time.Time,
+) (countCollected int, err error) {
+	s.collectCallCount++
+	return len(disks), nil
 }
 
 func TestMonitorManager_monitorDisks(t *testing.T) {
@@ -45,7 +47,7 @@ func TestMonitorManager_monitorDisks(t *testing.T) {
 
 	time.Sleep(2 * DefaultDiskStatsPollingInterval)
 	stop <- struct{}{}
-	require.Greater(t, testCollector.collectCount, 0)
+	require.Greater(t, testCollector.collectCallCount, 0)
 }
 
 func TestMonitor_StatsWindow(t *testing.T) {

--- a/pkg/storage/disk/monitor_tracer.go
+++ b/pkg/storage/disk/monitor_tracer.go
@@ -86,6 +86,16 @@ func (m *monitorTracer) RecordEvent(event traceEvent) {
 	}
 }
 
+// LastEventTime returns the time of the last traceEvent that was queued.
+func (m *monitorTracer) LastEventTime() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sizeLocked() == 0 {
+		return time.Time{}
+	}
+	return m.mu.trace[(m.mu.end-1)%m.capacity].time
+}
+
 // Latest retrieves the last traceEvent that was queued. Returns a zero-valued
 // traceEvent if none exists.
 func (m *monitorTracer) Latest() traceEvent {

--- a/pkg/storage/disk/platform_darwin.go
+++ b/pkg/storage/disk/platform_darwin.go
@@ -10,6 +10,7 @@ package disk
 
 import (
 	"io/fs"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/pebble/vfs"
@@ -18,8 +19,8 @@ import (
 
 type darwinCollector struct{}
 
-func (darwinCollector) collect([]*monitoredDisk) error {
-	return nil
+func (darwinCollector) collect(disks []*monitoredDisk, time time.Time) (int, error) {
+	return len(disks), nil
 }
 
 func newStatsCollector(fs vfs.FS) (*darwinCollector, error) {

--- a/pkg/storage/disk/platform_default.go
+++ b/pkg/storage/disk/platform_default.go
@@ -10,14 +10,15 @@ package disk
 
 import (
 	"io/fs"
+	"time"
 
 	"github.com/cockroachdb/pebble/vfs"
 )
 
 type defaultCollector struct{}
 
-func (defaultCollector) collect([]*monitoredDisk) error {
-	return nil
+func (defaultCollector) collect(disks []*monitoredDisk, time time.Time) (int, error) {
+	return len(disks), nil
 }
 
 func newStatsCollector(fs vfs.FS) (*defaultCollector, error) {

--- a/pkg/storage/disk/platform_linux.go
+++ b/pkg/storage/disk/platform_linux.go
@@ -11,9 +11,9 @@ package disk
 import (
 	"io"
 	"io/fs"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
 	"golang.org/x/sys/unix"
@@ -27,15 +27,16 @@ type linuxStatsCollector struct {
 }
 
 // collect collects disk stats for the identified devices.
-func (s *linuxStatsCollector) collect(disks []*monitoredDisk) error {
+func (s *linuxStatsCollector) collect(
+	disks []*monitoredDisk, now time.Time,
+) (countCollected int, err error) {
 	var n int
-	var err error
 	for {
 		n, err = s.File.ReadAt(s.buf, 0)
 		if errors.Is(err, io.EOF) {
 			break
 		} else if err != nil {
-			return err
+			return 0, err
 		}
 		// err == nil
 		//
@@ -49,7 +50,7 @@ func (s *linuxStatsCollector) collect(disks []*monitoredDisk) error {
 		// single read. Reallocate (doubling) the buffer and continue.
 		s.buf = make([]byte, len(s.buf)*2)
 	}
-	return parseDiskStats(s.buf[:n], disks, timeutil.Now())
+	return parseDiskStats(s.buf[:n], disks, now)
 }
 
 func newStatsCollector(fs vfs.FS) (*linuxStatsCollector, error) {


### PR DESCRIPTION
Log a warning periodically if a disk that should be monitored is not being monitored because it's not found in /proc/diskstats.

Additionally, on start up, print a store's monitored device ID.

Close #146321.
Epic: none
Release note: none