### PR TITLE
server,admission: use flight recorder to trace during CPU overload

### DIFF
--- a/pkg/cli/log_flags.go
+++ b/pkg/cli/log_flags.go
@@ -241,6 +241,7 @@ func setupLogging(ctx context.Context, cmd *cobra.Command, isServerCmd, applyCon
 	serverCfg.HeapProfileDirName = filepath.Join(outputDirectory, base.HeapProfileDir)
 	serverCfg.CPUProfileDirName = filepath.Join(outputDirectory, base.CPUProfileDir)
 	serverCfg.InflightTraceDirName = filepath.Join(outputDirectory, base.InflightTraceDir)
+	serverCfg.FlightRecorderDirName = filepath.Join(outputDirectory, "flight_recorder")
 
 	return nil
 }

--- a/pkg/server/config.go
+++ b/pkg/server/config.go
@@ -186,6 +186,8 @@ type BaseConfig struct {
 	// InflightTraceDirName is the directory name for job traces.
 	InflightTraceDirName string
 
+	FlightRecorderDirName string
+
 	// DefaultZoneConfig is used to set the default zone config inside the server.
 	// It can be overridden during tests by setting the DefaultZoneConfigOverride
 	// server testing knob. Whatever is installed here is in turn used to

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -289,6 +289,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	if opts, ok := cfg.TestingKnobs.AdmissionControlOptions.(*admission.Options); ok {
 		admissionOptions.Override(opts)
 	}
+	admissionOptions.FlightRecorderDirName = cfg.FlightRecorderDirName
 
 	engines, err := cfg.CreateEngines(ctx)
 	if err != nil {

--- a/pkg/util/admission/BUILD.bazel
+++ b/pkg/util/admission/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_cockroachdb_tokenbucket//:tokenbucket",
+        "@org_golang_x_exp//trace",
     ],
 )
 

--- a/pkg/util/admission/grant_coordinator.go
+++ b/pkg/util/admission/grant_coordinator.go
@@ -562,8 +562,15 @@ func makeRegularGrantCoordinator(
 		if err := os.MkdirAll(opts.FlightRecorderDirName, 0755); err != nil {
 			log.Warningf(context.Background(), "cannot create FlightRecorder dir: %v", err)
 		}
-		// The default targetPeriod of 10s is fine.
 		fr := trace.NewFlightRecorder()
+		// 10s also happens to be the default, but we set it anyway.
+		fr.SetPeriod(10 * time.Second)
+		// Set the size to 100MiB (default is 10MiB). We've seen a 19MiB trace
+		// file that captured ~2s of CPU time, so 100MiB should be enough for 10s.
+		// Note that there can be a maximum 3s lag in writing the state of the
+		// flight recorder due to the logic in slotGranter, so being able to
+		// capture ~5s in the trace should be more than sufficient.
+		fr.SetSize(100 << 20)
 		if err := fr.Start(); err != nil {
 			panic(err)
 		}

--- a/pkg/util/admission/kv_slot_adjuster.go
+++ b/pkg/util/admission/kv_slot_adjuster.go
@@ -107,6 +107,10 @@ func (kvsa *kvSlotAdjuster) CPULoad(runnable int, procs int, samplePeriod time.D
 	}
 
 	kvsa.totalSlotsMetric.Update(int64(kvsa.granter.totalSlots))
+	frEnabled := KVAdmissionFlightRecorderOnCPUOverload.Get(&kvsa.settings.SV)
+	if frEnabled {
+		kvsa.granter.tryFlightRecorderSnapshotLocked()
+	}
 }
 
 func (kvsa *kvSlotAdjuster) isOverloaded() bool {


### PR DESCRIPTION
The CPU overload signal is the admission CPU slotGranter observing 100ms of slot exhaustion over the last 3s. The traces are dumped to a flight_recorder sub-directory in the logs dir, and at most one will be generated every 10min.

Epic: none

Release note: None