### PR TITLE
release-25.2: sql/schemchanger: skip ghost secondary indexes during alter pk

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -4563,3 +4563,33 @@ statement ok
 DROP TYPE e1;
 
 subtest end
+
+# Validate that a unique index creation and alter primary key do not
+# not break as seen in #128420
+subtest add_unique_and_alter_primary_key
+
+statement ok
+CREATE TABLE t_128420 (i int not null);
+
+# Not supported in mixed version configurations
+skipif config local-legacy-schema-changer
+skipif config local-mixed-24.3
+skipif config local-mixed-25.1
+statement ok
+ALTER TABLE t_128420 ADD COLUMN box BOX2D NULL UNIQUE, ALTER PRIMARY KEY USING COLUMNS (i) USING HASH;
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-24.3
+skipif config local-mixed-25.1
+query TT
+show create table t_128420
+----
+t_128420  CREATE TABLE public.t_128420 (
+            i INT8 NOT NULL,
+            box BOX2D NULL,
+            crdb_internal_i_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(i))), 16:::INT8)) VIRTUAL,
+            CONSTRAINT t_128420_pkey PRIMARY KEY (i ASC) USING HASH WITH (bucket_count=16),
+            UNIQUE INDEX t_128420_box_key (box ASC)
+          )
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #146567.

/cc @cockroachdb/release

---

Previously, if a transaction added a new unique column and altered the primary key at the same time, the schema changer would incorrectly compare a newly added unique index with the *previous* primary key index. This was problematic because an `ALTER PRIMARY KEY` operation drops and recreates the primary key index.  Consequently, the newly added unique index would become a "ghost" index (created and dropped within the same transaction) by the time the comparison happened. This would lead to a failure as none of the key columns on the secondary index would be visible.

This patch modifies the index matching logic to detect and skip these ghost secondary indexes, preventing the erroneous comparison and the subsequent failure.

Fixes: #128420
Release note (bug fix): Addressed an internal error that can be hit when ADD COLUMN UNIQUE and ALTER PRIMARY KEY are executed within the same txn.

Release justification: low risk fix for a problem that can lead to an internal error during schema changes