### PR TITLE
release-25.2: plpgsql: prevent a crash in an edge case during formatting

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -676,6 +676,12 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 
+	if buildutil.CrdbTestBuild {
+		// Ensure that each statement is formatted regardless of logging
+		// settings.
+		_ = p.FormatAstAsRedactableString(stmt.AST, p.extendedEvalCtx.Annotations)
+	}
+
 	// This flag informs logging decisions.
 	// Some statements are not dispatched to the execution engine and need
 	// some special plan initialization for logging.
@@ -1672,6 +1678,12 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 	p.semaCtx.Placeholders.Assign(pinfo, vars.stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
+
+	if buildutil.CrdbTestBuild {
+		// Ensure that each statement is formatted regardless of logging
+		// settings.
+		_ = p.FormatAstAsRedactableString(vars.stmt.AST, p.extendedEvalCtx.Annotations)
+	}
 
 	// This flag informs logging decisions.
 	// Some statements are not dispatched to the execution engine and need

--- a/pkg/sql/logictest/testdata/logic_test/do
+++ b/pkg/sql/logictest/testdata/logic_test/do
@@ -274,3 +274,16 @@ CALL p();
 NOTICE: Hello, world!
 
 subtest end
+
+subtest regression_143974
+
+statement error pgcode 0A000 unimplemented: CREATE TYPE usage inside a function definition.*\n.*\n.*issue-v/110080
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+    CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+  END IF;
+END
+$$;
+
+subtest end

--- a/pkg/sql/parser/testdata/do
+++ b/pkg/sql/parser/testdata/do
@@ -364,3 +364,45 @@ at or near "EOF": syntax error
 DETAIL: source SQL:
 BEGIN DO
         ^
+
+parse
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+    CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+  END IF;
+END
+$$;
+----
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+	CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+END IF;
+END;
+$$;
+ -- normalized!
+DO $$
+BEGIN
+IF (NOT (EXISTS (SELECT (1) FROM pg_type WHERE ((typname) = ('mood'))))) THEN
+	CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+END IF;
+END;
+$$;
+ -- fully parenthesized
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT _ FROM pg_type WHERE typname = '_') THEN
+	CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+END IF;
+END;
+$$;
+ -- literals removed
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT 1 FROM _ WHERE _ = 'mood') THEN
+	CREATE TYPE _ AS ENUM (_, _, _);
+END IF;
+END;
+$$;
+ -- identifiers removed

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -181,10 +181,12 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 	if target != nil && sqlStmt.AST.StatementReturnType() != tree.Rows {
 		return nil, pgerror.New(pgcode.Syntax, "INTO used with a command that cannot return data")
 	}
+	ann := tree.MakeAnnotations(sqlStmt.NumAnnotations)
 	return &plpgsqltree.Execute{
-		SqlStmt: sqlStmt.AST,
-		Strict:  haveStrict,
-		Target:  target,
+		SqlStmt:     sqlStmt.AST,
+		Strict:      haveStrict,
+		Target:      target,
+		Annotations: &ann,
 	}, nil
 }
 
@@ -295,10 +297,12 @@ func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) 
 	}
 	// Move past the semicolon.
 	l.lastPos++
+	ann := tree.MakeAnnotations(sqlStmt.NumAnnotations)
 	return &plpgsqltree.Fetch{
-		Cursor: cursor,
-		Target: target,
-		IsMove: isMove,
+		Cursor:      cursor,
+		Target:      target,
+		IsMove:      isMove,
+		Annotations: &ann,
 	}, nil
 }
 
@@ -396,7 +400,11 @@ func (l *lexer) ParseReturnQuery() (plpgsqltree.Statement, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &plpgsqltree.ReturnQuery{SqlStmt: stmt.AST}, nil
+	ann := tree.MakeAnnotations(stmt.NumAnnotations)
+	return &plpgsqltree.ReturnQuery{
+		SqlStmt:     stmt.AST,
+		Annotations: &ann,
+	}, nil
 }
 
 // peekForExecute checks whether the next token is EXECUTE, used to identify

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -140,14 +140,13 @@ func (node *CreateRoutine) Format(ctx *FmtCtx) {
 			if i > 0 {
 				ctx.WriteByte(' ')
 			}
-			oldAnn := ctx.ann
-			ctx.ann = node.BodyAnnotations[i]
-			ctx.FormatNode(stmt)
-			if !isPLpgSQL {
-				// PL/pgSQL statements handle printing semicolons themselves.
-				ctx.WriteByte(';')
-			}
-			ctx.ann = oldAnn
+			ctx.WithAnnotations(node.BodyAnnotations[i], func() {
+				ctx.FormatNode(stmt)
+				if !isPLpgSQL {
+					// PL/pgSQL statements handle printing semicolons themselves.
+					ctx.WriteByte(';')
+				}
+			})
 		}
 		ctx.WriteString("$$")
 	} else if node.RoutineBody != nil {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -675,7 +675,7 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 // number of characters to be printed.
 func (ctx *FmtCtx) formatLimitLength(n NodeFormatter, maxLength int) {
 	temp := NewFmtCtx(ctx.flags)
-	temp.FormatNodeSummary(n)
+	temp.formatNodeSummary(n)
 	s := temp.CloseAndGetString()
 	if len(s) > maxLength {
 		truncated := s[:maxLength] + "..."
@@ -731,7 +731,7 @@ func (ctx *FmtCtx) formatSummaryInsert(node *Insert) {
 	expr := rows.Select
 	if _, ok := expr.(*SelectClause); ok {
 		ctx.WriteByte(' ')
-		ctx.FormatNodeSummary(rows)
+		ctx.formatNodeSummary(rows)
 	} else if node.Columns != nil {
 		ctx.WriteByte('(')
 		ctx.formatLimitLength(&node.Columns, ColumnLimit)
@@ -754,8 +754,8 @@ func (ctx *FmtCtx) formatSummaryUpdate(node *Update) {
 	}
 }
 
-// FormatNodeSummary recurses into a node for pretty-printing a summarized version.
-func (ctx *FmtCtx) FormatNodeSummary(n NodeFormatter) {
+// formatNodeSummary recurses into a node for pretty-printing a summarized version.
+func (ctx *FmtCtx) formatNodeSummary(n NodeFormatter) {
 	switch node := n.(type) {
 	case *Insert:
 		ctx.formatSummaryInsert(node)
@@ -775,7 +775,7 @@ func (ctx *FmtCtx) FormatNodeSummary(n NodeFormatter) {
 func AsStringWithFlags(n NodeFormatter, fl FmtFlags, opts ...FmtCtxOption) string {
 	ctx := NewFmtCtx(fl, opts...)
 	if fl.HasFlags(FmtSummary) {
-		ctx.FormatNodeSummary(n)
+		ctx.formatNodeSummary(n)
 	} else {
 		ctx.FormatNode(n)
 	}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -464,6 +464,17 @@ func (ctx *FmtCtx) WithoutConstantRedaction(fn func()) {
 	fn()
 }
 
+// WithAnnotations modifies FmtCtx to use the provided Annotations, calls fn,
+// then restores the original ones.
+func (ctx *FmtCtx) WithAnnotations(ann *Annotations, fn func()) {
+	defer func(oldAnn *Annotations) {
+		ctx.ann = oldAnn
+	}(ctx.ann)
+	ctx.ann = ann
+
+	fn()
+}
+
 // HasFlags returns true iff all of the given flags are set in the formatter
 // context.
 func (ctx *FmtCtx) HasFlags(f FmtFlags) bool {


### PR DESCRIPTION
Backport 2/2 commits from #146406 on behalf of @yuzefovich.

----

**sql: format all statements in test builds**

This commit improves our testing coverage somewhat so that in test
builds we now format each executed query unconditionally.

**plpgsql: prevent a crash in an edge case during formatting**

This commit fixes an issue that is similar to the one that was fixed in
22dabb08e76decbe2fc1c091431e05ebfba5e73f. In particular, each parser
(both SQL one and PLpgSQL one) keeps track of the number of annotations
found in the current stmt. Annotations are used during object name
resolution, and the AST nodes can reference annotation indices. If an
annotation index is set, then it assumes that during formatting the
corresponding annotation will be available in the supplied Annotations
container.

In the PLpgSQL parser we use an ephemeral SQL parser instance to process
SQL statements. Previously, we would simply discard the information about
whether any annotations were found in the SQL stmt which could lead to
undefined behavior down the line. This commit audits all usages of the
SQL parser from PLpgSQL one to ensure that we capture the number of
annotations used in that stmt and create the Annotations container with
that capacity, stored in the AST. This container is then substituted
into the FmtCtx for those ASTs. Note that since we currently don't
support DDLs from PLpgSQL, the annotation slots in the container won't
ever be set, so the contribution of this patch is preventing the crash.

Fixes: #143974.

Release note (bug fix): Previously, CockroachDB node could crash when
executing DO stmts when they contain currently unsupported DDL stmts like
CREATE TYPE in non-default configuration (additional logging like the one
controlled via `sql.log.all_statements.enabled` cluster setting needed
to be enabled). This bug was introduced in 25.1 release and is now
fixed.

----

Release justification: bug fix.