### PR TITLE
roachtest: hook up restore roachtests with new fixture framework

### DIFF
--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -50,10 +50,54 @@ var queriesThroughputAgg = clusterstats.AggQuery{
 
 type onlineRestoreSpecs struct {
 	restoreSpecs
+
+	// workload defines the workload that will run during the download phase of
+	// Online Restore. If set, must match the fixture that is being restored.
+	workload restoreWorkload
 	// linkPhaseTimeout is the timeout for the link phase of the restore, if set.
 	linkPhaseTimeout time.Duration
 	// downloadPhaseTimeout is the timeout for the download phase of the restore, if set.
 	downloadPhaseTimeout time.Duration
+}
+
+// restoreWorkload describes the workload that will run during the download
+// phase of Online Restore.
+type restoreWorkload interface {
+	// Run begins a workload that runs indefinitely until the passed context is
+	// canceled.
+	Run(ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs) error
+}
+
+type tpccRunOpts struct {
+	workers        int
+	maxOps         int
+	maxRate        int
+	waitFraction   float64
+	queryTraceFile string
+	seed           uint64
+	fakeTime       uint32
+}
+
+type tpccRestore struct {
+	opts tpccRunOpts
+}
+
+var _ restoreWorkload = &tpccRestore{}
+
+func (tpcc tpccRestore) Run(
+	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
+) error {
+	crdbNodes := sp.getCRDBNodes()
+	cmd := roachtestutil.NewCommand(`./cockroach workload run tpcc`).
+		MaybeFlag(tpcc.opts.workers > 0, "workers", tpcc.opts.workers).
+		MaybeFlag(tpcc.opts.waitFraction != 1, "wait", tpcc.opts.waitFraction).
+		MaybeFlag(tpcc.opts.maxOps != 0, "max-ops", tpcc.opts.maxOps).
+		MaybeFlag(tpcc.opts.maxRate != 0, "max-rate", tpcc.opts.maxRate).
+		MaybeFlag(tpcc.opts.seed != 0, "seed", tpcc.opts.seed).
+		MaybeFlag(tpcc.opts.fakeTime != 0, "fake-time", tpcc.opts.fakeTime).
+		MaybeFlag(tpcc.opts.queryTraceFile != "", "query-trace-file", tpcc.opts.queryTraceFile).
+		Arg("{pgurl:%d-%d}", crdbNodes[0], crdbNodes[len(crdbNodes)-1])
+	return c.RunE(ctx, option.WithNodes([]int{sp.getWorkloadNode()}), cmd.String())
 }
 
 func registerOnlineRestorePerf(r registry.Registry) {
@@ -64,51 +108,63 @@ func registerOnlineRestorePerf(r registry.Registry) {
 	// corresponding roachtest that runs a conventional restore over the same
 	// cluster topology and workload in order to measure post restore query
 	// latency relative to online restore (prefix restore/control/*).
+	//
+	// Performance optimizations to reduce download phase time require further
+	// investigation.
 	for _, sp := range []onlineRestoreSpecs{
-		{
-			// 400GB tpce Online Restore
-			restoreSpecs: restoreSpecs{
-				hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 1000 /* MB/s */, workloadNode: true}),
-				backup:                 makeRestoringBackupSpecs(backupSpecs{nonRevisionHistory: true, version: fixtureFromMasterVersion, numBackupsInChain: 5}),
-				timeout:                1 * time.Hour,
-				suites:                 registry.Suites(registry.Nightly),
-				restoreUptoIncremental: 1,
-				skip:                   "fails because of #118283",
-			},
-		},
 		{
 			// 350 GB tpcc Online Restore
 			restoreSpecs: restoreSpecs{
 				hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
-				backup: makeRestoringBackupSpecs(backupSpecs{
-					nonRevisionHistory: true,
-					cloud:              spec.GCE,
-					version:            "24.1",
-					workload:           tpccRestore{tpccRestoreOptions{warehouses: 5000, waitFraction: 0, workers: 100, maxRate: 300}},
-					customFixtureDir:   `'gs://cockroach-fixtures-us-east1/backups/tpc-c/v24.1/db/warehouses=5k?AUTH=implicit'`}),
-				timeout:                1 * time.Hour,
-				suites:                 registry.Suites(registry.Nightly),
-				restoreUptoIncremental: 0,
+				backup: backupSpecs{
+					cloud:   spec.GCE,
+					fixture: SmallFixture,
+				},
+				fullBackupOnly: true,
+				timeout:        1 * time.Hour,
+				suites:         registry.Suites(registry.Nightly),
 			},
-			linkPhaseTimeout:     30 * time.Second, // typically takes 15 seconds
-			downloadPhaseTimeout: 20 * time.Minute, // typically takes 10 minutes. Should get faster once we address #124767.
+			workload: tpccRestore{
+				opts: tpccRunOpts{waitFraction: 0, workers: 100, maxRate: 300},
+			},
+			linkPhaseTimeout:     45 * time.Second, // typically takes 20 seconds
+			downloadPhaseTimeout: 20 * time.Minute, // typically takes 10 minutes.
 		},
 		{
-			// 8.5TB tpcc Online Restore
+			// 350 GB tpcc Online Restore with 48 incrementals
+			restoreSpecs: restoreSpecs{
+				hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
+				backup: backupSpecs{
+					cloud:   spec.GCE,
+					fixture: SmallFixture,
+				},
+				fullBackupOnly: false,
+				timeout:        1 * time.Hour,
+				suites:         registry.Suites(registry.Nightly),
+			},
+			workload: tpccRestore{
+				opts: tpccRunOpts{waitFraction: 0, workers: 100, maxRate: 300},
+			},
+			linkPhaseTimeout:     45 * time.Second, // typically takes 20 seconds
+			downloadPhaseTimeout: 20 * time.Minute, // typically takes 10 minutes.
+		},
+		{
+			// 2TB tpcc Online Restore
 			restoreSpecs: restoreSpecs{
 				hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 1500, workloadNode: true}),
-				backup: makeRestoringBackupSpecs(backupSpecs{
-					nonRevisionHistory: true,
-					cloud:              spec.GCE,
-					version:            "24.1",
-					workload:           tpccRestore{tpccRestoreOptions{warehouses: 150000, waitFraction: 0, workers: 100, maxRate: 1000}},
-					customFixtureDir:   `'gs://cockroach-fixtures-us-east1/backups/tpc-c/v24.1/db/warehouses=150k?AUTH=implicit'`}),
-				timeout:                3 * time.Hour,
-				suites:                 registry.Suites(registry.Nightly),
-				restoreUptoIncremental: 0,
+				backup: backupSpecs{
+					cloud:   spec.GCE,
+					fixture: MediumFixture,
+				},
+				fullBackupOnly: true,
+				timeout:        3 * time.Hour,
+				suites:         registry.Suites(registry.Nightly),
+			},
+			workload: tpccRestore{
+				opts: tpccRunOpts{waitFraction: 0, workers: 100, maxRate: 1000},
 			},
 			linkPhaseTimeout:     10 * time.Minute, // typically takes 5 minutes
-			downloadPhaseTimeout: 4 * time.Hour,    // typically takes 2 hours. Should get faster once we address #124767.
+			downloadPhaseTimeout: 4 * time.Hour,    // typically takes 2 hours.
 		},
 	} {
 		for _, runOnline := range []bool{true, false} {
@@ -165,7 +221,7 @@ func registerOnlineRestorePerf(r registry.Registry) {
 									ctx,
 									c,
 									t.L(),
-									sp.backup.workload.DatabaseName(),
+									sp.backup.fixture.DatabaseName(),
 									restoreStats.downloadEndTimeLowerBound,
 								))
 							}
@@ -210,16 +266,19 @@ func registerOnlineRestoreCorrectness(r registry.Registry) {
 	sp := onlineRestoreSpecs{
 		restoreSpecs: restoreSpecs{
 			hardware: makeHardwareSpecs(hardwareSpecs{workloadNode: true}),
-			backup: makeRestoringBackupSpecs(backupSpecs{
-				nonRevisionHistory: true,
-				version:            fixtureFromMasterVersion,
-				workload:           tpccRestore{opts: tpccRestoreOptions{warehouses: 10, workers: 1, waitFraction: 0, maxOps: 1000}}}),
-			timeout:                15 * time.Minute,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: 1,
-			namePrefix:             "online/correctness",
-			skip:                   "skip for now - flaky",
-		}}
+			backup: backupSpecs{
+				cloud:   spec.AWS,
+				fixture: TinyFixture,
+			},
+			timeout:    15 * time.Minute,
+			suites:     registry.Suites(registry.Nightly),
+			namePrefix: "online/correctness",
+			skip:       "skip for now - flaky",
+		},
+		workload: tpccRestore{
+			opts: tpccRunOpts{workers: 1, waitFraction: 0, maxOps: 1000},
+		},
+	}
 	sp.initTestName()
 	r.Add(
 		registry.TestSpec{
@@ -493,7 +552,7 @@ func initCorrectnessRestoreSpecs(
 	t test.Test, baseSp onlineRestoreSpecs, seed uint64, fakeTime uint32, traceSuffix string,
 ) (onlineRestoreSpecs, tpccRestore) {
 	t.Helper()
-	tpccWorkload, ok := baseSp.backup.workload.(tpccRestore)
+	tpccWorkload, ok := baseSp.workload.(tpccRestore)
 	if !ok {
 		require.Fail(t, "only tpcc workloads are supported for correctness testing")
 	}
@@ -505,7 +564,7 @@ func initCorrectnessRestoreSpecs(
 	if tpccWorkload.opts.fakeTime == 0 {
 		tpccWorkload.opts.fakeTime = fakeTime
 	}
-	baseSp.backup.workload = tpccWorkload
+	baseSp.workload = tpccWorkload
 	return baseSp, tpccWorkload
 }
 
@@ -579,7 +638,7 @@ func runRestore(
 			return errors.Wrapf(err, "failed to add some empty tables")
 		}
 		restoreStartTime = timeutil.Now()
-		restoreCmd := rd.restoreCmd(fmt.Sprintf("DATABASE %s", sp.backup.workload.DatabaseName()), opts)
+		restoreCmd := rd.restoreCmd(ctx, fmt.Sprintf("DATABASE %s", sp.backup.fixture.DatabaseName()), opts)
 		t.L().Printf("Running %s", restoreCmd)
 		if _, err = db.ExecContext(ctx, restoreCmd); err != nil {
 			return err
@@ -602,7 +661,7 @@ func runRestore(
 			return nil
 		}
 		workloadStartTime = timeutil.Now()
-		err := sp.backup.workload.run(ctx, t, c, sp.hardware)
+		err := sp.workload.Run(ctx, t, c, sp.hardware)
 		// We expect the workload to return a context cancelled error because
 		// the roachtest driver cancels the monitor's context after the download job completes
 		if err != nil && ctx.Err() == nil {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -40,10 +40,6 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-// defaultRestoreUptoIncremental is the default number of backups in a chain we
-// will restore.
-const defaultRestoreUptoIncremental = 12
-
 var restoreAggregateFunction = func(test string, histogram *roachtestutil.HistogramMetric) (roachtestutil.AggregatedPerfMetrics, error) {
 	metricValue := histogram.Summaries[0].HighestTrackableValue / 1e9
 
@@ -60,17 +56,17 @@ var restoreAggregateFunction = func(test string, histogram *roachtestutil.Histog
 func registerRestoreNodeShutdown(r registry.Registry) {
 	sp := restoreSpecs{
 		hardware: makeHardwareSpecs(hardwareSpecs{}),
-		backup: makeRestoringBackupSpecs(
-			backupSpecs{workload: tpceRestore{customers: 1000}, version: "v22.2.1"}),
-		timeout:                1 * time.Hour,
-		fingerprint:            8445446819555404274,
-		restoreUptoIncremental: defaultRestoreUptoIncremental,
+		backup: backupSpecs{
+			cloud:   spec.GCE,
+			fixture: SmallFixture,
+		},
+		timeout: 1 * time.Hour,
 	}
 
 	makeRestoreStarter := func(ctx context.Context, t test.Test, c cluster.Cluster,
 		gatewayNode int, rd restoreDriver) jobStarter {
 		return func(c cluster.Cluster, l *logger.Logger) (jobspb.JobID, error) {
-			return rd.runDetached(ctx, "DATABASE tpce", gatewayNode)
+			return rd.runDetached(ctx, "DATABASE tpcc", gatewayNode)
 		}
 	}
 
@@ -129,14 +125,13 @@ func registerRestore(r registry.Registry) {
 		PrometheusNameSpace, Subsystem: "restore", Name: "duration"}, []string{"test_name"})
 
 	withPauseSpecs := restoreSpecs{
-		hardware: makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
-		backup: makeRestoringBackupSpecs(
-			backupSpecs{workload: tpceRestore{customers: 1000},
-				version: "v22.2.1"}),
-		timeout:                3 * time.Hour,
-		namePrefix:             "pause",
-		fingerprint:            8445446819555404274,
-		restoreUptoIncremental: defaultRestoreUptoIncremental,
+		hardware: makeHardwareSpecs(hardwareSpecs{}),
+		backup: backupSpecs{
+			cloud:   spec.GCE,
+			fixture: SmallFixture,
+		},
+		timeout:    3 * time.Hour,
+		namePrefix: "pause",
 	}
 	withPauseSpecs.initTestName()
 
@@ -237,7 +232,7 @@ func registerRestore(r registry.Registry) {
 				defer close(jobIDCh)
 				t.Status(`running restore`)
 				metricCollector := rd.initRestorePerfMetrics(ctx, durationGauge)
-				jobID, err := rd.runDetached(ctx, "DATABASE tpce", 1)
+				jobID, err := rd.runDetached(ctx, "DATABASE tpcc", 1)
 				require.NoError(t, err)
 				jobIDCh <- jobID
 
@@ -290,38 +285,41 @@ func registerRestore(r registry.Registry) {
 
 	for _, sp := range []restoreSpecs{
 		{
-			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
-			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
-			timeout:                1 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			hardware: makeHardwareSpecs(hardwareSpecs{}),
+			backup: backupSpecs{
+				cloud:   spec.GCE,
+				fixture: TinyFixture,
+			},
+			timeout: 1 * time.Hour,
+			suites:  registry.Suites(registry.Nightly),
 		},
 		{
-			// Note that the default specs in makeHardwareSpecs() spin up restore tests in aws,
-			// by default.
-			hardware:               makeHardwareSpecs(hardwareSpecs{}),
-			backup:                 makeRestoringBackupSpecs(backupSpecs{cloud: spec.GCE}),
-			timeout:                1 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			hardware: makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
+			backup:   backupSpecs{cloud: spec.AWS, fixture: MediumFixture},
+			timeout:  1 * time.Hour,
+			suites:   registry.Suites(registry.Nightly),
+		},
+		{
+			hardware: makeHardwareSpecs(hardwareSpecs{}),
+			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			timeout:  1 * time.Hour,
+			suites:   registry.Suites(registry.Nightly),
 		},
 		{
 			// Benchmarks using a low memory per core ratio - we don't expect ideal
 			// performance but nodes should not OOM.
-			hardware:               makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
-			backup:                 makeRestoringBackupSpecs(backupSpecs{cloud: spec.GCE}),
-			timeout:                1 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			hardware: makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
+			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			timeout:  1 * time.Hour,
+			suites:   registry.Suites(registry.Nightly),
 		},
 		{
 			// Benchmarks if per node throughput remains constant if the number of
 			// nodes doubles relative to default.
-			hardware:               makeHardwareSpecs(hardwareSpecs{nodes: 8, ebsThroughput: 250 /* MB/s */}),
-			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
-			timeout:                1 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 8}),
+			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			timeout:  1 * time.Hour,
+			suites:   registry.Suites(registry.Nightly),
 		},
 		{
 			// Benchmarks if per node throughput remains constant if the cluster
@@ -329,102 +327,50 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{
 				nodes: 9, ebsThroughput: 250, /* MB/s */
 				zones: []string{"us-east-2b", "us-west-2b", "eu-west-1b"}}), // These zones are AWS-specific.
-			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
-			timeout:                90 * time.Minute,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			backup:  backupSpecs{cloud: spec.AWS, fixture: MediumFixture},
+			timeout: 90 * time.Minute,
+			suites:  registry.Suites(registry.Nightly),
 		},
 		{
 			// Benchmarks if per node throughput doubles if the vcpu count doubles
 			// relative to default.
-			hardware:               makeHardwareSpecs(hardwareSpecs{cpus: 16, ebsThroughput: 250 /* MB/s */}),
-			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
-			timeout:                1 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 16}),
+			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			timeout:  1 * time.Hour,
+			suites:   registry.Suites(registry.Nightly),
 		},
 		{
-			// Ensures we can restore a 48 length incremental chain.
-			// Also benchmarks per node throughput for a long chain.
-			hardware:               makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
-			backup:                 makeRestoringBackupSpecs(backupSpecs{}),
-			timeout:                1 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: 48,
-		},
-		{
-			// The nightly 8TB Restore test.
-			// NB: bump disk throughput because this load saturates the default 125
-			// MB/s. See https://github.com/cockroachdb/cockroach/issues/107609.
-			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 2000,
-				ebsThroughput: 250 /* MB/s */}),
-			backup: makeRestoringBackupSpecs(backupSpecs{
-				version:  "v22.2.1",
-				workload: tpceRestore{customers: 500000}}),
-			timeout:                5 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
-		},
-		{
-			// The weekly 32TB Restore test.
-			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 15, cpus: 16, volumeSize: 5000,
-				ebsThroughput: 250 /* MB/s */}),
-			backup: makeRestoringBackupSpecs(backupSpecs{
-				version:  "v22.2.1",
-				workload: tpceRestore{customers: 2000000}}),
-			timeout:                24 * time.Hour,
-			suites:                 registry.Suites(registry.Weekly),
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
-		},
-		{
-			// The weekly 32TB, 400 incremental layer Restore test on AWS.
-			//
-			// NB: Prior to 23.1, restore would OOM on backups that had many
-			// incremental layers and many import spans. Together with having a 400
-			// incremental chain, this regression tests against the OOMs that we've
-			// seen in previous versions.
-			//
-			// NB 2: This test sets backup.restore_span.max_file_count to allow for
-			// restore span entries to extend. As of #119840, restore limits the
-			// number of files per restore span entry. When this file cap is less than
-			// the number of inc layers, restore slows signficantly, as the restore
-			// span entries become much smaller.
-			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 15, cpus: 16, volumeSize: 5000,
-				ebsThroughput: 250 /* MB/s */}),
-			backup: makeRestoringBackupSpecs(backupSpecs{
-				version:           "v22.2.4",
-				workload:          tpceRestore{customers: 2000000},
-				numBackupsInChain: 400,
-			}),
-			setUpStmts:             []string{"SET CLUSTER SETTING backup.restore_span.max_file_count = 800"},
-			timeout:                30 * time.Hour,
-			suites:                 registry.Suites(registry.Weekly),
-			restoreUptoIncremental: 400,
-		},
-		{
-			// The weekly 32TB, 400 incremental layer Restore test on GCP.
+			// The weekly 20TB Restore test.
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 15, cpus: 16, volumeSize: 5000}),
-			backup: makeRestoringBackupSpecs(backupSpecs{
-				version:           "v22.2.4",
-				workload:          tpceRestore{customers: 2000000},
-				cloud:             spec.GCE,
-				numBackupsInChain: 400,
-			}),
-			timeout:                30 * time.Hour,
-			suites:                 registry.Suites(registry.Weekly),
-			restoreUptoIncremental: 400,
-			skip:                   "a recent gcp pricing policy makes this test very expensive. unskip after #111371 is addressed",
+			backup:   backupSpecs{cloud: spec.GCE, fixture: LargeFixture},
+			timeout:  24 * time.Hour,
+			suites:   registry.Suites(registry.Weekly),
+		},
+		// Following three tests are just used to benchmark classic restore against
+		// OR with the exact same fixtures and hardware.
+		{
+			hardware:       makeHardwareSpecs(hardwareSpecs{}),
+			backup:         backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
+			timeout:        1 * time.Hour,
+			suites:         registry.Suites(registry.Nightly),
+			fullBackupOnly: true,
+			skip:           "used for adhoc benchmarking against OR",
 		},
 		{
-			// A teeny weeny 15GB restore that could be used to bisect scale agnostic perf regressions.
-			hardware: makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
-			backup: makeRestoringBackupSpecs(
-				backupSpecs{workload: tpceRestore{customers: 1000},
-					version: "v22.2.1"}),
-			timeout:                3 * time.Hour,
-			suites:                 registry.Suites(registry.Nightly),
-			fingerprint:            8445446819555404274,
-			restoreUptoIncremental: defaultRestoreUptoIncremental,
+			hardware:       makeHardwareSpecs(hardwareSpecs{}),
+			backup:         backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
+			fullBackupOnly: false,
+			timeout:        1 * time.Hour,
+			suites:         registry.Suites(registry.Nightly),
+			skip:           "used for adhoc benchmarking against OR",
+		},
+		{
+			hardware:       makeHardwareSpecs(hardwareSpecs{nodes: 10, volumeSize: 1500, workloadNode: true}),
+			backup:         backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			timeout:        3 * time.Hour,
+			suites:         registry.Suites(registry.Nightly),
+			fullBackupOnly: true,
+			skip:           "used for adhoc benchmarking against OR",
 		},
 		// TODO(msbutler): add the following tests once roachperf/grafana is hooked up and old tests are
 		// removed:
@@ -482,7 +428,7 @@ func registerRestore(r registry.Registry) {
 
 					t.Status(`running restore`)
 					metricCollector := rd.initRestorePerfMetrics(ctx, durationGauge)
-					if err := rd.run(ctx, ""); err != nil {
+					if err := rd.run(ctx, "DATABASE "+rd.sp.backup.fixture.DatabaseName()); err != nil {
 						return err
 					}
 					metricCollector()
@@ -616,51 +562,23 @@ func makeHardwareSpecs(override hardwareSpecs) hardwareSpecs {
 	return specs
 }
 
-var defaultRestoringBackupSpecs = backupSpecs{
-	// TODO(msbutler): write a script that automatically finds the latest versioned fixture.
-	version:           "v22.2.0",
-	cloud:             spec.AWS,
-	fullBackupDir:     "LATEST",
-	workload:          tpceRestore{customers: 25000},
-	numBackupsInChain: 48,
-}
-
 // backupSpecs define the backup that will get restored. These values should not
 // get updated during the test.
 type backupSpecs struct {
-	// version specifies the crdb version the backup was taken on.
-	version string
-
-	// cloud is the cloud storage provider the backup is stored on.
+	// cloud represents the cloud provider the backup is stored on.
 	cloud spec.Cloud
+
+	// fixture is the fixture that will be restored.
+	fixture BackupFixture
 
 	// allowLocal is true if the test should be allowed to run
 	// locally. We don't set this by default to avoid someone
 	// trying to run the very large roachtests locally.
 	allowLocal bool
 
-	// fullBackupDir specifies the full backup directory in the collection to restore from.
-	fullBackupDir string
-
-	// numBackupsInChain specifies the length of the chain of the backup. This field
-	// is only to be used during backup fixture generation to control how many
-	// incremental backups we layer on top of the full.
-	numBackupsInChain int
-
-	// workload defines the backed up workload.
-	workload backupWorkload
-
-	// nonRevisionHistory is true if the backup is not a revision history backup
-	// (note that the default backup in the restore roachtests contains revision
-	// history).
-	//
-	// TODO(msbutler): if another fixture requires a different backup option,
-	// create a new backupOpts struct.
-	nonRevisionHistory bool
-
-	// customFixtureDir is used when an engineer is naughty and doesn't create the
-	// backup fixture in the correct fixture path.
-	customFixtureDir string
+	// cached collection URI of the fixture, will be set automatically based on
+	// workload.
+	collectionURI string
 }
 
 func (bs backupSpecs) CloudIsCompatible(cloud spec.Cloud) error {
@@ -683,238 +601,33 @@ func (bs backupSpecs) CompatibleClouds() registry.CloudSet {
 	return r
 }
 
-func (bs backupSpecs) storagePrefix() string {
-	if bs.cloud == spec.AWS {
-		return "s3"
+func (bs *backupSpecs) CollectionURI(ctx context.Context, t test.Test) string {
+	if bs.collectionURI != "" {
+		return bs.collectionURI
 	}
-	return "gs"
+	registry := GetFixtureRegistry(ctx, t, bs.cloud)
+	fixtureMeta, err := registry.GetLatest(ctx, bs.fixture.Kind())
+	if err != nil {
+		t.Skipf("fixture %s is not available: %s", bs.fixture.Kind(), err)
+	}
+	url := registry.URI(fixtureMeta.DataPath)
+	return url.String()
 }
 
-func (bs backupSpecs) backupCollection() string {
-	// N.B. AWS buckets are _regional_ whereas GCS buckets are _multi-regional_. Thus, in order to avoid egress (cost),
-	// we use us-east-2 for AWS, which is the default region for all roachprod clusters. (See roachprod/vm/aws/aws.go)
-	if bs.customFixtureDir != "" {
-		return bs.customFixtureDir
-	}
-	properties := ""
-	if bs.nonRevisionHistory {
-		properties = "/rev-history=false"
-	}
-	switch bs.storagePrefix() {
-	case "s3":
-		return fmt.Sprintf(`'s3://cockroach-fixtures-us-east-2/backups/%s/%s/inc-count=%d%s?AUTH=implicit'`,
-			bs.workload.fixtureDir(), bs.version, bs.numBackupsInChain, properties)
-	case "gs":
-		return fmt.Sprintf(`'gs://cockroach-fixtures-us-east1/backups/%s/%s/inc-count=%d%s?AUTH=implicit'`,
-			bs.workload.fixtureDir(), bs.version, bs.numBackupsInChain, properties)
-	default:
-		panic(fmt.Sprintf("unknown storage prefix: %s", bs.storagePrefix()))
-	}
-}
-
-// getAOSTCmd returns a sql cmd that will return a system time that is equal to the end time of
-// the bs.backupsIncluded'th backup in the target backup chain.
-func (sp *restoreSpecs) getAostCmd() string {
+// getFullBackupEndTimeCmd returns a sql cmd that will return a system time for
+// a restore from the full backup of the latest chain.
+func (sp *restoreSpecs) getFullBackupEndTimeCmd(ctx context.Context, t test.Test) string {
 	return fmt.Sprintf(
-		`SELECT max(end_time) FROM [SELECT DISTINCT end_time FROM [SHOW BACKUP FROM %s IN %s] ORDER BY end_time LIMIT %d]`,
-		sp.backup.fullBackupDir,
-		sp.backup.backupCollection(),
-		sp.restoreUptoIncremental)
-}
-
-func makeBackupSpecs(override backupSpecs, specs backupSpecs) backupSpecs {
-	if override.cloud.IsSet() {
-		specs.cloud = override.cloud
-	}
-	if override.version != "" {
-		specs.version = override.version
-	}
-
-	if override.fullBackupDir != "" {
-		specs.fullBackupDir = override.fullBackupDir
-	}
-
-	if override.numBackupsInChain != 0 {
-		specs.numBackupsInChain = override.numBackupsInChain
-	}
-
-	if override.nonRevisionHistory != specs.nonRevisionHistory {
-		specs.nonRevisionHistory = override.nonRevisionHistory
-	}
-
-	if override.workload != nil {
-		specs.workload = override.workload
-	}
-	if override.customFixtureDir != "" {
-		specs.customFixtureDir = override.customFixtureDir
-	}
-	return specs
-}
-
-// makeRestoringBackupSpecs initializes the default restoring backup specs. The caller can override
-// any of the default backup specs by passing any non-nil params.
-func makeRestoringBackupSpecs(override backupSpecs) backupSpecs {
-	return makeBackupSpecs(override, defaultRestoringBackupSpecs)
-}
-
-type backupWorkload interface {
-	fixtureDir() string
-	String() string
-
-	// DatabaseName specifies the name of the database the workload will operate on.
-	DatabaseName() string
-
-	// init loads the cluster with the workload's schema and initial data.
-	init(ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs)
-
-	// run begins a workload that runs indefinitely until the passed context
-	// is cancelled.
-	run(ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs) error
-}
-
-type tpceRestore struct {
-	customers int
-	spec      *tpceSpec
-}
-
-func (tpce tpceRestore) getSpec(
-	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
-) *tpceSpec {
-	if tpce.spec != nil {
-		return tpce.spec
-	}
-	tpceSpec, err := initTPCESpec(ctx, t.L(), c)
-	require.NoError(t, err)
-	return tpceSpec
-}
-
-func (tpce tpceRestore) init(
-	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
-) {
-	spec := tpce.getSpec(ctx, t, c, sp)
-	spec.init(ctx, t, c, tpceCmdOptions{
-		customers:      tpce.customers,
-		racks:          sp.nodes,
-		connectionOpts: tpceConnectionOpts{fixtureBucket: defaultFixtureBucket},
-	})
-}
-
-func (tpce tpceRestore) run(
-	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
-) error {
-	spec := tpce.getSpec(ctx, t, c, sp)
-	details, err := spec.run(ctx, t, c, tpceCmdOptions{
-		// Set the duration to be a week to ensure the workload never exits early.
-		duration:       time.Hour * 7 * 24,
-		customers:      tpce.customers,
-		racks:          sp.nodes,
-		threads:        sp.cpus * sp.nodes,
-		connectionOpts: tpceConnectionOpts{fixtureBucket: defaultFixtureBucket},
-	})
-	out := details.Output(true)
-	t.L().Printf("TPCE run details: \n%s\n", out)
-	t.L().Printf("TPCE run error: %s\n", err)
-	return err
-}
-
-func (tpce tpceRestore) fixtureDir() string {
-	return fmt.Sprintf(`tpc-e/customers=%d`, tpce.customers)
-}
-
-func (tpce tpceRestore) String() string {
-	var builder strings.Builder
-	builder.WriteString("tpce/")
-	switch tpce.customers {
-	case 1000:
-		builder.WriteString("15GB")
-	case 5000:
-		builder.WriteString("80GB")
-	case 25000:
-		builder.WriteString("400GB")
-	case 500000:
-		builder.WriteString("8TB")
-	case 2000000:
-		builder.WriteString("32TB")
-	default:
-		panic("tpce customer count not recognized")
-	}
-	return builder.String()
-}
-
-func (tpce tpceRestore) DatabaseName() string {
-	return "tpce"
-}
-
-type tpccRestoreOptions struct {
-	warehouses     int
-	workers        int
-	maxOps         int
-	maxRate        int
-	waitFraction   float64
-	queryTraceFile string
-	seed           uint64
-	fakeTime       uint32
-}
-
-type tpccRestore struct {
-	opts tpccRestoreOptions
-}
-
-func (tpcc tpccRestore) init(
-	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
-) {
-	crdbNodes := sp.getCRDBNodes()
-	cmd := roachtestutil.NewCommand(`./cockroach workload init tpcc`).
-		MaybeFlag(tpcc.opts.warehouses > 0, "warehouses", tpcc.opts.warehouses).
-		MaybeFlag(tpcc.opts.seed != 0, "seed", tpcc.opts.seed).
-		MaybeFlag(tpcc.opts.fakeTime != 0, "fake-time", tpcc.opts.fakeTime).
-		Arg("{pgurl:%d-%d}", crdbNodes[0], crdbNodes[len(crdbNodes)-1])
-	c.Run(ctx, option.WithNodes([]int{sp.getWorkloadNode()}), cmd.String())
-}
-
-func (tpcc tpccRestore) run(
-	ctx context.Context, t test.Test, c cluster.Cluster, sp hardwareSpecs,
-) error {
-	crdbNodes := sp.getCRDBNodes()
-	cmd := roachtestutil.NewCommand(`./cockroach workload run tpcc`).
-		MaybeFlag(tpcc.opts.workers > 0, "workers", tpcc.opts.workers).
-		MaybeFlag(tpcc.opts.waitFraction != 1, "wait", tpcc.opts.waitFraction).
-		MaybeFlag(tpcc.opts.maxOps != 0, "max-ops", tpcc.opts.maxOps).
-		MaybeFlag(tpcc.opts.maxRate != 0, "max-rate", tpcc.opts.maxRate).
-		MaybeFlag(tpcc.opts.seed != 0, "seed", tpcc.opts.seed).
-		MaybeFlag(tpcc.opts.fakeTime != 0, "fake-time", tpcc.opts.fakeTime).
-		MaybeFlag(tpcc.opts.queryTraceFile != "", "query-trace-file", tpcc.opts.queryTraceFile).
-		Arg("{pgurl:%d-%d}", crdbNodes[0], crdbNodes[len(crdbNodes)-1])
-	return c.RunE(ctx, option.WithNodes([]int{sp.getWorkloadNode()}), cmd.String())
-}
-
-func (tpcc tpccRestore) fixtureDir() string {
-	return fmt.Sprintf("tpc-c/warehouses=%d", tpcc.opts.warehouses)
-}
-
-func (tpcc tpccRestore) String() string {
-	var builder strings.Builder
-	builder.WriteString("tpcc/")
-	switch tpcc.opts.warehouses {
-	case 10:
-		builder.WriteString("150MB")
-	case 5000:
-		builder.WriteString("350GB")
-	case 150000:
-		builder.WriteString("8TB")
-	default:
-		panic(fmt.Sprintf("tpcc warehouse %d count not recognized", tpcc.opts.warehouses))
-	}
-	return builder.String()
-}
-
-func (tpcc tpccRestore) DatabaseName() string {
-	return "tpcc"
+		`SELECT max(end_time) FROM [SELECT DISTINCT end_time FROM
+		[SHOW BACKUP FROM LATEST IN '%s'] ORDER BY end_time ASC LIMIT %d]`,
+		sp.backup.CollectionURI(ctx, t),
+		1, // restore either restores full chain or just the full backup
+	)
 }
 
 // restoreSpecs define input parameters to a restore roachtest set during
-// registration. They should not be modified within test_spec.run(), as they are shared
-// across driver runs.
+// registration. They should not be modified within test_spec.run(), as they are
+// shared across driver runs.
 type restoreSpecs struct {
 	hardware hardwareSpecs
 
@@ -923,9 +636,9 @@ type restoreSpecs struct {
 	timeout time.Duration
 	suites  registry.SuiteSet
 
-	// restoreUptoIncremental specifies the number of incremental backups in the
-	// chain to restore up to. If set to 0, no AOST is used.
-	restoreUptoIncremental int
+	// fullBackupOnly indicates if the restore should only restore the full
+	// backup. If false, restore will restore the entire chain instead.
+	fullBackupOnly bool
 
 	// namePrefix appears in the name of the roachtest, i.e. `restore/{prefix}/{config}`.
 	namePrefix string
@@ -962,13 +675,11 @@ func (sp *restoreSpecs) String() string {
 	bs := sp.backup
 
 	var builder strings.Builder
-	builder.WriteString("/" + bs.workload.String())
+	builder.WriteString("/" + bs.fixture.Kind())
 	builder.WriteString("/" + bs.cloud.String())
 
-	// Annotate the name with the number of incremental layers we are restoring if
-	// it differs from the default.
-	if sp.restoreUptoIncremental != defaultRestoreUptoIncremental {
-		builder.WriteString(fmt.Sprintf("/inc-count=%d", sp.restoreUptoIncremental))
+	if sp.fullBackupOnly {
+		builder.WriteString("/fullOnly")
 	}
 
 	return builder.String()
@@ -1021,32 +732,33 @@ func (rd *restoreDriver) prepareCluster(ctx context.Context) {
 
 // getAOST gets the AOST to use in the restore cmd.
 func (rd *restoreDriver) getAOST(ctx context.Context) {
-	if rd.sp.restoreUptoIncremental == 0 {
+	if !rd.sp.fullBackupOnly {
 		rd.aost = ""
 		return
 	}
 	var aost string
 	conn := rd.c.Conn(ctx, rd.t.L(), 1)
 	defer conn.Close()
-	err := conn.QueryRowContext(ctx, rd.sp.getAostCmd()).Scan(&aost)
-	require.NoError(rd.t, err, fmt.Sprintf("aost cmd failed: %s", rd.sp.getAostCmd()))
+	aostCmd := rd.sp.getFullBackupEndTimeCmd(ctx, rd.t)
+	err := conn.QueryRowContext(ctx, aostCmd).Scan(&aost)
+	require.NoError(rd.t, err, fmt.Sprintf("aost cmd failed: %s", aostCmd))
 	rd.aost = aost
 }
 
-func (rd *restoreDriver) restoreCmd(target, opts string) string {
+func (rd *restoreDriver) restoreCmd(ctx context.Context, target, opts string) string {
 	var aostSubCmd string
 	if rd.aost != "" {
 		aostSubCmd = fmt.Sprintf("AS OF SYSTEM TIME '%s'", rd.aost)
 	}
-	query := fmt.Sprintf(`RESTORE %s FROM %s IN %s %s %s`,
-		target, rd.sp.backup.fullBackupDir, rd.sp.backup.backupCollection(), aostSubCmd, opts)
+	query := fmt.Sprintf(`RESTORE %s FROM LATEST IN '%s' %s %s`,
+		target, rd.sp.backup.CollectionURI(ctx, rd.t), aostSubCmd, opts)
 	rd.t.L().Printf("Running restore cmd: %s", query)
 	return query
 }
 
 // run executes the restore, where target injects a restore target into the restore command.
 // Examples:
-// - "DATABASE tpce" will execute a database restore on the tpce cluster.
+// - "DATABASE tpcc" will execute a database restore on the tpcc cluster.
 // - "" will execute a cluster restore.
 func (rd *restoreDriver) run(ctx context.Context, target string) error {
 	conn, err := rd.c.ConnE(ctx, rd.t.L(), 1)
@@ -1054,7 +766,9 @@ func (rd *restoreDriver) run(ctx context.Context, target string) error {
 		return errors.Wrapf(err, "failed to connect to node 1; running restore")
 	}
 	defer conn.Close()
-	_, err = conn.ExecContext(ctx, rd.restoreCmd(target, "WITH unsafe_restore_incompatible_version"))
+	_, err = conn.ExecContext(
+		ctx, rd.restoreCmd(ctx, target, "WITH unsafe_restore_incompatible_version"),
+	)
 	return err
 }
 
@@ -1066,8 +780,9 @@ func (rd *restoreDriver) runDetached(
 		return 0, errors.Wrapf(err, "failed to connect to node %d; running restore detached", node)
 	}
 	defer db.Close()
-	if _, err = db.ExecContext(ctx, rd.restoreCmd(target,
-		"WITH DETACHED, unsafe_restore_incompatible_version")); err != nil {
+	if _, err = db.ExecContext(ctx, rd.restoreCmd(
+		ctx, target, "WITH DETACHED, unsafe_restore_incompatible_version",
+	)); err != nil {
 		return 0, err
 	}
 	var jobID jobspb.JobID

--- a/pkg/cmd/roachtest/tests/restore_test.go
+++ b/pkg/cmd/roachtest/tests/restore_test.go
@@ -6,7 +6,7 @@
 package tests
 
 import (
-	"sort"
+	"slices"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
@@ -53,22 +53,19 @@ func TestRestoreRegisteredNames(t *testing.T) {
 	expectedRestoreTests := []string{
 		"restore/nodeShutdown/coordinator",
 		"restore/nodeShutdown/worker",
-		"restore/pause/tpce/15GB/aws/nodes=4/cpus=8",
-		"restore/tpce/15GB/aws/nodes=4/cpus=8",
-		"restore/tpce/32TB/aws/inc-count=400/nodes=15/cpus=16",
-		"restore/tpce/32TB/aws/nodes=15/cpus=16",
-		"restore/tpce/32TB/gce/inc-count=400/nodes=15/cpus=16",
-		"restore/tpce/400GB/aws/inc-count=48/nodes=4/cpus=8",
-		"restore/tpce/400GB/aws/nodes=4/cpus=16",
-		"restore/tpce/400GB/aws/nodes=4/cpus=8",
-		"restore/tpce/400GB/aws/nodes=8/cpus=8",
-		"restore/tpce/400GB/aws/nodes=9/cpus=8/zones=us-east-2b,us-west-2b,eu-west-1b",
-		"restore/tpce/400GB/gce/nodes=4/cpus=8",
-		"restore/tpce/400GB/gce/nodes=4/cpus=8/lowmem",
-		"restore/tpce/8TB/aws/nodes=10/cpus=8",
+		"restore/pause/tpcc-5k/gce/nodes=4/cpus=8",
+		"restore/tpcc-10/gce/nodes=4/cpus=8",
+		"restore/tpcc-300k/gce/nodes=15/cpus=16",
+		"restore/tpcc-30k/aws/nodes=4/cpus=8",
+		"restore/tpcc-30k/aws/nodes=9/cpus=8/zones=us-east-2b,us-west-2b,eu-west-1b",
+		"restore/tpcc-30k/gce/fullOnly/nodes=10/cpus=8",
+		"restore/tpcc-30k/gce/nodes=4/cpus=16",
+		"restore/tpcc-30k/gce/nodes=4/cpus=8",
+		"restore/tpcc-30k/gce/nodes=4/cpus=8/lowmem",
+		"restore/tpcc-30k/gce/nodes=8/cpus=8",
+		"restore/tpcc-5k/gce/fullOnly/nodes=4/cpus=8",
+		"restore/tpcc-5k/gce/nodes=4/cpus=8",
 	}
-	sort.Slice(r.testNames, func(i, j int) bool {
-		return r.testNames[i] < r.testNames[j]
-	})
+	slices.Sort(r.testNames)
 	require.Equal(t, expectedRestoreTests, r.testNames)
 }

--- a/pkg/roachprod/blobfixture/metadata.go
+++ b/pkg/roachprod/blobfixture/metadata.go
@@ -87,7 +87,7 @@ type fixtureToDelete struct {
 // successor and the successor was made ready more than 24 hours ago. The 24
 // hour wait is to ensure no tests are in the middle of using the fixture.
 //
-// GC decisions are made soly based on the metadata. There is no attempt to
+// GC decisions are made solely based on the metadata. There is no attempt to
 // examine actual live data in object storage. This ensures the GC will only
 // delete data that is managed by the fixture registry, so its safe to mix
 // manually managed and non-managed fixtures. This decision may be worth

--- a/pkg/roachprod/blobfixture/registry.go
+++ b/pkg/roachprod/blobfixture/registry.go
@@ -45,7 +45,7 @@ type Registry struct {
 	// <uri>/metadata/<kind>/<timestamp> contains metadata for a fixture instance
 	// <uri>/<kind>/<timestamp> contains the actual fixture data
 	//
-	// The uri ispassed to the registry at construction time. The baseURI is
+	// The uri is passed to the registry at construction time. The baseURI is
 	// expected to be of the form "scheme://<bucket>/roachprod/<version>". So a
 	// full metadata path looks like:
 	// gs://cockroach-fixtures/roachprod/v25.1/metadata/backup-tpcc-30k/20220101-1504


### PR DESCRIPTION
Our current restore roachtest are relying on 3 year old fixtures. This patch updates our roachtest to instead rely on the new fixture framework so that our restore roachtests are always restoring from the latest fixtures.

Epic: None

Release note: None