### PR TITLE
sql: plumb function dependencies from optimizer into view descriptor

### DIFF
--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -1974,7 +1974,7 @@ func (ef *execFactory) ConstructCreateView(
 		return nil, err
 	}
 
-	planDeps, typeDepSet, _, err := toPlanDependencies(deps, typeDeps, intsets.Fast{} /* funcDeps */)
+	planDeps, typeDepSet, funcDepSet, err := toPlanDependencies(deps, typeDeps, intsets.Fast{} /* funcDeps */)
 	if err != nil {
 		return nil, err
 	}
@@ -1986,6 +1986,7 @@ func (ef *execFactory) ConstructCreateView(
 		columns:    columns,
 		planDeps:   planDeps,
 		typeDeps:   typeDepSet,
+		funcDeps:   funcDepSet,
 	}, nil
 }
 


### PR DESCRIPTION
This commit adds the plumbing necessary so that whenever the optimizer starts calculating function dependencies from views, they will start being stored in the view descriptor.

informs #146123
Release note: None