### PR TITLE
sql: report unit for some session variables

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3180,7 +3180,7 @@ cost_scans_with_default_col_size                           off                 N
 create_table_with_schema_locked                            off                 NULL  user     NULL      off                 off
 database                                                   test                NULL  user     NULL      ·                   test
 datestyle                                                  ISO, MDY            NULL  user     NULL      ISO, MDY            ISO, MDY
-deadlock_timeout                                           0                   NULL  user     NULL      0s                  0s
+deadlock_timeout                                           0                   ms    user     NULL      0s                  0s
 declare_cursor_statement_timeout_enabled                   on                  NULL  user     NULL      on                  on
 default_int_size                                           8                   NULL  user     NULL      8                   8
 default_table_access_method                                heap                NULL  user     NULL      heap                heap
@@ -3231,18 +3231,18 @@ experimental_hash_group_join_enabled                       off                 N
 extra_float_digits                                         1                   NULL  user     NULL      1                   1
 force_savepoint_restart                                    off                 NULL  user     NULL      off                 off
 foreign_key_cascades_limit                                 10000               NULL  user     NULL      10000               10000
-idle_in_transaction_session_timeout                        0                   NULL  user     NULL      0s                  0s
-idle_session_timeout                                       0                   NULL  user     NULL      0s                  0s
-index_join_streamer_batch_size                             8.0 MiB             NULL  user     NULL      8.0 MiB             8.0 MiB
+idle_in_transaction_session_timeout                        0                   ms    user     NULL      0s                  0s
+idle_session_timeout                                       0                   ms    user     NULL      0s                  0s
+index_join_streamer_batch_size                             8.0 MiB             B     user     NULL      8.0 MiB             8.0 MiB
 index_recommendations_enabled                              off                 NULL  user     NULL      on                  false
 inject_retry_errors_enabled                                off                 NULL  user     NULL      off                 off
 inject_retry_errors_on_commit_enabled                      off                 NULL  user     NULL      off                 off
 integer_datetimes                                          on                  NULL  user     NULL      on                  on
 intervalstyle                                              postgres            NULL  user     NULL      postgres            postgres
 is_superuser                                               on                  NULL  user     NULL      on                  on
-join_reader_index_join_strategy_batch_size                 4.0 MiB             NULL  user     NULL      4.0 MiB             4.0 MiB
-join_reader_no_ordering_strategy_batch_size                2.0 MiB             NULL  user     NULL      2.0 MiB             2.0 MiB
-join_reader_ordering_strategy_batch_size                   100 KiB             NULL  user     NULL      100 KiB             100 KiB
+join_reader_index_join_strategy_batch_size                 4.0 MiB             B     user     NULL      4.0 MiB             4.0 MiB
+join_reader_no_ordering_strategy_batch_size                2.0 MiB             B     user     NULL      2.0 MiB             2.0 MiB
+join_reader_ordering_strategy_batch_size                   100 KiB             B     user     NULL      100 KiB             100 KiB
 large_full_scan_rows                                       0                   NULL  user     NULL      0                   0
 lc_collate                                                 C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
 lc_ctype                                                   C.UTF-8             NULL  user     NULL      C.UTF-8             C.UTF-8
@@ -3253,7 +3253,7 @@ lc_time                                                    C.UTF-8             N
 legacy_varchar_typing                                      off                 NULL  user     NULL      off                 off
 locality                                                   region=test,dc=dc1  NULL  user     NULL      region=test,dc=dc1  region=test,dc=dc1
 locality_optimized_partitioned_index_scan                  on                  NULL  user     NULL      on                  on
-lock_timeout                                               0                   NULL  user     NULL      0s                  0s
+lock_timeout                                               0                   ms    user     NULL      0s                  0s
 log_timezone                                               UTC                 NULL  user     NULL      UTC                 UTC
 max_connections                                            -1                  NULL  user     NULL      -1                  -1
 max_identifier_length                                      128                 NULL  user     NULL      128                 128
@@ -3305,7 +3305,7 @@ pg_trgm.similarity_threshold                               0.3                 N
 plan_cache_mode                                            auto                NULL  user     NULL      auto                auto
 plpgsql_use_strict_into                                    off                 NULL  user     NULL      off                 off
 prefer_lookup_joins_for_fks                                off                 NULL  user     NULL      off                 off
-prepared_statements_cache_size                             0 B                 NULL  user     NULL      0 B                 0 B
+prepared_statements_cache_size                             0 B                 B     user     NULL      0 B                 0 B
 propagate_admission_header_to_leaf_transactions            on                  NULL  user     NULL      on                  on
 propagate_input_ordering                                   off                 NULL  user     NULL      off                 off
 recursion_depth_limit                                      1000                NULL  user     NULL      1000                1000
@@ -3324,7 +3324,7 @@ show_primary_key_constraint_on_not_visible_columns         on                  N
 sql_safe_updates                                           off                 NULL  user     NULL      off                 off
 ssl                                                        on                  NULL  user     NULL      on                  on
 standard_conforming_strings                                on                  NULL  user     NULL      on                  on
-statement_timeout                                          0                   NULL  user     NULL      0s                  0s
+statement_timeout                                          0                   ms    user     NULL      0s                  0s
 streamer_always_maintain_ordering                          off                 NULL  user     NULL      off                 off
 streamer_enabled                                           on                  NULL  user     NULL      on                  on
 streamer_head_of_line_only_fraction                        0.8                 NULL  user     NULL      0.8                 0.8
@@ -3350,7 +3350,7 @@ transaction_rows_read_log                                  0                   N
 transaction_rows_written_err                               0                   NULL  user     NULL      0                   0
 transaction_rows_written_log                               0                   NULL  user     NULL      0                   0
 transaction_status                                         NoTxn               NULL  user     NULL      NoTxn               NoTxn
-transaction_timeout                                        0                   NULL  user     NULL      0s                  0s
+transaction_timeout                                        0                   ms    user     NULL      0s                  0s
 troubleshooting_mode                                       off                 NULL  user     NULL      off                 off
 unbounded_parallel_scans                                   off                 NULL  user     NULL      off                 off
 unconstrained_non_covering_index_scan_enabled              off                 NULL  user     NULL      off                 off

--- a/pkg/sql/logictest/testdata/logic_test/set
+++ b/pkg/sql/logictest/testdata/logic_test/set
@@ -940,3 +940,22 @@ subtest end
 # Regression test for incorrectly marking this variable as boolean.
 statement ok
 SET copy_num_retries_per_batch = 5;
+
+# Tests for a byte-size setting where integer values are provided (which are
+# treated as number of bytes).
+statement ok
+SET distsql_workmem = 1048576
+
+query T
+SHOW distsql_workmem
+----
+1.0 MiB
+
+statement error distsql_workmem cannot be set to a negative value
+SET distsql_workmem = -1
+
+statement error distsql_workmem can only be set to a value greater than 1
+SET distsql_workmem = 1
+
+statement ok
+RESET distsql_workmem

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -3076,6 +3076,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-settings.html`,
 				return err
 			}
 			valueDatum := tree.NewDString(value)
+			var valueUnit = tree.DNull
+			if gen.Unit != "" {
+				valueUnit = tree.NewDString(gen.Unit)
+			}
 			var bootDatum tree.Datum = tree.DNull
 			var resetDatum tree.Datum = tree.DNull
 			if gen.Set == nil && gen.RuntimeSet == nil && gen.SetWithPlanner == nil {
@@ -3099,7 +3103,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-settings.html`,
 			if err := addRow(
 				tree.NewDString(strings.ToLower(vName)), // name
 				valueDatum,                              // setting
-				tree.DNull,                              // unit
+				valueUnit,                               // unit
 				tree.DNull,                              // category
 				tree.DNull,                              // short_desc
 				tree.DNull,                              // extra_desc

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -77,6 +77,11 @@ type sessionVar struct {
 	// either by SHOW or in the pg_catalog table.
 	Get func(evalCtx *extendedEvalContext, kv *kv.Txn) (string, error)
 
+	// Unit, if set, is a string representing the unit in which the value of
+	// this session variable is expressed by default. It can be empty in which
+	// case the unit is not defined.
+	Unit string
+
 	// Exists returns true if this custom session option exists in the current
 	// context. It's needed to support the current_setting builtin for custom
 	// options. It is only defined for custom options.
@@ -97,6 +102,10 @@ type sessionVar struct {
 	// the Set() method has to operate on strings, because it can be
 	// invoked at a point where there is no evalContext yet (e.g.
 	// upon session initialization in pgwire).
+	//
+	// Additional use case for this field is when we want to allow values of
+	// multiple types to be used when setting the variable (e.g. to accept both
+	// strings and integers).
 	GetStringVal getStringValFn
 
 	// Set performs mutations to effect the change desired by SET commands.
@@ -354,6 +363,7 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData().DeadlockTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10), nil
 		},
+		Unit: "ms",
 		GlobalDefault: func(sv *settings.Values) string {
 			return "0s"
 		},
@@ -590,6 +600,8 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return string(humanizeutil.IBytes(evalCtx.SessionData().WorkMemLimit)), nil
 		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("distsql_workmem"),
 		GlobalDefault: func(sv *settings.Values) string {
 			return string(humanizeutil.IBytes(settingWorkMemBytes.Get(sv)))
 		},
@@ -1260,6 +1272,7 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData().LockTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10), nil
 		},
+		Unit: "ms",
 		GlobalDefault: func(sv *settings.Values) string {
 			return clusterLockTimeout.String(sv)
 		},
@@ -1498,6 +1511,7 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData().TransactionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10), nil
 		},
+		Unit: "ms",
 		GlobalDefault: func(sv *settings.Values) string {
 			return "0s"
 		},
@@ -1661,6 +1675,7 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData().StmtTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10), nil
 		},
+		Unit: "ms",
 		GlobalDefault: func(sv *settings.Values) string {
 			return clusterStatementTimeout.String(sv)
 		},
@@ -1674,6 +1689,7 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData().IdleInSessionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10), nil
 		},
+		Unit: "ms",
 		GlobalDefault: func(sv *settings.Values) string {
 			return clusterIdleInSessionTimeout.String(sv)
 		},
@@ -1686,6 +1702,7 @@ var varGen = map[string]sessionVar{
 			ms := evalCtx.SessionData().IdleInTransactionSessionTimeout.Nanoseconds() / int64(time.Millisecond)
 			return strconv.FormatInt(ms, 10), nil
 		},
+		Unit: "ms",
 		GlobalDefault: func(sv *settings.Values) string {
 			return clusterIdleInTransactionSessionTimeout.String(sv)
 		},
@@ -2293,6 +2310,8 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return string(humanizeutil.IBytes(evalCtx.SessionData().JoinReaderOrderingStrategyBatchSize)), nil
 		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("join_reader_ordering_strategy_batch_size"),
 		GlobalDefault: func(sv *settings.Values) string {
 			return string(humanizeutil.IBytes(rowexec.JoinReaderOrderingStrategyBatchSize.Get(sv)))
 		},
@@ -2314,6 +2333,8 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return string(humanizeutil.IBytes(evalCtx.SessionData().JoinReaderNoOrderingStrategyBatchSize)), nil
 		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("join_reader_no_ordering_strategy_batch_size"),
 		GlobalDefault: func(sv *settings.Values) string {
 			return string(humanizeutil.IBytes(rowexec.JoinReaderNoOrderingStrategyBatchSize.Get(sv)))
 		},
@@ -2335,6 +2356,8 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return string(humanizeutil.IBytes(evalCtx.SessionData().JoinReaderIndexJoinStrategyBatchSize)), nil
 		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("join_reader_index_join_strategy_batch_size"),
 		GlobalDefault: func(sv *settings.Values) string {
 			return string(humanizeutil.IBytes(execinfra.JoinReaderIndexJoinStrategyBatchSize.Get(sv)))
 		},
@@ -2356,6 +2379,8 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return string(humanizeutil.IBytes(evalCtx.SessionData().IndexJoinStreamerBatchSize)), nil
 		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("index_join_streamer_batch_size"),
 		GlobalDefault: func(sv *settings.Values) string {
 			return string(humanizeutil.IBytes(colfetcher.IndexJoinStreamerBatchSize.Get(sv)))
 		},
@@ -3051,6 +3076,8 @@ var varGen = map[string]sessionVar{
 		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
 			return string(humanizeutil.IBytes(evalCtx.SessionData().PreparedStatementsCacheSize)), nil
 		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("prepared_statements_cache_size"),
 		GlobalDefault: func(_ *settings.Values) string {
 			return string(humanizeutil.IBytes(0))
 		},


### PR DESCRIPTION
Previously, we never populated the `unit` column of `pg_settings`
virtual table deviating from PostgreSQL. We now report the unit for
time-based and memory-based settings.

AFAIU the unit defines the default unit of the value which allows these
settings take in integer numbers with the unit providing the necessary
measurement dimension.

Fixes: #30717
Release note: None