### PR TITLE
microbench-ci: better mutex profiles

### DIFF
--- a/pkg/cmd/microbench-ci/run.go
+++ b/pkg/cmd/microbench-ci/run.go
@@ -32,7 +32,17 @@ func (b *Benchmark) command(revision Revision, profileSuffix string) *exec.Cmd {
 		path.Join(suite.binDir(revision), b.binaryName()),
 		b.args(suite.artifactsDir(revision), profileSuffix)...,
 	)
-	cmd.Env = append(os.Environ(), "COCKROACH_RANDOM_SEED=1")
+	env := os.Environ()
+	envGodebug := os.Getenv("GODEBUG")
+	if envGodebug != "" {
+		envGodebug += ","
+	}
+	// Ensure that GODEBUG=[...,]runtimecontentionstacks=1 is set to improve
+	// mutex profiles.
+	envGodebug += "runtimecontentionstacks=1"
+	env = append(env, "GODEBUG="+envGodebug)
+	env = append(env, "COCKROACH_RANDOM_SEED=1")
+	cmd.Env = env
 	return cmd
 }
 


### PR DESCRIPTION
By adding the `runtimecontentionstacks=1` to the GODEBUG env var, we can get better mutex profiles.

Epic: None
Release note: None