### PR TITLE
kvcoord: fix QueryLocks and LeaseInfo handling in txnWriteBuffer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -1193,9 +1193,16 @@ func (rr requestRecord) toResp(
 	case *kvpb.QueryLocksRequest, *kvpb.LeaseInfoRequest:
 		// These requests don't interact with buffered writes, so we simply
 		// let the response through unchanged.
+		ru = br
 
 	default:
 		return ru, kvpb.NewError(unsupportedMethodError(req.Method()))
+	}
+
+	if buildutil.CrdbTestBuild {
+		if ru.GetInner() == nil {
+			panic(errors.AssertionFailedf("expected response to be set for type %T", rr.origRequest))
+		}
 	}
 
 	return ru, nil


### PR DESCRIPTION
This commit fixes an oversight in how we handled QueryLocks and LeaseInfo requests in the txnWriteBuffer. We simply pass the request and the response through, but we forgot to properly propagate the response out. The bug was exposed in a recent refactor 65476fc7df1ca06e037e1e421544dfa574f7ddb8.

Epic: None
Release note: None