### PR TITLE
sql: fix dependent object type in rename error message

### DIFF
--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -217,13 +217,13 @@ pq: cannot drop table tbl1 because other objects depend on it
 exec-sql
 ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
 ----
-pq: cannot rename relation "sc1.tbl1" because view "tbl2" depends on it
+pq: cannot rename relation "sc1.tbl1" because table "tbl2" depends on it
 HINT: consider dropping "tbl2" first.
 
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because view "tbl2" depends on it
+pq: cannot set schema on relation "tbl1" because table "tbl2" depends on it
 HINT: consider dropping "tbl2" first.
 
 exec-sql

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -925,7 +925,7 @@ statement ok
 CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION trigger_func();
 
 # Relations are referenced by name, so renaming the table is not allowed.
-statement error pgcode 2BP01 cannot rename relation "t" because view "xy" depends on it
+statement error pgcode 2BP01 cannot rename relation "t" because table "xy" depends on it
 ALTER TABLE t RENAME TO t2;
 
 # Sequences are remapped to their IDs, so renaming is allowed.

--- a/pkg/sql/catalog/tabledesc/table_desc.go
+++ b/pkg/sql/catalog/tabledesc/table_desc.go
@@ -651,6 +651,11 @@ func (desc *wrapper) GetObjectType() privilege.ObjectType {
 
 // GetObjectTypeString implements the Object interface.
 func (desc *wrapper) GetObjectTypeString() string {
+	// Special handling for views since GetObjectType does not distinguish between
+	// views and regular tables.
+	if desc.IsView() {
+		return "view"
+	}
 	return string(desc.GetObjectType())
 }
 

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -191,7 +191,7 @@ func (p *planner) canRemoveDependentViewGeneric(
 	behavior tree.DropBehavior,
 ) error {
 	if behavior != tree.DropCascade {
-		return p.dependentViewError(ctx, typeName, objName, parentID, viewDesc, "drop")
+		return p.dependentRelationError(ctx, typeName, objName, parentID, viewDesc, "drop")
 	}
 
 	if err := p.CheckPrivilege(ctx, viewDesc, privilege.DROP); err != nil {

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -314,7 +314,7 @@ func NewDependentObjectErrorf(format string, args ...interface{}) error {
 func NewDependentBlocksOpError(op, objType, objName, dependentType, dependentName string) error {
 	return errors.WithHintf(
 		NewDependentObjectErrorf("cannot %s %s %q because %s %q depends on it",
-			op, objType, objName, dependentType, dependentName),
+			redact.SafeString(op), redact.SafeString(objType), objName, redact.SafeString(dependentType), dependentName),
 		"consider dropping %q first.", dependentName)
 }
 


### PR DESCRIPTION
Previously, attempting to rename a table that is referenced by a trigger would result in an error message mislabeling the dependent object as a view, regardless of its actual type. For example:
```
  cannot rename relation "t" because view "xy" depends on it
```

This commit corrects the error message to accurately reflect the type of the dependent object, such as "table" in the case of a trigger.

Informs #142370

Epic: none
Release note: none