### PR TITLE
security: add sql client error for TLSCipherRestrict

### DIFF
--- a/pkg/security/BUILD.bazel
+++ b/pkg/security/BUILD.bazel
@@ -50,6 +50,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//oserror",
+        "@com_github_cockroachdb_redact//:redact",
         "@com_github_go_ldap_ldap_v3//:ldap",
         "@org_golang_x_crypto//bcrypt",
         "@org_golang_x_crypto//ocsp",

--- a/pkg/security/tls_ciphersuites.go
+++ b/pkg/security/tls_ciphersuites.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 	"golang.org/x/exp/slices"
 )
 
@@ -179,7 +180,7 @@ func (*tlsRestrictConfiguration) configureTLSRestrict(ciphers []string) {
 			return &cipherRestrictError{errors.Errorf("cipher id %v does match implemented tls ciphers", selectedCipherID)}
 		}
 		if !slices.Contains(tlsRestrictConfig.c, cName) {
-			return &cipherRestrictError{errors.Newf("presented cipher %s not in allowed cipher suite list", cName)}
+			return &cipherRestrictError{errors.Newf("presented cipher %s not in allowed cipher suite list", redact.SafeString(cName))}
 		}
 		return
 	}

--- a/pkg/security/tls_test.go
+++ b/pkg/security/tls_test.go
@@ -138,7 +138,7 @@ func TestTLSCipherRestrict(t *testing.T) {
 			wantErr: false},
 		{name: "invalid ciphers", ciphers: []string{"TLS_ECDHE_ECDSA_WITH_CHACHA20_POLY1305_SHA256"}, wantErr: true,
 			httpsErr:  []string{"\": EOF", "connect: connection refused", "read: connection reset by peer", "http: server closed idle connection"},
-			sqlErr:    "failed to connect to `host=127.0.0.1 user=root database=`: failed to receive message (unexpected EOF)",
+			sqlErr:    "^failed to connect to `host=127\\.0\\.0\\.1 user=root database=`: server error \\(ERROR: cannot use SSL\\/TLS with the requested ciphers: presented cipher [^ ]+ not in allowed cipher suite list \\(SQLSTATE 08004\\)\\)$",
 			rpcErr:    "initial connection heartbeat failed: grpc:",
 			cipherErr: "^presented cipher [^ ]+ not in allowed cipher suite list$"},
 	}
@@ -242,7 +242,7 @@ func TestTLSCipherRestrict(t *testing.T) {
 				errVal := cipherErrC.err
 				cipherErrC.Unlock()
 				require.Regexp(t, tt.cipherErr, errVal.Error())
-				require.Equal(t, tt.sqlErr, err.Error())
+				require.Regexp(t, tt.sqlErr, err.Error())
 			}
 
 			// test rpc connection for root user.

--- a/pkg/sql/pgwire/pre_serve.go
+++ b/pkg/sql/pgwire/pre_serve.go
@@ -492,9 +492,8 @@ func (s *PreServeConnHandler) maybeUpgradeToSecureConn(
 		}
 		newConn = tls.Server(conn, tlsConfig)
 		// Conditionally perform handshake connection and determine additional restrictions.
-		serverErr = security.TLSCipherRestrict(newConn)
-		if serverErr != nil {
-			_ = newConn.Close()
+		if err := security.TLSCipherRestrict(newConn); err != nil {
+			clientErr = pgerror.Wrapf(err, pgcode.SQLserverRejectedEstablishmentOfSQLconnection, "cannot use SSL/TLS with the requested ciphers")
 			return
 		}
 		newConnType = hba.ConnHostSSL


### PR DESCRIPTION
Currently, TLSCipherRestrict added in #143554 does not log errors to client
making it difficult to debug issues related to ciphers presented in client tls
negotiation. We will be adding a client facing error message with code
`SQLSTATE: 08004` for `pgcode.SQLserverRejectedEstablishmentOfSQLconnection`.

fixes #136999
Epic CRDB-45351

Release Note(security): The client for the sql connection will additionally get a new error if trying to connect with unsupported cipher along with the error in `OPS` channel.
* client error:
```
 > ./cockroach sql --certs-dir=certs --url "postgresql://root@localhost:26257"

#
# Welcome to the CockroachDB SQL shell.
# All statements must be terminated by a semicolon.
# To exit, type: \q.
#
ERROR: cannot use SSL/TLS with the requested ciphers: presented cipher TLS_AES_128_GCM_SHA256 not in allowed cipher suite list
SQLSTATE: 08004
Failed running "sql"
```
* ops channel error:
```
E250512 06:53:28.160841 24028 1@server/server_sql.go:1977 ⋮ [T1,Vsystem,n1,client=‹127.0.0.1:62122›] 479  serving SQL client conn: presented cipher TLS_AES_128_GCM_SHA256 not in allowed cipher suite list
```