### PR TITLE
roachtest: metamorphically enable buffered writes

### DIFF
--- a/pkg/cmd/roachtest/operations/cluster_settings.go
+++ b/pkg/cmd/roachtest/operations/cluster_settings.go
@@ -108,6 +108,12 @@ func registerClusterSettings(r registry.Registry) {
 			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 12*time.Hour),
 			Owner:     registry.OwnerObservability,
 		},
+		{
+			// Periodically switch between two transaction protocol variants.
+			Name:      "kv.transaction.write_buffering.enabled",
+			Generator: timeBasedValues(timeutil.Now, []string{"true", "false"}, 6*time.Hour),
+			Owner:     registry.OwnerKV,
+		},
 	}
 	sanitizeOpName := func(name string) string {
 		return strings.ReplaceAll(name, ".", "_")


### PR DESCRIPTION
This commit adjusts the roachtest runner to enable buffered writes in 50% cases (unless the test is marked as a benchmark). It also adds a new operation to change the corresponding cluster setting too.

Informs: #143860.
Epic: None

Release note: None