### PR TITLE
scbuild: allow creating views/sequences under pg_temp

### DIFF
--- a/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
+++ b/pkg/sql/catalog/schemadesc/synthetic_schema_desc.go
@@ -114,7 +114,7 @@ func (p synthetic) ConcurrentSchemaChangeJobIDs() []catpb.JobID {
 // SkipNamespace implements the descriptor interface.
 // We never store synthetic descriptors.
 func (p synthetic) SkipNamespace() bool {
-	return true
+	return p.SchemaKind() != catalog.SchemaTemporary
 }
 
 // GetObjectType implements the Object interface.

--- a/pkg/sql/create_function.go
+++ b/pkg/sql/create_function.go
@@ -81,7 +81,7 @@ func (n *createFunctionNode) startExec(params runParams) error {
 		return err
 	}
 	if scDesc.SchemaKind() == catalog.SchemaTemporary {
-		return unimplemented.NewWithIssue(104687, "cannot create UDFs under a temporary schema")
+		return unimplemented.NewWithIssue(104687, "cannot create user-defined functions under a temporary schema")
 	}
 
 	telemetry.Inc(sqltelemetry.SchemaChangeCreateCounter("function"))

--- a/pkg/sql/create_sequence.go
+++ b/pkg/sql/create_sequence.go
@@ -20,7 +20,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -36,6 +39,22 @@ type createSequenceNode struct {
 	dbDesc catalog.DatabaseDescriptor
 }
 
+// resolveTemporaryStatus checks for the pg_temp naming convention from
+// Postgres, where qualifying an object name with pg_temp is equivalent to
+// explicitly specifying TEMP/TEMPORARY in the CREATE syntax.
+// resolveTemporaryStatus returns true if either(or both) of these conditions
+// are true.
+func resolveTemporaryStatus(
+	name tree.ObjectNamePrefix, persistence tree.Persistence,
+) (bool, error) {
+	// An explicit schema can only be provided in the CREATE TEMP statement
+	// iff it is pg_temp.
+	if persistence.IsTemporary() && name.ExplicitSchema && name.SchemaName != catconstants.PgTempSchemaName {
+		return false, pgerror.New(pgcode.InvalidTableDefinition, "cannot create temporary relation in non-temporary schema")
+	}
+	return name.SchemaName == catconstants.PgTempSchemaName || persistence.IsTemporary(), nil
+}
+
 func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (planNode, error) {
 	if err := checkSchemaChangeEnabled(
 		ctx,
@@ -43,6 +62,14 @@ func (p *planner) CreateSequence(ctx context.Context, n *tree.CreateSequence) (p
 		"CREATE SEQUENCE",
 	); err != nil {
 		return nil, err
+	}
+
+	if ok, err := resolveTemporaryStatus(n.Name.ObjectNamePrefix, n.Persistence); err != nil {
+		return nil, err
+	} else if ok {
+		n.Name.ObjectNamePrefix.SchemaName = ""
+		n.Name.ObjectNamePrefix.ExplicitSchema = false
+		n.Persistence = tree.PersistenceTemporary
 	}
 
 	un := n.Name.ToUnresolvedObjectName()

--- a/pkg/sql/logictest/testdata/logic_test/temp_table
+++ b/pkg/sql/logictest/testdata/logic_test/temp_table
@@ -483,7 +483,7 @@ DROP DATABASE database_108751 CASCADE
 subtest end
 
 # Verify that a good error message is returned for temporary types.
-subtest temp_type
+subtest pg_temp_type
 
 statement ok
 CREATE DATABASE database_142780
@@ -509,6 +509,98 @@ RESET database
 
 statement ok
 DROP DATABASE database_142780
+
+subtest end
+
+# Test that views can be created in the temporary schema directly.
+subtest pg_temp_view
+
+statement ok
+CREATE DATABASE database_145438
+
+statement ok
+USE database_145438
+
+statement ok
+SET experimental_enable_temp_tables = on
+
+statement ok
+CREATE VIEW pg_temp.temp_view AS SELECT 1;
+
+query I
+SELECT * FROM pg_temp.temp_view
+----
+1
+
+statement error cannot create temporary relation in non-temporary schema
+CREATE TEMP VIEW public.bad_temp_view AS SELECT 1;
+
+statement ok
+RESET database
+
+statement ok
+DROP DATABASE database_145438
+
+subtest end
+
+# Test that sequences can be created in the temporary schema directly.
+subtest pg_temp_sequence
+
+statement ok
+CREATE DATABASE database_145438
+
+statement ok
+USE database_145438
+
+statement ok
+SET experimental_enable_temp_tables = on
+
+statement ok
+CREATE SEQUENCE pg_temp.temp_seq;
+
+query I
+SELECT nextval('pg_temp.temp_seq');
+----
+1
+
+statement error cannot create temporary relation in non-temporary schema
+CREATE TEMP SEQUENCE public.bad_temp_seq;
+
+statement ok
+RESET database
+
+statement ok
+DROP DATABASE database_145438
+
+subtest end
+
+# Test that UDFs cannot be created in the temporary schema directly.
+subtest pg_temp_udf
+
+statement ok
+CREATE DATABASE database_142783
+
+statement ok
+USE database_142783
+
+statement ok
+SET experimental_enable_temp_tables = on
+
+statement error cannot create user-defined functions under a temporary schema
+CREATE FUNCTION pg_temp.temp_func() RETURNS int AS $$SELECT 1$$ LANGUAGE SQL;
+
+# Verify the error message after creating a temporary table.
+statement ok
+CREATE TEMP TABLE temp_table_142783 (a int primary key);
+
+statement error cannot create user-defined functions under a temporary schema
+CREATE FUNCTION pg_temp.temp_func() RETURNS int AS $$SELECT 1$$ LANGUAGE SQL;
+
+statement ok
+RESET database
+
+statement ok
+DROP DATABASE database_142783
 
 subtest end
 

--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -163,7 +163,7 @@ CREATE TEMP TABLE t_102964 (i INT PRIMARY KEY);
 let $temp_schema_102964
 SELECT schema_name FROM [SHOW SCHEMAS] WHERE schema_name LIKE 'pg_temp_%';
 
-statement error pgcode 0A000 unimplemented: cannot create UDFs under a temporary schema
+statement error pgcode 0A000 unimplemented: cannot create user-defined functions under a temporary schema
 CREATE FUNCTION $temp_schema_102964.f_102964 () RETURNS INT AS 'SELECT 1' LANGUAGE sql;
 
 subtest end

--- a/pkg/sql/opt/optbuilder/create_function.go
+++ b/pkg/sql/opt/optbuilder/create_function.go
@@ -36,6 +36,10 @@ func (b *Builder) buildCreateFunction(cf *tree.CreateRoutine, inScope *scope) (o
 		}
 	}
 
+	isTemp := resolveTemporaryStatus(cf.Name.ObjectNamePrefix, tree.PersistencePermanent)
+	if isTemp {
+		panic(unimplemented.NewWithIssue(104687, "cannot create user-defined functions under a temporary schema"))
+	}
 	sch, resName := b.resolveSchemaForCreateFunction(&cf.Name)
 	schID := b.factory.Metadata().AddSchema(sch)
 	cf.Name.ObjectNamePrefix = resName

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -19,6 +19,22 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 	preFuncResolver := b.semaCtx.FunctionResolver
 	b.semaCtx.FunctionResolver = nil
 
+	isTemp := resolveTemporaryStatus(cv.Name.ObjectNamePrefix, cv.Persistence)
+	if isTemp {
+		// Postgres allows using `pg_temp` as an alias for the session specific temp
+		// schema. In PG, the following are equivalent:
+		// CREATE TEMP TABLE t <=> CREATE TABLE pg_temp.t <=> CREATE TEMP TABLE pg_temp.t
+		//
+		// The temporary schema is created the first time a session creates a
+		// temporary object, so it is possible to use `pg_temp` in a fully qualified
+		// name when the temporary schema does not exist. To allow the name to be
+		// resolved, we unset the explicitly named schema and set the Persistence to
+		// temporary.
+		cv.Name.ObjectNamePrefix.SchemaName = ""
+		cv.Name.ObjectNamePrefix.ExplicitSchema = false
+		cv.Persistence = tree.PersistenceTemporary
+	}
+
 	// We build the select statement to:
 	//  - check the statement semantically,
 	//  - get the fully resolved names into the AST, and

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -458,10 +458,12 @@ func (b *Builder) resolveAndBuildScalar(
 	return b.buildScalar(texpr, inScope, nil, nil, colRefs)
 }
 
-// In Postgres, qualifying an object name with pg_temp is equivalent to explicitly
-// specifying TEMP/TEMPORARY in the CREATE syntax. resolveTemporaryStatus returns
-// true if either(or both) of these conditions are true.
-func resolveTemporaryStatus(name *tree.TableName, persistence tree.Persistence) bool {
+// resolveTemporaryStatus checks for the pg_temp naming convention from
+// Postgres, where qualifying an object name with pg_temp is equivalent to
+// explicitly specifying TEMP/TEMPORARY in the CREATE syntax.
+// resolveTemporaryStatus returns true if either(or both) of these conditions
+// are true.
+func resolveTemporaryStatus(name tree.ObjectNamePrefix, persistence tree.Persistence) bool {
 	// An explicit schema can only be provided in the CREATE TEMP TABLE statement
 	// iff it is pg_temp.
 	if persistence.IsTemporary() && name.ExplicitSchema && name.SchemaName != catconstants.PgTempSchemaName {

--- a/pkg/sql/schemachanger/scbuild/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/BUILD.bazel
@@ -52,7 +52,6 @@ go_library(
         "//pkg/sql/sqlerrors",
         "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
-        "//pkg/util/errorutil/unimplemented",
         "//pkg/util/log/eventpb",
         "//pkg/util/log/logpb",
         "//pkg/util/mon",

--- a/pkg/sql/schemachanger/scbuild/builder_state.go
+++ b/pkg/sql/schemachanger/scbuild/builder_state.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/syntheticprivilege"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -1022,9 +1021,6 @@ func (b *builderState) ResolveTargetObject(
 	b.ensureDescriptor(db.GetID())
 	if sc.SchemaKind() == catalog.SchemaVirtual {
 		panic(sqlerrors.NewCannotModifyVirtualSchemaError(sc.GetName()))
-	}
-	if sc.SchemaKind() == catalog.SchemaTemporary {
-		panic(unimplemented.NewWithIssue(104687, "cannot create UDFs under a temporary schema"))
 	}
 	b.ensureDescriptor(sc.GetID())
 	b.checkOwnershipOrPrivilegesOnSchemaDesc(objName.ObjectNamePrefix, sc, scbuildstmt.ResolveParams{RequiredPrivilege: requiredSchemaPriv})

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_sequence.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_sequence.go
@@ -6,7 +6,6 @@
 package scbuildstmt
 
 import (
-	"github.com/cockroachdb/cockroach/pkg/build"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -31,7 +30,13 @@ func CreateSequence(b BuildCtx, n *tree.CreateSequence) {
 // doCreateSequence creates a sequence and returns the sequence element that
 // has been created.
 func doCreateSequence(b BuildCtx, n *tree.CreateSequence) *scpb.Sequence {
-	dbElts, scElts := b.ResolveTargetObject(n.Name.ToUnresolvedObjectName(), privilege.CREATE)
+	var dbElts, scElts ElementResultSet
+	if resolveTemporaryStatus(n.Name.ObjectNamePrefix, n.Persistence) {
+		n.Persistence = tree.PersistenceTemporary
+		dbElts, scElts = MaybeCreateOrResolveTemporarySchema(b)
+	} else {
+		dbElts, scElts = b.ResolveTargetObject(n.Name.ToUnresolvedObjectName(), privilege.CREATE)
+	}
 	_, _, schemaElem := scpb.FindSchema(scElts)
 	_, _, dbElem := scpb.FindDatabase(dbElts)
 	_, _, scName := scpb.FindNamespace(scElts)
@@ -55,27 +60,6 @@ func doCreateSequence(b BuildCtx, n *tree.CreateSequence) *scpb.Sequence {
 			return nil
 		}
 		panic(sqlerrors.NewRelationAlreadyExistsError(n.Name.FQString()))
-	}
-
-	if n.Persistence.IsTemporary() {
-		if !b.SessionData().TempTablesEnabled {
-			panic(errors.WithTelemetry(
-				pgerror.WithCandidateCode(
-					errors.WithHint(
-						errors.WithIssueLink(
-							errors.Newf("temporary tables are only supported experimentally"),
-							errors.IssueLink{IssueURL: build.MakeIssueURL(46260)},
-						),
-						"You can enable temporary tables by running `SET experimental_enable_temp_tables = 'on'`.",
-					),
-					pgcode.ExperimentalFeature,
-				),
-				"sql.schema.temp_tables_disabled",
-			))
-		}
-		// Resolve the temporary schema element.
-		scElts = MaybeCreateOrResolveTemporarySchema(b)
-		schemaElem = scElts.FilterSchema().MustGetOneElement()
 	}
 
 	// Sanity check for duplication options on the sequence.

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain
@@ -4,7 +4,7 @@ SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true;
 /* test */
 EXPLAIN (DDL) CREATE TEMPORARY SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
 ----
-Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_456›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
  │         ├── 18 elements transitioning toward PUBLIC

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.explain_shape
@@ -4,5 +4,5 @@ SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true;
 /* test */
 EXPLAIN (DDL, SHAPE) CREATE TEMPORARY SEQUENCE sq1 MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
 ----
-Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
+Schema change plan for CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_456›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32;
  └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/create_temp_sequence/create_temp_sequence.side_effects
@@ -13,7 +13,7 @@ write *eventpb.CreateSequence to event log:
   sequenceName: defaultdb.pg_temp_123_456.sq1
   sql:
     descriptorId: 105
-    statement: CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹public›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
+    statement: CREATE TEMPORARY SEQUENCE ‹defaultdb›.‹pg_temp_123_456›.‹sq1› MINVALUE 1 MAXVALUE 9223372036854775807 INCREMENT 1 START 32
     tag: CREATE SEQUENCE
     user: root
 ## StatementPhase stage 1 of 1 with 27 MutationType ops


### PR DESCRIPTION
This patch adds proper handling for statements that create an object with the pg_temp schema explicitly specified. UDFs cannot be created in this schema, but views and sequences can be.

Some logic for CREATE statements is in the optbuilder, so the appropriate checks are added there when needed.

fixes https://github.com/cockroachdb/cockroach/issues/145438
Release note (bug fix): Fixed a bug that prevented temporary views and sequences from being created if the pg_temp schema was explicitly specified in the qualified name of the object being created.