### PR TITLE
revert "tree: add panic-catching to formatting code"

### DIFF
--- a/pkg/sql/sem/tree/BUILD.bazel
+++ b/pkg/sql/sem/tree/BUILD.bazel
@@ -161,7 +161,6 @@ go_library(
         "//pkg/util/collatedstring",
         "//pkg/util/duration",
         "//pkg/util/encoding",
-        "//pkg/util/errorutil",
         "//pkg/util/errorutil/unimplemented",
         "//pkg/util/intsets",
         "//pkg/util/ipaddr",


### PR DESCRIPTION
This partially reverts commit 01c83372c1bff32361411d4fe0b106a184c2149d.

Epic: None
Release note: None