### PR TITLE
smith/main: add new mutations configuration to smither options

### DIFF
--- a/pkg/cmd/smith/main.go
+++ b/pkg/cmd/smith/main.go
@@ -81,6 +81,7 @@ var (
 		"EnableWith":                 sqlsmith.EnableWith(),
 		"FavorCommonData":            sqlsmith.FavorCommonData(),
 		"IgnoreFNs":                  strArgOpt(sqlsmith.IgnoreFNs),
+		"InsUpdDelOnly":              sqlsmith.InsUpdDelOnly(),
 		"InsUpdOnly":                 sqlsmith.InsUpdOnly(),
 		"MaybeSortOutput":            sqlsmith.MaybeSortOutput(),
 		"MultiRegionDDLs":            sqlsmith.MultiRegionDDLs(),


### PR DESCRIPTION
A previous PR added the InsUpdDelOnly configuration that only includes mutations relevant for users interested in database writes. This PR adds that configuration to the smither options map.

Epic: none

Release note: none