### PR TITLE
util/mon,colexec/colexecdisk: reduce allocations

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1274,7 +1274,7 @@ func NewColOperator(
 				} else {
 					diskSpiller := colexecdisk.NewTwoInputDiskSpiller(
 						inputs[0].Root, inputs[1].Root, inMemoryHashJoiner.(colexecop.BufferingInMemoryOperator),
-						[]mon.Name{hashJoinerMemMonitorName},
+						[2]mon.Name{hashJoinerMemMonitorName, mon.EmptyName},
 						func(inputOne, inputTwo colexecop.Operator) colexecop.Operator {
 							opName := redact.SafeString("external-hash-joiner")
 							accounts := args.MonitorRegistry.CreateUnlimitedMemAccounts(
@@ -1441,7 +1441,7 @@ func NewColOperator(
 			evalCtx.SingleDatumAggMemAccount = ehaMemAccount
 			diskSpiller := colexecdisk.NewTwoInputDiskSpiller(
 				inputs[0].Root, inputs[1].Root, hgj,
-				[]mon.Name{hashJoinerMemMonitorName, hashAggregatorMemMonitorName},
+				[2]mon.Name{hashJoinerMemMonitorName, hashAggregatorMemMonitorName},
 				func(inputOne, inputTwo colexecop.Operator) colexecop.Operator {
 					// When we spill to disk, we just use a combo of an external
 					// hash join followed by an external hash aggregation.

--- a/pkg/util/mon/bytes_usage.go
+++ b/pkg/util/mon/bytes_usage.go
@@ -297,6 +297,9 @@ type Name struct {
 	i      uint16
 }
 
+// EmptyName is an empty, uninitialized Name.
+var EmptyName Name
+
 // nameSuffix is an enum the represents one of a finite list of possible
 // monitor name suffixes.
 type nameSuffix uint8
@@ -370,6 +373,11 @@ func (mn Name) WithSuffix(suffix nameSuffix) Name {
 func (mn Name) WithInt(i uint16) Name {
 	mn.i = i
 	return mn
+}
+
+// Empty returns true if the name is empty, i.e., uninitialized.
+func (mn Name) Empty() bool {
+	return mn == Name{}
 }
 
 // String returns the monitor prefix as a string.


### PR DESCRIPTION
#### colexec/colexecdisk: lazily construct monitor name strings

Monitor name strings are now built only when an out-of-memory error is
encountered, rather than always built when a disk spiller is created.

Release note: None

#### util/mon: use array for disk spiller monitor names

A fixed size array of type is now used instead of a slice for storing
`mon.Name`s in `diskSpillerBase`, reducing heap allocations. An empty
`mon.Name` is used for the second element in the array if there is only
one name.

Release note: None
