### PR TITLE
kvserver: reduce replica mu contention in updateProposalQuotaRaftMuLocked

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -2499,7 +2499,7 @@ func TestQuotaPool(t *testing.T) {
 	settings := cluster.MakeTestingClusterSettings()
 	// Override the kvflowcontrol.Mode setting to apply_to_elastic, as when
 	// apply_to_all is set (metamorphically), the quota pool will be disabled.
-	// See getQuotaPoolEnabledRLocked.
+	// See getQuotaPoolEnabled.
 	kvflowcontrol.Mode.Override(ctx, &settings.SV, kvflowcontrol.ApplyToElastic)
 	// Disable metamorphism and always run with fortification enabled, as it helps
 	// guard against unexpected leadership changes that the test doesn't expect.

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -127,58 +127,101 @@ func (r *Replica) replicationAdmissionControlModeToUse(ctx context.Context) rac2
 	return rac2.MsgAppPush
 }
 
+// updateProposalQuotaOnLeaderChangeRaftMuLocked handles the proposal quota
+// updates on leadership changes.
+func (r *Replica) updateProposalQuotaOnLeaderChangeRaftMuLocked(ctx context.Context) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.replicaID == r.shMu.leaderID {
+		// We're becoming the leader.
+		r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
+		r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
+	} else {
+		// We're becoming a follower.
+		r.mu.replicaFlowControlIntegration.onBecameFollower(ctx)
+		if r.mu.proposalQuota != nil {
+			// We unblock all ongoing and subsequent quota acquisition goroutines
+			// (if any) and release the quotaReleaseQueue so its allocs are pooled.
+			r.mu.proposalQuota.Close("leader change")
+			r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
+			r.mu.quotaReleaseQueue = nil
+			r.mu.proposalQuota = nil
+		}
+	}
+}
+
 func (r *Replica) updateProposalQuotaRaftMuLocked(
 	ctx context.Context, lastLeaderID roachpb.ReplicaID,
 ) {
 	now := r.Clock().PhysicalTime()
-	// Since RaftMu is locked, we can get r.shMu.state.Desc without holding the
+	// Since RaftMu is locked, we can read r.shMu struct without holding the
 	// replica mutex lock.
-	enabled := r.getQuotaPoolEnabled(ctx, r.shMu.state.Desc)
-	r.mu.Lock()
-	defer r.mu.Unlock()
+	quotaPoolEnabled := r.getQuotaPoolEnabled(ctx, r.shMu.state.Desc)
+	leadershipChanged := r.shMu.leaderID != lastLeaderID
+	currentlyLeader := r.replicaID == r.shMu.leaderID
 
-	status := r.mu.internalRaftGroup.BasicStatus()
+	if leadershipChanged {
+		r.updateProposalQuotaOnLeaderChangeRaftMuLocked(ctx)
+	}
+
+	if !currentlyLeader {
+		// If we are already a follower, there is already nothing to do. If we just
+		// became a follower, updateProposalQuotaOnLeaderChangeRaftMuLocked() should
+		// have made the necessary replica updates, and now there is nothing to do.
+		return
+	}
+
+	if !quotaPoolEnabled {
+		if r.mu.proposalQuota != nil {
+			r.mu.Lock()
+			// The quota pool was previously enabled on this leader, but it is no longer
+			// enabled. We release all quota back to the pool and close the pool.
+			r.mu.proposalQuota.Close("quota pool disabled")
+			r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
+			r.mu.quotaReleaseQueue = nil
+			r.mu.proposalQuota = nil
+			r.mu.Unlock()
+		}
+
+		if r.raftMu.flowControlLevel <= kvflowcontrol.V2NotEnabledWhenLeader {
+			// We only need to tick the replicaFlowControlIntegration interface if we
+			// are not using flowControlV2. If we are using flowControlV2, the calls
+			// or no-ops.
+			r.mu.Lock()
+			r.mu.replicaFlowControlIntegration.onRaftTicked(ctx)
+			r.mu.Unlock()
+		}
+		return
+	}
+
+	// At this point, we know that quotaPoolEnabled==true, and we are currently
+	// the leader.
+	//
 	// NB: We initialize and destroy the quota pool here, on leadership changes
 	// and when it's enabled/disabled via settings (see below). This obviates the
 	// need for a setting change callback, as handleRaftReady (the caller), will
 	// be called at least at the tick interval for a non-quiescent range.
 	shouldInitQuotaPool := false
-	if r.shMu.leaderID != lastLeaderID {
-		if r.replicaID == r.shMu.leaderID {
-			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
-			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
-			// We're the new leader but we only create the quota pool if it's enabled
-			// for the range and generally enabled for the cluster, see
-			// getQuotaPoolEnabled.
-			if enabled {
-				// Raft may propose commands itself (specifically the empty
-				// commands when leadership changes), and these commands don't go
-				// through the code paths where we acquire quota from the pool. To
-				// offset this we reset the quota pool whenever leadership changes
-				// hands.
-				shouldInitQuotaPool = true
-			}
-		} else {
-			// We're becoming a follower.
-			r.mu.replicaFlowControlIntegration.onBecameFollower(ctx)
-			if r.mu.proposalQuota != nil {
-				// We unblock all ongoing and subsequent quota acquisition goroutines
-				// (if any) and release the quotaReleaseQueue so its allocs are pooled.
-				r.mu.proposalQuota.Close("leader change")
-				r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
-				r.mu.quotaReleaseQueue = nil
-				r.mu.proposalQuota = nil
-			}
-			return
-		}
-	} else if r.replicaID == r.shMu.leaderID && r.mu.proposalQuota == nil && enabled {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	if leadershipChanged {
+		// We're the new leader but we only create the quota pool if it's enabled
+		// for the range and generally enabled for the cluster, see
+		// getQuotaPoolEnabled.
+		//
+		// Raft may propose commands itself (specifically the empty
+		// commands when leadership changes), and these commands don't go
+		// through the code paths where we acquire quota from the pool. To
+		// offset this we reset the quota pool whenever leadership changes
+		// hands.
+		shouldInitQuotaPool = true
+	} else if !leadershipChanged && r.mu.proposalQuota == nil {
 		r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
 		shouldInitQuotaPool = true
-	} else if r.replicaID != r.shMu.leaderID {
-		// We're a follower and have been since the last update. Nothing to do.
-		return
 	}
 
+	status := r.mu.internalRaftGroup.BasicStatus()
 	if shouldInitQuotaPool {
 		// We're becoming the leader and the quota pool is enabled for the range,
 		// or we were the leader and the quota pool has dynamically been enabled.
@@ -208,7 +251,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	// cannot correspond to values beyond the applied index there's no reason
 	// to consider progress beyond it as meaningful.
 	minIndex := kvpb.RaftIndex(status.Applied)
-
 	r.mu.internalRaftGroup.WithBasicProgress(func(id raftpb.PeerID, progress tracker.BasicProgress) {
 		rep, ok := r.shMu.state.Desc.GetReplicaDescriptorByID(roachpb.ReplicaID(id))
 		if !ok {
@@ -222,7 +264,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		// for purposes of quiescing. Failure to consider a dead/stuck node as
 		// such for the purposes of releasing quota can have bad consequences
 		// (writes will stall), whereas for quiescing the downside is lower.
-
 		if !r.mu.lastUpdateTimes.isFollowerActiveSince(rep.ReplicaID, now, r.store.cfg.RangeLeaseDuration) {
 			return
 		}
@@ -281,40 +322,31 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		}
 	})
 
-	if enabled {
-		if r.mu.proposalQuotaBaseIndex < minIndex {
-			// We've persisted at least minIndex-r.mu.proposalQuotaBaseIndex entries
-			// to the raft log on all 'active' replicas and applied at least minIndex
-			// entries locally since last we checked, so we are able to release the
-			// difference back to the quota pool.
-			numReleases := minIndex - r.mu.proposalQuotaBaseIndex
+	if r.mu.proposalQuotaBaseIndex < minIndex {
+		// We've persisted at least minIndex-r.mu.proposalQuotaBaseIndex entries
+		// to the raft log on all 'active' replicas and applied at least minIndex
+		// entries locally since last we checked, so we are able to release the
+		// difference back to the quota pool.
+		numReleases := minIndex - r.mu.proposalQuotaBaseIndex
 
-			// NB: Release deals with cases where allocs being released do not originate
-			// from this incarnation of quotaReleaseQueue, which can happen if a
-			// proposal acquires quota while this replica is the raft leader in some
-			// term and then commits while at a different term.
-			r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue[:numReleases]...)
-			r.mu.quotaReleaseQueue = r.mu.quotaReleaseQueue[numReleases:]
-			r.mu.proposalQuotaBaseIndex += numReleases
-		}
-		// Assert the sanity of the base index and the queue. Queue entries should
-		// correspond to applied entries. It should not be possible for the base
-		// index and the not yet released applied entries to not equal the applied
-		// index.
-		releasableIndex := r.mu.proposalQuotaBaseIndex + kvpb.RaftIndex(len(r.mu.quotaReleaseQueue))
-		if releasableIndex != kvpb.RaftIndex(status.Applied) {
-			log.Fatalf(ctx, "proposalQuotaBaseIndex (%d) + quotaReleaseQueueLen (%d) = %d"+
-				" must equal the applied index (%d)",
-				r.mu.proposalQuotaBaseIndex, len(r.mu.quotaReleaseQueue), releasableIndex,
-				status.Applied)
-		}
-	} else if !enabled && r.mu.proposalQuota != nil {
-		// The quota pool was previously enabled on this leader, but it is no longer
-		// enabled. We release all quota back to the pool and close the pool.
-		r.mu.proposalQuota.Close("quota pool disabled")
-		r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue...)
-		r.mu.quotaReleaseQueue = nil
-		r.mu.proposalQuota = nil
+		// NB: Release deals with cases where allocs being released do not originate
+		// from this incarnation of quotaReleaseQueue, which can happen if a
+		// proposal acquires quota while this replica is the raft leader in some
+		// term and then commits while at a different term.
+		r.mu.proposalQuota.Release(r.mu.quotaReleaseQueue[:numReleases]...)
+		r.mu.quotaReleaseQueue = r.mu.quotaReleaseQueue[numReleases:]
+		r.mu.proposalQuotaBaseIndex += numReleases
+	}
+	// Assert the sanity of the base index and the queue. Queue entries should
+	// correspond to applied entries. It should not be possible for the base
+	// index and the not yet released applied entries to not equal the applied
+	// index.
+	releasableIndex := r.mu.proposalQuotaBaseIndex + kvpb.RaftIndex(len(r.mu.quotaReleaseQueue))
+	if releasableIndex != kvpb.RaftIndex(status.Applied) {
+		log.Fatalf(ctx, "proposalQuotaBaseIndex (%d) + quotaReleaseQueueLen (%d) = %d"+
+			" must equal the applied index (%d)",
+			r.mu.proposalQuotaBaseIndex, len(r.mu.quotaReleaseQueue), releasableIndex,
+			status.Applied)
 	}
 
 	// Tick the replicaFlowControlIntegration interface. This is as convenient a

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -156,21 +156,19 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	now := r.Clock().PhysicalTime()
 	// Since RaftMu is locked, we can read r.shMu struct without holding the
 	// replica mutex lock.
-	quotaPoolEnabled := r.getQuotaPoolEnabled(ctx, r.shMu.state.Desc)
 	leadershipChanged := r.shMu.leaderID != lastLeaderID
-	currentlyLeader := r.replicaID == r.shMu.leaderID
-
 	if leadershipChanged {
 		r.updateProposalQuotaOnLeaderChangeRaftMuLocked(ctx)
 	}
 
-	if !currentlyLeader {
+	if currentlyLeader := r.replicaID == r.shMu.leaderID; !currentlyLeader {
 		// If we are already a follower, there is already nothing to do. If we just
 		// became a follower, updateProposalQuotaOnLeaderChangeRaftMuLocked() should
 		// have made the necessary replica updates, and now there is nothing to do.
 		return
 	}
 
+	quotaPoolEnabled := r.getQuotaPoolEnabled(ctx, r.shMu.state.Desc)
 	if !quotaPoolEnabled {
 		if r.mu.proposalQuota != nil {
 			r.mu.Lock()

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -8,7 +8,6 @@ package kvserver
 import (
 	"bytes"
 	"context"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -146,8 +145,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 	shouldInitQuotaPool := false
 	if r.shMu.leaderID != lastLeaderID {
 		if r.replicaID == r.shMu.leaderID {
-			r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
-			r.mu.lastUpdateTimes.updateOnBecomeLeader(r.shMu.state.Desc.Replicas().Descriptors(), now)
 			r.mu.replicaFlowControlIntegration.onBecameLeader(ctx)
 			r.mu.lastProposalAtTicks = r.mu.ticks // delay imminent quiescence
 			// We're the new leader but we only create the quota pool if it's enabled
@@ -163,7 +160,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 			}
 		} else {
 			// We're becoming a follower.
-			r.mu.lastUpdateTimes = nil
 			r.mu.replicaFlowControlIntegration.onBecameFollower(ctx)
 			if r.mu.proposalQuota != nil {
 				// We unblock all ongoing and subsequent quota acquisition goroutines

--- a/pkg/kv/kvserver/replica_proposal_quota.go
+++ b/pkg/kv/kvserver/replica_proposal_quota.go
@@ -208,10 +208,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 
 	// We're still the leader.
 	// Find the minimum index that active followers have acknowledged.
-
-	// commitIndex is used to determine whether a newly added replica has fully
-	// caught up.
-	commitIndex := kvpb.RaftIndex(status.Commit)
 	// Initialize minIndex to the currently applied index. The below progress
 	// checks will only decrease the minIndex. Given that the quotaReleaseQueue
 	// cannot correspond to values beyond the applied index there's no reason
@@ -287,13 +283,6 @@ func (r *Replica) updateProposalQuotaRaftMuLocked(
 		}
 		if progress.Match > 0 && kvpb.RaftIndex(progress.Match) < minIndex {
 			minIndex = kvpb.RaftIndex(progress.Match)
-		}
-		// If this is the most recently added replica, and it has caught up, clear
-		// our state that was tracking it. This is unrelated to managing proposal
-		// quota, but this is a convenient place to do so.
-		if rep.ReplicaID == r.mu.lastReplicaAdded && kvpb.RaftIndex(progress.Match) >= commitIndex {
-			r.mu.lastReplicaAdded = 0
-			r.mu.lastReplicaAddedTime = time.Time{}
 		}
 	})
 

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -1369,6 +1369,7 @@ func (r *Replica) handleRaftReadyRaftMuLocked(
 		// send-queue for the new leaseholder.
 		r.store.scheduler.EnqueueRaftReady(r.RangeID)
 	}
+	r.maybeInitOrResetLastUpdateTimes(lastLeaderID, r.shMu.leaderID /* currentLeaderId */)
 
 	// NB: All early returns other than the one due to not having a ready
 	// which also makes the below call are due to fatal errors.
@@ -3074,6 +3075,31 @@ func (r *Replica) updateLastUpdateTimesUsingStoreLivenessRLocked(
 		if storeClockTimestamp.ToTimestamp().LessEq(curExp) {
 			r.mu.lastUpdateTimes.update(desc.ReplicaID, r.Clock().PhysicalTime())
 		}
+	}
+}
+
+// maybeInitOrResetLastUpdateTimes initializes or resets the lastUpdateTimes
+// on leadership changes.
+func (r *Replica) maybeInitOrResetLastUpdateTimes(
+	lastLeaderID roachpb.ReplicaID, currentLeaderId roachpb.ReplicaID,
+) {
+	if lastLeaderID == currentLeaderId {
+		// There has been no leadership change, so we don't need to do anything.
+		return
+	}
+
+	// Only on leadership changes we take the replica mutex and initialize or
+	// reset the lastUpdateTimes map.
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if r.replicaID == currentLeaderId {
+		// We are the new leader, initialize the lastUpdateTimes map.
+		r.mu.lastUpdateTimes = make(map[roachpb.ReplicaID]time.Time)
+		r.mu.lastUpdateTimes.updateOnBecomeLeader(r.shMu.state.Desc.Replicas().Descriptors(),
+			r.Clock().PhysicalTime())
+	} else {
+		// We're becoming a follower, reset the lastUpdateTimes map.
+		r.mu.lastUpdateTimes = nil
 	}
 }
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -7316,7 +7316,7 @@ func TestQuotaPoolReleasedOnFailedProposal(t *testing.T) {
 	tsc := TestStoreConfig(nil /* clock */)
 	// Override the kvflowcontrol.Mode setting to apply_to_elastic, as when
 	// apply_to_all is set (metamorphically), the quota pool will be disabled.
-	// See getQuotaPoolEnabledRLocked.
+	// See getQuotaPoolEnabled.
 	kvflowcontrol.Mode.Override(ctx, &tsc.Settings.SV, kvflowcontrol.ApplyToElastic)
 	tsc.TestingKnobs.TestingProposalFilter = func(args kvserverbase.ProposalFilterArgs) *kvpb.Error {
 		if v := args.Ctx.Value(magicKey{}); v != nil {
@@ -7360,7 +7360,7 @@ func TestQuotaPoolAccessOnDestroyedReplica(t *testing.T) {
 
 	// Override the kvflowcontrol.Mode setting to apply_to_elastic, as when
 	// apply_to_all is set (metamorphically), the quota pool will be disabled.
-	// See getQuotaPoolEnabledRLocked.
+	// See getQuotaPoolEnabled.
 	tsc := TestStoreConfig(nil /* clock */)
 	kvflowcontrol.Mode.Override(ctx, &tsc.Settings.SV, kvflowcontrol.ApplyToElastic)
 	tc.StartWithStoreConfig(ctx, t, stopper, tsc)

--- a/pkg/raft/rawnode.go
+++ b/pkg/raft/rawnode.go
@@ -423,6 +423,10 @@ func (rn *RawNode) SparseStatus() SparseStatus {
 // ReplicaProgress returns the progress for the replica with the given ID.
 // It returns nil if the replica is not being tracked.
 func (rn *RawNode) ReplicaProgress(id pb.PeerID) *tracker.Progress {
+	if rn == nil || rn.raft == nil {
+		// If the replica has been deleted, the rn and/or rn.raft will be nil.
+		return nil
+	}
 	return getReplicaProgress(rn.raft, id)
 }
 


### PR DESCRIPTION
This PR refactors updateProposalQuotaRaftMuLocked() to reduce the replica mutex contention, especially in the normal case (QuotaPool is disabled, and the leadership is stable).

Changes done by this commit:

1. Create a short path for the case where we are not the leader.
2. Create a short path for the case where QuotaPool is not enabled.
We only take the write lock in cases where we already had proposal quota that needs to be release, or if the flow control level causes the replicaFlowControlIntegration.onRaftTicked to be a no-op.
3. Untangle the rest of the cases where the QuotaPool is enabled.


benchdiff results:

```
rm -f /tmp/*.pb.gz && env GODEBUG=runtimecontentionstacks=1 benchdiff -b --old e0393de6614ddad81a8209733945be46e967e993 -c 10 ./pkg/sql/tests -r BenchmarkParallelSysbench/SQL/3node/oltp_read_write --mutexprofile -d=3000x

name                                           old time/op    new time/op    delta
ParallelSysbench/SQL/3node/oltp_read_write-24    1.15ms ± 7%    1.15ms ± 4%   ~     (p=1.000 n=10+9)

name                                           old errs/op    new errs/op    delta
ParallelSysbench/SQL/3node/oltp_read_write-24      0.01 ±46%      0.01 ±32%   ~     (p=0.469 n=10+10)

name                                           old alloc/op   new alloc/op   delta
ParallelSysbench/SQL/3node/oltp_read_write-24    2.05MB ± 1%    2.06MB ± 1%   ~     (p=0.052 n=10+10)

name                                           old allocs/op  new allocs/op  delta
ParallelSysbench/SQL/3node/oltp_read_write-24     8.18k ± 1%     8.20k ± 1%   ~     (p=0.101 n=10+10)
```

Mutex contention graph after running the microbenchmark on my GCE worker:

```
rm -f /tmp/*.pb.gz && env GODEBUG=runtimecontentionstacks=1 go test ./pkg/sql/tests -run - -bench BenchmarkParallelSysbench/SQL/3node/oltp_read_write -v -test.benchtime=3000x -test.outputdir=/tmp -test.mutexprofile=mutex.pb.gz -test.mutexprofilefraction=100 -test.timeout 25s 2>&1
```

Before:
<img width="1906" alt="Screenshot 2025-05-12 at 3 40 08 PM" src="https://github.com/user-attachments/assets/0059db5d-fc17-4344-ae1e-7d37770fba0c" />

After:
<img width="1908" alt="Screenshot 2025-05-12 at 3 39 48 PM" src="https://github.com/user-attachments/assets/f3ee3869-8b46-45bc-bf63-ba2af958cb84" />


References: #140235

Release note: None