### PR TITLE
release-25.1: sql/schemchanger: skip ghost secondary indexes during alter pk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4507,3 +4507,52 @@ statement ok
 DROP TYPE e1;
 
 subtest end
+
+subtest set_logged
+
+statement ok
+CREATE TABLE t_set_logged (a INT PRIMARY KEY);
+
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE t_set_logged SET LOGGED;
+----
+NOTICE: SET LOGGED is not supported and has no effect
+
+skipif config weak-iso-level-configs
+query T noticetrace
+ALTER TABLE t_set_logged SET UNLOGGED;
+----
+NOTICE: SET UNLOGGED is not supported and has no effect
+
+subtest end
+
+# Validate that a unique index creation and alter primary key do not
+# not break as seen in #128420
+subtest add_unique_and_alter_primary_key
+
+statement ok
+CREATE TABLE t_128420 (i int not null);
+
+# Not supported in mixed version configurations
+skipif config local-legacy-schema-changer
+skipif config local-mixed-24.3
+skipif config local-mixed-25.1
+statement ok
+ALTER TABLE t_128420 ADD COLUMN box BOX2D NULL UNIQUE, ALTER PRIMARY KEY USING COLUMNS (i) USING HASH;
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-24.3
+skipif config local-mixed-25.1
+query TT
+show create table t_128420
+----
+t_128420  CREATE TABLE public.t_128420 (
+            i INT8 NOT NULL,
+            box BOX2D NULL,
+            crdb_internal_i_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(i))), 16:::INT8)) VIRTUAL,
+            CONSTRAINT t_128420_pkey PRIMARY KEY (i ASC) USING HASH WITH (bucket_count=16),
+            UNIQUE INDEX t_128420_box_key (box ASC)
+          );
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_alter_primary_key.go
@@ -765,7 +765,7 @@ func maybeAddUniqueIndexForOldPrimaryKey(
 	rowidToDrop *scpb.Column,
 ) {
 	if !shouldCreateUniqueIndexOnOldPrimaryKeyColumns(
-		b, tbl, oldPrimaryIndex.IndexID, newPrimaryIndex.IndexID, rowidToDrop,
+		b, t.n, tbl, oldPrimaryIndex.IndexID, newPrimaryIndex.IndexID, rowidToDrop,
 	) {
 		return
 	}
@@ -897,6 +897,7 @@ func addIndexNameForNewUniqueSecondaryIndex(b BuildCtx, tbl *scpb.Table, indexID
 //   - There is no existing secondary index on the old primary key columns.
 func shouldCreateUniqueIndexOnOldPrimaryKeyColumns(
 	b BuildCtx,
+	n tree.NodeFormatter,
 	tbl *scpb.Table,
 	oldPrimaryIndexID, newPrimaryIndexID catid.IndexID,
 	rowidToDrop *scpb.Column,
@@ -951,7 +952,18 @@ func shouldCreateUniqueIndexOnOldPrimaryKeyColumns(
 	alreadyHasSecondaryIndexOnPKColumns := func(
 		b BuildCtx, tableID catid.DescID, oldPrimaryIndexID catid.IndexID,
 	) (found bool) {
-		scpb.ForEachSecondaryIndex(b.QueryByID(tableID), func(
+		// In 25.2 we added the rule "primary index with new columns should validated
+		// before secondary indexes" and "secondary indexes should be in a validated
+		// state before primary indexes can go public" in dep_add_index.go, which
+		// allow us to properly handle more complex cases with ADD COLUMN UNIQUE and
+		// ALTER PRIMARY KEY IN the same transaction. (Otherwise, secondary indexes
+		// can be made public too early). Without this rule versions before 25.2 will fail
+		// during runtime trying to create the new secondary index.
+		if !b.ClusterSettings().Version.IsActive(b, clusterversion.V25_2) &&
+			!b.QueryByID(tableID).Filter(ghostElementFilter).FilterSecondaryIndex().IsEmpty() {
+			panic(scerrors.NotImplementedErrorf(n, "ghost secondary index elements found"))
+		}
+		scpb.ForEachSecondaryIndex(b.QueryByID(tableID).Filter(notFilter(ghostElementFilter)), func(
 			current scpb.Status, target scpb.TargetStatus, candidate *scpb.SecondaryIndex,
 		) {
 			if !mustRetrieveIndexElement(b, tableID, candidate.IndexID).IsUnique {


### PR DESCRIPTION
Backport 1/1 commits from #146567.

/cc @cockroachdb/release

---

Previously, if a transaction added a new unique column and altered the primary key at the same time, the schema changer would incorrectly compare a newly added unique index with the *previous* primary key index. This was problematic because an `ALTER PRIMARY KEY` operation drops and recreates the primary key index.  Consequently, the newly added unique index would become a "ghost" index (created and dropped within the same transaction) by the time the comparison happened. This would lead to a failure as none of the key columns on the secondary index would be visible.

This patch modifies the index matching logic to detect and skip these ghost secondary indexes, preventing the erroneous comparison and the subsequent failure.

Fixes: #128420
Release note (bug fix): Addressed an internal error that can be hit when ADD COLUMN UNIQUE and ALTER PRIMARY KEY are executed within the same txn.
