### PR TITLE
kvserver,kvclient: add ExpectExclusionSince write option

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -2442,6 +2442,20 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: distsender.rpc.err.exclusionviolationerrtype
+      exported_name: distsender_rpc_err_exclusionviolationerrtype
+      description: |
+        Number of ExclusionViolationErrType errors received replica-bound RPCs
+
+        This counts how often error of the specified type was received back from replicas
+        as part of executing possibly range-spanning requests. Failures to reach the target
+        replica will be accounted for as 'roachpb.CommunicationErrType' and unclassified
+        errors as 'roachpb.InternalErrType'.
+      y_axis_label: Errors
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: distsender.rpc.err.indeterminatecommiterrtype
       exported_name: distsender_rpc_err_indeterminatecommiterrtype
       description: |
@@ -9610,6 +9624,14 @@ layers:
     - name: txn.restarts.commitdeadlineexceeded
       exported_name: txn_restarts_commitdeadlineexceeded
       description: Number of restarts due to a transaction exceeding its deadline
+      y_axis_label: Restarted Transactions
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: txn.restarts.exclusionviolation
+      exported_name: txn_restarts_exclusionviolation
+      description: Number of restarts due to an exclusion violation
       y_axis_label: Restarted Transactions
       type: COUNTER
       unit: COUNT

--- a/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
+++ b/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
@@ -1,0 +1,106 @@
+# LogicTest: !3node-tenant
+# cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
+
+statement ok
+SET CLUSTER SETTING sql.txn.write_buffering_for_weak_isolation.enabled=true
+
+statement ok
+SET CLUSTER SETTING kv.lock_table.unreplicated_lock_reliability.split.enabled=false
+
+statement ok
+CREATE TABLE t (pk INT PRIMARY KEY)
+
+statement ok
+GRANT ALL ON t TO testuser
+
+subtest read_committed_discovers_lost_lock_at_commit
+user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled=true
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+INSERT INTO t VALUES (1)
+
+user root
+
+# This split clears the lock table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (10)
+
+# This write should block but doesn't because of the lost lock.
+statement ok
+INSERT INTO t VALUES (1)
+
+user testuser
+
+# Add another write to t to ensure we are propagating the ts correctly.
+# Note that currently we don't detect the failure here. If we add the lock loss
+# detection to locking gets we could.
+statement ok
+UPSERT INTO t VALUES (1)
+
+# Lock loss detection should detect the lost lock on commit when we go to
+# write the value.
+statement error write exclusion on key
+COMMIT
+
+subtest read_committed_discovers_lost_lock_at_mid_txn_flush
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+INSERT INTO t VALUES (2)
+
+user root
+
+# This split clears the lock table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (8)
+
+# This write should block but doesn't because of the lost lock.
+statement ok
+INSERT INTO t VALUES (2)
+
+user testuser
+
+# Lock loss detection should detect the lost lock when we
+# flush the buffer because of a DeleteRangeRequest
+statement error write exclusion on key
+DELETE FROM t WHERE pk > 10
+
+statement ok
+ROLLBACK
+
+subtest serializable_observes_write_too_old
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+statement ok
+INSERT INTO t VALUES (3)
+
+user root
+
+# This split clears the lock table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (7)
+
+# This write should block but doesn't because of the lost lock.
+statement ok
+INSERT INTO t VALUES (3)
+
+user testuser
+
+# A serializable transaction should see a WriteTooOld error here since the read timestamp doesn't move.
+statement error WriteTooOld
+DELETE FROM t WHERE pk > 10
+
+statement ok
+ROLLBACK

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 35,
+    shard_count = 36,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2715,6 +2715,13 @@ func TestReadCommittedLogic_zone_config_system_tenant(
 	runLogicTest(t, "zone_config_system_tenant")
 }
 
+func TestReadCommittedLogicCCL_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestReadCommittedLogicCCL_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2701,6 +2701,13 @@ func TestRepeatableReadLogic_zone_config_system_tenant(
 	runLogicTest(t, "zone_config_system_tenant")
 }
 
+func TestRepeatableReadLogicCCL_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestRepeatableReadLogicCCL_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -89,6 +89,13 @@ func TestCCLLogic_auto_rehoming(
 	runCCLLogicTest(t, "auto_rehoming")
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_builtins(
 	t *testing.T,
 ) {

--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -99,6 +99,7 @@ go_library(
         "@com_github_cockroachdb_errors//errorspb",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
         "@com_github_gogo_protobuf//proto",
         "@com_github_google_btree//:btree",
         "@io_opentelemetry_go_otel//attribute",

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -887,6 +887,9 @@ func (tc *TxnCoordSender) handleRetryableErrLocked(ctx context.Context, pErr *kv
 	case *kvpb.ReadWithinUncertaintyIntervalError:
 		tc.metrics.RestartsReadWithinUncertainty.Inc()
 
+	case *kvpb.ExclusionViolationError:
+		tc.metrics.RestartsExclusionViolation.Inc()
+
 	case *kvpb.TransactionAbortedError:
 		tc.metrics.RestartsTxnAborted.Inc()
 

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -48,6 +48,7 @@ type TxnMetrics struct {
 	RestartsAsyncWriteFailure      telemetry.CounterWithMetric
 	RestartsCommitDeadlineExceeded telemetry.CounterWithMetric
 	RestartsReadWithinUncertainty  telemetry.CounterWithMetric
+	RestartsExclusionViolation     telemetry.CounterWithMetric
 	RestartsTxnAborted             telemetry.CounterWithMetric
 	RestartsTxnPush                telemetry.CounterWithMetric
 	RestartsUnknown                telemetry.CounterWithMetric
@@ -258,6 +259,12 @@ var (
 		Measurement: "Restarted Transactions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRestartsExclusionViolation = metric.Metadata{
+		Name:        "txn.restarts.exclusionviolation",
+		Help:        "Number of restarts due to an exclusion violation",
+		Measurement: "Restarted Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRestartsTxnAborted = metric.Metadata{
 		Name:        "txn.restarts.txnaborted",
 		Help:        "Number of restarts due to an abort by a concurrent transaction (usually due to deadlock)",
@@ -371,6 +378,7 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		RestartsAsyncWriteFailure:            telemetry.NewCounterWithMetric(metaRestartsAsyncWriteFailure),
 		RestartsCommitDeadlineExceeded:       telemetry.NewCounterWithMetric(metaRestartsCommitDeadlineExceeded),
 		RestartsReadWithinUncertainty:        telemetry.NewCounterWithMetric(metaRestartsReadWithinUncertainty),
+		RestartsExclusionViolation:           telemetry.NewCounterWithMetric(metaRestartsExclusionViolation),
 		RestartsTxnAborted:                   telemetry.NewCounterWithMetric(metaRestartsTxnAborted),
 		RestartsTxnPush:                      telemetry.NewCounterWithMetric(metaRestartsTxnPush),
 		RestartsUnknown:                      telemetry.NewCounterWithMetric(metaRestartsUnknown),

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2521,11 +2521,45 @@ func (writeOptions *WriteOptions) GetOriginTimestamp() hlc.Timestamp {
 	return writeOptions.OriginTimestamp
 }
 
-func (r *ConditionalPutRequest) Validate() error {
+func (r *ConditionalPutRequest) Validate(_ Header) error {
 	if !r.OriginTimestamp.IsEmpty() {
 		if r.AllowIfDoesNotExist {
 			return errors.AssertionFailedf("invalid ConditionalPutRequest: AllowIfDoesNotExist and non-empty OriginTimestamp are incompatible")
 		}
+	}
+	return nil
+}
+
+func (r *PutRequest) Validate(bh Header) error {
+	if err := validateExclusionTimestampForBatch(r.ExpectExclusionSince, bh); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid PutRequest")
+	}
+	return nil
+}
+
+func (r *DeleteRequest) Validate(bh Header) error {
+	if err := validateExclusionTimestampForBatch(r.ExpectExclusionSince, bh); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid DeleteRequest")
+	}
+	return nil
+}
+
+func validateExclusionTimestampForBatch(ts hlc.Timestamp, h Header) error {
+	if ts.IsEmpty() {
+		return nil
+	}
+
+	// TODO(ssd): It would be nice to put this first, but then we fail the
+	// gcassert linter, I assume because the code gets optimized away.
+	if !buildutil.CrdbTestBuild {
+		return nil
+	}
+
+	// CanForwardReadTimestamp implies we haven't served a read, so it makes no
+	// sense that ExpectExclusionSince would be set since it is the result of a
+	// locking read.
+	if h.CanForwardReadTimestamp {
+		return errors.New("unexpected ExpectExclusionSince in batch with CanForwardReadTimestamp set")
 	}
 	return nil
 }

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -292,6 +292,13 @@ message PutRequest {
   // no lower than "exclusive" needs to be acquired on the key, even if it
   // doesn't exist.
   bool must_acquire_exclusive_lock = 5;
+
+  // ExpectExclusionSince, if set, indicates that the request should return an
+  // error if this key has been written to at a timestamp at or after the given
+  // timestamp. This is different from the ReadTimestamp of the transaction in
+  // that it allows a writer to verify an unreplicated lock acquired at an
+  // earlier timestamp has provided the required protection.
+  util.hlc.Timestamp expect_exclusion_since = 6 [(gogoproto.nullable) = false];
 }
 
 // A PutResponse is the return value from the Put() method.
@@ -411,6 +418,13 @@ message DeleteRequest {
   //
   // TODO(ssd): Separate the behaviour of FoundKey to not depend on this flag.
   bool must_acquire_exclusive_lock = 2;
+
+  // ExpectExclusionSince, if set, indicates that the request should return an
+  // error if this key has been written to at a timestamp at or after the given
+  // timestamp. This is different from the ReadTimestamp of the transaction in
+  // that it allows a writer to verify an unreplicated lock acquired at an
+  // earlier timestamp has provided the require protection.
+  util.hlc.Timestamp expect_exclusion_since = 3 [(gogoproto.nullable) = false];
 }
 
 // A DeleteResponse is the return value from the Delete() method.

--- a/pkg/kv/kvpb/errordetailtype_string.go
+++ b/pkg/kv/kvpb/errordetailtype_string.go
@@ -49,6 +49,7 @@ func _() {
 	_ = x[LockConflictErrType-45]
 	_ = x[ReplicaUnavailableErrType-46]
 	_ = x[ProxyFailedErrType-47]
+	_ = x[ExclusionViolationErrType-48]
 	_ = x[CommunicationErrType-22]
 	_ = x[InternalErrType-25]
 }
@@ -127,6 +128,8 @@ func (i ErrorDetailType) String() string {
 		return "ReplicaUnavailableErrType"
 	case ProxyFailedErrType:
 		return "ProxyFailedErrType"
+	case ExclusionViolationErrType:
+		return "ExclusionViolationErrType"
 	case CommunicationErrType:
 		return "CommunicationErrType"
 	case InternalErrType:

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -297,6 +297,8 @@ const (
 	LockConflictErrType                     ErrorDetailType = 45
 	ReplicaUnavailableErrType               ErrorDetailType = 46
 	ProxyFailedErrType                      ErrorDetailType = 47
+	ExclusionViolationErrType               ErrorDetailType = 48
+
 	// When adding new error types, don't forget to update NumErrors below.
 
 	// CommunicationErrType indicates a gRPC error; this is not an ErrorDetail.
@@ -306,7 +308,7 @@ const (
 	// detail. The value 25 is chosen because it's reserved in the errors proto.
 	InternalErrType ErrorDetailType = 25
 
-	NumErrors int = 48
+	NumErrors int = 49
 )
 
 // Register the migration of all errors that used to be in the roachpb package
@@ -1854,6 +1856,51 @@ func NewSnapshotReservationTimeoutError(
 	}
 }
 
+// NewExclusionViolationError creates a new ExclusionViolationError. This error
+// is returned by requests that encounter an existing value written at a
+// timestamp at which they expected to have an exclusive lock on the key. This
+// error implies that the lock was lost, which is possible for unreplicated locks.
+func NewExclusionViolationError(
+	exclusionTS, actualTS hlc.Timestamp, key roachpb.Key,
+) *ExclusionViolationError {
+	return &ExclusionViolationError{
+		ExpectedExclusionSinceTimestamp: exclusionTS,
+		ViolationTimestamp:              actualTS,
+		Key:                             key.Clone(),
+	}
+}
+
+func (e *ExclusionViolationError) SafeFormatError(p errors.Printer) (next error) {
+	p.Printf("write exclusion on key %s expected since %s but found write at %s",
+		e.Key,
+		e.ExpectedExclusionSinceTimestamp,
+		e.ViolationTimestamp,
+	)
+	return nil
+}
+
+func (e *ExclusionViolationError) Error() string {
+	return redact.Sprint(e).StripMarkers()
+}
+
+func (*ExclusionViolationError) canRestartTransaction() TransactionRestart {
+	return TransactionRestart_IMMEDIATE
+}
+
+// Type is part of the ErrorDetailInterface.
+func (e *ExclusionViolationError) Type() ErrorDetailType {
+	return ExclusionViolationErrType
+}
+
+// RetryTimestamp returns the timestamp that should be used to retry an
+// operation after encountering a ExclusionViolationError.
+func (e *ExclusionViolationError) RetryTimestamp() hlc.Timestamp {
+	return e.ViolationTimestamp.Next()
+}
+
+var _ ErrorDetailInterface = &ExclusionViolationError{}
+var _ transactionRestartError = &ExclusionViolationError{}
+
 func init() {
 	encode := func(ctx context.Context, err error) (msgPrefix string, safeDetails []string, payload proto.Message) {
 		errors.As(err, &payload) // payload = err.(proto.Message)
@@ -1914,3 +1961,4 @@ var _ errors.SafeFormatter = &ReplicaUnavailableError{}
 var _ errors.SafeFormatter = &ProxyFailedError{}
 var _ errors.SafeFormatter = &KeyCollisionError{}
 var _ errors.SafeFormatter = &SnapshotReservationTimeoutError{}
+var _ errors.SafeFormatter = &ExclusionViolationError{}

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -793,8 +793,8 @@ message InsufficientSpaceError {
 }
 
 
-// PebbleCorruptionError indicates that pebble thinks that there is a data                                                                                                                                                                                  
-// corruption.                                                                                                                                                                                                                                                
+// PebbleCorruptionError indicates that pebble thinks that there is a data
+// corruption.
 message PebbleCorruptionError {
   optional int64 store_id = 1 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "StoreID",
@@ -803,4 +803,16 @@ message PebbleCorruptionError {
   optional bool is_remote = 3 [(gogoproto.nullable) = false];
   optional string extra_msg = 4 [(gogoproto.nullable) = false];
 }
-   
+
+// ExclusionViolationError indicates that a key was written to at a timestamp at
+// which a caller assumed it had an exclusive lock on the key.
+message ExclusionViolationError {
+  // ExclusionTimestamp is the timestamp at which the request expected its
+  // exclusive access started.
+  optional util.hlc.Timestamp expected_exclusion_since_timestamp = 1 [(gogoproto.nullable) = false];
+  // ViolationTimestamp is the timestamp at which the request found a write that
+  // violated its exclusive access.
+  optional util.hlc.Timestamp violation_timestamp = 2 [(gogoproto.nullable) = false];
+  // Key is the key on which exclusion was violated.
+  optional bytes key = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+}

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -54,7 +54,7 @@ func ConditionalPut(
 		ts = h.Timestamp
 	}
 
-	if err := args.Validate(); err != nil {
+	if err := args.Validate(h); err != nil {
 		return result.Result{}, err
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -28,11 +28,16 @@ func Delete(
 	h := cArgs.Header
 	reply := resp.(*kvpb.DeleteResponse)
 
+	if err := args.Validate(h); err != nil {
+		return result.Result{}, err
+	}
+
 	opts := storage.MVCCWriteOptions{
 		Txn:                            h.Txn,
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		ExclusionTimestamp:             args.ExpectExclusionSince,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		OriginID:                       h.WriteOptions.GetOriginID(),
 		OriginTimestamp:                h.WriteOptions.GetOriginTimestamp(),

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -51,11 +51,16 @@ func Put(
 		ts = h.Timestamp
 	}
 
+	if err := args.Validate(h); err != nil {
+		return result.Result{}, err
+	}
+
 	opts := storage.MVCCWriteOptions{
 		Txn:                            h.Txn,
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		ExclusionTimestamp:             args.ExpectExclusionSince,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		OriginID:                       h.WriteOptions.GetOriginID(),
 		OriginTimestamp:                h.WriteOptions.GetOriginTimestamp(),

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3543,7 +3543,7 @@ func (ex *connExecutor) setTransactionModes(
 		if err := ex.state.setIsolationLevel(level); err != nil {
 			return pgerror.WithCandidateCode(err, pgcode.ActiveSQLTransaction)
 		}
-		if level != isolation.Serializable {
+		if (level != isolation.Serializable) && !allowBufferedWritesForWeakIsolation.Get(&ex.server.cfg.Settings.SV) {
 			// TODO(#143497): we currently only support buffered writes under
 			// serializable isolation.
 			ex.state.mu.txn.SetBufferedWritesEnabled(false)
@@ -3584,6 +3584,13 @@ var allowRepeatableReadIsolation = settings.RegisterBoolSetting(
 	false,
 	settings.WithName("sql.txn.repeatable_read_isolation.enabled"),
 	settings.WithPublic,
+)
+
+var allowBufferedWritesForWeakIsolation = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	"sql.txn.write_buffering_for_weak_isolation.enabled",
+	"set to true to allow write buffering for transactions at weak isolation levels",
+	false,
 )
 
 var logIsolationLevelLimiter = log.Every(10 * time.Second)

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -241,7 +241,7 @@ func (ts *txnState) resetForNewSQLTxn(
 			if err := ts.setIsolationLevelLocked(isoLevel); err != nil {
 				panic(err)
 			}
-			if isoLevel != isolation.Serializable {
+			if isoLevel != isolation.Serializable && !allowBufferedWritesForWeakIsolation.Get(&tranCtx.settings.SV) {
 				// TODO(#143497): we currently only support buffered writes
 				// under serializable isolation.
 				bufferedWritesEnabled = false

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1244,6 +1244,7 @@ func cmdDelete(e *evalCtx) error {
 			Stats:                          e.ms,
 			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 			MaxLockConflicts:               e.getMaxLockConflicts(),
+			ExclusionTimestamp:             e.getTsWithName("expect-exclusion-since"),
 		}
 		foundKey, acq, err := storage.MVCCDelete(e.ctx, rw, key, ts, opts)
 		if err == nil || errors.HasType(err, &kvpb.WriteTooOldError{}) {
@@ -1508,6 +1509,7 @@ func cmdPut(e *evalCtx) error {
 			Stats:                          e.ms,
 			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 			MaxLockConflicts:               e.getMaxLockConflicts(),
+			ExclusionTimestamp:             e.getTsWithName("expect-exclusion-since"),
 		}
 		acq, err := storage.MVCCPut(e.ctx, rw, key, ts, val, opts)
 		if err != nil {

--- a/pkg/storage/testdata/mvcc_histories/del_with_exclusion_ts
+++ b/pkg/storage/testdata/mvcc_histories/del_with_exclusion_ts
@@ -1,0 +1,86 @@
+# Write at a timestamp above the exclusion timestamp results in a write exclusion error.
+run ok
+put k=a v=v1 ts=2
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+del k=a ts=3 expect-exclusion-since=1
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "a" expected since 1.000000000,0 but found write at 2.000000000,0
+
+# Exclusion timestamp are inclusive
+run error
+del k=a ts=3 expect-exclusion-since=2
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "a" expected since 2.000000000,0 but found write at 2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from a different transaction still results in a LockConflictError.
+run ok
+with t=A k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+del k=a ts=3 expect-exclusion-since=1
+----
+>> at end:
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from the same transaction is allowed.
+run ok
+with t=B k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {span=a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run ok
+txn_advance t=B ts=3
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+txn_step t=B
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+del t=B k=a ts=2 expect-exclusion-since=1
+----
+del: "a": found key true
+del: lock acquisition = {span=a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/3.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/put_with_exclusion_ts
+++ b/pkg/storage/testdata/mvcc_histories/put_with_exclusion_ts
@@ -1,0 +1,85 @@
+# Write at a timestamp above the exclusion timestamp results in a write exclusion error.
+run ok
+put k=a v=v1 ts=2
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+put k=a v=v2 ts=3 expect-exclusion-since=1
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "a" expected since 1.000000000,0 but found write at 2.000000000,0
+
+# Exclusion timestamp are inclusive
+run error
+put k=a v=v2 ts=3 expect-exclusion-since=2
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "a" expected since 2.000000000,0 but found write at 2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from a different transaction still results in a LockConflictError.
+run ok
+with t=A k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+put k=a v=v2 ts=3 expect-exclusion-since=1
+----
+>> at end:
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from the same transaction is allowed.
+run ok
+with t=B k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {span=a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run ok
+txn_advance t=B ts=3
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+txn_step t=B
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+put t=B k=a v=v2 ts=2 expect-exclusion-since=1
+----
+put: lock acquisition = {span=a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
+>> at end:
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/3.000000000,0 -> /BYTES/v2


### PR DESCRIPTION
The new ExpectExclusionSince write option can use by callers of the KV API to verify that a key has not seen a write since the given timestamp. This is separate from the ReadTimestamp of the transaction because the caller may want to verify that an unreplicated exclusive lock taken at an earlier timestamp hasn't been lost.

Informs #142977

Release note: None