### PR TITLE
release-24.1: sql/distsql: preserve JobID in redacted logs

### DIFF
--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -393,7 +393,7 @@ func (ds *ServerImpl) setupFlow(
 	}
 
 	if !f.IsLocal() {
-		flowCtx.AmbientContext.AddLogTag("f", flowCtx.ID.Short())
+		flowCtx.AmbientContext.AddLogTag("f", redact.SafeString(flowCtx.ID.Short()))
 		if req.JobTag != "" {
 			flowCtx.AmbientContext.AddLogTag("job", req.JobTag)
 		}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -53,6 +53,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
+	"github.com/cockroachdb/redact"
 )
 
 var settingDistSQLNumRunners = settings.RegisterIntSetting(
@@ -404,12 +405,12 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if len(statementSQL) > setupFlowRequestStmtMaxLength {
 		statementSQL = statementSQL[:setupFlowRequestStmtMaxLength]
 	}
-	getJobTag := func(ctx context.Context) string {
+	getJobTag := func(ctx context.Context) redact.SafeString {
 		tags := logtags.FromContext(ctx)
 		if tags != nil {
 			for _, tag := range tags.Get() {
 				if tag.Key() == "job" {
-					return tag.ValueStr()
+					return redact.SafeString(tag.ValueStr())
 				}
 			}
 		}

--- a/pkg/sql/execinfrapb/api.proto
+++ b/pkg/sql/execinfrapb/api.proto
@@ -26,7 +26,8 @@ message SetupFlowRequest {
   reserved 1, 2;
 
   optional util.tracing.tracingpb.TraceInfo trace_info = 11;
-  optional string job_tag = 13 [(gogoproto.nullable) = false];
+  optional string job_tag = 13 [(gogoproto.nullable) = false,
+    (gogoproto.casttype) = "github.com/cockroachdb/redact.SafeString"];
 
   // LeafTxnInputState is the input parameter for the *kv.Txn needed for
   // executing the flow.


### PR DESCRIPTION
Backport 1/1 commits from #146362.

/cc @cockroachdb/release

---

Previously, the JobID log tag could be redacted, making it difficult to trace TTL job execution when viewing redacted logs. This change ensures the JobID is logged as a redact.SafeString, allowing it to appear in redacted outputs for easier debugging.

Additionally, the flowCtx.ID is now also saved as a safe string too.

Epic: none
Release note: none

Release justification: improves job observability