### PR TITLE
cli: introduce store-to-node-map-file flag in tsdump upload

### DIFF
--- a/pkg/cli/BUILD.bazel
+++ b/pkg/cli/BUILD.bazel
@@ -272,6 +272,7 @@ go_library(
         "@com_github_spf13_pflag//:pflag",
         "@com_google_cloud_go_storage//:storage",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_golang_google_api//option",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1604,6 +1604,7 @@ func init() {
 	f.StringVar(&debugTimeSeriesDumpOpts.zendeskTicket, "zendesk-ticket", "", "zendesk ticket to use in datadog upload")
 	f.StringVar(&debugTimeSeriesDumpOpts.organizationName, "org-name", "", "organization name to use in datadog upload")
 	f.StringVar(&debugTimeSeriesDumpOpts.userName, "user-name", "", "name of the user to perform datadog upload")
+	f.StringVar(&debugTimeSeriesDumpOpts.storeToNodeMapYAMLFile, "store-to-node-map-file", "", "yaml file path which contains the mapping of store ID to node ID for datadog upload.")
 
 	f = debugSendKVBatchCmd.Flags()
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,

--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -37,18 +37,19 @@ import (
 // TODO(knz): this struct belongs elsewhere.
 // See: https://github.com/cockroachdb/cockroach/issues/49509
 var debugTimeSeriesDumpOpts = struct {
-	format           tsDumpFormat
-	from, to         timestampValue
-	clusterLabel     string
-	yaml             string
-	targetURL        string
-	ddApiKey         string
-	ddSite           string
-	httpToken        string
-	clusterID        string
-	zendeskTicket    string
-	organizationName string
-	userName         string
+	format                 tsDumpFormat
+	from, to               timestampValue
+	clusterLabel           string
+	yaml                   string
+	targetURL              string
+	ddApiKey               string
+	ddSite                 string
+	httpToken              string
+	clusterID              string
+	zendeskTicket          string
+	organizationName       string
+	userName               string
+	storeToNodeMapYAMLFile string
 }{
 	format:       tsDumpText,
 	from:         timestampValue{},


### PR DESCRIPTION
Previously, tsdump datadog upload was not uploading `node_id` as label for store related metrics. This was due to absense of mapping for store with node. The corresponding information is present in crdb_internal.kv_store_status table.  This patch introduces additional flag as `store-to-node-map-file` which accepts the yaml file path which holds the information of store to node mapping. We utilise this information in datadog upload so that we can emit `node_id` as a label for store related metrics.

Fixes: CRDB-49422
Epic: None
Release note: None

---
command : `./cockroach debug tsdump --format datadog --dd-api-key $KEY --cluster-label="crl-test" --dd-site=us5 --store-to-node-map-file={YAML_FILE_PATH} tsdump.raw`

screenshots:
images which represents widgets which depicts `store_id: 1` to `node_id: 15`
<img width="543" alt="Screenshot 2025-05-14 at 11 42 13 AM" src="https://github.com/user-attachments/assets/20f337a5-0e2c-4e60-91ce-eedb71425f33" />

<img width="1097" alt="Screenshot 2025-05-14 at 11 43 50 AM" src="https://github.com/user-attachments/assets/484333fe-1f6d-4b58-aa21-7584743737b0" />

