### PR TITLE
release-25.2: sql: fix vectorized COPY planning

### DIFF
--- a/pkg/sql/opt/optbuilder/insert.go
+++ b/pkg/sql/opt/optbuilder/insert.go
@@ -298,7 +298,7 @@ func (b *Builder) buildInsert(ins *tree.Insert, inScope *scope) (outScope *scope
 		if ins.OnConflict != nil {
 			panic(errors.AssertionFailedf("vectorized insert with on conflict is not supported"))
 		}
-		if ins.Returning != nil {
+		if ins.Returning != tree.AbsentReturningClause {
 			panic(errors.AssertionFailedf("vectorized insert with returning is not supported"))
 		}
 	}

--- a/pkg/sql/sem/tree/insert.go
+++ b/pkg/sql/sem/tree/insert.go
@@ -90,7 +90,7 @@ func (node *Insert) VectorInsert() bool {
 	if !ok {
 		return false
 	}
-	_, vectorRows := literalValues.Rows.(VectorRows)
+	_, vectorRows := literalValues.Rows.(*VectorRows)
 	return vectorRows
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #146696 on behalf of @yuzefovich.

----

This commit fixes a bug that was added in e2bbd6c7e40ce5bb5debdb0b40220009fb4bad88 which made it so that the vectorized fast-path for COPY was no longer planned. The bug is pretty simple, but we were missing test coverage to ensure that the vectorized fast-path is taken. It's not exactly easy to observe because COPY uses a separate code path (i.e. regular things like EXPLAIN and DistSQL diagrams aren't available), so this commit adds a regression test by examining the trace searching for the log message that only the vectorInserter emits.

Fixes: #146690.

Release note (bug fix): CockroachDB would previously not use the vectorized fast-path for COPY when it's supported. The bug is only present in previous 25.2 releases and is now fixed.

----

Release justification: bug fix.