### PR TITLE
docgen: expose WITH/WITHOUT HOLD syntax in SQL cursor diagram

### DIFF
--- a/docs/generated/sql/bnf/declare_cursor_stmt.bnf
+++ b/docs/generated/sql/bnf/declare_cursor_stmt.bnf
@@ -1,2 +1,4 @@
 declare_cursor_stmt ::=
-	'DECLARE' cursor_name opt_binary opt_sensitivity opt_scroll 'CURSOR' opt_hold 'FOR' select_stmt
+	'DECLARE' cursor_name opt_binary opt_sensitivity opt_scroll 'CURSOR' 'WITH' 'HOLD' 'FOR' select_stmt
+	| 'DECLARE' cursor_name opt_binary opt_sensitivity opt_scroll 'CURSOR' 'WITHOUT' 'HOLD' 'FOR' select_stmt
+	| 'DECLARE' cursor_name opt_binary opt_sensitivity opt_scroll 'CURSOR'  'FOR' select_stmt

--- a/pkg/cmd/docgen/diagrams.go
+++ b/pkg/cmd/docgen/diagrams.go
@@ -915,6 +915,10 @@ var specs = []stmtSpec{
 			"'PASSWORD' string_or_placeholder":  "'PASSWORD' password"},
 	},
 	{
+		name:   "declare_cursor_stmt",
+		inline: []string{"opt_hold"},
+	},
+	{
 		name: "default_value_column_level",
 		stmt: "stmt_block",
 		replace: map[string]string{


### PR DESCRIPTION
This PR exposes the WITH HOLD / WITHOUT HOLD syntax in the DECLARE ... CURSOR diagram as follows:

<img width="903" alt="image" src="https://github.com/user-attachments/assets/92c448fa-143b-47bb-aa8a-38b68542e123" />

Relates to https://github.com/cockroachdb/docs/pull/19590. 

Epic: none
Release note: none
Release justification: non-production code change