### PR TITLE
split: add range id to split finder logs

### DIFF
--- a/pkg/kv/kvserver/asim/state/split_decider.go
+++ b/pkg/kv/kvserver/asim/state/split_decider.go
@@ -79,7 +79,7 @@ func NewSplitDecider(settings *config.SimulationSettings) *SplitDecider {
 
 func (s *SplitDecider) newDecider() *split.Decider {
 	decider := &split.Decider{}
-	split.Init(decider, s.splitConfig, &split.LoadSplitterMetrics{
+	split.Init(decider, roachpb.RangeID(0), s.splitConfig, &split.LoadSplitterMetrics{
 		PopularKeyCount:     metric.NewCounter(metric.Metadata{}),
 		NoSplitKeyCount:     metric.NewCounter(metric.Metadata{}),
 		ClearDirectionCount: metric.NewCounter(metric.Metadata{}),

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -186,6 +186,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		r.loadStats = load.NewReplicaLoad(store.Clock(), store.cfg.StorePool.GetNodeLocalityString)
 		split.Init(
 			&r.loadBasedSplitter,
+			r.RangeID,
 			newReplicaSplitConfig(store.ClusterSettings()),
 			store.metrics.LoadSplitterMetrics,
 			store.rebalanceObjManager.Objective().ToSplitObjective(),

--- a/pkg/kv/kvserver/split/load_based_splitter_test.go
+++ b/pkg/kv/kvserver/split/load_based_splitter_test.go
@@ -325,7 +325,7 @@ func (dc deciderConfig) makeDecider(randSource rand.Source) *Decider {
 		statThreshold: dc.threshold,
 	}
 
-	Init(d, &loadSplitConfig, newSplitterMetrics(), dc.objective)
+	Init(d, roachpb.RangeID(0), &loadSplitConfig, newSplitterMetrics(), dc.objective)
 	return d
 }
 

--- a/pkg/util/log/logtestutils/BUILD.bazel
+++ b/pkg/util/log/logtestutils/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "log_test_utils.go",
         "structured_log_spy.go",
+        "log_spy.go",
         "telemetry_logging_test_utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/log/logtestutils",

--- a/pkg/util/log/logtestutils/log_spy.go
+++ b/pkg/util/log/logtestutils/log_spy.go
@@ -1,0 +1,115 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logtestutils
+
+import (
+	"encoding/json"
+	"math"
+	"strings"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+)
+
+// LogSpy is a simple test utility which intercepts and stores
+// log entries for testing purposes. It is not be used outside
+// of tests.
+type LogSpy struct {
+	testState *testing.T
+
+	filters []func(entry logpb.Entry) bool
+
+	logs []logpb.Entry
+
+	mu struct {
+		syncutil.Mutex
+	}
+}
+
+func NewLogSpy(t *testing.T, filters ...func(entry logpb.Entry) bool) *LogSpy {
+	return &LogSpy{
+		testState: t,
+		filters:   filters,
+		logs:      []logpb.Entry{},
+	}
+}
+
+// Intercept satisfies the log.Interceptor interface.
+// It parses the log entry, checks if it passes the filters if
+// any exist and if it does, stores it in the logs slice.
+func (s *LogSpy) Intercept(body []byte) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	var entry logpb.Entry
+	err := json.Unmarshal(body, &entry)
+
+	if err != nil {
+		s.testState.Fatal(err)
+	}
+
+	for _, filter := range s.filters {
+		if !filter(entry) {
+			return
+		}
+	}
+
+	s.logs = append(s.logs, entry)
+}
+
+// The read functions below discard the logs which are consumed.
+func (s *LogSpy) ReadAll() []logpb.Entry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.readLocked(math.MaxUint32)
+}
+
+func (s *LogSpy) Read(n int) []logpb.Entry {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	return s.readLocked(n)
+}
+
+func (s *LogSpy) readLocked(n int) []logpb.Entry {
+	if n > len(s.logs) {
+		n = len(s.logs)
+	}
+
+	entries := s.logs[:n]
+	s.logs = s.logs[n:]
+
+	return entries
+}
+
+// Has checks whether the spy has any log which passes the passed
+// in filters.
+func (s *LogSpy) Has(filters ...func(logpb.Entry) bool) bool {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+logLoop:
+	for _, entry := range s.logs {
+		for _, f := range filters {
+			if !f(entry) {
+				continue logLoop
+			}
+		}
+		// only gets here if all filters matched this log
+		return true
+	}
+	return false
+}
+
+// Matches returns a filter that matches log entries which contain
+// the input string.
+func MatchesF(s string) func(entry logpb.Entry) bool {
+	return func(entry logpb.Entry) bool {
+		return strings.Contains(entry.Message, s)
+	}
+}


### PR DESCRIPTION
split: add range id to split finder logs

Right now there are two parts of the system which provide information to users about hotspots. The splitfinder logs alert when popular keys, or clear access direction is seen in a sampled distribution. The hot ranges log gives information about the schema objects affected by the cluster's hottest replicas. However, there is no meaningful way now to tie the two together.

This small PR adds the range id to the splitfinder logs, so that operators can correlate hot ranges with certain access patterns with the underlying schema objects which are affected.

Fixes: #138766
Epic: CRDB-43150

Release note: None