### PR TITLE
storage/disk: improve logging of device IDs

### DIFF
--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -820,6 +820,7 @@ func (cfg *Config) CreateEngines(ctx context.Context) (Engines, error) {
 			if err != nil {
 				return Engines{}, errors.Wrap(err, "creating disk monitor")
 			}
+			detail(redact.Sprintf("store %d: disk deviceID: %s", i, monitor.DeviceID()))
 
 			statsCollector, err := cfg.DiskWriteStats.GetOrCreateCollector(spec.Path)
 			if err != nil {

--- a/pkg/storage/disk/BUILD.bazel
+++ b/pkg/storage/disk/BUILD.bazel
@@ -16,10 +16,12 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/util/envutil",
+        "//pkg/util/log",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
+        "@com_github_cockroachdb_redact//:redact",
     ] + select({
         "@io_bazel_rules_go//go/platform:android": [
             "//pkg/util/sysutil",
@@ -57,5 +59,13 @@ go_test(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_stretchr_testify//require",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/util/timeutil",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/util/timeutil",
+        ],
+        "//conditions:default": [],
+    }),
 )

--- a/pkg/storage/disk/linux_parse_test.go
+++ b/pkg/storage/disk/linux_parse_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/datadriven"
 	"github.com/cockroachdb/pebble/vfs"
 	"github.com/stretchr/testify/require"
@@ -59,7 +60,7 @@ func TestLinux_CollectDiskStats(t *testing.T) {
 				// resizing logic.
 				buf: make([]byte, 16),
 			}
-			err := s.collect(disks)
+			_, err := s.collect(disks, timeutil.Now())
 			if err != nil {
 				return err.Error()
 			}

--- a/pkg/storage/disk/monitor.go
+++ b/pkg/storage/disk/monitor.go
@@ -6,15 +6,17 @@
 package disk
 
 import (
-	"fmt"
+	"context"
 	"slices"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
+	"github.com/cockroachdb/redact"
 )
 
 var DefaultDiskStatsPollingInterval = envutil.EnvOrDefaultDuration("COCKROACH_DISK_STATS_POLLING_INTERVAL", 100*time.Millisecond)
@@ -28,7 +30,12 @@ type DeviceID struct {
 
 // String returns the string representation of the device ID.
 func (d DeviceID) String() string {
-	return fmt.Sprintf("%d:%d", d.major, d.minor)
+	return redact.StringWithoutMarkers(d)
+}
+
+// SafeFormat implements redact.SafeFormatter.
+func (d DeviceID) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("%d:%d", d.major, d.minor)
 }
 
 // MonitorManager provides observability into a pool of disks by sampling disk stats
@@ -128,7 +135,7 @@ func (m *MonitorManager) unrefDisk(disk *monitoredDisk) {
 }
 
 type statsCollector interface {
-	collect(disks []*monitoredDisk) error
+	collect(disks []*monitoredDisk, now time.Time) (countCollected int, err error)
 }
 
 // monitorDisks runs a loop collecting disk stats for all monitored disks.
@@ -137,9 +144,13 @@ type statsCollector interface {
 // race where the MonitorManager creates a new stop channel after unrefDisk sends a message
 // across the old stop channel.
 func (m *MonitorManager) monitorDisks(collector statsCollector, stop chan struct{}) {
+	// TODO(jackson): Should we propagate a context here to replace the stop
+	// channel?
+	ctx := context.TODO()
 	ticker := time.NewTicker(DefaultDiskStatsPollingInterval)
 	defer ticker.Stop()
 
+	every := log.Every(5 * time.Minute)
 	for {
 		select {
 		case <-stop:
@@ -150,13 +161,27 @@ func (m *MonitorManager) monitorDisks(collector statsCollector, stop chan struct
 			disks := m.mu.disks
 			m.mu.Unlock()
 
-			if err := collector.collect(disks); err != nil {
+			now := timeutil.Now()
+			countCollected, err := collector.collect(disks, now)
+			if err != nil {
 				for i := range disks {
 					disks[i].tracer.RecordEvent(traceEvent{
 						time:  timeutil.Now(),
 						stats: Stats{},
 						err:   err,
 					})
+				}
+			} else if countCollected != len(disks) && every.ShouldLog() {
+				// Log a warning if we collected fewer disk stats than expected.
+				log.Warningf(ctx, "collected %d disk stats, expected %d", countCollected, len(disks))
+				cutoff := now.Add(-10 * time.Second)
+				for i := range disks {
+					if lastEventTime := disks[i].tracer.LastEventTime(); lastEventTime.IsZero() {
+						log.Warningf(ctx, "disk %s has not recorded any stats", disks[i].deviceID)
+					} else if lastEventTime.Before(cutoff) {
+						log.Warningf(ctx, "disk %s has not recorded any stats since %s",
+							disks[i].deviceID, lastEventTime)
+					}
 				}
 			}
 		}
@@ -225,6 +250,11 @@ type Monitor struct {
 		// Tracks the time of the last invocation of IncrementalStats.
 		lastIncrementedAt time.Time
 	}
+}
+
+// DeviceID returns the device ID of the disk being monitored.
+func (m *Monitor) DeviceID() DeviceID {
+	return m.deviceID
 }
 
 // CumulativeStats returns the most-recent stats observed.

--- a/pkg/storage/disk/monitor_test.go
+++ b/pkg/storage/disk/monitor_test.go
@@ -17,12 +17,14 @@ import (
 )
 
 type spyCollector struct {
-	collectCount int
+	collectCallCount int
 }
 
-func (s *spyCollector) collect(disks []*monitoredDisk) error {
-	s.collectCount++
-	return nil
+func (s *spyCollector) collect(
+	disks []*monitoredDisk, now time.Time,
+) (countCollected int, err error) {
+	s.collectCallCount++
+	return len(disks), nil
 }
 
 func TestMonitorManager_monitorDisks(t *testing.T) {
@@ -45,7 +47,7 @@ func TestMonitorManager_monitorDisks(t *testing.T) {
 
 	time.Sleep(2 * DefaultDiskStatsPollingInterval)
 	stop <- struct{}{}
-	require.Greater(t, testCollector.collectCount, 0)
+	require.Greater(t, testCollector.collectCallCount, 0)
 }
 
 func TestMonitor_StatsWindow(t *testing.T) {

--- a/pkg/storage/disk/monitor_tracer.go
+++ b/pkg/storage/disk/monitor_tracer.go
@@ -86,6 +86,16 @@ func (m *monitorTracer) RecordEvent(event traceEvent) {
 	}
 }
 
+// LastEventTime returns the time of the last traceEvent that was queued.
+func (m *monitorTracer) LastEventTime() time.Time {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	if m.sizeLocked() == 0 {
+		return time.Time{}
+	}
+	return m.mu.trace[(m.mu.end-1)%m.capacity].time
+}
+
 // Latest retrieves the last traceEvent that was queued. Returns a zero-valued
 // traceEvent if none exists.
 func (m *monitorTracer) Latest() traceEvent {

--- a/pkg/storage/disk/platform_darwin.go
+++ b/pkg/storage/disk/platform_darwin.go
@@ -9,6 +9,7 @@ package disk
 
 import (
 	"io/fs"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/pebble/vfs"
@@ -17,8 +18,8 @@ import (
 
 type darwinCollector struct{}
 
-func (darwinCollector) collect([]*monitoredDisk) error {
-	return nil
+func (darwinCollector) collect(disks []*monitoredDisk, time time.Time) (int, error) {
+	return len(disks), nil
 }
 
 func newStatsCollector(fs vfs.FS) (*darwinCollector, error) {

--- a/pkg/storage/disk/platform_default.go
+++ b/pkg/storage/disk/platform_default.go
@@ -9,14 +9,15 @@ package disk
 
 import (
 	"io/fs"
+	"time"
 
 	"github.com/cockroachdb/pebble/vfs"
 )
 
 type defaultCollector struct{}
 
-func (defaultCollector) collect([]*monitoredDisk) error {
-	return nil
+func (defaultCollector) collect(disks []*monitoredDisk, time time.Time) (int, error) {
+	return len(disks), nil
 }
 
 func newStatsCollector(fs vfs.FS) (*defaultCollector, error) {


### PR DESCRIPTION
Log a warning periodically if a disk that should be monitored is not being monitored because it's not found in /proc/diskstats.

Additionally, on start up, print a store's monitored device ID.

Close #146321.
Epic: none
Release note: none