### PR TITLE
kvclient: add request record summary to write buffer tracing 

### DIFF
--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -2169,8 +2169,12 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 			// shell.
 		} else {
 			traceType := ""
+			compact := ""
 			if strings.Contains(c.iCtx.autoTrace, "kv") {
 				traceType = "kv"
+			}
+			if strings.Contains(c.iCtx.autoTrace, "compact") {
+				compact = "COMPACT"
 			}
 			if err := c.runWithInterruptableCtx(func(ctx context.Context) error {
 				defer c.maybeFlushOutput()
@@ -2179,7 +2183,7 @@ func (c *cliState) doRunStatements(nextState cliStateEnum) cliStateEnum {
 					c.iCtx.queryOutput, // query output
 					c.iCtx.stdout,      // timings
 					c.iCtx.stderr,      // errors
-					clisqlclient.MakeQuery(fmt.Sprintf("SHOW %s TRACE FOR SESSION", traceType)))
+					clisqlclient.MakeQuery(fmt.Sprintf("SHOW %s %s TRACE FOR SESSION", compact, traceType)))
 			}); err != nil {
 				clierror.OutputError(c.iCtx.stderr, err, true /*showSeverity*/, false /*verbose*/)
 				if c.exitErr == nil {

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -4101,6 +4101,8 @@ func (ex *connExecutor) enableTracing(modes []string) error {
 			traceKV = true
 		case "cluster":
 			recordingType = tracingpb.RecordingVerbose
+		case "compact":
+			// compact modifies the output format.
 		default:
 			return pgerror.Newf(pgcode.Syntax,
 				"set tracing: unknown mode %q", s)

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -479,3 +479,32 @@ query II
 SELECT pk,v FROM t5 WHERE pk = 1
 ----
 1  1
+
+subtest tracing
+
+statement ok
+CREATE TABLE t6 (pk INT PRIMARY KEY, v INT, FAMILY (pk, v), INDEX (v), INDEX ((v+5)))
+
+statement ok
+BEGIN
+
+statement ok
+SET TRACING = "on"
+
+statement ok
+INSERT INTO t6 VALUES (1,1)
+
+# This assertion depends on write buffering not being disabled because
+# of the version or transaction isolation level. Skip configurations
+# that result in buffered writes being disabled.
+skipif config local-read-committed local-repeatable-read local-mixed-24.3 local-mixed-25.1
+query T
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE location LIKE '%write_buffer.go%'
+----
+txn write buffer modified the batch; fully buffered: Put:2; transformed: ConditionalPut:1
+
+statement ok
+SET TRACING = "off"
+
+statement ok
+COMMIT


### PR DESCRIPTION
This might help someone understand why the batch ultimately sent to KV
is incongruous with trace entries added by the SQL layer.

Epic: none

Release note: None