### PR TITLE
release-24.1: kvserver: skip TestLeaseQueueShedsOnIOOverload under duress

### DIFF
--- a/pkg/kv/kvserver/lease_queue_test.go
+++ b/pkg/kv/kvserver/lease_queue_test.go
@@ -343,6 +343,11 @@ func TestLeaseQueueRaceReplicateQueue(t *testing.T) {
 func TestLeaseQueueShedsOnIOOverload(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+
+	// The SucceedsSoon has been observed to occasionally time out in both
+	// deadlock and race builds.
+	skip.UnderDuressWithIssue(t, 138903)
+
 	ctx := context.Background()
 
 	tc := testcluster.StartTestCluster(t, 3, base.TestClusterArgs{})


### PR DESCRIPTION
Backport 1/1 commits from #144460.

/cc @cockroachdb/release

Addresses #146035.
Closes #146514.

---

See #144379.
See #138903.

Epic: None
Release note: None
