### PR TITLE
release-24.3: kvserver: skip test on failed re-listen

### DIFF
--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -34,7 +34,13 @@ func ListenAndServeGRPC(
 	if err != nil {
 		return ln, err
 	}
+	if err := ServeGRPC(stopper, server, ln); err != nil {
+		return nil, err
+	}
+	return ln, nil
+}
 
+func ServeGRPC(stopper *stop.Stopper, server *grpc.Server, ln net.Listener) error {
 	ctx := context.TODO()
 
 	stopper.AddCloser(stop.CloserFn(server.Stop))
@@ -44,15 +50,12 @@ func ListenAndServeGRPC(
 	}
 	if err := stopper.RunAsyncTask(ctx, "listen-quiesce", waitQuiesce); err != nil {
 		waitQuiesce(ctx)
-		return nil, err
+		return err
 	}
 
-	if err := stopper.RunAsyncTask(ctx, "serve", func(context.Context) {
+	return stopper.RunAsyncTask(ctx, "serve", func(context.Context) {
 		FatalIfUnexpected(server.Serve(ln))
-	}); err != nil {
-		return nil, err
-	}
-	return ln, nil
+	})
 }
 
 var httpLogger = log.NewStdLogger(severity.ERROR, "net/http")


### PR DESCRIPTION
Backport 1/1 commits from #146267 on behalf of @tbg.

----

A test can't listen() on a random port, then close the listener, and expect the
same port to be available for a subsequent listen(). Skip the test if the port
is not available the second time around; this is very rare but can happen.

See https://github.com/cockroachdb/cockroach/issues/146175.

Epic: none


----

Release justification: Test only.