### PR TITLE
sql/schemachanger: track column and index dependencies on triggers

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4328,3 +4328,174 @@ DELETE FROM parent146889 WHERE k = 1;
 NOTICE: 0
 
 subtest end
+
+subtest dependency_142370
+
+statement ok
+create table t1(n int primary key, j int, k int);
+
+statement ok
+create index i1 on t1(k ASC);
+
+statement ok
+create index i2 on t1(k DESC);
+
+statement ok
+create table other(n int primary key, j int, k int);
+
+statement ok
+create index i1 on other(k ASC);
+
+statement ok
+create index i2 on other(k DESC);
+
+statement ok
+CREATE FUNCTION f1 ()
+RETURNS VOID
+LANGUAGE SQL
+AS $$
+  SELECT 1
+$$;
+
+statement ok
+CREATE TYPE e AS ENUM('a');
+
+statement ok
+CREATE OR REPLACE FUNCTION audit_changes()
+                                RETURNS TRIGGER AS $$
+                                BEGIN
+                                 SELECT f1();
+                                 SELECT *, 'a'::e FROM t1@i1 WHERE j=32;
+                                 SELECT *, 'a'::e FROM t1@i2 WHERE j=32;
+                                 SELECT *, 'a'::e FROM other@i1 WHERE j=32;
+                                 SELECT *, 'a'::e FROM other@i2 WHERE j=32;
+                                 RETURN NULL;
+                                END;
+                                $$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE TRIGGER audit_trigger AFTER INSERT OR UPDATE OR DELETE ON t1 FOR EACH ROW EXECUTE FUNCTION audit_changes();
+
+statement error pq: cannot drop column "j" because trigger "audit_trigger" on table "t1" depends on it
+alter table t1 drop column j;
+
+statement error pq: cannot drop column "j" because trigger "audit_trigger" on table "t1" depends on it
+alter table other drop column j;
+
+statement error pq: cannot alter type of column "j" because trigger "audit_trigger" on table "t1" depends on it
+alter table t1 alter column j set data type text;
+
+statement error pq: cannot alter type of column "j" because trigger "audit_trigger" on table "t1" depends on it
+alter table other alter column j set data type text;
+
+# TODO(142370): This should be blocked because the trigger references the table,
+# but we currently don't detect self-dependencies.
+statement ok
+drop index t1@i1;
+
+statement error pq: cannot drop index "i1" because trigger "audit_trigger" on table "t1" depends on it
+drop index other@i1;
+
+statement error pq: unimplemented: DROP INDEX cascade is not supported with triggers
+drop index other@i1 cascade;
+
+statement error pq: cannot drop function "f1" because other objects \(\[test.public.t1\]\) still depend on it
+DROP FUNCTION f1;
+
+statement error pq: unimplemented: drop function cascade not supported
+DROP FUNCTION f1 CASCADE;
+
+statement error pq: cannot drop type "e" because other objects \(\[test.public.t1\]\) still depend on it
+DROP TYPE e;
+
+statement error pq: unimplemented: DROP TYPE CASCADE is not yet supported
+DROP TYPE e CASCADE;
+
+statement error pq: cannot drop table other because other objects depend on it
+DROP TABLE other;
+
+# Verify the trigger still works
+# TODO(142370): this fails for now because we were allowed to drop the index earlier.
+statement error pq: while building trigger expression: index "i1" not found
+INSERT INTO t1 VALUES (0,0,0);
+
+statement ok
+create index i1 on t1(k);
+
+# This test doesn't run with the legacy schema config because CREATE/DROP
+# trigger isn't implemented there. We enable legacy to run DDL to verify
+# the dependencies.
+let $use_decl_sc
+SHOW use_declarative_schema_changer
+
+statement ok
+set use_declarative_schema_changer = 'off';
+
+# Disable schema locking to ensure that errors from it do not interfere
+# with dependency checking.
+statement ok
+ALTER TABLE t1 SET (schema_locked = false);
+
+statement ok
+ALTER TABLE other SET (schema_locked = false);
+
+skipif config local-mixed-24.3
+statement error pq: ALTER COLUMN TYPE is only implemented in the declarative schema changer
+alter table t1 alter column j set data type text;
+
+statement error pq: cannot alter type of column "j" because table "t1" depends on it
+alter table other alter column j set data type text;
+
+# TODO(142370): allowed because we don't pick up self-dependencies yet
+statement ok
+alter table t1 drop column j;
+
+statement error pq: cannot drop column "j" because table "t1" depends on it
+alter table other drop column j;
+
+# TODO(142370): allowed because we don't pick up self-dependencies yet
+statement ok
+drop index t1@i1;
+
+statement error pq: index "i1" does not exist
+drop index t1@i1 CASCADE;
+
+statement error pq: cannot drop index "i1" because table "t1" depends on it
+drop index other@i1;
+
+statement error pq: cannot drop function "f1" because other objects \(\[test.public.t1\]\) still depend on it
+DROP FUNCTION f1;
+
+statement error pq: unimplemented: drop function cascade not supported
+DROP FUNCTION f1 CASCADE;
+
+statement error pq: cannot drop type "e" because other objects \(\[test.public.t1\]\) still depend on it
+DROP TYPE e;
+
+statement error pq: unimplemented: DROP TYPE CASCADE is not yet supported
+DROP TYPE e CASCADE;
+
+statement error pq: cannot drop relation "other" because table "t1" depends on it
+DROP TABLE other;
+
+statement ok
+set use_declarative_schema_changer = $use_decl_sc;
+
+# Verify the trigger still works
+# TODO(142370): this fails because we were wrongly allowed to drop index i1 earlier
+statement error pq: while building trigger expression: index "i1" not found
+INSERT INTO t1(n,k) VALUES (1,1);
+
+statement ok
+DROP TABLE other CASCADE;
+
+statement error pq: relation "t1" does not exist
+DROP TRIGGER audit_trigger ON t1;
+
+statement ok
+DROP TYPE e;
+
+statement ok
+DROP FUNCTION f1;
+
+subtest end

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.side_effects
@@ -39,7 +39,6 @@ upsert descriptor #104
   -  schemaLocked: true
   +  triggers:
   +  - actionTime: BEFORE
-  +    dependsOn: []
   +    dependsOnRoutines:
   +    - 105
   +    enabled: true
@@ -129,7 +128,6 @@ upsert descriptor #104
   -  schemaLocked: true
   +  triggers:
   +  - actionTime: BEFORE
-  +    dependsOn: []
   +    dependsOnRoutines:
   +    - 105
   +    enabled: true

--- a/pkg/sql/schemachanger/scbuild/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scbuild/testdata/create_trigger
@@ -35,7 +35,7 @@ CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f(
 - [[TriggerFunctionCall:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
   {funcArgs: [], funcBody: "DECLARE\nfoo @100106 := 'a';\nBEGIN\nINSERT INTO defaultdb.public.ab VALUES ((new).x, (new).y);\nRAISE NOTICE '% %', public.g(), nextval(108:::REGCLASS);\nRETURN new;\nEND;\n", funcId: 110, tableId: 104, triggerId: 1}
 - [[TriggerDeps:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT]
-  {tableId: 104, triggerId: 1, usesRelationIds: [105, 108], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
+  {tableId: 104, triggerId: 1, usesRelations: [{columnIds: [1, 2], id: 105}, {id: 108}], usesRoutineIds: [109, 110], usesTypeIds: [106, 107]}
 
 # TODO(#126362, #135655): uncomment this test case.
 # build

--- a/pkg/sql/schemachanger/scexec/scmutationexec/references.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/references.go
@@ -690,13 +690,18 @@ func (i *immediateVisitor) UpdateTableBackReferencesInRelations(
 		return err
 	}
 	forwardRefs := backRefTbl.GetAllReferencedTableIDs()
-	for _, relID := range op.RelationIDs {
-		referenced, err := i.checkOutTable(ctx, relID)
+	for _, ref := range op.RelationReferences {
+		referenced, err := i.checkOutTable(ctx, ref.ID)
 		if err != nil {
 			return err
 		}
 		newBackRefIsDupe := false
-		newBackRef := descpb.TableDescriptor_Reference{ID: op.TableID, ByID: referenced.IsSequence()}
+		newBackRef := descpb.TableDescriptor_Reference{
+			ID:        op.TableID,
+			IndexID:   ref.IndexID,
+			ColumnIDs: ref.ColumnIDs,
+			ByID:      referenced.IsSequence(),
+		}
 		removeBackRefs := !forwardRefs.Contains(referenced.GetID())
 		newDependedOnBy := referenced.DependedOnBy[:0]
 		for _, backRef := range referenced.DependedOnBy {

--- a/pkg/sql/schemachanger/scexec/scmutationexec/trigger.go
+++ b/pkg/sql/schemachanger/scexec/scmutationexec/trigger.go
@@ -8,6 +8,7 @@ package scmutationexec
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scop"
 	"github.com/cockroachdb/errors"
@@ -110,7 +111,11 @@ func (i *immediateVisitor) SetTriggerForwardReferences(
 	if err != nil {
 		return err
 	}
-	trigger.DependsOn = op.Deps.UsesRelationIDs
+	relationIDs := catalog.MakeDescriptorIDSet()
+	for _, ref := range op.Deps.UsesRelations {
+		relationIDs.Add(ref.ID)
+	}
+	trigger.DependsOn = relationIDs.Ordered()
 	trigger.DependsOnTypes = op.Deps.UsesTypeIDs
 	trigger.DependsOnRoutines = op.Deps.UsesRoutineIDs
 	return nil

--- a/pkg/sql/schemachanger/scop/immediate_mutation.go
+++ b/pkg/sql/schemachanger/scop/immediate_mutation.go
@@ -1013,10 +1013,14 @@ type UpdateFunctionRelationReferences struct {
 	FunctionReferences []descpb.ID
 }
 
+// UpdateTableBackReferencesInRelations updates the DependedOnBy metadata in
+// relation descriptors (e.g., tableDesc) for triggers. It handles both adding
+// and removing dependencies. The function relies on forward references being
+// set beforehand to determine whether a back-reference should be added or removed.
 type UpdateTableBackReferencesInRelations struct {
 	immediateMutationOp
-	TableID     descpb.ID
-	RelationIDs []descpb.ID
+	TableID            descpb.ID
+	RelationReferences []scpb.TriggerDeps_RelationReference
 }
 
 type SetObjectParentID struct {

--- a/pkg/sql/schemachanger/scpb/BUILD.bazel
+++ b/pkg/sql/schemachanger/scpb/BUILD.bazel
@@ -115,6 +115,7 @@ go_test(
     deps = [
         "//pkg/clusterversion",
         "//pkg/sql/catalog/catpb",
+        "//pkg/sql/sem/catid",
         "//pkg/sql/sem/idxtype",
         "@com_github_stretchr_testify//require",
     ],

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -628,11 +628,26 @@ message TriggerFunctionCall {
 }
 
 message TriggerDeps {
+  message RelationReference {
+    uint32 id = 1 [(gogoproto.customname) = "ID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+    repeated uint32 column_ids = 2 [(gogoproto.customname) = "ColumnIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.ColumnID"];
+    uint32 index_id = 3 [(gogoproto.customname) = "IndexID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.IndexID"];
+  }
+
   uint32 table_id = 1 [(gogoproto.customname) = "TableID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   uint32 trigger_id = 2 [(gogoproto.customname) = "TriggerID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.TriggerID"];
-  repeated uint32 uses_relation_ids = 3 [(gogoproto.customname) = "UsesRelationIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  // UsesRelationIDs is a deprecated field that tracks the IDs of relations
+  // used by this trigger. It remains for backward compatibility with older
+  // versions and is superseded by UsesRelations.
+  repeated uint32 uses_relation_ids = 3 [deprecated = true, (gogoproto.customname) = "UsesRelationIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  // UsesRelations specifies the relations that this trigger depends on.
+  // In addition to the relation itself, it may include optional ColumnIDs
+  // or IndexIDs to capture fine-grained dependencies.
+  repeated RelationReference uses_relations = 6 [(gogoproto.nullable) = false];
   repeated uint32 uses_type_ids = 4 [(gogoproto.customname) = "UsesTypeIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   repeated uint32 uses_routine_ids = 5 [(gogoproto.customname) = "UsesRoutineIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+
+  // NEXT VALUE: 7
 }
 
 message EnumType {

--- a/pkg/sql/schemachanger/scpb/migration.go
+++ b/pkg/sql/schemachanger/scpb/migration.go
@@ -43,6 +43,21 @@ func migrateDeprecatedFields(
 		migrated = true
 	}
 
+	// In TriggerDeps, map the deprecated UsesRelationIDs to a
+	// TriggerDeps_RelationReference.
+	if deps := target.GetTriggerDeps(); deps != nil {
+		if len(deps.UsesRelationIDs) > 0 {
+			deps.UsesRelations = make([]TriggerDeps_RelationReference, len(deps.UsesRelationIDs))
+			for i := range deps.UsesRelationIDs {
+				deps.UsesRelations[i] = TriggerDeps_RelationReference{
+					ID: deps.UsesRelationIDs[i],
+				}
+			}
+			deps.UsesRelationIDs = nil
+			migrated = true
+		}
+	}
+
 	// Migrate ComputeExpr field  to separate ColumnComputeExpression target.
 	if columnType := target.GetColumnType(); columnType != nil {
 		if columnType.ComputeExpr != nil {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -474,6 +474,7 @@ object TriggerDeps
 TriggerDeps :  TableID
 TriggerDeps :  TriggerID
 TriggerDeps : []UsesRelationIDs
+TriggerDeps : []UsesRelations
 TriggerDeps : []UsesTypeIDs
 TriggerDeps : []UsesRoutineIDs
 

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_trigger_deps.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_trigger_deps.go
@@ -17,19 +17,19 @@ func init() {
 			scpb.Status_ABSENT,
 			to(scpb.Status_PUBLIC,
 				emit(func(this *scpb.TriggerDeps) *scop.SetTriggerForwardReferences {
-					if len(this.UsesRelationIDs) == 0 && len(this.UsesTypeIDs) == 0 &&
+					if len(this.UsesRelations) == 0 && len(this.UsesTypeIDs) == 0 &&
 						len(this.UsesRoutineIDs) == 0 {
 						return nil
 					}
 					return &scop.SetTriggerForwardReferences{Deps: *protoutil.Clone(this).(*scpb.TriggerDeps)}
 				}),
 				emit(func(this *scpb.TriggerDeps) *scop.UpdateTableBackReferencesInRelations {
-					if len(this.UsesRelationIDs) == 0 {
+					if len(this.UsesRelations) == 0 {
 						return nil
 					}
 					return &scop.UpdateTableBackReferencesInRelations{
-						TableID:     this.TableID,
-						RelationIDs: this.UsesRelationIDs,
+						TableID:            this.TableID,
+						RelationReferences: this.UsesRelations,
 					}
 				}),
 				emit(func(this *scpb.TriggerDeps) *scop.UpdateTableBackReferencesInTypes {
@@ -57,12 +57,12 @@ func init() {
 			scpb.Status_PUBLIC,
 			to(scpb.Status_ABSENT,
 				emit(func(this *scpb.TriggerDeps) *scop.UpdateTableBackReferencesInRelations {
-					if len(this.UsesRelationIDs) == 0 {
+					if len(this.UsesRelations) == 0 {
 						return nil
 					}
 					return &scop.UpdateTableBackReferencesInRelations{
-						TableID:     this.TableID,
-						RelationIDs: this.UsesRelationIDs,
+						TableID:            this.TableID,
+						RelationReferences: this.UsesRelations,
 					}
 				}),
 				emit(func(this *scpb.TriggerDeps) *scop.UpdateTableBackReferencesInTypes {

--- a/pkg/sql/schemachanger/scplan/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scplan/testdata/create_trigger
@@ -67,7 +67,7 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
       Deps:
         TableID: 104
         TriggerID: 1
-        UsesRelationIDs: []
+        UsesRelations: []
         UsesRoutineIDs:
         - 105
     *scop.AddTriggerBackReferencesInRoutines
@@ -143,7 +143,7 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
       Deps:
         TableID: 104
         TriggerID: 1
-        UsesRelationIDs: []
+        UsesRelations: []
         UsesRoutineIDs:
         - 105
     *scop.AddTriggerBackReferencesInRoutines


### PR DESCRIPTION
Enhance the schema changer to record dependencies between triggers and the columns or indexes they reference. Previously, these dependencies were not tracked, allowing operations such as dropping a column or index used by a trigger to proceed without error.

The TriggerDeps descriptor element, which previously tracked dependencies as simple table references, now records column and index IDs per table. A new field, `UsesRelations`, captures these finer-grained dependencies and replaces the now-deprecated `UsesRelationIDs`.

To reduce the scope of this change, dependency tracking is currently omitted for triggers that reference their own table. This limitation will be addressed in a future update. I figured this was fine so it's no worse than what we have now.

Informs: #142370

Epic: none
Release note (bug fix): Prevent dropping columns or indexes that are still referenced by triggers. Previously, these operations could succeed silently, potentially breaking trigger functionality. 