### PR TITLE
release-25.1: sql/distsql: preserve JobID in redacted logs

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -379,7 +379,7 @@ func (ds *ServerImpl) setupFlow(
 
 	if !f.IsLocal() {
 		bld := logtags.BuildBuffer()
-		bld.Add("f", flowCtx.ID.Short().String())
+		bld.Add("f", flowCtx.ID.Short())
 		if req.JobTag != "" {
 			bld.Add("job", req.JobTag)
 		}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -56,6 +56,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 var settingDistSQLNumRunners = settings.RegisterIntSetting(
@@ -426,7 +427,7 @@ func (dsp *DistSQLPlanner) setupFlows(
 		// In distributed plans populate some extra state.
 		setupReq.EvalContext = execinfrapb.MakeEvalContext(&evalCtx.Context)
 		if jobTag, ok := logtags.FromContext(ctx).GetTag("job"); ok {
-			setupReq.JobTag = jobTag.ValueStr()
+			setupReq.JobTag = redact.SafeString(jobTag.ValueStr())
 		}
 	}
 	if evalCtx.SessionData().PropagateAdmissionHeaderToLeafTransactions && localState.Txn != nil {

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -27,7 +27,8 @@ message SetupFlowRequest {
 
   optional util.tracing.tracingpb.TraceInfo trace_info = 11;
   // JobTag is only populated in distributed flows.
-  optional string job_tag = 13 [(gogoproto.nullable) = false];
+  optional string job_tag = 13 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/redact.SafeString"];
 
   // LeafTxnInputState is the input parameter for the *kv.Txn needed for
   // executing the flow.


### PR DESCRIPTION
Backport 1/1 commits from #146362 on behalf of @spilchen.

----

Previously, the JobID log tag could be redacted, making it difficult to trace TTL job execution when viewing redacted logs. This change ensures the JobID is logged as a redact.SafeString, allowing it to appear in redacted outputs for easier debugging.

Additionally, the flowCtx.ID is now also saved as a safe string too.

Epic: none
Release note: none

----

Release justification: improves job observability