### PR TITLE
sql: rewrite UDF references in views to be by ID

### DIFF
--- a/pkg/sql/alter_function.go
+++ b/pkg/sql/alter_function.go
@@ -94,7 +94,7 @@ func (n *alterFunctionOptionsNode) startExec(params runParams) error {
 		}
 	}
 
-	if err := setFuncOptions(params, fnDesc, n.n.Options); err != nil {
+	if err := setFuncOptions(params, fnDesc, n.n.Options, nil /* planDeps */); err != nil {
 		return err
 	}
 
@@ -217,14 +217,12 @@ func (n *alterFunctionRenameNode) startExec(params runParams) error {
 		return err
 	}
 	if len(dependentObjects) > 0 {
-		// TODO(#146475): once functions are rewritten to use ID references, we can
-		// allow renames for views.
 		return errors.UnimplementedErrorf(
 			errors.IssueLink{
 				IssueURL: build.MakeIssueURL(83233),
 				Detail:   "renames are disallowed because references are by name",
 			},
-			"cannot rename function %q because other functions or views ([%v]) still depend on it",
+			"cannot rename function %q because other functions ([%v]) still depend on it",
 			fnDesc.Name, strings.Join(dependentObjects, ", "))
 	}
 
@@ -386,7 +384,7 @@ func (n *alterFunctionSetSchemaNode) startExec(params runParams) error {
 				Detail: "set schema is disallowed because there are references from " +
 					"other objects by name",
 			},
-			"cannot set schema for function %q because other functions or views ([%v]) still depend on it",
+			"cannot set schema for function %q because other functions ([%v]) still depend on it",
 			fnDesc.Name, strings.Join(dependentObjects, ", "))
 	}
 
@@ -535,17 +533,7 @@ func getFuncRefsDisallowingAlter(
 		if err != nil {
 			return nil, err
 		}
-		switch t := desc.(type) {
-		case catalog.TableDescriptor:
-			if !t.IsView() {
-				continue
-			}
-			fullyResolvedName, err := params.p.GetQualifiedTableNameByID(
-				params.ctx, int64(dep.ID), tree.ResolveAnyTableKind)
-			if err != nil {
-				return nil, err
-			}
-			dependentObjects = append(dependentObjects, fullyResolvedName.FQString())
+		switch desc.(type) {
 		case catalog.FunctionDescriptor:
 			fullyResolvedName, err := params.p.GetQualifiedFunctionNameByID(params.ctx, int64(dep.ID))
 			if err != nil {

--- a/pkg/sql/catalog/schemaexpr/expr.go
+++ b/pkg/sql/catalog/schemaexpr/expr.go
@@ -113,8 +113,8 @@ func DequalifyAndValidateExpr(
 	getAllNonDropColumnsFn := func() colinfo.ResultColumns {
 		return colinfo.ResultColumnsFromColumns(desc.GetID(), desc.NonDropColumns())
 	}
-	columnLookupByNameFn := func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-		col, err := catalog.MustFindColumnByTreeName(desc, columnName)
+	columnLookupByNameFn := func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+		col, err := catalog.MustFindColumnByTreeName(desc, columnItem.ColumnName)
 		if err != nil || col.Dropped() {
 			return false, false, 0, nil
 		}
@@ -249,8 +249,8 @@ func FormatExprForExpressionIndexDisplay(
 }
 
 func makeColumnLookupFnForTableDesc(desc catalog.TableDescriptor) ColumnLookupFn {
-	return func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-		col, err := catalog.MustFindColumnByTreeName(desc, columnName)
+	return func(colItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+		col, err := catalog.MustFindColumnByTreeName(desc, colItem.ColumnName)
 		if err != nil || col.Dropped() {
 			return false, false, 0, nil
 		}
@@ -269,10 +269,10 @@ func ParseTriggerWhenExprForDisplay(
 	semaCtx *tree.SemaContext,
 	fmtFlags tree.FmtFlags,
 ) (tree.Expr, error) {
-	lookupFn := func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+	lookupFn := func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
 		// Trigger WHEN expressions can reference only the special OLD and NEW
 		// columns.
-		switch columnName {
+		switch columnItem.ColumnName {
 		case "old", "new":
 			return true, true, 0, tableTyp
 		}

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1241,7 +1241,7 @@ func getFinalSourceQuery(
 
 	// Use IDs instead of sequence names because name resolution depends on
 	// session data, and the internal executor has different session data.
-	sequenceReplacedQuery, err := replaceSeqNamesWithIDs(params.ctx, params.p, ctx.CloseAndGetString(), false /* multiStmt */)
+	sequenceReplacedQuery, err := replaceSeqNamesWithIDs(params.ctx, params.p, ctx.CloseAndGetString())
 	if err != nil {
 		return "", err
 	}

--- a/pkg/sql/create_view.go
+++ b/pkg/sql/create_view.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/resolver"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/schemaexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/seqexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -27,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	plpgsql "github.com/cockroachdb/cockroach/pkg/sql/plpgsql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -255,7 +257,9 @@ func (n *createViewNode) startExec(params runParams) error {
 					params.p.EvalContext().Settings,
 					createView.Persistence,
 					n.dbDesc.IsMultiRegion(),
-					params.p)
+					params.p,
+					n.planDeps,
+				)
 				if err != nil {
 					return err
 				}
@@ -428,6 +432,7 @@ func makeViewTableDesc(
 	persistence tree.Persistence,
 	isMultiRegion bool,
 	sc resolver.SchemaResolver,
+	planDeps planDependencies,
 ) (tabledesc.Mutable, error) {
 	desc := tabledesc.InitTableDescriptor(
 		id,
@@ -457,6 +462,12 @@ func makeViewTableDesc(
 		return tabledesc.Mutable{}, err
 	}
 	desc.ViewQuery = typeReplacedQuery
+
+	funcReplacedQuery, err := serializeUserDefinedFunctions(ctx, semaCtx, desc.ViewQuery, planDeps)
+	if err != nil {
+		return tabledesc.Mutable{}, err
+	}
+	desc.ViewQuery = funcReplacedQuery
 
 	if err := addResultColumns(ctx, semaCtx, evalCtx, st, &desc, resultColumns); err != nil {
 		return tabledesc.Mutable{}, err
@@ -566,6 +577,16 @@ func serializeUserDefinedTypes(
 	ctx context.Context, semaCtx *tree.SemaContext, queries string, multiStmt bool, parentType string,
 ) (string, error) {
 	return serializeUserDefinedTypesLang(ctx, semaCtx, queries, multiStmt, parentType, catpb.Function_SQL)
+}
+
+// serializeUserDefinedFunctions walks the given query and replaces any user
+// defined function references with their OIDs, so that renaming the function
+// does not cause corruption. It returns a new query string containing the
+// function OIDs. It assumes that the query language is SQL.
+func serializeUserDefinedFunctions(
+	ctx context.Context, semaCtx *tree.SemaContext, queries string, deps planDependencies,
+) (string, error) {
+	return serializeUserDefinedFunctionsLang(ctx, semaCtx, queries, deps, false /* multiStmt */, catpb.Function_SQL)
 }
 
 // serializeUserDefinedTypesLang walks the given query and serializes any
@@ -710,6 +731,112 @@ func serializeUserDefinedTypesLang(
 	return fmtCtx.CloseAndGetString(), nil
 }
 
+// serializeUserDefinedFunctionsLang walks the given query and replaces any user
+// defined function references with their OIDs, so that renaming the function
+// does not cause corruption. It returns a new query string containing the
+// function OIDs. The query may be in either the SQL or PLpgSQL language,
+// indicated by lang.
+func serializeUserDefinedFunctionsLang(
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	queries string,
+	deps planDependencies,
+	multiStmt bool,
+	lang catpb.Function_Language,
+) (string, error) {
+	// replaceFunc will replace user-defined function references with OIDs.
+	replaceFunc := func(expr tree.Expr) (recurse bool, newExpr tree.Expr, err error) {
+		if expr == nil {
+			return false, expr, nil
+		}
+
+		// Only attempt to replace FuncExpr expressions.
+		_, ok := expr.(*tree.FuncExpr)
+		if !ok {
+			return true, expr, nil
+		}
+		// semaCtx may be nil if this is a virtual view being created at init time.
+		if semaCtx == nil {
+			return false, expr, nil
+		}
+
+		replacedExpr, _, err := schemaexpr.ReplaceColumnVars(expr, func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+			for _, dep := range deps {
+				for _, c := range dep.desc.AccessibleColumns() {
+					if c.GetName() == string(columnName) {
+						return true, true, c.GetID(), c.GetType()
+					}
+				}
+			}
+			return true, true, 0, types.Any
+		})
+		if err != nil {
+			return false, expr, err
+		}
+		// Type check the expression to resolve function references.
+		typedExpr, err := replacedExpr.TypeCheck(ctx, semaCtx, types.Any)
+		if err != nil {
+			return false, expr, err
+		}
+
+		// Replace UDF names with OID references
+		newTypedExpr, err := schemaexpr.MaybeReplaceUDFNameWithOIDReferenceInTypedExpr(typedExpr)
+		if err != nil {
+			return false, expr, err
+		}
+
+		return true, newTypedExpr, nil
+	}
+
+	fmtCtx := tree.NewFmtCtx(tree.FmtSimple)
+	switch lang {
+	case catpb.Function_SQL:
+		var stmts tree.Statements
+		if multiStmt {
+			parsedStmts, err := parser.Parse(queries)
+			if err != nil {
+				return "", errors.Wrap(err, "failed to parse query")
+			}
+			stmts = make(tree.Statements, len(parsedStmts))
+			for i, stmt := range parsedStmts {
+				stmts[i] = stmt.AST
+			}
+		} else {
+			stmt, err := parser.ParseOne(queries)
+			if err != nil {
+				return "", errors.Wrap(err, "failed to parse query")
+			}
+			stmts = tree.Statements{stmt.AST}
+		}
+		for i, stmt := range stmts {
+			newStmt, err := tree.SimpleStmtVisit(stmt, replaceFunc)
+			if err != nil {
+				return "", err
+			}
+			if i > 0 {
+				fmtCtx.WriteString("\n")
+			}
+			fmtCtx.FormatNode(newStmt)
+			if multiStmt {
+				fmtCtx.WriteString(";")
+			}
+		}
+	case catpb.Function_PLPGSQL:
+		var stmts plpgsqltree.Statement
+		plstmt, err := plpgsql.Parse(queries)
+		if err != nil {
+			return "", errors.Wrap(err, "failed to parse query string")
+		}
+		stmts = plstmt.AST
+
+		v := plpgsqltree.SQLStmtVisitor{Fn: replaceFunc}
+		newStmt := plpgsqltree.Walk(&v, stmts)
+		fmtCtx.FormatNode(newStmt)
+	}
+
+	return fmtCtx.CloseAndGetString(), nil
+}
+
 // replaceViewDesc modifies and returns the input view descriptor changed
 // to hold the new view represented by n. Note that back references from
 // tables that the new view depends on still need to be added. This function
@@ -739,6 +866,12 @@ func (p *planner) replaceViewDesc(
 		return nil, err
 	}
 	toReplace.ViewQuery = typeReplacedQuery
+
+	funcReplacedQuery, err := serializeUserDefinedFunctions(ctx, p.SemaCtx(), toReplace.ViewQuery, n.planDeps)
+	if err != nil {
+		return nil, err
+	}
+	toReplace.ViewQuery = funcReplacedQuery
 
 	// Check that the new view has at least as many columns as the old view before
 	// adding result columns.

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -301,7 +301,7 @@ CREATE SCHEMA altSchema;
 CREATE FUNCTION altSchema.f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE TABLE t1_with_b_2_ref(j int default altSchema.f_called_by_b() CHECK (altSchema.f_called_by_b() > 0));
 
-statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions or views \(\[test.public.f_called_by_b2\]\) still depend on it
+statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions \(\[test.public.f_called_by_b2\]\) still depend on it
 ALTER FUNCTION f_called_by_b SET SCHEMA altSchema;
 
 skipif config local-legacy-schema-changer

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1240,4 +1240,63 @@ SELECT * FROM v_builtin ORDER BY 1;
 statement ok
 DROP VIEW v_builtin;
 
+# Test a view that references two tables with the same column name, using that column as an argument to a UDF.
+statement ok
+CREATE TABLE t1_ambiguous (id INT PRIMARY KEY, name TEXT);
+
+statement ok
+CREATE TABLE t2_ambiguous (id INT PRIMARY KEY, name TEXT, status TEXT);
+
+statement ok
+INSERT INTO t1_ambiguous VALUES (1, 'Alice'), (2, 'Bob');
+
+statement ok
+INSERT INTO t2_ambiguous VALUES (1, 'Charlie', 'active'), (2, 'David', 'inactive');
+
+statement ok
+CREATE FUNCTION udf_concat(a TEXT, b TEXT) RETURNS TEXT LANGUAGE SQL AS 'SELECT a || '' - '' || b';
+
+# Create a view that joins two tables with the same column name and uses a UDF on those columns.
+statement ok
+CREATE VIEW v_ambiguous_cols AS 
+SELECT t1.id, t1.name AS name1, t2.name AS name2, udf_concat(t1.name, t2.name) AS combined_names
+FROM t1_ambiguous t1 
+JOIN t2_ambiguous t2 ON t1.id = t2.id;
+
+# Verify the view works correctly.
+query ITTT
+SELECT * FROM v_ambiguous_cols ORDER BY id;
+----
+1  Alice  Charlie  Alice - Charlie
+2  Bob    David    Bob - David
+
+# Verify that the UDF reference in the view is by ID.
+query T
+SELECT crdb_internal.pb_to_json('desc', descriptor)->'table'->>'viewQuery'
+FROM system.descriptor
+WHERE id = 'v_ambiguous_cols'::regclass::oid;
+----
+SELECT t1.id, t1.name AS name1, t2.name AS name2, [FUNCTION 100184](t1.name, t2.name) AS combined_names FROM test.public.t1_ambiguous AS t1 JOIN test.public.t2_ambiguous AS t2 ON t1.id = t2.id
+
+# Check the create statement shows the UDF reference correctly.
+query T
+SELECT create_statement FROM [SHOW CREATE VIEW v_ambiguous_cols];
+----
+CREATE VIEW public.v_ambiguous_cols (
+  id,
+  name1,
+  name2,
+  combined_names
+) AS SELECT t1.id, t1.name AS name1, t2.name AS name2, public.udf_concat(t1.name, t2.name) AS combined_names FROM test.public.t1_ambiguous AS t1 JOIN test.public.t2_ambiguous AS t2 ON t1.id = t2.id;
+
+# Clean up.
+statement ok
+DROP VIEW v_ambiguous_cols;
+
+statement ok
+DROP FUNCTION udf_concat;
+
+statement ok
+DROP TABLE t1_ambiguous, t2_ambiguous;
+
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1062,8 +1062,45 @@ CREATE FUNCTION f_setof() RETURNS SETOF xy LANGUAGE SQL AS $$ SELECT * FROM xy $
 statement ok
 CREATE VIEW v AS SELECT x, y, f_scalar() FROM f_setof();
 
+# Verify that the UDF reference in the view descriptor is by ID.
+query T
+SELECT crdb_internal.pb_to_json('desc', descriptor)->'table'->>'viewQuery'
+FROM system.descriptor
+WHERE id = 'v'::regclass::oid
+----
+SELECT x, y, [FUNCTION 100177]() FROM ROWS FROM ([FUNCTION 100178]())
+
+# Verify that the by-ID reference is formatted with a name in SHOW.
+query T
+SELECT create_statement FROM [SHOW CREATE VIEW v];
+----
+CREATE VIEW public.v (
+  x,
+  y,
+  f_scalar
+) AS SELECT x, y, public.f_scalar() FROM public.f_setof();
+
 statement ok
 CREATE MATERIALIZED VIEW mv AS SELECT x, y, f_scalar() FROM f_setof();
+
+# Check by-ID references for materialized views.
+query T
+SELECT crdb_internal.pb_to_json('desc', descriptor)->'table'->>'viewQuery'
+FROM system.descriptor
+WHERE id = 'mv'::regclass::oid
+----
+SELECT x, y, [FUNCTION 100177]() FROM ROWS FROM ([FUNCTION 100178]())
+
+# Verify that the by-ID reference is formatted with a name in SHOW.
+query T
+SELECT create_statement FROM [SHOW CREATE VIEW mv];
+----
+CREATE MATERIALIZED VIEW public.mv (
+  x,
+  y,
+  f_scalar,
+  rowid
+) AS SELECT x, y, public.f_scalar() FROM public.f_setof();
 
 query III
 SELECT * FROM v ORDER BY x, y;
@@ -1151,17 +1188,30 @@ SELECT * FROM mv;
 statement ok
 SET ROLE root;
 
-statement error pgcode 0A000 cannot rename function "f_scalar" because other functions or views \(\[test.public.v, test.public.mv\]\) still depend on it
+# Verify that the functions used by the view can be renamed and moved to another schema.
+statement ok
 ALTER FUNCTION f_scalar RENAME TO f_scalar_renamed;
 
-statement error pgcode 0A000 cannot rename function "f_setof" because other functions or views \(\[test.public.v, test.public.mv\]\) still depend on it
+statement ok
+ALTER FUNCTION f_scalar_renamed SET SCHEMA sc;
+
+statement ok
 ALTER FUNCTION f_setof RENAME TO f_setof_renamed;
 
-statement error pgcode 2BP01 pq: cannot drop function "f_scalar" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
-DROP FUNCTION f_scalar;
+query T
+SELECT create_statement FROM [SHOW CREATE VIEW v];
+----
+CREATE VIEW public.v (
+  x,
+  y,
+  f_scalar
+) AS SELECT x, y, sc.f_scalar_renamed() FROM public.f_setof_renamed();
 
-statement error pgcode 2BP01 pq: cannot drop function "f_setof" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
-DROP FUNCTION f_setof;
+statement error pgcode 2BP01 pq: cannot drop function "f_scalar_renamed" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
+DROP FUNCTION sc.f_scalar_renamed;
+
+statement error pgcode 2BP01 pq: cannot drop function "f_setof_renamed" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
+DROP FUNCTION f_setof_renamed;
 
 statement ok
 DROP VIEW v;
@@ -1170,10 +1220,10 @@ statement ok
 DROP MATERIALIZED VIEW mv;
 
 statement ok
-DROP FUNCTION f_scalar;
+DROP FUNCTION sc.f_scalar_renamed;
 
 statement ok
-DROP FUNCTION f_setof;
+DROP FUNCTION f_setof_renamed;
 
 # Test a view referencing a builtin function.
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -55,14 +55,14 @@ statement error pgcode 42883 unknown function: recursion_check\(\)
 CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;
 
 # Validate that function renaming is blocked.
-statement error pgcode 0A000 cannot rename function \"lower_hello\" because other functions or views \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+statement error pgcode 0A000 cannot rename function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
 ALTER FUNCTION lower_hello rename to lower_hello_new
 
 statement ok
 CREATE SCHEMA sc2;
 
 # Validate that function schema changes are blocked.
-statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other functions or views \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
 ALTER FUNCTION lower_hello SET SCHEMA sc2;
 
 statement ok

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -11,7 +11,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
-	"github.com/cockroachdb/errors"
 )
 
 func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope *scope) {
@@ -59,24 +58,6 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 		b.schemaTypeDeps = intsets.Fast{}
 		b.qualifyDataSourceNamesInAST = false
 		delete(b.sourceViews, viewFQString)
-
-		switch recErr := recover().(type) {
-		case nil:
-			// No error.
-		case error:
-			if errors.Is(recErr, tree.ErrRoutineUndefined) {
-				panic(
-					errors.WithHint(
-						recErr,
-						"There is probably a typo in function name. Or the intention was to use a user-defined "+
-							"function in the view query, which is currently not supported.",
-					),
-				)
-			}
-			panic(recErr)
-		default:
-			panic(recErr)
-		}
 	}()
 
 	defScope := b.buildStmtAtRoot(cv.AsSource, nil /* desiredTypes */)

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -123,8 +123,8 @@ func alterTableAddCheck(
 		func() colinfo.ResultColumns {
 			return getNonDropResultColumns(b, tbl.TableID)
 		},
-		func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-			return columnLookupFn(b, tbl.TableID, columnName)
+		func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+			return columnLookupFn(b, tbl.TableID, columnItem)
 		},
 	)
 	if err != nil {
@@ -522,8 +522,8 @@ func alterTableAddUniqueWithoutIndex(
 			func() colinfo.ResultColumns {
 				return getNonDropResultColumns(b, tbl.TableID)
 			},
-			func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-				return columnLookupFn(b, tbl.TableID, columnName)
+			func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+				return columnLookupFn(b, tbl.TableID, columnItem)
 			},
 		)
 		if err != nil {
@@ -680,9 +680,9 @@ func getNonDropResultColumns(b BuildCtx, tableID catid.DescID) (ret colinfo.Resu
 // columnLookupFn can look up information of a column by name.
 // It should be exclusively used in DequalifyAndValidateExprImpl.
 func columnLookupFn(
-	b BuildCtx, tableID catid.DescID, columnName tree.Name,
+	b BuildCtx, tableID catid.DescID, columnItem *tree.ColumnItem,
 ) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-	columnID := getColumnIDFromColumnName(b, tableID, columnName, false /* required */)
+	columnID := getColumnIDFromColumnName(b, tableID, columnItem.ColumnName, false /* required */)
 	if columnID == 0 {
 		return false, false, 0, nil
 	}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_column_type.go
@@ -215,8 +215,8 @@ func validateNewTypeForComputedColumn(
 		func() colinfo.ResultColumns {
 			return getNonDropResultColumns(b, tableID)
 		},
-		func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-			return columnLookupFn(b, tableID, columnName)
+		func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+			return columnLookupFn(b, tableID, columnItem)
 		},
 	)
 	if err != nil {
@@ -531,8 +531,8 @@ func getComputeExpressionForBackfill(
 		func() colinfo.ResultColumns {
 			return getNonDropResultColumns(b, tableID)
 		},
-		func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-			return columnLookupFn(b, tableID, columnName)
+		func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+			return columnLookupFn(b, tableID, columnItem)
 		},
 	)
 	if err != nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_policy.go
@@ -281,8 +281,8 @@ func validateAndResolveTypesInExpr(
 		func() colinfo.ResultColumns {
 			return getNonDropResultColumns(b, tableID)
 		},
-		func(columnName tree.Name) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
-			return columnLookupFn(b, tableID, columnName)
+		func(columnItem *tree.ColumnItem) (exists bool, accessible bool, id catid.ColumnID, typ *types.T) {
+			return columnLookupFn(b, tableID, columnItem)
 		},
 	)
 	if err != nil {

--- a/pkg/sql/sem/tree/constant.go
+++ b/pkg/sql/sem/tree/constant.go
@@ -408,7 +408,7 @@ func (expr *NumVal) ResolveAsType(
 			return nil, err
 		}
 		o, err := IntToOid(MustBeDInt(d))
-		return NewDOid(o), err
+		return NewDOidWithType(o, typ), err
 	default:
 		return nil, errors.AssertionFailedf("could not resolve %T %v into a %s", expr, expr, typ.SQLStringForError())
 	}

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -403,6 +403,7 @@ func (v virtualSchemaView) initVirtualTableDesc(
 		tree.PersistencePermanent,
 		false, // isMultiRegion
 		nil,   // sc
+		nil,   // planDeps
 	)
 	return mutDesc.TableDescriptor, err
 }


### PR DESCRIPTION
### sql: rewrite UDF references in views to be by ID

This allows for renaming UDFs that are referenced by views. We use the
same logic that we use for rewriting DEFAULT or computed column
expressions.

To get this to work, we need to be able to type-check the exprssions in
the view query, and that required resolving column references by using
the optimizer's plan dependencies.

### sql: improve column name resolution when resolving UDFs in views

This patch makes it so we can handle a view query that has two source
tables that have identical column tables. If the source tables also have
identical names, then we fall back to not attempting to resolve the
column type.

fixes #146123
informs https://github.com/cockroachdb/cockroach/issues/87699

Release note: None