### PR TITLE
drt: add create table as operation

### DIFF
--- a/pkg/cmd/roachtest/operations/sql_objects.go
+++ b/pkg/cmd/roachtest/operations/sql_objects.go
@@ -111,6 +111,23 @@ func registerCreateSQLOperations(r registry.Registry) {
 			},
 		},
 		{
+			name:       "create-table-as",
+			objectType: "TABLE",
+			prefix:     "roachtest_ctas",
+			createSQL: func(name string) string {
+				return fmt.Sprintf(`
+			CREATE TABLE %s AS
+			SELECT
+				i_id,
+				i_name,
+				i_price,
+				length(i_name) AS name_len,
+				now() AS loaded_at
+			FROM item
+			WHERE i_price > (SELECT avg(i_price) FROM item)`, name)
+			},
+		},
+		{
 			name:       "create-sequence",
 			objectType: "SEQUENCE",
 			prefix:     "roachtest_sequence",


### PR DESCRIPTION
This PR adds a `CREATE TABLE AS` operation using the generic SQL operation interface

Epic: none
Fixes: #138441
Release note: None