### PR TITLE
sql: add shard_cluster_key_encode{32,64}() helper functions

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -7276,6 +7276,14 @@ def go_deps():
         ],
     )
     go_repository(
+        name = "com_github_oklog_ulid_v2",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/oklog/ulid/v2",
+        # TODO: mirror this repo (to fix, run `./dev generate bazel --mirror`)
+        sum = "h1:+9lhoxAP56we25tyYETBBY1YLA2SaoLvUFgrP2miPJU=",
+        version = "v2.1.0",
+    )
+    go_repository(
         name = "com_github_olekukonko_tablewriter",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/olekukonko/tablewriter",
@@ -8241,6 +8249,14 @@ def go_deps():
         urls = [
             "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/schollz/closestmatch/com_github_schollz_closestmatch-v2.1.0+incompatible.zip",
         ],
+    )
+    go_repository(
+        name = "com_github_sean__go_sharded_cluster_keys",
+        build_file_proto_mode = "disable_global",
+        importpath = "github.com/sean-/go-sharded-cluster-keys",
+        # TODO: mirror this repo (to fix, run `./dev generate bazel --mirror`)
+        sum = "h1:SbgHP+OnZ5zoI0h/YHuSZTQDl/8BhnC5vgkMpPVftO0=",
+        version = "v0.0.0-20250513233829-780785014d3d",
     )
     go_repository(
         name = "com_github_sean__seed",

--- a/go.mod
+++ b/go.mod
@@ -435,6 +435,7 @@ require (
 	github.com/rs/xid v1.3.0 // indirect
 	github.com/russross/blackfriday/v2 v2.1.0 // indirect
 	github.com/sahilm/fuzzy v0.1.0 // indirect
+	github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513233829-780785014d3d // indirect
 	github.com/segmentio/asm v1.2.0 // indirect
 	github.com/sirupsen/logrus v1.9.1 // indirect
 	github.com/slok/go-http-metrics v0.10.0 // indirect

--- a/go.sum
+++ b/go.sum
@@ -2218,6 +2218,12 @@ github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdh
 github.com/satori/go.uuid v1.2.1-0.20181028125025-b2ce2384e17b/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/scaleway/scaleway-sdk-go v1.0.0-beta.7.0.20210223165440-c65ae3540d44/go.mod h1:CJJ5VAbozOl0yEw7nHB9+7BXTJbIn6h7W+f6Gau5IP8=
 github.com/schollz/closestmatch v2.1.0+incompatible/go.mod h1:RtP1ddjLong6gTkbtmuhtR2uUrrJOpYzYRvbcPAid+g=
+github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513185917-48b3b358338f h1:sXGpPK4u0uIL1MJ+pHOXta2JQs7N4fT5jxDXbcOyqHA=
+github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513185917-48b3b358338f/go.mod h1:wUdmJHvEFPKK8XV1eYFR0o2xLm2aFPvR7jArxamgyqg=
+github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513215550-55432c9fb51c h1:auRPHI7I+CZaENqZjAs55AzHbKX2Ek/c3KbMK7HYZZo=
+github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513215550-55432c9fb51c/go.mod h1:yViaJOGIXsA0ETptgjtHM3uxfT1y6/171hwXBystjGg=
+github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513233829-780785014d3d h1:SbgHP+OnZ5zoI0h/YHuSZTQDl/8BhnC5vgkMpPVftO0=
+github.com/sean-/go-sharded-cluster-keys v0.0.0-20250513233829-780785014d3d/go.mod h1:3WG70goX2lArruVzntk8igc4i96O/RcQYrEGJLxclT0=
 github.com/sean-/seed v0.0.0-20170313163322-e2103e2c3529/go.mod h1:DxrIzT+xaE7yg65j358z/aeFdxmN0P9QXhEzd20vsDc=
 github.com/seccomp/libseccomp-golang v0.9.1/go.mod h1:GbW5+tmTXfcxTToHLXlScSlAvWlF4P2Ca7zGrPiEpWo=
 github.com/seccomp/libseccomp-golang v0.9.2-0.20210429002308-3879420cc921/go.mod h1:JA8cRccbGaA1s33RQf7Y1+q9gHmZX1yB/z9WDN1C6fg=

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -149,6 +149,8 @@ go_library(
         "@com_github_knz_strtime//:strtime",
         "@com_github_lib_pq//oid",
         "@com_github_pierrec_lz4_v4//:lz4",
+        "@com_github_sean__go_sharded_cluster_keys//key32",
+        "@com_github_sean__go_sharded_cluster_keys//key64",
         "@com_github_twpayne_go_geom//:go-geom",
         "@com_github_twpayne_go_geom//encoding/ewkb",
         "@org_golang_x_crypto//bcrypt",

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2662,6 +2662,8 @@ var builtinOidsArray = []string{
 	2699: `jsonb_path_match(target: jsonb, path: jsonpath) -> bool`,
 	2700: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb) -> bool`,
 	2701: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> bool`,
+	2702: `crdb_internal.shard_cluster_key_encode32(val: int, mask_size: int, mask_offset: int) -> int4`,
+	2703: `crdb_internal.shard_cluster_key_encode64(val: int, mask_size: int, mask_offset: int) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
Epic: none
Release note: None

Example usage for `PRIMARY KEY`:
```sql
CREATE TABLE t1 (
  monotonic_id INT8 NOT NULL,
  row_data JSONB,
  pk INT8 NOT NULL NOT VISIBLE AS (
    crdb_internal.shard_cluster_key_encode64(monotonic_id, 13, 11)
  ) VIRTUAL,
  PRIMARY KEY(pk)
);

ALTER TABLE t1 SPLIT AT
  SELECT ((9223372036854775807::bigint / 128) * (prefix - 128))::INT8 AS split_at
  FROM generate_series(1, 255) AS prefix
  WITH EXPIRATION NOW() + '1 hour'::INTERVAL;
ALTER TABLE t1 SCATTER;

INSERT INTO t1 (monotonic_id) VALUES (2047), (2048);
SELECT *, pk FROM t1;
```

Example usage for secondary `INDEX`:
```sql
CREATE TABLE t2 (
  id UUID NOT NULL DEFAULT gen_random_uuid(),
  monotonic_id INT8 NOT NULL,
  row_data JSONB,
  idx1 INT8 NOT NULL NOT VISIBLE AS (
    crdb_internal.shard_cluster_key_encode64(monotonic_id, 13, 11)
  ) VIRTUAL,
  PRIMARY KEY(id)
);
CREATE INDEX t2_monotonic_id_idx ON t2 (idx1);

ALTER INDEX t2_monotonic_id_idx SPLIT AT
  SELECT ((9223372036854775807::bigint / 128) * (prefix - 128))::INT8 AS split_at
  FROM generate_series(1, 255) AS prefix
  WITH EXPIRATION NOW() + '1 hour'::INTERVAL;
ALTER INDEX t2_monotonic_id_idx SCATTER;

INSERT INTO t2 (monotonic_id) VALUES (2047), (2048);
SELECT *, idx1 FROM t2;
```