### PR TITLE
opt: refactor and fix building of RETURNING expressions

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -760,6 +760,19 @@ INSERT INTO ins VALUES (13) RETURNING (SELECT k FROM other);
 ----
 99
 
+statement ok
+CREATE FUNCTION insert_15(n INT) RETURNS INT AS $$
+  INSERT INTO ins VALUES (15) RETURNING n;
+$$ LANGUAGE SQL
+
+query I
+SELECT insert_15(0)
+----
+0
+
+statement ok
+DROP FUNCTION insert_15
+
 # Verify that only rows that pass the USING expression are allowed (even numbers).
 statement ok
 INSERT INTO ins VALUES (2),(4) RETURNING c1;
@@ -4721,7 +4734,7 @@ SELECT * FROM employees
 statement error pq: new row violates row-level security policy for table "employees"
 INSERT INTO employees (id, name, department) VALUES (3, 'Eve', 'Engineering')
 
-# Test UPDATE with role inheritance - should succeed, 
+# Test UPDATE with role inheritance - should succeed,
 # but the update will not go as the default with ENABLED ROW LEVEL SECURITY.
 statement ok
 UPDATE employees SET name = 'Alice 2.0' WHERE name = 'Alice'
@@ -4935,7 +4948,7 @@ CREATE TRIGGER force_bob_ownership
   FOR EACH ROW
   EXECUTE FUNCTION change_owner_to_bob();
 
-# Try to insert a row - this should fail because the trigger modifies 
+# Try to insert a row - this should fail because the trigger modifies
 # the owner to 'bob' which violates alice's RLS policy.
 statement error pq: new row violates row-level security policy for table "trigger_rls_table"
 INSERT INTO trigger_rls_table VALUES (9, 900, 'alice');

--- a/pkg/sql/opt/optbuilder/delete.go
+++ b/pkg/sql/opt/optbuilder/delete.go
@@ -124,5 +124,6 @@ func (mb *mutationBuilder) buildDelete(returning *tree.ReturningExprs) {
 		mb.outScope.expr, mb.uniqueChecks, mb.fkChecks, private,
 	)
 
-	mb.buildReturning(returning)
+	returningInScope, returningOutScope := mb.buildReturningScopes(returning, nil /* colRefs */)
+	mb.buildReturning(returning, returningInScope, returningOutScope)
 }

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -780,7 +780,12 @@ func (mb *mutationBuilder) buildInsert(
 		// ON CONFLICT clause that automatically requires SELECT policies.
 		var colRefs opt.ColSet
 		returningInScope, returningOutScope = mb.buildReturningScopes(returning, &colRefs)
-		includeSelectPolicies = !colRefs.Empty()
+		for i, n := 0, mb.tab.ColumnCount(); i < n; i++ {
+			if colRefs.Contains(mb.tabID.ColumnID(i)) {
+				includeSelectPolicies = true
+				break
+			}
+		}
 	} else {
 		returningInScope, returningOutScope = mb.buildReturningScopes(returning, nil /* colRefs */)
 	}

--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -760,24 +760,29 @@ func (mb *mutationBuilder) buildInsert(
 	// check constraint, refer to the correct columns.
 	mb.disambiguateColumns()
 
-	// Apply SELECT policies if:
+	// Build the scopes for the RETURNING clause early (if present). The
+	// returning expression is built later on, but for RLS we need to build the
+	// scopes and collect column references in order to determine whether SELECT
+	// policies should be applied as check constraints, which are built prior to
+	// the returning expression. RLS SELECT policies are applied as check
+	// constraints if the RETURNING clause references columns in the target
+	// table.
+	//
+	// RLS SELECT policies are applied as check constraints if:
 	// - There is an ON CONFLICT clause, which always requires SELECT policies
 	//   due to the conflict scan accessing existing data.
 	// - The RETURNING clause references any columns, which also necessitates
 	//   SELECT policies.
+	var returningInScope, returningOutScope *scope
 	includeSelectPolicies := hasOnConflict
-	if mb.tab.IsRowLevelSecurityEnabled() && !includeSelectPolicies && returning != nil {
-		// RETURNING is constructed last and depends on the final scope, so we can’t
-		// build it early or move it. However, we can build temporary scopes to
-		// gather referenced columns (colRefs) just to determine if SELECT policies
-		// are needed. If policies are already required or RLS is not enabled, we skip
-		// this work.
+	if mb.tab.IsRowLevelSecurityEnabled() && !includeSelectPolicies {
+		// Only track column references if RLS is enabled and there is no
+		// ON CONFLICT clause that automatically requires SELECT policies.
 		var colRefs opt.ColSet
-		_, _ = mb.maybeBuildReturningScopes(returning, &colRefs)
-		// For INSERT, the RETURNING clause can only reference columns from the target table.
-		// So, it's sufficient to check whether any columns are referenced, rather than
-		// verifying if each one belongs to the table.
+		returningInScope, returningOutScope = mb.buildReturningScopes(returning, &colRefs)
 		includeSelectPolicies = !colRefs.Empty()
+	} else {
+		returningInScope, returningOutScope = mb.buildReturningScopes(returning, nil /* colRefs */)
 	}
 
 	// Add any check constraint boolean columns to the input.
@@ -800,7 +805,7 @@ func (mb *mutationBuilder) buildInsert(
 		mb.outScope.expr, mb.uniqueChecks, mb.fastPathUniqueChecks, mb.fkChecks, private,
 	)
 
-	mb.buildReturning(returning)
+	mb.buildReturning(returning, returningInScope, returningOutScope)
 }
 
 // buildInputForDoNothing wraps the input expression in ANTI JOIN expressions,
@@ -1021,7 +1026,8 @@ func (mb *mutationBuilder) buildUpsert(returning *tree.ReturningExprs) {
 		mb.outScope.expr, mb.uniqueChecks, mb.fkChecks, private,
 	)
 
-	mb.buildReturning(returning)
+	returningInScope, returningOutScope := mb.buildReturningScopes(returning, nil /* colRefs */)
+	mb.buildReturning(returning, returningInScope, returningOutScope)
 }
 
 // projectUpsertColumns projects a set of merged columns that will be either

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -897,7 +897,7 @@ build
 INSERT INTO t1(c1) VALUES (10) RETURNING (select 1);
 ----
 project
- ├── columns: "?column?":15
+ ├── columns: "?column?":12
  ├── insert t1
  │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null
  │    ├── insert-mapping:
@@ -925,15 +925,15 @@ project
  │         └── projections
  │              └── char_length(c2_default:8) < 10 [as=rls:13]
  └── projections
-      └── subquery [as="?column?":15]
+      └── subquery [as="?column?":12]
            └── max1-row
-                ├── columns: "?column?":14!null
+                ├── columns: "?column?":11!null
                 └── project
-                     ├── columns: "?column?":14!null
+                     ├── columns: "?column?":11!null
                      ├── values
                      │    └── ()
                      └── projections
-                          └── 1 [as="?column?":14]
+                          └── 1 [as="?column?":11]
 
 exec-ddl
 DROP POLICY p_select on t1;

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -935,6 +935,67 @@ project
                      └── projections
                           └── 1 [as="?column?":11]
 
+# The RETURNING clause references a column, but not one in the target table, so
+# the SELECT policy should not apply with the function is called.
+exec-ddl
+CREATE FUNCTION insert_zero_into_t1(n INT) RETURNS INT AS $$
+  INSERT INTO t1 VALUES (0) RETURNING n;
+$$ LANGUAGE SQL
+----
+
+build format=show-scalars
+SELECT insert_zero_into_t1(10)
+----
+project
+ ├── columns: insert_zero_into_t1:14
+ ├── values
+ │    └── tuple
+ └── projections
+      └── udf: insert_zero_into_t1 [as=insert_zero_into_t1:14]
+           ├── args
+           │    └── const: 10
+           ├── params: n:1
+           └── body
+                └── limit
+                     ├── columns: n:12
+                     ├── project
+                     │    ├── columns: n:12
+                     │    ├── insert t1
+                     │    │    ├── columns: c1:2!null c2:3 c3:4 rowid:5!null
+                     │    │    ├── insert-mapping:
+                     │    │    │    ├── column1:8 => c1:2
+                     │    │    │    ├── c2_default:9 => c2:3
+                     │    │    │    ├── c3_default:10 => c3:4
+                     │    │    │    └── rowid_default:11 => rowid:5
+                     │    │    ├── return-mapping:
+                     │    │    │    ├── column1:8 => c1:2
+                     │    │    │    ├── c2_default:9 => c2:3
+                     │    │    │    ├── c3_default:10 => c3:4
+                     │    │    │    └── rowid_default:11 => rowid:5
+                     │    │    ├── check columns: rls:13
+                     │    │    └── project
+                     │    │         ├── columns: rls:13 column1:8!null c2_default:9 c3_default:10 rowid_default:11
+                     │    │         ├── project
+                     │    │         │    ├── columns: c2_default:9 c3_default:10 rowid_default:11 column1:8!null
+                     │    │         │    ├── values
+                     │    │         │    │    ├── columns: column1:8!null
+                     │    │         │    │    └── tuple
+                     │    │         │    │         └── const: 0
+                     │    │         │    └── projections
+                     │    │         │         ├── cast: STRING [as=c2_default:9]
+                     │    │         │         │    └── null
+                     │    │         │         ├── cast: DATE [as=c3_default:10]
+                     │    │         │         │    └── null
+                     │    │         │         └── function: unique_rowid [as=rowid_default:11]
+                     │    │         └── projections
+                     │    │              └── lt [as=rls:13]
+                     │    │                   ├── function: char_length
+                     │    │                   │    └── variable: c2_default:9
+                     │    │                   └── const: 10
+                     │    └── projections
+                     │         └── variable: n:1 [as=n:12]
+                     └── const: 1
+
 exec-ddl
 DROP POLICY p_select on t1;
 ----

--- a/pkg/sql/opt/xform/testdata/external/tpce
+++ b/pkg/sql/opt/xform/testdata/external/tpce
@@ -671,9 +671,9 @@ with &1 (update_last_trade)
                 ├── key: (141)
                 ├── fd: (141)-->(142-144)
                 ├── project
-                │    ├── columns: "?column?":87
+                │    ├── columns: "?column?":64
                 │    ├── volatile, mutations
-                │    ├── fd: ()-->(87)
+                │    ├── fd: ()-->(64)
                 │    ├── insert trade_history
                 │    │    ├── columns: trade_history.th_t_id:52!null trade_history.th_st_id:54!null
                 │    │    ├── insert-mapping:
@@ -702,30 +702,30 @@ with &1 (update_last_trade)
                 │    │    └── f-k-checks
                 │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
                 │    │         │    └── anti-join (lookup trade)
-                │    │         │         ├── columns: th_t_id:64!null
-                │    │         │         ├── key columns: [64] = [65]
+                │    │         │         ├── columns: th_t_id:65!null
+                │    │         │         ├── key columns: [65] = [66]
                 │    │         │         ├── lookup columns are key
-                │    │         │         ├── key: (64)
+                │    │         │         ├── key: (65)
                 │    │         │         ├── with-scan &4
-                │    │         │         │    ├── columns: th_t_id:64!null
+                │    │         │         │    ├── columns: th_t_id:65!null
                 │    │         │         │    ├── mapping:
-                │    │         │         │    │    └──  tr_t_id:57 => th_t_id:64
-                │    │         │         │    └── key: (64)
+                │    │         │         │    │    └──  tr_t_id:57 => th_t_id:65
+                │    │         │         │    └── key: (65)
                 │    │         │         └── filters (true)
                 │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
                 │    │              └── anti-join (lookup status_type)
-                │    │                   ├── columns: th_st_id:82!null
-                │    │                   ├── key columns: [82] = [83]
+                │    │                   ├── columns: th_st_id:83!null
+                │    │                   ├── key columns: [83] = [84]
                 │    │                   ├── lookup columns are key
-                │    │                   ├── fd: ()-->(82)
+                │    │                   ├── fd: ()-->(83)
                 │    │                   ├── with-scan &4
-                │    │                   │    ├── columns: th_st_id:82!null
+                │    │                   │    ├── columns: th_st_id:83!null
                 │    │                   │    ├── mapping:
-                │    │                   │    │    └──  th_st_id_cast:63 => th_st_id:82
-                │    │                   │    └── fd: ()-->(82)
+                │    │                   │    │    └──  th_st_id_cast:63 => th_st_id:83
+                │    │                   │    └── fd: ()-->(83)
                 │    │                   └── filters (true)
                 │    └── projections
-                │         └── NULL [as="?column?":87]
+                │         └── NULL [as="?column?":64]
                 └── with &7 (update_trade_submitted)
                      ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                      ├── volatile, mutations
@@ -2936,11 +2936,11 @@ with &2 (insert_trade)
  ├── key: ()
  ├── fd: ()-->(121)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":42!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(42)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
@@ -2961,85 +2961,85 @@ with &2 (insert_trade)
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── return-mapping:
  │    │    │    └── column1:18 => t_id:1
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:42!null check2:43!null check3:44!null check4:45!null check5:46!null
+ │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:43!null check2:44!null check3:45!null check4:46!null check5:47!null
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41,43-47)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48!null
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47!null
+ │    │         │         │    ├── columns: t_st_id:48!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53!null
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52!null
+ │    │         │         │    ├── columns: t_tt_id:53!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60!null
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59!null
+ │    │         │         │    ├── columns: t_s_symb:60!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":42]
  └── with &4 (insert_trade_history)
       ├── columns: "?column?":121!null
       ├── cardinality: [1 - 1]
@@ -3047,11 +3047,11 @@ with &2 (insert_trade)
       ├── key: ()
       ├── fd: ()-->(121)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":97!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(97)
       │    ├── insert trade_history
       │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
       │    │    ├── insert-mapping:
@@ -3075,38 +3075,38 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:93 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116!null
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115!null
+      │    │                   │    ├── columns: th_st_id:116!null
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":97]
       └── values
            ├── columns: "?column?":121!null
            ├── cardinality: [1 - 1]
@@ -3191,11 +3191,11 @@ with &2 (insert_trade)
  ├── key: ()
  ├── fd: ()-->(195)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":42!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(42)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
@@ -3216,85 +3216,85 @@ with &2 (insert_trade)
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── return-mapping:
  │    │    │    └── column1:18 => t_id:1
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:42!null check2:43!null check3:44!null check4:45!null check5:46!null
+ │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:43!null check2:44!null check3:45!null check4:46!null check5:47!null
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41,43-47)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48!null
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47!null
+ │    │         │         │    ├── columns: t_st_id:48!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53!null
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52!null
+ │    │         │         │    ├── columns: t_tt_id:53!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60!null
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59!null
+ │    │         │         │    ├── columns: t_s_symb:60!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":42]
  └── with &4 (insert_trade_history)
       ├── columns: "?column?":195!null
       ├── cardinality: [1 - 1]
@@ -3302,11 +3302,11 @@ with &2 (insert_trade)
       ├── key: ()
       ├── fd: ()-->(195)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":97!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(97)
       │    ├── insert trade_history
       │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
       │    │    ├── insert-mapping:
@@ -3330,38 +3330,38 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:93 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116!null
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115!null
+      │    │                   │    ├── columns: th_st_id:116!null
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":97]
       └── with &6 (insert_trade_request)
            ├── columns: "?column?":195!null
            ├── cardinality: [1 - 1]
@@ -3369,11 +3369,11 @@ with &2 (insert_trade)
            ├── key: ()
            ├── fd: ()-->(195)
            ├── project
-           │    ├── columns: "?column?":194!null
+           │    ├── columns: "?column?":139!null
            │    ├── cardinality: [1 - 1]
            │    ├── volatile, mutations
            │    ├── key: ()
-           │    ├── fd: ()-->(194)
+           │    ├── fd: ()-->(139)
            │    ├── insert trade_request
            │    │    ├── columns: trade_request.tr_t_id:121!null
            │    │    ├── insert-mapping:
@@ -3385,86 +3385,86 @@ with &2 (insert_trade)
            │    │    │    └── column6:134 => trade_request.tr_b_id:126
            │    │    ├── return-mapping:
            │    │    │    └── column1:129 => trade_request.tr_t_id:121
-           │    │    ├── check columns: check1:139 check2:140
-           │    │    ├── partial index put columns: partial_index_put1:141
+           │    │    ├── check columns: check1:140 check2:141
+           │    │    ├── partial index put columns: partial_index_put1:142
            │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(121)
            │    │    ├── values
-           │    │    │    ├── columns: column1:129!null column6:134!null tr_tt_id_cast:135!null tr_s_symb_cast:136!null tr_qty_cast:137!null tr_bid_price_cast:138!null check1:139!null check2:140!null partial_index_put1:141!null
+           │    │    │    ├── columns: column1:129!null column6:134!null tr_tt_id_cast:135!null tr_s_symb_cast:136!null tr_qty_cast:137!null tr_bid_price_cast:138!null check1:140!null check2:141!null partial_index_put1:142!null
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(129,134-141)
+           │    │    │    ├── fd: ()-->(129,134-138,140-142)
            │    │    │    └── (0, 0, 'TMB', 'SYMB', 10, 100.00, true, true, false)
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
            │    │         │    └── anti-join (lookup trade)
-           │    │         │         ├── columns: tr_t_id:142!null
-           │    │         │         ├── key columns: [142] = [143]
+           │    │         │         ├── columns: tr_t_id:143!null
+           │    │         │         ├── key columns: [143] = [144]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(142)
+           │    │         │         ├── fd: ()-->(143)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_t_id:142!null
+           │    │         │         │    ├── columns: tr_t_id:143!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:129 => tr_t_id:142
+           │    │         │         │    │    └──  column1:129 => tr_t_id:143
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(142)
+           │    │         │         │    └── fd: ()-->(143)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
            │    │         │    └── anti-join (lookup trade_type)
-           │    │         │         ├── columns: tr_tt_id:160!null
-           │    │         │         ├── key columns: [160] = [161]
+           │    │         │         ├── columns: tr_tt_id:161!null
+           │    │         │         ├── key columns: [161] = [162]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(160)
+           │    │         │         ├── fd: ()-->(161)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_tt_id:160!null
+           │    │         │         │    ├── columns: tr_tt_id:161!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_tt_id_cast:135 => tr_tt_id:160
+           │    │         │         │    │    └──  tr_tt_id_cast:135 => tr_tt_id:161
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(160)
+           │    │         │         │    └── fd: ()-->(161)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
            │    │         │    └── anti-join (lookup security)
-           │    │         │         ├── columns: tr_s_symb:167!null
-           │    │         │         ├── key columns: [167] = [168]
+           │    │         │         ├── columns: tr_s_symb:168!null
+           │    │         │         ├── key columns: [168] = [169]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(167)
+           │    │         │         ├── fd: ()-->(168)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_s_symb:167!null
+           │    │         │         │    ├── columns: tr_s_symb:168!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_s_symb_cast:136 => tr_s_symb:167
+           │    │         │         │    │    └──  tr_s_symb_cast:136 => tr_s_symb:168
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(167)
+           │    │         │         │    └── fd: ()-->(168)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
            │    │              └── anti-join (lookup broker)
-           │    │                   ├── columns: tr_b_id:186!null
-           │    │                   ├── key columns: [186] = [187]
+           │    │                   ├── columns: tr_b_id:187!null
+           │    │                   ├── key columns: [187] = [188]
            │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
-           │    │                   ├── fd: ()-->(186)
+           │    │                   ├── fd: ()-->(187)
            │    │                   ├── with-scan &5
-           │    │                   │    ├── columns: tr_b_id:186!null
+           │    │                   │    ├── columns: tr_b_id:187!null
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column6:134 => tr_b_id:186
+           │    │                   │    │    └──  column6:134 => tr_b_id:187
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(186)
+           │    │                   │    └── fd: ()-->(187)
            │    │                   └── filters (true)
            │    └── projections
-           │         └── 1 [as="?column?":194]
+           │         └── 1 [as="?column?":139]
            └── values
                 ├── columns: "?column?":195!null
                 ├── cardinality: [1 - 1]
@@ -4300,11 +4300,11 @@ with &2 (update_trade_commission)
            ├── key: ()
            ├── fd: ()-->(104)
            ├── project
-           │    ├── columns: "?column?":103!null
+           │    ├── columns: "?column?":80!null
            │    ├── cardinality: [1 - 1]
            │    ├── volatile, mutations
            │    ├── key: ()
-           │    ├── fd: ()-->(103)
+           │    ├── fd: ()-->(80)
            │    ├── insert trade_history
            │    │    ├── columns: trade_history.th_t_id:71!null trade_history.th_st_id:73!null
            │    │    ├── insert-mapping:
@@ -4328,38 +4328,38 @@ with &2 (update_trade_commission)
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
            │    │         │    └── anti-join (lookup trade)
-           │    │         │         ├── columns: th_t_id:80!null
-           │    │         │         ├── key columns: [80] = [81]
+           │    │         │         ├── columns: th_t_id:81!null
+           │    │         │         ├── key columns: [81] = [82]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(80)
+           │    │         │         ├── fd: ()-->(81)
            │    │         │         ├── with-scan &4
-           │    │         │         │    ├── columns: th_t_id:80!null
+           │    │         │         │    ├── columns: th_t_id:81!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:76 => th_t_id:80
+           │    │         │         │    │    └──  column1:76 => th_t_id:81
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(80)
+           │    │         │         │    └── fd: ()-->(81)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
            │    │              └── anti-join (lookup status_type)
-           │    │                   ├── columns: th_st_id:98!null
-           │    │                   ├── key columns: [98] = [99]
+           │    │                   ├── columns: th_st_id:99!null
+           │    │                   ├── key columns: [99] = [100]
            │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
-           │    │                   ├── fd: ()-->(98)
+           │    │                   ├── fd: ()-->(99)
            │    │                   ├── with-scan &4
-           │    │                   │    ├── columns: th_st_id:98!null
+           │    │                   │    ├── columns: th_st_id:99!null
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:98
+           │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:99
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(98)
+           │    │                   │    └── fd: ()-->(99)
            │    │                   └── filters (true)
            │    └── projections
-           │         └── 1 [as="?column?":103]
+           │         └── 1 [as="?column?":80]
            └── values
                 ├── columns: "?column?":104!null
                 ├── cardinality: [1 - 1]
@@ -4400,11 +4400,11 @@ with &2 (insert_settlement)
  ├── key: ()
  ├── fd: ()-->(81)
  ├── project
- │    ├── columns: "?column?":31!null
+ │    ├── columns: "?column?":13!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(31)
+ │    ├── fd: ()-->(13)
  │    ├── insert settlement
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
@@ -4428,22 +4428,22 @@ with &2 (insert_settlement)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
  │    │              └── anti-join (lookup trade)
- │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
+ │    │                   ├── columns: se_t_id:14!null
+ │    │                   ├── key columns: [14] = [15]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(13)
+ │    │                   ├── fd: ()-->(14)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: se_t_id:13!null
+ │    │                   │    ├── columns: se_t_id:14!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
+ │    │                   │    │    └──  column1:7 => se_t_id:14
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":31]
+ │         └── 1 [as="?column?":13]
  └── with &4 (insert_cash_transaction)
       ├── columns: ca_bal:81!null
       ├── cardinality: [0 - 1]
@@ -4451,11 +4451,11 @@ with &2 (insert_settlement)
       ├── key: ()
       ├── fd: ()-->(81)
       ├── project
-      │    ├── columns: "?column?":62!null
+      │    ├── columns: "?column?":44!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(62)
+      │    ├── fd: ()-->(44)
       │    ├── insert cash_transaction
       │    │    ├── columns: cash_transaction.ct_t_id:32!null
       │    │    ├── insert-mapping:
@@ -4479,22 +4479,22 @@ with &2 (insert_settlement)
       │    │    └── f-k-checks
       │    │         └── f-k-checks-item: cash_transaction(ct_t_id) -> trade(t_id)
       │    │              └── anti-join (lookup trade)
-      │    │                   ├── columns: ct_t_id:44!null
-      │    │                   ├── key columns: [44] = [45]
+      │    │                   ├── columns: ct_t_id:45!null
+      │    │                   ├── key columns: [45] = [46]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(44)
+      │    │                   ├── fd: ()-->(45)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: ct_t_id:44!null
+      │    │                   │    ├── columns: ct_t_id:45!null
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column1:38 => ct_t_id:44
+      │    │                   │    │    └──  column1:38 => ct_t_id:45
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(44)
+      │    │                   │    └── fd: ()-->(45)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":62]
+      │         └── 1 [as="?column?":44]
       └── project
            ├── columns: ca_bal:81!null
            ├── cardinality: [0 - 1]
@@ -4550,11 +4550,11 @@ with &2 (insert_settlement)
  ├── key: ()
  ├── fd: ()-->(40)
  ├── project
- │    ├── columns: "?column?":31!null
+ │    ├── columns: "?column?":13!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(31)
+ │    ├── fd: ()-->(13)
  │    ├── insert settlement
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
@@ -4578,22 +4578,22 @@ with &2 (insert_settlement)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
  │    │              └── anti-join (lookup trade)
- │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
+ │    │                   ├── columns: se_t_id:14!null
+ │    │                   ├── key columns: [14] = [15]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(13)
+ │    │                   ├── fd: ()-->(14)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: se_t_id:13!null
+ │    │                   │    ├── columns: se_t_id:14!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
+ │    │                   │    │    └──  column1:7 => se_t_id:14
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":31]
+ │         └── 1 [as="?column?":13]
  └── project
       ├── columns: ca_bal:40!null
       ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/xform/testdata/external/tpce-no-stats
+++ b/pkg/sql/opt/xform/testdata/external/tpce-no-stats
@@ -689,9 +689,9 @@ with &1 (update_last_trade)
                 ├── key: (141)
                 ├── fd: (141)-->(142-144)
                 ├── project
-                │    ├── columns: "?column?":87
+                │    ├── columns: "?column?":64
                 │    ├── volatile, mutations
-                │    ├── fd: ()-->(87)
+                │    ├── fd: ()-->(64)
                 │    ├── insert trade_history
                 │    │    ├── columns: trade_history.th_t_id:52!null trade_history.th_st_id:54!null
                 │    │    ├── insert-mapping:
@@ -720,30 +720,30 @@ with &1 (update_last_trade)
                 │    │    └── f-k-checks
                 │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
                 │    │         │    └── anti-join (lookup trade)
-                │    │         │         ├── columns: th_t_id:64!null
-                │    │         │         ├── key columns: [64] = [65]
+                │    │         │         ├── columns: th_t_id:65!null
+                │    │         │         ├── key columns: [65] = [66]
                 │    │         │         ├── lookup columns are key
-                │    │         │         ├── key: (64)
+                │    │         │         ├── key: (65)
                 │    │         │         ├── with-scan &4
-                │    │         │         │    ├── columns: th_t_id:64!null
+                │    │         │         │    ├── columns: th_t_id:65!null
                 │    │         │         │    ├── mapping:
-                │    │         │         │    │    └──  tr_t_id:57 => th_t_id:64
-                │    │         │         │    └── key: (64)
+                │    │         │         │    │    └──  tr_t_id:57 => th_t_id:65
+                │    │         │         │    └── key: (65)
                 │    │         │         └── filters (true)
                 │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
                 │    │              └── anti-join (lookup status_type)
-                │    │                   ├── columns: th_st_id:82!null
-                │    │                   ├── key columns: [82] = [83]
+                │    │                   ├── columns: th_st_id:83!null
+                │    │                   ├── key columns: [83] = [84]
                 │    │                   ├── lookup columns are key
-                │    │                   ├── fd: ()-->(82)
+                │    │                   ├── fd: ()-->(83)
                 │    │                   ├── with-scan &4
-                │    │                   │    ├── columns: th_st_id:82!null
+                │    │                   │    ├── columns: th_st_id:83!null
                 │    │                   │    ├── mapping:
-                │    │                   │    │    └──  th_st_id_cast:63 => th_st_id:82
-                │    │                   │    └── fd: ()-->(82)
+                │    │                   │    │    └──  th_st_id_cast:63 => th_st_id:83
+                │    │                   │    └── fd: ()-->(83)
                 │    │                   └── filters (true)
                 │    └── projections
-                │         └── NULL [as="?column?":87]
+                │         └── NULL [as="?column?":64]
                 └── with &7 (update_trade_submitted)
                      ├── columns: tr_t_id:141!null tr_bid_price:142!null tr_tt_id:143!null tr_qty:144!null
                      ├── volatile, mutations
@@ -2956,11 +2956,11 @@ with &2 (insert_trade)
  ├── key: ()
  ├── fd: ()-->(121)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":42!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(42)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
@@ -2981,85 +2981,85 @@ with &2 (insert_trade)
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── return-mapping:
  │    │    │    └── column1:18 => t_id:1
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:42!null check2:43!null check3:44!null check4:45!null check5:46!null
+ │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:43!null check2:44!null check3:45!null check4:46!null check5:47!null
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41,43-47)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48!null
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47!null
+ │    │         │         │    ├── columns: t_st_id:48!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53!null
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52!null
+ │    │         │         │    ├── columns: t_tt_id:53!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60!null
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59!null
+ │    │         │         │    ├── columns: t_s_symb:60!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":42]
  └── with &4 (insert_trade_history)
       ├── columns: "?column?":121!null
       ├── cardinality: [1 - 1]
@@ -3067,11 +3067,11 @@ with &2 (insert_trade)
       ├── key: ()
       ├── fd: ()-->(121)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":97!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(97)
       │    ├── insert trade_history
       │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
       │    │    ├── insert-mapping:
@@ -3095,38 +3095,38 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:93 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116!null
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115!null
+      │    │                   │    ├── columns: th_st_id:116!null
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":97]
       └── values
            ├── columns: "?column?":121!null
            ├── cardinality: [1 - 1]
@@ -3211,11 +3211,11 @@ with &2 (insert_trade)
  ├── key: ()
  ├── fd: ()-->(195)
  ├── project
- │    ├── columns: "?column?":87!null
+ │    ├── columns: "?column?":42!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(87)
+ │    ├── fd: ()-->(42)
  │    ├── insert trade
  │    │    ├── columns: t_id:1!null
  │    │    ├── insert-mapping:
@@ -3236,85 +3236,85 @@ with &2 (insert_trade)
  │    │    │    └── column15:32 => t_lifo:15
  │    │    ├── return-mapping:
  │    │    │    └── column1:18 => t_id:1
- │    │    ├── check columns: check1:42 check2:43 check3:44 check4:45 check5:46
+ │    │    ├── check columns: check1:43 check2:44 check3:45 check4:46 check5:47
  │    │    ├── input binding: &1
  │    │    ├── cardinality: [1 - 1]
  │    │    ├── volatile, mutations
  │    │    ├── key: ()
  │    │    ├── fd: ()-->(1)
  │    │    ├── values
- │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:42!null check2:43!null check3:44!null check4:45!null check5:46!null
+ │    │    │    ├── columns: column1:18!null column2:19!null column5:22!null column9:26!null column11:28 column15:32!null t_st_id_cast:33!null t_tt_id_cast:34!null t_s_symb_cast:35!null t_qty_cast:36!null t_bid_price_cast:37!null t_exec_name_cast:38!null t_chrg_cast:39!null t_comm_cast:40!null t_tax_cast:41!null check1:43!null check2:44!null check3:45!null check4:46!null check5:47!null
  │    │    │    ├── cardinality: [1 - 1]
  │    │    │    ├── key: ()
- │    │    │    ├── fd: ()-->(18,19,22,26,28,32-46)
+ │    │    │    ├── fd: ()-->(18,19,22,26,28,32-41,43-47)
  │    │    │    └── (0, '2020-06-17 22:27:42.148484', true, 0, NULL, true, 'SBMT', 'TMB', 'SYMB', 10, 100.00, 'Name', 1.00, 0.00, 0.00, true, true, true, true, true)
  │    │    └── f-k-checks
  │    │         ├── f-k-checks-item: trade(t_st_id) -> status_type(st_id)
  │    │         │    └── anti-join (lookup status_type)
- │    │         │         ├── columns: t_st_id:47!null
- │    │         │         ├── key columns: [47] = [48]
+ │    │         │         ├── columns: t_st_id:48!null
+ │    │         │         ├── key columns: [48] = [49]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(47)
+ │    │         │         ├── fd: ()-->(48)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_st_id:47!null
+ │    │         │         │    ├── columns: t_st_id:48!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:47
+ │    │         │         │    │    └──  t_st_id_cast:33 => t_st_id:48
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(47)
+ │    │         │         │    └── fd: ()-->(48)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_tt_id) -> trade_type(tt_id)
  │    │         │    └── anti-join (lookup trade_type)
- │    │         │         ├── columns: t_tt_id:52!null
- │    │         │         ├── key columns: [52] = [53]
+ │    │         │         ├── columns: t_tt_id:53!null
+ │    │         │         ├── key columns: [53] = [54]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(52)
+ │    │         │         ├── fd: ()-->(53)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_tt_id:52!null
+ │    │         │         │    ├── columns: t_tt_id:53!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:52
+ │    │         │         │    │    └──  t_tt_id_cast:34 => t_tt_id:53
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(52)
+ │    │         │         │    └── fd: ()-->(53)
  │    │         │         └── filters (true)
  │    │         ├── f-k-checks-item: trade(t_s_symb) -> security(s_symb)
  │    │         │    └── anti-join (lookup security)
- │    │         │         ├── columns: t_s_symb:59!null
- │    │         │         ├── key columns: [59] = [60]
+ │    │         │         ├── columns: t_s_symb:60!null
+ │    │         │         ├── key columns: [60] = [61]
  │    │         │         ├── lookup columns are key
  │    │         │         ├── cardinality: [0 - 1]
  │    │         │         ├── key: ()
- │    │         │         ├── fd: ()-->(59)
+ │    │         │         ├── fd: ()-->(60)
  │    │         │         ├── with-scan &1
- │    │         │         │    ├── columns: t_s_symb:59!null
+ │    │         │         │    ├── columns: t_s_symb:60!null
  │    │         │         │    ├── mapping:
- │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:59
+ │    │         │         │    │    └──  t_s_symb_cast:35 => t_s_symb:60
  │    │         │         │    ├── cardinality: [1 - 1]
  │    │         │         │    ├── key: ()
- │    │         │         │    └── fd: ()-->(59)
+ │    │         │         │    └── fd: ()-->(60)
  │    │         │         └── filters (true)
  │    │         └── f-k-checks-item: trade(t_ca_id) -> customer_account(ca_id)
  │    │              └── anti-join (lookup customer_account)
- │    │                   ├── columns: t_ca_id:78!null
- │    │                   ├── key columns: [78] = [79]
+ │    │                   ├── columns: t_ca_id:79!null
+ │    │                   ├── key columns: [79] = [80]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(78)
+ │    │                   ├── fd: ()-->(79)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: t_ca_id:78!null
+ │    │                   │    ├── columns: t_ca_id:79!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column9:26 => t_ca_id:78
+ │    │                   │    │    └──  column9:26 => t_ca_id:79
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(78)
+ │    │                   │    └── fd: ()-->(79)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":87]
+ │         └── 1 [as="?column?":42]
  └── with &4 (insert_trade_history)
       ├── columns: "?column?":195!null
       ├── cardinality: [1 - 1]
@@ -3322,11 +3322,11 @@ with &2 (insert_trade)
       ├── key: ()
       ├── fd: ()-->(195)
       ├── project
-      │    ├── columns: "?column?":120!null
+      │    ├── columns: "?column?":97!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(120)
+      │    ├── fd: ()-->(97)
       │    ├── insert trade_history
       │    │    ├── columns: trade_history.th_t_id:88!null trade_history.th_st_id:90!null
       │    │    ├── insert-mapping:
@@ -3350,38 +3350,38 @@ with &2 (insert_trade)
       │    │    └── f-k-checks
       │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
       │    │         │    └── anti-join (lookup trade)
-      │    │         │         ├── columns: th_t_id:97!null
-      │    │         │         ├── key columns: [97] = [98]
+      │    │         │         ├── columns: th_t_id:98!null
+      │    │         │         ├── key columns: [98] = [99]
       │    │         │         ├── lookup columns are key
       │    │         │         ├── cardinality: [0 - 1]
       │    │         │         ├── key: ()
-      │    │         │         ├── fd: ()-->(97)
+      │    │         │         ├── fd: ()-->(98)
       │    │         │         ├── with-scan &3
-      │    │         │         │    ├── columns: th_t_id:97!null
+      │    │         │         │    ├── columns: th_t_id:98!null
       │    │         │         │    ├── mapping:
-      │    │         │         │    │    └──  column1:93 => th_t_id:97
+      │    │         │         │    │    └──  column1:93 => th_t_id:98
       │    │         │         │    ├── cardinality: [1 - 1]
       │    │         │         │    ├── key: ()
-      │    │         │         │    └── fd: ()-->(97)
+      │    │         │         │    └── fd: ()-->(98)
       │    │         │         └── filters (true)
       │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
       │    │              └── anti-join (lookup status_type)
-      │    │                   ├── columns: th_st_id:115!null
-      │    │                   ├── key columns: [115] = [116]
+      │    │                   ├── columns: th_st_id:116!null
+      │    │                   ├── key columns: [116] = [117]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(115)
+      │    │                   ├── fd: ()-->(116)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: th_st_id:115!null
+      │    │                   │    ├── columns: th_st_id:116!null
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:115
+      │    │                   │    │    └──  th_st_id_cast:96 => th_st_id:116
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(115)
+      │    │                   │    └── fd: ()-->(116)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":120]
+      │         └── 1 [as="?column?":97]
       └── with &6 (insert_trade_request)
            ├── columns: "?column?":195!null
            ├── cardinality: [1 - 1]
@@ -3389,11 +3389,11 @@ with &2 (insert_trade)
            ├── key: ()
            ├── fd: ()-->(195)
            ├── project
-           │    ├── columns: "?column?":194!null
+           │    ├── columns: "?column?":139!null
            │    ├── cardinality: [1 - 1]
            │    ├── volatile, mutations
            │    ├── key: ()
-           │    ├── fd: ()-->(194)
+           │    ├── fd: ()-->(139)
            │    ├── insert trade_request
            │    │    ├── columns: trade_request.tr_t_id:121!null
            │    │    ├── insert-mapping:
@@ -3405,86 +3405,86 @@ with &2 (insert_trade)
            │    │    │    └── column6:134 => trade_request.tr_b_id:126
            │    │    ├── return-mapping:
            │    │    │    └── column1:129 => trade_request.tr_t_id:121
-           │    │    ├── check columns: check1:139 check2:140
-           │    │    ├── partial index put columns: partial_index_put1:141
+           │    │    ├── check columns: check1:140 check2:141
+           │    │    ├── partial index put columns: partial_index_put1:142
            │    │    ├── input binding: &5
            │    │    ├── cardinality: [1 - 1]
            │    │    ├── volatile, mutations
            │    │    ├── key: ()
            │    │    ├── fd: ()-->(121)
            │    │    ├── values
-           │    │    │    ├── columns: column1:129!null column6:134!null tr_tt_id_cast:135!null tr_s_symb_cast:136!null tr_qty_cast:137!null tr_bid_price_cast:138!null check1:139!null check2:140!null partial_index_put1:141!null
+           │    │    │    ├── columns: column1:129!null column6:134!null tr_tt_id_cast:135!null tr_s_symb_cast:136!null tr_qty_cast:137!null tr_bid_price_cast:138!null check1:140!null check2:141!null partial_index_put1:142!null
            │    │    │    ├── cardinality: [1 - 1]
            │    │    │    ├── key: ()
-           │    │    │    ├── fd: ()-->(129,134-141)
+           │    │    │    ├── fd: ()-->(129,134-138,140-142)
            │    │    │    └── (0, 0, 'TMB', 'SYMB', 10, 100.00, true, true, false)
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_request(tr_t_id) -> trade(t_id)
            │    │         │    └── anti-join (lookup trade)
-           │    │         │         ├── columns: tr_t_id:142!null
-           │    │         │         ├── key columns: [142] = [143]
+           │    │         │         ├── columns: tr_t_id:143!null
+           │    │         │         ├── key columns: [143] = [144]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(142)
+           │    │         │         ├── fd: ()-->(143)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_t_id:142!null
+           │    │         │         │    ├── columns: tr_t_id:143!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:129 => tr_t_id:142
+           │    │         │         │    │    └──  column1:129 => tr_t_id:143
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(142)
+           │    │         │         │    └── fd: ()-->(143)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_tt_id) -> trade_type(tt_id)
            │    │         │    └── anti-join (lookup trade_type)
-           │    │         │         ├── columns: tr_tt_id:160!null
-           │    │         │         ├── key columns: [160] = [161]
+           │    │         │         ├── columns: tr_tt_id:161!null
+           │    │         │         ├── key columns: [161] = [162]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(160)
+           │    │         │         ├── fd: ()-->(161)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_tt_id:160!null
+           │    │         │         │    ├── columns: tr_tt_id:161!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_tt_id_cast:135 => tr_tt_id:160
+           │    │         │         │    │    └──  tr_tt_id_cast:135 => tr_tt_id:161
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(160)
+           │    │         │         │    └── fd: ()-->(161)
            │    │         │         └── filters (true)
            │    │         ├── f-k-checks-item: trade_request(tr_s_symb) -> security(s_symb)
            │    │         │    └── anti-join (lookup security)
-           │    │         │         ├── columns: tr_s_symb:167!null
-           │    │         │         ├── key columns: [167] = [168]
+           │    │         │         ├── columns: tr_s_symb:168!null
+           │    │         │         ├── key columns: [168] = [169]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(167)
+           │    │         │         ├── fd: ()-->(168)
            │    │         │         ├── with-scan &5
-           │    │         │         │    ├── columns: tr_s_symb:167!null
+           │    │         │         │    ├── columns: tr_s_symb:168!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  tr_s_symb_cast:136 => tr_s_symb:167
+           │    │         │         │    │    └──  tr_s_symb_cast:136 => tr_s_symb:168
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(167)
+           │    │         │         │    └── fd: ()-->(168)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_request(tr_b_id) -> broker(b_id)
            │    │              └── anti-join (lookup broker)
-           │    │                   ├── columns: tr_b_id:186!null
-           │    │                   ├── key columns: [186] = [187]
+           │    │                   ├── columns: tr_b_id:187!null
+           │    │                   ├── key columns: [187] = [188]
            │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
-           │    │                   ├── fd: ()-->(186)
+           │    │                   ├── fd: ()-->(187)
            │    │                   ├── with-scan &5
-           │    │                   │    ├── columns: tr_b_id:186!null
+           │    │                   │    ├── columns: tr_b_id:187!null
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  column6:134 => tr_b_id:186
+           │    │                   │    │    └──  column6:134 => tr_b_id:187
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(186)
+           │    │                   │    └── fd: ()-->(187)
            │    │                   └── filters (true)
            │    └── projections
-           │         └── 1 [as="?column?":194]
+           │         └── 1 [as="?column?":139]
            └── values
                 ├── columns: "?column?":195!null
                 ├── cardinality: [1 - 1]
@@ -4320,11 +4320,11 @@ with &2 (update_trade_commission)
            ├── key: ()
            ├── fd: ()-->(104)
            ├── project
-           │    ├── columns: "?column?":103!null
+           │    ├── columns: "?column?":80!null
            │    ├── cardinality: [1 - 1]
            │    ├── volatile, mutations
            │    ├── key: ()
-           │    ├── fd: ()-->(103)
+           │    ├── fd: ()-->(80)
            │    ├── insert trade_history
            │    │    ├── columns: trade_history.th_t_id:71!null trade_history.th_st_id:73!null
            │    │    ├── insert-mapping:
@@ -4348,38 +4348,38 @@ with &2 (update_trade_commission)
            │    │    └── f-k-checks
            │    │         ├── f-k-checks-item: trade_history(th_t_id) -> trade(t_id)
            │    │         │    └── anti-join (lookup trade)
-           │    │         │         ├── columns: th_t_id:80!null
-           │    │         │         ├── key columns: [80] = [81]
+           │    │         │         ├── columns: th_t_id:81!null
+           │    │         │         ├── key columns: [81] = [82]
            │    │         │         ├── lookup columns are key
            │    │         │         ├── cardinality: [0 - 1]
            │    │         │         ├── key: ()
-           │    │         │         ├── fd: ()-->(80)
+           │    │         │         ├── fd: ()-->(81)
            │    │         │         ├── with-scan &4
-           │    │         │         │    ├── columns: th_t_id:80!null
+           │    │         │         │    ├── columns: th_t_id:81!null
            │    │         │         │    ├── mapping:
-           │    │         │         │    │    └──  column1:76 => th_t_id:80
+           │    │         │         │    │    └──  column1:76 => th_t_id:81
            │    │         │         │    ├── cardinality: [1 - 1]
            │    │         │         │    ├── key: ()
-           │    │         │         │    └── fd: ()-->(80)
+           │    │         │         │    └── fd: ()-->(81)
            │    │         │         └── filters (true)
            │    │         └── f-k-checks-item: trade_history(th_st_id) -> status_type(st_id)
            │    │              └── anti-join (lookup status_type)
-           │    │                   ├── columns: th_st_id:98!null
-           │    │                   ├── key columns: [98] = [99]
+           │    │                   ├── columns: th_st_id:99!null
+           │    │                   ├── key columns: [99] = [100]
            │    │                   ├── lookup columns are key
            │    │                   ├── cardinality: [0 - 1]
            │    │                   ├── key: ()
-           │    │                   ├── fd: ()-->(98)
+           │    │                   ├── fd: ()-->(99)
            │    │                   ├── with-scan &4
-           │    │                   │    ├── columns: th_st_id:98!null
+           │    │                   │    ├── columns: th_st_id:99!null
            │    │                   │    ├── mapping:
-           │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:98
+           │    │                   │    │    └──  th_st_id_cast:79 => th_st_id:99
            │    │                   │    ├── cardinality: [1 - 1]
            │    │                   │    ├── key: ()
-           │    │                   │    └── fd: ()-->(98)
+           │    │                   │    └── fd: ()-->(99)
            │    │                   └── filters (true)
            │    └── projections
-           │         └── 1 [as="?column?":103]
+           │         └── 1 [as="?column?":80]
            └── values
                 ├── columns: "?column?":104!null
                 ├── cardinality: [1 - 1]
@@ -4420,11 +4420,11 @@ with &2 (insert_settlement)
  ├── key: ()
  ├── fd: ()-->(81)
  ├── project
- │    ├── columns: "?column?":31!null
+ │    ├── columns: "?column?":13!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(31)
+ │    ├── fd: ()-->(13)
  │    ├── insert settlement
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
@@ -4448,22 +4448,22 @@ with &2 (insert_settlement)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
  │    │              └── anti-join (lookup trade)
- │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
+ │    │                   ├── columns: se_t_id:14!null
+ │    │                   ├── key columns: [14] = [15]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(13)
+ │    │                   ├── fd: ()-->(14)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: se_t_id:13!null
+ │    │                   │    ├── columns: se_t_id:14!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
+ │    │                   │    │    └──  column1:7 => se_t_id:14
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":31]
+ │         └── 1 [as="?column?":13]
  └── with &4 (insert_cash_transaction)
       ├── columns: ca_bal:81!null
       ├── cardinality: [0 - 1]
@@ -4471,11 +4471,11 @@ with &2 (insert_settlement)
       ├── key: ()
       ├── fd: ()-->(81)
       ├── project
-      │    ├── columns: "?column?":62!null
+      │    ├── columns: "?column?":44!null
       │    ├── cardinality: [1 - 1]
       │    ├── volatile, mutations
       │    ├── key: ()
-      │    ├── fd: ()-->(62)
+      │    ├── fd: ()-->(44)
       │    ├── insert cash_transaction
       │    │    ├── columns: cash_transaction.ct_t_id:32!null
       │    │    ├── insert-mapping:
@@ -4499,22 +4499,22 @@ with &2 (insert_settlement)
       │    │    └── f-k-checks
       │    │         └── f-k-checks-item: cash_transaction(ct_t_id) -> trade(t_id)
       │    │              └── anti-join (lookup trade)
-      │    │                   ├── columns: ct_t_id:44!null
-      │    │                   ├── key columns: [44] = [45]
+      │    │                   ├── columns: ct_t_id:45!null
+      │    │                   ├── key columns: [45] = [46]
       │    │                   ├── lookup columns are key
       │    │                   ├── cardinality: [0 - 1]
       │    │                   ├── key: ()
-      │    │                   ├── fd: ()-->(44)
+      │    │                   ├── fd: ()-->(45)
       │    │                   ├── with-scan &3
-      │    │                   │    ├── columns: ct_t_id:44!null
+      │    │                   │    ├── columns: ct_t_id:45!null
       │    │                   │    ├── mapping:
-      │    │                   │    │    └──  column1:38 => ct_t_id:44
+      │    │                   │    │    └──  column1:38 => ct_t_id:45
       │    │                   │    ├── cardinality: [1 - 1]
       │    │                   │    ├── key: ()
-      │    │                   │    └── fd: ()-->(44)
+      │    │                   │    └── fd: ()-->(45)
       │    │                   └── filters (true)
       │    └── projections
-      │         └── 1 [as="?column?":62]
+      │         └── 1 [as="?column?":44]
       └── project
            ├── columns: ca_bal:81!null
            ├── cardinality: [0 - 1]
@@ -4570,11 +4570,11 @@ with &2 (insert_settlement)
  ├── key: ()
  ├── fd: ()-->(40)
  ├── project
- │    ├── columns: "?column?":31!null
+ │    ├── columns: "?column?":13!null
  │    ├── cardinality: [1 - 1]
  │    ├── volatile, mutations
  │    ├── key: ()
- │    ├── fd: ()-->(31)
+ │    ├── fd: ()-->(13)
  │    ├── insert settlement
  │    │    ├── columns: settlement.se_t_id:1!null
  │    │    ├── insert-mapping:
@@ -4598,22 +4598,22 @@ with &2 (insert_settlement)
  │    │    └── f-k-checks
  │    │         └── f-k-checks-item: settlement(se_t_id) -> trade(t_id)
  │    │              └── anti-join (lookup trade)
- │    │                   ├── columns: se_t_id:13!null
- │    │                   ├── key columns: [13] = [14]
+ │    │                   ├── columns: se_t_id:14!null
+ │    │                   ├── key columns: [14] = [15]
  │    │                   ├── lookup columns are key
  │    │                   ├── cardinality: [0 - 1]
  │    │                   ├── key: ()
- │    │                   ├── fd: ()-->(13)
+ │    │                   ├── fd: ()-->(14)
  │    │                   ├── with-scan &1
- │    │                   │    ├── columns: se_t_id:13!null
+ │    │                   │    ├── columns: se_t_id:14!null
  │    │                   │    ├── mapping:
- │    │                   │    │    └──  column1:7 => se_t_id:13
+ │    │                   │    │    └──  column1:7 => se_t_id:14
  │    │                   │    ├── cardinality: [1 - 1]
  │    │                   │    ├── key: ()
- │    │                   │    └── fd: ()-->(13)
+ │    │                   │    └── fd: ()-->(14)
  │    │                   └── filters (true)
  │    └── projections
- │         └── 1 [as="?column?":31]
+ │         └── 1 [as="?column?":13]
  └── project
       ├── columns: ca_bal:40!null
       ├── cardinality: [0 - 1]


### PR DESCRIPTION
#### opt: refactor building of RETURNING expressions and scopes

The logic for constructing `RETURNING` clauses has been refactored. The
logic is almost identical to what it was before. The only difference is
that we now always build the returning scopes for inserts before
building check constraints and we only build those scopes once even if
RLS is enabled. The latter is beneficial for reducing the max column ID
of query plans, helping to avoid the "slow path" of column sets which
require heap allocations - a column set with a column ID greater than
128 hits this slow path.

Release note: None

#### opt: fix application of RLS SELECT policies for INSERTs

It was previously assumed that a `RETURNING` clause of an `INSERT` could
only reference columns of the target table. Therefore, we simply checked
whether or not any columns were referenced in the `RETURNING` clause to
determine if RLS SELECT policies should be applied as check constraints.

However, our assumption was incorrect. If the `INSERT` is within a UDF
or stored procedure, the `RETURNING` clause can reference parameters.
These references should not cause RLS SELECT policies to be applied.
This commit fixes this.

Fixes #146470

Release note: None
