### PR TITLE
kvclient,kvcoord: update some issue references

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_span_refresher.go
@@ -329,7 +329,7 @@ func (sr *txnSpanRefresher) maybeRefreshAndRetrySend(
 	// Try refreshing the txn spans so we can retry.
 	if refreshErr := sr.tryRefreshTxnSpans(ctx, refreshFrom, refreshToTxn); refreshErr != nil {
 		log.Eventf(ctx, "refresh failed; propagating original retry error")
-		// TODO(lidor): we should add refreshErr info to the returned error. See issue #41057.
+		// TODO(#146734): We should add refreshErr info to the returned error.
 		return nil, pErr
 	}
 

--- a/pkg/sql/sqlstats/insights/integration/insights_test.go
+++ b/pkg/sql/sqlstats/insights/integration/insights_test.go
@@ -516,11 +516,20 @@ func TestTransactionInsightsFailOnCommit(t *testing.T) {
 
 	connDefault.Exec(t, "SET CLUSTER SETTING sql.contention.event_store.resolution_interval = '100ms'")
 	// Disable write buffering since this test assumes that
-	// kvpb.TransactionRetryWithProtoRefreshError.ConflictingTxn is populated
-	// which is only the case for some retry reasons (like REASON_INTENT during
-	// a refresh) that doesn't happen with write buffering.
-	// TODO(#146238): confirm whether this behavior is expected, and perhaps
-	// adjust the test to be agnostic to buffered writes.
+	// kvpb.TransactionRetryWithProtoRefreshError.ConflictingTxn
+	// is populated which is only the case for some retry reasons
+	// (like REASON_INTENT during a refresh) that doesn't happen
+	// with write buffering.
+	//
+	// Write buffering produces a different error than the
+	// non-buffered case because of #146732.
+	//
+	// Despite #146732, however, we should be able to annotate the
+	// error received in this test with conflicting txn
+	// information.
+	//
+	// TODO(#146732, #146734): Allow write buffering in this test
+	// once one of the two bugs are fixed.
 	connDefault.Exec(t, "SET CLUSTER SETTING kv.transaction.write_buffering.enabled = false")
 
 	// Set up myUsers table with 2 users.


### PR DESCRIPTION
I've made more specific bugs to cover why
TestTransactionInsightsFailOnCommit currently has buffered writes disabled.

Informs #146238

Release note: None