### PR TITLE
sql,multiregion: fix DROP REGION of system database for serverless

### DIFF
--- a/pkg/sql/alter_database.go
+++ b/pkg/sql/alter_database.go
@@ -494,29 +494,7 @@ func (p *planner) AlterDatabaseDropRegion(
 		if err := p.checkCanDropSystemDatabaseRegion(ctx, n.Region); err != nil {
 			return nil, err
 		}
-		tablesToClean := []string{"sqlliveness", "lease", "sql_instances"}
-		for _, t := range tablesToClean {
-			livenessQuery := fmt.Sprintf(
-				`SELECT count(*) > 0 FROM system.%s WHERE crdb_region = '%s' AND 
-          crdb_internal.sql_liveness_is_alive(session_id)`, t, n.Region)
-			row, err := p.QueryRowEx(ctx, "check-session-liveness-for-region",
-				sessiondata.NodeUserSessionDataOverride, livenessQuery)
-			if err != nil {
-				return nil, err
-			}
-			// Block dropping n.Region if any associated session is active.
-			if tree.MustBeDBool(row[0]) {
-				return nil, errors.WithHintf(
-					pgerror.Newf(
-						pgcode.InvalidDatabaseDefinition,
-						"cannot drop region %q",
-						n.Region,
-					),
-					"You must not have any active sessions that are in this region. "+
-						"Ensure that there no nodes that still belong to region %q", n.Region,
-				)
-			}
-		}
+
 		// For the region_liveness table, we can just safely remove the reference
 		// (if any) of the dropping region from the table.
 		if _, err := p.ExecEx(ctx, "remove-region-liveness-ref",
@@ -618,10 +596,37 @@ func (p *planner) checkCanDropSystemDatabaseRegion(ctx context.Context, region t
 		})
 		return errors.WithHintf(
 			pgerror.Newf(pgcode.DependentObjectsStillExist,
-				"cannot drop region %v from the system database while that region is still in use",
+				"cannot drop region %q from the system database while that region is still in use",
 				&region,
 			), "region is in use by databases: %v", &databases)
 	}
+
+	tablesToClean := []string{"sqlliveness", "lease", "sql_instances"}
+	for _, t := range tablesToClean {
+		// Use the synchronous version of sql_liveness_is_alive to make sure
+		// data is fresh.
+		livenessQuery := fmt.Sprintf(
+			`SELECT count(*) > 0 FROM system.%s WHERE crdb_region = $1 AND
+          crdb_internal.sql_liveness_is_alive(session_id, true)`, t)
+		row, err := p.QueryRowEx(ctx, "check-session-liveness-for-region",
+			sessiondata.NodeUserSessionDataOverride, livenessQuery, region)
+		if err != nil {
+			return err
+		}
+		// Block dropping n.Region if any associated session is active.
+		if tree.MustBeDBool(row[0]) {
+			return errors.WithHintf(
+				pgerror.Newf(
+					pgcode.InvalidDatabaseDefinition,
+					"cannot drop region %q from the system database while there are live nodes in that region",
+					region,
+				),
+				"You must not have any active sessions that are in this region. "+
+					"Ensure that there no nodes that still belong to region %q", region,
+			)
+		}
+	}
+
 	return nil
 }
 

--- a/pkg/testutils/sqlutils/sql_runner.go
+++ b/pkg/testutils/sqlutils/sql_runner.go
@@ -92,7 +92,7 @@ func (sr *SQLRunner) ExecWithMessage(
 	helperOrNoop(t)()
 	r, err := sr.DB.ExecContext(context.Background(), query, args...)
 	if err != nil {
-		t.Fatalf("%serror executing query=%q args=%q: %s", fmtMessage(message), query, args, err)
+		t.Fatalf("%serror executing query=%q args=%q: %s", fmtMessage(message), query, args, pgerror.FullError(err))
 	}
 	return r
 }
@@ -104,7 +104,7 @@ func (sr *SQLRunner) ExecMultiple(t Fataler, queries ...string) {
 	for _, query := range queries {
 		_, err := sr.DB.ExecContext(context.Background(), query)
 		if err != nil {
-			t.Fatalf("error executing '%s': %s", query, err)
+			t.Fatalf("error executing '%s': %s", query, pgerror.FullError(err))
 		}
 	}
 }


### PR DESCRIPTION
When https://github.com/cockroachdb/cockroach/issues/137095 was initially resolved, it was not properly tested, so the functionality did not work correctly. This PR adds a working test and fixes the issues in the implementation.

This functionality still doesn't work for the system tenant. https://github.com/cockroachdb/cockroach/issues/146590 tracks that work.

This does not have a release note, as the functionality is only intended to be used by our SRE team.

fixes https://github.com/cockroachdb/cockroach/issues/144592

----

### sql: move check for live sessions while dropping region

### sql: fix system DB region cleanup to use physical representation

The code that was supposed to clean up the region from system tables
when a region was being dropped from the system database was incorrect.
It was using the logical representation, but the physical representation
is needed.

This patch also updates a test to check this behavior, and removes a
redundant test that didn't really test what it should since it never
created a tenant in the region being dropped.

### sqlutils: show full error with hint in helper functions

This will make the error include hints and details that were attached to
it.

### sql: move code for cleaning regions from system database

This logic was happening during the planning stage, but that was
undesirable because planning a query should not perform destructive
actions. Now it happens during execution instead.

As part of this, the code to check if the region being dropped exists
was moved further up in the startExec function.

