### PR TITLE
sql: enable BufferedWrites in a TestTxnAutoRetry and TestAbortedTxnOnlyRetriedOnce

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -33,7 +33,7 @@ var BufferedWritesEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.enabled",
 	"if enabled, transactional writes are buffered on the client",
-	metamorphic.ConstantWithTestBool("kv.transactional.write_buffering.enabled", false /* defaultValue */),
+	metamorphic.ConstantWithTestBool("kv.transaction.write_buffering.enabled", false /* defaultValue */),
 	settings.WithPublic,
 )
 

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/tests"
@@ -111,45 +112,59 @@ type injectionApproaches []injectionApproach
 func (ia injectionApproaches) Len() int      { return len(ia) }
 func (ia injectionApproaches) Swap(i, j int) { ia[i], ia[j] = ia[j], ia[i] }
 
-func injectErrors(req kvpb.Request, hdr kvpb.Header, magicVals *filterVals, verifyTxn bool) error {
+func injectErrors(
+	st *cluster.Settings, req kvpb.Request, hdr kvpb.Header, magicVals *filterVals, verifyTxn bool,
+) error {
 	magicVals.Lock()
 	defer magicVals.Unlock()
 
-	switch req := req.(type) {
+	var rawBytes []byte
+	switch r := req.(type) {
 	case *kvpb.ConditionalPutRequest:
-		// Create a list of each injection approach and shuffle the order of
-		// injection for some additional randomness.
-		injections := injectionApproaches{
-			{counts: magicVals.restartCounts, errFn: func() error {
-				// Note we use a retry error that cannot be automatically retried
-				// by the transaction coord sender.
-				return kvpb.NewTransactionRetryError(kvpb.RETRY_REASON_UNKNOWN, "injected err")
-			}},
-			{counts: magicVals.abortCounts, errFn: func() error {
-				return kvpb.NewTransactionAbortedError(kvpb.ABORT_REASON_ABORTED_RECORD_FOUND)
-			}},
+		rawBytes = r.Value.RawBytes
+	case *kvpb.PutRequest:
+		// Buffered writes might decompose our INSERT into a locking Get and a Put.
+		// Note that we can't look _only_ for a Put because some transactions that
+		// result in a single batch aren't buffered.
+		if kvcoord.BufferedWritesEnabled.Get(&st.SV) {
+			rawBytes = r.Value.RawBytes
+		} else {
+			return nil
 		}
-		shuffle.Shuffle(injections)
-
-		for _, injection := range injections {
-			for key, count := range injection.counts {
-				if verifyTxn {
-					if err := checkCorrectTxn(string(req.Value.RawBytes), magicVals, hdr.Txn); err != nil {
-						return err
-					}
-				}
-				if count > 0 && bytes.Contains(req.Value.RawBytes, []byte(key)) {
-					injection.counts[key]--
-					err := injection.errFn()
-					magicVals.failedValues[string(req.Value.RawBytes)] = failureRecord{err, hdr.Txn}
-					return err
-				}
-			}
-		}
-		return nil
 	default:
 		return nil
 	}
+
+	// Create a list of each injection approach and shuffle the order of
+	// injection for some additional randomness.
+	injections := injectionApproaches{
+		{counts: magicVals.restartCounts, errFn: func() error {
+			// Note we use a retry error that cannot be automatically retried
+			// by the transaction coord sender.
+			return kvpb.NewTransactionRetryError(kvpb.RETRY_REASON_UNKNOWN, "injected err")
+		}},
+		{counts: magicVals.abortCounts, errFn: func() error {
+			return kvpb.NewTransactionAbortedError(kvpb.ABORT_REASON_ABORTED_RECORD_FOUND)
+		}},
+	}
+	shuffle.Shuffle(injections)
+
+	for _, injection := range injections {
+		for key, count := range injection.counts {
+			if verifyTxn {
+				if err := checkCorrectTxn(string(rawBytes), magicVals, hdr.Txn); err != nil {
+					return err
+				}
+			}
+			if count > 0 && bytes.Contains(rawBytes, []byte(key)) {
+				injection.counts[key]--
+				err := injection.errFn()
+				magicVals.failedValues[string(rawBytes)] = failureRecord{err, hdr.Txn}
+				return err
+			}
+		}
+	}
+	return nil
 }
 
 // checkRestart checks that there are no errors left to inject.
@@ -180,7 +195,7 @@ func checkRestarts(t *testing.T, magicVals *filterVals) {
 // The TxnAborter needs to be hooked up to a Server's
 // Knobs.StatementFilter, so that the Aborter sees what statements are being
 // executed. This is done by calling HookupToExecutor(), which returns a
-// stuitable ExecutorTestingKnobs.
+// suitable ExecutorTestingKnobs.
 // A statement can be registered for abortion (meaning, the statement's
 // transaction will be TransactionAborted) with QueueStmtForAbortion(). When the
 // Aborter sees that statement, it will run a higher priority transaction that
@@ -244,7 +259,7 @@ type TxnAborter struct {
 }
 
 type restartInfo struct {
-	// The numberic value being inserted in col 'k'.
+	// The numeric value being inserted in col 'k'.
 	key int
 	// The remaining number of times to abort the txn.
 	abortCount     int
@@ -456,9 +471,6 @@ func TestTxnAutoRetry(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	s := srv.ApplicationLayer()
 
-	// TODO(#146238): either remove this or leave a comment for why it's ok.
-	kvcoord.BufferedWritesEnabled.Override(ctx, &s.ClusterSettings().SV, false)
-
 	{
 		pgURL, cleanup := s.PGUrl(t,
 			serverutils.CertsDirPrefix("TestTxnAutoRetry"), serverutils.User(username.RootUser))
@@ -497,7 +509,7 @@ func TestTxnAutoRetry(t *testing.T) {
 	}
 	cleanupFilter := cmdFilters.AppendFilter(
 		func(args kvserverbase.FilterArgs) *kvpb.Error {
-			if err := injectErrors(args.Req, args.Hdr, magicVals, true /* verifyTxn */); err != nil {
+			if err := injectErrors(s.ClusterSettings(), args.Req, args.Hdr, magicVals, true /* verifyTxn */); err != nil {
 				return kvpb.NewErrorWithTxn(err, args.Hdr.Txn)
 			}
 			return nil
@@ -539,7 +551,7 @@ func TestTxnAutoRetry(t *testing.T) {
 	// TODO(knz): This test can be made more robust by exposing the
 	// current allocation count in monitor and checking that it has the
 	// same value at the beginning of each retry.
-	rows, err := sqlDB.Query(`
+	query := `
 BEGIN;
 INSERT INTO t.public.test(k, v, t) VALUES (1, 'boulanger', cluster_logical_timestamp()) RETURNING 1;
 END;
@@ -553,7 +565,19 @@ END;
 BEGIN;
 INSERT INTO t.public.test(k, v, t) VALUES (5, 'josephine', cluster_logical_timestamp()) RETURNING 1;
 INSERT INTO t.public.test(k, v, t) VALUES (6, 'laureal', cluster_logical_timestamp()) RETURNING 1;
-`)
+`
+	// Buffered writes will not encounter the injected errors until a commit is
+	// issued in the final transaction. For this test we face a small trade-off.
+	// We could, with some work, arrange to inject the error during a locking Get
+	// on the given key at the expense of observing the error at a point where we
+	// typically wouldn't. Here, we issue a DeleteRange to force a mid-txn flush
+	// of the buffer so we are still testing that we get the retry behavior even
+	// if we encounter the error before COMMIT.
+	if kvcoord.BufferedWritesEnabled.Get(&s.ClusterSettings().SV) {
+		query += "\nDELETE FROM t.public.test WHERE k > 100"
+	}
+
+	rows, err := sqlDB.Query(query)
 	if err != nil {
 		t.Fatal(err)
 	}
@@ -601,7 +625,7 @@ INSERT INTO t.public.test(k, v, t) VALUES (6, 'laureal', cluster_logical_timesta
 	}
 	cleanupFilter = cmdFilters.AppendFilter(
 		func(args kvserverbase.FilterArgs) *kvpb.Error {
-			if err := injectErrors(args.Req, args.Hdr, magicVals, true /* verifyTxn */); err != nil {
+			if err := injectErrors(s.ClusterSettings(), args.Req, args.Hdr, magicVals, true /* verifyTxn */); err != nil {
 				return kvpb.NewErrorWithTxn(err, args.Hdr.Txn)
 			}
 			return nil
@@ -641,9 +665,6 @@ func TestAbortedTxnOnlyRetriedOnce(t *testing.T) {
 	defer srv.Stopper().Stop(context.Background())
 	s := srv.ApplicationLayer()
 
-	// TODO(#146238): either remove this or leave a comment for why it's ok.
-	kvcoord.BufferedWritesEnabled.Override(ctx, &s.ClusterSettings().SV, false)
-
 	{
 		pgURL, cleanup := s.PGUrl(t,
 			serverutils.CertsDirPrefix("TestAbortedTxnOnlyRetriedOnce"), serverutils.User(username.RootUser))
@@ -675,8 +696,47 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 	if !ok {
 		t.Fatalf("aborter has no state on %q", insertStmt)
 	}
-	if execCount != 2 {
-		t.Fatalf("expected %q to be executed 2 times, but got %d", insertStmt, execCount)
+
+	expectedExecCount := 2
+	if kvcoord.BufferedWritesEnabled.Get(&s.ClusterSettings().SV) {
+		// In some sense, setting expected count to 3 here defeats the purpose of
+		// the test. To justify this, here is an explanation of why we get the extra
+		// retry:
+		//
+		// This test attempts to abort this statement by running a high priority
+		// DELETE:
+		//
+		//      BEGIN;
+		//    	SET TRANSACTION PRIORITY HIGH
+		//      DELETE FROM t.test WHERE k = $1
+		//      COMMIT;
+		//
+		// via a StatementFilter that executes after the INSERT has been evaluated.
+		//
+		// What makes this work in the non-buffered-writes case is that the test
+		// also sets the DisableAutoCommitDuringExec testing knob. As a result, the
+		// INSERT generates an intent write, the DELETE encounters the write and
+		// PushTxn(PUSH_ABORT)s the INSERT transaction. Then, the conn executor
+		// attempts to commit the INSERT and finds the record of the abort.
+		//
+		// But, buffered writes essentially "undoes" the DisableAutoCommitDuringExec
+		// flag by buffering the original write from the INSERT. When the conn
+		// executor finally sends an EndTxn, we first encounter the DELETE's write
+		// and get a WriteTooOld error. This WriteTooOld error results in the first
+		// retry. When the first retry attempts to commit, it encounters the abort
+		// span, generating the second retry.
+		//
+		// One question I'm unclear on is whether re-using the same transaction
+		// after the WriteTooOld error is the best strategy in practice.
+		//
+		// We could disable write buffering when DisableAutoCommitDuringExec is set
+		// or disable this test under buffered writes, but I've opted to keep the
+		// test enabled so we get some signal in case this situation changes.
+		expectedExecCount = 3
+	}
+
+	if execCount != expectedExecCount {
+		t.Fatalf("expected %q to be executed %d times, but got %d", insertStmt, expectedExecCount, execCount)
 	}
 }
 
@@ -823,7 +883,7 @@ CREATE TABLE t.test (k INT PRIMARY KEY, v TEXT);
 				}
 				cleanupFilter := cmdFilters.AppendFilter(
 					func(args kvserverbase.FilterArgs) *kvpb.Error {
-						if err := injectErrors(args.Req, args.Hdr, tc.magicVals, true /* verifyTxn */); err != nil {
+						if err := injectErrors(s.ClusterSettings(), args.Req, args.Hdr, tc.magicVals, true /* verifyTxn */); err != nil {
 							return kvpb.NewErrorWithTxn(err, args.Hdr.Txn)
 						}
 						return nil


### PR DESCRIPTION
Tests related to transaction retries often depend on intercepting and modifying specific KV requests generated by SQL transactions. Since buffered writes transforms requests and in general changes the timeline of transactions, it invalidates the tests assumptions. We are currently auditing tests where we've disabled buffered writes to ensure we haven't ignored an actual problem.

Here, I enable buffered writes in two tests and explain why some assertions need to change when buffered writes are enabled.

Informs #146238

Release note: None