### PR TITLE
release-23.2: build: remove ssh key on exit only on TeamCity agents

### DIFF
--- a/build/teamcity-support.sh
+++ b/build/teamcity-support.sh
@@ -12,7 +12,8 @@ source "$root/build/teamcity-common-support.sh"
 source "$root/build/teamcity/util.sh"
 
 remove_files_on_exit() {
-  rm -f ~/.ssh/id_rsa{,.pub}
+  # Remove the ssh key on exit only on TeamCity agents, not on the local machine.
+  rm -f ~agent/.ssh/id_rsa{,.pub}
   common_support_remove_files_on_exit
 }
 trap remove_files_on_exit EXIT


### PR DESCRIPTION
Backport 1/1 commits from #146366 on behalf of @rail.

----

Previously, we used `~/.ssh/id_rsa{,.pub}` to remove the SSH key on exit. This caused issues when running the script locally, as it would attempt to remove the SSH key from the local machine. The fix is to use `~agent/.ssh/id_rsa` instead, which is specific to TeamCity agents.

Release note: none
Epic: none

----

Release justification: not part of the product