### PR TITLE
release-24.3: crosscluster/physical: add verbose logging to reader standby job

### DIFF
--- a/pkg/ccl/crosscluster/physical/standby_read_ts_poller_job.go
+++ b/pkg/ccl/crosscluster/physical/standby_read_ts_poller_job.go
@@ -140,6 +140,10 @@ func (r *standbyReadTSPollerResumer) poll(ctx context.Context, execCfg *sql.Exec
 			if replicatedTime.Equal(previousReplicatedTimestamp) {
 				continue
 			}
+			if log.V(1) {
+				log.Infof(ctx, "attempting to advance reader tenant catalog to %s",
+					replicatedTime)
+			}
 			previousReplicatedTimestamp = replicatedTime
 			if err = replication.SetupOrAdvanceStandbyReaderCatalog(
 				ctx,


### PR DESCRIPTION
Backport 1/1 commits from #145573.

/cc @cockroachdb/release

---

Epic: none

Release note: none
