### PR TITLE
release-24.1: roachtest: deflake declarative_schema_changer/job-compatibility-mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -61,6 +61,11 @@ func setShortGCTTLInSystemZoneConfig(
 		return err
 	}
 
+	// Ensure the system database has a longer TTL interval, which is needed to avoid
+	// flakes on system database queries for upgrades.
+	if err := h.Exec(r, "ALTER DATABASE system CONFIGURE ZONE USING gc.ttlseconds=60;"); err != nil {
+		return err
+	}
 	return h.Exec(r, "ALTER RANGE default CONFIGURE ZONE USING gc.ttlseconds = 1;")
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #146219.

/cc @cockroachdb/release

---

Previously, the job compatibility test could run into flakes because it reduced the GC TTL to one second. This could cause some system database queries to fail during upgrade preconditions. To address this, this patch leaves a 1-minute GC TTL on the system database, which prevents the low TTL from interfering with internal operations for upgrades.

Fixes: #144920

Release note: None
Release justification: low risk test only fix
