### PR TITLE
release-25.2: sql/tests: exclude crdb_internal.fingerprint from RSG tests

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -414,7 +414,8 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					"crdb_internal.request_statement_bundle",
 					"crdb_internal.reset_activity_tables",
 					"crdb_internal.revalidate_unique_constraints_in_all_tables",
-					"crdb_internal.validate_ttl_scheduled_jobs":
+					"crdb_internal.validate_ttl_scheduled_jobs",
+					"crdb_internal.fingerprint":
 					// Skipped due to long execution time.
 					continue
 				}


### PR DESCRIPTION
Backport 1/1 commits from #146668 on behalf of @rafiss.

----

This is an internal function that can take a long time to execute if a large timestamp is provided. There isn't much value in testing it here.

fixes https://github.com/cockroachdb/cockroach/issues/146424
fixes https://github.com/cockroachdb/cockroach/issues/146421
fixes https://github.com/cockroachdb/cockroach/issues/146495
Release note: None

----

Release justification: test only change