### PR TITLE
sql/tests/rsg: cancel context when a query takes too long

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -201,6 +201,10 @@ func (db *verifyFormatDB) execWithResettableTimeout(
 
 	defer db.Incr(sql)()
 
+	var cancel context.CancelCauseFunc
+	ctx, cancel = context.WithCancelCause(ctx)
+	defer cancel(nil)
+
 	funcdone := make(chan error, 1)
 	go func() {
 		_, err := db.db.ExecContext(ctx, sql)
@@ -264,7 +268,8 @@ func (db *verifyFormatDB) execWithResettableTimeout(
 						// 2 minute wait and miss potential hangs (if the test times out first).
 						// Whereas this approach will wait 2 minutes after the completion of
 						// (1), only waiting an extra second more.
-						targetDuration = duration - db.mu.lastCompletedStmt.Add(duration).Sub(timeutil.Now())
+						remainingDurationSinceLastStmt := db.mu.lastCompletedStmt.Add(duration).Sub(timeutil.Now())
+						targetDuration = duration - remainingDurationSinceLastStmt
 						// Avoid having super tight spins, wait at least a second.
 						if targetDuration <= time.Second {
 							targetDuration = time.Second
@@ -273,6 +278,13 @@ func (db *verifyFormatDB) execWithResettableTimeout(
 						maxResets -= 1
 						return nil
 					}
+				}
+				cancel(errors.Newf("cancelling query after %v", duration))
+				select {
+				case <-funcdone:
+					return nil
+				case <-time.After(5 * time.Second):
+					t.Logf("didn't respect context cancellation within 5 seconds: %s", sql)
 				}
 				b := allstacks.GetWithBuf(make([]byte, 1024*1024))
 				t.Logf("%s\n", b)


### PR DESCRIPTION
This patch ensures that the test cancels a long running query when it takes too long, rather than just letting it continue running. This should help avoid hanging goroutines in CRDB when the test fails.

informs https://github.com/cockroachdb/cockroach/issues/146495
Release note: None