### PR TITLE
release-25.2: sql/sem: reject AS OF timestamps set in the future

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -502,7 +502,7 @@ func createChangefeedJobRecord(
 
 	if opts.HasEndTime() {
 		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(opts.GetEndTime())}
-		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context)
+		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context, asof.OptionAllowFutureTimestamp)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -6558,7 +6558,7 @@ func TestChangefeedErrors(t *testing.T) {
 	)
 
 	sqlDB.ExpectErrWithTimeout(
-		t, `request timestamp .* too far in future`,
+		t, `timestamp '.*' is in the future`,
 		`EXPERIMENTAL CHANGEFEED FOR foo WITH cursor=$1`, timeutil.Now().Add(time.Hour),
 	)
 

--- a/pkg/sql/logictest/testdata/logic_test/as_of
+++ b/pkg/sql/logictest/testdata/logic_test/as_of
@@ -50,11 +50,14 @@ SELECT * FROM t AS OF SYSTEM TIME follower_read_timestamp('boom')
 statement error pq: AS OF SYSTEM TIME: only constant expressions, with_min_timestamp, with_max_staleness, or follower_read_timestamp are allowed
 SELECT * FROM t AS OF SYSTEM TIME now()
 
-statement error pq: request timestamp .* too far in future
+statement error pq: AS OF SYSTEM TIME: interval value '10s' is in the future
 SELECT * FROM t AS OF SYSTEM TIME '10s'
 
-query I
+statement error pq: AS OF SYSTEM TIME: interval value '00:00:00.000001' is in the future
 SELECT * FROM t AS OF SYSTEM TIME interval '1 microsecond'
+
+query I
+SELECT * FROM t AS OF SYSTEM TIME '-1μs'
 ----
 2
 
@@ -167,3 +170,34 @@ WITH x AS (UPDATE t SET i = 3 WHERE i = 2 RETURNING i) SELECT * FROM x AS OF SYS
 
 statement error cannot execute SELECT FOR UPDATE in a read-only transaction
 SELECT * FROM t AS OF SYSTEM TIME '-1ms' FOR UPDATE
+
+subtest as_of_future
+
+statement error pq: AS OF SYSTEM TIME: interval value '1 microsecond' is in the future
+REFRESH MATERIALIZED VIEW nonexistent AS OF SYSTEM TIME ('1 microsecond')
+
+statement error pq: AS OF SYSTEM TIME: interval value '00:00:00.000001' is in the future
+REFRESH MATERIALIZED VIEW nonexistent AS OF SYSTEM TIME (INTERVAL '1 microsecond')
+
+statement error pq: AS OF SYSTEM TIME: timestamp '2090-05-08 12:00:00' is in the future
+REFRESH MATERIALIZED VIEW nonexistent AS OF SYSTEM TIME '2090-05-08 12:00:00'
+
+statement error pq: AS OF SYSTEM TIME: interval value '1 microsecond' is in the future
+CREATE TABLE wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME ('1 microsecond')
+
+statement error pq: AS OF SYSTEM TIME: interval value '00:00:00.000001' is in the future
+CREATE TABLE wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME (INTERVAL '1 microsecond')
+
+statement error pq: AS OF SYSTEM TIME: timestamp '2090-05-08 12:00:00' is in the future
+CREATE TABLE wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME '2090-05-08 12:00:00'
+
+statement error pq: AS OF SYSTEM TIME: interval value '1 microsecond' is in the future
+CREATE VIEW wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME ('1 microsecond')
+
+statement error pq: AS OF SYSTEM TIME: interval value '00:00:00.000001' is in the future
+CREATE VIEW wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME (INTERVAL '1 microsecond')
+
+statement error pq: AS OF SYSTEM TIME: timestamp '2090-05-08 12:00:00' is in the future
+CREATE VIEW wontcreate AS SELECT * FROM nonexistent AS OF SYSTEM TIME '2090-05-08 12:00:00'
+
+subtest end

--- a/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
+++ b/pkg/sql/pgwire/testdata/pgtest/bind_and_resolve
@@ -50,7 +50,7 @@ ErrorResponse
 ReadyForQuery
 ReadyForQuery
 ----
-{"Type":"ErrorResponse","Code":"XXUUU"}
+{"Type":"ErrorResponse","Code":"22023"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
 

--- a/pkg/sql/sem/asof/as_of.go
+++ b/pkg/sql/sem/asof/as_of.go
@@ -83,6 +83,7 @@ func resolveFuncType(
 
 type evalOptions struct {
 	allowBoundedStaleness bool
+	allowFutureTimestamp  bool
 }
 
 // EvalOption is an option to pass into Eval.
@@ -94,6 +95,13 @@ var OptionAllowBoundedStaleness EvalOption = func(
 	o evalOptions,
 ) evalOptions {
 	o.allowBoundedStaleness = true
+	return o
+}
+
+var OptionAllowFutureTimestamp EvalOption = func(
+	o evalOptions,
+) evalOptions {
+	o.allowFutureTimestamp = true
 	return o
 }
 
@@ -206,7 +214,11 @@ func Eval(
 	}
 
 	stmtTimestamp := evalCtx.GetStmtTimestamp()
-	ret.Timestamp, err = DatumToHLC(evalCtx, stmtTimestamp, d, AsOf)
+	usage := AsOf
+	if o.allowFutureTimestamp {
+		usage = AsOfFuture
+	}
+	ret.Timestamp, err = DatumToHLC(evalCtx, stmtTimestamp, d, usage)
 	if err != nil {
 		return eval.AsOfSystemTime{}, errors.Wrap(err, "AS OF SYSTEM TIME")
 	}
@@ -253,6 +265,9 @@ const (
 	// ALTER VIRTUAL CLUSTER ... COMPLETE REPLICATION statement.
 	ReplicationCutover
 
+	// AsOfFuture is like AsOf, except the timestamp is allowed to be in the future.
+	AsOfFuture
+
 	// ShowTenantFingerprint is when the DatumToHLC() is used for an SHOW
 	// EXPERIMENTAL_FINGERPRINTS FROM TENANT ... WITH START TIMESTAMP statement.
 	//
@@ -261,7 +276,9 @@ const (
 	ShowTenantFingerprint = AsOf
 )
 
-// DatumToHLC performs the conversion from a Datum to an HLC timestamp.
+// DatumToHLC performs the conversion from a Datum to an HLC timestamp. If the
+// timestamp is used for 'AS OF SYSTEM TIME', it ensures the timestamp is not in
+// the future.
 func DatumToHLC(
 	evalCtx *eval.Context, stmtTimestamp time.Time, d tree.Datum, usage DatumToHLCUsage,
 ) (hlc.Timestamp, error) {
@@ -291,6 +308,8 @@ func DatumToHLC(
 		if iv, err := tree.ParseIntervalWithTypeMetadata(evalCtx.GetIntervalStyle(), s, types.DefaultIntervalTypeMetadata); err == nil {
 			if (iv == duration.Duration{}) {
 				convErr = errors.Errorf("interval value %v too small, absolute value must be >= %v", d, time.Microsecond)
+			} else if (usage == AsOf && iv.Compare(duration.Duration{}) > 0) {
+				convErr = errors.Errorf("interval value %v is in the future", d)
 			} else if (usage == Split && iv.Compare(duration.Duration{}) < 0) {
 				convErr = errors.Errorf("interval value %v too small, SPLIT AT interval must be >= %v", d, time.Microsecond)
 			}
@@ -309,6 +328,8 @@ func DatumToHLC(
 	case *tree.DInterval:
 		if (usage == Split && d.Duration.Compare(duration.Duration{}) < 0) {
 			convErr = errors.Errorf("interval value %v too small, SPLIT interval must be >= %v", d, time.Microsecond)
+		} else if (usage == AsOf && d.Duration.Compare(duration.Duration{}) > 0) {
+			convErr = errors.Errorf("interval value %v is in the future", d)
 		}
 		ts.WallTime = duration.Add(stmtTimestamp, d.Duration).UnixNano()
 	default:
@@ -324,6 +345,29 @@ func DatumToHLC(
 		return ts, errors.Errorf("zero timestamp is invalid")
 	} else if ts.Less(zero) {
 		return ts, errors.Errorf("timestamp before 1970-01-01T00:00:00Z is invalid")
+	} else if usage == AsOf {
+		// Disallow fixed timestamps too far in the future. Allow some tolerance
+		// for clock skew and internal transaction contexts.
+
+		const hardCodedSkewTolerance = 500 * time.Millisecond
+		maxAllowedWallTime := stmtTimestamp.Add(hardCodedSkewTolerance).UnixNano()
+
+		if evalCtx.Txn != nil && evalCtx.Txn.DB() != nil {
+			// Allow additional tolerance based on actual clock offset.
+			clockSkew := evalCtx.Txn.DB().Clock().MaxOffset()
+			maxAllowedWallTime = max(maxAllowedWallTime,
+				stmtTimestamp.Add(clockSkew).UnixNano())
+
+			// For certain internal queries (e.g., lease counting), allow up to the
+			// provisional commit timestamp.
+			maxAllowedWallTime = max(maxAllowedWallTime,
+				evalCtx.Txn.ProvisionalCommitTimestamp().WallTime)
+		}
+
+		if ts.WallTime > maxAllowedWallTime {
+			return ts, errors.Errorf("timestamp %v is in the future", d)
+		}
 	}
+
 	return ts, nil
 }


### PR DESCRIPTION
Backport 2/2 commits from #146446 on behalf of @spilchen.

----

Recent support for AS OF timestamps in CTAS and MQTs exposed inconsistent behavior when the timestamp is set in the future:
- In some cases, operations fail with a KV read error.
- In others, they pause briefly before returning.
- When the timestamp is significantly in the future, operations may hang indefinitely.

 This behaviour was observed in issue #145781, where a future AS OF timestamp caused TestRandomSyntaxGeneration to fail due to a hang.

This change ensures AS OF timestamps are not in the future:
- For computed timestamps (e.g., using intervals), enforcement is strict.
- For fixed timestamps, a tolerance is allowed to accommodate clock skew and other cases.

One exception remains: AS OF timestamps are still allowed in the future when creating a CHANGEFEED, as its end_time parameter is expected to be in the future and flows through as an AS OF time.

Fixes #145781

Epic: none
Release note (bug fix): Prevent use of future AS OF timestamps in CTAS and materialized views. Previously, such timestamps could cause hangs.

----

Release justification: Fixes a hang that was found with new 25.2 usage of ASOF timestamps with MQTs