### PR TITLE
roachtest/pg_regress: address a couple of stale TODOs

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/explain.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/explain.diffs
@@ -463,7 +463,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  select jsonb_pretty(
    explain_filter_to_json('explain (analyze, verbose, buffers, format json)
                           select * from tenk1 order by tenthous')
-@@ -374,188 +260,17 @@
+@@ -374,188 +260,19 @@
    #- '{0,Plan,Plans,0,Sort Method}'
    #- '{0,Plan,Plans,0,Sort Space Type}'
  );
@@ -635,7 +635,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/explain.out --lab
  create temp table t1(f1 float8);
  create function pg_temp.mysin(float8) returns float8 language plpgsql
  as 'begin return sin($1); end';
-+ERROR:  sin(): no value provided for placeholder: $1
++ERROR:  unimplemented: cannot create user-defined functions under a temporary schema
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/104687/_version_
  select explain_filter('explain (verbose) select * from t1 where pg_temp.mysin(f1) < 0.5');
 -                       explain_filter                       
 -------------------------------------------------------------

--- a/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/plpgsql.diffs
@@ -1995,7 +1995,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function bad_sql2() returns int as $$
  declare r record;
  begin
-@@ -2515,81 +2797,115 @@
+@@ -2515,81 +2797,116 @@
      end loop;
      return 5;
  end;$$ language plpgsql;
@@ -2062,7 +2062,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
 +We appreciate your feedback.
 +
-+-- select void_return_expr();
++select void_return_expr();
++ERROR:  unknown function: void_return_expr()
  -- but ordinary functions are not
  create function missing_return_expr() returns int as $$
  begin
@@ -2153,7 +2154,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- SQLSTATE and SQLERRM test
  --
-@@ -2597,14 +2913,11 @@
+@@ -2597,14 +2914,11 @@
  begin
      raise notice '% %', sqlstate, sqlerrm;
  end; $$ language plpgsql;
@@ -2170,7 +2171,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test2() returns void as $$
  begin
      begin
-@@ -2613,13 +2926,10 @@
+@@ -2613,13 +2927,10 @@
          end;
      end;
  end; $$ language plpgsql;
@@ -2186,7 +2187,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function excpt_test3() returns void as $$
  begin
      begin
-@@ -2639,31 +2949,61 @@
+@@ -2639,31 +2950,61 @@
  	    raise notice '% %', sqlstate, sqlerrm;
      end;
  end; $$ language plpgsql;
@@ -2215,10 +2216,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select excpt_test3();
@@ -2243,10 +2244,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select excpt_test4();
@@ -2262,7 +2263,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- parameters of raise stmt can be expressions
  create function raise_exprs() returns void as $$
  declare
-@@ -2714,13 +3054,11 @@
+@@ -2714,13 +3055,11 @@
    insert into foo values(5,6) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2280,7 +2281,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2728,10 +3066,11 @@
+@@ -2728,10 +3067,11 @@
    insert into foo values(7,8),(9,10) returning * into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2295,7 +2296,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2739,13 +3078,11 @@
+@@ -2739,13 +3079,11 @@
    execute 'insert into foo values(5,6) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2313,7 +2314,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2753,23 +3090,17 @@
+@@ -2753,23 +3091,17 @@
    execute 'insert into foo values(7,8),(9,10) returning *' into x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2342,7 +2343,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  
  create or replace function stricttest() returns void as $$
  declare x record;
-@@ -2778,13 +3109,11 @@
+@@ -2778,13 +3110,11 @@
    select * from foo where f1 = 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2360,7 +2361,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2792,9 +3121,11 @@
+@@ -2792,9 +3122,11 @@
    select * from foo where f1 = 0 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2374,7 +2375,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2802,10 +3133,11 @@
+@@ -2802,10 +3134,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2389,7 +2390,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2813,13 +3145,11 @@
+@@ -2813,13 +3146,11 @@
    execute 'select * from foo where f1 = 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2407,7 +2408,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2827,9 +3157,11 @@
+@@ -2827,9 +3158,11 @@
    execute 'select * from foo where f1 = 0' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2421,7 +2422,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2837,12 +3169,17 @@
+@@ -2837,12 +3170,17 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2441,7 +2442,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2853,10 +3190,11 @@
+@@ -2853,10 +3191,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2456,7 +2457,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2867,10 +3205,11 @@
+@@ -2867,10 +3206,11 @@
    select * from foo where f1 = p1 and f1::text = p3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2471,7 +2472,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare
  x record;
-@@ -2881,11 +3220,11 @@
+@@ -2881,11 +3221,11 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2487,7 +2488,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2893,10 +3232,11 @@
+@@ -2893,10 +3233,11 @@
    select * from foo where f1 > 3 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2502,7 +2503,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2904,10 +3244,11 @@
+@@ -2904,10 +3245,11 @@
    execute 'select * from foo where f1 = $1 or f1::text = $2' using 0, 'foo' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2517,7 +2518,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2915,10 +3256,11 @@
+@@ -2915,10 +3257,11 @@
    execute 'select * from foo where f1 > $1' using 1 into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2532,7 +2533,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  declare x record;
  begin
-@@ -2926,9 +3268,11 @@
+@@ -2926,9 +3269,11 @@
    execute 'select * from foo where f1 > 3' into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2546,7 +2547,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stricttest() returns void as $$
  -- override the global
  #print_strict_params off
-@@ -2941,10 +3285,12 @@
+@@ -2941,10 +3286,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2562,7 +2563,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.print_strict_params;
  create or replace function stricttest() returns void as $$
  -- override the global
-@@ -2958,11 +3304,12 @@
+@@ -2958,11 +3305,12 @@
    select * from foo where f1 > p1 or f1::text = p3  into strict x;
    raise notice 'x.f1 = %, x.f2 = %', x.f1, x.f2;
  end$$ language plpgsql;
@@ -2579,7 +2580,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test warnings and errors
  set plpgsql.extra_warnings to 'all';
  set plpgsql.extra_warnings to 'none';
-@@ -2979,23 +3326,16 @@
+@@ -2979,23 +3327,16 @@
  begin
  end
  $$ language plpgsql;
@@ -2610,7 +2611,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function shadowtest(in1 int)
  	returns table (out1 int) as $$
  declare
-@@ -3004,18 +3344,15 @@
+@@ -3004,18 +3345,15 @@
  begin
  end
  $$ language plpgsql;
@@ -2636,7 +2637,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in a second DECLARE block
  create or replace function shadowtest()
  	returns void as $$
-@@ -3027,10 +3364,13 @@
+@@ -3027,10 +3365,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2653,7 +2654,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- several levels of shadowing
  create or replace function shadowtest(in1 int)
  	returns void as $$
-@@ -3042,13 +3382,13 @@
+@@ -3042,13 +3383,13 @@
  	begin
  	end;
  end$$ language plpgsql;
@@ -2673,7 +2674,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shadowing in cursor definitions
  create or replace function shadowtest()
  	returns void as $$
-@@ -3057,34 +3397,49 @@
+@@ -3057,34 +3398,49 @@
  c1 cursor (f1 int) for select 1;
  begin
  end$$ language plpgsql;
@@ -2738,7 +2739,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- runtime extra checks
  set plpgsql.extra_warnings to 'too_many_rows';
  do $$
-@@ -3093,8 +3448,6 @@
+@@ -3093,8 +3449,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2747,7 +2748,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'too_many_rows';
  do $$
  declare x int;
-@@ -3102,9 +3455,6 @@
+@@ -3102,9 +3456,6 @@
    select v from generate_series(1,2) g(v) into x;
  end;
  $$;
@@ -2757,7 +2758,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
  set plpgsql.extra_warnings to 'strict_multi_assignment';
-@@ -3118,12 +3468,6 @@
+@@ -3118,12 +3469,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2770,7 +2771,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  set plpgsql.extra_errors to 'strict_multi_assignment';
  do $$
  declare
-@@ -3135,10 +3479,6 @@
+@@ -3135,10 +3480,6 @@
    select 1,2,3 into x, y;
  end
  $$;
@@ -2781,7 +2782,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create table test_01(a int, b int, c int);
  alter table test_01 drop column a;
  -- the check is active only when source table is not empty
-@@ -3154,10 +3494,6 @@
+@@ -3154,10 +3495,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2792,7 +2793,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3168,10 +3504,6 @@
+@@ -3168,10 +3505,6 @@
  end;
  $$;
  NOTICE:  ok
@@ -2803,7 +2804,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare
    t test_01;
-@@ -3179,10 +3511,6 @@
+@@ -3179,10 +3512,6 @@
    select 1 into t; -- should fail;
  end;
  $$;
@@ -2814,7 +2815,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table test_01;
  reset plpgsql.extra_errors;
  reset plpgsql.extra_warnings;
-@@ -3201,16 +3529,9 @@
+@@ -3201,16 +3530,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2833,7 +2834,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c no scroll cursor for select f1 from int4_tbl;
-@@ -3225,10 +3546,9 @@
+@@ -3225,10 +3547,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2846,7 +2847,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3243,16 +3563,11 @@
+@@ -3243,16 +3564,11 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2867,7 +2868,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3267,14 +3582,27 @@
+@@ -3267,14 +3583,27 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2887,11 +2888,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  open c scroll for execute 'select f1 from int4_tbl';
 +                    ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -2902,7 +2903,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c refcursor;
-@@ -3290,13 +3618,27 @@
+@@ -3290,13 +3619,27 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2928,15 +2929,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select * from sc_test();
 +ERROR:  unknown function: sc_test()
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3316,14 +3658,9 @@
+@@ -3316,14 +3659,9 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2953,7 +2954,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function sc_test() returns setof integer as $$
  declare
    c cursor for select * from generate_series(1, 10);
-@@ -3338,13 +3675,11 @@
+@@ -3338,13 +3676,11 @@
    close c;
  end;
  $$ language plpgsql;
@@ -2970,7 +2971,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test qualified variable names
  create function pl_qual_names (param1 int) returns void as $$
  <<outerblock>>
-@@ -3362,17 +3697,15 @@
+@@ -3362,17 +3698,15 @@
    end;
  end;
  $$ language plpgsql;
@@ -2995,7 +2996,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- tests for RETURN QUERY
  create function ret_query1(out int, out int) returns setof record as $$
  begin
-@@ -3383,24 +3716,13 @@
+@@ -3383,24 +3717,13 @@
      return next;
  end;
  $$ language plpgsql;
@@ -3026,7 +3027,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type record_type as (x text, y int, z boolean);
  create or replace function ret_query2(lim int) returns setof record_type as $$
  begin
-@@ -3408,20 +3730,9 @@
+@@ -3408,20 +3731,9 @@
                   from generate_series(-8, lim) s (x) where s.x % 2 = 0;
  end;
  $$ language plpgsql;
@@ -3049,7 +3050,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test EXECUTE USING
  create function exc_using(int, text) returns int as $$
  declare i int;
-@@ -3433,19 +3744,27 @@
+@@ -3433,19 +3745,27 @@
    return i;
  end
  $$ language plpgsql;
@@ -3075,10 +3076,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select exc_using(5, 'foobar');
@@ -3088,7 +3089,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function exc_using(int) returns void as $$
  declare
    c refcursor;
-@@ -3461,19 +3780,29 @@
+@@ -3461,19 +3781,29 @@
    return;
  end;
  $$ language plpgsql;
@@ -3119,9 +3120,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select exc_using(5);
 +ERROR:  unknown function: exc_using()
  drop function exc_using(int);
@@ -3129,7 +3130,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test FOR-over-cursor
  create or replace function forc01() returns void as $$
  declare
-@@ -3513,32 +3842,28 @@
+@@ -3513,32 +3843,28 @@
    return;
  end;
  $$ language plpgsql;
@@ -3161,11 +3162,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  c cursor(r1 integer, r2 integer)
 +          ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -3180,7 +3181,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function forc01() returns void as $$
  declare
    c cursor for select * from forc_test;
-@@ -3549,35 +3874,39 @@
+@@ -3549,35 +3875,39 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3207,11 +3208,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  for r in c loop
 +        ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -3247,7 +3248,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (10 rows)
  
  -- same, with a cursor whose portal name doesn't match variable name
-@@ -3595,38 +3924,42 @@
+@@ -3595,38 +3925,42 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3317,7 +3318,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- it's okay to re-use a cursor variable name, even when bound
  do $$
  declare cnt int := 0;
-@@ -3642,7 +3975,24 @@
+@@ -3642,7 +3976,24 @@
    end loop;
    raise notice 'cnt = %', cnt;
  end $$;
@@ -3343,7 +3344,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail because cursor has no query bound to it
  create or replace function forc_bad() returns void as $$
  declare
-@@ -3653,9 +4003,24 @@
+@@ -3653,9 +4004,24 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -3371,7 +3372,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY EXECUTE
  create or replace function return_dquery()
  returns setof int as $$
-@@ -3664,16 +4029,26 @@
+@@ -3664,16 +4030,26 @@
    return query execute 'select * from (values($1),($2)) f' using 40,50;
  end;
  $$ language plpgsql;
@@ -3393,10 +3394,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select * from return_dquery();
@@ -3406,7 +3407,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test RETURN QUERY with dropped columns
  create table tabwithcols(a int, b int, c int, d int);
  insert into tabwithcols values(10,20,30,40),(50,60,70,80);
-@@ -3684,46 +4059,36 @@
+@@ -3684,46 +4060,36 @@
    return query execute 'select * from tabwithcols';
  end;
  $$ language plpgsql;
@@ -3429,10 +3430,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +select * from returnqueryf();
@@ -3475,7 +3476,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop table tabwithcols;
  --
  -- Tests for composite-type results
-@@ -3753,6 +4118,9 @@
+@@ -3753,6 +4119,9 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3485,7 +3486,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select compos();
    compos   
  -----------
-@@ -3778,9 +4146,11 @@
+@@ -3778,9 +4147,11 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3500,7 +3501,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ... but this does
  create or replace function compos() returns compostype as $$
  begin
-@@ -3803,12 +4173,11 @@
+@@ -3803,12 +4174,11 @@
    return v;
  end;
  $$ language plpgsql;
@@ -3517,7 +3518,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: return row expr in return statement.
  create or replace function composrec() returns record as $$
  begin
-@@ -3850,9 +4219,9 @@
+@@ -3850,9 +4220,9 @@
    return 1 + 1;
  end;
  $$ language plpgsql;
@@ -3529,7 +3530,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- RETURN variable is a different code path ...
  create or replace function compos() returns compostype as $$
  declare x int := 42;
-@@ -3861,8 +4230,7 @@
+@@ -3861,8 +4231,7 @@
  end;
  $$ language plpgsql;
  select * from compos();
@@ -3539,7 +3540,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  -- test: invalid use of composite variable in scalar-returning function
  create or replace function compos() returns int as $$
-@@ -3874,8 +4242,7 @@
+@@ -3874,8 +4243,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3549,7 +3550,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test: invalid use of composite expression in scalar-returning function
  create or replace function compos() returns int as $$
  begin
-@@ -3883,8 +4250,7 @@
+@@ -3883,8 +4251,7 @@
  end;
  $$ language plpgsql;
  select compos();
@@ -3559,7 +3560,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function compos();
  drop type compostype;
  --
-@@ -3904,7 +4270,6 @@
+@@ -3904,7 +4271,6 @@
  HINT:  some hint
  ERROR:  1 2 3
  DETAIL:  some detail info
@@ -3567,7 +3568,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Since we can't actually see the thrown SQLSTATE in default psql output,
  -- test it like this; this also tests re-RAISE
  create or replace function raise_test() returns void as $$
-@@ -3917,11 +4282,33 @@
+@@ -3917,11 +4283,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3604,7 +3605,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise 'check me'
-@@ -3932,11 +4319,33 @@
+@@ -3932,11 +4320,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3641,7 +3642,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- SQLSTATE specification in WHEN
  create or replace function raise_test() returns void as $$
  begin
-@@ -3948,11 +4357,33 @@
+@@ -3948,11 +4358,33 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3678,7 +3679,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using detail = 'some detail info';
-@@ -3962,11 +4393,32 @@
+@@ -3962,11 +4394,32 @@
        raise;
  end;
  $$ language plpgsql;
@@ -3714,7 +3715,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero;
-@@ -3974,7 +4426,6 @@
+@@ -3974,7 +4427,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  division_by_zero
@@ -3722,7 +3723,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise sqlstate '1234F';
-@@ -3982,7 +4433,6 @@
+@@ -3982,7 +4434,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  1234F
@@ -3730,7 +3731,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise division_by_zero using message = 'custom' || ' message';
-@@ -3990,7 +4440,6 @@
+@@ -3990,7 +4441,6 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3738,7 +3739,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise using message = 'custom' || ' message', errcode = '22012';
-@@ -3998,34 +4447,48 @@
+@@ -3998,34 +4448,48 @@
  $$ language plpgsql;
  select raise_test();
  ERROR:  custom message
@@ -3794,7 +3795,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test access to exception data
  create function zero_divide() returns int as $$
  declare v int := 0;
-@@ -4033,6 +4496,7 @@
+@@ -4033,6 +4497,7 @@
    return 10 / v;
  end;
  $$ language plpgsql;
@@ -3802,7 +3803,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function raise_test() returns void as $$
  begin
    raise exception 'custom exception'
-@@ -4055,13 +4519,27 @@
+@@ -4055,13 +4520,27 @@
      _sqlstate, _message, replace(_context, E'\n', ' <- ');
  end;
  $$ language plpgsql;
@@ -3821,11 +3822,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  perform zero_divide();
 +                       ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -3836,7 +3837,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
          _hint text;
-@@ -4076,13 +4554,27 @@
+@@ -4076,13 +4555,27 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3855,11 +3856,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +  perform raise_test();
 +                      ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -3870,7 +3871,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- fail, cannot use stacked diagnostics statement outside handler
  create or replace function stacked_diagnostics_test() returns void as $$
  declare _detail text;
-@@ -4096,11 +4588,25 @@
+@@ -4096,11 +4589,25 @@
    raise notice 'message: %, detail: %, hint: %', _message, _detail, _hint;
  end;
  $$ language plpgsql;
@@ -3898,7 +3899,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check cases where implicit SQLSTATE variable could be confused with
  -- SQLSTATE as a keyword, cf bug #5524
  create or replace function raise_test() returns void as $$
-@@ -4112,10 +4618,26 @@
+@@ -4112,10 +4619,26 @@
      raise sqlstate '22012' using message = 'substitute message';
  end;
  $$ language plpgsql;
@@ -3928,7 +3929,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop function raise_test();
  -- test passing column_name, constraint_name, datatype_name, table_name
  -- and schema_name error fields
-@@ -4143,14 +4665,23 @@
+@@ -4143,14 +4666,23 @@
      _column_name, _constraint_name, _datatype_name, _table_name, _schema_name;
  end;
  $$ language plpgsql;
@@ -3948,9 +3949,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select stacked_diagnostics_test();
 +ERROR:  unknown function: stacked_diagnostics_test()
  drop function stacked_diagnostics_test();
@@ -3958,7 +3959,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test variadic functions
  create or replace function vari(variadic int[])
  returns void as $$
-@@ -4159,36 +4690,34 @@
+@@ -4159,36 +4691,34 @@
      raise notice '%', $1[i];
    end loop; end;
  $$ language plpgsql;
@@ -4018,7 +4019,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- coercion test
  create or replace function pleast(variadic numeric[])
  returns numeric as $$
-@@ -4200,30 +4729,20 @@
+@@ -4200,30 +4730,20 @@
    return aux;
  end;
  $$ language plpgsql immutable strict;
@@ -4059,7 +4060,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- in case of conflict, non-variadic version is preferred
  create or replace function pleast(numeric)
  returns numeric as $$
-@@ -4232,15 +4751,13 @@
+@@ -4232,15 +4752,13 @@
    return $1;
  end;
  $$ language plpgsql immutable strict;
@@ -4079,7 +4080,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- test table functions
  create function tftest(int) returns table(a int, b int) as $$
  begin
-@@ -4248,13 +4765,13 @@
+@@ -4248,13 +4766,13 @@
  end;
  $$ language plpgsql immutable strict;
  select * from tftest(10);
@@ -4100,7 +4101,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (5 rows)
  
  create or replace function tftest(a1 int) returns table(a int, b int) as $$
-@@ -4291,19 +4808,31 @@
+@@ -4291,19 +4809,31 @@
    raise notice '% %', found, rc;
  end;
  $$ language plpgsql;
@@ -4136,15 +4137,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select * from rttest();
 +ERROR:  unknown function: rttest()
  -- check some error cases, too
  create or replace function rttest()
  returns setof int as $$
-@@ -4311,25 +4840,45 @@
+@@ -4311,25 +4841,45 @@
    return query select 10 into no_such_table;
  end;
  $$ language plpgsql;
@@ -4198,7 +4199,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test for proper cleanup at subtransaction exit.  This example
  -- exposed a bug in PG 8.2.
  CREATE FUNCTION leaker_1(fail BOOL) RETURNS INTEGER AS $$
-@@ -4344,6 +4893,7 @@
+@@ -4344,6 +4894,7 @@
    RETURN 1;
  END;
  $$ LANGUAGE plpgsql;
@@ -4206,7 +4207,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION leaker_2(fail BOOL, OUT error_code INTEGER, OUT new_id INTEGER)
    RETURNS RECORD AS $$
  BEGIN
-@@ -4356,18 +4906,11 @@
+@@ -4356,18 +4907,11 @@
  END;
  $$ LANGUAGE plpgsql;
  SELECT * FROM leaker_1(false);
@@ -4228,7 +4229,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DROP FUNCTION leaker_2(bool);
  -- Test for appropriate cleanup of non-simple expression evaluations
  -- (bug in all versions prior to August 2010)
-@@ -4385,13 +4928,27 @@
+@@ -4385,13 +4929,27 @@
    RETURN arr;
  END;
  $$ LANGUAGE plpgsql;
@@ -4261,7 +4262,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION nonsimple_expr_test() RETURNS integer AS $$
  declare
     i integer NOT NULL := 0;
-@@ -4405,13 +4962,13 @@
+@@ -4405,13 +4963,13 @@
    return i;
  end;
  $$ LANGUAGE plpgsql;
@@ -4280,7 +4281,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test cases involving recursion and error recovery in simple expressions
  -- (bugs in all versions before October 2010).  The problems are most
-@@ -4427,15 +4984,13 @@
+@@ -4427,15 +4985,13 @@
    end if;
  end;
  $$ language plpgsql;
@@ -4299,7 +4300,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function error1(text) returns text language sql as
  $$ SELECT relname::text FROM pg_class c WHERE c.oid = $1::regclass $$;
  create function error2(p_name_table text) returns text language plpgsql as $$
-@@ -4444,12 +4999,13 @@
+@@ -4444,12 +5000,13 @@
  end$$;
  BEGIN;
  create table public.stuffs (stuff text);
@@ -4316,7 +4317,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  select error2('public.stuffs');
   error2 
  --------
-@@ -4457,70 +5013,72 @@
+@@ -4457,70 +5014,72 @@
  (1 row)
  
  rollback;
@@ -4428,7 +4429,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test handling of cast cache inside DO blocks
  -- (to check the original crash case, this must be a cast not previously
  -- used in this session)
-@@ -4534,45 +5092,29 @@
+@@ -4534,45 +5093,29 @@
    return 1/0;
  end
  $$;
@@ -4485,7 +4486,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  create or replace function strtest() returns text as $$
-@@ -4625,21 +5167,26 @@
+@@ -4625,21 +5168,26 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4525,7 +4526,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  DO $$
  DECLARE r record;
  BEGIN
-@@ -4648,11 +5195,23 @@
+@@ -4648,11 +5196,23 @@
          RAISE NOTICE '%, %', r.roomno, r.comment;
      END LOOP;
  END$$;
@@ -4554,7 +4555,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of errors thrown from/into anonymous code blocks.
  do $outer$
  begin
-@@ -4672,16 +5231,19 @@
+@@ -4672,16 +5232,19 @@
    end loop;
  end;
  $outer$;
@@ -4584,7 +4585,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check variable scoping -- a var is not available in its own or prior
  -- default expressions, but it is available in later ones.
  do $$
-@@ -4691,10 +5253,6 @@
+@@ -4691,10 +5254,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4595,7 +4596,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare y int := x + 1;  -- error
          x int := 42;
-@@ -4703,10 +5261,6 @@
+@@ -4703,10 +5262,6 @@
  end;
  $$;
  ERROR:  column "x" does not exist
@@ -4606,7 +4607,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare x int := 42;
          y int := x + 1;
-@@ -4726,7 +5280,11 @@
+@@ -4726,7 +5281,11 @@
    end;
  end;
  $$;
@@ -4619,7 +4620,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check handling of conflicts between plpgsql vars and table columns.
  set plpgsql.variable_conflict = error;
  create function conflict_test() returns setof int8_tbl as $$
-@@ -4738,13 +5296,26 @@
+@@ -4738,13 +5297,26 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4652,7 +4653,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_variable
  declare r record;
-@@ -4755,16 +5326,12 @@
+@@ -4755,16 +5327,12 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4674,7 +4675,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function conflict_test() returns setof int8_tbl as $$
  #variable_conflict use_column
  declare r record;
-@@ -4775,17 +5342,14 @@
+@@ -4775,17 +5343,14 @@
    end loop;
  end;
  $$ language plpgsql;
@@ -4698,7 +4699,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Check that an unreserved keyword can be used as a variable name
  create function unreserved_test() returns int as $$
  declare
-@@ -4795,12 +5359,15 @@
+@@ -4795,12 +5360,15 @@
    return forward;
  end
  $$ language plpgsql;
@@ -4719,7 +4720,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    return int := 42;
-@@ -4809,12 +5376,20 @@
+@@ -4809,12 +5377,20 @@
    return return;
  end
  $$ language plpgsql;
@@ -4745,7 +4746,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function unreserved_test() returns int as $$
  declare
    comment int := 21;
-@@ -4824,19 +5399,26 @@
+@@ -4824,19 +5400,26 @@
    return comment;
  end
  $$ language plpgsql;
@@ -4782,7 +4783,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test FOREACH over arrays
  --
-@@ -4850,26 +5432,27 @@
+@@ -4850,26 +5433,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4818,9 +4819,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
-+We appreciate your feedback.
  
++We appreciate your feedback.
++
 +select foreach_test(ARRAY[1,2,3,4]);
 +ERROR:  unknown function: foreach_test()
 +select foreach_test(ARRAY[[1,2],[3,4]]);
@@ -4828,7 +4829,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int;
-@@ -4880,13 +5463,28 @@
+@@ -4880,13 +5464,28 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4861,7 +4862,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int[];
-@@ -4897,21 +5495,27 @@
+@@ -4897,21 +5496,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4902,7 +4903,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- higher level of slicing
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -4923,26 +5527,31 @@
+@@ -4923,26 +5528,31 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4949,7 +4950,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create type xy_tuple AS (x int, y int);
  -- iteration over array of records
  create or replace function foreach_test(anyarray)
-@@ -4955,25 +5564,27 @@
+@@ -4955,25 +5565,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -4994,7 +4995,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function foreach_test(anyarray)
  returns void as $$
  declare x int; y int;
-@@ -4984,25 +5595,27 @@
+@@ -4984,25 +5596,27 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5039,7 +5040,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- slicing over array of composite types
  create or replace function foreach_test(anyarray)
  returns void as $$
-@@ -5014,22 +5627,29 @@
+@@ -5014,22 +5628,29 @@
    end loop;
    end;
  $$ language plpgsql;
@@ -5082,7 +5083,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  drop type xy_tuple;
  --
  -- Assorted tests for array subscript assignment
-@@ -5043,28 +5663,30 @@
+@@ -5043,28 +5664,30 @@
    r.ar[2] := 'replace';
    return r.ar;
  end$$;
@@ -5129,7 +5130,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create function testoa(x1 int, x2 int, x3 int) returns orderedarray
  language plpgsql as $$
  declare res orderedarray;
-@@ -5073,26 +5695,19 @@
+@@ -5073,26 +5696,19 @@
    res[2] := x3;
    return res;
  end$$;
@@ -5163,7 +5164,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test handling of expanded arrays
  --
-@@ -5101,72 +5716,48 @@
+@@ -5101,72 +5717,48 @@
    declare r int[];
    begin r := array[$1, $1]; return r; end;
  $$ stable;
@@ -5257,7 +5258,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare a int[] := array[1,2];
  begin
-@@ -5190,6 +5781,19 @@
+@@ -5190,6 +5782,19 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5277,7 +5278,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5201,6 +5805,7 @@
+@@ -5201,6 +5806,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5285,7 +5286,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5212,44 +5817,18 @@
+@@ -5212,44 +5818,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5336,7 +5337,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- access to call stack from exception
  create function inner_func(int)
  returns int as $$
-@@ -5272,6 +5851,26 @@
+@@ -5272,6 +5852,26 @@
    return 2 * $1;
  end;
  $$ language plpgsql;
@@ -5363,7 +5364,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_func(int)
  returns int as $$
  declare
-@@ -5283,6 +5882,7 @@
+@@ -5283,6 +5883,7 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5371,7 +5372,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  create or replace function outer_outer_func(int)
  returns int as $$
  declare
-@@ -5294,44 +5894,18 @@
+@@ -5294,44 +5895,18 @@
    return myresult;
  end;
  $$ language plpgsql;
@@ -5422,7 +5423,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- Test pg_routine_oid
  create function current_function(text)
  returns regprocedure as $$
-@@ -5342,13 +5916,17 @@
+@@ -5342,13 +5917,17 @@
    return fn_oid;
  end;
  $$ language plpgsql;
@@ -5445,7 +5446,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- shouldn't fail in DO, even though there's no useful data
  do $$
  declare
-@@ -5358,7 +5936,13 @@
+@@ -5358,7 +5937,13 @@
    raise notice 'pg_routine_oid = %', fn_oid;
  end;
  $$;
@@ -5460,7 +5461,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test ASSERT
  --
-@@ -5367,20 +5951,55 @@
+@@ -5367,20 +5952,55 @@
    assert 1=1;  -- should succeed
  end;
  $$;
@@ -5520,7 +5521,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- check controlling GUC
  set plpgsql.check_asserts = off;
  do $$
-@@ -5388,6 +6007,19 @@
+@@ -5388,6 +6008,19 @@
    assert 1=0;  -- won't be tested
  end;
  $$;
@@ -5540,7 +5541,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  reset plpgsql.check_asserts;
  -- test custom message
  do $$
-@@ -5396,8 +6028,19 @@
+@@ -5396,8 +6029,19 @@
    assert 1=0, format('assertion failed, var = "%s"', var);
  end;
  $$;
@@ -5562,7 +5563,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- ensure assertions are not trapped by 'others'
  do $$
  begin
-@@ -5406,32 +6049,55 @@
+@@ -5406,32 +6050,55 @@
    null; -- do nothing
  end;
  $$;
@@ -5622,7 +5623,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  do $$
  declare v_test plpgsql_arr_domain;
  begin
-@@ -5439,14 +6105,14 @@
+@@ -5439,14 +6106,14 @@
    v_test := v_test || 2;
  end;
  $$;
@@ -5639,7 +5640,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- test usage of transition tables in AFTER triggers
  --
-@@ -5472,25 +6138,40 @@
+@@ -5472,25 +6139,40 @@
    RETURN new;
  END;
  $$;
@@ -5687,7 +5688,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION transition_table_base_upd_func()
    RETURNS trigger
    LANGUAGE plpgsql
-@@ -5512,30 +6193,42 @@
+@@ -5512,30 +6194,42 @@
    RETURN new;
  END;
  $$;
@@ -5740,7 +5741,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_level2
  (
        level2_no serial NOT NULL ,
-@@ -5543,6 +6236,7 @@
+@@ -5543,6 +6237,7 @@
        level1_node_name varchar(255),
         PRIMARY KEY (level2_no)
  ) WITHOUT OIDS;
@@ -5748,7 +5749,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE TABLE transition_table_status
  (
        level int NOT NULL,
-@@ -5563,11 +6257,29 @@
+@@ -5563,11 +6258,29 @@
      RETURN NULL;
    END;
  $$;
@@ -5778,7 +5779,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level1_ri_parent_upd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5595,6 +6307,9 @@
+@@ -5595,6 +6308,9 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level1_ri_parent_upd_func();
@@ -5788,7 +5789,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE FUNCTION transition_table_level2_ri_child_insupd_func()
    RETURNS TRIGGER
    LANGUAGE plpgsql
-@@ -5610,16 +6325,37 @@
+@@ -5610,16 +6326,37 @@
      RETURN NULL;
    END;
  $$;
@@ -5826,7 +5827,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- create initial test data
  INSERT INTO transition_table_level1 (level1_no)
    SELECT generate_series(1,200);
-@@ -5627,6 +6363,7 @@
+@@ -5627,6 +6364,7 @@
  INSERT INTO transition_table_level2 (level2_no, parent_no)
    SELECT level2_no, level2_no / 50 + 1 AS parent_no
      FROM generate_series(1,9999) level2_no;
@@ -5834,7 +5835,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  ANALYZE transition_table_level2;
  INSERT INTO transition_table_status (level, node_no, status)
    SELECT 1, level1_no, 0 FROM transition_table_level1;
-@@ -5651,30 +6388,23 @@
+@@ -5651,30 +6389,23 @@
    REFERENCING OLD TABLE AS dx
    FOR EACH STATEMENT EXECUTE PROCEDURE
      transition_table_level2_bad_usage_func();
@@ -5869,7 +5870,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  -- attempt modifications which would not break RI (should all succeed)
  DELETE FROM transition_table_level1
    WHERE level1_no BETWEEN 201 AND 1000;
-@@ -5683,7 +6413,7 @@
+@@ -5683,7 +6414,7 @@
  SELECT count(*) FROM transition_table_level1;
   count 
  -------
@@ -5878,7 +5879,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  DELETE FROM transition_table_level2
-@@ -5691,7 +6421,7 @@
+@@ -5691,7 +6422,7 @@
  SELECT count(*) FROM transition_table_level2;
   count 
  -------
@@ -5887,7 +5888,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  (1 row)
  
  CREATE TABLE alter_table_under_transition_tables
-@@ -5717,36 +6447,30 @@
+@@ -5717,36 +6448,30 @@
    REFERENCING OLD TABLE AS d NEW TABLE AS i
    FOR EACH STATEMENT EXECUTE PROCEDURE
      alter_table_under_transition_tables_upd_func();
@@ -5928,7 +5929,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Test multiple reference to a transition table
  --
-@@ -5764,19 +6488,37 @@
+@@ -5764,19 +6489,37 @@
  CREATE TRIGGER my_trigger AFTER UPDATE ON multi_test
    REFERENCING NEW TABLE AS new_test OLD TABLE as old_test
    FOR EACH STATEMENT EXECUTE PROCEDURE multi_test_trig();
@@ -5968,7 +5969,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION get_from_partitioned_table(partitioned_table.a%type)
  RETURNS partitioned_table AS $$
  DECLARE
-@@ -5787,13 +6529,13 @@
+@@ -5787,13 +6530,13 @@
      SELECT * INTO result FROM partitioned_table WHERE a = a_val;
      RETURN result;
  END; $$ LANGUAGE plpgsql;
@@ -5988,7 +5989,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  CREATE OR REPLACE FUNCTION list_partitioned_table()
  RETURNS SETOF partitioned_table.a%TYPE AS $$
  DECLARE
-@@ -5806,14 +6548,13 @@
+@@ -5806,14 +6549,13 @@
      END LOOP;
      RETURN;
  END; $$ LANGUAGE plpgsql;
@@ -6009,7 +6010,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/plpgsql.out --lab
  --
  -- Check argument name is used instead of $n in error message
  --
-@@ -5822,6 +6563,16 @@
+@@ -5822,6 +6564,16 @@
    GET DIAGNOSTICS x = ROW_COUNT;
    RETURN;
  END; $$ LANGUAGE plpgsql;

--- a/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
@@ -1659,9 +1659,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
-+We appreciate your feedback.
 +
++We appreciate your feedback.
+ 
 +select insert_tt2('foollog','barlog') limit 1;
 +ERROR:  unknown function: insert_tt2()
  select * from tt;
@@ -1741,21 +1741,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1871,31 +1424,24 @@
+@@ -1871,8 +1424,6 @@
  
  select * from array_to_set(array['one', 'two']); -- fail
  ERROR:  a column definition list is required for functions returning "record"
 -LINE 1: select * from array_to_set(array['one', 'two']);
 -                      ^
  -- after-the-fact coercion of the columns is now possible, too
--select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
--  f1  | f2  
--------+-----
-- 1.00 | one
-- 2.00 | two
--(2 rows)
--
-+-- select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
+ select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
+   f1  | f2  
+@@ -1883,19 +1434,20 @@
+ 
  -- and if it doesn't work, you get a compile-time not run-time error
  select * from array_to_set(array['one', 'two']) as t(f1 point,f2 text);
 -ERROR:  return type mismatch in function declared to return record
@@ -1785,18 +1781,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- but without, it can be:
  create or replace function array_to_set(anyarray) returns setof record as $$
    select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
-@@ -1914,26 +1460,21 @@
-   2 | two
+@@ -1922,18 +1474,19 @@
  (2 rows)
  
--select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
--  f1  | f2  
--------+-----
-- 1.00 | one
-- 2.00 | two
--(2 rows)
--
-+-- select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
  select * from array_to_set(array['one', 'two']) as t(f1 point,f2 text);
 -ERROR:  return type mismatch in function declared to return record
 -DETAIL:  Final statement returns integer instead of point at column 1.
@@ -1824,7 +1811,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  create temp table rngfunc(f1 int8, f2 int8);
  create function testrngfunc() returns record as $$
    insert into rngfunc values (1,2) returning *;
-@@ -1952,8 +1493,6 @@
+@@ -1952,8 +1505,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1833,7 +1820,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  create function testrngfunc() returns setof record as $$
    insert into rngfunc values (1,2), (3,4) returning *;
-@@ -1974,8 +1513,6 @@
+@@ -1974,8 +1525,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1842,7 +1829,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  -- Check that typmod imposed by a composite type is honored
  create type rngfunc_type as (f1 numeric(35,6), f2 numeric(35,2));
-@@ -1984,12 +1521,11 @@
+@@ -1984,12 +1533,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1860,7 +1847,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -1998,13 +1534,11 @@
+@@ -1998,13 +1546,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1879,7 +1866,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2016,12 +1550,11 @@
+@@ -2016,12 +1562,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1897,7 +1884,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2030,13 +1563,11 @@
+@@ -2030,13 +1575,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1916,7 +1903,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2049,13 +1580,11 @@
+@@ -2049,13 +1592,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1935,7 +1922,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2064,12 +1593,11 @@
+@@ -2064,12 +1605,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1953,7 +1940,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2081,13 +1609,11 @@
+@@ -2081,13 +1621,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1972,7 +1959,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2096,13 +1622,11 @@
+@@ -2096,13 +1634,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1991,7 +1978,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2112,62 +1636,45 @@
+@@ -2112,62 +1648,45 @@
  create or replace function testrngfunc() returns setof rngfunc_type as $$
    select 1, 2 union select 3, 4 order by 1;
  $$ language sql immutable;
@@ -2075,7 +2062,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- Check some cases involving added/dropped columns in a rowtype result
  --
-@@ -2178,79 +1685,37 @@
+@@ -2178,79 +1697,37 @@
  create or replace function get_first_user() returns users as
  $$ SELECT * FROM users ORDER BY userid LIMIT 1; $$
  language sql stable;
@@ -2168,7 +2155,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -2264,18 +1729,14 @@
+@@ -2264,18 +1741,14 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2191,7 +2178,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- likewise, check we don't crash if the dependency goes wrong
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -2286,19 +1747,18 @@
+@@ -2286,19 +1759,18 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2217,7 +2204,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop table users;
  -- check behavior with type coercion required for a set-op
  create or replace function rngfuncbar() returns setof text as
-@@ -2320,17 +1780,11 @@
+@@ -2320,17 +1792,11 @@
  
  -- this function is now inlinable, too:
  explain (verbose, costs off) select * from rngfuncbar();
@@ -2240,7 +2227,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function rngfuncbar();
  -- check handling of a SQL function with multiple OUT params (bug #5777)
  create or replace function rngfuncbar(out integer, out numeric) as
-@@ -2344,115 +1798,93 @@
+@@ -2344,115 +1810,93 @@
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2) $$ language sql;
  select * from rngfuncbar();  -- fail
@@ -2407,7 +2394,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (0 rows)
  
  drop type rngfunc2;
-@@ -2463,18 +1895,11 @@
+@@ -2463,18 +1907,11 @@
     from unnest(array['{"lectures": [{"id": "1"}]}'::jsonb])
          as unnested_modules(module)) as ss,
    jsonb_to_recordset(ss.lecture) as j (id text);

--- a/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
@@ -5057,22 +5057,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int PRIMARY KEY);
  CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
-@@ -4273,12 +3155,13 @@
- ALTER TABLE r1 FORCE ROW LEVEL SECURITY;
- -- Works fine
- UPDATE r1 SET a = 30;
-+ERROR:  new row violates row-level security policy for table "r1"
- -- Show updated rows
- ALTER TABLE r1 NO FORCE ROW LEVEL SECURITY;
- TABLE r1;
-  a  
- ----
-- 30
-+ 10
- (1 row)
- 
- -- reset value in r1 for test with RETURNING
-@@ -4308,28 +3191,31 @@
+@@ -4308,28 +3190,31 @@
  ERROR:  new row violates row-level security policy for table "r1"
  DROP TABLE r1;
  -- Check dependency handling
@@ -5107,7 +5092,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Should return one
-@@ -4338,7 +3224,7 @@
+@@ -4338,7 +3223,7 @@
  					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_carol');
   ?column? 
  ----------
@@ -5116,7 +5101,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Should return zero
-@@ -4351,15 +3237,19 @@
+@@ -4351,15 +3236,19 @@
  (1 row)
  
  -- DROP OWNED BY testing
@@ -5138,7 +5123,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
  DROP OWNED BY regress_rls_dob_role1;
  DROP POLICY p1 ON dob_t1; -- should succeed
-@@ -4367,14 +3257,15 @@
+@@ -4367,14 +3256,15 @@
  CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1 USING (true);
  DROP OWNED BY regress_rls_dob_role1;
  DROP POLICY p1 ON dob_t1; -- should fail, already gone
@@ -5155,7 +5140,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DROP USER regress_rls_dob_role1;
  DROP USER regress_rls_dob_role2;
  -- Bug #15708: view + table with RLS should check policies as view owner
-@@ -4384,81 +3275,97 @@
+@@ -4384,81 +3274,97 @@
  INSERT INTO rls_tbl VALUES (10);
  ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
  CREATE POLICY p1 ON rls_tbl USING (EXISTS (SELECT 1 FROM ref_tbl));
@@ -5287,7 +5272,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- CVE-2023-2455: inlining an SRF may introduce an RLS dependency
  create table rls_t (c text);
  insert into rls_t values ('invisible to bob');
-@@ -4489,39 +3396,8 @@
+@@ -4489,39 +3395,8 @@
  --
  -- Clean up objects
  --

--- a/pkg/cmd/roachtest/testdata/pg_regress/rowtypes.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rowtypes.diffs
@@ -255,7 +255,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowtypes.out --la
 -LINE 1: select ROW('ABC','DEF') ~~ ROW('DEF','ABC') as fail;
 -                                ^
 -HINT:  Row comparison operators must be associated with btree operator families.
-+ERROR:  unsupported unary operator: ~ <tuple{string, string}>
++ERROR:  unsupported comparison operator: <tuple> LIKE <tuple>
  -- Comparisons of ROW() expressions can cope with some type mismatches
  select ROW(1,2) = ROW(1,2::int8);
   ?column? 

--- a/pkg/cmd/roachtest/testdata/pg_regress/stats.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/stats.diffs
@@ -96,7 +96,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- rollback a savepoint: this should count 4 inserts and have 2
  -- live tuples after commit (and 2 dead ones due to aborted subxact)
  BEGIN;
-@@ -73,203 +113,161 @@
+@@ -73,82 +113,88 @@
  INSERT INTO trunc_stats_test3 DEFAULT VALUES;
  INSERT INTO trunc_stats_test3 DEFAULT VALUES;
  TRUNCATE trunc_stats_test3;
@@ -216,13 +216,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  COMMIT;
  ----
  -- Basic tests for track_functions
- ---
- CREATE FUNCTION stats_test_func1() RETURNS VOID LANGUAGE plpgsql AS $$BEGIN END;$$;
- SELECT 'stats_test_func1()'::regprocedure::oid AS stats_test_func1_oid \gset
--CREATE FUNCTION stats_test_func2() RETURNS VOID LANGUAGE plpgsql AS $$BEGIN END;$$;
--SELECT 'stats_test_func2()'::regprocedure::oid AS stats_test_func2_oid \gset
-+-- CREATE FUNCTION stats_test_func2() RETURNS VOID LANGUAGE plpgsql AS $$BEGIN END;$$;
-+-- SELECT 'stats_test_func2()'::regprocedure::oid AS stats_test_func2_oid \gset
+@@ -160,48 +206,21 @@
  -- test that stats are accumulated
  BEGIN;
  SET LOCAL stats_fetch_consistency = none;
@@ -279,35 +273,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  COMMIT;
  -- Verify that function stats are not transactional
  -- rolled back savepoint in committing transaction
- BEGIN;
- SELECT stats_test_func2();
-- stats_test_func2 
--------------------
-- 
--(1 row)
--
-+ERROR:  unknown function: stats_test_func2()
- SAVEPOINT foo;
-+ERROR:  current transaction is aborted, commands ignored until end of transaction block
- SELECT stats_test_func2();
-- stats_test_func2 
--------------------
-- 
--(1 row)
--
-+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+@@ -221,17 +240,9 @@
+ 
  ROLLBACK TO SAVEPOINT foo;
-+ERROR:  savepoint "foo" does not exist
  SELECT pg_stat_get_xact_function_calls(:stats_test_func2_oid);
 - pg_stat_get_xact_function_calls 
 ----------------------------------
 -                               2
 -(1 row)
 -
-+ERROR:  at or near ":": syntax error
-+DETAIL:  source SQL:
-+SELECT pg_stat_get_xact_function_calls(:stats_test_func2_oid)
-+                                       ^
++ERROR:  unknown function: pg_stat_get_xact_function_calls()
  SELECT stats_test_func2();
 - stats_test_func2 
 -------------------
@@ -318,13 +293,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  COMMIT;
  -- rolled back transaction
  BEGIN;
- SELECT stats_test_func2();
-- stats_test_func2 
--------------------
-- 
--(1 row)
--
-+ERROR:  unknown function: stats_test_func2()
+@@ -243,33 +254,27 @@
+ 
  ROLLBACK;
  SELECT pg_stat_force_next_flush();
 - pg_stat_force_next_flush 
@@ -348,11 +318,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
 -------------------+-------
 - stats_test_func2 |     4
 -(1 row)
--
-+ERROR:  at or near ":": syntax error
-+DETAIL:  source SQL:
-+SELECT funcname, calls FROM pg_stat_user_functions WHERE funcid = :stats_test_func2_oid
-+                                                                  ^
++ funcname | calls 
++----------+-------
++(0 rows)
+ 
  -- check that a rolled back drop function stats leaves stats alive
  BEGIN;
  SELECT funcname, calls FROM pg_stat_user_functions WHERE funcid = :stats_test_func1_oid;
@@ -369,7 +338,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- shouldn't be visible via view
  SELECT funcname, calls FROM pg_stat_user_functions WHERE funcid = :stats_test_func1_oid;
   funcname | calls 
-@@ -278,68 +276,53 @@
+@@ -278,39 +283,30 @@
  
  -- but still via oid access
  SELECT pg_stat_get_function_calls(:stats_test_func1_oid);
@@ -419,49 +388,29 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- check that function dropped in a subtransaction leaves no stats behind
  BEGIN;
  SELECT stats_test_func2();
-- stats_test_func2 
--------------------
-- 
--(1 row)
--
-+ERROR:  unknown function: stats_test_func2()
- SAVEPOINT a;
-+ERROR:  current transaction is aborted, commands ignored until end of transaction block
- SELECT stats_test_func2();
-- stats_test_func2 
--------------------
-- 
--(1 row)
--
-+ERROR:  current transaction is aborted, commands ignored until end of transaction block
+@@ -328,18 +324,16 @@
+ 
  SAVEPOINT b;
-+ERROR:  current transaction is aborted, commands ignored until end of transaction block
  DROP FUNCTION stats_test_func2();
-+ERROR:  current transaction is aborted, commands ignored until end of transaction block
++NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
  COMMIT;
++WARNING:  there is no transaction in progress
  SELECT funcname, calls FROM pg_stat_user_functions WHERE funcid = :stats_test_func2_oid;
-- funcname | calls 
------------+-------
--(0 rows)
--
-+ERROR:  at or near ":": syntax error
-+DETAIL:  source SQL:
-+SELECT funcname, calls FROM pg_stat_user_functions WHERE funcid = :stats_test_func2_oid
-+                                                                  ^
+  funcname | calls 
+ ----------+-------
+ (0 rows)
+ 
  SELECT pg_stat_get_function_calls(:stats_test_func2_oid);
 - pg_stat_get_function_calls 
 -----------------------------
 -                           
 -(1 row)
 -
-+ERROR:  at or near ":": syntax error
-+DETAIL:  source SQL:
-+SELECT pg_stat_get_function_calls(:stats_test_func2_oid)
-+                                  ^
++ERROR:  unknown function: pg_stat_get_function_calls()
  -- Check that stats for relations are dropped. For that we need to access stats
  -- by oid after the DROP TABLE. Save oids.
  CREATE TABLE drop_stats_test();
-@@ -352,210 +335,113 @@
+@@ -352,210 +346,113 @@
  INSERT INTO drop_stats_test_subxact DEFAULT VALUES;
  SELECT 'drop_stats_test_subxact'::regclass::oid AS drop_stats_test_subxact_oid \gset
  SELECT pg_stat_force_next_flush();
@@ -715,7 +664,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -----
  -- Test that last_seq_scan, last_idx_scan are correctly maintained
  --
-@@ -566,204 +452,202 @@
+@@ -566,204 +463,202 @@
  -----
  BEGIN;
  CREATE TEMPORARY TABLE test_last_scan(idx_col int primary key, noidx_col int);
@@ -1035,7 +984,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -----
  -- Test reset of some stats for shared table
  -----
-@@ -776,33 +660,25 @@
+@@ -776,33 +671,25 @@
  BEGIN;
  SELECT current_database() as datname \gset
  COMMENT ON DATABASE :"datname" IS 'This is a test comment';
@@ -1075,7 +1024,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  
  -- set back comment
  \if :{?description_before}
-@@ -815,220 +691,170 @@
+@@ -815,220 +702,170 @@
  -----
  -- Test that sessions is incremented when a new session is started in pg_stat_database
  SELECT sessions AS db_stat_sessions FROM pg_stat_database WHERE datname = (SELECT current_database()) \gset
@@ -1386,7 +1335,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  COMMIT;
  ----
  -- Changing stats_fetch_consistency in a transaction.
-@@ -1036,90 +862,51 @@
+@@ -1036,90 +873,51 @@
  BEGIN;
  -- Stats filled under the cache mode
  SET LOCAL stats_fetch_consistency = cache;
@@ -1494,7 +1443,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  select a from stats_test_tab1 where a = 3;
   a 
  ---
-@@ -1127,28 +914,19 @@
+@@ -1127,28 +925,19 @@
  (1 row)
  
  SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
@@ -1529,7 +1478,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  SELECT 'stats_test_idx1'::regclass::oid AS stats_test_idx1_oid \gset
  select a from stats_test_tab1 where a = 3;
   a 
-@@ -1157,20 +935,14 @@
+@@ -1157,20 +946,14 @@
  (1 row)
  
  SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
@@ -1554,7 +1503,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  SELECT 'stats_test_idx1'::regclass::oid AS stats_test_idx1_oid \gset
  select a from stats_test_tab1 where a = 3;
   a 
-@@ -1179,58 +951,37 @@
+@@ -1179,58 +962,37 @@
  (1 row)
  
  SELECT pg_stat_have_stats('relation', :dboid, :stats_test_idx1_oid);
@@ -1627,7 +1576,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- Test that the following operations are tracked in pg_stat_io:
  -- - reads of target blocks into shared buffers
  -- - writes of shared buffers to permanent storage
-@@ -1243,118 +994,126 @@
+@@ -1243,118 +1005,126 @@
  -- extends.
  SELECT sum(extends) AS io_sum_shared_before_extends
    FROM pg_stat_io WHERE context = 'normal' AND object = 'relation' \gset
@@ -1813,7 +1762,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  DROP TABLE test_io_shared;
  -- Test that the follow IOCONTEXT_LOCAL IOOps are tracked in pg_stat_io:
  -- - eviction of local buffers in order to reuse them
-@@ -1366,23 +1125,33 @@
+@@ -1366,23 +1136,33 @@
  -- accessed by previous tests in this session.
  \c
  SET temp_buffers TO 100;
@@ -1852,7 +1801,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- Read in evicted buffers, generating reads.
  SELECT COUNT(*) FROM test_io_local;
   count 
-@@ -1391,45 +1160,54 @@
+@@ -1391,45 +1171,54 @@
  (1 row)
  
  SELECT pg_stat_force_next_flush();
@@ -1927,7 +1876,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- Test that reuse of strategy buffers and reads of blocks into these reused
  -- buffers while VACUUMing are tracked in pg_stat_io. If there is sufficient
  -- demand for shared buffers from concurrent queries, some buffers may be
-@@ -1443,87 +1221,102 @@
+@@ -1443,87 +1232,102 @@
  -- shared buffers -- preventing us from testing BAS_VACUUM BufferAccessStrategy
  -- reads.
  SET wal_skip_threshold = '1 kB';
@@ -2070,7 +2019,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  CREATE FUNCTION wait_for_hot_stats() RETURNS void AS $$
  DECLARE
    start_time timestamptz := clock_timestamp();
-@@ -1544,6 +1337,31 @@
+@@ -1544,6 +1348,31 @@
      EXTRACT(epoch FROM clock_timestamp() - start_time);
  END
  $$ LANGUAGE plpgsql;
@@ -2102,7 +2051,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  UPDATE brin_hot SET val = -3 WHERE id = 42;
  -- We can't just call wait_for_hot_stats() at this point, because we only
  -- transmit stats when the session goes idle, and we probably didn't
-@@ -1553,19 +1371,12 @@
+@@ -1553,19 +1382,12 @@
  -- then send its stats before dying.
  \c -
  SELECT wait_for_hot_stats();
@@ -2125,7 +2074,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  -- Test handling of index predicates - updating attributes in precicates
  -- should not block HOT when summarizing indexes are involved. We update
  -- a row that was not indexed due to the index predicate, and becomes
-@@ -1573,14 +1384,28 @@
+@@ -1573,14 +1395,28 @@
  CREATE TABLE brin_hot_2 (a int, b int);
  INSERT INTO brin_hot_2 VALUES (1, 100);
  CREATE INDEX ON brin_hot_2 USING brin (b) WHERE a = 2;
@@ -2160,7 +2109,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  SELECT COUNT(*) FROM brin_hot_2 WHERE a = 2 AND b = 100;
   count 
  -------
-@@ -1588,15 +1413,13 @@
+@@ -1588,15 +1424,13 @@
  (1 row)
  
  SET enable_seqscan = off;
@@ -2182,7 +2131,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  SELECT COUNT(*) FROM brin_hot_2 WHERE a = 2 AND b = 100;
   count 
  -------
-@@ -1608,18 +1431,31 @@
+@@ -1608,18 +1442,31 @@
  -- BRIN column.
  -- https://postgr.es/m/05ebcb44-f383-86e3-4f31-0a97a55634cf@enterprisedb.com
  CREATE TABLE brin_hot_3 (a int, filler text) WITH (fillfactor = 10);
@@ -2222,7 +2171,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats.out --label
  SELECT COUNT(*) FROM brin_hot_3 WHERE a = 2;
   count 
  -------
-@@ -1628,4 +1464,5 @@
+@@ -1628,4 +1475,5 @@
  
  DROP TABLE brin_hot_3;
  SET enable_seqscan = on;

--- a/pkg/cmd/roachtest/testdata/pg_regress/temp.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/temp.diffs
@@ -191,7 +191,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
    as $$select 'public'::text$$ language sql;
  create function pg_temp.whoami() returns text
    as $$select 'temp'::text$$ language sql;
-+ERROR:  unimplemented: cannot create UDFs under a temporary schema
++ERROR:  unimplemented: cannot create user-defined functions under a temporary schema
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/104687/_version_
  -- default should have pg_temp implicitly first, but only for tables
@@ -422,12 +422,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  -- Tests with two-phase commit
  -- Transactions creating objects in a temporary namespace cannot be used
  -- with two-phase commit.
-@@ -327,33 +422,99 @@
+@@ -327,33 +422,51 @@
  begin;
  create function pg_temp.twophase_func() returns void as
    $$ select '2pc_func'::text $$ language sql;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-+ERROR:  unimplemented: cannot create UDFs under a temporary schema
++ERROR:  unimplemented: cannot create user-defined functions under a temporary schema
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/104687/_version_
  prepare transaction 'twophase_func';
@@ -436,7 +436,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  -- Function drop
  create function pg_temp.twophase_func() returns void as
    $$ select '2pc_func'::text $$ language sql;
-+ERROR:  unimplemented: cannot create UDFs under a temporary schema
++ERROR:  unimplemented: cannot create user-defined functions under a temporary schema
 +HINT:  You have attempted to use a feature that is not yet implemented.
 +See: https://go.crdb.dev/issue-v/104687/_version_
  begin;
@@ -468,67 +468,19 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  begin;
  create view pg_temp.twophase_view as select 1;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-+ERROR:  internal error: invalid schema kind for getNonTemporarySchemaForCreate: 2
-+DETAIL:  stack trace:
-+pkg/sql/create_table.go:109: getNonTemporarySchemaForCreate()
-+pkg/sql/create_table.go:160: getSchemaForCreateTable()
-+pkg/sql/create_view.go:135: startExec()
-+pkg/sql/plan.go:580: startExec()
-+pkg/sql/plan_node_to_row_source.go:181: Start()
-+pkg/sql/colexec/columnarizer.go:178: Init()
-+pkg/sql/colflow/stats.go:96: init()
-+pkg/sql/colexecerror/error.go:162: CatchVectorizedRuntimeError()
-+pkg/sql/colflow/stats.go:105: Init()
-+pkg/sql/colflow/flow_coordinator.go:236: func2()
-+pkg/sql/colexecerror/error.go:162: CatchVectorizedRuntimeError()
-+pkg/sql/colflow/flow_coordinator.go:235: init()
-+pkg/sql/colflow/flow_coordinator.go:269: Run()
-+pkg/sql/colflow/vectorized_flow.go:316: Run()
-+pkg/sql/distsql_running.go:990: Run()
-+pkg/sql/distsql_running.go:2093: PlanAndRun()
-+pkg/sql/distsql_running.go:1797: func3()
-+pkg/sql/distsql_running.go:1800: PlanAndRunAll()
-+pkg/sql/conn_executor_exec.go:3452: execWithDistSQLEngine()
-+pkg/sql/conn_executor_exec.go:2983: dispatchToExecutionEngine()
-+pkg/sql/conn_executor_exec.go:1079: execStmtInOpenState()
-+pkg/sql/conn_executor_exec.go:171: func2()
-+pkg/sql/conn_executor_exec.go:4460: execWithProfiling()
-+pkg/sql/conn_executor_exec.go:170: execStmt()
-+pkg/sql/conn_executor.go:2342: func1()
-+pkg/sql/conn_executor.go:2347: execCmd()
-+pkg/sql/conn_executor.go:2264: run()
-+pkg/sql/conn_executor.go:1048: ServeConn()
-+pkg/sql/pgwire/conn.go:252: processCommands()
-+pkg/sql/pgwire/server.go:1197: func4()
-+src/runtime/asm_amd64.s:1700: goexit()
-+
-+HINT:  You have encountered an unexpected error.
-+
-+Please check the public issue tracker to check whether this problem is
-+already tracked. If you cannot find it there, please report the error
-+with details by creating a new issue.
-+
-+If you would rather not post publicly, please contact us directly
-+using the support form.
-+
-+We appreciate your feedback.
-+
  prepare transaction 'twophase_view';
 -ERROR:  cannot PREPARE a transaction that has operated on temporary objects
 +WARNING:  there is no transaction in progress
  begin;
  create sequence pg_temp.twophase_seq;
 +NOTICE:  auto-committing transaction before processing DDL due to autocommit_before_ddl setting
-+ERROR:  unimplemented: cannot create UDFs under a temporary schema
-+HINT:  You have attempted to use a feature that is not yet implemented.
-+See: https://go.crdb.dev/issue-v/104687/_version_
  prepare transaction 'twophase_sequence';
 -ERROR:  cannot PREPARE a transaction that has operated on temporary objects
 +WARNING:  there is no transaction in progress
  -- Temporary tables cannot be used with two-phase commit.
  create temp table twophase_tab (a int);
  begin;
-@@ -363,19 +524,22 @@
+@@ -363,19 +476,22 @@
  (0 rows)
  
  prepare transaction 'twophase_tab';
@@ -555,7 +507,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/temp.out --label=
  -- Corner case: current_schema may create a temporary schema if namespace
  -- creation is pending, so check after that.  First reset the connection
  -- to remove the temporary namespace.
-@@ -385,8 +549,7 @@
+@@ -385,8 +501,7 @@
  SELECT current_schema() ~ 'pg_temp' AS is_temp_schema;
   is_temp_schema 
  ----------------

--- a/pkg/cmd/roachtest/testdata/pg_regress/tuplesort.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/tuplesort.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --label=/mnt/data1/postgres/src/test/regress/results/tuplesort.out /mnt/data1/postgres/src/test/regress/expected/tuplesort.out /mnt/data1/postgres/src/test/regress/results/tuplesort.out
 --- /mnt/data1/postgres/src/test/regress/expected/tuplesort.out
 +++ /mnt/data1/postgres/src/test/regress/results/tuplesort.out
-@@ -1,12 +1,27 @@
+@@ -1,12 +1,26 @@
  -- only use parallelism when explicitly intending to do so
  SET max_parallel_maintenance_workers = 0;
 +ERROR:  unrecognized configuration parameter "max_parallel_maintenance_workers"
@@ -23,14 +23,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  -- have the same prefix, as abbreviated keys for uuids just use the
  -- first sizeof(Datum) bytes.
 +CREATE TEMP SEQUENCE id_seq;
-+ERROR:  relation "root.public.id_seq" already exists
  CREATE TEMP TABLE abbrev_abort_uuids (
 -    id serial not null,
 +    id int not null default nextval('id_seq'),
      abort_increasing uuid,
      abort_decreasing uuid,
      noabort_increasing uuid,
-@@ -18,6 +33,8 @@
+@@ -18,6 +32,8 @@
          (to_char(g.i % 10009, '00000000FM')||'-0000-0000-0000-'||to_char(g.i, '000000000000FM'))::uuid noabort_increasing,
          (to_char(((20000 - g.i) % 10009), '00000000FM')||'-0000-0000-0000-'||to_char(20000 - g.i, '000000000000FM'))::uuid noabort_decreasing
      FROM generate_series(0, 20000, 1) g(i);
@@ -39,7 +38,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  -- and a few NULLs
  INSERT INTO abbrev_abort_uuids(id) VALUES(0);
  INSERT INTO abbrev_abort_uuids DEFAULT VALUES;
-@@ -32,106 +49,42 @@
+@@ -32,106 +48,42 @@
  ----
  -- plain sort triggering abbreviated abort
  SELECT abort_increasing, abort_decreasing FROM abbrev_abort_uuids ORDER BY abort_increasing OFFSET 20000 - 4;
@@ -170,7 +169,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  
  ----
  -- Check index creation uses of tuplesort wrt. abbreviated keys
-@@ -142,39 +95,33 @@
+@@ -142,39 +94,33 @@
  -- verify
  EXPLAIN (COSTS OFF)
  SELECT id, noabort_increasing, noabort_decreasing FROM abbrev_abort_uuids ORDER BY noabort_increasing LIMIT 5;
@@ -197,8 +196,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
 + id | noabort_increasing | noabort_decreasing 
 +----+--------------------+--------------------
 +  0 |                    | 
-+ 22 |                    | 
-+ 23 |                    | 
++  1 |                    | 
++  2 |                    | 
 +(3 rows)
  
  EXPLAIN (COSTS OFF)
@@ -226,13 +225,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
 + id | noabort_increasing | noabort_decreasing 
 +----+--------------------+--------------------
 +  0 |                    | 
-+ 22 |                    | 
-+ 23 |                    | 
++  1 |                    | 
++  2 |                    | 
 +(3 rows)
  
  -- index creation using abbreviated keys, hitting abort
  CREATE INDEX abbrev_abort_uuids__abort_increasing_idx ON abbrev_abort_uuids (abort_increasing);
-@@ -182,39 +129,33 @@
+@@ -182,39 +128,33 @@
  -- verify
  EXPLAIN (COSTS OFF)
  SELECT id, abort_increasing, abort_decreasing FROM abbrev_abort_uuids ORDER BY abort_increasing LIMIT 5;
@@ -259,8 +258,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
 + id | abort_increasing | abort_decreasing 
 +----+------------------+------------------
 +  0 |                  | 
-+ 22 |                  | 
-+ 23 |                  | 
++  1 |                  | 
++  2 |                  | 
 +(3 rows)
  
  EXPLAIN (COSTS OFF)
@@ -288,13 +287,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
 + id | abort_increasing | abort_decreasing 
 +----+------------------+------------------
 +  0 |                  | 
-+ 22 |                  | 
-+ 23 |                  | 
++  1 |                  | 
++  2 |                  | 
 +(3 rows)
  
  ----
  -- Check CLUSTER uses of tuplesort wrt. abbreviated keys
-@@ -222,126 +163,126 @@
+@@ -222,126 +162,126 @@
  -- when aborting, increasing order
  BEGIN;
  SET LOCAL enable_indexscan = false;
@@ -493,7 +492,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  ROLLBACK;
  ----
  -- test forward and backward scans for in-memory and disk based tuplesort
-@@ -349,195 +290,118 @@
+@@ -349,195 +289,118 @@
  -- in-memory
  BEGIN;
  SET LOCAL enable_indexscan = false;
@@ -754,7 +753,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  COMMIT;
  ----
  -- test tuplesort using both in-memory and disk sort
-@@ -564,14 +428,41 @@
+@@ -564,14 +427,41 @@
      SELECT * FROM abbrev_abort_uuids
      UNION ALL
      SELECT NULL, NULL, NULL, NULL, NULL) s;
@@ -801,7 +800,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  SELECT
      (array_agg(id ORDER BY id DESC NULLS FIRST))[0:5],
      (array_agg(abort_increasing ORDER BY abort_increasing DESC NULLS LAST))[0:5],
-@@ -585,11 +476,18 @@
+@@ -585,11 +475,18 @@
      SELECT * FROM abbrev_abort_uuids
      UNION ALL
      SELECT NULL, NULL, NULL, NULL, NULL) s;
@@ -825,7 +824,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  ROLLBACK;
  ----
  -- test tuplesort mark/restore
-@@ -600,8 +498,22 @@
+@@ -600,8 +497,22 @@
     SELECT a.i, b.i, a.i * b.i FROM generate_series(1, 500) a(i), generate_series(1, 5) b(i);
  BEGIN;
  SET LOCAL enable_nestloop = off;
@@ -848,7 +847,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/tuplesort.out --l
  -- set query into variable once, to avoid repetition of the fairly long query
  SELECT $$
      SELECT col12, count(distinct a.col1), count(distinct a.col2), count(distinct b.col1), count(distinct b.col2), count(*)
-@@ -612,81 +524,31 @@
+@@ -612,81 +523,31 @@
      ORDER BY 2 DESC, 1 DESC, 3 DESC, 4 DESC, 5 DESC, 6 DESC
      LIMIT 10
  $$ AS qry \gset

--- a/pkg/cmd/roachtest/testdata/pg_regress/window.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/window.diffs
@@ -3985,11 +3985,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/window.out --labe
  SELECT i, b, bool_and(b) OVER w, bool_or(b) OVER w
    FROM (VALUES (1,true), (2,true), (3,false), (4,false), (5,true)) v(i,b)
    WINDOW w AS (ORDER BY i ROWS BETWEEN CURRENT ROW AND 1 FOLLOWING);
-@@ -4830,23 +4413,12 @@
+@@ -4830,23 +4413,14 @@
        FROM generate_series(1,5) s
      WINDOW w AS (ORDER BY s ROWS BETWEEN CURRENT ROW AND GROUP_SIZE FOLLOWING)
  $$ LANGUAGE SQL STABLE;
-+ERROR:  argument of ROWS must not contain variables
++ERROR:  unimplemented: cannot create user-defined functions under a temporary schema
++HINT:  You have attempted to use a feature that is not yet implemented.
++See: https://go.crdb.dev/issue-v/104687/_version_
  EXPLAIN (costs off) SELECT * FROM pg_temp.f(2);
 -                      QUERY PLAN                      
 -------------------------------------------------------

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -1151,9 +1151,7 @@ index a460f82fb7..a9f7b99b84 100644
    VALUES ('"'"'test'"'"', DEFAULT), ('"'"'More'"'"', 11), (upper('"'"'more'"'"'), 7+9)
 `},
 	// Serial is non-deterministic.
-	// TODO(#114846): Enable array_to_set function calls when internal
-	// error is fixed.
-	// TODO(#118702): Remove the patch around getrngfunc9 when
+	// TODO(#114676): Remove the patch around getrngfunc9 when
 	// the internal error is fixed.
 	{"rangefuncs.sql", `diff --git a/src/test/regress/sql/rangefuncs.sql b/src/test/regress/sql/rangefuncs.sql
 index 63351e1412..07d3216a9d 100644
@@ -1178,24 +1176,6 @@ index 63351e1412..07d3216a9d 100644
  
  create function insert_tt(text) returns int as
  $$ insert into tt(data) values($1) returning f1 $$
-@@ -537,7 +538,7 @@ select array_to_set(array['"'"'one'"'"', '"'"'two'"'"']);
- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 int,f2 text);
- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']); -- fail
- -- after-the-fact coercion of the columns is now possible, too
--select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 numeric(4,2),f2 text);
-+-- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 numeric(4,2),f2 text);
- -- and if it doesn'"'"'t work, you get a compile-time not run-time error
- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 point,f2 text);
- 
-@@ -553,7 +554,7 @@ $$ language sql immutable;
- 
- select array_to_set(array['"'"'one'"'"', '"'"'two'"'"']);
- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 int,f2 text);
--select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 numeric(4,2),f2 text);
-+-- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 numeric(4,2),f2 text);
- select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 point,f2 text);
- explain (verbose, costs off)
-   select * from array_to_set(array['"'"'one'"'"', '"'"'two'"'"']) as t(f1 numeric(4,2),f2 text);
 `},
 	// Serial is non-deterministic and non-monotonic in CRDB, so we modify the tests for serial slightly
 	// to only print non-serial columns.
@@ -1448,26 +1428,7 @@ index 2c0f87a651..26bd75bbf0 100644
  
  -- **************** pg_class ****************
 `},
-	// TODO(#114858): Remove this patch when the internal error is fixed.
-	{"stats.sql", `diff --git a/src/test/regress/sql/stats.sql b/src/test/regress/sql/stats.sql
-index 1e21e55c6d..a2b6cce79e 100644
---- a/src/test/regress/sql/stats.sql
-+++ b/src/test/regress/sql/stats.sql
-@@ -131,8 +131,8 @@ COMMIT;
- ---
- CREATE FUNCTION stats_test_func1() RETURNS VOID LANGUAGE plpgsql AS $$BEGIN END;$$;
- SELECT '"'"'stats_test_func1()'"'"'::regprocedure::oid AS stats_test_func1_oid \gset
--CREATE FUNCTION stats_test_func2() RETURNS VOID LANGUAGE plpgsql AS $$BEGIN END;$$;
--SELECT '"'"'stats_test_func2()'"'"'::regprocedure::oid AS stats_test_func2_oid \gset
-+-- CREATE FUNCTION stats_test_func2() RETURNS VOID LANGUAGE plpgsql AS $$BEGIN END;$$;
-+-- SELECT '"'"'stats_test_func2()'"'"'::regprocedure::oid AS stats_test_func2_oid \gset
- 
- -- test that stats are accumulated
- BEGIN;
-`},
-	// TODO(#114849): Remove the patch around void_return_expr when the
-	// internal error is fixed.
-	// TODO(#118702): Remove the patch around wslot_slotlink_view when
+	// TODO(#114676): Remove the patch around wslot_slotlink_view when
 	// the internal error is fixed.
 	{"plpgsql.sql", `diff --git a/src/test/regress/sql/plpgsql.sql b/src/test/regress/sql/plpgsql.sql
 index 924d524094..eb7bc0cf87 100644
@@ -1570,15 +1531,6 @@ index 924d524094..eb7bc0cf87 100644
  
  
  
-@@ -2171,7 +2171,7 @@ begin
-     perform 2+2;
- end;$$ language plpgsql;
- 
--select void_return_expr();
-+-- select void_return_expr();
- 
- -- but ordinary functions are not
- create function missing_return_expr() returns int as $$
 @@ -2191,25 +2191,25 @@ drop function missing_return_expr();
  create table eifoo (i integer, y integer);
  create type eitype as (i integer, y integer);


### PR DESCRIPTION
This commit audits all the TODOs that we have in the pg_regress runner by removing those that we have fixed and updating issue numbers when originally referenced issues were closed as duplicates.

Fixes: #146498.

Release note: None