### PR TITLE
cspann: support other distance metrics in K-means

### DIFF
--- a/pkg/sql/vecindex/cspann/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
     deps = [
         "//pkg/sql/vecindex/cspann/quantize",
         "//pkg/sql/vecindex/cspann/utils",
+        "//pkg/sql/vecindex/cspann/vecdist",
         "//pkg/sql/vecindex/cspann/workspace",
         "//pkg/util/buildutil",
         "//pkg/util/container/heap",

--- a/pkg/sql/vecindex/cspann/fixup_split.go
+++ b/pkg/sql/vecindex/cspann/fixup_split.go
@@ -540,10 +540,8 @@ func (fw *fixupWorker) computeSplitCentroids(
 
 	default:
 		// Compute centroids using K-means.
-		tempOffsets := fw.workspace.AllocUint64s(vectors.Count)
-		defer fw.workspace.FreeUint64s(tempOffsets)
 		kmeans := BalancedKmeans{Workspace: &fw.workspace, Rand: fw.rng}
-		kmeans.ComputeCentroids(vectors, leftCentroid, rightCentroid, pinLeftCentroid, tempOffsets)
+		kmeans.ComputeCentroids(vectors, leftCentroid, rightCentroid, pinLeftCentroid)
 	}
 }
 

--- a/pkg/sql/vecindex/cspann/kmeans_test.go
+++ b/pkg/sql/vecindex/cspann/kmeans_test.go
@@ -11,8 +11,8 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/testutils"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/vecdist"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/workspace"
-	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
 	"gonum.org/v1/gonum/floats/scalar"
@@ -20,43 +20,45 @@ import (
 )
 
 func TestBalancedKMeans(t *testing.T) {
-	calcCentroid := func(vectors vector.Set, offsets []uint64) vector.T {
-		centroid := make(vector.T, vectors.Dims)
-		for _, offset := range offsets {
-			num32.Add(centroid, vectors.At(int(offset)))
-		}
-		num32.Scale(1/float32(len(offsets)), centroid)
-		return centroid
-	}
-
-	calcMeanDistance := func(vectors vector.Set, centroid vector.T, offsets []uint64) float32 {
+	calcMeanDistance := func(
+		distanceMetric vecdist.Metric,
+		vectors vector.Set,
+		centroid vector.T,
+		offsets []uint64,
+	) float32 {
 		var distanceSum float32
 		for _, offset := range offsets {
-			distanceSum += num32.L2Distance(vectors.At(int(offset)), centroid)
+			distanceSum += vecdist.Measure(distanceMetric, vectors.At(int(offset)), centroid)
 		}
 		return distanceSum / float32(len(offsets))
 	}
 
 	workspace := &workspace.T{}
 	rng := rand.New(rand.NewSource(42))
-	kmeans := BalancedKmeans{Workspace: workspace, Rand: rng}
 	dataset := testutils.LoadDataset(t, testutils.ImagesDataset)
 
 	testCases := []struct {
-		desc         string
-		vectors      vector.Set
-		leftOffsets  []uint64
-		rightOffsets []uint64
-		skipPinTest  bool
+		desc           string
+		distanceMetric vecdist.Metric
+		vectors        vector.Set
+		leftOffsets    []uint64
+		rightOffsets   []uint64
+		leftCentroid   vector.T
+		rightCentroid  vector.T
+		skipPinTest    bool
 	}{
 		{
-			desc:         "partition vector set with only 2 elements",
-			vectors:      vector.MakeSetFromRawData([]float32{1, 2}, 1),
-			leftOffsets:  []uint64{1},
-			rightOffsets: []uint64{0},
+			desc:           "partition vector set with only 2 elements",
+			distanceMetric: vecdist.L2Squared,
+			vectors:        vector.MakeSetFromRawData([]float32{1, 2}, 1),
+			leftOffsets:    []uint64{1},
+			rightOffsets:   []uint64{0},
+			leftCentroid:   []float32{2},
+			rightCentroid:  []float32{1},
 		},
 		{
-			desc: "partition vector set with duplicates values",
+			desc:           "partition vector set with duplicates values",
+			distanceMetric: vecdist.L2Squared,
 			vectors: vector.MakeSetFromRawData([]float32{
 				1, 1,
 				1, 1,
@@ -64,109 +66,178 @@ func TestBalancedKMeans(t *testing.T) {
 				1, 1,
 				1, 1,
 			}, 2),
-			leftOffsets:  []uint64{0, 1},
-			rightOffsets: []uint64{2, 3, 4},
+			leftOffsets:   []uint64{0, 1},
+			rightOffsets:  []uint64{2, 3, 4},
+			leftCentroid:  []float32{1, 1},
+			rightCentroid: []float32{1, 1},
 		},
 		{
-			desc: "partition 5x3 set of vectors",
+			desc:           "partition 5x3 set of vectors",
+			distanceMetric: vecdist.L2Squared,
 			vectors: vector.MakeSetFromRawData([]float32{
 				1, 2, 3,
 				2, 5, 10,
 				4, 6, 1,
 				10, 15, 20,
-				3, 8, 1,
+				4, 7, 2,
 			}, 3),
-			leftOffsets:  []uint64{0, 2, 4},
-			rightOffsets: []uint64{1, 3},
+			leftOffsets:   []uint64{0, 2, 4},
+			rightOffsets:  []uint64{1, 3},
+			leftCentroid:  []float32{3, 5, 2},
+			rightCentroid: []float32{6, 10, 15},
 		},
 		{
 			// Unbalanced vector set, with 4 vectors close together and 1 far.
 			// One of the close vectors will be grouped with the far vector due
 			// to the balancing constraint.
-			desc: "unbalanced vector set",
+			desc:           "unbalanced vector set",
+			distanceMetric: vecdist.L2Squared,
 			vectors: vector.MakeSetFromRawData([]float32{
-				2, 2,
+				3, 0,
 				2, 1,
 				1, 2,
-				1, 1,
+				4, 2,
 				20, 30,
 			}, 2),
-			leftOffsets:  []uint64{1, 2, 3},
-			rightOffsets: []uint64{0, 4},
+			leftOffsets:   []uint64{0, 1, 2},
+			rightOffsets:  []uint64{3, 4},
+			leftCentroid:  []float32{2, 1},
+			rightCentroid: []float32{12, 16},
 		},
 		{
-			desc: "very small values close to one another",
+			desc:           "very small values close to one another",
+			distanceMetric: vecdist.L2Squared,
 			vectors: vector.MakeSetFromRawData([]float32{
 				1.23e-10, 2.58e-10,
 				1.25e-10, 2.60e-10,
 				1.26e-10, 2.61e-10,
 				1.24e-10, 2.59e-10,
 			}, 2),
-			leftOffsets:  []uint64{1, 2},
-			rightOffsets: []uint64{0, 3},
+			leftOffsets:   []uint64{1, 2},
+			rightOffsets:  []uint64{0, 3},
+			leftCentroid:  vector.T{1.255e-10, 2.605e-10},
+			rightCentroid: vector.T{1.235e-10, 2.585e-10},
 		},
 		{
-			desc:    "high-dimensional unit vectors",
-			vectors: dataset.Slice(0, 100),
+			desc:           "inner product distance",
+			distanceMetric: vecdist.InnerProduct,
+			vectors: vector.MakeSetFromRawData([]float32{
+				1, 2, 3,
+				2, 5, -10,
+				-4, 6, 1,
+				9, -14, 20,
+				5, 9, 4,
+			}, 3),
+			leftOffsets:  []uint64{0, 3},
+			rightOffsets: []uint64{1, 2, 4},
+		},
+		{
+			desc:           "cosine distance",
+			distanceMetric: vecdist.Cosine,
+			vectors: vector.MakeSetFromRawData([]float32{
+				1, 0, 0,
+				0.57735, 0.57735, 0.57735,
+				0, 0, 1,
+				0, 1, 0,
+				0.95672, -0.06355, -0.28399,
+			}, 3),
+			leftOffsets:  []uint64{0, 4},
+			rightOffsets: []uint64{1, 2, 3},
+		},
+		{
+			desc:           "high-dimensional unit vectors, Euclidean distance",
+			distanceMetric: vecdist.L2Squared,
+			vectors:        dataset.Slice(0, 100),
 			// It's challenging to test pinLeftCentroid for this case, due to the
 			// inherent randomness of the K-means++ algorithm. The other test cases
 			// should be sufficient to test that, however.
 			skipPinTest: true,
 		},
+		{
+			desc:           "high-dimensional unit vectors, InnerProduct distance",
+			distanceMetric: vecdist.InnerProduct,
+			vectors:        dataset.Slice(0, 100),
+			skipPinTest:    true,
+		},
+		{
+			desc:           "high-dimensional unit vectors, Cosine distance",
+			distanceMetric: vecdist.Cosine,
+			vectors:        dataset.Slice(0, 100),
+			skipPinTest:    true,
+		},
 	}
 
 	for _, tc := range testCases {
 		t.Run(tc.desc, func(t *testing.T) {
+			kmeans := BalancedKmeans{
+				Workspace:      workspace,
+				Rand:           rng,
+				DistanceMetric: tc.distanceMetric,
+			}
+
+			// Compute centroids for the vectors.
 			leftCentroid := make(vector.T, tc.vectors.Dims)
 			rightCentroid := make(vector.T, tc.vectors.Dims)
+			kmeans.ComputeCentroids(
+				tc.vectors, leftCentroid, rightCentroid, false /* pinLeftCentroid */)
+
+			// Assign vectors to closest centroid.
 			offsets := make([]uint64, tc.vectors.Count)
-			leftOffsets, rightOffsets := kmeans.ComputeCentroids(
-				tc.vectors, leftCentroid, rightCentroid, false /* pinLeftCentroid */, offsets)
-			require.Equal(t, calcCentroid(tc.vectors, leftOffsets), leftCentroid)
-			require.Equal(t, calcCentroid(tc.vectors, rightOffsets), rightCentroid)
-			ratio := float64(len(leftOffsets)) / float64(len(rightOffsets))
-			require.False(t, ratio < 0.5)
-			require.False(t, ratio > 2)
+			leftOffsets, rightOffsets := kmeans.AssignPartitions(
+				tc.vectors, leftCentroid, rightCentroid, offsets)
+			slices.Sort(leftOffsets)
+			slices.Sort(rightOffsets)
 			if tc.leftOffsets != nil {
 				require.Equal(t, tc.leftOffsets, leftOffsets)
 			}
 			if tc.rightOffsets != nil {
 				require.Equal(t, tc.rightOffsets, rightOffsets)
 			}
+			if tc.leftCentroid != nil {
+				require.Equal(t, tc.leftCentroid, leftCentroid)
+			} else {
+				// Fallback on calculation.
+				expected := make(vector.T, tc.vectors.Dims)
+				calcPartitionCentroid(tc.distanceMetric, tc.vectors, leftOffsets, expected)
+				require.InDeltaSlice(t, expected, leftCentroid, 1e-6)
+			}
+			if tc.rightCentroid != nil {
+				require.Equal(t, tc.rightCentroid, rightCentroid)
+			} else {
+				// Fallback on calculation.
+				expected := make(vector.T, tc.vectors.Dims)
+				calcPartitionCentroid(tc.distanceMetric, tc.vectors, rightOffsets, expected)
+				require.InDeltaSlice(t, expected, rightCentroid, 1e-6)
+			}
+			ratio := float64(len(leftOffsets)) / float64(len(rightOffsets))
+			require.False(t, ratio < 0.45)
+			require.False(t, ratio > 2.05)
 
 			// Ensure that distance to left centroid is less for vectors in the left
 			// partition than those in the right partition.
-			leftMean := calcMeanDistance(tc.vectors, leftCentroid, leftOffsets)
-			rightMean := calcMeanDistance(tc.vectors, leftCentroid, rightOffsets)
+			leftMean := calcMeanDistance(tc.distanceMetric, tc.vectors, leftCentroid, leftOffsets)
+			rightMean := calcMeanDistance(tc.distanceMetric, tc.vectors, leftCentroid, rightOffsets)
 			require.LessOrEqual(t, leftMean, rightMean)
-
-			// Check that AssignPartitions returns the same offsets.
-			offsets2 := make([]uint64, tc.vectors.Count)
-			leftOffsets2, rightOffsets2 := kmeans.AssignPartitions(
-				tc.vectors, leftCentroid, rightCentroid, offsets2)
-			slices.Sort(leftOffsets2)
-			slices.Sort(rightOffsets2)
-			require.Equal(t, leftOffsets, leftOffsets2)
-			require.Equal(t, rightOffsets, rightOffsets2)
 
 			if !tc.skipPinTest {
 				// Check that pinning the left centroid returns the same right centroid.
-				leftOffsets, rightOffsets = kmeans.ComputeCentroids(
-					tc.vectors, leftCentroid, rightCentroid, true /* pinLeftCentroid */, offsets)
-				require.Equal(t, calcCentroid(tc.vectors, leftOffsets), leftCentroid)
-				require.Equal(t, calcCentroid(tc.vectors, rightOffsets), rightCentroid)
+				newLeftCentroid := slices.Clone(leftCentroid)
+				newRightCentroid := make(vector.T, len(rightCentroid))
+				kmeans.ComputeCentroids(
+					tc.vectors, newLeftCentroid, newRightCentroid, true /* pinLeftCentroid */)
+				require.Equal(t, leftCentroid, newLeftCentroid)
+				require.Equal(t, rightCentroid, newRightCentroid)
 			}
 		})
 	}
 
 	t.Run("use global random number generator", func(t *testing.T) {
-		kmeans = BalancedKmeans{Workspace: workspace}
+		kmeans := BalancedKmeans{Workspace: workspace}
 		vectors := vector.MakeSetFromRawData([]float32{1, 2, 3, 4}, 2)
 		leftCentroid := make(vector.T, 2)
 		rightCentroid := make(vector.T, 2)
-		offsets := make([]uint64, vectors.Count)
 		kmeans.ComputeCentroids(
-			vectors, leftCentroid, rightCentroid, false /* pinLeftCentroid */, offsets)
+			vectors, leftCentroid, rightCentroid, false /* pinLeftCentroid */)
 	})
 }
 
@@ -247,6 +318,60 @@ func TestMeanOfVariances(t *testing.T) {
 			mean := stat.Mean(variances, nil)
 			mean = scalar.Round(mean, 4)
 			require.Equal(t, mean, result)
+		})
+	}
+}
+
+func TestCalcPartitionCentroid(t *testing.T) {
+	testCases := []struct {
+		name           string
+		distanceMetric vecdist.Metric
+		vectors        vector.Set
+		offsets        []uint64
+		expected       vector.T
+	}{
+		{
+			name:           "L2Squared simple mean",
+			distanceMetric: vecdist.L2Squared,
+			// Only use the [1,2] and [3,4] vectors.
+			vectors:  vector.MakeSetFromRawData([]float32{1, 2, 10, 11, 3, 4, 12, 13}, 2),
+			offsets:  []uint64{0, 2},
+			expected: vector.T{2, 3},
+		},
+		{
+			name:           "Cosine normalization",
+			distanceMetric: vecdist.Cosine,
+			// Only use the [1,0] and [0,1] vectors.
+			vectors:  vector.MakeSetFromRawData([]float32{10, 11, 1, 0, 12, 13, 0, 1}, 2),
+			offsets:  []uint64{1, 3},
+			expected: vector.T{0.7071, 0.7071},
+		},
+		{
+			// The degenerate case for cosine occurs when the sum of the input
+			// vectors is the zero vector. When this happens, the norm is zero
+			// and the direction of the vector can't be determined. In that case,
+			// return the zero vector.
+			name:           "Cosine degenerate zero vector",
+			distanceMetric: vecdist.Cosine,
+			vectors:        vector.MakeSetFromRawData([]float32{0.7071, 0.7071, -0.7071, -0.7071}, 2),
+			offsets:        []uint64{0, 1},
+			expected:       vector.T{0, 0},
+		},
+		{
+			name:           "InnerProduct with 3 dimensions",
+			distanceMetric: vecdist.InnerProduct,
+			vectors:        vector.MakeSetFromRawData([]float32{-5, 2, -3, 4, 8, 6, 10, 2, -3}, 3),
+			offsets:        []uint64{0, 1, 2},
+			expected:       vector.T{0.6, 0.8, 0},
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			centroid := make(vector.T, tc.vectors.Dims)
+			calcPartitionCentroid(tc.distanceMetric, tc.vectors, tc.offsets, centroid)
+			require.InDeltaSlice(
+				t, tc.expected, centroid, 1e-4, "centroid not as expected: %0.4f", centroid)
 		})
 	}
 }

--- a/pkg/sql/vecindex/cspann/testdata/search-embeddings.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-embeddings.ddt
@@ -5,49 +5,49 @@
 new-index dims=512 min-partition-size=4 max-partition-size=16 quality-samples=8 beam-size=4 load-embeddings=1000 hide-tree
 ----
 Created index with 1000 vectors with 512 dimensions.
-3 levels, 211 partitions.
+3 levels, 201 partitions.
 CV stats:
-  level 2 - mean: 0.1158, stdev: 0.0246
-  level 3 - mean: 0.0917, stdev: 0.0085
+  level 2 - mean: 0.1149, stdev: 0.0228
+  level 3 - mean: 0.0000, stdev: 0.0000
 
 # Search with small beam size.
 search max-results=1 use-dataset=5000 beam-size=1
 ----
-vec302: 0.6601
-25 leaf vectors, 46 vectors, 15 full vectors, 4 partitions
+vec356: 0.5976
+20 leaf vectors, 42 vectors, 13 full vectors, 4 partitions
 
 # Search for additional results.
 search max-results=6 use-dataset=5000 beam-size=1
 ----
+vec356: 0.5976
 vec302: 0.6601
-vec329: 0.6871
-vec386: 0.7301
-vec240: 0.7723
-vec347: 0.7745
-vec340: 0.7858
-25 leaf vectors, 46 vectors, 15 full vectors, 4 partitions
+vec25: 0.761
+vec704: 0.7916
+vec246: 0.8141
+vec37: 0.8214
+20 leaf vectors, 42 vectors, 13 full vectors, 4 partitions
 
 # Use a larger beam size.
 search max-results=6 use-dataset=5000 beam-size=4
 ----
+vec771: 0.5624
+vec356: 0.5976
 vec640: 0.6525
 vec302: 0.6601
-vec329: 0.6871
-vec386: 0.7301
-vec117: 0.7576
+vec309: 0.7311
 vec25: 0.761
-80 leaf vectors, 116 vectors, 23 full vectors, 11 partitions
+81 leaf vectors, 119 vectors, 22 full vectors, 11 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-dataset=5000 beam-size=4 skip-rerank
 ----
-vec640: 0.6404 ± 0.04
-vec302: 0.6539 ± 0.03
-vec329: 0.6734 ± 0.04
-vec386: 0.7114 ± 0.04
-vec340: 0.7533 ± 0.04
-vec347: 0.7588 ± 0.03
-80 leaf vectors, 116 vectors, 0 full vectors, 11 partitions
+vec771: 0.5698 ± 0.04
+vec356: 0.5972 ± 0.03
+vec302: 0.66 ± 0.03
+vec640: 0.6676 ± 0.04
+vec704: 0.7344 ± 0.04
+vec309: 0.7405 ± 0.03
+81 leaf vectors, 119 vectors, 0 full vectors, 11 partitions
 
 # Return top 25 results with large beam size.
 search max-results=25 use-dataset=5000 beam-size=16
@@ -57,7 +57,6 @@ vec356: 0.5976
 vec640: 0.6525
 vec302: 0.6601
 vec329: 0.6871
-vec95: 0.7008
 vec249: 0.7268
 vec386: 0.7301
 vec309: 0.7311
@@ -65,54 +64,55 @@ vec633: 0.7513
 vec117: 0.7576
 vec556: 0.7595
 vec25: 0.761
-vec872: 0.7707
-vec859: 0.7708
+vec776: 0.7633
 vec240: 0.7723
 vec347: 0.7745
 vec11: 0.777
 vec340: 0.7858
 vec239: 0.7878
+vec704: 0.7916
+vec220: 0.7957
 vec848: 0.7958
 vec387: 0.8038
 vec637: 0.8039
 vec410: 0.8062
 vec979: 0.8066
-313 leaf vectors, 391 vectors, 92 full vectors, 39 partitions
+344 leaf vectors, 447 vectors, 82 full vectors, 40 partitions
 
 # Search for an "easy" result, where adaptive search inspects less partitions.
 recall topk=20 use-dataset=8601 beam-size=4
 ----
-50.00% recall@20
-21.00 leaf vectors, 44.00 vectors, 21.00 full vectors, 4.00 partitions
+45.00% recall@20
+19.00 leaf vectors, 45.00 vectors, 19.00 full vectors, 5.00 partitions
 
 # Search for a "hard" result, where adaptive search inspects more partitions.
 recall topk=20 use-dataset=2717 beam-size=4
 ----
 30.00% recall@20
-80.00 leaf vectors, 136.00 vectors, 38.00 full vectors, 13.00 partitions
+93.00 leaf vectors, 125.00 vectors, 49.00 full vectors, 11.00 partitions
 
 # Test recall at different beam sizes.
 recall topk=10 beam-size=2 samples=50
 ----
-31.60% recall@10
-24.86 leaf vectors, 47.86 vectors, 15.52 full vectors, 4.66 partitions
+28.00% recall@10
+21.66 leaf vectors, 42.18 vectors, 14.82 full vectors, 3.96 partitions
 
 recall topk=10 beam-size=4 samples=50
 ----
-48.40% recall@10
-49.36 leaf vectors, 78.26 vectors, 19.10 full vectors, 7.58 partitions
+53.80% recall@10
+54.76 leaf vectors, 86.06 vectors, 20.20 full vectors, 7.96 partitions
 
 recall topk=10 beam-size=8 samples=50
 ----
-75.00% recall@10
-111.70 leaf vectors, 159.82 vectors, 23.90 full vectors, 15.30 partitions
+79.40% recall@10
+117.38 leaf vectors, 169.66 vectors, 22.98 full vectors, 15.64 partitions
 
 recall topk=10 beam-size=16 samples=50
 ----
-90.00% recall@10
-246.20 leaf vectors, 315.88 vectors, 26.54 full vectors, 30.32 partitions
+93.20% recall@10
+239.10 leaf vectors, 333.72 vectors, 26.88 full vectors, 30.80 partitions
 
 recall topk=10 beam-size=32 samples=50
 ----
-97.20% recall@10
-489.78 leaf vectors, 591.66 vectors, 29.34 full vectors, 57.32 partitions
+97.60% recall@10
+470.64 leaf vectors, 575.64 vectors, 28.50 full vectors, 53.44 partitions

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -738,11 +738,11 @@ format-tree root=2
 ----
 • 2 (5.3333, 6.6667) [Updating:1]
 │
-├───• vec10 (5, 8)
 ├───• vec7 (3, 5)
+├───• vec9 (6, 5)
 ├───• vec3 (4, 3)
-├───• vec4 (8, 11)
-└───• vec8 (6, 8)
+├───• vec6 (8, 6)
+└───• vec5 (14, 1)
 
 delete discard-fixups
 vec3
@@ -763,10 +763,10 @@ format-tree root=2
 ----
 • 2 (5.3333, 6.6667) [Updating:1]
 │
-├───• vec10 (5, 8)
 ├───• vec7 (3, 5)
-├───• vec8 (6, 8)
-└───• vec4 (8, 11)
+├───• vec9 (6, 5)
+├───• vec5 (14, 1)
+└───• vec6 (8, 6)
 
 # Delete vector after vectors have been cleared in the root. This should remove
 # the vector from sub-partition #3.
@@ -777,11 +777,10 @@ force-split partition-key=1 steps=1
 delete discard-fixups root=3
 vec4
 ----
-• 3 (9.6667, 3.6667) [Updating:1]
+• 3 (6.3333, 9) [Updating:1]
 │
-├───• vec6 (8, 6)
-├───• vec9 (6, 5)
-└───• vec5 (14, 1)
+├───• vec8 (6, 8)
+└───• vec10 (5, 8)
 
 # Delete vector in AddingLevel state. This should remove the vector from
 # sub-partition #3.
@@ -792,10 +791,10 @@ force-split partition-key=1 steps=1
 delete discard-fixups root=3
 vec5
 ----
-• 3 (9.6667, 3.6667) [Updating:1]
+• 3 (6.3333, 9) [Updating:1]
 │
-├───• vec6 (8, 6)
-└───• vec9 (6, 5)
+├───• vec8 (6, 8)
+└───• vec10 (5, 8)
 
 # Finish split of root partition.
 force-split partition-key=1
@@ -804,11 +803,11 @@ force-split partition-key=1
 │
 ├───• 2 (5.3333, 6.6667)
 │   │
-│   ├───• vec10 (5, 8)
 │   ├───• vec7 (3, 5)
-│   └───• vec8 (6, 8)
+│   ├───• vec9 (6, 5)
+│   └───• vec6 (8, 6)
 │
-└───• 3 (9.6667, 3.6667)
+└───• 3 (6.3333, 9)
     │
-    ├───• vec6 (8, 6)
-    └───• vec9 (6, 5)
+    ├───• vec8 (6, 8)
+    └───• vec10 (5, 8)


### PR DESCRIPTION
Add support for InnerProduct and Cosine distance metrics to the BalancedKMeans class. Centroids are always normalized for these metrics. For InnerProduct, this is to prevent centroids with large magnitudes from attracting disproportionate numbers of vectors. For Cosine, all vectors need to be normalized, including centroids. Update the K-means++ algorithm to handle the negative distances that InnerProduct can return.

Also remove unused return values from ComputeCentroids; those were a vestige from the past and are no longer needed.

Epic: CRDB-42943
Release note: None