### PR TITLE
sql: propagate TestingKnobs.ForceProductionValues to remote nodes

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -354,6 +354,7 @@ func (ds *ServerImpl) setupFlow(
 		}
 		evalCtx.SetStmtTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.StmtTimestampNanos))
 		evalCtx.SetTxnTimestamp(timeutil.Unix(0 /* sec */, req.EvalContext.TxnTimestampNanos))
+		evalCtx.TestingKnobs.ForceProductionValues = req.EvalContext.TestingKnobsForceProductionValues
 	}
 
 	// Create the FlowCtx for the flow.

--- a/pkg/sql/execinfrapb/api.go
+++ b/pkg/sql/execinfrapb/api.go
@@ -48,9 +48,10 @@ func MakeEvalContext(evalCtx *eval.Context) EvalContext {
 	sessionDataProto := evalCtx.SessionData().SessionData
 	sessiondata.MarshalNonLocal(evalCtx.SessionData(), &sessionDataProto)
 	return EvalContext{
-		SessionData:        sessionDataProto,
-		StmtTimestampNanos: evalCtx.StmtTimestamp.UnixNano(),
-		TxnTimestampNanos:  evalCtx.TxnTimestamp.UnixNano(),
+		SessionData:                       sessionDataProto,
+		StmtTimestampNanos:                evalCtx.StmtTimestamp.UnixNano(),
+		TxnTimestampNanos:                 evalCtx.TxnTimestamp.UnixNano(),
+		TestingKnobsForceProductionValues: evalCtx.TestingKnobs.ForceProductionValues,
 	}
 }
 

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -85,6 +85,7 @@ message EvalContext {
   optional int64 txn_timestamp_nanos = 2 [(gogoproto.nullable) = false];
   reserved 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14;
   optional sessiondatapb.SessionData session_data = 15 [(gogoproto.nullable) = false];
+  optional bool testing_knobs_force_production_values = 16  [(gogoproto.nullable) = false];
 }
 
 message SimpleResponse {


### PR DESCRIPTION
This commit fixes an oversight in how we handle `eval.Context.TestingKnobs.ForceProductionValues`. Namely, previously we forgot to propagate this information from the gateway to remote nodes, so the latter would not respect this knob. This is now fixed.

Fixes: #146350.

Release note: None