### PR TITLE
storage: pass context to Engine.{Compact,CompactRange}

### DIFF
--- a/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
+++ b/pkg/ccl/storageccl/engineccl/encrypted_fs_test.go
@@ -415,7 +415,7 @@ func TestPebbleEncryption2(t *testing.T) {
 		)
 		require.NoError(t, err)
 		require.NoError(t, db.Flush())
-		require.NoError(t, db.Compact())
+		require.NoError(t, db.Compact(context.Background()))
 		require.True(t, validateKeys(db))
 		db.Close()
 	}

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -973,7 +973,7 @@ func runDebugCompact(cmd *cobra.Command, args []string) error {
 	// Begin compacting the store in a separate goroutine.
 	errCh := make(chan error, 1)
 	go func() {
-		errCh <- errors.Wrap(db.Compact(), "while compacting")
+		errCh <- errors.Wrap(db.Compact(context.Background()), "while compacting")
 	}()
 
 	// Print the current LSM every minute.

--- a/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_refresh_range_test.go
@@ -166,7 +166,7 @@ func TestRefreshRangeTimeBoundIterator(t *testing.T) {
 	if err := db.Flush(); err != nil {
 		t.Fatal(err)
 	}
-	if err := db.Compact(); err != nil {
+	if err := db.Compact(ctx); err != nil {
 		t.Fatal(err)
 	}
 

--- a/pkg/kv/kvserver/node_liveness_test.go
+++ b/pkg/kv/kvserver/node_liveness_test.go
@@ -1376,7 +1376,7 @@ func BenchmarkNodeLivenessScanStorage(b *testing.B) {
 			}
 			if l == 0 {
 				// Since did many flushes, compact everything down.
-				require.NoError(b, eng.Compact())
+				require.NoError(b, eng.Compact(ctx))
 			} else {
 				// Flush the next level. This will become a L0 sub-level.
 				require.NoError(b, eng.Flush())
@@ -1435,7 +1435,7 @@ func BenchmarkNodeLivenessScanStorage(b *testing.B) {
 							eng := setupEng(b, numLiveVersions, haveDeadKeys)
 							defer eng.Close()
 							if compacted {
-								require.NoError(b, eng.Compact())
+								require.NoError(b, eng.Compact(ctx))
 							}
 							b.ResetTimer()
 							blockBytes := uint64(0)

--- a/pkg/kv/kvserver/raftstorebench/bench.go
+++ b/pkg/kv/kvserver/raftstorebench/bench.go
@@ -94,9 +94,9 @@ func Run(t T, cfg Config) Result {
 	lsmStatsToFile(t, cfg, "uncompacted", o.smEng.GetMetrics(), o.raftEng.GetMetrics())
 
 	logf(t, "compacting")
-	require.NoError(t, smEng.Compact())
+	require.NoError(t, smEng.Compact(context.Background()))
 	if !cfg.SingleEngine {
-		require.NoError(t, raftEng.Compact())
+		require.NoError(t, raftEng.Compact(context.Background()))
 	}
 	logf(t, "done compacting")
 

--- a/pkg/kv/kvserver/rditer/replica_data_iter_test.go
+++ b/pkg/kv/kvserver/rditer/replica_data_iter_test.go
@@ -574,7 +574,7 @@ func benchReplicaEngineDataIterator(b *testing.B, numRanges, numKeysPerRange, va
 	}
 	require.NoError(b, batch.Commit(true /* sync */))
 	require.NoError(b, eng.Flush())
-	require.NoError(b, eng.Compact())
+	require.NoError(b, eng.Compact(ctx))
 
 	snapshot := eng.NewSnapshot()
 	defer snapshot.Close()

--- a/pkg/kv/kvserver/stores_server.go
+++ b/pkg/kv/kvserver/stores_server.go
@@ -145,7 +145,7 @@ func (is Server) CompactEngineSpan(
 	resp := &CompactEngineSpanResponse{}
 	err := is.execStoreCommand(ctx, req.StoreRequestHeader,
 		func(ctx context.Context, s *Store) error {
-			return s.TODOEngine().CompactRange(req.Span.Key, req.Span.EndKey)
+			return s.TODOEngine().CompactRange(ctx, req.Span.Key, req.Span.EndKey)
 		})
 	return resp, err
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1169,7 +1169,8 @@ func (n *Node) startPeriodicLivenessCompaction(
 								}.Encode()
 
 							timeBeforeCompaction := timeutil.Now()
-							if err := store.StateEngine().CompactRange(startEngineKey, endEngineKey); err != nil {
+							if err := store.StateEngine().CompactRange(
+								context.Background(), startEngineKey, endEngineKey); err != nil {
 								log.Errorf(ctx, "failed compacting liveness replica: %+v with error: %s", repl, err)
 							}
 

--- a/pkg/storage/bench_data_test.go
+++ b/pkg/storage/bench_data_test.go
@@ -186,7 +186,7 @@ func (e extendedInitial) Build(ctx context.Context, b *testing.B, eng Engine) er
 func withCompactedDB(base initialState) initialState {
 	return extendInitialConditions(base,
 		func(ctx context.Context, b *testing.B, eng Engine) error {
-			return eng.Compact()
+			return eng.Compact(ctx)
 		}, "compacted")
 }
 

--- a/pkg/storage/engine.go
+++ b/pkg/storage/engine.go
@@ -927,7 +927,7 @@ type Engine interface {
 	// Properties returns the low-level properties for the engine's underlying storage.
 	Properties() roachpb.StoreProperties
 	// Compact forces compaction over the entire database.
-	Compact() error
+	Compact(ctx context.Context) error
 	// Env returns the filesystem environment used by the Engine.
 	Env() *fs.Env
 	// Excise removes all data for the given span from the engine.
@@ -1074,7 +1074,7 @@ type Engine interface {
 	) error
 	// CompactRange ensures that the specified range of key value pairs is
 	// optimized for space efficiency.
-	CompactRange(start, end roachpb.Key) error
+	CompactRange(ctx context.Context, start, end roachpb.Key) error
 	// ScanStorageInternalKeys returns key level statistics for each level of a pebble store (that overlap start and end).
 	ScanStorageInternalKeys(start, end roachpb.Key, megabytesPerSecond int64) ([]enginepb.StorageInternalKeysMetrics, error)
 	// GetTableMetrics returns information about sstables that overlap start and end.

--- a/pkg/storage/metamorphic/operations.go
+++ b/pkg/storage/metamorphic/operations.go
@@ -799,7 +799,7 @@ type compactOp struct {
 }
 
 func (c compactOp) run(ctx context.Context) string {
-	err := c.m.engine.CompactRange(c.key, c.endKey)
+	err := c.m.engine.CompactRange(ctx, c.key, c.endKey)
 	if err != nil {
 		return fmt.Sprintf("error: %s", err.Error())
 	}

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -318,7 +318,7 @@ func TestMVCCHistories(t *testing.T) {
 
 		e := newEvalCtx(ctx, engine)
 		defer func() {
-			require.NoError(t, engine.Compact())
+			require.NoError(t, engine.Compact(ctx))
 			m := engine.GetMetrics().Metrics
 			if m.Keys.MissizedTombstonesCount > 0 {
 				// A missized tombstone is a Pebble DELSIZED tombstone that encodes

--- a/pkg/storage/mvcc_incremental_iterator_test.go
+++ b/pkg/storage/mvcc_incremental_iterator_test.go
@@ -1291,7 +1291,7 @@ func TestMVCCIncrementalIteratorIntentDeletion(t *testing.T) {
 	_, err = MVCCPut(ctx, db, kC, txnC1.ReadTimestamp, vC1, MVCCWriteOptions{Txn: txnC1})
 	require.NoError(t, err)
 	require.NoError(t, db.Flush())
-	require.NoError(t, db.Compact())
+	require.NoError(t, db.Compact(ctx))
 	_, _, _, _, err = MVCCResolveWriteIntent(ctx, db, nil, intent(txnA1), MVCCResolveWriteIntentOptions{})
 	require.NoError(t, err)
 	_, _, _, _, err = MVCCResolveWriteIntent(ctx, db, nil, intent(txnB1), MVCCResolveWriteIntentOptions{})
@@ -1654,7 +1654,7 @@ func BenchmarkMVCCIncrementalIteratorForOldData(b *testing.B) {
 		if err := eng.Flush(); err != nil {
 			b.Fatal(err)
 		}
-		if err := eng.Compact(); err != nil {
+		if err := eng.Compact(context.Background()); err != nil {
 			b.Fatal(err)
 		}
 	}

--- a/pkg/storage/mvcc_test.go
+++ b/pkg/storage/mvcc_test.go
@@ -4166,7 +4166,7 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 	writeToEngine(t, eng, puts, &txn, debug)
 	// The two SET calls for writing the intent are collapsed down to L6.
 	require.NoError(t, eng.Flush())
-	require.NoError(t, eng.Compact())
+	require.NoError(t, eng.Compact(ctx))
 
 	txn.WriteTimestamp = timestamps[1]
 	txn.Sequence = seq
@@ -4223,7 +4223,7 @@ func TestRandomizedSavepointRollbackAndIntentResolution(t *testing.T) {
 	require.NoError(t, err)
 	// Compact the engine so that SINGLEDEL consumes the SETWITHDEL, becoming a
 	// DEL.
-	require.NoError(t, eng.Compact())
+	require.NoError(t, eng.Compact(ctx))
 	iter, err := eng.NewMVCCIterator(context.Background(), MVCCKeyAndIntentsIterKind, IterOptions{LowerBound: lu.Span.Key, UpperBound: lu.Span.EndKey})
 	if err != nil {
 		t.Fatal(err)
@@ -5077,7 +5077,7 @@ func TestMVCCGarbageCollect(t *testing.T) {
 	}
 	// Compact the engine; the ForTesting() config option will assert that all
 	// DELSIZED tombstones were appropriately sized.
-	require.NoError(t, engine.Compact())
+	require.NoError(t, engine.Compact(ctx))
 }
 
 // TestMVCCGarbageCollectNonDeleted verifies that the first value for
@@ -5126,7 +5126,7 @@ func TestMVCCGarbageCollectNonDeleted(t *testing.T) {
 
 	// Compact the engine; the ForTesting() config option will assert that all
 	// DELSIZED tombstones were appropriately sized.
-	require.NoError(t, engine.Compact())
+	require.NoError(t, engine.Compact(ctx))
 }
 
 // TestMVCCGarbageCollectIntent verifies that an intent cannot be GC'd.
@@ -5163,7 +5163,7 @@ func TestMVCCGarbageCollectIntent(t *testing.T) {
 	}
 	// Compact the engine; the ForTesting() config option will assert that all
 	// DELSIZED tombstones were appropriately sized.
-	require.NoError(t, engine.Compact())
+	require.NoError(t, engine.Compact(ctx))
 }
 
 // TestMVCCGarbageCollectPanicsWithMixOfLocalAndGlobalKeys verifies that
@@ -5366,7 +5366,7 @@ func TestMVCCGarbageCollectUsesSeekLTAppropriately(t *testing.T) {
 			runTestCase(t, tc, engine)
 			// Compact the engine; the ForTesting() config option will assert
 			// that all DELSIZED tombstones were appropriately sized.
-			require.NoError(t, engine.Compact())
+			require.NoError(t, engine.Compact(context.Background()))
 		})
 	}
 }
@@ -5973,7 +5973,7 @@ func TestMVCCGarbageCollectRanges(t *testing.T) {
 
 			// Compact the engine; the ForTesting() config option will assert
 			// that all DELSIZED tombstones were appropriately sized.
-			require.NoError(t, engine.Compact())
+			require.NoError(t, engine.Compact(ctx))
 		})
 	}
 }
@@ -6233,7 +6233,7 @@ func TestMVCCGarbageCollectClearRangeInlinedValue(t *testing.T) {
 		"expected error '%s' found '%s'", expectedError, err)
 	// Compact the engine; the ForTesting() config option will assert that all
 	// DELSIZED tombstones were appropriately sized.
-	require.NoError(t, engine.Compact())
+	require.NoError(t, engine.Compact(ctx))
 }
 
 func TestMVCCGarbageCollectClearPointsInRange(t *testing.T) {
@@ -6303,7 +6303,7 @@ func TestMVCCGarbageCollectClearPointsInRange(t *testing.T) {
 
 	// Compact the engine; the ForTesting() config option will assert that all
 	// DELSIZED tombstones were appropriately sized.
-	require.NoError(t, engine.Compact())
+	require.NoError(t, engine.Compact(ctx))
 }
 
 func TestMVCCGarbageCollectClearRangeFailure(t *testing.T) {
@@ -6434,7 +6434,7 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 		}
 
 		if i == 1 {
-			if err := engine.Compact(); err != nil {
+			if err := engine.Compact(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}
@@ -6447,7 +6447,7 @@ func TestMVCCTimeSeriesPartialMerge(t *testing.T) {
 		}
 
 		if i == 1 {
-			if err := engine.Compact(); err != nil {
+			if err := engine.Compact(ctx); err != nil {
 				t.Fatal(err)
 			}
 		}

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2060,12 +2060,12 @@ func (p *Pebble) ApproximateDiskBytes(
 }
 
 // Compact implements the Engine interface.
-func (p *Pebble) Compact() error {
-	return p.db.Compact(context.TODO(), nil /* start */, EncodeMVCCKey(MVCCKeyMax), true /* parallel */)
+func (p *Pebble) Compact(ctx context.Context) error {
+	return p.db.Compact(ctx, nil /* start */, EncodeMVCCKey(MVCCKeyMax), true /* parallel */)
 }
 
 // CompactRange implements the Engine interface.
-func (p *Pebble) CompactRange(start, end roachpb.Key) error {
+func (p *Pebble) CompactRange(ctx context.Context, start, end roachpb.Key) error {
 	// TODO(jackson): Consider changing Engine.CompactRange's signature to take
 	// in EngineKeys so that it's unambiguous that the arguments have already
 	// been encoded as engine keys. We do need to encode these keys in protocol
@@ -2079,7 +2079,7 @@ func (p *Pebble) CompactRange(start, end roachpb.Key) error {
 	if ek, ok := DecodeEngineKey(end); !ok || ek.Validate() != nil {
 		return errors.Errorf("invalid end key: %q", end)
 	}
-	return p.db.Compact(context.TODO(), start, end, true /* parallel */)
+	return p.db.Compact(ctx, start, end, true /* parallel */)
 }
 
 // RegisterFlushCompletedCallback implements the Engine interface.


### PR DESCRIPTION
This allows manual compactions to be cancelled.

Epic: none

Release note: None