### PR TITLE
structlogging: unredact the hot range log schema objects

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -463,9 +463,9 @@ An event of type `hot_ranges_stats`
 | `WriteBytesPerSecond` | Write bytes per second is the recent number of bytes written per second on this range. | no |
 | `ReadBytesPerSecond` | Read bytes per second is the recent number of bytes read per second on this range. | no |
 | `CPUTimePerSecond` | CPU time per second is the recent cpu usage in nanoseconds of this range. | no |
-| `Databases` | Databases for the range. | yes |
-| `Tables` | Tables for the range | yes |
-| `Indexes` | Indexes for the range | yes |
+| `Databases` | Databases for the range. | no |
+| `Tables` | Tables for the range | no |
+| `Indexes` | Indexes for the range | no |
 
 
 #### Common fields

--- a/pkg/util/log/eventpb/health_events.proto
+++ b/pkg/util/log/eventpb/health_events.proto
@@ -95,11 +95,11 @@ message HotRangesStats {
   double cpu_time_per_second = 13 [(gogoproto.customname) = "CPUTimePerSecond", (gogoproto.jsontag) = ",omitempty"];
 
   // Databases for the range.
-  repeated string databases = 16;
+  repeated string databases = 16 [(gogoproto.moretags) = "redact:\"nonsensitive\""];
   // Tables for the range
-  repeated string tables = 17;
+  repeated string tables = 17 [(gogoproto.moretags) = "redact:\"nonsensitive\""];
   // Indexes for the range
-  repeated string indexes = 18;
+  repeated string indexes = 18 [(gogoproto.moretags) = "redact:\"nonsensitive\""];
 
   // previously used for database, table, and index name
   // syntax reserved 4 to 6 breaks json encoding checks

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -3287,9 +3287,7 @@ func (m *HotRangesStats) AppendJSONFields(printComma bool, b redact.RedactableBy
 				b = append(b, ',')
 			}
 			b = append(b, '"')
-			b = append(b, redact.StartMarker()...)
-			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
-			b = append(b, redact.EndMarker()...)
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -3306,9 +3304,7 @@ func (m *HotRangesStats) AppendJSONFields(printComma bool, b redact.RedactableBy
 				b = append(b, ',')
 			}
 			b = append(b, '"')
-			b = append(b, redact.StartMarker()...)
-			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
-			b = append(b, redact.EndMarker()...)
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
 			b = append(b, '"')
 		}
 		b = append(b, ']')
@@ -3325,9 +3321,7 @@ func (m *HotRangesStats) AppendJSONFields(printComma bool, b redact.RedactableBy
 				b = append(b, ',')
 			}
 			b = append(b, '"')
-			b = append(b, redact.StartMarker()...)
-			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(v)))))
-			b = append(b, redact.EndMarker()...)
+			b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), v))
 			b = append(b, '"')
 		}
 		b = append(b, ']')


### PR DESCRIPTION
structlogging: unredact the hot range log schema objects

Right now, the hot ranges logger logs schema objects, but in a redactable format so that their actual values are hidden to users who've enabled redaction on their log sinks.

This change undoes this, so that users can know where in their database hotspots are occuring.

Fixes: #145557
Epic: CRDB-43150

Release note: None