### PR TITLE
release-25.1: plpgsql: prevent a crash in an edge case during formatting

### DIFF
--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -635,6 +635,12 @@ func (ex *connExecutor) execStmtInOpenState(
 	p.semaCtx.Placeholders.Assign(pinfo, stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
 
+	if buildutil.CrdbTestBuild {
+		// Ensure that each statement is formatted regardless of logging
+		// settings.
+		_ = p.FormatAstAsRedactableString(stmt.AST, p.extendedEvalCtx.Annotations)
+	}
+
 	// This flag informs logging decisions.
 	// Some statements are not dispatched to the execution engine and need
 	// some special plan initialization for logging.
@@ -1629,6 +1635,12 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 	p.extendedEvalCtx.Annotations = &p.semaCtx.Annotations
 	p.semaCtx.Placeholders.Assign(pinfo, vars.stmt.NumPlaceholders)
 	p.extendedEvalCtx.Placeholders = &p.semaCtx.Placeholders
+
+	if buildutil.CrdbTestBuild {
+		// Ensure that each statement is formatted regardless of logging
+		// settings.
+		_ = p.FormatAstAsRedactableString(vars.stmt.AST, p.extendedEvalCtx.Annotations)
+	}
 
 	// This flag informs logging decisions.
 	// Some statements are not dispatched to the execution engine and need

--- a/pkg/sql/logictest/testdata/logic_test/do
+++ b/pkg/sql/logictest/testdata/logic_test/do
@@ -274,3 +274,16 @@ CALL p();
 NOTICE: Hello, world!
 
 subtest end
+
+subtest regression_143974
+
+statement error pgcode 0A000 unimplemented: CREATE TYPE usage inside a function definition.*\n.*\n.*issue-v/110080
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+    CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+  END IF;
+END
+$$;
+
+subtest end

--- a/pkg/sql/parser/testdata/do
+++ b/pkg/sql/parser/testdata/do
@@ -364,3 +364,45 @@ at or near "EOF": syntax error
 DETAIL: source SQL:
 BEGIN DO
         ^
+
+parse
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+    CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+  END IF;
+END
+$$;
+----
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'mood') THEN
+	CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+END IF;
+END;
+$$;
+ -- normalized!
+DO $$
+BEGIN
+IF (NOT (EXISTS (SELECT (1) FROM pg_type WHERE ((typname) = ('mood'))))) THEN
+	CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+END IF;
+END;
+$$;
+ -- fully parenthesized
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT _ FROM pg_type WHERE typname = '_') THEN
+	CREATE TYPE mood AS ENUM ('happy', 'sad', 'neutral');
+END IF;
+END;
+$$;
+ -- literals removed
+DO $$
+BEGIN
+IF NOT EXISTS (SELECT 1 FROM _ WHERE _ = 'mood') THEN
+	CREATE TYPE _ AS ENUM (_, _, _);
+END IF;
+END;
+$$;
+ -- identifiers removed

--- a/pkg/sql/plpgsql/parser/lexer.go
+++ b/pkg/sql/plpgsql/parser/lexer.go
@@ -181,10 +181,12 @@ func (l *lexer) MakeExecSqlStmt() (*plpgsqltree.Execute, error) {
 	if target != nil && sqlStmt.AST.StatementReturnType() != tree.Rows {
 		return nil, pgerror.New(pgcode.Syntax, "INTO used with a command that cannot return data")
 	}
+	ann := tree.MakeAnnotations(sqlStmt.NumAnnotations)
 	return &plpgsqltree.Execute{
-		SqlStmt: sqlStmt.AST,
-		Strict:  haveStrict,
-		Target:  target,
+		SqlStmt:     sqlStmt.AST,
+		Strict:      haveStrict,
+		Target:      target,
+		Annotations: &ann,
 	}, nil
 }
 
@@ -295,10 +297,12 @@ func (l *lexer) MakeFetchOrMoveStmt(isMove bool) (plpgsqltree.Statement, error) 
 	}
 	// Move past the semicolon.
 	l.lastPos++
+	ann := tree.MakeAnnotations(sqlStmt.NumAnnotations)
 	return &plpgsqltree.Fetch{
-		Cursor: cursor,
-		Target: target,
-		IsMove: isMove,
+		Cursor:      cursor,
+		Target:      target,
+		IsMove:      isMove,
+		Annotations: &ann,
 	}, nil
 }
 

--- a/pkg/sql/plpgsql/parser/plpgsql.y
+++ b/pkg/sql/plpgsql/parser/plpgsql.y
@@ -6,6 +6,7 @@ import (
 
   "github.com/cockroachdb/cockroach/pkg/build"
   "github.com/cockroachdb/cockroach/pkg/sql/parser"
+  "github.com/cockroachdb/cockroach/pkg/sql/parser/statements"
   "github.com/cockroachdb/cockroach/pkg/sql/scanner"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
   "github.com/cockroachdb/cockroach/pkg/sql/sem/plpgsqltree"
@@ -173,7 +174,11 @@ func (u *plpgsqlSymUnion) cursorScrollOption() tree.CursorScrollOption {
 }
 
 func (u *plpgsqlSymUnion) sqlStatement() tree.Statement {
-    return u.val.(tree.Statement)
+    return u.val.(statements.Statement[tree.Statement]).AST
+}
+
+func (u *plpgsqlSymUnion) numAnnotations() tree.AnnotationIdx {
+    return u.val.(statements.Statement[tree.Statement]).NumAnnotations
 }
 
 func (u *plpgsqlSymUnion) variables() []plpgsqltree.Variable {
@@ -478,10 +483,12 @@ decl_statement: decl_varname decl_const decl_datatype decl_collate decl_notnull 
   }
 | decl_varname opt_scrollable CURSOR decl_cursor_args decl_is_for decl_cursor_query
   {
+    ann := tree.MakeAnnotations($6.numAnnotations())
     $$.val = &plpgsqltree.CursorDeclaration{
       Name: plpgsqltree.Variable($1),
       Scroll: $2.cursorScrollOption(),
       Query: $6.sqlStatement(),
+      Annotations: &ann,
     }
   }
 ;
@@ -509,7 +516,7 @@ decl_cursor_query: stmt_until_semi ';'
     if len(stmts) != 1 {
       return setErr(plpgsqllex, errors.New("expected exactly one SQL statement for cursor"))
     }
-    $$.val = stmts[0].AST
+    $$.val = stmts[0]
   }
 ;
 
@@ -1419,10 +1426,12 @@ stmt_open: OPEN IDENT ';'
     if len(stmts) != 1 {
       return setErr(plpgsqllex, errors.New("expected exactly one SQL statement for cursor"))
     }
+    ann := tree.MakeAnnotations(stmts[0].NumAnnotations)
     $$.val = &plpgsqltree.Open{
       CurVar: plpgsqltree.Variable($2),
       Scroll: $3.cursorScrollOption(),
       Query: stmts[0].AST,
+      Annotations: &ann,
     }
   }
 ;

--- a/pkg/sql/sem/plpgsqltree/statements.go
+++ b/pkg/sql/sem/plpgsqltree/statements.go
@@ -183,9 +183,10 @@ func (s *Declaration) WalkStmt(visitor StatementVisitor) Statement {
 
 type CursorDeclaration struct {
 	StatementImpl
-	Name   Variable
-	Scroll tree.CursorScrollOption
-	Query  tree.Statement
+	Name        Variable
+	Scroll      tree.CursorScrollOption
+	Query       tree.Statement
+	Annotations *tree.Annotations
 }
 
 func (s *CursorDeclaration) CopyNode() *CursorDeclaration {
@@ -194,16 +195,18 @@ func (s *CursorDeclaration) CopyNode() *CursorDeclaration {
 }
 
 func (s *CursorDeclaration) Format(ctx *tree.FmtCtx) {
-	ctx.FormatNode(&s.Name)
-	switch s.Scroll {
-	case tree.Scroll:
-		ctx.WriteString(" SCROLL")
-	case tree.NoScroll:
-		ctx.WriteString(" NO SCROLL")
-	}
-	ctx.WriteString(" CURSOR FOR ")
-	ctx.FormatNode(s.Query)
-	ctx.WriteString(";\n")
+	ctx.WithAnnotations(s.Annotations, func() {
+		ctx.FormatNode(&s.Name)
+		switch s.Scroll {
+		case tree.Scroll:
+			ctx.WriteString(" SCROLL")
+		case tree.NoScroll:
+			ctx.WriteString(" NO SCROLL")
+		}
+		ctx.WriteString(" CURSOR FOR ")
+		ctx.FormatNode(s.Query)
+		ctx.WriteString(";\n")
+	})
 }
 
 func (s *CursorDeclaration) PlpgSQLStatementTag() string {
@@ -956,9 +959,10 @@ func (s *Assert) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_execsql
 type Execute struct {
 	StatementImpl
-	SqlStmt tree.Statement
-	Strict  bool // INTO STRICT flag
-	Target  []Variable
+	SqlStmt     tree.Statement
+	Strict      bool // INTO STRICT flag
+	Target      []Variable
+	Annotations *tree.Annotations
 }
 
 func (s *Execute) CopyNode() *Execute {
@@ -968,20 +972,22 @@ func (s *Execute) CopyNode() *Execute {
 }
 
 func (s *Execute) Format(ctx *tree.FmtCtx) {
-	ctx.FormatNode(s.SqlStmt)
-	if s.Target != nil {
-		ctx.WriteString(" INTO ")
-		if s.Strict {
-			ctx.WriteString("STRICT ")
-		}
-		for i := range s.Target {
-			if i > 0 {
-				ctx.WriteString(", ")
+	ctx.WithAnnotations(s.Annotations, func() {
+		ctx.FormatNode(s.SqlStmt)
+		if s.Target != nil {
+			ctx.WriteString(" INTO ")
+			if s.Strict {
+				ctx.WriteString("STRICT ")
 			}
-			ctx.FormatNode(&s.Target[i])
+			for i := range s.Target {
+				if i > 0 {
+					ctx.WriteString(", ")
+				}
+				ctx.FormatNode(&s.Target[i])
+			}
 		}
-	}
-	ctx.WriteString(";\n")
+		ctx.WriteString(";\n")
+	})
 }
 
 func (s *Execute) PlpgSQLStatementTag() string {
@@ -1185,9 +1191,10 @@ func (s *GetDiagnostics) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_open
 type Open struct {
 	StatementImpl
-	CurVar Variable
-	Scroll tree.CursorScrollOption
-	Query  tree.Statement
+	CurVar      Variable
+	Scroll      tree.CursorScrollOption
+	Query       tree.Statement
+	Annotations *tree.Annotations
 }
 
 func (s *Open) CopyNode() *Open {
@@ -1196,19 +1203,21 @@ func (s *Open) CopyNode() *Open {
 }
 
 func (s *Open) Format(ctx *tree.FmtCtx) {
-	ctx.WriteString("OPEN ")
-	ctx.FormatNode(&s.CurVar)
-	switch s.Scroll {
-	case tree.Scroll:
-		ctx.WriteString(" SCROLL")
-	case tree.NoScroll:
-		ctx.WriteString(" NO SCROLL")
-	}
-	if s.Query != nil {
-		ctx.WriteString(" FOR ")
-		ctx.FormatNode(s.Query)
-	}
-	ctx.WriteString(";\n")
+	ctx.WithAnnotations(s.Annotations, func() {
+		ctx.WriteString("OPEN ")
+		ctx.FormatNode(&s.CurVar)
+		switch s.Scroll {
+		case tree.Scroll:
+			ctx.WriteString(" SCROLL")
+		case tree.NoScroll:
+			ctx.WriteString(" NO SCROLL")
+		}
+		if s.Query != nil {
+			ctx.WriteString(" FOR ")
+			ctx.FormatNode(s.Query)
+		}
+		ctx.WriteString(";\n")
+	})
 }
 
 func (s *Open) PlpgSQLStatementTag() string {
@@ -1224,37 +1233,40 @@ func (s *Open) WalkStmt(visitor StatementVisitor) Statement {
 // stmt_move (where IsMove = true)
 type Fetch struct {
 	StatementImpl
-	Cursor tree.CursorStmt
-	Target []Variable
-	IsMove bool
+	Cursor      tree.CursorStmt
+	Target      []Variable
+	IsMove      bool
+	Annotations *tree.Annotations
 }
 
 func (s *Fetch) Format(ctx *tree.FmtCtx) {
-	if s.IsMove {
-		ctx.WriteString("MOVE ")
-	} else {
-		ctx.WriteString("FETCH ")
-	}
-	if dir := s.Cursor.FetchType.String(); dir != "" {
-		ctx.WriteString(dir)
-		ctx.WriteString(" ")
-	}
-	if s.Cursor.FetchType.HasCount() {
-		ctx.WriteString(strconv.Itoa(int(s.Cursor.Count)))
-		ctx.WriteString(" ")
-	}
-	ctx.WriteString("FROM ")
-	ctx.FormatName(string(s.Cursor.Name))
-	if s.Target != nil {
-		ctx.WriteString(" INTO ")
-		for i := range s.Target {
-			if i > 0 {
-				ctx.WriteString(", ")
-			}
-			ctx.FormatNode(&s.Target[i])
+	ctx.WithAnnotations(s.Annotations, func() {
+		if s.IsMove {
+			ctx.WriteString("MOVE ")
+		} else {
+			ctx.WriteString("FETCH ")
 		}
-	}
-	ctx.WriteString(";\n")
+		if dir := s.Cursor.FetchType.String(); dir != "" {
+			ctx.WriteString(dir)
+			ctx.WriteString(" ")
+		}
+		if s.Cursor.FetchType.HasCount() {
+			ctx.WriteString(strconv.Itoa(int(s.Cursor.Count)))
+			ctx.WriteString(" ")
+		}
+		ctx.WriteString("FROM ")
+		ctx.FormatName(string(s.Cursor.Name))
+		if s.Target != nil {
+			ctx.WriteString(" INTO ")
+			for i := range s.Target {
+				if i > 0 {
+					ctx.WriteString(", ")
+				}
+				ctx.FormatNode(&s.Target[i])
+			}
+		}
+		ctx.WriteString(";\n")
+	})
 }
 
 func (s *Fetch) PlpgSQLStatementTag() string {

--- a/pkg/sql/sem/tree/create_routine.go
+++ b/pkg/sql/sem/tree/create_routine.go
@@ -140,14 +140,13 @@ func (node *CreateRoutine) Format(ctx *FmtCtx) {
 			if i > 0 {
 				ctx.WriteByte(' ')
 			}
-			oldAnn := ctx.ann
-			ctx.ann = node.BodyAnnotations[i]
-			ctx.FormatNode(stmt)
-			if !isPLpgSQL {
-				// PL/pgSQL statements handle printing semicolons themselves.
-				ctx.WriteByte(';')
-			}
-			ctx.ann = oldAnn
+			ctx.WithAnnotations(node.BodyAnnotations[i], func() {
+				ctx.FormatNode(stmt)
+				if !isPLpgSQL {
+					// PL/pgSQL statements handle printing semicolons themselves.
+					ctx.WriteByte(';')
+				}
+			})
 		}
 		ctx.WriteString("$$")
 	} else if node.RoutineBody != nil {

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -671,7 +671,7 @@ func (ctx *FmtCtx) FormatNode(n NodeFormatter) {
 // number of characters to be printed.
 func (ctx *FmtCtx) formatLimitLength(n NodeFormatter, maxLength int) {
 	temp := NewFmtCtx(ctx.flags)
-	temp.FormatNodeSummary(n)
+	temp.formatNodeSummary(n)
 	s := temp.CloseAndGetString()
 	if len(s) > maxLength {
 		truncated := s[:maxLength] + "..."
@@ -727,7 +727,7 @@ func (ctx *FmtCtx) formatSummaryInsert(node *Insert) {
 	expr := rows.Select
 	if _, ok := expr.(*SelectClause); ok {
 		ctx.WriteByte(' ')
-		ctx.FormatNodeSummary(rows)
+		ctx.formatNodeSummary(rows)
 	} else if node.Columns != nil {
 		ctx.WriteByte('(')
 		ctx.formatLimitLength(&node.Columns, ColumnLimit)
@@ -750,8 +750,8 @@ func (ctx *FmtCtx) formatSummaryUpdate(node *Update) {
 	}
 }
 
-// FormatNodeSummary recurses into a node for pretty-printing a summarized version.
-func (ctx *FmtCtx) FormatNodeSummary(n NodeFormatter) {
+// formatNodeSummary recurses into a node for pretty-printing a summarized version.
+func (ctx *FmtCtx) formatNodeSummary(n NodeFormatter) {
 	switch node := n.(type) {
 	case *Insert:
 		ctx.formatSummaryInsert(node)
@@ -771,7 +771,7 @@ func (ctx *FmtCtx) FormatNodeSummary(n NodeFormatter) {
 func AsStringWithFlags(n NodeFormatter, fl FmtFlags, opts ...FmtCtxOption) string {
 	ctx := NewFmtCtx(fl, opts...)
 	if fl.HasFlags(FmtSummary) {
-		ctx.FormatNodeSummary(n)
+		ctx.formatNodeSummary(n)
 	} else {
 		ctx.FormatNode(n)
 	}

--- a/pkg/sql/sem/tree/format.go
+++ b/pkg/sql/sem/tree/format.go
@@ -460,6 +460,17 @@ func (ctx *FmtCtx) WithoutConstantRedaction(fn func()) {
 	fn()
 }
 
+// WithAnnotations modifies FmtCtx to use the provided Annotations, calls fn,
+// then restores the original ones.
+func (ctx *FmtCtx) WithAnnotations(ann *Annotations, fn func()) {
+	defer func(oldAnn *Annotations) {
+		ctx.ann = oldAnn
+	}(ctx.ann)
+	ctx.ann = ann
+
+	fn()
+}
+
 // HasFlags returns true iff all of the given flags are set in the formatter
 // context.
 func (ctx *FmtCtx) HasFlags(f FmtFlags) bool {


### PR DESCRIPTION
Backport 2/2 commits from #146406.

/cc @cockroachdb/release

---

**tree: add panic-catching to formatting code**

We've seen a couple of node crashes due to runtime errors during
formatting AST. This behavior doesn't seem warranted, so this commit
adds the panic-catching mechanism to the main entry point of the
formatting code. We don't have an easy way to propagate the caught error
(this would require modifying almost a thousand of callsites), so we
simply write the error message into the buffer. Such behavior is
somewhat unfortunate, yet it seems better than a node crash. No panics
will be caught in the test builds.

Additionally, this commit improves our testing coverage somewhat so that
in test builds we now format each executed query unconditionally.

**plpgsql: prevent a crash in an edge case during formatting**

This commit fixes an issue that is similar to the one that was fixed in
22dabb08e76decbe2fc1c091431e05ebfba5e73f. In particular, each parser
(both SQL one and PLpgSQL one) keeps track of the number of annotations
found in the current stmt. Annotations are used during object name
resolution, and the AST nodes can reference annotation indices. If an
annotation index is set, then it assumes that during formatting the
corresponding annotation will be available in the supplied Annotations
container.

In the PLpgSQL parser we use an ephemeral SQL parser instance to process
SQL statements. Previously, we would simply discard the information about
whether any annotations were found in the SQL stmt which could lead to
undefined behavior down the line. This commit audits all usages of the
SQL parser from PLpgSQL one to ensure that we capture the number of
annotations used in that stmt and create the Annotations container with
that capacity, stored in the AST. This container is then substituted
into the FmtCtx for those ASTs. Note that since we currently don't
support DDLs from PLpgSQL, the annotation slots in the container won't
ever be set, so the contribution of this patch is preventing the crash.

Fixes: #143974.

Release note (bug fix): Previously, CockroachDB node could crash when
executing DO stmts when they contain currently unsupported DDL stmts like
CREATE TYPE in non-default configuration (additional logging like the one
controlled via `sql.log.all_statements.enabled` cluster setting needed
to be enabled). This bug was introduced in 25.1 release and is now
fixed.

Release justification: bug fix.