### PR TITLE
release-24.3: parser: fix format/parse roundtrip for unique index

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -10829,6 +10829,7 @@ index_def:
         Predicate:        $11.expr(),
         Invisibility:     $12.indexInvisibility(),
       },
+      FormatAsIndex:    true,
     }
   }
 | INVERTED INDEX_BEFORE_PAREN '(' index_params ')' opt_partition_by_index opt_with_storage_parameter_list opt_where_clause opt_index_visible

--- a/pkg/sql/parser/testdata/create_table
+++ b/pkg/sql/parser/testdata/create_table
@@ -548,35 +548,35 @@ CREATE TABLE _ (_ INT8 UNIQUE) -- identifiers removed
 parse
 CREATE TABLE a (b INT, UNIQUE INDEX foo (b))
 ----
-CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b)) -- normalized!
-CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b)) -- fully parenthesized
-CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b)) -- literals removed
-CREATE TABLE _ (_ INT8, CONSTRAINT _ UNIQUE (_)) -- identifiers removed
+CREATE TABLE a (b INT8, UNIQUE INDEX foo (b)) -- normalized!
+CREATE TABLE a (b INT8, UNIQUE INDEX foo (b)) -- fully parenthesized
+CREATE TABLE a (b INT8, UNIQUE INDEX foo (b)) -- literals removed
+CREATE TABLE _ (_ INT8, UNIQUE INDEX _ (_)) -- identifiers removed
 
 parse
 CREATE TABLE a (b INT, UNIQUE INDEX foo (b) WHERE c > 3)
 ----
-CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b) WHERE c > 3) -- normalized!
-CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b) WHERE ((c) > (3))) -- fully parenthesized
-CREATE TABLE a (b INT8, CONSTRAINT foo UNIQUE (b) WHERE c > _) -- literals removed
-CREATE TABLE _ (_ INT8, CONSTRAINT _ UNIQUE (_) WHERE _ > 3) -- identifiers removed
+CREATE TABLE a (b INT8, UNIQUE INDEX foo (b) WHERE c > 3) -- normalized!
+CREATE TABLE a (b INT8, UNIQUE INDEX foo (b) WHERE ((c) > (3))) -- fully parenthesized
+CREATE TABLE a (b INT8, UNIQUE INDEX foo (b) WHERE c > _) -- literals removed
+CREATE TABLE _ (_ INT8, UNIQUE INDEX _ (_) WHERE _ > 3) -- identifiers removed
 
 parse
 CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1)))
 ----
-CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1))) -- normalized!
-CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN ((1)))) -- fully parenthesized
-CREATE TABLE a (UNIQUE (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (_))) -- literals removed
-CREATE TABLE _ (UNIQUE (_) PARTITION BY LIST (_) (PARTITION _ VALUES IN (1))) -- identifiers removed
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (1)))
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN ((1)))) -- fully parenthesized
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST (c) (PARTITION d VALUES IN (_))) -- literals removed
+CREATE TABLE _ (UNIQUE INDEX (_) PARTITION BY LIST (_) (PARTITION _ VALUES IN (1))) -- identifiers removed
 
 # Regression test for #95238
 parse
 CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN (1)))
 ----
-CREATE TABLE a (UNIQUE (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN (1))) -- normalized!
-CREATE TABLE a (UNIQUE (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN ((1)))) -- fully parenthesized
-CREATE TABLE a (UNIQUE (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN (_))) -- literals removed
-CREATE TABLE _ (UNIQUE (_) PARTITION BY LIST (_) (PARTITION _ VALUES IN (1))) -- identifiers removed
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN (1)))
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN ((1)))) -- fully parenthesized
+CREATE TABLE a (UNIQUE INDEX (b) PARTITION BY LIST ("c d") (PARTITION "e f" VALUES IN (_))) -- literals removed
+CREATE TABLE _ (UNIQUE INDEX (_) PARTITION BY LIST (_) (PARTITION _ VALUES IN (1))) -- identifiers removed
 
 parse
 CREATE TABLE a (b INT8 UNIQUE WITHOUT INDEX)
@@ -2559,3 +2559,35 @@ CREATE TABLE a (a VECTOR)
 CREATE TABLE a (a VECTOR) -- fully parenthesized
 CREATE TABLE a (a VECTOR) -- literals removed
 CREATE TABLE _ (_ VECTOR) -- identifiers removed
+
+parse
+CREATE TABLE t (a INT PRIMARY KEY, b INT, UNIQUE INDEX ( b NULLS FIRST ) USING HASH WITH ( 'foo' = 'bar' ))
+----
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH ('foo' = 'bar')) -- normalized!
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH ('foo' = ('bar'))) -- fully parenthesized
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH ('foo' = '_')) -- literals removed
+CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, UNIQUE INDEX (_ NULLS FIRST) USING HASH WITH ('foo' = 'bar')) -- identifiers removed
+
+parse
+CREATE TABLE t (a INT PRIMARY KEY, b INT, UNIQUE INDEX ( b NULLS FIRST ) USING HASH WITH BUCKET_COUNT = 10 WITH ( 'foo' = 'bar' ))
+----
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH BUCKET_COUNT = 10 WITH ('foo' = 'bar')) -- normalized!
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH BUCKET_COUNT = (10) WITH ('foo' = ('bar'))) -- fully parenthesized
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b NULLS FIRST) USING HASH WITH BUCKET_COUNT = _ WITH ('foo' = '_')) -- literals removed
+CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, UNIQUE INDEX (_ NULLS FIRST) USING HASH WITH BUCKET_COUNT = 10 WITH ('foo' = 'bar')) -- identifiers removed
+
+parse
+CREATE TABLE t (a INT PRIMARY KEY, b INT, UNIQUE INDEX (b) USING HASH)
+----
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b) USING HASH) -- normalized!
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b) USING HASH) -- fully parenthesized
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX (b) USING HASH) -- literals removed
+CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, UNIQUE INDEX (_) USING HASH) -- identifiers removed
+
+parse
+CREATE TABLE t (a INT PRIMARY KEY, b INT, UNIQUE INDEX idx (b) WITH ( 'foo' = 'bar' ))
+----
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX idx (b) WITH ('foo' = 'bar')) -- normalized!
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX idx (b) WITH ('foo' = ('bar'))) -- fully parenthesized
+CREATE TABLE t (a INT8 PRIMARY KEY, b INT8, UNIQUE INDEX idx (b) WITH ('foo' = '_')) -- literals removed
+CREATE TABLE _ (_ INT8 PRIMARY KEY, _ INT8, UNIQUE INDEX _ (_) WITH ('foo' = 'bar')) -- identifiers removed

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1803,12 +1803,19 @@ func (node *UniqueConstraintTableDef) doc(p *PrettyCfg) pretty.Doc {
 		if node.WithoutIndex {
 			title = pretty.ConcatSpace(title, pretty.Keyword("WITHOUT INDEX"))
 		}
+		if node.FormatAsIndex {
+			title = pretty.ConcatSpace(title, pretty.Keyword("INDEX"))
+		}
+	}
+	if node.Name != "" {
+		if node.FormatAsIndex {
+			title = pretty.ConcatSpace(title, p.Doc(&node.Name))
+		} else {
+			constraint := pretty.ConcatSpace(pretty.Keyword("CONSTRAINT"), p.Doc(&node.Name))
+			title = pretty.ConcatSpace(constraint, title)
+		}
 	}
 	title = pretty.ConcatSpace(title, p.bracket("(", p.Doc(&node.Columns), ")"))
-	if node.Name != "" {
-		clauses = append(clauses, title)
-		title = pretty.ConcatSpace(pretty.Keyword("CONSTRAINT"), p.Doc(&node.Name))
-	}
 	if node.Sharded != nil {
 		clauses = append(clauses, p.Doc(node.Sharded))
 	}

--- a/pkg/testutils/sqlutils/parse.go
+++ b/pkg/testutils/sqlutils/parse.go
@@ -47,8 +47,6 @@ func parseOne(t *testing.T, input string, plpgsql bool) (tree.NodeFormatter, err
 // check that a successfully parsed expression round trips and correctly handles
 // formatting flags.
 func VerifyParseFormat(t *testing.T, input, pos string, plpgsql bool) string {
-	t.Helper()
-
 	// Check parse.
 	stmts, err := parse(t, input, plpgsql)
 	if err != nil {

--- a/pkg/testutils/sqlutils/pretty.go
+++ b/pkg/testutils/sqlutils/pretty.go
@@ -15,8 +15,6 @@ import (
 // VerifyStatementPrettyRoundtrip verifies that the SQL statements in s
 // correctly round trip through the pretty printer.
 func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
-	t.Helper()
-
 	stmts, err := parser.Parse(sql)
 	if err != nil {
 		t.Fatalf("%s: %s", err, sql)
@@ -41,7 +39,6 @@ func VerifyStatementPrettyRoundtrip(t *testing.T, sql string) {
 func verifyStatementPrettyRoundTrip(
 	t *testing.T, sql string, origStmt tree.NodeFormatter, plpgsql bool,
 ) {
-	t.Helper()
 	// Dataflow of the statement through these checks:
 	//
 	//             sql (from test file)


### PR DESCRIPTION
Backport 2/2 commits from #144821.

/cc @cockroachdb/release

Release justification: formatting change

---

If a unique index was created with storage parameters or as a
hash-sharded index, it would be formatted as a unique constraint. That
was incorrect, since constraints don't support those syntaxes.

fixes https://github.com/cockroachdb/cockroach/issues/144727

Release note: None
