### PR TITLE
worfkflows: fix blathers bot login name

### DIFF
--- a/.github/workflows/auto-merge-backports.yml
+++ b/.github/workflows/auto-merge-backports.yml
@@ -63,7 +63,7 @@ jobs:
               const approved = pr.reviews.nodes.some(
                 r =>
                   r.state === 'APPROVED' &&
-                  r.author?.login === 'blathers-crl[bot]'
+                  r.author?.login === 'blathers-crl'
               );
 
               if (!approved) {


### PR DESCRIPTION
This fixes the login name of the blathers bot in the auto-merge-backports.yml workflow file. The bot's login name was previously set to 'blathers-crl[bot]', but it should be 'blathers-crl' without the '[bot]' suffix.

Release note: none
Epic: none