### PR TITLE
sql: make privilege operations thread-safe

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -284,7 +284,7 @@ func (p *planner) CheckPrivilege(
 // options are inherited from parent roles.
 func (p *planner) MustCheckGrantOptionsForUser(
 	ctx context.Context,
-	privs *catpb.PrivilegeDescriptor,
+	privs *catpb.LockedPrivilegeDescriptor,
 	privilegeObject privilege.Object,
 	privList privilege.List,
 	user username.SQLUsername,
@@ -317,7 +317,7 @@ func (p *planner) MustCheckGrantOptionsForUser(
 // user has the priviliges in question.
 func (p *planner) CheckGrantOptionsForUser(
 	ctx context.Context,
-	privs *catpb.PrivilegeDescriptor,
+	privs *catpb.LockedPrivilegeDescriptor,
 	privilegeObject privilege.Object,
 	privList privilege.List,
 	user username.SQLUsername,

--- a/pkg/sql/cacheutil/cache.go
+++ b/pkg/sql/cacheutil/cache.go
@@ -68,8 +68,8 @@ func (c *Cache[K, V]) LoadValueOutsideOfCacheSingleFlight(
 	if res.Err != nil {
 		return nil, res.Err
 	}
-	val := res.Val.(*V)
-	return val, nil
+	val := res.Val.(V)
+	return &val, nil
 }
 
 // MaybeWriteBackToCache tries to put the key, value into the

--- a/pkg/sql/catalog/catpb/BUILD.bazel
+++ b/pkg/sql/catalog/catpb/BUILD.bazel
@@ -52,6 +52,7 @@ go_library(
         "//pkg/sql/privilege",
         "//pkg/sql/sem/catconstants",
         "//pkg/sql/sem/catid",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
     ],
 )

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6663,10 +6663,13 @@ func makeClusterDatabasePrivilegesFromDescriptor(
 		for _, u := range privs {
 			userNameStr := tree.NewDString(u.User.Normalized())
 			for _, priv := range u.Privileges {
+				lockedPrivDesc := &catpb.LockedPrivilegeDescriptor{
+					PrivilegeDescriptor: *db.GetPrivileges(),
+				}
 				// We use this function to check for the grant option so that the
 				// object owner also gets is_grantable=true.
 				isGrantable, err := p.CheckGrantOptionsForUser(
-					ctx, db.GetPrivileges(), db, []privilege.Kind{priv.Kind}, u.User,
+					ctx, lockedPrivDesc, db, []privilege.Kind{priv.Kind}, u.User,
 				)
 				if err != nil {
 					return err

--- a/pkg/sql/grant_revoke.go
+++ b/pkg/sql/grant_revoke.go
@@ -267,8 +267,11 @@ func (n *changeDescriptorBackedPrivilegesNode) startExec(params runParams) error
 					}
 				}
 			}
+			lockedDescriptor := &catpb.LockedPrivilegeDescriptor{
+				PrivilegeDescriptor: *descriptor.GetPrivileges(),
+			}
 
-			err := p.MustCheckGrantOptionsForUser(ctx, descriptor.GetPrivileges(), descriptor, n.desiredprivs, p.User(), n.isGrant)
+			err := p.MustCheckGrantOptionsForUser(ctx, lockedDescriptor, descriptor, n.desiredprivs, p.User(), n.isGrant)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/dbdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
@@ -135,8 +136,11 @@ func (p *planner) HasAnyPrivilegeForSpecifier(
 		}
 
 		if priv.GrantOption {
+			lockedDesc := &catpb.LockedPrivilegeDescriptor{
+				PrivilegeDescriptor: *desc.GetPrivileges(),
+			}
 			isGrantable, err := p.CheckGrantOptionsForUser(
-				ctx, desc.GetPrivileges(), desc, []privilege.Kind{priv.Kind}, user,
+				ctx, lockedDesc, desc, []privilege.Kind{priv.Kind}, user,
 			)
 			if err != nil {
 				return eval.HasNoPrivilege, err

--- a/pkg/sql/syntheticprivilegecache/accumulator.go
+++ b/pkg/sql/syntheticprivilegecache/accumulator.go
@@ -83,6 +83,8 @@ func (s *accumulator) addRow(path, user tree.DString, privArr, grantOptionArr *t
 }
 
 // finish returns the privilege descriptor.
-func (s *accumulator) finish() *catpb.PrivilegeDescriptor {
-	return s.desc
+func (s *accumulator) finish() *catpb.LockedPrivilegeDescriptor {
+	return &catpb.LockedPrivilegeDescriptor{
+		PrivilegeDescriptor: *s.desc,
+	}
 }


### PR DESCRIPTION
Added proper locking to `privilege.go` to fix data race condition.
This required adding the interface `PrivilegeDescriptorInterface`
and the struct `LockedPrivilegeDescriptor` which is similar to the
original `PrivilegeDescriptor` struct except that it has a RWMutex.

```
New Locking Mechanism:

grant -> WriteLock

checkPrivilege -> ReadOnlyLock
```

Fixes: #142992
Epic: CRDB-49398
Release note: none