### PR TITLE
db-console: add client side hot range filtering by node

### DIFF
--- a/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
+++ b/pkg/ui/workspaces/db-console/src/redux/apiReducers.ts
@@ -131,6 +131,8 @@ export const hotRangesReducerObj = new PaginatedCachedDataReducer(
 
 export const refreshHotRanges = hotRangesReducerObj.refresh;
 
+export const clearHotRanges = hotRangesReducerObj.clearData;
+
 export const tableRequestToID = (req: api.IndexStatsRequestMessage): string =>
   generateTableID(req.database, req.table);
 

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRanges.module.styl
@@ -18,3 +18,12 @@
 .hotranges-dropdown-filter
   width max-content
   margin-top $line-height--x-small
+
+.hotranges-node-selector
+  min-width: 200px
+  margin-right: 16px
+
+.checkbox-option-input
+  margin-right: 5px
+.checkbox-option-label
+  display: inline-block

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/hotRangesFilter.tsx
@@ -2,390 +2,121 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
+//
+import classNames from "classnames/bind";
+import React, { useMemo } from "react"
+import { useSelector } from "react-redux";
+import { Row, Col } from "antd";
 
 import {
-  Button,
-  FilterCheckboxOption,
-  FilterCheckboxOptionItem,
-  FilterCheckboxOptionsType,
   FilterDropdown,
   FilterSearchOption,
+  FilterCheckboxOption,
+  FilterCheckboxOptionItem,
 } from "@cockroachlabs/cluster-ui";
-import { cockroach } from "@cockroachlabs/crdb-protobuf-client";
-import classNames from "classnames/bind";
-import isArray from "lodash/isArray";
-import isEmpty from "lodash/isEmpty";
-import isString from "lodash/isString";
-import noop from "lodash/noop";
-import React, { useCallback, useEffect, useState, useMemo } from "react";
-import ReactDOM from "react-dom";
-import { useHistory } from "react-router-dom";
 
 import styles from "./hotRanges.module.styl";
 
-type HotRange = cockroach.server.serverpb.HotRangesResponseV2.IHotRange;
+import { selectNodeLocalities } from "src/redux/localities";
+import { Filters } from "./useFilters";
+import NodeIDSelector from "./nodeIdSelect";
+import { selectDatabases } from "../statements/statementsPage";
 
 const cx = classNames.bind(styles);
 
 export type HotRangesFilterProps = {
-  hotRanges: HotRange[];
-  onChange: (filteredHotRanges: HotRange[]) => void;
-  nodeIdToLocalityMap: Map<number, string>;
-  clearButtonContainer: Element;
+  filters: Filters;
+  applyFilters: (filters: Filters) => void;
 };
 
 export const HotRangesFilter = (props: HotRangesFilterProps) => {
-  const { hotRanges, onChange, nodeIdToLocalityMap } = props;
+  const { filters, applyFilters } = props;
+  const [localFilters, setLocalFilters] = React.useState<Filters>(filters);
+  const { node_ids, store_id, databases, table, index, localities } = localFilters;
+  const mergeFilters = (extraFilters: Filters) => setLocalFilters({ ...localFilters, ...extraFilters });
 
-  // nodeIdsOptions is a list of uniq node IDs that are available in
-  // provided list of hot ranges.
-  const nodeIdsOptions = useMemo(
-    () =>
-      Array.from(new Set(hotRanges.map(r => `${r.node_id}`)))
-        .sort()
-        .map(nodeId => ({ label: nodeId, value: nodeId })),
-    [hotRanges],
-  );
+  // The below setters are used for the various filters.
+  const setStore = (store_id: string) => mergeFilters({ store_id });
+  const setDatabases = (databaseOptions: FilterCheckboxOptionItem[]) => {
+    const databases = databaseOptions.map(o => o.value);
+    mergeFilters({ databases });
+  }
+  const setTable = (table: string) => mergeFilters({ table });
+  const setIndex = (index: string) => mergeFilters({ index });
+  const setLocalities = (localityOptions: FilterCheckboxOptionItem[]) => {
+    const localities = localityOptions.map(o => o.value);
+    mergeFilters({ localities });
+  }
 
-  // databaseOptions is a list of uniq database names that are available in
-  // provided list of hot ranges.
-  const databaseOptions = useMemo(
-    () =>
-      Array.from(new Set(hotRanges.map(r => r.databases).flat()))
-        .filter(i => !isEmpty(i))
-        .sort()
-        .map(dbName => ({ label: dbName, value: dbName })),
-    [hotRanges],
-  );
+  const nodeIdToLocalityMap = useSelector(selectNodeLocalities);
+  const localityOptions = Array.from(nodeIdToLocalityMap.values())
+    .sort()
+    .map(locality => ({ label: locality, value: locality }));
 
-  // localitiesOptions is a list of uniq localities that are available in
-  // provided list of hot ranges.
-  const localitiesOptions = useMemo(
-    () =>
-      Array.from(nodeIdToLocalityMap.values())
-        .sort()
-        .map(locality => ({ label: locality, value: locality })),
-    [nodeIdToLocalityMap],
-  );
+  const onSubmit = () => {
+    applyFilters(localFilters);
+  };
 
-  const history = useHistory();
+  const onNodeIdSubmit = (node_ids: string[]) => {
+    applyFilters({ ...localFilters, node_ids });
+  }
 
-  // define filter names that are used in URL search params to preserve filter options.
-  const nodeIds = "node_ids";
-  const storeId = "store_id";
-  const dbNames = "db_names";
-  const table = "table";
-  const indexName = "index";
-  const localities = "localities";
+  const databaseNames = useSelector(selectDatabases)
+  const databaseOptions = databaseNames.map(db => ({ label: db, value: db }));
 
-  // initialize states of filter options with values from URL search params.
-  const [filterNodeIds, setFilterNodeIds] = useState<FilterCheckboxOptionsType>(
-    [],
-  );
-  const [filterStoreId, setFilterStoreId] = useState<string>();
-  const [filterDbNames, setFilterDbNames] = useState<FilterCheckboxOptionsType>(
-    [],
-  );
-  const [filterTableName, setFilterTableName] = useState<string>();
-  const [filterIndexName, setFilterIndexName] = useState<string>();
-  const [filterLocalities, setFilterLocalities] =
-    useState<FilterCheckboxOptionsType>([]);
+  const selectedOptions = (values: string[]) => values.map((v: string) => ({ label: v, value: v }));
 
-  // stagedFilteredHotRanges preserves intermediate filters states that are selected but
-  // is not Applied yet.
-  const [stagedFilteredHotRanges, setStagedFilteredHotRanges] = useState<
-    HotRange[]
-  >([]);
-
-  // getFiltersCount returns how many filter options are selected.
-  const getFiltersCount = useCallback(
-    (filters: Array<FilterCheckboxOptionsType | string>) =>
-      filters.filter(f => !isEmpty(f)).length,
-    [],
-  );
-
-  const [filtersCount, setFiltersCount] = useState<number>(0);
-
-  // filterBy function performs actual filtering of hot ranges regarding provided
-  // filters options.
-  const filterBy = useCallback(
-    (
-      ranges: HotRange[],
-      nodeIds: FilterCheckboxOptionsType,
-      storeId: string,
-      dbNames: FilterCheckboxOptionsType,
-      tableName: string,
-      indexName: string,
-      localities: FilterCheckboxOptionsType,
-    ) => {
-      const hasNoFilters = [
-        nodeIds,
-        storeId,
-        dbNames,
-        tableName,
-        indexName,
-        localities,
-      ].every(isEmpty);
-
-      if (hasNoFilters) {
-        return ranges;
-      }
-
-      let filtered = [...ranges];
-
-      if (!isEmpty(nodeIds)) {
-        filtered = filtered.filter(r =>
-          nodeIds.some(
-            (f: FilterCheckboxOptionItem) => f.value === r.node_id?.toString(),
-          ),
-        );
-      }
-
-      if (!isEmpty(storeId)) {
-        filtered = filtered.filter(r =>
-          r.store_id.toString().includes(storeId),
-        );
-      }
-
-      if (!isEmpty(dbNames)) {
-        filtered = filtered.filter(r =>
-          dbNames.some((f: FilterCheckboxOptionItem) =>
-            r.databases?.includes(f.value),
-          ),
-        );
-      }
-
-      if (!isEmpty(tableName)) {
-        filtered = filtered.filter(r => r.tables?.includes(tableName));
-      }
-
-      if (!isEmpty(indexName)) {
-        filtered = filtered.filter(r => r.indexes?.includes(indexName));
-      }
-
-      if (!isEmpty(localities)) {
-        filtered = filtered.filter(r => {
-          const locality = nodeIdToLocalityMap.get(r.node_id);
-          return localities.some(
-            (f: FilterCheckboxOptionItem) => f.value === locality,
-          );
-        });
-      }
-      return filtered;
-    },
-    [nodeIdToLocalityMap],
-  );
-
-  // Following effect is required to filter hot ranges every time when
-  // hot ranges list is updated after filters are changed (it is possible
-  // when: a) filter options are retrieved from URL search params; b) when
-  // hot ranges are periodically updated and new data is received from server).
-  useEffect(() => {
-    const searchParams = new URLSearchParams(history.location.search);
-    const nodeIdsFilter = (searchParams.get(nodeIds) || "")
-      .split("|")
-      .filter(i => !isEmpty(i))
-      .map(i => ({ label: i, value: i }));
-    const storeIdFilter = searchParams.get(storeId);
-    const dbNamesFilter = (searchParams.get(dbNames) || "")
-      .split("|")
-      .filter(i => !isEmpty(i))
-      .map(i => ({ label: i, value: i }));
-    const tableNameFilter = searchParams.get(table);
-    const indexNameFilter = searchParams.get(indexName);
-    const localitiesFilter = (searchParams.get(localities) || "")
-      .split("|")
-      .filter(i => !isEmpty(i))
-      .map(i => ({ label: i, value: i }));
-
-    setFilterNodeIds(nodeIdsFilter);
-    setFilterStoreId(storeIdFilter);
-    setFilterDbNames(dbNamesFilter);
-    setFilterTableName(tableNameFilter);
-    setFilterIndexName(indexNameFilter);
-    setFilterLocalities(localitiesFilter);
-
-    setFiltersCount(
-      getFiltersCount([
-        nodeIdsFilter,
-        storeIdFilter,
-        dbNamesFilter,
-        tableNameFilter,
-        indexNameFilter,
-        localitiesFilter,
-      ]),
-    );
-
-    const filtered = filterBy(
-      hotRanges,
-      nodeIdsFilter,
-      storeIdFilter,
-      dbNamesFilter,
-      tableNameFilter,
-      indexNameFilter,
-      localitiesFilter,
-    );
-    onChange(filtered);
-  }, [hotRanges, onChange, history, filterBy, getFiltersCount]);
-
-  useEffect(() => {
-    const filtered = filterBy(
-      hotRanges,
-      filterNodeIds,
-      filterStoreId,
-      filterDbNames,
-      filterTableName,
-      filterIndexName,
-      filterLocalities,
-    );
-    setStagedFilteredHotRanges(filtered);
-  }, [
-    filterNodeIds,
-    filterStoreId,
-    filterDbNames,
-    filterTableName,
-    filterIndexName,
-    filterLocalities,
-    hotRanges,
-    filterBy,
-  ]);
-
-  const getSearchParams = useCallback(() => {
-    const params = new URLSearchParams();
-    const filters: Array<[string, FilterCheckboxOptionsType | string]> = [
-      [nodeIds, filterNodeIds],
-      [storeId, filterStoreId],
-      [dbNames, filterDbNames],
-      [table, filterTableName],
-      [indexName, filterIndexName],
-      [localities, filterLocalities],
-    ];
-    filters
-      .filter(f => !isEmpty(f[1]))
-      .forEach(([name, value]) => {
-        if (isArray(value)) {
-          params.set(name, value.map(f => f.value).join("|"));
-        }
-        if (isString(value)) {
-          params.set(name, value);
-        }
-      });
-    return params;
-  }, [
-    filterNodeIds,
-    filterStoreId,
-    filterDbNames,
-    filterTableName,
-    filterIndexName,
-    filterLocalities,
-  ]);
-
-  // onApply is a callback function that is fired when user click "Apply" button
-  // in DropdownFilter.
-  const onApply = useCallback(() => {
-    setFiltersCount(
-      getFiltersCount([
-        filterNodeIds,
-        filterStoreId,
-        filterDbNames,
-        filterTableName,
-        filterIndexName,
-        filterLocalities,
-      ]),
-    );
-    onChange(stagedFilteredHotRanges);
-    history.location.search = getSearchParams().toString();
-    history.replace(history.location);
-  }, [
-    getFiltersCount,
-    filterNodeIds,
-    filterStoreId,
-    filterDbNames,
-    filterTableName,
-    filterIndexName,
-    filterLocalities,
-    onChange,
-    stagedFilteredHotRanges,
-    history,
-    getSearchParams,
-  ]);
-
-  // onClearClick function clears all filters, URL search params, and resets filters counter.
-  const onClearClick = useCallback(() => {
-    setFilterNodeIds([]);
-    setFilterStoreId(undefined);
-    setFilterDbNames([]);
-    setFilterTableName(undefined);
-    setFilterIndexName(undefined);
-    setFilterLocalities([]);
-    onChange(hotRanges);
-    setFiltersCount(0);
-    history.location.search = getSearchParams().toString();
-    history.replace(history.location);
-  }, [onChange, hotRanges, history, getSearchParams]);
+  const filterCount = useMemo(() => {
+    const allFilters = [store_id, table, index, ...localities, ...databases];
+    return allFilters.filter(f => !!f).length;
+  }, [filters]);
 
   return (
-    <div>
-      <FilterDropdown
-        label={`Filter (${filtersCount})`}
-        onSubmit={onApply}
-        className={cx("hotranges-dropdown-filter")}
-      >
-        <FilterCheckboxOption
-          label="Node ID"
-          options={nodeIdsOptions}
-          placeholder="Select"
-          value={filterNodeIds}
-          onSelectionChanged={(options: any) => {
-            setFilterNodeIds(options);
-          }}
+    <Row className={cx("hotranges-dropdown-filter")}>
+      <Col className={cx("hotranges-node-selector")}>
+        <NodeIDSelector
+          node_ids={node_ids}
+          onSubmit={onNodeIdSubmit}
         />
-        <FilterSearchOption
-          label="Store ID"
-          onChanged={setFilterStoreId}
-          onSubmit={noop}
-          value={filterStoreId}
-        />
-        <FilterCheckboxOption
-          label="Database"
-          options={databaseOptions}
-          value={filterDbNames}
-          placeholder="Select"
-          onSelectionChanged={(options: any) => {
-            setFilterDbNames(options as any);
-          }}
-        />
-        <FilterSearchOption
-          label="Table"
-          onChanged={setFilterTableName}
-          onSubmit={noop}
-          value={filterTableName}
-        />
-        <FilterSearchOption
-          label="Index"
-          onChanged={setFilterIndexName}
-          onSubmit={noop}
-          value={filterIndexName}
-        />
-        <FilterCheckboxOption
-          label="Locality"
-          options={localitiesOptions}
-          placeholder="Select"
-          onSelectionChanged={(o: any) => setFilterLocalities(o as any)}
-          value={filterLocalities}
-        />
-      </FilterDropdown>
-      {props.clearButtonContainer &&
-        filtersCount > 0 &&
-        ReactDOM.createPortal(
-          <>
-            <span>&nbsp;&nbsp;&nbsp;-</span>
-            <Button onClick={onClearClick} type="flat" size="small">
-              clear filter
-            </Button>
-          </>,
-          props.clearButtonContainer,
-        )}
-    </div>
+      </Col>
+      <Col>
+        <FilterDropdown
+          label={`Filter (${filterCount})`}
+          onSubmit={onSubmit}
+        >
+          <FilterSearchOption
+            label="Store ID"
+            onChanged={setStore}
+            value={store_id}
+          />
+          <FilterCheckboxOption
+            label="Databases"
+            options={databaseOptions}
+            placeholder="Select"
+            value={selectedOptions(databases)}
+            onSelectionChanged={setDatabases}
+          />
+          <FilterSearchOption
+            label="Table"
+            onChanged={setTable}
+            value={table}
+          />
+          <FilterSearchOption
+            label="Index"
+            onChanged={setIndex}
+            value={index}
+          />
+          <FilterCheckboxOption
+            label="Locality"
+            options={localityOptions}
+            placeholder="Select"
+            value={selectedOptions(localities)}
+            onSelectionChanged={setLocalities}
+          />
+
+        </FilterDropdown>
+      </Col>
+    </Row >
   );
 };
+

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/index.tsx
@@ -11,22 +11,22 @@ import {
   TimezoneContext,
 } from "@cockroachlabs/cluster-ui";
 import classNames from "classnames/bind";
-import React, { useRef, useEffect, useState, useContext } from "react";
+import React, { useRef, useMemo, useEffect, useContext } from "react";
 import { Helmet } from "react-helmet";
 import { useDispatch, useSelector } from "react-redux";
 
 import { cockroach } from "src/js/protos";
-import { refreshHotRanges } from "src/redux/apiReducers";
+import { refreshHotRanges, clearHotRanges, refreshDatabases } from "src/redux/apiReducers";
 import {
   hotRangesSelector,
   isLoadingSelector,
-  isValidSelector,
   lastErrorSelector,
   lastSetAtSelector,
 } from "src/redux/hotRanges";
 import { selectNodeLocalities } from "src/redux/localities";
 import { performanceBestPracticesHotSpots } from "src/util/docs";
 import { HotRangesFilter } from "src/views/hotRanges/hotRangesFilter";
+import useFilters, { filterRanges } from "src/views/hotRanges/useFilters";
 
 import ErrorBoundary from "../app/components/errorMessage/errorBoundary";
 
@@ -35,28 +35,36 @@ import HotRangesTable from "./hotRangesTable";
 
 const cx = classNames.bind(styles);
 const HotRangesRequest = cockroach.server.serverpb.HotRangesRequest;
-type HotRange = cockroach.server.serverpb.HotRangesResponseV2.IHotRange;
 
 const HotRangesPage = () => {
   const dispatch = useDispatch();
   const hotRanges = useSelector(hotRangesSelector);
-  const isValid = useSelector(isValidSelector);
   const lastError = useSelector(lastErrorSelector);
   const lastSetAt = useSelector(lastSetAtSelector);
   const isLoading = useSelector(isLoadingSelector);
   const nodeIdToLocalityMap = useSelector(selectNodeLocalities);
   const timezone = useContext(TimezoneContext);
 
-  useEffect(() => {
-    if (!isValid) {
-      dispatch(refreshHotRanges(new HotRangesRequest()));
-    }
-  }, [dispatch, isValid]);
+  const { filters, applyFilters } = useFilters();
 
-  const [filteredHotRanges, setFilteredHotRanges] =
-    useState<HotRange[]>(hotRanges);
+  // dispatch hot ranges call whenever the filters change and are not empty
+  useEffect(() => {
+    if (filters.node_ids.length > 0) {
+      dispatch(refreshHotRanges(new HotRangesRequest({ nodes: filters.node_ids })));
+    } else {
+      dispatch(clearHotRanges());
+    }
+  }, [filters.node_ids]);
+
+  // load the databases if possible.
+  useEffect(() => {
+    dispatch(refreshDatabases());
+  }, []);
 
   const clearButtonRef = useRef<HTMLSpanElement>();
+  const filteredRanges = useMemo(() => {
+    return filterRanges(hotRanges, filters, nodeIdToLocalityMap);
+  }, [filters, hotRanges]);
 
   return (
     <React.Fragment>
@@ -72,19 +80,14 @@ const HotRangesPage = () => {
           find and reduce hot spots.
         </Anchor>
       </Text>
-      <HotRangesFilter
-        hotRanges={hotRanges}
-        onChange={setFilteredHotRanges}
-        nodeIdToLocalityMap={nodeIdToLocalityMap}
-        clearButtonContainer={clearButtonRef.current}
-      />
+      <HotRangesFilter filters={filters} applyFilters={applyFilters} />
       <ErrorBoundary>
         <Loading
           loading={isLoading}
           error={lastError}
           render={() => (
             <HotRangesTable
-              hotRangesList={filteredHotRanges}
+              hotRangesList={filteredRanges}
               lastUpdate={
                 lastSetAt &&
                 util.FormatWithTimezone(

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/nodeIdSelect.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/nodeIdSelect.tsx
@@ -1,0 +1,109 @@
+import React, { useState } from "react";
+import { Select, Tag } from "antd";
+import classNames from "classnames/bind";
+
+import { useSelector } from "react-redux";
+
+import { nodeIDsStringifiedSelector } from "src/redux/nodes";
+
+import styles from "./hotRanges.module.styl";
+
+const cx = classNames.bind(styles);
+
+const ALL_KEY = "all";
+const ALL_OPTION = { label: "All (⚠ may be slow)", value: ALL_KEY };
+
+export default function NodeIDSelector(props: NodeIDSelectorProps) {
+  const { node_ids, onSubmit } = props;
+  const [nodes, setNodes] = useState<string[]>(node_ids);
+  const options = [ALL_OPTION].concat(useSelector(nodeIDsStringifiedSelector).map(n => ({
+    value: n,
+    label: "N" + n,
+  })));
+
+  const onSelect = (value: string) => {
+    if (value === ALL_KEY) {
+      setNodes(options.map(o => o.value));
+    } else {
+      if (nodes.length === options.length - 2) {
+        setNodes([ALL_KEY, value, ...nodes]);
+      } else {
+        setNodes([value, ...nodes]);
+      }
+    }
+  }
+
+  const onDeselect = (value: string) => {
+    if (value === ALL_KEY) {
+      setNodes([]);
+    } else {
+      // strip the value, and the all option if it's selected.
+      setNodes(nodes.filter(n => ![ALL_KEY, value].includes(n)))
+    }
+  }
+
+  const onBlur = () => {
+    onSubmit(nodes.filter(n => n !== ALL_KEY));
+  };
+
+  const onClear = () => {
+    setNodes([]);
+    onSubmit([]);
+  };
+
+  return (
+    <div>
+      <Select
+        mode="multiple"
+        className="select__container"
+        optionLabelProp="name"
+        options={options.map(o => ({
+          value: o.value,
+          name: o.label,
+          label: <CheckboxOption label={o.label} checked={nodes.includes(o.value)} />,
+        }))}
+        placeholder="Select Nodes"
+        value={nodes}
+        popupMatchSelectWidth={false}
+        maxTagCount={5}
+        allowClear={true}
+        onSelect={onSelect}
+        onDeselect={onDeselect}
+        onBlur={onBlur}
+        onClear={onClear}
+        tagRender={WithoutAllTag}
+        optionRender={CheckboxOption}
+      />
+    </div>
+  );
+}
+
+type NodeIDSelectorProps = {
+  node_ids: string[];
+  setNodes: (nodes: string[]) => void;
+  onSubmit: (nodes: string[]) => void;
+};
+
+// WithoutAllTag is an override which hides the all tag from the
+// selected tag list.
+const WithoutAllTag = ({ label, value }: { label: string; value: string }) => {
+  if (value === "all") {
+    return null;
+  }
+  return <Tag>{label}</Tag>;
+}
+
+const CheckboxOption = ({ label, checked }: any) => {
+  return (
+    <span>
+      <input
+        className={cx("checkbox-option-input")}
+        type="checkbox"
+        checked={checked}
+        onChange={() => null}
+      />
+      <label className={cx("checkbox-option-label")}>{label}</label>
+    </span>
+  );
+};
+

--- a/pkg/ui/workspaces/db-console/src/views/hotRanges/useFilters.ts
+++ b/pkg/ui/workspaces/db-console/src/views/hotRanges/useFilters.ts
@@ -1,0 +1,108 @@
+import { useEffect, useState } from "react";
+import type { History } from "history";
+import { useHistory, useLocation } from "react-router-dom";
+import { isEmpty } from "lodash";
+
+import { cockroach } from "src/js/protos";
+
+type HotRange = cockroach.server.serverpb.HotRangesResponseV2.IHotRange;
+
+export interface Filters {
+  node_ids?: string[];
+  store_id?: string;
+  databases?: string[];
+  table?: string;
+  index?: string;
+  localities?: string[];
+}
+
+// useFilters is a custom hook for managing the filter state of the
+// hot ranges page. It is separate from the state management
+// for the filters component. It both manages the state for the filters,
+// as well as loads, persists it to the URL so that deep linking
+// is possible.
+export default function useFilters() {
+  // On initial mount, we attempt to load the filter state
+  // from session storage or the query parameters.
+  const { search } = useLocation(); // Add this
+  const getInitialFilters = (() => {
+    return loadSearchParams(new URLSearchParams(search)) || {};
+  });
+  const [filters, setFilters] = useState<Filters>(getInitialFilters());
+  const history = useHistory();
+
+  function applyFilters(newFilters: Filters) {
+    setSearchParams(history, newFilters);
+    setFilters(newFilters);
+  }
+
+  return { filters, applyFilters };
+}
+
+function loadSearchParams(query: URLSearchParams): Filters {
+  const loadArray = (key: string) => {
+    const raw = query.get(key);
+    if (raw) {
+      return raw.split(",");
+    }
+    return [];
+  };
+
+  return {
+    node_ids: loadArray("node_ids"),
+    databases: loadArray("databases"),
+    localities: loadArray("localities"),
+    store_id: query.get("store_id"),
+    table: query.get("table"),
+    index: query.get("index"),
+  };
+}
+
+function setSearchParams(history: History, filters: Filters) {
+  const params = new URLSearchParams();
+  filters.node_ids?.length &&
+    params.set("node_ids", filters.node_ids?.join(","));
+  filters.localities?.length && params.set("localities", filters.localities?.join(","));
+  filters.databases?.length && params.set("databases", filters.databases?.join(","));
+  filters.store_id && params.set("store_id", filters.store_id);
+  filters.table && params.set("table", filters.table);
+  filters.index && params.set("index", filters.index);
+  history.location.search = params.toString();
+  history.replace(history.location);
+}
+
+export function filterRanges(
+  ranges: HotRange[],
+  filters: Filters,
+  nodeIdToLocalityMap: Map<number, string>,
+): any[] {
+  const { store_id, databases, table, index, localities } = filters;
+  var filtered = ranges;
+
+  if (!isEmpty(store_id)) {
+    filtered = filtered.filter(r => r.store_id.toString().includes(store_id));
+  }
+
+  if (!isEmpty(databases)) {
+    filtered = filtered.filter(r =>
+      databases.some((db: string) => r.databases?.includes(db)),
+    );
+  }
+
+  if (!isEmpty(table)) {
+    filtered = filtered.filter(r => r.tables?.includes(table));
+  }
+
+  if (!isEmpty(index)) {
+    filtered = filtered.filter(r => r.indexes?.includes(index));
+  }
+
+  if (!isEmpty(localities)) {
+    filtered = filtered.filter(r => {
+      const locality = nodeIdToLocalityMap.get(r.node_id);
+      return localities.some((l: string) => l === locality);
+    });
+  }
+
+  return filtered;
+}


### PR DESCRIPTION
db-console: add client side hot range filtering by node

Loading the hot ranges page is a performance intensive operation in large clusters, due to the fact the a cluster fanout is required to gather the information. Despite having a node filter within the component, the filtering has historically been applied after the api has responded with the full cluster's information.

This change moves the filtering of the nodes to the back end, and cleans up some of how the filters are organized.

Fixes: #143528
Epic: CRDB-43150

Release note (ui change): Moves the hot ranges node filter out of the primary filter container in the hot ranges page, and applies the filtering on the backend.