### PR TITLE
cspann: cleanup and fixes for quantizers and search set

### DIFF
--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -1319,7 +1319,7 @@ func TestVectorEncoding(t *testing.T) {
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "defaultdb", "prefix_cols")
 
 	testVector := vector.T{1, 2, 4}
-	encodedVector, err := vecencoding.EncodeUnquantizerVector([]byte{}, 0, testVector)
+	encodedVector, err := vecencoding.EncodeUnquantizerVector([]byte{}, testVector)
 	require.NoError(t, err)
 
 	vh := VectorIndexEncodingHelper{
@@ -1411,7 +1411,7 @@ func TestVectorCompositeEncoding(t *testing.T) {
 	tableDesc := desctestutils.TestingGetPublicTableDescriptor(kvDB, codec, "defaultdb", "prefix_cols")
 
 	testVector := vector.T{1, 2, 4}
-	encodedVector, err := vecencoding.EncodeUnquantizerVector([]byte{}, 0, testVector)
+	encodedVector, err := vecencoding.EncodeUnquantizerVector([]byte{}, testVector)
 	require.NoError(t, err)
 
 	vh := VectorIndexEncodingHelper{

--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -408,10 +408,10 @@ func (suite *StoreTestSuite) TestSearchPartitions() {
 
 			// Validate search results.
 			result1 := cspann.SearchResult{
-				QueryDistance: 4.2, ErrorBound: 50.99, CentroidDistance: 7.21,
+				QueryDistance: 4.2, ErrorBound: 50.99,
 				ParentPartitionKey: testPartitionKey2, ChildKey: partitionKey4, ValueBytes: valueBytes4}
 			result2 := cspann.SearchResult{
-				QueryDistance: 8, ErrorBound: 0, CentroidDistance: 0,
+				QueryDistance: 8, ErrorBound: 0,
 				ParentPartitionKey: testPartitionKey, ChildKey: partitionKey3, ValueBytes: valueBytes3}
 			suite.Equal(cspann.SearchResults{result1, result2}, RoundResults(searchSet.PopResults(), 2))
 

--- a/pkg/sql/vecindex/cspann/commontest/storetests.go
+++ b/pkg/sql/vecindex/cspann/commontest/storetests.go
@@ -408,10 +408,10 @@ func (suite *StoreTestSuite) TestSearchPartitions() {
 
 			// Validate search results.
 			result1 := cspann.SearchResult{
-				QuerySquaredDistance: 4.2, ErrorBound: 50.99, CentroidDistance: 7.21,
+				QueryDistance: 4.2, ErrorBound: 50.99, CentroidDistance: 7.21,
 				ParentPartitionKey: testPartitionKey2, ChildKey: partitionKey4, ValueBytes: valueBytes4}
 			result2 := cspann.SearchResult{
-				QuerySquaredDistance: 8, ErrorBound: 0, CentroidDistance: 0,
+				QueryDistance: 8, ErrorBound: 0, CentroidDistance: 0,
 				ParentPartitionKey: testPartitionKey, ChildKey: partitionKey3, ValueBytes: valueBytes3}
 			suite.Equal(cspann.SearchResults{result1, result2}, RoundResults(searchSet.PopResults(), 2))
 

--- a/pkg/sql/vecindex/cspann/commontest/utils.go
+++ b/pkg/sql/vecindex/cspann/commontest/utils.go
@@ -61,7 +61,6 @@ func RoundResults(results cspann.SearchResults, prec int) cspann.SearchResults {
 		result := &results[i]
 		result.QueryDistance = float32(scalar.Round(float64(result.QueryDistance), prec))
 		result.ErrorBound = float32(scalar.Round(float64(result.ErrorBound), prec))
-		result.CentroidDistance = float32(scalar.Round(float64(result.CentroidDistance), prec))
 		result.Vector = testutils.RoundFloats(result.Vector, prec)
 	}
 	return results
@@ -75,7 +74,6 @@ func ValidatePartitionsEqual(t *testing.T, l, r *cspann.Partition) {
 	require.Equal(t, l.ValueBytes(), r.ValueBytes(), "valueBytes do not match")
 	require.Equal(t, q1.GetCentroid(), q2.GetCentroid(), "centroids do not match")
 	require.Equal(t, q1.GetCount(), q2.GetCount(), "counts do not match")
-	require.Equal(t, q1.GetCentroidDistances(), q2.GetCentroidDistances(), "distances do not match")
 	if eq, ok := q1.(equaler); ok {
 		require.True(t, eq.Equal(q2))
 	}

--- a/pkg/sql/vecindex/cspann/commontest/utils.go
+++ b/pkg/sql/vecindex/cspann/commontest/utils.go
@@ -59,7 +59,7 @@ func RunTransaction(
 func RoundResults(results cspann.SearchResults, prec int) cspann.SearchResults {
 	for i := range results {
 		result := &results[i]
-		result.QuerySquaredDistance = float32(scalar.Round(float64(result.QuerySquaredDistance), prec))
+		result.QueryDistance = float32(scalar.Round(float64(result.QueryDistance), prec))
 		result.ErrorBound = float32(scalar.Round(float64(result.ErrorBound), prec))
 		result.CentroidDistance = float32(scalar.Round(float64(result.CentroidDistance), prec))
 		result.Vector = testutils.RoundFloats(result.Vector, prec)

--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -793,7 +793,7 @@ func (vi *Index) fallbackOnTargets(
 
 		// Calculate the distance of the query vector to the centroids.
 		for i := range tempResults {
-			tempResults[i].QuerySquaredDistance = num32.L2SquaredDistance(vec, tempResults[i].Vector)
+			tempResults[i].QueryDistance = num32.L2SquaredDistance(vec, tempResults[i].Vector)
 			searchSet.Add(&tempResults[i])
 		}
 
@@ -899,7 +899,7 @@ func (vi *Index) rerankSearchResults(
 	// Compute exact distances for the vectors.
 	for i := range candidates {
 		candidate := &candidates[i]
-		candidate.QuerySquaredDistance = num32.L2SquaredDistance(candidate.Vector, queryVector)
+		candidate.QueryDistance = num32.L2SquaredDistance(candidate.Vector, queryVector)
 		candidate.ErrorBound = 0
 	}
 

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -237,11 +237,10 @@ func (s *testState) Search(d *datadriven.TestData) string {
 		result := &results[i]
 		var errorBound string
 		if result.ErrorBound != 0 {
-			errorBound = fmt.Sprintf("± %s ", utils.FormatFloat(result.ErrorBound, 2))
+			errorBound = fmt.Sprintf(" ± %s", utils.FormatFloat(result.ErrorBound, 2))
 		}
-		fmt.Fprintf(&buf, "%s: %s %s(centroid=%s)\n",
-			string(result.ChildKey.KeyBytes), utils.FormatFloat(result.QueryDistance, 4),
-			errorBound, utils.FormatFloat(result.CentroidDistance, 2))
+		fmt.Fprintf(&buf, "%s: %s%s\n",
+			string(result.ChildKey.KeyBytes), utils.FormatFloat(result.QueryDistance, 4), errorBound)
 	}
 
 	buf.WriteString(fmt.Sprintf("%d leaf vectors, ", searchSet.Stats.QuantizedLeafVectorCount))

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -900,7 +900,7 @@ func TestRandomizeVector(t *testing.T) {
 	errorBounds := make([]float32, count)
 	quantizer.EstimateDistances(&workspace, originalSet, original.At(0), distances, errorBounds)
 	require.Equal(t, []float32{0, 272.75, 550.86, 950.93, 2421.41}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{37.58, 46.08, 57.55, 69.46, 110.57}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{27.87, 46.08, 57.55, 69.46, 110.57}, testutils.RoundFloats(errorBounds, 2))
 
 	quantizer.EstimateDistances(&workspace, randomizedSet, randomized.At(0), distances, errorBounds)
 	require.Equal(t, []float32{5.1, 292.72, 454.95, 1011.85, 2475.87}, testutils.RoundFloats(distances, 2))

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -240,7 +240,7 @@ func (s *testState) Search(d *datadriven.TestData) string {
 			errorBound = fmt.Sprintf("± %s ", utils.FormatFloat(result.ErrorBound, 2))
 		}
 		fmt.Fprintf(&buf, "%s: %s %s(centroid=%s)\n",
-			string(result.ChildKey.KeyBytes), utils.FormatFloat(result.QuerySquaredDistance, 4),
+			string(result.ChildKey.KeyBytes), utils.FormatFloat(result.QueryDistance, 4),
 			errorBound, utils.FormatFloat(result.CentroidDistance, 2))
 	}
 
@@ -285,7 +285,7 @@ func (s *testState) SearchForInsert(d *datadriven.TestData) string {
 	s.Index.UnRandomizeVector(result.Vector, original)
 	utils.WriteVector(&buf, original, 4)
 
-	fmt.Fprintf(&buf, ", sqdist=%s", utils.FormatFloat(result.QuerySquaredDistance, 4))
+	fmt.Fprintf(&buf, ", sqdist=%s", utils.FormatFloat(result.QueryDistance, 4))
 	if result.ErrorBound != 0 {
 		fmt.Fprintf(&buf, "±%s", utils.FormatFloat(result.ErrorBound, 2))
 	}

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -140,7 +140,7 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 				err := txn2.SearchPartitions(ctx, treeKey, toSearch, vector.T{0, 0}, &searchSet)
 				require.NoError(t, err)
 				result1 := cspann.SearchResult{
-					QuerySquaredDistance: 25, ErrorBound: 0, CentroidDistance: 5,
+					QueryDistance: 25, ErrorBound: 0, CentroidDistance: 5,
 					ParentPartitionKey: cspann.RootKey, ChildKey: childKey2, ValueBytes: valueBytes2}
 				require.Equal(t, cspann.SearchResults{result1}, searchSet.PopResults())
 				require.Equal(t, 2, toSearch[0].Count)

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -140,7 +140,7 @@ func TestInMemoryStoreConcurrency(t *testing.T) {
 				err := txn2.SearchPartitions(ctx, treeKey, toSearch, vector.T{0, 0}, &searchSet)
 				require.NoError(t, err)
 				result1 := cspann.SearchResult{
-					QueryDistance: 25, ErrorBound: 0, CentroidDistance: 5,
+					QueryDistance: 25, ErrorBound: 0,
 					ParentPartitionKey: cspann.RootKey, ChildKey: childKey2, ValueBytes: valueBytes2}
 				require.Equal(t, cspann.SearchResults{result1}, searchSet.PopResults())
 				require.Equal(t, 2, toSearch[0].Count)
@@ -253,8 +253,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 		cspann.MakeReadyPartitionMetadata(1, centroid),
 		unquantizer,
 		&quantize.UnQuantizedVectorSet{
-			Centroid:          centroid,
-			CentroidDistances: []float32{1, 2, 3},
+			Centroid: centroid,
 			Vectors: vector.Set{
 				Dims:  2,
 				Count: 3,
@@ -271,8 +270,7 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 		cspann.MakeReadyPartitionMetadata(2, centroid),
 		raBitQuantizer,
 		&quantize.UnQuantizedVectorSet{
-			Centroid:          centroid,
-			CentroidDistances: []float32{1, 2, 3, 4},
+			Centroid: centroid,
 			Vectors: vector.Set{
 				Dims:  2,
 				Count: 3,

--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -161,7 +161,6 @@ func (p *Partition) Search(
 	tempErrorBounds := tempFloats[count : count*2]
 	p.quantizer.EstimateDistances(
 		w, p.quantizedSet, queryVector, tempDistances, tempErrorBounds)
-	centroidDistances := p.quantizedSet.GetCentroidDistances()
 
 	// Add candidates to the search set, which is responsible for retaining the
 	// top-k results.
@@ -169,7 +168,6 @@ func (p *Partition) Search(
 		searchSet.tempResult = SearchResult{
 			QueryDistance:      tempDistances[i],
 			ErrorBound:         tempErrorBounds[i],
-			CentroidDistance:   centroidDistances[i],
 			ParentPartitionKey: partitionKey,
 			ChildKey:           p.childKeys[i],
 			ValueBytes:         p.valueBytes[i],

--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -157,22 +157,22 @@ func (p *Partition) Search(
 	defer w.FreeFloats(tempFloats)
 
 	// Estimate distances of the data vectors from the query vector.
-	tempSquaredDistances := tempFloats[:count]
+	tempDistances := tempFloats[:count]
 	tempErrorBounds := tempFloats[count : count*2]
 	p.quantizer.EstimateDistances(
-		w, p.quantizedSet, queryVector, tempSquaredDistances, tempErrorBounds)
+		w, p.quantizedSet, queryVector, tempDistances, tempErrorBounds)
 	centroidDistances := p.quantizedSet.GetCentroidDistances()
 
 	// Add candidates to the search set, which is responsible for retaining the
 	// top-k results.
-	for i := range tempSquaredDistances {
+	for i := range tempDistances {
 		searchSet.tempResult = SearchResult{
-			QuerySquaredDistance: tempSquaredDistances[i],
-			ErrorBound:           tempErrorBounds[i],
-			CentroidDistance:     centroidDistances[i],
-			ParentPartitionKey:   partitionKey,
-			ChildKey:             p.childKeys[i],
-			ValueBytes:           p.valueBytes[i],
+			QueryDistance:      tempDistances[i],
+			ErrorBound:         tempErrorBounds[i],
+			CentroidDistance:   centroidDistances[i],
+			ParentPartitionKey: partitionKey,
+			ChildKey:           p.childKeys[i],
+			ValueBytes:         p.valueBytes[i],
 		}
 		searchSet.Add(&searchSet.tempResult)
 	}

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -210,11 +210,11 @@ func TestPartition(t *testing.T) {
 		count = partition.Search(&workspace, RootKey, vector.T{1, 1}, &searchSet)
 		require.Equal(t, 5, count)
 		result1 := SearchResult{
-			QuerySquaredDistance: 1, ErrorBound: 0, CentroidDistance: 3.2830, ParentPartitionKey: 1, ChildKey: childKey10, ValueBytes: valueBytes10}
+			QueryDistance: 1, ErrorBound: 0, CentroidDistance: 3.2830, ParentPartitionKey: 1, ChildKey: childKey10, ValueBytes: valueBytes10}
 		result2 := SearchResult{
-			QuerySquaredDistance: 13, ErrorBound: 0, CentroidDistance: 0.3333, ParentPartitionKey: 1, ChildKey: childKey40, ValueBytes: valueBytes40}
+			QueryDistance: 13, ErrorBound: 0, CentroidDistance: 0.3333, ParentPartitionKey: 1, ChildKey: childKey40, ValueBytes: valueBytes40}
 		result3 := SearchResult{
-			QuerySquaredDistance: 17, ErrorBound: 0, CentroidDistance: 1.6667, ParentPartitionKey: 1, ChildKey: childKey20, ValueBytes: valueBytes20}
+			QueryDistance: 17, ErrorBound: 0, CentroidDistance: 1.6667, ParentPartitionKey: 1, ChildKey: childKey20, ValueBytes: valueBytes20}
 		results = roundResults(searchSet.PopResults(), 4)
 		require.Equal(t, SearchResults{result1, result2, result3}, results)
 	})
@@ -271,7 +271,7 @@ func TestPartition(t *testing.T) {
 func roundResults(results SearchResults, prec int) SearchResults {
 	for i := range results {
 		result := &results[i]
-		result.QuerySquaredDistance = float32(scalar.Round(float64(result.QuerySquaredDistance), prec))
+		result.QueryDistance = float32(scalar.Round(float64(result.QueryDistance), prec))
 		result.ErrorBound = float32(scalar.Round(float64(result.ErrorBound), prec))
 		result.CentroidDistance = float32(scalar.Round(float64(result.CentroidDistance), prec))
 		result.Vector = testutils.RoundFloats(result.Vector, prec)

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -96,7 +96,7 @@ func TestPartition(t *testing.T) {
 		require.NotEqual(t, partition, cloned)
 
 		cloned = partition.Clone()
-		cloned.quantizedSet.(*quantize.UnQuantizedVectorSet).CentroidDistances[0] = 99
+		cloned.quantizedSet.(*quantize.UnQuantizedVectorSet).Vectors.At(0)[0] = 99
 		require.NotEqual(t, partition, cloned)
 	})
 
@@ -210,11 +210,11 @@ func TestPartition(t *testing.T) {
 		count = partition.Search(&workspace, RootKey, vector.T{1, 1}, &searchSet)
 		require.Equal(t, 5, count)
 		result1 := SearchResult{
-			QueryDistance: 1, ErrorBound: 0, CentroidDistance: 3.2830, ParentPartitionKey: 1, ChildKey: childKey10, ValueBytes: valueBytes10}
+			QueryDistance: 1, ErrorBound: 0, ParentPartitionKey: 1, ChildKey: childKey10, ValueBytes: valueBytes10}
 		result2 := SearchResult{
-			QueryDistance: 13, ErrorBound: 0, CentroidDistance: 0.3333, ParentPartitionKey: 1, ChildKey: childKey40, ValueBytes: valueBytes40}
+			QueryDistance: 13, ErrorBound: 0, ParentPartitionKey: 1, ChildKey: childKey40, ValueBytes: valueBytes40}
 		result3 := SearchResult{
-			QueryDistance: 17, ErrorBound: 0, CentroidDistance: 1.6667, ParentPartitionKey: 1, ChildKey: childKey20, ValueBytes: valueBytes20}
+			QueryDistance: 17, ErrorBound: 0, ParentPartitionKey: 1, ChildKey: childKey20, ValueBytes: valueBytes20}
 		results = roundResults(searchSet.PopResults(), 4)
 		require.Equal(t, SearchResults{result1, result2, result3}, results)
 	})
@@ -273,7 +273,6 @@ func roundResults(results SearchResults, prec int) SearchResults {
 		result := &results[i]
 		result.QueryDistance = float32(scalar.Round(float64(result.QueryDistance), prec))
 		result.ErrorBound = float32(scalar.Round(float64(result.ErrorBound), prec))
-		result.CentroidDistance = float32(scalar.Round(float64(result.CentroidDistance), prec))
 		result.Vector = testutils.RoundFloats(result.Vector, prec)
 	}
 	return results

--- a/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
@@ -33,6 +33,7 @@ go_library(
         "rabitqpb.go",
         "unquantizedpb.go",
         "unquantizer.go",
+        "validate.go",
     ],
     embed = [":quantize_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize",
@@ -44,6 +45,7 @@ go_library(
         "//pkg/util/num32",
         "//pkg/util/vector",
         "@com_github_cockroachdb_errors//:errors",
+        "@org_gonum_v1_gonum//floats/scalar",
     ],
 )
 

--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -35,6 +35,9 @@ message RaBitQuantizedVectorSet {
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
+  // NOTE: By default, this is the mean centroid for the L2Squared distance
+  // metric, but is the spherical centroid for InnerProduct and Cosine metrics.
+  // The spherical centroid is simply the mean centroid, but normalized.
   // NOTE: The centroid should be treated as immutable.
   repeated float centroid = 1;
   // Codes is a set of RaBitQ quantization codes, with one code per quantized
@@ -42,8 +45,8 @@ message RaBitQuantizedVectorSet {
   RaBitQCodeSet codes = 2 [(gogoproto.nullable) = false];
   // CodeCounts records the count of "1" bits in each of the quantization codes.
   repeated uint32 code_counts = 3;
-  // CentroidDistances is a slice of the exact distances of the original
-  // full-size vectors from the centroid.
+  // CentroidDistances is a slice of the exact Euclidean distances (non-squared)
+  // of the original full-size vectors from the centroid.
   repeated float centroid_distances = 4;
   // QuantizedDotProducts is a slice of the exact inner products between the
   // original full-size vectors and their corresponding quantized vectors.
@@ -64,6 +67,9 @@ message UnQuantizedVectorSet {
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
+  // NOTE: By default, this is the mean centroid for the L2Squared distance
+  // metric, but is the spherical centroid for InnerProduct and Cosine metrics.
+  // The spherical centroid is simply the mean centroid, but normalized.
   // NOTE: The centroid should be treated as immutable.
   repeated float centroid = 1;
   reserved 2; // CentroidDistances

--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -66,9 +66,7 @@ message UnQuantizedVectorSet {
   // is not updated when vectors are added or removed.
   // NOTE: The centroid should be treated as immutable.
   repeated float centroid = 1;
-  // CentroidDistances is a slice of the exact distances of the vectors in the
-  // set from the centroid.
-  repeated float centroid_distances = 2;
+  reserved 2; // CentroidDistances
   // Vectors is the set of original full-size vectors.
   cockroach.util.vector.Set vectors = 3 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/vecindex/cspann/quantize/quantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer.go
@@ -72,6 +72,9 @@ type QuantizedVectorSet interface {
 
 	// GetCentroid returns the full-size centroid vector for the set. The
 	// centroid is the average of the vectors across all dimensions.
+	// NOTE: By default, this is the mean centroid for the L2Squared distance
+	// metric, but is the spherical centroid for InnerProduct and Cosine metrics.
+	// The spherical centroid is simply the mean centroid, but normalized.
 	// NOTE: This centroid is calculated once, when the set is first created. It
 	// is not updated when quantized vectors are added to or removed from the set.
 	// Since it is immutable, this method is thread-safe.

--- a/pkg/sql/vecindex/cspann/quantize/quantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer.go
@@ -77,10 +77,6 @@ type QuantizedVectorSet interface {
 	// Since it is immutable, this method is thread-safe.
 	GetCentroid() vector.T
 
-	// GetCentroidDistances returns the exact distances of each full-size vector
-	// from the centroid.
-	GetCentroidDistances() []float32
-
 	// ReplaceWithLast removes the quantized vector at the given offset from the
 	// set, replacing it with the last quantized vector in the set. The modified
 	// set has one less element and the last quantized vector's position changes.

--- a/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
@@ -41,7 +41,7 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 		quantizer.EstimateDistances(
 			&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
 		require.Equal(t, []float32{17, 0, 41, 13, 41}, testutils.RoundFloats(distances, 2))
-		require.Equal(t, []float32{7.21, 16.12, 14.42, 0, 14.42},
+		require.Equal(t, []float32{7.21, 14.12, 14.42, 0, 14.42},
 			testutils.RoundFloats(errorBounds, 2))
 		require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
 
@@ -176,6 +176,68 @@ func TestRaBitQuantizerEdge(t *testing.T) {
 	})
 }
 
+// Test InnerProduct distance metric.
+func TestRaBitQuantizerInnerProduct(t *testing.T) {
+	var workspace workspace.T
+	quantizer := NewRaBitQuantizer(2, 42, vecdist.InnerProduct)
+	require.Equal(t, 2, quantizer.GetDims())
+
+	// Add 3 vectors and verify spherical centroid.
+	vectors := vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
+	quantizedSet := quantizer.Quantize(&workspace, vectors).(*RaBitQuantizedVectorSet)
+	require.Equal(t, []float32{0.8, 0.6},
+		testutils.RoundFloats(quantizedSet.GetCentroid(), 4))
+
+	// Ensure distances and error bounds are correct.
+	distances := make([]float32, quantizedSet.GetCount())
+	errorBounds := make([]float32, quantizedSet.GetCount())
+	quantizer.EstimateDistances(&workspace, quantizedSet, vector.T{3, 4}, distances, errorBounds)
+	require.Equal(t, []float32{-28.6, -12.8, -38.67}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{12.68, 4.05, 19.51}, testutils.RoundFloats(errorBounds, 2))
+
+	// Query vector is the centroid.
+	quantizer.EstimateDistances(&workspace, quantizedSet, quantizedSet.GetCentroid(),
+		distances, errorBounds)
+	require.Equal(t, []float32{-5.2, -2, -7.8}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0, 0, 0}, testutils.RoundFloats(errorBounds, 2))
+
+	// Call NewQuantizedSet and ensure capacity.
+	quantizedSet = quantizer.NewQuantizedVectorSet(
+		5, quantizedSet.GetCentroid()).(*RaBitQuantizedVectorSet)
+	require.Equal(t, 5, cap(quantizedSet.CentroidDotProducts))
+}
+
+// Test Cosine distance metric.
+func TestRaBitQuantizerCosine(t *testing.T) {
+	var workspace workspace.T
+	quantizer := NewRaBitQuantizer(2, 42, vecdist.Cosine)
+	require.Equal(t, 2, quantizer.GetDims())
+
+	// Add 3 vectors and verify spherical centroid.
+	vectors := vector.MakeSetFromRawData([]float32{1, 0, 0, 1, 0.70710678, 0.70710678}, 2)
+	quantizedSet := quantizer.Quantize(&workspace, vectors).(*RaBitQuantizedVectorSet)
+	require.Equal(t, []float32{0.7071, 0.7071},
+		testutils.RoundFloats(quantizedSet.GetCentroid(), 4))
+
+	// Ensure distances and error bounds are correct.
+	distances := make([]float32, quantizedSet.GetCount())
+	errorBounds := make([]float32, quantizedSet.GetCount())
+	quantizer.EstimateDistances(&workspace, quantizedSet, vector.T{-1, 0}, distances, errorBounds)
+	require.Equal(t, []float32{2, 1.41, 1.71}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0.41, 1, 0}, testutils.RoundFloats(errorBounds, 2))
+
+	// Query vector is the centroid.
+	quantizer.EstimateDistances(&workspace, quantizedSet, quantizedSet.GetCentroid(),
+		distances, errorBounds)
+	require.Equal(t, []float32{0.29, 0.29, 0}, testutils.RoundFloats(distances, 2))
+	require.Equal(t, []float32{0, 0, 0}, testutils.RoundFloats(errorBounds, 2))
+
+	// Call NewQuantizedSet and ensure capacity.
+	quantizedSet = quantizer.NewQuantizedVectorSet(
+		5, quantizedSet.GetCentroid()).(*RaBitQuantizedVectorSet)
+	require.Equal(t, 5, cap(quantizedSet.CentroidDotProducts))
+}
+
 // Load some real OpenAI embeddings and spot check calculations.
 func TestRaBitQuantizeEmbeddings(t *testing.T) {
 	var workspace workspace.T
@@ -208,7 +270,7 @@ func TestRaBitQuantizeEmbeddings(t *testing.T) {
 	num32.Round(errorBounds, 4)
 	require.Equal(t, float32(0), distances[0])
 	require.Equal(t, float32(1.1069), distances[99])
-	require.Equal(t, float32(0.0477), errorBounds[0])
+	require.Equal(t, float32(0.0247), errorBounds[0])
 	require.Equal(t, float32(0.0476), errorBounds[99])
 }
 

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
@@ -119,11 +119,6 @@ func (vs *RaBitQuantizedVectorSet) GetCentroid() vector.T {
 	return vs.Centroid
 }
 
-// GetCentroidDistances implements the QuantizedVectorSet interface.
-func (vs *RaBitQuantizedVectorSet) GetCentroidDistances() []float32 {
-	return vs.CentroidDistances
-}
-
 // ReplaceWithLast implements the QuantizedVectorSet interface.
 func (vs *RaBitQuantizedVectorSet) ReplaceWithLast(offset int) {
 	lastOffset := len(vs.CodeCounts) - 1

--- a/pkg/sql/vecindex/cspann/quantize/testdata/calculate-recall.ddt
+++ b/pkg/sql/vecindex/cspann/quantize/testdata/calculate-recall.ddt
@@ -8,15 +8,15 @@
 calculate-recall dataset=images-512d-10k
 ----
 Euclidean: 69.50% recall@10
-Cosine: 69.50% recall@10
-InnerProduct: 69.50% recall@10
+InnerProduct: 67.00% recall@10
+Cosine: 67.00% recall@10
 
 # Repeat, but with randomized rotations to "mix" the vectors.
 calculate-recall dataset=images-512d-10k randomize
 ----
 Euclidean: 81.50% recall@10
-Cosine: 81.50% recall@10
-InnerProduct: 81.50% recall@10
+InnerProduct: 77.50% recall@10
+Cosine: 77.50% recall@10
 
 # ----------------------------------------------------------------------
 # Calculate average recall on random vectors with 20 dimensions.
@@ -24,16 +24,16 @@ InnerProduct: 81.50% recall@10
 calculate-recall dataset=random-20d-1k
 ----
 Euclidean: 88.00% recall@10
-Cosine: 93.00% recall@10
 InnerProduct: 93.00% recall@10
+Cosine: 78.00% recall@10
 
 # Repeat with randomization. Since these are already random, there should be no
 # material difference.
 calculate-recall dataset=random-20d-1k randomize
 ----
 Euclidean: 91.50% recall@10
-Cosine: 90.50% recall@10
-InnerProduct: 90.50% recall@10
+InnerProduct: 89.00% recall@10
+Cosine: 81.00% recall@10
 
 # ----------------------------------------------------------------------
 # Calculate average recall on 28x28 greyscale pixel images (flattened to 784
@@ -42,15 +42,15 @@ InnerProduct: 90.50% recall@10
 calculate-recall dataset=fashion-784d-1k
 ----
 Euclidean: 77.00% recall@10
-Cosine: 75.50% recall@10
-InnerProduct: 75.50% recall@10
+InnerProduct: 77.50% recall@10
+Cosine: 72.50% recall@10
 
 # Repeat with randomization.
 calculate-recall dataset=fashion-784d-1k randomize
 ----
 Euclidean: 87.00% recall@10
-Cosine: 88.00% recall@10
-InnerProduct: 88.00% recall@10
+InnerProduct: 85.00% recall@10
+Cosine: 84.50% recall@10
 
 # ----------------------------------------------------------------------
 # Calculate average recall on Laion image embeddings with 768 dimensions.
@@ -58,15 +58,15 @@ InnerProduct: 88.00% recall@10
 calculate-recall dataset=laion-768d-1k
 ----
 Euclidean: 73.00% recall@10
-Cosine: 74.00% recall@10
-InnerProduct: 74.00% recall@10
+InnerProduct: 60.00% recall@10
+Cosine: 60.50% recall@10
 
 # Repeat with randomization.
 calculate-recall dataset=laion-768d-1k randomize
 ----
 Euclidean: 79.50% recall@10
-Cosine: 79.50% recall@10
-InnerProduct: 79.50% recall@10
+InnerProduct: 77.00% recall@10
+Cosine: 78.00% recall@10
 
 # ----------------------------------------------------------------------
 # Calculate average recall on DBpedia text embeddings with 1536 dimensions.
@@ -74,12 +74,12 @@ InnerProduct: 79.50% recall@10
 calculate-recall dataset=dbpedia-1536d-1k
 ----
 Euclidean: 80.50% recall@10
-Cosine: 80.50% recall@10
-InnerProduct: 80.50% recall@10
+InnerProduct: 84.00% recall@10
+Cosine: 84.00% recall@10
 
 # Repeat with randomization.
 calculate-recall dataset=dbpedia-1536d-1k randomize
 ----
 Euclidean: 85.00% recall@10
-Cosine: 85.00% recall@10
-InnerProduct: 85.00% recall@10
+InnerProduct: 83.00% recall@10
+Cosine: 83.00% recall@10

--- a/pkg/sql/vecindex/cspann/quantize/testdata/estimate-distances.ddt
+++ b/pkg/sql/vecindex/cspann/quantize/testdata/estimate-distances.ddt
@@ -3,96 +3,126 @@ estimate-distances query=[0,2]
 [-2,0]
 [2,0]
 ----
-Centroid = (0, 0)
 L2Squared
-  (-2, 0): exact is 8, estimate is 0 ± 5.66
-  (2, 0): exact is 8, estimate is 0 ± 5.66
+  Query = (0, 2)
+  Centroid = (0, 0)
+  (-2, 0): exact is 8, estimate is 0 ± 5.7
+  (2, 0): exact is 8, estimate is 0 ± 5.7
 InnerProduct
-  (-2, 0): exact is 0, estimate is -4 ± 2.83
-  (2, 0): exact is 0, estimate is -4 ± 2.83
+  Query = (0, 2)
+  Centroid = (0, 0)
+  (-2, 0): exact is 0, estimate is -4 ± 2.8
+  (2, 0): exact is 0, estimate is -4 ± 2.8
 Cosine
-  (-1, 0): exact is 1, estimate is 0 ± 0.71
-  (1, 0): exact is 1, estimate is 0 ± 0.71
+  Query = (0, 1)
+  Centroid = (0, 0)
+  (-1, 0): exact is 1, estimate is 0 ± 0.7071
+  (1, 0): exact is 1, estimate is 0 ± 0.7071
 
 # Translate centroid to non-origin point [2,2].
 estimate-distances query=[2,4]
 [0,2]
 [4,2]
 ----
-Centroid = (2, 2)
 L2Squared
-  (0, 2): exact is 8, estimate is 0 ± 5.66
-  (4, 2): exact is 8, estimate is 0 ± 5.66
+  Query = (2, 4)
+  Centroid = (2, 2)
+  (0, 2): exact is 8, estimate is 0 ± 5.7
+  (4, 2): exact is 8, estimate is 0 ± 5.7
 InnerProduct
-  (0, 2): exact is -8, estimate is -12 ± 2.83
-  (4, 2): exact is -16, estimate is -20 ± 2.83
+  Query = (2, 4)
+  Centroid = (0.7071, 0.7071)
+  (0, 2): exact is -8, estimate is -6.8 ± 3.7
+  (4, 2): exact is -16, estimate is -20 ± 8.8
 Cosine
-  (0, 1): exact is 0.106, estimate is 0.088 ± 0.06
-  (0.8944, 0.4472): exact is 0.2, estimate is 0.218 ± 0.06
+  Query = (0.4472, 0.8944)
+  Centroid = (0.5257, 0.8507)
+  (0, 1): exact is 0.106, estimate is 0.0993 ± 0.0347
+  (0.8944, 0.4472): exact is 0.2, estimate is 0.2007 ± 0.0347
 
 # Centroid is [0,0], query vector equals one of the data vectors.
 estimate-distances query=[2,0]
 [-2,0]
 [2,0]
 ----
-Centroid = (0, 0)
 L2Squared
-  (-2, 0): exact is 16, estimate is 16 ± 5.66
-  (2, 0): exact is 0, estimate is 0 ± 5.66
+  Query = (2, 0)
+  Centroid = (0, 0)
+  (-2, 0): exact is 16, estimate is 16 ± 5.7
+  (2, 0): exact is 0, estimate is 0 ± 5.7
 InnerProduct
-  (-2, 0): exact is 4, estimate is 4 ± 2.83
-  (2, 0): exact is -4, estimate is -4 ± 2.83
+  Query = (2, 0)
+  Centroid = (0, 0)
+  (-2, 0): exact is 4, estimate is 4 ± 2.8
+  (2, 0): exact is -4, estimate is -4 ± 2.8
 Cosine
-  (-1, 0): exact is 2, estimate is 2 ± 0.71
-  (1, 0): exact is 0, estimate is 0 ± 0.71
+  Query = (1, 0)
+  Centroid = (0, 0)
+  (-1, 0): exact is 2, estimate is 2 ± 0.7071
+  (1, 0): exact is 0, estimate is 0 ± 0.7071
 
 # Translate centroid to non-origin point [2,2].
 estimate-distances query=[4,2]
 [0,2]
 [4,2]
 ----
-Centroid = (2, 2)
 L2Squared
-  (0, 2): exact is 16, estimate is 16 ± 5.66
-  (4, 2): exact is 0, estimate is 0 ± 5.66
+  Query = (4, 2)
+  Centroid = (2, 2)
+  (0, 2): exact is 16, estimate is 16 ± 5.7
+  (4, 2): exact is 0, estimate is 0 ± 5.7
 InnerProduct
-  (0, 2): exact is -4, estimate is -4 ± 2.83
-  (4, 2): exact is -20, estimate is -20 ± 2.83
+  Query = (4, 2)
+  Centroid = (0.7071, 0.7071)
+  (0, 2): exact is -4, estimate is -2.5 ± 3.7
+  (4, 2): exact is -20, estimate is -20 ± 8.8
 Cosine
-  (0, 1): exact is 0.553, estimate is 0.553 ± 0.2
-  (0.8944, 0.4472): exact is 0, estimate is 0 ± 0.2
+  Query = (0.8944, 0.4472)
+  Centroid = (0.5257, 0.8507)
+  (0, 1): exact is 0.553, estimate is 0.6403 ± 0.2112
+  (0.8944, 0.4472): exact is 0, estimate is 0 ± 0.2112
 
 # Query vector is parallel, but longer, than one of the data vectors.
 estimate-distances query=[4,0]
 [-2,0]
 [2,0]
 ----
-Centroid = (0, 0)
 L2Squared
-  (-2, 0): exact is 36, estimate is 36 ± 11.31
-  (2, 0): exact is 4, estimate is 4 ± 11.31
+  Query = (4, 0)
+  Centroid = (0, 0)
+  (-2, 0): exact is 36, estimate is 36 ± 11.3
+  (2, 0): exact is 4, estimate is 4 ± 11.3
 InnerProduct
-  (-2, 0): exact is 8, estimate is 8 ± 5.66
-  (2, 0): exact is -8, estimate is -8 ± 5.66
+  Query = (4, 0)
+  Centroid = (0, 0)
+  (-2, 0): exact is 8, estimate is 8 ± 5.7
+  (2, 0): exact is -8, estimate is -8 ± 5.7
 Cosine
-  (-1, 0): exact is 2, estimate is 2 ± 0.71
-  (1, 0): exact is 0, estimate is 0 ± 0.71
+  Query = (1, 0)
+  Centroid = (0, 0)
+  (-1, 0): exact is 2, estimate is 2 ± 0.7071
+  (1, 0): exact is 0, estimate is 0 ± 0.7071
 
 # Query vector is equal to the centroid.
 estimate-distances query=[2,2]
 [0,2]
 [4,2]
 ----
-Centroid = (2, 2)
 L2Squared
+  Query = (2, 2)
+  Centroid = (2, 2)
   (0, 2): exact is 4, estimate is 4
   (4, 2): exact is 4, estimate is 4
 InnerProduct
-  (0, 2): exact is -4, estimate is -4
-  (4, 2): exact is -12, estimate is -12
+  Query = (2, 2)
+  Centroid = (0.7071, 0.7071)
+  (0, 2): exact is -4, estimate is -3.2 ± 1.9
+  (4, 2): exact is -12, estimate is -13.1 ± 4.6
 Cosine
-  (0, 1): exact is 0.293, estimate is 0.278 ± 0.1
-  (0.8944, 0.4472): exact is 0.051, estimate is 0.067 ± 0.1
+  Query = (0.7071, 0.7071)
+  Centroid = (0.5257, 0.8507)
+  (0, 1): exact is 0.293, estimate is 0.3199 ± 0.0894
+  (0.8944, 0.4472): exact is 0.051, estimate is 0.0504 ± 0.0894
 
 # All data vectors are the same, query is the same.
 estimate-distances query=[2,2]
@@ -100,19 +130,24 @@ estimate-distances query=[2,2]
 [2,2]
 [2,2]
 ----
-Centroid = (2, 2)
 L2Squared
+  Query = (2, 2)
+  Centroid = (2, 2)
   (2, 2): exact is 0, estimate is 0
   (2, 2): exact is 0, estimate is 0
   (2, 2): exact is 0, estimate is 0
 InnerProduct
-  (2, 2): exact is -8, estimate is -8
-  (2, 2): exact is -8, estimate is -8
-  (2, 2): exact is -8, estimate is -8
+  Query = (2, 2)
+  Centroid = (0.7071, 0.7071)
+  (2, 2): exact is -8, estimate is -8 ± 2.4
+  (2, 2): exact is -8, estimate is -8 ± 2.4
+  (2, 2): exact is -8, estimate is -8 ± 2.4
 Cosine
-  (0.7071, 0.7071): exact is 0, estimate is 0
-  (0.7071, 0.7071): exact is 0, estimate is 0
-  (0.7071, 0.7071): exact is 0, estimate is 0
+  Query = (0.7071, 0.7071)
+  Centroid = (0.7071, 0.7071)
+  (0.7071, 0.7071): exact is 0, estimate is 0 ± 0
+  (0.7071, 0.7071): exact is 0, estimate is 0 ± 0
+  (0.7071, 0.7071): exact is 0, estimate is 0 ± 0
 
 # All data vectors are the same, query is different.
 estimate-distances query=[3,4]
@@ -120,19 +155,24 @@ estimate-distances query=[3,4]
 [2,2]
 [2,2]
 ----
-Centroid = (2, 2)
 L2Squared
+  Query = (3, 4)
+  Centroid = (2, 2)
   (2, 2): exact is 5, estimate is 5
   (2, 2): exact is 5, estimate is 5
   (2, 2): exact is 5, estimate is 5
 InnerProduct
-  (2, 2): exact is -14, estimate is -14
-  (2, 2): exact is -14, estimate is -14
-  (2, 2): exact is -14, estimate is -14
+  Query = (3, 4)
+  Centroid = (0.7071, 0.7071)
+  (2, 2): exact is -14, estimate is -14 ± 5.2
+  (2, 2): exact is -14, estimate is -14 ± 5.2
+  (2, 2): exact is -14, estimate is -14 ± 5.2
 Cosine
-  (0.7071, 0.7071): exact is 0.01, estimate is 0.01
-  (0.7071, 0.7071): exact is 0.01, estimate is 0.01
-  (0.7071, 0.7071): exact is 0.01, estimate is 0.01
+  Query = (0.6, 0.8)
+  Centroid = (0.7071, 0.7071)
+  (0.7071, 0.7071): exact is 0.01, estimate is 0.0101 ± 0
+  (0.7071, 0.7071): exact is 0.01, estimate is 0.0101 ± 0
+  (0.7071, 0.7071): exact is 0.01, estimate is 0.0101 ± 0
 
 # All data vectors and query vector are zeros.
 estimate-distances query=[0,0]
@@ -140,19 +180,24 @@ estimate-distances query=[0,0]
 [0,0]
 [0,0]
 ----
-Centroid = (0, 0)
 L2Squared
+  Query = (0, 0)
+  Centroid = (0, 0)
   (0, 0): exact is 0, estimate is 0
   (0, 0): exact is 0, estimate is 0
   (0, 0): exact is 0, estimate is 0
 InnerProduct
+  Query = (0, 0)
+  Centroid = (0, 0)
   (0, 0): exact is 0, estimate is 0
   (0, 0): exact is 0, estimate is 0
   (0, 0): exact is 0, estimate is 0
 Cosine
-  (0.7071, 0.7071): exact is 0, estimate is 0
-  (0.7071, 0.7071): exact is 0, estimate is 0
-  (0.7071, 0.7071): exact is 0, estimate is 0
+  Query = (0, 0)
+  Centroid = (0, 0)
+  (0, 0): exact is 1, estimate is 1
+  (0, 0): exact is 1, estimate is 1
+  (0, 0): exact is 1, estimate is 1
 
 # All data vectors are colinear, but at different scales.
 estimate-distances query=[10,0]
@@ -160,16 +205,21 @@ estimate-distances query=[10,0]
 [4,0]
 [16,0]
 ----
-Centroid = (7, 0)
 L2Squared
-  (1, 0): exact is 81, estimate is 81 ± 25.46
-  (4, 0): exact is 36, estimate is 36 ± 12.73
-  (16, 0): exact is 36, estimate is 36 ± 38.18
+  Query = (10, 0)
+  Centroid = (7, 0)
+  (1, 0): exact is 81, estimate is 81 ± 25.5
+  (4, 0): exact is 36, estimate is 36 ± 12.7
+  (16, 0): exact is 36, estimate is 36 ± 38.2
 InnerProduct
-  (1, 0): exact is -10, estimate is -10 ± 12.73
-  (4, 0): exact is -40, estimate is -40 ± 6.36
-  (16, 0): exact is -160, estimate is -160 ± 19.09
+  Query = (10, 0)
+  Centroid = (1, 0)
+  (1, 0): exact is -10, estimate is -10
+  (4, 0): exact is -40, estimate is -40 ± 19.1
+  (16, 0): exact is -160, estimate is -160 ± 95.5
 Cosine
+  Query = (1, 0)
+  Centroid = (1, 0)
   (1, 0): exact is 0, estimate is 0
   (1, 0): exact is 0, estimate is 0
   (1, 0): exact is 0, estimate is 0
@@ -183,28 +233,33 @@ estimate-distances query=[3,4]
 [1,8]
 [12,5]
 ----
-Centroid = (4.5, 3.5)
 L2Squared
-  (5, -1): exact is 29, estimate is 39.4 ± 10.12
-  (2, 2): exact is 5, estimate is 6.75 ± 6.52
-  (3, 4): exact is 0, estimate is 0 ± 3.54
-  (4, 3): exact is 2, estimate is 2 ± 1.58
-  (1, 8): exact is 20, estimate is 18.75 ± 12.75
+  Query = (3, 4)
+  Centroid = (4.5, 3.5)
+  (5, -1): exact is 29, estimate is 39.4 ± 10.1
+  (2, 2): exact is 5, estimate is 6.8 ± 6.5
+  (3, 4): exact is 0, estimate is 0 ± 3.5
+  (4, 3): exact is 2, estimate is 2 ± 1.6
+  (1, 8): exact is 20, estimate is 18.7 ± 12.7
   (12, 5): exact is 82, estimate is 74 ± 17.1
 InnerProduct
-  (5, -1): exact is -11, estimate is -5.8 ± 5.06
-  (2, 2): exact is -14, estimate is -13.125 ± 3.26
-  (3, 4): exact is -25, estimate is -25 ± 1.77
-  (4, 3): exact is -24, estimate is -24 ± 0.79
-  (1, 8): exact is -35, estimate is -35.625 ± 6.37
-  (12, 5): exact is -56, estimate is -60 ± 8.55
+  Query = (3, 4)
+  Centroid = (0.7894, 0.6139)
+  (5, -1): exact is -11, estimate is -3.1 ± 12.9
+  (2, 2): exact is -14, estimate is -13.9 ± 5.3
+  (3, 4): exact is -25, estimate is -25 ± 11.6
+  (4, 3): exact is -24, estimate is -24.8 ± 11.4
+  (1, 8): exact is -35, estimate is -49.7 ± 21.1
+  (12, 5): exact is -56, estimate is -68.4 ± 34.4
 Cosine
-  (0.9806, -0.1961): exact is 0.569, estimate is 0.565 ± 0.15
-  (0.7071, 0.7071): exact is 0.01, estimate is 0.025 ± 0.03
-  (0.6, 0.8): exact is 0, estimate is 0 ± 0.05
-  (0.8, 0.6): exact is 0.04, estimate is 0.028 ± 0.02
-  (0.124, 0.9923): exact is 0.132, estimate is 0.119 ± 0.14
-  (0.9231, 0.3846): exact is 0.138, estimate is 0.146 ± 0.05
+  Query = (0.6, 0.8)
+  Centroid = (0.7827, 0.6224)
+  (0.9806, -0.1961): exact is 0.569, estimate is 0.6384 ± 0.1517
+  (0.7071, 0.7071): exact is 0.01, estimate is 0.0099 ± 0.0205
+  (0.6, 0.8): exact is 0, estimate is 0 ± 0.0459
+  (0.8, 0.6): exact is 0.04, estimate is 0.0401 ± 0.0051
+  (0.124, 0.9923): exact is 0.132, estimate is 0.1179 ± 0.1361
+  (0.9231, 0.3846): exact is 0.138, estimate is 0.1432 ± 0.0497
 
 # Query is far outside the data cloud.
 estimate-distances query=[100,100]
@@ -213,30 +268,35 @@ estimate-distances query=[100,100]
 [3,4]
 [4,3]
 [1,8]
-[12,5]
+[12,6]
 ----
-Centroid = (4.5, 3.5)
 L2Squared
-  (5, -1): exact is 19226, estimate is 18461.199 ± 869.33
-  (2, 2): exact is 19208, estimate is 19257 ± 559.78
-  (3, 4): exact is 18625, estimate is 18432.5 ± 303.58
-  (4, 3): exact is 18625, estimate is 18625 ± 135.77
-  (1, 8): exact is 18265, estimate is 18456.875 ± 1094.58
-  (12, 5): exact is 16769, estimate is 15995 ± 1468.54
+  Query = (100, 100)
+  Centroid = (4.5, 3.6667)
+  (5, -1): exact is 19226, estimate is 18429.5 ± 900.4
+  (2, 2): exact is 19208, estimate is 19240.7 ± 576.4
+  (3, 4): exact is 18625, estimate is 18400.6 ± 294.8
+  (4, 3): exact is 18625, estimate is 18629.4 ± 159.9
+  (1, 8): exact is 18265, estimate is 18424.8 ± 1068.6
+  (12, 6): exact is 16580, estimate is 16054.9 ± 1506.8
 InnerProduct
-  (5, -1): exact is -400, estimate is -782.4 ± 434.66
-  (2, 2): exact is -400, estimate is -375.5 ± 279.89
-  (3, 4): exact is -700, estimate is -796.25 ± 151.79
-  (4, 3): exact is -700, estimate is -700 ± 67.88
-  (1, 8): exact is -900, estimate is -804.063 ± 547.29
-  (12, 5): exact is -1700, estimate is -2087 ± 734.27
+  Query = (100, 100)
+  Centroid = (0.7752, 0.6317)
+  (5, -1): exact is -400, estimate is -142.4 ± 449.7
+  (2, 2): exact is -400, estimate is -400.8 ± 182.3
+  (3, 4): exact is -700, estimate is -723.1 ± 400.8
+  (4, 3): exact is -700, estimate is -713.1 ± 397.3
+  (1, 8): exact is -900, estimate is -1566.8 ± 732
+  (12, 6): exact is -1800, estimate is -2005.7 ± 1235.5
 Cosine
-  (0.9806, -0.1961): exact is 0.445, estimate is 0.419 ± 0.09
-  (0.7071, 0.7071): exact is 0, estimate is 0 ± 0.02
-  (0.6, 0.8): exact is 0.01, estimate is 0.019 ± 0.03
-  (0.8, 0.6): exact is 0.01, estimate is 0.004 ± 0.01
-  (0.124, 0.9923): exact is 0.211, estimate is 0.199 ± 0.08
-  (0.9231, 0.3846): exact is 0.075, estimate is 0.082 ± 0.03
+  Query = (0.7071, 0.7071)
+  Centroid = (0.7748, 0.6322)
+  (0.9806, -0.1961): exact is 0.445, estimate is 0.4698 ± 0.0609
+  (0.7071, 0.7071): exact is 0, estimate is 0 ± 0.0072
+  (0.6, 0.8): exact is 0.01, estimate is 0.01 ± 0.0173
+  (0.8, 0.6): exact is 0.01, estimate is 0.0101 ± 0.0029
+  (0.124, 0.9923): exact is 0.211, estimate is 0.2036 ± 0.0531
+  (0.8944, 0.4472): exact is 0.051, estimate is 0.0521 ± 0.0157
 
 # Data cloud is far away from origin.
 estimate-distances query=[108,108]
@@ -247,28 +307,33 @@ estimate-distances query=[108,108]
 [101,108]
 [112,105]
 ----
-Centroid = (104.5, 103.5)
 L2Squared
+  Query = (108, 108)
+  Centroid = (104.5, 103.5)
   (105, 99): exact is 90, estimate is 61.2 ± 36.5
-  (102, 102): exact is 72, estimate is 75 ± 23.51
-  (103, 104): exact is 41, estimate is 32.5 ± 12.75
+  (102, 102): exact is 72, estimate is 75 ± 23.5
+  (103, 104): exact is 41, estimate is 32.5 ± 12.7
   (104, 103): exact is 41, estimate is 41 ± 5.7
-  (101, 108): exact is 49, estimate is 56.875 ± 45.96
-  (112, 105): exact is 25, estimate is 0 ± 61.66
+  (101, 108): exact is 49, estimate is 56.9 ± 46
+  (112, 105): exact is 25, estimate is 0 ± 48.7
 InnerProduct
-  (105, 99): exact is -22032, estimate is -22046.398 ± 18.25
-  (102, 102): exact is -22032, estimate is -22030.5 ± 11.75
-  (103, 104): exact is -22356, estimate is -22360.25 ± 6.37
-  (104, 103): exact is -22356, estimate is -22356 ± 2.85
-  (101, 108): exact is -22572, estimate is -22568.062 ± 22.98
-  (112, 105): exact is -23436, estimate is -23455 ± 30.83
+  Query = (108, 108)
+  Centroid = (0.7105, 0.7037)
+  (105, 99): exact is -22032, estimate is -22051 ± 15376.4
+  (102, 102): exact is -22032, estimate is -22032 ± 15369.7
+  (103, 104): exact is -22356, estimate is -22356.5 ± 15597.5
+  (104, 103): exact is -22356, estimate is -22356.5 ± 15597.5
+  (101, 108): exact is -22572, estimate is -22597.3 ± 15758
+  (112, 105): exact is -23436, estimate is -23460.4 ± 16364.6
 Cosine
-  (0.7276, 0.686): exact is 0, estimate is 0 ± 0
+  Query = (0.7071, 0.7071)
+  Centroid = (0.7104, 0.7038)
+  (0.7276, 0.686): exact is 0, estimate is 0.0004 ± 0.0001
   (0.7071, 0.7071): exact is 0, estimate is 0 ± 0
   (0.7037, 0.7105): exact is 0, estimate is 0 ± 0
   (0.7105, 0.7037): exact is 0, estimate is 0 ± 0
-  (0.683, 0.7304): exact is 0.001, estimate is 0.001 ± 0
-  (0.7295, 0.6839): exact is 0.001, estimate is 0.001 ± 0
+  (0.683, 0.7304): exact is 0.001, estimate is 0.0006 ± 0.0001
+  (0.7295, 0.6839): exact is 0.001, estimate is 0.0005 ± 0.0001
 
 # Test more dimensions.
 estimate-distances query=[4,3,7,8]
@@ -279,25 +344,30 @@ estimate-distances query=[4,3,7,8]
 [1,8,10,12]
 [12,5,6,-4]
 ----
-Centroid = (4.5, 3.5, 4.8333, 6.1667)
 L2Squared
-  (5, -1, 3, 10): exact is 37, estimate is 49.681 ± 18.16
-  (2, 2, -5, 4): exact is 165, estimate is 159.348 ± 30.66
-  (3, 4, 8, 7): exact is 4, estimate is 4.246 ± 10.64
-  (4, 3, 7, 8): exact is 0, estimate is 0.076 ± 8.56
-  (1, 8, 10, 12): exact is 59, estimate is 62.744 ± 28.24
-  (12, 5, 6, -4): exact is 213, estimate is 182.124 ± 37.37
+  Query = (4, 3, 7, 8)
+  Centroid = (4.5, 3.5, 4.8333, 6.1667)
+  (5, -1, 3, 10): exact is 37, estimate is 49.7 ± 18.2
+  (2, 2, -5, 4): exact is 165, estimate is 159.3 ± 30.7
+  (3, 4, 8, 7): exact is 4, estimate is 4.2 ± 10.6
+  (4, 3, 7, 8): exact is 0, estimate is 0.1 ± 8.6
+  (1, 8, 10, 12): exact is 59, estimate is 62.7 ± 28.2
+  (12, 5, 6, -4): exact is 213, estimate is 182.1 ± 37.4
 InnerProduct
-  (5, -1, 3, 10): exact is -118, estimate is -111.659 ± 9.08
-  (2, 2, -5, 4): exact is -11, estimate is -13.826 ± 15.33
-  (3, 4, 8, 7): exact is -136, estimate is -135.877 ± 5.32
-  (4, 3, 7, 8): exact is -138, estimate is -137.962 ± 4.28
-  (1, 8, 10, 12): exact is -194, estimate is -192.128 ± 14.12
-  (12, 5, 6, -4): exact is -73, estimate is -88.438 ± 18.68
+  Query = (4, 3, 7, 8)
+  Centroid = (0.4644, 0.3612, 0.4988, 0.6364)
+  (5, -1, 3, 10): exact is -118, estimate is -116.8 ± 58.1
+  (2, 2, -5, 4): exact is -11, estimate is -40 ± 36.8
+  (3, 4, 8, 7): exact is -136, estimate is -138 ± 58.1
+  (4, 3, 7, 8): exact is -138, estimate is -137.8 ± 58
+  (1, 8, 10, 12): exact is -194, estimate is -218 ± 89.8
+  (12, 5, 6, -4): exact is -73, estimate is -59.7 ± 77.3
 Cosine
-  (0.4303, -0.0861, 0.2582, 0.8607): exact is 0.135, estimate is 0.225 ± 0.08
-  (0.2857, 0.2857, -0.7143, 0.5714): exact is 0.866, estimate is 0.708 ± 0.17
-  (0.2554, 0.3405, 0.681, 0.5959): exact is 0.014, estimate is 0.024 ± 0.07
-  (0.3405, 0.2554, 0.5959, 0.681): exact is 0, estimate is 0 ± 0.06
-  (0.0569, 0.4551, 0.5689, 0.6827): exact is 0.061, estimate is 0.062 ± 0.08
-  (0.8072, 0.3363, 0.4036, -0.2691): exact is 0.582, estimate is 0.414 ± 0.15
+  Query = (0.3405, 0.2554, 0.5959, 0.681)
+  Centroid = (0.4839, 0.3529, 0.3988, 0.6944)
+  (0.4303, -0.0861, 0.2582, 0.8607): exact is 0.135, estimate is 0.1517 ± 0.0648
+  (0.2857, 0.2857, -0.7143, 0.5714): exact is 0.866, estimate is 0.6193 ± 0.1497
+  (0.2554, 0.3405, 0.681, 0.5959): exact is 0.014, estimate is 0 ± 0.0481
+  (0.3405, 0.2554, 0.5959, 0.681): exact is 0, estimate is 0 ± 0.032
+  (0.0569, 0.4551, 0.5689, 0.6827): exact is 0.061, estimate is 0.0605 ± 0.0619
+  (0.8072, 0.3363, 0.4036, -0.2691): exact is 0.582, estimate is 0.4077 ± 0.1336

--- a/pkg/sql/vecindex/cspann/quantize/unquantizedpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizedpb.go
@@ -5,12 +5,7 @@
 
 package quantize
 
-import (
-	"slices"
-
-	"github.com/cockroachdb/cockroach/pkg/util/num32"
-	"github.com/cockroachdb/cockroach/pkg/util/vector"
-)
+import "github.com/cockroachdb/cockroach/pkg/util/vector"
 
 // GetCount implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) GetCount() int {
@@ -22,17 +17,11 @@ func (vs *UnQuantizedVectorSet) GetCentroid() vector.T {
 	return vs.Centroid
 }
 
-// GetCentroidDistances implements the QuantizedVectorSet interface.
-func (vs *UnQuantizedVectorSet) GetCentroidDistances() []float32 {
-	return vs.CentroidDistances
-}
-
 // Clone implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
 	return &UnQuantizedVectorSet{
-		Centroid:          vs.Centroid, // Centroid is immutable
-		CentroidDistances: slices.Clone(vs.CentroidDistances),
-		Vectors:           vs.Vectors.Clone(),
+		Centroid: vs.Centroid, // Centroid is immutable
+		Vectors:  vs.Vectors.Clone(),
 	}
 }
 
@@ -40,27 +29,15 @@ func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
 func (vs *UnQuantizedVectorSet) Clear(centroid vector.T) {
 	// vs.Centroid is immutable, so do not try to reuse its memory.
 	vs.Centroid = centroid
-	vs.CentroidDistances = vs.CentroidDistances[:0]
 	vs.Vectors.Clear()
 }
 
 // AddSet adds the given set of vectors to this set.
 func (vs *UnQuantizedVectorSet) AddSet(vectors vector.Set) {
 	vs.Vectors.AddSet(vectors)
-
-	// Compute the distance of each new vector to the set's centroid.
-	prevCount := len(vs.CentroidDistances)
-	vs.CentroidDistances = slices.Grow(vs.CentroidDistances, vectors.Count)
-	vs.CentroidDistances = vs.CentroidDistances[:prevCount+vectors.Count]
-	for i := 0; i < vectors.Count; i++ {
-		vs.CentroidDistances[prevCount+i] = num32.L2Distance(vectors.At(i), vs.Centroid)
-	}
 }
 
 // ReplaceWithLast implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) ReplaceWithLast(offset int) {
-	lastOffset := vs.Vectors.Count - 1
 	vs.Vectors.ReplaceWithLast(offset)
-	vs.CentroidDistances[offset] = vs.CentroidDistances[lastOffset]
-	vs.CentroidDistances = vs.CentroidDistances[:lastOffset]
 }

--- a/pkg/sql/vecindex/cspann/quantize/unquantizedpb_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizedpb_test.go
@@ -8,7 +8,6 @@ package quantize
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
 )
@@ -28,23 +27,17 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	vectors = vector.MakeSetFromRawData([]float32{7, 8, 9, 10}, 2)
 	quantizedSet.AddSet(vectors)
 	require.Equal(t, 5, quantizedSet.GetCount())
-	distances := testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 4)
-	require.Equal(t, []float32{3, 2.2361, 4.1231, 6.7082, 9.434}, distances)
 
 	// Ensure that cloning does not disturb anything.
 	cloned := quantizedSet.Clone().(*UnQuantizedVectorSet)
-	cloned.CentroidDistances[0] = 10
 	copy(cloned.Vectors.At(0), vector.T{0, 0})
 	cloned.ReplaceWithLast(1)
 
 	// Remove vector.
 	quantizedSet.ReplaceWithLast(2)
 	require.Equal(t, 4, quantizedSet.GetCount())
-	distances = testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 4)
-	require.Equal(t, []float32{3, 2.2361, 9.434, 6.7082}, distances)
 
 	// Check that clone is unaffected.
 	require.Equal(t, []float32{4, 2}, cloned.Centroid)
-	require.Equal(t, []float32{10, 9.43, 4.12, 6.71}, testutils.RoundFloats(cloned.CentroidDistances, 2))
 	require.Equal(t, vector.Set{Dims: 2, Count: 4, Data: []float32{0, 0, 9, 10, 5, 6, 7, 8}}, cloned.Vectors)
 }

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer.go
@@ -8,6 +8,7 @@ package quantize
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/vecdist"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/workspace"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 )
@@ -43,13 +44,22 @@ func (q *UnQuantizer) GetDistanceMetric() vecdist.Metric {
 
 // Quantize implements the Quantizer interface.
 func (q *UnQuantizer) Quantize(w *workspace.T, vectors vector.Set) QuantizedVectorSet {
+	if buildutil.CrdbTestBuild && q.distanceMetric == vecdist.Cosine {
+		validateUnitVectors(vectors)
+	}
+
 	unquantizedSet := &UnQuantizedVectorSet{
 		Centroid: make(vector.T, q.dims),
 		Vectors:  vector.MakeSet(q.dims),
 	}
 	if vectors.Count != 0 {
-		vectors.Centroid(unquantizedSet.Centroid)
 		unquantizedSet.AddSet(vectors)
+		vectors.Centroid(unquantizedSet.Centroid)
+		if q.distanceMetric == vecdist.InnerProduct || q.distanceMetric == vecdist.Cosine {
+			// Use spherical centroid for inner product and cosine distances,
+			// which is the mean centroid, but normalized.
+			num32.Normalize(unquantizedSet.Centroid)
+		}
 	}
 	return unquantizedSet
 }
@@ -58,12 +68,20 @@ func (q *UnQuantizer) Quantize(w *workspace.T, vectors vector.Set) QuantizedVect
 func (q *UnQuantizer) QuantizeInSet(
 	w *workspace.T, quantizedSet QuantizedVectorSet, vectors vector.Set,
 ) {
+	if buildutil.CrdbTestBuild && q.distanceMetric == vecdist.Cosine {
+		validateUnitVectors(vectors)
+	}
+
 	unquantizedSet := quantizedSet.(*UnQuantizedVectorSet)
 	unquantizedSet.AddSet(vectors)
 }
 
 // NewQuantizedVectorSet implements the Quantizer interface
 func (q *UnQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+	if buildutil.CrdbTestBuild && q.distanceMetric == vecdist.Cosine {
+		validateUnitVector(centroid)
+	}
+
 	dataBuffer := make([]float32, 0, capacity*q.GetDims())
 	unquantizedSet := &UnQuantizedVectorSet{
 		Centroid: centroid,
@@ -80,25 +98,15 @@ func (q *UnQuantizer) EstimateDistances(
 	distances []float32,
 	errorBounds []float32,
 ) {
+	if buildutil.CrdbTestBuild && q.distanceMetric == vecdist.Cosine {
+		validateUnitVector(queryVector)
+	}
+
 	unquantizedSet := quantizedSet.(*UnQuantizedVectorSet)
 
-	for i := 0; i < unquantizedSet.Vectors.Count; i++ {
+	for i := range unquantizedSet.Vectors.Count {
 		dataVector := unquantizedSet.Vectors.At(i)
-		switch q.distanceMetric {
-		case vecdist.L2Squared:
-			distances[i] = num32.L2SquaredDistance(queryVector, dataVector)
-
-		case vecdist.InnerProduct:
-			// Negate inner product to get distance (i.e. the lower the distance,
-			// the more similar the vectors).
-			distances[i] = -num32.Dot(queryVector, dataVector)
-
-		case vecdist.Cosine:
-			// Compute cosine distance as 1 - cosine similarity. The caller is
-			// expected to have normalized the query and data vectors, so cosine
-			// similarity is just the inner product.
-			distances[i] = 1 - num32.Dot(queryVector, dataVector)
-		}
+		distances[i] = vecdist.Measure(q.distanceMetric, queryVector, dataVector)
 	}
 
 	// Distances are exact, so error bounds are always zero.

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer_test.go
@@ -41,15 +41,15 @@ func TestUnQuantizerSimple(t *testing.T) {
 	errorBounds := make([]float32, quantizedSet.GetCount())
 	quantizer.EstimateDistances(
 		&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
-	require.Equal(t, []float32{17, 1, 41, 13, 41}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{0, 0, 0, 0, 0}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{17, 1, 41, 13, 41}, distances)
+	require.Equal(t, []float32{0, 0, 0, 0, 0}, errorBounds)
 	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
 
 	// Query vector is centroid.
 	quantizer.EstimateDistances(
 		&workspace, quantizedSet, vector.T{0, 0}, distances, errorBounds)
-	require.Equal(t, []float32{29, 5, 61, 25, 61}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{0, 0, 0, 0, 0}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{29, 5, 61, 25, 61}, distances, 2)
+	require.Equal(t, []float32{0, 0, 0, 0, 0}, errorBounds, 2)
 
 	// Remove quantized vectors.
 	quantizedSet.ReplaceWithLast(1)
@@ -60,8 +60,8 @@ func TestUnQuantizerSimple(t *testing.T) {
 	errorBounds = errorBounds[:2]
 	quantizer.EstimateDistances(
 		&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
-	require.Equal(t, []float32{17, 41}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{0, 0}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{17, 41}, distances)
+	require.Equal(t, []float32{0, 0}, errorBounds)
 
 	// Remove remaining quantized vectors.
 	quantizedSet.ReplaceWithLast(0)
@@ -86,6 +86,32 @@ func TestUnQuantizerSimple(t *testing.T) {
 	errorBounds = errorBounds[:1]
 	quantizer.EstimateDistances(
 		&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
-	require.Equal(t, []float32{18}, testutils.RoundFloats(distances, 2))
-	require.Equal(t, []float32{0}, testutils.RoundFloats(errorBounds, 2))
+	require.Equal(t, []float32{18}, distances, 2)
+	require.Equal(t, []float32{0}, errorBounds, 2)
+
+	// Test InnerProduct distance metric.
+	quantizer = NewUnQuantizer(2, vecdist.InnerProduct)
+	vectors = vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
+	quantizedSet = quantizer.Quantize(&workspace, vectors)
+	require.Equal(t, vector.T{0.8, 0.6}, quantizedSet.GetCentroid())
+
+	distances = distances[:3]
+	errorBounds = errorBounds[:3]
+	quantizer.EstimateDistances(
+		&workspace, quantizedSet, vector.T{3, 2}, distances, errorBounds)
+	require.Equal(t, []float32{-19, -7, -28}, distances)
+	require.Equal(t, []float32{0, 0, 0}, errorBounds)
+
+	// Test Cosine distance metric.
+	quantizer = NewUnQuantizer(2, vecdist.Cosine)
+	vectors = vector.MakeSetFromRawData([]float32{-1, 0, 0, 1, 0.70710678, 0.70710678}, 2)
+	quantizedSet = quantizer.Quantize(&workspace, vectors)
+	require.Equal(t, []float32{-0.1691, 0.9856}, testutils.RoundFloats(quantizedSet.GetCentroid(), 4))
+
+	distances = distances[:3]
+	errorBounds = errorBounds[:3]
+	quantizer.EstimateDistances(
+		&workspace, quantizedSet, vector.T{1, 0}, distances, errorBounds)
+	require.Equal(t, []float32{2, 1, 0.29289323}, distances)
+	require.Equal(t, []float32{0, 0, 0}, errorBounds)
 }

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer_test.go
@@ -25,21 +25,16 @@ func TestUnQuantizerSimple(t *testing.T) {
 	vectors := vector.MakeSet(2)
 	quantizedSet := quantizer.Quantize(&workspace, vectors)
 	require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32(nil), testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 
 	// Add 3 vectors and verify centroid and centroid distances.
 	vectors = vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
 	quantizedSet = quantizer.Quantize(&workspace, vectors)
 	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32{1.41, 3.16, 2.83},
-		testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 
 	// Add 2 more vectors to existing set.
 	vectors = vector.MakeSetFromRawData([]float32{4, 3, 6, 5}, 2)
 	quantizer.QuantizeInSet(&workspace, quantizedSet, vectors)
 	require.Equal(t, 5, quantizedSet.GetCount())
-	require.Equal(t, []float32{1.41, 3.16, 2.83, 0, 2.83},
-		testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 
 	// Ensure distances and error bounds are correct.
 	distances := make([]float32, quantizedSet.GetCount())
@@ -61,8 +56,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 	quantizedSet.ReplaceWithLast(3)
 	quantizedSet.ReplaceWithLast(1)
 	require.Equal(t, 2, quantizedSet.GetCount())
-	require.Equal(t, []float32{1.41, 2.83},
-		testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 	distances = distances[:2]
 	errorBounds = errorBounds[:2]
 	quantizer.EstimateDistances(
@@ -75,7 +68,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 	quantizedSet.ReplaceWithLast(0)
 	require.Equal(t, 0, quantizedSet.GetCount())
 	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32{}, testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 	distances = distances[:0]
 	errorBounds = errorBounds[:0]
 	quantizer.EstimateDistances(
@@ -85,14 +77,11 @@ func TestUnQuantizerSimple(t *testing.T) {
 	vectors = vector.MakeSet(2)
 	quantizedSet = quantizer.Quantize(&workspace, vectors)
 	require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
-	require.Equal(t, []float32(nil), quantizedSet.GetCentroidDistances())
 
 	// Add single vector to quantized set.
 	vectors = vector.T{4, 4}.AsSet()
 	quantizer.QuantizeInSet(&workspace, quantizedSet, vectors)
 	require.Equal(t, 1, quantizedSet.GetCount())
-	require.Equal(t, []float32{5.66},
-		testutils.RoundFloats(quantizedSet.GetCentroidDistances(), 2))
 	distances = distances[:1]
 	errorBounds = errorBounds[:1]
 	quantizer.EstimateDistances(

--- a/pkg/sql/vecindex/cspann/quantize/validate.go
+++ b/pkg/sql/vecindex/cspann/quantize/validate.go
@@ -1,0 +1,37 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package quantize
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
+	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/cockroachdb/errors"
+	"gonum.org/v1/gonum/floats/scalar"
+)
+
+// validateUnitVector panics if the given vector is not a unit vector or the
+// zero vector (for degenerate case where norm=0).
+// NOTE: This should only be used in test builds.
+func validateUnitVector(vec vector.T) {
+	if buildutil.CrdbTestBuild {
+		norm := num32.SquaredNorm(vec)
+		if norm != 0 && scalar.Round(float64(norm), 4) != 1 {
+			panic(errors.AssertionFailedf("vector is not a unit vector: %s", vec))
+		}
+	}
+}
+
+// validateUnitVectors panics if the given vectors are not unit vectors or zero
+// vectors (for degenerate case where norm=0).
+// NOTE: This should only be used in test builds.
+func validateUnitVectors(vectors vector.Set) {
+	if buildutil.CrdbTestBuild {
+		for i := range vectors.Count {
+			validateUnitVector(vectors.At(i))
+		}
+	}
+}

--- a/pkg/sql/vecindex/cspann/search_set.go
+++ b/pkg/sql/vecindex/cspann/search_set.go
@@ -20,11 +20,11 @@ type SearchResults []SearchResult
 // SearchResult contains a set of results from searching partitions for data
 // vectors that are nearest to a query vector.
 type SearchResult struct {
-	// QuerySquaredDistance is the estimated squared distance of the data vector
-	// from the query vector.
-	QuerySquaredDistance float32
+	// QueryDistance is the estimated distance of the data vector from the query
+	// vector. The quantizer used by the index determines the distance metric.
+	QueryDistance float32
 	// ErrorBound captures the uncertainty of the distance estimate, which is
-	// highly likely to fall within QuerySquaredDistance ± ErrorBound.
+	// highly likely to fall within QueryDistance ± ErrorBound.
 	ErrorBound float32
 	// CentroidDistance is the (non-squared) exact distance of the data vector
 	// from its partition's centroid.
@@ -50,7 +50,7 @@ type SearchResult struct {
 // MaybeCloser returns true if this result's data vector may be closer (or the
 // same distance) to the query vector than the given result's data vector.
 func (r *SearchResult) MaybeCloser(r2 *SearchResult) bool {
-	return r.QuerySquaredDistance-r.ErrorBound <= r2.QuerySquaredDistance+r2.ErrorBound
+	return r.QueryDistance-r.ErrorBound <= r2.QueryDistance+r2.ErrorBound
 }
 
 // Compare returns an integer comparing two search results. The result is zero
@@ -69,8 +69,8 @@ func (r *SearchResult) Compare(r2 *SearchResult) int {
 	//
 
 	// Compare distances.
-	distance1 := r.QuerySquaredDistance
-	distance2 := r2.QuerySquaredDistance
+	distance1 := r.QueryDistance
+	distance2 := r2.QueryDistance
 	if distance1 < distance2 {
 		return -1
 	} else if distance1 > distance2 {
@@ -294,7 +294,7 @@ func (ss *SearchSet) FindBestDistances(distances []float64) []float64 {
 	maxDistance := float32(-1)
 	maxOffset := -1
 	for i := range k {
-		distance := ss.candidates[i].QuerySquaredDistance
+		distance := ss.candidates[i].QueryDistance
 		if distance > maxDistance {
 			maxDistance = distance
 			maxOffset = i
@@ -305,7 +305,7 @@ func (ss *SearchSet) FindBestDistances(distances []float64) []float64 {
 	// For each remaining candidate, if its distance is smaller than the largest
 	// in our result so far, replace that largest one.
 	for i := k; i < n; i++ {
-		distance := ss.candidates[i].QuerySquaredDistance
+		distance := ss.candidates[i].QueryDistance
 		if distance < maxDistance {
 			// Find the largest distance in our current result.
 			distances[maxOffset] = float64(distance)

--- a/pkg/sql/vecindex/cspann/search_set.go
+++ b/pkg/sql/vecindex/cspann/search_set.go
@@ -26,9 +26,6 @@ type SearchResult struct {
 	// ErrorBound captures the uncertainty of the distance estimate, which is
 	// highly likely to fall within QueryDistance ± ErrorBound.
 	ErrorBound float32
-	// CentroidDistance is the (non-squared) exact distance of the data vector
-	// from its partition's centroid.
-	CentroidDistance float32
 	// ParentPartitionKey is the key of the parent of the partition that contains
 	// the data vector.
 	ParentPartitionKey PartitionKey

--- a/pkg/sql/vecindex/cspann/search_set_test.go
+++ b/pkg/sql/vecindex/cspann/search_set_test.go
@@ -20,35 +20,30 @@ func TestSearchResult(t *testing.T) {
 	r1 := SearchResult{
 		QueryDistance:      1,
 		ErrorBound:         0.5,
-		CentroidDistance:   10,
 		ParentPartitionKey: 100,
 		ChildKey:           ChildKey{KeyBytes: []byte{10}},
 	}
 	r2 := SearchResult{
 		QueryDistance:      2,
 		ErrorBound:         0,
-		CentroidDistance:   20,
 		ParentPartitionKey: 200,
 		ChildKey:           ChildKey{KeyBytes: []byte{20}},
 	}
 	r3 := SearchResult{
 		QueryDistance:      2,
 		ErrorBound:         1,
-		CentroidDistance:   20,
 		ParentPartitionKey: 200,
 		ChildKey:           ChildKey{KeyBytes: []byte{30}},
 	}
 	r4 := SearchResult{
 		QueryDistance:      2,
 		ErrorBound:         1,
-		CentroidDistance:   30,
 		ParentPartitionKey: 300,
 		ChildKey:           ChildKey{KeyBytes: []byte{40}},
 	}
 	r5 := SearchResult{
 		QueryDistance:      4,
 		ErrorBound:         1,
-		CentroidDistance:   30,
 		ParentPartitionKey: 300,
 		ChildKey:           ChildKey{KeyBytes: []byte{40}},
 	}
@@ -96,21 +91,21 @@ func TestSearchSet(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	result1 := SearchResult{
-		QueryDistance: 3, ErrorBound: 0.5, CentroidDistance: 10, ParentPartitionKey: 100, ChildKey: ChildKey{KeyBytes: []byte{10}}}
+		QueryDistance: 3, ErrorBound: 0.5, ParentPartitionKey: 100, ChildKey: ChildKey{KeyBytes: []byte{10}}}
 	result2 := SearchResult{
-		QueryDistance: 6, ErrorBound: 1, CentroidDistance: 20, ParentPartitionKey: 200, ChildKey: ChildKey{KeyBytes: []byte{20}}}
+		QueryDistance: 6, ErrorBound: 1, ParentPartitionKey: 200, ChildKey: ChildKey{KeyBytes: []byte{20}}}
 	result3 := SearchResult{
-		QueryDistance: 1, ErrorBound: 0.5, CentroidDistance: 30, ParentPartitionKey: 300, ChildKey: ChildKey{KeyBytes: []byte{30}}}
+		QueryDistance: 1, ErrorBound: 0.5, ParentPartitionKey: 300, ChildKey: ChildKey{KeyBytes: []byte{30}}}
 	result4 := SearchResult{
-		QueryDistance: 4, ErrorBound: 0.5, CentroidDistance: 40, ParentPartitionKey: 400, ChildKey: ChildKey{KeyBytes: []byte{40}}}
+		QueryDistance: 4, ErrorBound: 0.5, ParentPartitionKey: 400, ChildKey: ChildKey{KeyBytes: []byte{40}}}
 	result5 := SearchResult{
-		QueryDistance: 6, ErrorBound: 1.5, CentroidDistance: 50, ParentPartitionKey: 500, ChildKey: ChildKey{KeyBytes: []byte{50}}}
+		QueryDistance: 6, ErrorBound: 1.5, ParentPartitionKey: 500, ChildKey: ChildKey{KeyBytes: []byte{50}}}
 	result6 := SearchResult{
-		QueryDistance: 5, ErrorBound: 1, CentroidDistance: 60, ParentPartitionKey: 600, ChildKey: ChildKey{KeyBytes: []byte{60}}}
+		QueryDistance: 5, ErrorBound: 1, ParentPartitionKey: 600, ChildKey: ChildKey{KeyBytes: []byte{60}}}
 	result7 := SearchResult{
-		QueryDistance: 4, ErrorBound: 1.5, CentroidDistance: 70, ParentPartitionKey: 700, ChildKey: ChildKey{KeyBytes: []byte{70}}}
+		QueryDistance: 4, ErrorBound: 1.5, ParentPartitionKey: 700, ChildKey: ChildKey{KeyBytes: []byte{70}}}
 	result8 := SearchResult{
-		QueryDistance: 0.5, ErrorBound: 0.5, CentroidDistance: 80, ParentPartitionKey: 800, ChildKey: ChildKey{KeyBytes: []byte{80}}}
+		QueryDistance: 0.5, ErrorBound: 0.5, ParentPartitionKey: 800, ChildKey: ChildKey{KeyBytes: []byte{80}}}
 
 	t.Run("empty set", func(t *testing.T) {
 		searchSet := SearchSet{MaxResults: 3, MaxExtraResults: 7}

--- a/pkg/sql/vecindex/cspann/search_set_test.go
+++ b/pkg/sql/vecindex/cspann/search_set_test.go
@@ -18,39 +18,39 @@ func TestSearchResult(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	r1 := SearchResult{
-		QuerySquaredDistance: 1,
-		ErrorBound:           0.5,
-		CentroidDistance:     10,
-		ParentPartitionKey:   100,
-		ChildKey:             ChildKey{KeyBytes: []byte{10}},
+		QueryDistance:      1,
+		ErrorBound:         0.5,
+		CentroidDistance:   10,
+		ParentPartitionKey: 100,
+		ChildKey:           ChildKey{KeyBytes: []byte{10}},
 	}
 	r2 := SearchResult{
-		QuerySquaredDistance: 2,
-		ErrorBound:           0,
-		CentroidDistance:     20,
-		ParentPartitionKey:   200,
-		ChildKey:             ChildKey{KeyBytes: []byte{20}},
+		QueryDistance:      2,
+		ErrorBound:         0,
+		CentroidDistance:   20,
+		ParentPartitionKey: 200,
+		ChildKey:           ChildKey{KeyBytes: []byte{20}},
 	}
 	r3 := SearchResult{
-		QuerySquaredDistance: 2,
-		ErrorBound:           1,
-		CentroidDistance:     20,
-		ParentPartitionKey:   200,
-		ChildKey:             ChildKey{KeyBytes: []byte{30}},
+		QueryDistance:      2,
+		ErrorBound:         1,
+		CentroidDistance:   20,
+		ParentPartitionKey: 200,
+		ChildKey:           ChildKey{KeyBytes: []byte{30}},
 	}
 	r4 := SearchResult{
-		QuerySquaredDistance: 2,
-		ErrorBound:           1,
-		CentroidDistance:     30,
-		ParentPartitionKey:   300,
-		ChildKey:             ChildKey{KeyBytes: []byte{40}},
+		QueryDistance:      2,
+		ErrorBound:         1,
+		CentroidDistance:   30,
+		ParentPartitionKey: 300,
+		ChildKey:           ChildKey{KeyBytes: []byte{40}},
 	}
 	r5 := SearchResult{
-		QuerySquaredDistance: 4,
-		ErrorBound:           1,
-		CentroidDistance:     30,
-		ParentPartitionKey:   300,
-		ChildKey:             ChildKey{KeyBytes: []byte{40}},
+		QueryDistance:      4,
+		ErrorBound:         1,
+		CentroidDistance:   30,
+		ParentPartitionKey: 300,
+		ChildKey:           ChildKey{KeyBytes: []byte{40}},
 	}
 
 	// MaybeCloser.
@@ -96,21 +96,21 @@ func TestSearchSet(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	result1 := SearchResult{
-		QuerySquaredDistance: 3, ErrorBound: 0.5, CentroidDistance: 10, ParentPartitionKey: 100, ChildKey: ChildKey{KeyBytes: []byte{10}}}
+		QueryDistance: 3, ErrorBound: 0.5, CentroidDistance: 10, ParentPartitionKey: 100, ChildKey: ChildKey{KeyBytes: []byte{10}}}
 	result2 := SearchResult{
-		QuerySquaredDistance: 6, ErrorBound: 1, CentroidDistance: 20, ParentPartitionKey: 200, ChildKey: ChildKey{KeyBytes: []byte{20}}}
+		QueryDistance: 6, ErrorBound: 1, CentroidDistance: 20, ParentPartitionKey: 200, ChildKey: ChildKey{KeyBytes: []byte{20}}}
 	result3 := SearchResult{
-		QuerySquaredDistance: 1, ErrorBound: 0.5, CentroidDistance: 30, ParentPartitionKey: 300, ChildKey: ChildKey{KeyBytes: []byte{30}}}
+		QueryDistance: 1, ErrorBound: 0.5, CentroidDistance: 30, ParentPartitionKey: 300, ChildKey: ChildKey{KeyBytes: []byte{30}}}
 	result4 := SearchResult{
-		QuerySquaredDistance: 4, ErrorBound: 0.5, CentroidDistance: 40, ParentPartitionKey: 400, ChildKey: ChildKey{KeyBytes: []byte{40}}}
+		QueryDistance: 4, ErrorBound: 0.5, CentroidDistance: 40, ParentPartitionKey: 400, ChildKey: ChildKey{KeyBytes: []byte{40}}}
 	result5 := SearchResult{
-		QuerySquaredDistance: 6, ErrorBound: 1.5, CentroidDistance: 50, ParentPartitionKey: 500, ChildKey: ChildKey{KeyBytes: []byte{50}}}
+		QueryDistance: 6, ErrorBound: 1.5, CentroidDistance: 50, ParentPartitionKey: 500, ChildKey: ChildKey{KeyBytes: []byte{50}}}
 	result6 := SearchResult{
-		QuerySquaredDistance: 5, ErrorBound: 1, CentroidDistance: 60, ParentPartitionKey: 600, ChildKey: ChildKey{KeyBytes: []byte{60}}}
+		QueryDistance: 5, ErrorBound: 1, CentroidDistance: 60, ParentPartitionKey: 600, ChildKey: ChildKey{KeyBytes: []byte{60}}}
 	result7 := SearchResult{
-		QuerySquaredDistance: 4, ErrorBound: 1.5, CentroidDistance: 70, ParentPartitionKey: 700, ChildKey: ChildKey{KeyBytes: []byte{70}}}
+		QueryDistance: 4, ErrorBound: 1.5, CentroidDistance: 70, ParentPartitionKey: 700, ChildKey: ChildKey{KeyBytes: []byte{70}}}
 	result8 := SearchResult{
-		QuerySquaredDistance: 0.5, ErrorBound: 0.5, CentroidDistance: 80, ParentPartitionKey: 800, ChildKey: ChildKey{KeyBytes: []byte{80}}}
+		QueryDistance: 0.5, ErrorBound: 0.5, CentroidDistance: 80, ParentPartitionKey: 800, ChildKey: ChildKey{KeyBytes: []byte{80}}}
 
 	t.Run("empty set", func(t *testing.T) {
 		searchSet := SearchSet{MaxResults: 3, MaxExtraResults: 7}

--- a/pkg/sql/vecindex/cspann/searcher.go
+++ b/pkg/sql/vecindex/cspann/searcher.go
@@ -335,7 +335,7 @@ func (s *levelSearcher) NextBatch(ctx context.Context) (ok bool, err error) {
 		var zscore float64
 		if len(s.parentResults) >= s.idx.options.QualitySamples {
 			for i := range s.idx.options.QualitySamples {
-				s.idxCtx.tempQualitySamples[i] = float64(s.parentResults[i].QuerySquaredDistance)
+				s.idxCtx.tempQualitySamples[i] = float64(s.parentResults[i].QueryDistance)
 			}
 			samples := s.idxCtx.tempQualitySamples[:s.idx.options.QualitySamples]
 			zscore = s.idx.stats.ReportSearch(s.parent.Level(), samples, s.idxCtx.options.UpdateStats)

--- a/pkg/sql/vecindex/cspann/testdata/delete.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/delete.ddt
@@ -194,7 +194,7 @@ vec3
 search max-results=1
 (4, 3)
 ----
-vec4: 5 (centroid=1.12)
+vec4: 5
 4 leaf vectors, 6 vectors, 4 full vectors, 3 partitions
 
 # Again, with higher max results.
@@ -203,9 +203,9 @@ vec4: 5 (centroid=1.12)
 search max-results=2
 (4, 3)
 ----
-vec4: 5 (centroid=1.12)
-vec1: 10 (centroid=1.58)
-vec2: 10 (centroid=1.12)
+vec4: 5
+vec1: 10
+vec2: 10
 3 leaf vectors, 5 vectors, 3 full vectors, 3 partitions
 
 # Vector should now be gone from the index.
@@ -288,7 +288,7 @@ vec3
 search max-results=1
 (4, 3)
 ----
-vec4: 5 (centroid=7.07)
+vec4: 5
 4 leaf vectors, 4 vectors, 4 full vectors, 1 partitions
 
 # Split should detect missing vector and remove it.

--- a/pkg/sql/vecindex/cspann/testdata/insert.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/insert.ddt
@@ -100,13 +100,13 @@ vec2: (-5, -5)
 search max-results=10 beam-size=8
 (-5, -5)
 ----
-vec2: 0 (centroid=8.8)
-vec7: 50 (centroid=2.03)
-vec1: 85 (centroid=0.67)
-vec8: 106 (centroid=2.03)
-vec3: 145 (centroid=2.6)
-vec4: 145 (centroid=2.6)
-vec9: 178 (centroid=5.21)
-vec6: 397 (centroid=7.07)
-vec5: 425 (centroid=5.1)
+vec2: 0
+vec7: 50
+vec1: 85
+vec8: 106
+vec3: 145
+vec4: 145
+vec9: 178
+vec6: 397
+vec5: 425
 10 leaf vectors, 13 vectors, 9 full vectors, 4 partitions

--- a/pkg/sql/vecindex/cspann/testdata/read-only.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/read-only.ddt
@@ -33,10 +33,10 @@ Loaded 13 vectors.
 search max-results=2 beam-size=3
 (1, 6)
 ----
-vec4: 2 (centroid=1.25)
-vec10: 4 (centroid=1.75)
-vec5: 4 (centroid=2.02)
-vec8: 4 (centroid=2.25)
+vec4: 2
+vec10: 4
+vec5: 4
+vec8: 4
 13 leaf vectors, 16 vectors, 10 full vectors, 4 partitions
 
 format-tree
@@ -68,9 +68,9 @@ format-tree
 search max-results=3 beam-size=3
 (8, 5)
 ----
-vec9: 18 (centroid=4.95)
-vec11: 25 (centroid=2.36)
-vec5: 26 (centroid=2.02)
+vec9: 18
+vec11: 25
+vec5: 26
 13 leaf vectors, 16 vectors, 11 full vectors, 4 partitions
 
 format-tree

--- a/pkg/sql/vecindex/cspann/testdata/search-embeddings.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-embeddings.ddt
@@ -13,70 +13,70 @@ CV stats:
 # Search with small beam size.
 search max-results=1 use-dataset=5000 beam-size=1
 ----
-vec302: 0.6601 (centroid=0.53)
+vec302: 0.6601
 25 leaf vectors, 46 vectors, 15 full vectors, 4 partitions
 
 # Search for additional results.
 search max-results=6 use-dataset=5000 beam-size=1
 ----
-vec302: 0.6601 (centroid=0.53)
-vec329: 0.6871 (centroid=0.67)
-vec386: 0.7301 (centroid=0.57)
-vec240: 0.7723 (centroid=0.66)
-vec347: 0.7745 (centroid=0.5)
-vec340: 0.7858 (centroid=0.59)
+vec302: 0.6601
+vec329: 0.6871
+vec386: 0.7301
+vec240: 0.7723
+vec347: 0.7745
+vec340: 0.7858
 25 leaf vectors, 46 vectors, 15 full vectors, 4 partitions
 
 # Use a larger beam size.
 search max-results=6 use-dataset=5000 beam-size=4
 ----
-vec640: 0.6525 (centroid=0.55)
-vec302: 0.6601 (centroid=0.53)
-vec329: 0.6871 (centroid=0.67)
-vec386: 0.7301 (centroid=0.57)
-vec117: 0.7576 (centroid=0.51)
-vec25: 0.761 (centroid=0.45)
+vec640: 0.6525
+vec302: 0.6601
+vec329: 0.6871
+vec386: 0.7301
+vec117: 0.7576
+vec25: 0.761
 80 leaf vectors, 116 vectors, 23 full vectors, 11 partitions
 
 # Turn off re-ranking, which results in increased inaccuracy.
 search max-results=6 use-dataset=5000 beam-size=4 skip-rerank
 ----
-vec640: 0.6404 ± 0.04 (centroid=0.55)
-vec302: 0.6539 ± 0.03 (centroid=0.53)
-vec329: 0.6734 ± 0.04 (centroid=0.67)
-vec386: 0.7114 ± 0.04 (centroid=0.57)
-vec340: 0.7533 ± 0.04 (centroid=0.59)
-vec347: 0.7588 ± 0.03 (centroid=0.5)
+vec640: 0.6404 ± 0.04
+vec302: 0.6539 ± 0.03
+vec329: 0.6734 ± 0.04
+vec386: 0.7114 ± 0.04
+vec340: 0.7533 ± 0.04
+vec347: 0.7588 ± 0.03
 80 leaf vectors, 116 vectors, 0 full vectors, 11 partitions
 
 # Return top 25 results with large beam size.
 search max-results=25 use-dataset=5000 beam-size=16
 ----
-vec771: 0.5624 (centroid=0.66)
-vec356: 0.5976 (centroid=0.49)
-vec640: 0.6525 (centroid=0.55)
-vec302: 0.6601 (centroid=0.53)
-vec329: 0.6871 (centroid=0.67)
-vec95: 0.7008 (centroid=0.6)
-vec249: 0.7268 (centroid=0.4)
-vec386: 0.7301 (centroid=0.57)
-vec309: 0.7311 (centroid=0.48)
-vec633: 0.7513 (centroid=0.42)
-vec117: 0.7576 (centroid=0.51)
-vec556: 0.7595 (centroid=0.5)
-vec25: 0.761 (centroid=0.45)
-vec872: 0.7707 (centroid=0.6)
-vec859: 0.7708 (centroid=0.5)
-vec240: 0.7723 (centroid=0.66)
-vec347: 0.7745 (centroid=0.5)
-vec11: 0.777 (centroid=0.52)
-vec340: 0.7858 (centroid=0.59)
-vec239: 0.7878 (centroid=0.5)
-vec848: 0.7958 (centroid=0.6)
-vec387: 0.8038 (centroid=0.45)
-vec637: 0.8039 (centroid=0.49)
-vec410: 0.8062 (centroid=0.46)
-vec979: 0.8066 (centroid=0.55)
+vec771: 0.5624
+vec356: 0.5976
+vec640: 0.6525
+vec302: 0.6601
+vec329: 0.6871
+vec95: 0.7008
+vec249: 0.7268
+vec386: 0.7301
+vec309: 0.7311
+vec633: 0.7513
+vec117: 0.7576
+vec556: 0.7595
+vec25: 0.761
+vec872: 0.7707
+vec859: 0.7708
+vec240: 0.7723
+vec347: 0.7745
+vec11: 0.777
+vec340: 0.7858
+vec239: 0.7878
+vec848: 0.7958
+vec387: 0.8038
+vec637: 0.8039
+vec410: 0.8062
+vec979: 0.8066
 313 leaf vectors, 391 vectors, 92 full vectors, 39 partitions
 
 # Search for an "easy" result, where adaptive search inspects less partitions.

--- a/pkg/sql/vecindex/cspann/testdata/search.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search.ddt
@@ -16,15 +16,15 @@ vec3: (4, 3)
 search
 (7, 4)
 ----
-vec2: 0 (centroid=8.06)
+vec2: 0
 3 leaf vectors, 3 vectors, 3 full vectors, 1 partitions
 
 # Search for vector with no exact match.
 search max-results=2
 (3, 5)
 ----
-vec3: 5 (centroid=5)
-vec1: 13 (centroid=2.24)
+vec3: 5
+vec1: 13
 3 leaf vectors, 3 vectors, 3 full vectors, 1 partitions
 
 # ----------------------------------------------------------------------
@@ -115,16 +115,16 @@ force-split partition-key=1
 search max-results=2 beam-size=1
 (1, 6)
 ----
-vec9: 5 (centroid=2.92)
-vec8: 13 (centroid=2.12)
+vec9: 5
+vec8: 13
 3 leaf vectors, 7 vectors, 3 full vectors, 3 partitions
 
 # Search for closest vectors with beam-size=2.
 search max-results=2 beam-size=2
 (1, 6)
 ----
-vec7: 5 (centroid=2.06)
-vec9: 5 (centroid=2.92)
+vec7: 5
+vec9: 5
 6 leaf vectors, 10 vectors, 6 full vectors, 4 partitions
 
 # ----------------------------------------------------------------------
@@ -161,10 +161,10 @@ vec6: (4, 9)
 search max-results=3
 (5, 10)
 ----
-vec1: 2 (centroid=0)
-vec2: 2 (centroid=0)
-vec3: 2 (centroid=0)
-vec4: 2 (centroid=0)
+vec1: 2
+vec2: 2
+vec3: 2
+vec4: 2
 4 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
 
 # ----------------------------------------------------------------------
@@ -201,10 +201,10 @@ vec1: (-2, -2)
 search max-results=6
 (1, 1)
 ----
-vec3: 13 (centroid=1.41)
-vec1: 18 (centroid=5.52)
-vec5: 25 (centroid=1.41)
-vec4: 41 (centroid=2.92)
+vec3: 13
+vec1: 18
+vec5: 25
+vec4: 41
 4 leaf vectors, 7 vectors, 4 full vectors, 3 partitions
 
 # Do not rerank results. This may cause a different vec1 duplicate to be
@@ -212,10 +212,10 @@ vec4: 41 (centroid=2.92)
 search max-results=6 skip-rerank
 (8, 9)
 ----
-vec1: 9.4346 ± 10.12 (centroid=1.58)
-vec2: 36.5654 ± 10.12 (centroid=1.58)
-vec3: 55.698 ± 15.23 (centroid=1.41)
-vec5: 64.302 ± 15.23 (centroid=1.41)
+vec1: 9.4346 ± 10.12
+vec2: 36.5654 ± 10.12
+vec3: 55.698 ± 15.23
+vec5: 64.302 ± 15.23
 4 leaf vectors, 7 vectors, 0 full vectors, 3 partitions
 
 # ----------------------------------------------------------------------
@@ -276,5 +276,5 @@ vec5
 search max-results=1
 (0, 0)
 ----
-vec6: 500000 (centroid=70.71)
+vec6: 500000
 6 leaf vectors, 9 vectors, 6 full vectors, 4 partitions

--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -781,7 +781,7 @@ vec5: (2, -4)
 search beam-size=16
 (2, -4)
 ----
-vec5: 0 (centroid=2)
+vec5: 0
 7 leaf vectors, 17 vectors, 5 full vectors, 11 partitions
 
 format-tree
@@ -820,7 +820,7 @@ format-tree
 search beam-size=16
 (2, -4)
 ----
-vec5: 0 (centroid=2)
+vec5: 0
 5 leaf vectors, 17 vectors, 5 full vectors, 13 partitions
 
 format-tree
@@ -863,7 +863,7 @@ format-tree
 search beam-size=16
 (2, -4)
 ----
-vec5: 0 (centroid=2)
+vec5: 0
 5 leaf vectors, 19 vectors, 5 full vectors, 15 partitions
 
 format-tree
@@ -1040,9 +1040,9 @@ vec7: (7, 4)
 search
 (7, 4)
 ----
-vec2: 0 (centroid=0)
-vec6: 0 (centroid=0)
-vec7: 0 (centroid=0)
+vec2: 0
+vec6: 0
+vec7: 0
 5 leaf vectors, 12 vectors, 5 full vectors, 6 partitions
 
 format-tree

--- a/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-root-step.ddt
@@ -250,12 +250,12 @@ force-split partition-key=1 steps=1
 search max-results=4 discard-fixups
 (-1, 2)
 ----
-vec1: 4 (centroid=4.24)
-vec7: 5 (centroid=2.24)
-vec8: 5 (centroid=2.24)
-vec3: 26 (centroid=0)
-vec4: 26 (centroid=0)
-vec9: 26 (centroid=1.41)
+vec1: 4
+vec7: 5
+vec8: 5
+vec3: 26
+vec4: 26
+vec9: 26
 9 leaf vectors, 13 vectors, 9 full vectors, 5 partitions
 
 # Move to the DrainingForSplit state, where sub-partition #6 has vectors.
@@ -304,12 +304,12 @@ format-tree root=6
 search max-results=4 discard-fixups
 (-1, 2)
 ----
-vec1: 4 (centroid=4.24)
-vec7: 5 (centroid=2.24)
-vec8: 5 (centroid=2.24)
-vec3: 26 (centroid=0)
-vec4: 26 (centroid=0)
-vec9: 26 (centroid=1.41)
+vec1: 4
+vec7: 5
+vec8: 5
+vec3: 26
+vec4: 26
+vec9: 26
 9 leaf vectors, 15 vectors, 9 full vectors, 7 partitions
 
 # Move to the point where partition #1 children have been cleared.
@@ -321,12 +321,12 @@ force-split partition-key=1 steps=2
 search max-results=4 discard-fixups
 (-1, 2)
 ----
-vec1: 4 (centroid=4.24)
-vec7: 5 (centroid=2.24)
-vec8: 5 (centroid=2.24)
-vec3: 26 (centroid=0)
-vec4: 26 (centroid=0)
-vec9: 26 (centroid=1.41)
+vec1: 4
+vec7: 5
+vec8: 5
+vec3: 26
+vec4: 26
+vec9: 26
 9 leaf vectors, 13 vectors, 9 full vectors, 7 partitions
 
 # Move to the AddingLevel state, where root partition's level has increased.
@@ -338,12 +338,12 @@ force-split partition-key=1 steps=1
 search max-results=4 discard-fixups
 (-1, 2)
 ----
-vec1: 4 (centroid=4.24)
-vec7: 5 (centroid=2.24)
-vec8: 5 (centroid=2.24)
-vec3: 26 (centroid=0)
-vec4: 26 (centroid=0)
-vec9: 26 (centroid=1.41)
+vec1: 4
+vec7: 5
+vec8: 5
+vec3: 26
+vec4: 26
+vec9: 26
 9 leaf vectors, 13 vectors, 9 full vectors, 7 partitions
 
 # Move to point where sub-partitions #6 and #7 have been added to the root.
@@ -380,12 +380,12 @@ force-split partition-key=1 steps=4
 search max-results=4 discard-fixups
 (-1, 2)
 ----
-vec1: 4 (centroid=4.24)
-vec7: 5 (centroid=2.24)
-vec8: 5 (centroid=2.24)
-vec3: 26 (centroid=0)
-vec4: 26 (centroid=0)
-vec9: 26 (centroid=1.41)
+vec1: 4
+vec7: 5
+vec8: 5
+vec3: 26
+vec4: 26
+vec9: 26
 9 leaf vectors, 15 vectors, 9 full vectors, 7 partitions
 
 # Finish the split.
@@ -422,12 +422,12 @@ force-split partition-key=1 steps=1
 search max-results=4 discard-fixups
 (-1, 2)
 ----
-vec1: 4 (centroid=4.24)
-vec7: 5 (centroid=2.24)
-vec8: 5 (centroid=2.24)
-vec3: 26 (centroid=0)
-vec4: 26 (centroid=0)
-vec9: 26 (centroid=1.41)
+vec1: 4
+vec7: 5
+vec8: 5
+vec3: 26
+vec4: 26
+vec9: 26
 9 leaf vectors, 15 vectors, 9 full vectors, 7 partitions
 
 # ----------------------------------------------------------------------

--- a/pkg/sql/vecindex/cspann/testdata/split.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split.ddt
@@ -136,17 +136,17 @@ force-split partition-key=9 parent-partition-key=10
 search max-results=3 beam-size=1
 (4, 7)
 ----
-vec7: 2 (centroid=2.12)
-vec4: 32 (centroid=2.12)
+vec7: 2
+vec4: 32
 2 leaf vectors, 6 vectors, 2 full vectors, 3 partitions
 
 # Search for closest vectors with beam-size=3.
 search max-results=3 beam-size=3
 (4, 7)
 ----
-vec7: 2 (centroid=2.12)
-vec10: 5 (centroid=0.71)
-vec12: 9 (centroid=0.71)
+vec7: 2
+vec10: 5
+vec12: 9
 6 leaf vectors, 14 vectors, 6 full vectors, 6 partitions
 
 # ----------------------------------------------------------------------

--- a/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/tree-key.ddt
@@ -46,7 +46,7 @@ vec8: (-2, 8)
 search tree=2
 (5, 5)
 ----
-vec7: 26 (centroid=4.18)
+vec7: 26
 5 leaf vectors, 7 vectors, 5 full vectors, 3 partitions
 
 # Delete from tree #2.
@@ -155,7 +155,7 @@ vec1
 search max-results=1 tree=1
 (1, 2)
 ----
-vec6: 5 (centroid=2.36)
+vec6: 5
 6 leaf vectors, 8 vectors, 6 full vectors, 3 partitions
 
 # Vector should now be gone from the index.

--- a/pkg/sql/vecindex/searcher_test.go
+++ b/pkg/sql/vecindex/searcher_test.go
@@ -151,17 +151,17 @@ func TestSearcher(t *testing.T) {
 	prefix = encoding.EncodeVarintAscending(prefix, 100)
 	require.NoError(t, searcher.Search(ctx, prefix, original))
 	res := searcher.NextResult()
-	require.InDelta(t, float32(1), res.QuerySquaredDistance, 0.01)
+	require.InDelta(t, float32(1), res.QueryDistance, 0.01)
 	res = searcher.NextResult()
-	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
+	require.InDelta(t, float32(20), res.QueryDistance, 0.01)
 	require.Nil(t, searcher.NextResult())
 
 	// Search again to ensure search state is reset.
 	require.NoError(t, searcher.Search(ctx, prefix, original))
 	res = searcher.NextResult()
-	require.InDelta(t, float32(1), res.QuerySquaredDistance, 0.01)
+	require.InDelta(t, float32(1), res.QueryDistance, 0.01)
 	res = searcher.NextResult()
-	require.InDelta(t, float32(20), res.QuerySquaredDistance, 0.01)
+	require.InDelta(t, float32(20), res.QueryDistance, 0.01)
 	require.Nil(t, searcher.NextResult())
 
 	// Search for a vector to delete that doesn't exist (reuse memory).

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -88,9 +88,7 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 						switch quantizedSet := quantizedSet.(type) {
 						case *quantize.UnQuantizedVectorSet:
 							var err error
-							buf, err = vecencoding.EncodeUnquantizerVector(buf,
-								quantizedSet.GetCentroidDistances()[i], set.At(i),
-							)
+							buf, err = vecencoding.EncodeUnquantizerVector(buf, set.At(i))
 							require.NoError(t, err)
 						case *quantize.RaBitQuantizedVectorSet:
 							buf = vecencoding.EncodeRaBitQVector(buf,
@@ -150,7 +148,6 @@ func testingAssertPartitionsEqual(t *testing.T, l, r *cspann.Partition) {
 	q1, q2 := l.QuantizedSet(), r.QuantizedSet()
 	require.Equal(t, q1.GetCentroid(), q2.GetCentroid(), "centroids do not match")
 	require.Equal(t, q1.GetCount(), q2.GetCount(), "counts do not match")
-	require.Equal(t, q1.GetCentroidDistances(), q2.GetCentroidDistances(), "distances do not match")
 	switch leftSet := q1.(type) {
 	case *quantize.UnQuantizedVectorSet:
 		rightSet, ok := q2.(*quantize.UnQuantizedVectorSet)
@@ -162,6 +159,8 @@ func testingAssertPartitionsEqual(t *testing.T, l, r *cspann.Partition) {
 		require.Equal(t, leftSet.CodeCounts, rightSet.CodeCounts, "code counts do not match")
 		require.Equal(t, leftSet.Codes, rightSet.Codes, "codes do not match")
 		require.Equal(t, leftSet.QuantizedDotProducts, rightSet.QuantizedDotProducts, "dot products do not match")
+		require.Equal(t, leftSet.CentroidDistances, rightSet.CentroidDistances,
+			"centroid distances do not match")
 	default:
 		t.Fatalf("unexpected type %T", q1)
 	}

--- a/pkg/sql/vecindex/vecstore/codec.go
+++ b/pkg/sql/vecindex/vecstore/codec.go
@@ -187,8 +187,7 @@ func (pc *partitionCodec) setStoreCodec(partitionKey cspann.PartitionKey) {
 func encodeVectorFromSet(vs quantize.QuantizedVectorSet, idx int) ([]byte, error) {
 	switch t := vs.(type) {
 	case *quantize.UnQuantizedVectorSet:
-		return vecencoding.EncodeUnquantizerVector(
-			[]byte{}, t.CentroidDistances[idx], t.Vectors.At(idx))
+		return vecencoding.EncodeUnquantizerVector([]byte{}, t.Vectors.At(idx))
 	case *quantize.RaBitQuantizedVectorSet:
 		return vecencoding.EncodeRaBitQVector(
 			[]byte{}, t.CodeCounts[idx], t.CentroidDistances[idx], t.QuantizedDotProducts[idx], t.Codes.At(idx),

--- a/pkg/util/num32/vec.go
+++ b/pkg/util/num32/vec.go
@@ -12,20 +12,15 @@ import (
 )
 
 // Normalize scales the dst vector so that it's a unit vector (L2 norm is 1). If
-// dst is a zero vector, then return a unit vector with all dimensions set to
-// 1/sqrt(dims). This function is commonly used to prepare vectors for cosine
-// similarity or distance computations, where unit length is required.
+// dst is a zero vector, then return a zero vector. This function is commonly
+// used to prepare vectors for cosine similarity or distance computations, where
+// unit length is required.
 func Normalize(dst []float32) {
+	// If norm is zero, then this is the degenerate case where dst is the zero
+	// vector - just return it unchanged.
 	norm := Norm(dst)
 	if norm != 0 {
 		Scale(1/norm, dst)
-	} else {
-		// Degenerate case where dst is the zero vector. In this case, return an
-		// arbitrary unit vector with all dimensions set to 1/sqrt(dims).
-		invSqrtDims := 1 / Sqrt(float32(len(dst)))
-		for i := range dst {
-			dst[i] = invSqrtDims
-		}
 	}
 }
 

--- a/pkg/util/num32/vec_test.go
+++ b/pkg/util/num32/vec_test.go
@@ -23,12 +23,12 @@ func TestNormalize(t *testing.T) {
 		res []float32
 	}{
 		{v: []float32{}, res: []float32{}},
-		{v: []float32{0}, res: []float32{1}},
+		{v: []float32{0}, res: []float32{0}},
 		{v: []float32{1}, res: []float32{1}},
-		{v: []float32{0, 0}, res: []float32{0.7071, 0.7071}},
+		{v: []float32{0, 0}, res: []float32{0, 0}},
 		{v: []float32{0, 1}, res: []float32{0, 1}},
 		{v: []float32{1, 1}, res: []float32{0.7071, 0.7071}},
-		{v: []float32{0, 0, 0}, res: []float32{0.5774, 0.5774, 0.5774}},
+		{v: []float32{0, 0, 0}, res: []float32{0, 0, 0}},
 		{v: []float32{1, 2, 3}, res: []float32{0.2673, 0.5345, 0.8018}},
 	}
 


### PR DESCRIPTION
#### cspann: ensure unit vectors in quantizers when required

Construct a unit vector centroid in the quantizers when using the InnerProduct
or Cosine distance metric. This is required for accurate distances in the
Cosine case. In the InnerProduct case, it avoids partition centroids with high
magnitudes that "attract" vectors simply because of their magnitude.

In test builds, check that all query and data vectors are unit vectors when
using the Cosine distance metric.

Add more testing for Cosine and InnerProduct distance metrics, as used by the
quantizers.

#### cspann: remove centroid distances from quantized and search sets

Remove GetCentroidDistances() from QuantizedVectorSet and remove
CentroidDistance from SearchResult. The centroid distances were never
being used.

#### cspann: rename SearchResult.QuerySquaredDistance to QueryDistance

Now that we're introducing alternative distance metrics, the search result no
longer always returns a squared L2 distance. Rename the field to QueryDistance
to be agnostic to the distance metric that's used.