### PR TITLE
release-25.2: fix zone config related bugs inside ALTER TABLE

### DIFF
--- a/pkg/ccl/schemachangerccl/ccl_generated_test.go
+++ b/pkg/ccl/schemachangerccl/ccl_generated_test.go
@@ -15,6 +15,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 )
 
+func TestBackupRollbacks_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupRollbacks_ccl_add_column_regional_by_row(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -132,6 +139,13 @@ func TestBackupRollbacks_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.BackupRollbacks(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestBackupRollbacksMixedVersion_ccl_add_column_regional_by_row(t *testing.T) {
@@ -253,6 +267,13 @@ func TestBackupRollbacksMixedVersion_ccl_drop_trigger(t *testing.T) {
 	sctest.BackupRollbacksMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestBackupSuccess_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestBackupSuccess_ccl_add_column_regional_by_row(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -370,6 +391,13 @@ func TestBackupSuccess_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.BackupSuccess(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestBackupSuccessMixedVersion_ccl_add_column_regional_by_row(t *testing.T) {
@@ -491,6 +519,13 @@ func TestBackupSuccessMixedVersion_ccl_drop_trigger(t *testing.T) {
 	sctest.BackupSuccessMixedVersion(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_ccl_add_column_regional_by_row(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -608,6 +643,13 @@ func TestEndToEndSideEffects_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.EndToEndSideEffects(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestExecuteWithDMLInjection_ccl_add_column_regional_by_row(t *testing.T) {
@@ -729,6 +771,13 @@ func TestExecuteWithDMLInjection_ccl_drop_trigger(t *testing.T) {
 	sctest.ExecuteWithDMLInjection(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_ccl_add_column_regional_by_row(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -846,6 +895,13 @@ func TestGenerateSchemaChangeCorpus_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.GenerateSchemaChangeCorpus(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestPause_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestPause_ccl_add_column_regional_by_row(t *testing.T) {
@@ -967,6 +1023,13 @@ func TestPause_ccl_drop_trigger(t *testing.T) {
 	sctest.Pause(t, path, MultiRegionTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_ccl_add_column_regional_by_row(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1084,6 +1147,13 @@ func TestPauseMixedVersion_ccl_drop_trigger(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger"
 	sctest.PauseMixedVersion(t, path, MultiRegionTestClusterFactory{})
+}
+
+func TestRollback_ccl_add_column_multiple_regional_by_row(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row"
+	sctest.Rollback(t, path, MultiRegionTestClusterFactory{})
 }
 
 func TestRollback_ccl_add_column_regional_by_row(t *testing.T) {

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.definition
@@ -2,7 +2,8 @@ setup
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
   k INT PRIMARY KEY,
-  V STRING
+  V STRING,
+  m INT
 ) LOCALITY REGIONAL BY ROW;
 ----
 
@@ -37,5 +38,5 @@ SELECT crdb_internal.validate_multi_region_zone_configs()
 # This will require zone configuration changes to be stacked between indexes.
 #,
 test
-ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE
 ----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.definition
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.definition
@@ -1,0 +1,41 @@
+setup
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+----
+
+# Disabled because of #146360 concurrent inserts broken on RBR tables
+# with ADD COLUMN UNIQUE
+#stage-exec phase=PostCommitPhase stage=:
+#USE multiregion_db;
+#INSERT INTO table_regional_by_row VALUES ($stageKey);
+#INSERT INTO table_regional_by_row VALUES ($stageKey * -1);
+#DELETE FROM table_regional_by_row WHERE k = $stageKey;
+#----
+
+# Disabled because of #146360 concurrent inserts broken on RBR tables
+# with ADD COLUMN UNIQUE
+#stage-exec phase=PostCommitNonRevertiblePhase stage=:
+#USE multiregion_db;
+#INSERT INTO table_regional_by_row VALUES (1000 + $stageKey);
+#INSERT INTO table_regional_by_row VALUES ((1000 + $stageKey) * -1);
+#DELETE FROM table_regional_by_row WHERE k = (1000 + $stageKey);
+#----
+
+stage-exec phase=PostCommitPhase stage=:
+USE multiregion_db;
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+
+stage-exec phase=PostCommitNonRevertiblePhase stage=:
+USE multiregion_db;
+SELECT crdb_internal.validate_multi_region_zone_configs()
+----
+
+# This will require zone configuration changes to be stacked between indexes.
+#,
+test
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE
+----

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain
@@ -2,225 +2,367 @@
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
   k INT PRIMARY KEY,
-  V STRING
+  V STRING,
+  m INT
 ) LOCALITY REGIONAL BY ROW;
 
 /* test */
-EXPLAIN (DDL) ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
 ----
-Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
  ├── StatementPhase
  │    └── Stage 1 of 1 in StatementPhase
- │         ├── 16 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), Expr: unique_rowid()}
- │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
- │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), Expr: unique_rowid()}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 6 (table_regional_by_row_pkey+)}
- │         ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │         ├── 15 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), Expr: unique_rowid()}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         ├── 17 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
- │         └── 22 Mutation operations
- │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":108}}
- │              ├── SetColumnName {"ColumnID":4,"Name":"j","TableID":108}
- │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsNullable":true,"TableID":108}}
- │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":4,"TableID":108}}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 7}
+ │         ├── 4 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
+ │         │    └── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m-)}
+ │         └── 34 Mutation operations
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
- │              ├── SetColumnName {"ColumnID":5,"Name":"l","TableID":108}
+ │              ├── SetColumnName {"ColumnID":5,"Name":"j","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"IsNullable":true,"TableID":108}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":6,"TableID":108}}
+ │              ├── SetColumnName {"ColumnID":6,"Name":"l","TableID":108}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"IsNullable":true,"TableID":108}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":6,"TableID":108}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":7}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":108}}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":7,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":108,"TemporaryIndexID":9}}
+ │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":8,"TableID":108}}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
- │              └── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":108}
+ │              └── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
- │    │    ├── 16 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
- │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j+)}
- │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j+), TypeName: "INT8"}
- │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), Expr: unique_rowid()}
- │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
- │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
- │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l+)}
- │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l+), TypeName: "INT8"}
- │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), Expr: unique_rowid()}
- │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 6 (table_regional_by_row_pkey+)}
- │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │    │    ├── 15 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), Expr: unique_rowid()}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), Expr: unique_rowid()}
+ │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    ├── 17 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
  │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
  │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
- │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
- │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 7}
+ │    │    ├── 4 elements transitioning toward ABSENT
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
+ │    │    │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
+ │    │    │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
+ │    │    │    └── ABSENT           → PUBLIC ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m-)}
  │    │    └── 1 Mutation operation
  │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
  │    └── Stage 2 of 2 in PreCommitPhase
- │         ├── 16 elements transitioning toward PUBLIC
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), Expr: unique_rowid()}
- │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
- │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 6 (table_regional_by_row_pkey+)}
- │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
- │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l+)}
- │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l+), TypeName: "INT8"}
- │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), Expr: unique_rowid()}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 6 (table_regional_by_row_pkey+)}
- │         ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │         ├── 15 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), Expr: unique_rowid()}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 8 (table_regional_by_row_pkey+)}
+ │         ├── 17 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
  │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
  │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
- │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
- │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
- │         └── 26 Mutation operations
- │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":108}}
- │              ├── SetColumnName {"ColumnID":4,"Name":"j","TableID":108}
- │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsNullable":true,"TableID":108}}
- │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":4,"TableID":108}}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 6 (table_regional_by_row_pkey~)}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 7}
+ │         ├── 4 elements transitioning toward ABSENT
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
+ │         │    ├── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v-)}
+ │         │    ├── PUBLIC → WRITE_ONLY       Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
+ │         │    └── PUBLIC → ABSENT           ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m-)}
+ │         └── 39 Mutation operations
  │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
- │              ├── SetColumnName {"ColumnID":5,"Name":"l","TableID":108}
+ │              ├── SetColumnName {"ColumnID":5,"Name":"j","TableID":108}
  │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"IsNullable":true,"TableID":108}}
  │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":6,"TableID":108}}
+ │              ├── SetColumnName {"ColumnID":6,"Name":"l","TableID":108}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":6,"IsNullable":true,"TableID":108}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":6,"TableID":108}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":7}}
  │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":108}}
  │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":108}
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":7,"TableID":108}}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":108,"TemporaryIndexID":9}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":108}
+ │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":8,"TableID":108}}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":2,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":2,"Name":"crdb_internal_co...","TableID":108}
+ │              ├── MakePublicColumnWriteOnly {"ColumnID":3,"TableID":108}
+ │              ├── SetColumnName {"ColumnID":3,"Name":"crdb_internal_co...","TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
- │    ├── Stage 1 of 15 in PostCommitPhase
+ │    ├── Stage 1 of 23 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
- │    │    │    └── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+)}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
  │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
  │    │    └── 5 Mutation operations
- │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":4,"TableID":108}
  │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":5,"TableID":108}
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":6,"TableID":108}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":7,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 2 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    ├── Stage 2 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    └── 1 Backfill operation
  │    │         └── BackfillIndex {"IndexID":6,"SourceIndexID":1,"TableID":108}
- │    ├── Stage 3 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    ├── Stage 3 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":6,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 4 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    ├── Stage 4 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    └── 3 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":6,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 5 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    ├── Stage 5 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    └── 1 Backfill operation
  │    │         └── MergeIndex {"BackfilledIndexID":6,"TableID":108,"TemporaryIndexID":7}
- │    ├── Stage 6 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
- │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    ├── Stage 6 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":6,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 7 of 15 in PostCommitPhase
- │    │    ├── 1 element transitioning toward PUBLIC
- │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    ├── Stage 7 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
  │    │    └── 1 Validation operation
  │    │         └── ValidateIndex {"IndexID":6,"TableID":108}
- │    ├── Stage 8 of 15 in PostCommitPhase
+ │    ├── Stage 8 of 23 in PostCommitPhase
+ │    │    ├── 8 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── VALIDATED → PUBLIC           PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── ABSENT    → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    ├── ABSENT    → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+ │    │    │    ├── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 9}
+ │    │    │    └── ABSENT    → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 9}
+ │    │    ├── 3 elements transitioning toward ABSENT
+ │    │    │    ├── PUBLIC    → VALIDATED        PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+ │    │    │    ├── PUBLIC    → ABSENT           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    └── PUBLIC    → ABSENT           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 13 Mutation operations
+ │    │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":108}
+ │    │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":108}
+ │    │         ├── SetIndexName {"IndexID":6,"Name":"table_regional_b...","TableID":108}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":9,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":108}}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":108}
+ │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":9,"TableID":108}}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+ │    │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 9 of 23 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":9,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 10 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":8,"SourceIndexID":6,"TableID":108}
+ │    ├── Stage 11 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":8,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 12 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":8,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 13 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":8,"TableID":108,"TemporaryIndexID":9}
+ │    ├── Stage 14 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":8,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 15 of 23 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+ │    │    └── 1 Validation operation
+ │    │         └── ValidateIndex {"IndexID":8,"TableID":108}
+ │    ├── Stage 16 of 23 in PostCommitPhase
  │    │    ├── 16 elements transitioning toward PUBLIC
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 2 (table_regional_by_row_j_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key+)}
- │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 4 (table_regional_by_row_l_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key+)}
- │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key+)}
  │    │    │    ├── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+)}
  │    │    │    └── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
  │    │    ├── 8 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 3}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 3}
  │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
- │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
- │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 5}
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 5}
  │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
- │    │    │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+)}
  │    │    └── 28 Mutation operations
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":108}
@@ -236,70 +378,70 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":108}
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":4,"TableID":108}}
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":5,"TableID":108}}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":4,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 9 of 15 in PostCommitPhase
+ │    ├── Stage 17 of 23 in PostCommitPhase
  │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+)}
  │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
- │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+)}
  │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":108}
  │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 10 of 15 in PostCommitPhase
+ │    ├── Stage 18 of 23 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
- │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 2 Backfill operations
- │    │         ├── BackfillIndex {"IndexID":2,"SourceIndexID":6,"TableID":108}
- │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":6,"TableID":108}
- │    ├── Stage 11 of 15 in PostCommitPhase
+ │    │         ├── BackfillIndex {"IndexID":2,"SourceIndexID":8,"TableID":108}
+ │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":8,"TableID":108}
+ │    ├── Stage 19 of 23 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
- │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":108}
  │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 12 of 15 in PostCommitPhase
+ │    ├── Stage 20 of 23 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
- │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 4 Mutation operations
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":108}
  │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    ├── Stage 13 of 15 in PostCommitPhase
+ │    ├── Stage 21 of 23 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
- │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    └── 2 Backfill operations
  │    │         ├── MergeIndex {"BackfilledIndexID":2,"TableID":108,"TemporaryIndexID":3}
  │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":108,"TemporaryIndexID":5}
- │    ├── Stage 14 of 15 in PostCommitPhase
+ │    ├── Stage 22 of 23 in PostCommitPhase
  │    │    ├── 2 elements transitioning toward PUBLIC
- │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
- │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
- │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
- │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+)}
  │    │    └── 6 Mutation operations
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
  │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
@@ -307,96 +449,147 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
- │    └── Stage 15 of 15 in PostCommitPhase
+ │    └── Stage 23 of 23 in PostCommitPhase
  │         ├── 2 elements transitioning toward PUBLIC
- │         │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
- │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │         │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
  │         └── 2 Validation operations
  │              ├── ValidateIndex {"IndexID":2,"TableID":108}
  │              └── ValidateIndex {"IndexID":4,"TableID":108}
  └── PostCommitNonRevertiblePhase
-      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 6 elements transitioning toward PUBLIC
-      │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
-      │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── ABSENT                → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey+)}
-      │    │    ├── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
-      │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
-      │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
-      │    ├── 14 elements transitioning toward TRANSIENT_ABSENT
+      ├── Stage 1 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 2 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+      │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+      │    ├── 20 elements transitioning toward TRANSIENT_ABSENT
       │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 3}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 7}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 3}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
-      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
-      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 5}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 9}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 5}
       │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
-      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
-      │    ├── 3 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
-      │    │    ├── PUBLIC                → ABSENT           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey-)}
-      │    └── 28 Mutation operations
-      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":108}
-      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":108}
-      │         ├── SetIndexName {"IndexID":6,"Name":"table_regional_b...","TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey+)}
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    └── VALIDATED             → DELETE_ONLY      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+      │    └── 33 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":2,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":108}
       │         ├── RefreshStats {"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
       │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
-      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":108}
-      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
-      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":5,"TableID":108}
-      │         ├── RefreshStats {"TableID":108}
-      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
-      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
-      │    ├── 4 elements transitioning toward ABSENT
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 1 (table_regional_by_row_pkey-)}
-      │    │    └── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
-      │    └── 6 Mutation operations
       │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
-      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Ordinal":1,"TableID":108}
       │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"Kind":2,"Ordinal":1,"TableID":108}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
       │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
-      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
-           ├── 3 elements transitioning toward TRANSIENT_ABSENT
-           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
-           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
-           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
-           ├── 2 elements transitioning toward ABSENT
-           │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
-           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
-           └── 7 Mutation operations
-                ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
+      ├── Stage 2 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── VALIDATED   → PUBLIC              PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey+), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    ├── ABSENT      → PUBLIC              IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 8 (table_regional_by_row_pkey+)}
+      │    │    ├── WRITE_ONLY  → PUBLIC              Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+)}
+      │    │    └── WRITE_ONLY  → PUBLIC              Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+)}
+      │    ├── 3 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── PUBLIC      → TRANSIENT_VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → TRANSIENT_ABSENT    IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    └── PUBLIC      → TRANSIENT_ABSENT    IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── DELETE_ONLY → ABSENT              PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+      │    └── 11 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── SetIndexName {"IndexID":8,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":8,"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":5,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":6,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 3 of 4 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_VALIDATED → TRANSIENT_DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    ├── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j+), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    │    └── PUBLIC              → TRANSIENT_ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l+), IndexID: 6 (table_regional_by_row_pkey~)}
+      │    └── 9 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 4 of 4 in PostCommitNonRevertiblePhase
+           ├── 6 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey~)}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    └── PUBLIC                → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           ├── 5 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v-)}
+           │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 2 (v-), TypeName: "STRING"}
+           │    ├── DELETE_ONLY           → ABSENT           Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m-)}
+           │    ├── PUBLIC                → ABSENT           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 3 (m-), TypeName: "INT8"}
+           │    └── PUBLIC                → ABSENT           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
+           └── 11 Mutation operations
                 ├── CreateGCJobForIndex {"IndexID":1,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
                 ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
                 ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":2,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
                 ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
                 ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
                 └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain
@@ -1,0 +1,402 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+----
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 16 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), Expr: unique_rowid()}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
+ │         └── 22 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":108}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"j","TableID":108}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsNullable":true,"TableID":108}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":4,"TableID":108}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
+ │              ├── SetColumnName {"ColumnID":5,"Name":"l","TableID":108}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"IsNullable":true,"TableID":108}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":7}}
+ │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":108}}
+ │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":7,"TableID":108}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+ │              └── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+ ├── PreCommitPhase
+ │    ├── Stage 1 of 2 in PreCommitPhase
+ │    │    ├── 16 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), Expr: unique_rowid()}
+ │    │    │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l+)}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l+), TypeName: "INT8"}
+ │    │    │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), Expr: unique_rowid()}
+ │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+ │    │    │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
+ │    │    │    └── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
+ │    │    └── 1 Mutation operation
+ │    │         └── UndoAllInTxnImmediateMutationOpSideEffects
+ │    └── Stage 2 of 2 in PreCommitPhase
+ │         ├── 16 elements transitioning toward PUBLIC
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), Expr: unique_rowid()}
+ │         │    ├── ABSENT → BACKFILL_ONLY    PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── ABSENT → PUBLIC           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         │    ├── ABSENT → DELETE_ONLY      Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l+)}
+ │         │    ├── ABSENT → PUBLIC           ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l+), TypeName: "INT8"}
+ │         │    ├── ABSENT → PUBLIC           ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), Expr: unique_rowid()}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 6 (table_regional_by_row_pkey+)}
+ │         ├── 7 elements transitioning toward TRANSIENT_ABSENT
+ │         │    ├── ABSENT → DELETE_ONLY      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │         │    ├── ABSENT → TRANSIENT_ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+ │         │    ├── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
+ │         │    └── ABSENT → PUBLIC           IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
+ │         └── 26 Mutation operations
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":4,"TableID":108}}
+ │              ├── SetColumnName {"ColumnID":4,"Name":"j","TableID":108}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":4,"IsNullable":true,"TableID":108}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":4,"TableID":108}}
+ │              ├── MakeAbsentColumnDeleteOnly {"Column":{"ColumnID":5,"TableID":108}}
+ │              ├── SetColumnName {"ColumnID":5,"Name":"l","TableID":108}
+ │              ├── UpsertColumnType {"ColumnType":{"ColumnID":5,"IsNullable":true,"TableID":108}}
+ │              ├── AddColumnDefaultExpression {"Default":{"ColumnID":5,"TableID":108}}
+ │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":6,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":108,"TemporaryIndexID":7}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":108}
+ │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":6,"TableID":108}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+ │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":7,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":108}}
+ │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":108}
+ │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":7,"TableID":108}}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+ │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}
+ │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ ├── PostCommitPhase
+ │    ├── Stage 1 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
+ │    │    │    └── DELETE_ONLY → WRITE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+ │    │    └── 5 Mutation operations
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":4,"TableID":108}
+ │    │         ├── MakeDeleteOnlyColumnWriteOnly {"ColumnID":5,"TableID":108}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":7,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 2 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── BackfillIndex {"IndexID":6,"SourceIndexID":1,"TableID":108}
+ │    ├── Stage 3 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── BACKFILLED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":6,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 4 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 3 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":6,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 5 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGE_ONLY → MERGED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 1 Backfill operation
+ │    │         └── MergeIndex {"BackfilledIndexID":6,"TableID":108,"TemporaryIndexID":7}
+ │    ├── Stage 6 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── MERGED     → WRITE_ONLY            PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    ├── 1 element transitioning toward TRANSIENT_ABSENT
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":6,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 7 of 15 in PostCommitPhase
+ │    │    ├── 1 element transitioning toward PUBLIC
+ │    │    │    └── WRITE_ONLY → VALIDATED PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+ │    │    └── 1 Validation operation
+ │    │         └── ValidateIndex {"IndexID":6,"TableID":108}
+ │    ├── Stage 8 of 15 in PostCommitPhase
+ │    │    ├── 16 elements transitioning toward PUBLIC
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → BACKFILL_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    ├── ABSENT → PUBLIC        IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+)}
+ │    │    │    └── ABSENT → PUBLIC        IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+ │    │    ├── 8 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 3}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+ │    │    │    ├── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 5}
+ │    │    │    ├── ABSENT → PUBLIC        IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+ │    │    │    └── ABSENT → DELETE_ONLY   TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    └── 28 Mutation operations
+ │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":2,"TableID":108}
+ │    │         ├── SetIndexName {"IndexID":2,"Name":"table_regional_b...","TableID":108}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":3,"TableID":108}
+ │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":2,"TableID":108}}
+ │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":3,"TableID":108}}
+ │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":108}
+ │    │         ├── SetIndexName {"IndexID":4,"Name":"table_regional_b...","TableID":108}
+ │    │         ├── MakeAbsentTempIndexDeleteOnly {"IsSecondaryIndex":true}
+ │    │         ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":108}
+ │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":4,"TableID":108}}
+ │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":5,"TableID":108}}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 9 of 15 in PostCommitPhase
+ │    │    ├── 4 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    ├── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+ │    │    │    ├── DELETE_ONLY → WRITE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    └── ABSENT      → PUBLIC     IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":3,"TableID":108}
+ │    │         ├── MakeDeleteOnlyIndexWriteOnly {"IndexID":5,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 10 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── BACKFILL_ONLY → BACKFILLED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 2 Backfill operations
+ │    │         ├── BackfillIndex {"IndexID":2,"SourceIndexID":6,"TableID":108}
+ │    │         └── BackfillIndex {"IndexID":4,"SourceIndexID":6,"TableID":108}
+ │    ├── Stage 11 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── BACKFILLED → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":2,"TableID":108}
+ │    │         ├── MakeBackfillingIndexDeleteOnly {"IndexID":4,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 12 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── DELETE_ONLY → MERGE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 4 Mutation operations
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":2,"TableID":108}
+ │    │         ├── MakeBackfilledIndexMerging {"IndexID":4,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    ├── Stage 13 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── MERGE_ONLY → MERGED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    └── 2 Backfill operations
+ │    │         ├── MergeIndex {"BackfilledIndexID":2,"TableID":108,"TemporaryIndexID":3}
+ │    │         └── MergeIndex {"BackfilledIndexID":4,"TableID":108,"TemporaryIndexID":5}
+ │    ├── Stage 14 of 15 in PostCommitPhase
+ │    │    ├── 2 elements transitioning toward PUBLIC
+ │    │    │    ├── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    │    └── MERGED     → WRITE_ONLY            SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │    │    ├── 2 elements transitioning toward TRANSIENT_ABSENT
+ │    │    │    ├── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    │    └── WRITE_ONLY → TRANSIENT_DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+ │    │    └── 6 Mutation operations
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+ │    │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":2,"TableID":108}
+ │    │         ├── MakeMergedIndexWriteOnly {"IndexID":4,"TableID":108}
+ │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+ │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
+ │    └── Stage 15 of 15 in PostCommitPhase
+ │         ├── 2 elements transitioning toward PUBLIC
+ │         │    ├── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │         │    └── WRITE_ONLY → VALIDATED SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+ │         └── 2 Validation operations
+ │              ├── ValidateIndex {"IndexID":2,"TableID":108}
+ │              └── ValidateIndex {"IndexID":4,"TableID":108}
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 6 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+)}
+      │    │    ├── VALIDATED             → PUBLIC           PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey+), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── ABSENT                → PUBLIC           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey+)}
+      │    │    ├── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key+), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+      │    │    ├── WRITE_ONLY            → PUBLIC           Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+)}
+      │    │    └── VALIDATED             → PUBLIC           SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key+), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+), RecreateSourceIndexID: 0}
+      │    ├── 14 elements transitioning toward TRANSIENT_ABSENT
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j+), IndexID: 3}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 7}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l+), IndexID: 5}
+      │    │    ├── PUBLIC                → TRANSIENT_ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    └── TRANSIENT_DELETE_ONLY → TRANSIENT_ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey+)}
+      │    ├── 3 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED        PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+      │    │    ├── PUBLIC                → ABSENT           IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC                → ABSENT           IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey-)}
+      │    └── 28 Mutation operations
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":1,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"table_regional_b...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeValidatedSecondaryIndexPublic {"IndexID":4,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":6,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":4,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":5,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 1 (table_regional_by_row_pkey-)}
+      │    │    └── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+      │    └── 6 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":1,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":1,"Kind":2,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 3 elements transitioning toward TRANSIENT_ABSENT
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    └── PUBLIC      → TRANSIENT_ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           ├── 2 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT           PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-), ConstraintID: 1}
+           │    └── PUBLIC      → ABSENT           IndexData:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey-)}
+           └── 7 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":1,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":1,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain_shape
@@ -1,0 +1,31 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+----
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index table_regional_by_row_pkey- in relation table_regional_by_row
+ │    └── into table_regional_by_row_pkey+ (k, crdb_region; v, j+, l+)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
+ │    └── from table_regional_by_row@[7] into table_regional_by_row_pkey+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index table_regional_by_row_pkey+ in relation table_regional_by_row
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index table_regional_by_row_pkey+ in relation table_regional_by_row
+ │    ├── into table_regional_by_row_j_key+ (crdb_region, j+: k)
+ │    └── into table_regional_by_row_l_key+ (crdb_region, l+: k)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
+ │    ├── from table_regional_by_row@[3] into table_regional_by_row_j_key+
+ │    └── from table_regional_by_row@[5] into table_regional_by_row_l_key+
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index table_regional_by_row_j_key+ in relation table_regional_by_row
+ ├── validate UNIQUE constraint backed by index table_regional_by_row_l_key+ in relation table_regional_by_row
+ └── execute 3 system table mutations transactions

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain_shape
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.explain_shape
@@ -2,25 +2,34 @@
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
   k INT PRIMARY KEY,
-  V STRING
+  V STRING,
+  m INT
 ) LOCALITY REGIONAL BY ROW;
 
 /* test */
-EXPLAIN (DDL, SHAPE) ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL, SHAPE) ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
 ----
-Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
+Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid();
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index table_regional_by_row_pkey- in relation table_regional_by_row
- │    └── into table_regional_by_row_pkey+ (k, crdb_region; v, j+, l+)
+ │    └── into table_regional_by_row_pkey~ (crdb_region, k; j+, m-, v-, l+)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
- │    └── from table_regional_by_row@[7] into table_regional_by_row_pkey+
+ │    └── from table_regional_by_row@[7] into table_regional_by_row_pkey~
+ ├── execute 1 system table mutations transaction
+ ├── validate UNIQUE constraint backed by index table_regional_by_row_pkey~ in relation table_regional_by_row
+ ├── execute 2 system table mutations transactions
+ ├── backfill using primary index table_regional_by_row_pkey~ in relation table_regional_by_row
+ │    └── into table_regional_by_row_pkey+ (k, crdb_region; j+, l+)
+ ├── execute 2 system table mutations transactions
+ ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
+ │    └── from table_regional_by_row@[9] into table_regional_by_row_pkey+
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index table_regional_by_row_pkey+ in relation table_regional_by_row
  ├── execute 2 system table mutations transactions
  ├── backfill using primary index table_regional_by_row_pkey+ in relation table_regional_by_row
  │    ├── into table_regional_by_row_j_key+ (crdb_region, j+: k)
- │    └── into table_regional_by_row_l_key+ (crdb_region, l+: k)
+ │    └── into table_regional_by_row_l_key+ (l+, crdb_region: k)
  ├── execute 2 system table mutations transactions
  ├── merge temporary indexes into backfilled indexes in relation table_regional_by_row
  │    ├── from table_regional_by_row@[3] into table_regional_by_row_j_key+
@@ -28,4 +37,4 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  ├── execute 1 system table mutations transaction
  ├── validate UNIQUE constraint backed by index table_regional_by_row_j_key+ in relation table_regional_by_row
  ├── validate UNIQUE constraint backed by index table_regional_by_row_l_key+ in relation table_regional_by_row
- └── execute 3 system table mutations transactions
+ └── execute 4 system table mutations transactions

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.side_effects
@@ -2,7 +2,8 @@
 CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
 CREATE TABLE multiregion_db.public.table_regional_by_row (
   k INT PRIMARY KEY,
-  V STRING
+  V STRING,
+  m INT
 ) LOCALITY REGIONAL BY ROW;
 ----
 ...
@@ -13,15 +14,17 @@ CREATE TABLE multiregion_db.public.table_regional_by_row (
 +object {104 105 table_regional_by_row} -> 108
 
 /* test */
-ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
 ----
 begin transaction #1
 # begin StatementPhase
 checking for feature: ALTER TABLE
 increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.drop_column
 increment telemetry for sql.schema.alter_table.add_column
 increment telemetry for sql.schema.qualifcation.default_expr
 increment telemetry for sql.schema.new_column_type.int8
+increment telemetry for sql.schema.alter_table.drop_column
 increment telemetry for sql.schema.alter_table.add_column
 increment telemetry for sql.schema.qualifcation.default_expr
 increment telemetry for sql.schema.new_column_type.int8
@@ -29,7 +32,7 @@ write *eventpb.AlterTable to event log:
   mutationId: 1
   sql:
     descriptorId: 108
-    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
@@ -37,32 +40,69 @@ write *eventpb.AlterTable to event log:
   mutationId: 1
   sql:
     descriptorId: 108
-    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
     tag: ALTER TABLE
     user: root
   tableName: multiregion_db.public.table_regional_by_row
-## StatementPhase stage 1 of 1 with 22 MutationType ops
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 108
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+    tag: ALTER TABLE
+    user: root
+  tableName: multiregion_db.public.table_regional_by_row
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 108
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+    tag: ALTER TABLE
+    user: root
+  tableName: multiregion_db.public.table_regional_by_row
+## StatementPhase stage 1 of 1 with 34 MutationType ops
 upsert descriptor #108
   ...
-       - 2
+         oid: 20
+         width: 64
+  -  - id: 2
+  -    name: v
+  -    nullable: true
+  -    type:
+  -      family: StringFamily
+  -      oid: 25
+  -  - id: 3
+  -    name: m
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     - defaultExpr: default_to_database_primary_region(gateway_region())::@100106
+       hidden: true
+  ...
        - 3
-  +    - 4
+       - 4
   +    - 5
+  +    - 6
        columnNames:
        - k
-       - v
+  -    - v
+  -    - m
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_3_name_placeholder
        - crdb_region
   +    - j
   +    - l
-       defaultColumnId: 2
        name: primary
+     formatVersion: 3
   ...
        regionalByRow: {}
      modificationTime: {}
   +  mutations:
   +  - column:
   +      defaultExpr: unique_rowid()
-  +      id: 4
+  +      id: 5
   +      name: j
   +      nullable: true
   +      type:
@@ -74,7 +114,7 @@ upsert descriptor #108
   +    state: DELETE_ONLY
   +  - column:
   +      defaultExpr: unique_rowid()
-  +      id: 5
+  +      id: 6
   +      name: l
   +      nullable: true
   +      type:
@@ -97,7 +137,7 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
+  +      - 4
   +      - 1
   +      keyColumnNames:
   +      - crdb_region
@@ -122,10 +162,12 @@ upsert descriptor #108
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
-  +      - 4
+  +      - 3
   +      - 5
+  +      - 6
   +      storeColumnNames:
-  +      - v
+  +      - crdb_internal_column_2_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
   +      - j
   +      - l
   +      unique: true
@@ -146,7 +188,7 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
+  +      - 4
   +      - 1
   +      keyColumnNames:
   +      - crdb_region
@@ -171,10 +213,12 @@ upsert descriptor #108
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
-  +      - 4
+  +      - 3
   +      - 5
+  +      - 6
   +      storeColumnNames:
-  +      - v
+  +      - crdb_internal_column_2_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
   +      - j
   +      - l
   +      unique: true
@@ -183,16 +227,93 @@ upsert descriptor #108
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      - 6
+  +      storeColumnNames:
+  +      - j
+  +      - l
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: table_regional_by_row
-  -  nextColumnId: 4
+  -  nextColumnId: 5
   -  nextConstraintId: 2
-  +  nextColumnId: 6
-  +  nextConstraintId: 8
+  +  nextColumnId: 7
+  +  nextConstraintId: 9
      nextFamilyId: 1
   -  nextIndexId: 2
-  +  nextIndexId: 8
+  +  nextIndexId: 9
      nextMutationId: 1
      parentId: 104
+  ...
+       - 3
+       storeColumnNames:
+  -    - v
+  -    - m
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_3_name_placeholder
+       unique: true
+       vecConfig: {}
   ...
        time: {}
      unexposedParentSchemaId: 105
@@ -203,8 +324,26 @@ upsert descriptor #108
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 26 MutationType ops
+## PreCommitPhase stage 2 of 2 with 39 MutationType ops
 upsert descriptor #108
+  ...
+         oid: 20
+         width: 64
+  -  - id: 2
+  -    name: v
+  -    nullable: true
+  -    type:
+  -      family: StringFamily
+  -      oid: 25
+  -  - id: 3
+  -    name: m
+  -    nullable: true
+  -    type:
+  -      family: IntFamily
+  -      oid: 20
+  -      width: 64
+     - defaultExpr: default_to_database_primary_region(gateway_region())::@100106
+       hidden: true
   ...
      createAsOfTime:
        wallTime: "1640995200000000000"
@@ -216,10 +355,9 @@ upsert descriptor #108
   +    nameMapping:
   +      columns:
   +        "1": k
-  +        "2": v
-  +        "3": crdb_region
-  +        "4": j
-  +        "5": l
+  +        "4": crdb_region
+  +        "5": j
+  +        "6": l
   +        "4294967292": crdb_internal_origin_timestamp
   +        "4294967293": crdb_internal_origin_id
   +        "4294967294": tableoid
@@ -230,12 +368,12 @@ upsert descriptor #108
   +      indexes:
   +        "2": table_regional_by_row_j_key
   +        "4": table_regional_by_row_l_key
-  +        "6": table_regional_by_row_pkey
+  +        "8": table_regional_by_row_pkey
   +      name: table_regional_by_row
   +    relevantStatements:
   +    - statement:
-  +        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
-  +        statement: ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
+  +        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+  +        statement: ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
   +        statementTag: ALTER TABLE
   +    revertible: true
   +    targetRanks: <redacted>
@@ -243,25 +381,28 @@ upsert descriptor #108
      families:
      - columnIds:
   ...
-       - 2
        - 3
-  +    - 4
+       - 4
   +    - 5
+  +    - 6
        columnNames:
        - k
-       - v
+  -    - v
+  -    - m
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_3_name_placeholder
        - crdb_region
   +    - j
   +    - l
-       defaultColumnId: 2
        name: primary
+     formatVersion: 3
   ...
        regionalByRow: {}
      modificationTime: {}
   +  mutations:
   +  - column:
   +      defaultExpr: unique_rowid()
-  +      id: 4
+  +      id: 5
   +      name: j
   +      nullable: true
   +      type:
@@ -273,7 +414,7 @@ upsert descriptor #108
   +    state: DELETE_ONLY
   +  - column:
   +      defaultExpr: unique_rowid()
-  +      id: 5
+  +      id: 6
   +      name: l
   +      nullable: true
   +      type:
@@ -296,7 +437,7 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
+  +      - 4
   +      - 1
   +      keyColumnNames:
   +      - crdb_region
@@ -321,10 +462,12 @@ upsert descriptor #108
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
-  +      - 4
+  +      - 3
   +      - 5
+  +      - 6
   +      storeColumnNames:
-  +      - v
+  +      - crdb_internal_column_2_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
   +      - j
   +      - l
   +      unique: true
@@ -345,7 +488,7 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
+  +      - 4
   +      - 1
   +      keyColumnNames:
   +      - crdb_region
@@ -370,10 +513,12 @@ upsert descriptor #108
   +      sharded: {}
   +      storeColumnIds:
   +      - 2
-  +      - 4
+  +      - 3
   +      - 5
+  +      - 6
   +      storeColumnNames:
-  +      - v
+  +      - crdb_internal_column_2_name_placeholder
+  +      - crdb_internal_column_3_name_placeholder
   +      - j
   +      - l
   +      unique: true
@@ -382,23 +527,100 @@ upsert descriptor #108
   +      version: 4
   +    mutationId: 1
   +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      - 6
+  +      storeColumnNames:
+  +      - j
+  +      - l
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+  +  - column:
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
      name: table_regional_by_row
-  -  nextColumnId: 4
+  -  nextColumnId: 5
   -  nextConstraintId: 2
-  +  nextColumnId: 6
-  +  nextConstraintId: 8
+  +  nextColumnId: 7
+  +  nextConstraintId: 9
      nextFamilyId: 1
   -  nextIndexId: 2
-  +  nextIndexId: 8
+  +  nextIndexId: 9
      nextMutationId: 1
      parentId: 104
+  ...
+       - 3
+       storeColumnNames:
+  -    - v
+  -    - m
+  +    - crdb_internal_column_2_name_placeholder
+  +    - crdb_internal_column_3_name_placeholder
+       unique: true
+       vecConfig: {}
   ...
        time: {}
      unexposedParentSchemaId: 105
   -  version: "1"
   +  version: "2"
 persist all catalog changes to storage
-create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
+create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
   descriptor IDs: [108]
 # end PreCommitPhase
 commit transaction #1
@@ -407,7 +629,7 @@ notified job registry to adopt jobs: [1]
 begin transaction #2
 commit transaction #2
 begin transaction #3
-## PostCommitPhase stage 1 of 15 with 5 MutationType ops
+## PostCommitPhase stage 1 of 23 with 5 MutationType ops
 upsert descriptor #108
   ...
        direction: ADD
@@ -428,22 +650,22 @@ upsert descriptor #108
        mutationId: 1
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
-     name: table_regional_by_row
-     nextColumnId: 6
+     - direction: ADD
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 105
   -  version: "2"
   +  version: "3"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 2 of 23 with 1 BackfillType op pending"
 commit transaction #3
 begin transaction #4
-## PostCommitPhase stage 2 of 15 with 1 BackfillType op
+## PostCommitPhase stage 2 of 23 with 1 BackfillType op
 backfill indexes [6] from index #1 in table #108
 commit transaction #4
 begin transaction #5
-## PostCommitPhase stage 3 of 15 with 3 MutationType ops
+## PostCommitPhase stage 3 of 23 with 3 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -458,10 +680,10 @@ upsert descriptor #108
   -  version: "3"
   +  version: "4"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 1 MutationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 4 of 23 with 1 MutationType op pending"
 commit transaction #5
 begin transaction #6
-## PostCommitPhase stage 4 of 15 with 3 MutationType ops
+## PostCommitPhase stage 4 of 23 with 3 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -476,14 +698,14 @@ upsert descriptor #108
   -  version: "4"
   +  version: "5"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 1 BackfillType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 5 of 23 with 1 BackfillType op pending"
 commit transaction #6
 begin transaction #7
-## PostCommitPhase stage 5 of 15 with 1 BackfillType op
+## PostCommitPhase stage 5 of 23 with 1 BackfillType op
 merge temporary indexes [7] into backfilled indexes [6] in table #108
 commit transaction #7
 begin transaction #8
-## PostCommitPhase stage 6 of 15 with 4 MutationType ops
+## PostCommitPhase stage 6 of 23 with 4 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -499,22 +721,350 @@ upsert descriptor #108
        mutationId: 1
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
-     name: table_regional_by_row
-     nextColumnId: 6
+     - direction: ADD
+       index:
   ...
        time: {}
      unexposedParentSchemaId: 105
   -  version: "5"
   +  version: "6"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 1 ValidationType op pending"
+update progress of schema change job #1: "PostCommitPhase stage 7 of 23 with 1 ValidationType op pending"
 commit transaction #8
 begin transaction #9
-## PostCommitPhase stage 7 of 15 with 1 ValidationType op
+## PostCommitPhase stage 7 of 23 with 1 ValidationType op
 validate forward indexes [6] in table #108
 commit transaction #9
 begin transaction #10
-## PostCommitPhase stage 8 of 15 with 28 MutationType ops
+## PostCommitPhase stage 8 of 23 with 13 MutationType ops
+upsert descriptor #108
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+  -      constraintId: 6
+  +      constraintId: 7
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 6
+  +      id: 7
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_region
+         - k
+  -      name: crdb_internal_index_6_name_placeholder
+  +      name: crdb_internal_index_7_name_placeholder
+         partitioning:
+           list:
+  ...
+         - l
+         unique: true
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 8
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 8
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 4
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_8_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 5
+  +      - 6
+  +      storeColumnNames:
+  +      - j
+  +      - l
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - column:
+  +      id: 2
+  +      name: crdb_internal_column_2_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: StringFamily
+  +        oid: 25
+  +    direction: DROP
+  +    mutationId: 1
+       state: WRITE_ONLY
+  +  - column:
+  +      id: 3
+  +      name: crdb_internal_column_3_name_placeholder
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: DROP
+  +    mutationId: 1
+  +    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 7
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 7
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_region
+         - k
+  -      name: crdb_internal_index_7_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning:
+           list:
+  ...
+         - 2
+         - 3
+  -      - 5
+  -      - 6
+         storeColumnNames:
+         - crdb_internal_column_2_name_placeholder
+         - crdb_internal_column_3_name_placeholder
+  -      - j
+  -      - l
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  -      constraintId: 8
+  +      constraintId: 9
+         createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 8
+  +      id: 9
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_region
+         - k
+  -      name: crdb_internal_index_8_name_placeholder
+  +      name: crdb_internal_index_9_name_placeholder
+         partitioning:
+           list:
+  ...
+         - l
+         unique: true
+  +      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  -  - column:
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: StringFamily
+  -        oid: 25
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - column:
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 7
+  -  nextConstraintId: 9
+  +  nextConstraintId: 10
+     nextFamilyId: 1
+  -  nextIndexId: 9
+  +  nextIndexId: 10
+     nextMutationId: 1
+     parentId: 104
+     partitionAllBy: true
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 6
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 6
+       interleave: {}
+       keyColumnDirections:
+  ...
+       - 2
+       - 3
+  +    - 5
+  +    - 6
+       storeColumnNames:
+       - crdb_internal_column_2_name_placeholder
+       - crdb_internal_column_3_name_placeholder
+  +    - j
+  +    - l
+       unique: true
+       vecConfig: {}
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 9 of 23 with 1 MutationType op pending"
+commit transaction #10
+begin transaction #11
+## PostCommitPhase stage 9 of 23 with 3 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 7
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "7"
+  +  version: "8"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 10 of 23 with 1 BackfillType op pending"
+commit transaction #11
+begin transaction #12
+## PostCommitPhase stage 10 of 23 with 1 BackfillType op
+backfill indexes [8] from index #6 in table #108
+commit transaction #12
+begin transaction #13
+## PostCommitPhase stage 11 of 23 with 3 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - column:
+         id: 2
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 12 of 23 with 1 MutationType op pending"
+commit transaction #13
+begin transaction #14
+## PostCommitPhase stage 12 of 23 with 3 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - column:
+         id: 2
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "9"
+  +  version: "10"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 13 of 23 with 1 BackfillType op pending"
+commit transaction #14
+begin transaction #15
+## PostCommitPhase stage 13 of 23 with 1 BackfillType op
+merge temporary indexes [9] into backfilled indexes [8] in table #108
+commit transaction #15
+begin transaction #16
+## PostCommitPhase stage 14 of 23 with 4 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  +    state: WRITE_ONLY
+     - column:
+         id: 2
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: ADD
+  +  - direction: DROP
+       index:
+         constraintId: 9
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 7
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "10"
+  +  version: "11"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 15 of 23 with 1 ValidationType op pending"
+commit transaction #16
+begin transaction #17
+## PostCommitPhase stage 15 of 23 with 1 ValidationType op
+validate forward indexes [8] in table #108
+commit transaction #17
+begin transaction #18
+## PostCommitPhase stage 16 of 23 with 28 MutationType ops
 upsert descriptor #108
   ...
        mutationId: 1
@@ -532,8 +1082,8 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 5
   +      keyColumnNames:
   +      - crdb_region
   +      - j
@@ -575,8 +1125,8 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
   +      - 4
+  +      - 5
   +      keyColumnNames:
   +      - crdb_region
   +      - j
@@ -620,8 +1170,8 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
-  +      - 5
+  +      - 4
+  +      - 6
   +      keyColumnNames:
   +      - crdb_region
   +      - l
@@ -663,8 +1213,8 @@ upsert descriptor #108
   +      - ASC
   +      - ASC
   +      keyColumnIds:
-  +      - 3
-  +      - 5
+  +      - 4
+  +      - 6
   +      keyColumnNames:
   +      - crdb_region
   +      - l
@@ -696,17 +1246,17 @@ upsert descriptor #108
   +    mutationId: 1
   +    state: DELETE_ONLY
      name: table_regional_by_row
-     nextColumnId: 6
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "6"
-  +  version: "7"
+  -  version: "11"
+  +  version: "12"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 2 MutationType ops pending"
-commit transaction #10
-begin transaction #11
-## PostCommitPhase stage 9 of 15 with 4 MutationType ops
+update progress of schema change job #1: "PostCommitPhase stage 17 of 23 with 2 MutationType ops pending"
+commit transaction #18
+begin transaction #19
+## PostCommitPhase stage 17 of 23 with 4 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -721,21 +1271,21 @@ upsert descriptor #108
   -    state: DELETE_ONLY
   +    state: WRITE_ONLY
      name: table_regional_by_row
-     nextColumnId: 6
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "7"
-  +  version: "8"
+  -  version: "12"
+  +  version: "13"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 2 BackfillType ops pending"
-commit transaction #11
-begin transaction #12
-## PostCommitPhase stage 10 of 15 with 2 BackfillType ops
-backfill indexes [2 4] from index #6 in table #108
-commit transaction #12
-begin transaction #13
-## PostCommitPhase stage 11 of 15 with 4 MutationType ops
+update progress of schema change job #1: "PostCommitPhase stage 18 of 23 with 2 BackfillType ops pending"
+commit transaction #19
+begin transaction #20
+## PostCommitPhase stage 18 of 23 with 2 BackfillType ops
+backfill indexes [2 4] from index #8 in table #108
+commit transaction #20
+begin transaction #21
+## PostCommitPhase stage 19 of 23 with 4 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -754,13 +1304,13 @@ upsert descriptor #108
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "8"
-  +  version: "9"
+  -  version: "13"
+  +  version: "14"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 2 MutationType ops pending"
-commit transaction #13
-begin transaction #14
-## PostCommitPhase stage 12 of 15 with 4 MutationType ops
+update progress of schema change job #1: "PostCommitPhase stage 20 of 23 with 2 MutationType ops pending"
+commit transaction #21
+begin transaction #22
+## PostCommitPhase stage 20 of 23 with 4 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -779,17 +1329,17 @@ upsert descriptor #108
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "9"
-  +  version: "10"
+  -  version: "14"
+  +  version: "15"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 2 BackfillType ops pending"
-commit transaction #14
-begin transaction #15
-## PostCommitPhase stage 13 of 15 with 2 BackfillType ops
+update progress of schema change job #1: "PostCommitPhase stage 21 of 23 with 2 BackfillType ops pending"
+commit transaction #22
+begin transaction #23
+## PostCommitPhase stage 21 of 23 with 2 BackfillType ops
 merge temporary indexes [3 5] into backfilled indexes [2 4] in table #108
-commit transaction #15
-begin transaction #16
-## PostCommitPhase stage 14 of 15 with 6 MutationType ops
+commit transaction #23
+begin transaction #24
+## PostCommitPhase stage 22 of 23 with 6 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -822,46 +1372,25 @@ upsert descriptor #108
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: table_regional_by_row
-     nextColumnId: 6
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "10"
-  +  version: "11"
+  -  version: "15"
+  +  version: "16"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 2 ValidationType ops pending"
-commit transaction #16
-begin transaction #17
-## PostCommitPhase stage 15 of 15 with 2 ValidationType ops
+update progress of schema change job #1: "PostCommitPhase stage 23 of 23 with 2 ValidationType ops pending"
+commit transaction #24
+begin transaction #25
+## PostCommitPhase stage 23 of 23 with 2 ValidationType ops
 validate forward indexes [2] in table #108
 validate forward indexes [4] in table #108
-commit transaction #17
-begin transaction #18
-## PostCommitNonRevertiblePhase stage 1 of 3 with 28 MutationType ops
+commit transaction #25
+begin transaction #26
+## PostCommitNonRevertiblePhase stage 1 of 4 with 33 MutationType ops
 upsert descriptor #108
   ...
-         udtMetadata:
-           arrayTypeOid: 100107
-  +  - defaultExpr: unique_rowid()
-  +    id: 4
-  +    name: j
-  +    nullable: true
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
-  +  - defaultExpr: unique_rowid()
-  +    id: 5
-  +    name: l
-  +    nullable: true
-  +    type:
-  +      family: IntFamily
-  +      oid: 20
-  +      width: 64
-     createAsOfTime:
-       wallTime: "1640995200000000000"
-  ...
-           statement: ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
+           statement: ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
            statementTag: ALTER TABLE
   -    revertible: true
        targetRanks: <redacted>
@@ -881,8 +1410,8 @@ upsert descriptor #108
   +    - ASC
   +    - ASC
   +    keyColumnIds:
-  +    - 3
   +    - 4
+  +    - 5
   +    keyColumnNames:
   +    - crdb_region
   +    - j
@@ -921,8 +1450,8 @@ upsert descriptor #108
   +    - ASC
   +    - ASC
   +    keyColumnIds:
-  +    - 3
-  +    - 5
+  +    - 4
+  +    - 6
   +    keyColumnNames:
   +    - crdb_region
   +    - l
@@ -952,51 +1481,28 @@ upsert descriptor #108
   +    version: 4
      localityConfig:
        regionalByRow: {}
-     modificationTime: {}
-     mutations:
-  -  - column:
-  -      defaultExpr: unique_rowid()
-  -      id: 4
-  -      name: j
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: ADD
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-  -  - column:
-  -      defaultExpr: unique_rowid()
-  -      id: 5
-  -      name: l
-  -      nullable: true
-  -      type:
-  -        family: IntFamily
-  -        oid: 20
-  -        width: 64
-  -    direction: ADD
-  -    mutationId: 1
-  -    state: WRITE_ONLY
-  -  - direction: ADD
+  ...
+       mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: DROP
   -    index:
-  -      constraintId: 6
+  -      constraintId: 7
   -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 6
+  -      id: 7
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
+  -      - 4
   -      - 1
   -      keyColumnNames:
   -      - crdb_region
   -      - k
-  -      name: crdb_internal_index_6_name_placeholder
+  -      name: crdb_internal_index_7_name_placeholder
   -      partitioning:
   -        list:
   -        - name: us-east1
@@ -1016,52 +1522,88 @@ upsert descriptor #108
   -      sharded: {}
   -      storeColumnIds:
   -      - 2
-  -      - 4
+  -      - 3
   -      - 5
+  -      - 6
   -      storeColumnNames:
-  -      - v
+  -      - crdb_internal_column_2_name_placeholder
+  -      - crdb_internal_column_3_name_placeholder
   -      - j
   -      - l
   -      unique: true
+  -      useDeletePreservingEncoding: true
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
+  -    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       direction: DROP
+       mutationId: 1
   -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - column:
+         id: 3
+  ...
+       direction: DROP
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
      - direction: DROP
        index:
-  -      constraintId: 7
-  -      createdExplicitly: true
-  +      constraintId: 1
-  +      createdAtNanos: "1640995200000000000"
-         encodingType: 1
-         foreignKey: {}
-         geoConfig: {}
-  -      id: 7
-  +      id: 1
-         interleave: {}
-         keyColumnDirections:
   ...
-         - crdb_region
-         - k
-  -      name: crdb_internal_index_7_name_placeholder
-  +      name: crdb_internal_index_1_name_placeholder
-         partitioning:
-           list:
-  ...
-         storeColumnIds:
-         - 2
-  -      - 4
-  -      - 5
-         storeColumnNames:
-         - v
-  -      - j
-  -      - l
-         unique: true
-  -      useDeletePreservingEncoding: true
-         vecConfig: {}
          version: 4
        mutationId: 1
-  -    state: DELETE_ONLY
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 9
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 9
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 1
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - k
+  -      name: crdb_internal_index_9_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 5
+  -      - 6
+  -      storeColumnNames:
+  -      - j
+  -      - l
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+       state: DELETE_ONLY
   -  - direction: ADD
   -    index:
   -      constraintId: 2
@@ -1075,8 +1617,8 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
   -      - 4
+  -      - 5
   -      keyColumnNames:
   -      - crdb_region
   -      - j
@@ -1105,7 +1647,7 @@ upsert descriptor #108
   -      vecConfig: {}
   -      version: 4
   -    mutationId: 1
-       state: WRITE_ONLY
+  -    state: WRITE_ONLY
   -  - direction: DROP
   -    index:
   -      constraintId: 3
@@ -1118,8 +1660,8 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
   -      - 4
+  -      - 5
   -      keyColumnNames:
   -      - crdb_region
   -      - j
@@ -1163,8 +1705,8 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
-  -      - 5
+  -      - 4
+  -      - 6
   -      keyColumnNames:
   -      - crdb_region
   -      - l
@@ -1206,8 +1748,8 @@ upsert descriptor #108
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
-  -      - 5
+  -      - 4
+  -      - 6
   -      keyColumnNames:
   -      - crdb_region
   -      - l
@@ -1239,44 +1781,192 @@ upsert descriptor #108
   -    mutationId: 1
   -    state: DELETE_ONLY
      name: table_regional_by_row
-     nextColumnId: 6
-  ...
-     partitionAllBy: true
-     primaryIndex:
-  -    constraintId: 1
-  -    createdAtNanos: "1640995200000000000"
-  +    constraintId: 6
-  +    createdExplicitly: true
-       encodingType: 1
-       foreignKey: {}
-       geoConfig: {}
-  -    id: 1
-  +    id: 6
-       interleave: {}
-       keyColumnDirections:
-  ...
-       storeColumnIds:
-       - 2
-  +    - 4
-  +    - 5
-       storeColumnNames:
-       - v
-  +    - j
-  +    - l
-       unique: true
-       vecConfig: {}
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "11"
-  +  version: "12"
+  -  version: "16"
+  +  version: "17"
 persist all catalog changes to storage
 adding table for stats refresh: 108
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending"
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 4 with 9 MutationType ops pending"
 set schema change job #1 to non-cancellable
-commit transaction #18
-begin transaction #19
-## PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops
+commit transaction #26
+begin transaction #27
+## PostCommitNonRevertiblePhase stage 2 of 4 with 11 MutationType ops
+upsert descriptor #108
+  ...
+         udtMetadata:
+           arrayTypeOid: 100107
+  +  - defaultExpr: unique_rowid()
+  +    id: 5
+  +    name: j
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - defaultExpr: unique_rowid()
+  +    id: 6
+  +    name: l
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+     mutations:
+     - column:
+  -      defaultExpr: unique_rowid()
+  -      id: 5
+  -      name: j
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      id: 6
+  -      name: l
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 8
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 8
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 4
+  -      - 1
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - k
+  -      name: crdb_internal_index_8_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 5
+  -      - 6
+  -      storeColumnNames:
+  -      - j
+  -      - l
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - column:
+         id: 2
+         name: crdb_internal_column_2_name_placeholder
+  ...
+     - direction: DROP
+       index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  +      constraintId: 6
+  +      createdExplicitly: true
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 1
+  +      id: 6
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_region
+         - k
+  -      name: crdb_internal_index_1_name_placeholder
+  +      name: crdb_internal_index_6_name_placeholder
+         partitioning:
+           list:
+  ...
+         - 2
+         - 3
+  +      - 5
+  +      - 6
+         storeColumnNames:
+         - crdb_internal_column_2_name_placeholder
+         - crdb_internal_column_3_name_placeholder
+  +      - j
+  +      - l
+         unique: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 7
+  ...
+     partitionAllBy: true
+     primaryIndex:
+  -    constraintId: 6
+  +    constraintId: 8
+       createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 6
+  +    id: 8
+       interleave: {}
+       keyColumnDirections:
+  ...
+       sharded: {}
+       storeColumnIds:
+  -    - 2
+  -    - 3
+       - 5
+       - 6
+       storeColumnNames:
+  -    - crdb_internal_column_2_name_placeholder
+  -    - crdb_internal_column_3_name_placeholder
+       - j
+       - l
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "17"
+  +  version: "18"
+persist all catalog changes to storage
+adding table for stats refresh: 108
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 4 with 7 MutationType ops pending"
+commit transaction #27
+begin transaction #28
+## PostCommitNonRevertiblePhase stage 3 of 4 with 9 MutationType ops
 upsert descriptor #108
   ...
          version: 4
@@ -1284,17 +1974,17 @@ upsert descriptor #108
   -    state: WRITE_ONLY
   +    state: DELETE_ONLY
      name: table_regional_by_row
-     nextColumnId: 6
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "12"
-  +  version: "13"
+  -  version: "18"
+  +  version: "19"
 persist all catalog changes to storage
-update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 5 MutationType ops pending"
-commit transaction #19
-begin transaction #20
-## PostCommitNonRevertiblePhase stage 3 of 3 with 7 MutationType ops
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 4 of 4 with 9 MutationType ops pending"
+commit transaction #28
+begin transaction #29
+## PostCommitNonRevertiblePhase stage 4 of 4 with 11 MutationType ops
 upsert descriptor #108
   ...
      createAsOfTime:
@@ -1307,10 +1997,9 @@ upsert descriptor #108
   -    nameMapping:
   -      columns:
   -        "1": k
-  -        "2": v
-  -        "3": crdb_region
-  -        "4": j
-  -        "5": l
+  -        "4": crdb_region
+  -        "5": j
+  -        "6": l
   -        "4294967292": crdb_internal_origin_timestamp
   -        "4294967293": crdb_internal_origin_id
   -        "4294967294": tableoid
@@ -1321,40 +2010,73 @@ upsert descriptor #108
   -      indexes:
   -        "2": table_regional_by_row_j_key
   -        "4": table_regional_by_row_l_key
-  -        "6": table_regional_by_row_pkey
+  -        "8": table_regional_by_row_pkey
   -      name: table_regional_by_row
   -    relevantStatements:
   -    - statement:
-  -        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
-  -        statement: ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
+  -        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› DROP COLUMN ‹v›, ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN ‹m›, ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+  -        statement: ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
   -        statementTag: ALTER TABLE
   -    targetRanks: <redacted>
   -    targets: <redacted>
      families:
      - columnIds:
+       - 1
+  -    - 2
+  -    - 3
+       - 4
+       - 5
+  ...
+       columnNames:
+       - k
+  -    - crdb_internal_column_2_name_placeholder
+  -    - crdb_internal_column_3_name_placeholder
+       - crdb_region
+       - j
   ...
        regionalByRow: {}
      modificationTime: {}
   -  mutations:
+  -  - column:
+  -      id: 2
+  -      name: crdb_internal_column_2_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: StringFamily
+  -        oid: 25
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - column:
+  -      id: 3
+  -      name: crdb_internal_column_3_name_placeholder
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: DROP
+  -    mutationId: 1
+  -    state: DELETE_ONLY
   -  - direction: DROP
   -    index:
-  -      constraintId: 1
-  -      createdAtNanos: "1640995200000000000"
+  -      constraintId: 6
+  -      createdExplicitly: true
   -      encodingType: 1
   -      foreignKey: {}
   -      geoConfig: {}
-  -      id: 1
+  -      id: 6
   -      interleave: {}
   -      keyColumnDirections:
   -      - ASC
   -      - ASC
   -      keyColumnIds:
-  -      - 3
+  -      - 4
   -      - 1
   -      keyColumnNames:
   -      - crdb_region
   -      - k
-  -      name: crdb_internal_index_1_name_placeholder
+  -      name: crdb_internal_index_6_name_placeholder
   -      partitioning:
   -        list:
   -        - name: us-east1
@@ -1374,8 +2096,14 @@ upsert descriptor #108
   -      sharded: {}
   -      storeColumnIds:
   -      - 2
+  -      - 3
+  -      - 5
+  -      - 6
   -      storeColumnNames:
-  -      - v
+  -      - crdb_internal_column_2_name_placeholder
+  -      - crdb_internal_column_3_name_placeholder
+  -      - j
+  -      - l
   -      unique: true
   -      vecConfig: {}
   -      version: 4
@@ -1383,14 +2111,14 @@ upsert descriptor #108
   -    state: DELETE_ONLY
   +  mutations: []
      name: table_regional_by_row
-     nextColumnId: 6
+     nextColumnId: 7
   ...
        time: {}
      unexposedParentSchemaId: 105
-  -  version: "13"
-  +  version: "14"
+  -  version: "19"
+  +  version: "20"
 persist all catalog changes to storage
-create job #2 (non-cancelable: true): "GC for ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
+create job #2 (non-cancelable: true): "GC for ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
   descriptor IDs: [108]
 update progress of schema change job #1: "all stages completed"
 set schema change job #1 to non-cancellable
@@ -1398,6 +2126,6 @@ updated schema change job #1 descriptor IDs to []
 write *eventpb.FinishSchemaChange to event log:
   sc:
     descriptorId: 108
-commit transaction #20
+commit transaction #29
 notified job registry to adopt jobs: [2]
 # end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row.side_effects
@@ -1,0 +1,1403 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+----
+...
++database {0 0 multiregion_db} -> 104
++schema {104 0 public} -> 105
++object {104 105 crdb_internal_region} -> 106
++object {104 105 _crdb_internal_region} -> 107
++object {104 105 table_regional_by_row} -> 108
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+increment telemetry for sql.schema.alter_table
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.qualifcation.default_expr
+increment telemetry for sql.schema.new_column_type.int8
+increment telemetry for sql.schema.alter_table.add_column
+increment telemetry for sql.schema.qualifcation.default_expr
+increment telemetry for sql.schema.new_column_type.int8
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 108
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+    tag: ALTER TABLE
+    user: root
+  tableName: multiregion_db.public.table_regional_by_row
+write *eventpb.AlterTable to event log:
+  mutationId: 1
+  sql:
+    descriptorId: 108
+    statement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+    tag: ALTER TABLE
+    user: root
+  tableName: multiregion_db.public.table_regional_by_row
+## StatementPhase stage 1 of 1 with 22 MutationType ops
+upsert descriptor #108
+  ...
+       - 2
+       - 3
+  +    - 4
+  +    - 5
+       columnNames:
+       - k
+       - v
+       - crdb_region
+  +    - j
+  +    - l
+       defaultColumnId: 2
+       name: primary
+  ...
+       regionalByRow: {}
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      id: 4
+  +      name: j
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      id: 5
+  +      name: l
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 4
+  +      - 5
+  +      storeColumnNames:
+  +      - v
+  +      - j
+  +      - l
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 4
+  +      - 5
+  +      storeColumnNames:
+  +      - v
+  +      - j
+  +      - l
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+  -  nextColumnId: 4
+  -  nextConstraintId: 2
+  +  nextColumnId: 6
+  +  nextConstraintId: 8
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 8
+     nextMutationId: 1
+     parentId: 104
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 26 MutationType ops
+upsert descriptor #108
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  declarativeSchemaChangerState:
+  +    authorization:
+  +      userName: root
+  +    currentStatuses: <redacted>
+  +    jobId: "1"
+  +    nameMapping:
+  +      columns:
+  +        "1": k
+  +        "2": v
+  +        "3": crdb_region
+  +        "4": j
+  +        "5": l
+  +        "4294967292": crdb_internal_origin_timestamp
+  +        "4294967293": crdb_internal_origin_id
+  +        "4294967294": tableoid
+  +        "4294967295": crdb_internal_mvcc_timestamp
+  +      families:
+  +        "0": primary
+  +      id: 108
+  +      indexes:
+  +        "2": table_regional_by_row_j_key
+  +        "4": table_regional_by_row_l_key
+  +        "6": table_regional_by_row_pkey
+  +      name: table_regional_by_row
+  +    relevantStatements:
+  +    - statement:
+  +        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+  +        statement: ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
+  +        statementTag: ALTER TABLE
+  +    revertible: true
+  +    targetRanks: <redacted>
+  +    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       - 2
+       - 3
+  +    - 4
+  +    - 5
+       columnNames:
+       - k
+       - v
+       - crdb_region
+  +    - j
+  +    - l
+       defaultColumnId: 2
+       name: primary
+  ...
+       regionalByRow: {}
+     modificationTime: {}
+  +  mutations:
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      id: 4
+  +      name: j
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - column:
+  +      defaultExpr: unique_rowid()
+  +      id: 5
+  +      name: l
+  +      nullable: true
+  +      type:
+  +        family: IntFamily
+  +        oid: 20
+  +        width: 64
+  +    direction: ADD
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 6
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 6
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_6_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 4
+  +      - 5
+  +      storeColumnNames:
+  +      - v
+  +      - j
+  +      - l
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 7
+  +      createdExplicitly: true
+  +      encodingType: 1
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 7
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 1
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - k
+  +      name: crdb_internal_index_7_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnIds:
+  +      - 2
+  +      - 4
+  +      - 5
+  +      storeColumnNames:
+  +      - v
+  +      - j
+  +      - l
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+  -  nextColumnId: 4
+  -  nextConstraintId: 2
+  +  nextColumnId: 6
+  +  nextConstraintId: 8
+     nextFamilyId: 1
+  -  nextIndexId: 2
+  +  nextIndexId: 8
+     nextMutationId: 1
+     parentId: 104
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+create job #1 (non-cancelable: false): "ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
+  descriptor IDs: [108]
+# end PreCommitPhase
+commit transaction #1
+notified job registry to adopt jobs: [1]
+# begin PostCommitPhase
+begin transaction #2
+commit transaction #2
+begin transaction #3
+## PostCommitPhase stage 1 of 15 with 5 MutationType ops
+upsert descriptor #108
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - column:
+         defaultExpr: unique_rowid()
+  ...
+       direction: ADD
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "2"
+  +  version: "3"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 2 of 15 with 1 BackfillType op pending"
+commit transaction #3
+begin transaction #4
+## PostCommitPhase stage 2 of 15 with 1 BackfillType op
+backfill indexes [6] from index #1 in table #108
+commit transaction #4
+begin transaction #5
+## PostCommitPhase stage 3 of 15 with 3 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "3"
+  +  version: "4"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 4 of 15 with 1 MutationType op pending"
+commit transaction #5
+begin transaction #6
+## PostCommitPhase stage 4 of 15 with 3 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "4"
+  +  version: "5"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 5 of 15 with 1 BackfillType op pending"
+commit transaction #6
+begin transaction #7
+## PostCommitPhase stage 5 of 15 with 1 BackfillType op
+merge temporary indexes [7] into backfilled indexes [6] in table #108
+commit transaction #7
+begin transaction #8
+## PostCommitPhase stage 6 of 15 with 4 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 7
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "5"
+  +  version: "6"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 7 of 15 with 1 ValidationType op pending"
+commit transaction #8
+begin transaction #9
+## PostCommitPhase stage 7 of 15 with 1 ValidationType op
+validate forward indexes [6] in table #108
+commit transaction #9
+begin transaction #10
+## PostCommitPhase stage 8 of 15 with 28 MutationType ops
+upsert descriptor #108
+  ...
+       mutationId: 1
+       state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 2
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 2
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 4
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - j
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: table_regional_by_row_j_key
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 3
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 3
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 4
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - j
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_3_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 4
+  +      createdAtNanos: "1640998800000000000"
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 4
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 5
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - l
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: table_regional_by_row_l_key
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: BACKFILLING
+  +  - direction: ADD
+  +    index:
+  +      constraintId: 5
+  +      createdExplicitly: true
+  +      foreignKey: {}
+  +      geoConfig: {}
+  +      id: 5
+  +      interleave: {}
+  +      keyColumnDirections:
+  +      - ASC
+  +      - ASC
+  +      keyColumnIds:
+  +      - 3
+  +      - 5
+  +      keyColumnNames:
+  +      - crdb_region
+  +      - l
+  +      keySuffixColumnIds:
+  +      - 1
+  +      name: crdb_internal_index_5_name_placeholder
+  +      partitioning:
+  +        list:
+  +        - name: us-east1
+  +          subpartitioning: {}
+  +          values:
+  +          - BgFA
+  +        - name: us-east2
+  +          subpartitioning: {}
+  +          values:
+  +          - BgGA
+  +        - name: us-east3
+  +          subpartitioning: {}
+  +          values:
+  +          - BgHA
+  +        numColumns: 1
+  +        numImplicitColumns: 1
+  +      sharded: {}
+  +      storeColumnNames: []
+  +      unique: true
+  +      useDeletePreservingEncoding: true
+  +      vecConfig: {}
+  +      version: 4
+  +    mutationId: 1
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "6"
+  +  version: "7"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 9 of 15 with 2 MutationType ops pending"
+commit transaction #10
+begin transaction #11
+## PostCommitPhase stage 9 of 15 with 4 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: WRITE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "7"
+  +  version: "8"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 10 of 15 with 2 BackfillType ops pending"
+commit transaction #11
+begin transaction #12
+## PostCommitPhase stage 10 of 15 with 2 BackfillType ops
+backfill indexes [2 4] from index #6 in table #108
+commit transaction #12
+begin transaction #13
+## PostCommitPhase stage 11 of 15 with 4 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: BACKFILLING
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "8"
+  +  version: "9"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 12 of 15 with 2 MutationType ops pending"
+commit transaction #13
+begin transaction #14
+## PostCommitPhase stage 12 of 15 with 4 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  +    state: MERGING
+     - direction: ADD
+       index:
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "9"
+  +  version: "10"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 13 of 15 with 2 BackfillType ops pending"
+commit transaction #14
+begin transaction #15
+## PostCommitPhase stage 13 of 15 with 2 BackfillType ops
+merge temporary indexes [3 5] into backfilled indexes [2 4] in table #108
+commit transaction #15
+begin transaction #16
+## PostCommitPhase stage 14 of 15 with 6 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 3
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     - direction: ADD
+       index:
+  ...
+         version: 4
+       mutationId: 1
+  -    state: MERGING
+  -  - direction: ADD
+  +    state: WRITE_ONLY
+  +  - direction: DROP
+       index:
+         constraintId: 5
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "10"
+  +  version: "11"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitPhase stage 15 of 15 with 2 ValidationType ops pending"
+commit transaction #16
+begin transaction #17
+## PostCommitPhase stage 15 of 15 with 2 ValidationType ops
+validate forward indexes [2] in table #108
+validate forward indexes [4] in table #108
+commit transaction #17
+begin transaction #18
+## PostCommitNonRevertiblePhase stage 1 of 3 with 28 MutationType ops
+upsert descriptor #108
+  ...
+         udtMetadata:
+           arrayTypeOid: 100107
+  +  - defaultExpr: unique_rowid()
+  +    id: 4
+  +    name: j
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+  +  - defaultExpr: unique_rowid()
+  +    id: 5
+  +    name: l
+  +    nullable: true
+  +    type:
+  +      family: IntFamily
+  +      oid: 20
+  +      width: 64
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  ...
+           statement: ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
+           statementTag: ALTER TABLE
+  -    revertible: true
+       targetRanks: <redacted>
+       targets: <redacted>
+  ...
+     formatVersion: 3
+     id: 108
+  +  indexes:
+  +  - constraintId: 2
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 2
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    - ASC
+  +    keyColumnIds:
+  +    - 3
+  +    - 4
+  +    keyColumnNames:
+  +    - crdb_region
+  +    - j
+  +    keySuffixColumnIds:
+  +    - 1
+  +    name: table_regional_by_row_j_key
+  +    partitioning:
+  +      list:
+  +      - name: us-east1
+  +        subpartitioning: {}
+  +        values:
+  +        - BgFA
+  +      - name: us-east2
+  +        subpartitioning: {}
+  +        values:
+  +        - BgGA
+  +      - name: us-east3
+  +        subpartitioning: {}
+  +        values:
+  +        - BgHA
+  +      numColumns: 1
+  +      numImplicitColumns: 1
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+  +  - constraintId: 4
+  +    createdAtNanos: "1640998800000000000"
+  +    createdExplicitly: true
+  +    foreignKey: {}
+  +    geoConfig: {}
+  +    id: 4
+  +    interleave: {}
+  +    keyColumnDirections:
+  +    - ASC
+  +    - ASC
+  +    keyColumnIds:
+  +    - 3
+  +    - 5
+  +    keyColumnNames:
+  +    - crdb_region
+  +    - l
+  +    keySuffixColumnIds:
+  +    - 1
+  +    name: table_regional_by_row_l_key
+  +    partitioning:
+  +      list:
+  +      - name: us-east1
+  +        subpartitioning: {}
+  +        values:
+  +        - BgFA
+  +      - name: us-east2
+  +        subpartitioning: {}
+  +        values:
+  +        - BgGA
+  +      - name: us-east3
+  +        subpartitioning: {}
+  +        values:
+  +        - BgHA
+  +      numColumns: 1
+  +      numImplicitColumns: 1
+  +    sharded: {}
+  +    storeColumnNames: []
+  +    unique: true
+  +    vecConfig: {}
+  +    version: 4
+     localityConfig:
+       regionalByRow: {}
+     modificationTime: {}
+     mutations:
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      id: 4
+  -      name: j
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - column:
+  -      defaultExpr: unique_rowid()
+  -      id: 5
+  -      name: l
+  -      nullable: true
+  -      type:
+  -        family: IntFamily
+  -        oid: 20
+  -        width: 64
+  -    direction: ADD
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 6
+  -      createdExplicitly: true
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 6
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 1
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - k
+  -      name: crdb_internal_index_6_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      - 4
+  -      - 5
+  -      storeColumnNames:
+  -      - v
+  -      - j
+  -      - l
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+     - direction: DROP
+       index:
+  -      constraintId: 7
+  -      createdExplicitly: true
+  +      constraintId: 1
+  +      createdAtNanos: "1640995200000000000"
+         encodingType: 1
+         foreignKey: {}
+         geoConfig: {}
+  -      id: 7
+  +      id: 1
+         interleave: {}
+         keyColumnDirections:
+  ...
+         - crdb_region
+         - k
+  -      name: crdb_internal_index_7_name_placeholder
+  +      name: crdb_internal_index_1_name_placeholder
+         partitioning:
+           list:
+  ...
+         storeColumnIds:
+         - 2
+  -      - 4
+  -      - 5
+         storeColumnNames:
+         - v
+  -      - j
+  -      - l
+         unique: true
+  -      useDeletePreservingEncoding: true
+         vecConfig: {}
+         version: 4
+       mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 2
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 2
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 4
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: table_regional_by_row_j_key
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+       state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 3
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 3
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 4
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - j
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_3_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  -  - direction: ADD
+  -    index:
+  -      constraintId: 4
+  -      createdAtNanos: "1640998800000000000"
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 4
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 5
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - l
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: table_regional_by_row_l_key
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: WRITE_ONLY
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 5
+  -      createdExplicitly: true
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 5
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 5
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - l
+  -      keySuffixColumnIds:
+  -      - 1
+  -      name: crdb_internal_index_5_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnNames: []
+  -      unique: true
+  -      useDeletePreservingEncoding: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+     partitionAllBy: true
+     primaryIndex:
+  -    constraintId: 1
+  -    createdAtNanos: "1640995200000000000"
+  +    constraintId: 6
+  +    createdExplicitly: true
+       encodingType: 1
+       foreignKey: {}
+       geoConfig: {}
+  -    id: 1
+  +    id: 6
+       interleave: {}
+       keyColumnDirections:
+  ...
+       storeColumnIds:
+       - 2
+  +    - 4
+  +    - 5
+       storeColumnNames:
+       - v
+  +    - j
+  +    - l
+       unique: true
+       vecConfig: {}
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "11"
+  +  version: "12"
+persist all catalog changes to storage
+adding table for stats refresh: 108
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 2 of 3 with 4 MutationType ops pending"
+set schema change job #1 to non-cancellable
+commit transaction #18
+begin transaction #19
+## PostCommitNonRevertiblePhase stage 2 of 3 with 6 MutationType ops
+upsert descriptor #108
+  ...
+         version: 4
+       mutationId: 1
+  -    state: WRITE_ONLY
+  +    state: DELETE_ONLY
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "12"
+  +  version: "13"
+persist all catalog changes to storage
+update progress of schema change job #1: "PostCommitNonRevertiblePhase stage 3 of 3 with 5 MutationType ops pending"
+commit transaction #19
+begin transaction #20
+## PostCommitNonRevertiblePhase stage 3 of 3 with 7 MutationType ops
+upsert descriptor #108
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  declarativeSchemaChangerState:
+  -    authorization:
+  -      userName: root
+  -    currentStatuses: <redacted>
+  -    jobId: "1"
+  -    nameMapping:
+  -      columns:
+  -        "1": k
+  -        "2": v
+  -        "3": crdb_region
+  -        "4": j
+  -        "5": l
+  -        "4294967292": crdb_internal_origin_timestamp
+  -        "4294967293": crdb_internal_origin_id
+  -        "4294967294": tableoid
+  -        "4294967295": crdb_internal_mvcc_timestamp
+  -      families:
+  -        "0": primary
+  -      id: 108
+  -      indexes:
+  -        "2": table_regional_by_row_j_key
+  -        "4": table_regional_by_row_l_key
+  -        "6": table_regional_by_row_pkey
+  -      name: table_regional_by_row
+  -    relevantStatements:
+  -    - statement:
+  -        redactedStatement: ALTER TABLE ‹multiregion_db›.‹public›.‹table_regional_by_row› ADD COLUMN ‹j› INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN ‹l› INT8 UNIQUE DEFAULT unique_rowid()
+  -        statement: ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()
+  -        statementTag: ALTER TABLE
+  -    targetRanks: <redacted>
+  -    targets: <redacted>
+     families:
+     - columnIds:
+  ...
+       regionalByRow: {}
+     modificationTime: {}
+  -  mutations:
+  -  - direction: DROP
+  -    index:
+  -      constraintId: 1
+  -      createdAtNanos: "1640995200000000000"
+  -      encodingType: 1
+  -      foreignKey: {}
+  -      geoConfig: {}
+  -      id: 1
+  -      interleave: {}
+  -      keyColumnDirections:
+  -      - ASC
+  -      - ASC
+  -      keyColumnIds:
+  -      - 3
+  -      - 1
+  -      keyColumnNames:
+  -      - crdb_region
+  -      - k
+  -      name: crdb_internal_index_1_name_placeholder
+  -      partitioning:
+  -        list:
+  -        - name: us-east1
+  -          subpartitioning: {}
+  -          values:
+  -          - BgFA
+  -        - name: us-east2
+  -          subpartitioning: {}
+  -          values:
+  -          - BgGA
+  -        - name: us-east3
+  -          subpartitioning: {}
+  -          values:
+  -          - BgHA
+  -        numColumns: 1
+  -        numImplicitColumns: 1
+  -      sharded: {}
+  -      storeColumnIds:
+  -      - 2
+  -      storeColumnNames:
+  -      - v
+  -      unique: true
+  -      vecConfig: {}
+  -      version: 4
+  -    mutationId: 1
+  -    state: DELETE_ONLY
+  +  mutations: []
+     name: table_regional_by_row
+     nextColumnId: 6
+  ...
+       time: {}
+     unexposedParentSchemaId: 105
+  -  version: "13"
+  +  version: "14"
+persist all catalog changes to storage
+create job #2 (non-cancelable: true): "GC for ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid()"
+  descriptor IDs: [108]
+update progress of schema change job #1: "all stages completed"
+set schema change job #1 to non-cancellable
+updated schema change job #1 descriptor IDs to []
+write *eventpb.FinishSchemaChange to event log:
+  sc:
+    descriptorId: 108
+commit transaction #20
+notified job registry to adopt jobs: [2]
+# end PostCommitPhase

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_10_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_10_of_15.explain
@@ -1,0 +1,131 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 10 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_10_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_10_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 10 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_11_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_11_of_15.explain
@@ -1,0 +1,131 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 11 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_11_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_11_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 11 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_12_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_12_of_15.explain
@@ -1,0 +1,131 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 12 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_12_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_12_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 12 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── DELETE_ONLY           → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_13_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_13_of_15.explain
@@ -1,0 +1,135 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 13 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 17 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 17 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_13_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_13_of_23.explain
@@ -1,0 +1,140 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 13 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 11 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_14_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_14_of_15.explain
@@ -1,0 +1,135 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 14 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 17 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 17 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_14_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_14_of_23.explain
@@ -1,0 +1,140 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 14 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 9 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 11 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_15_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_15_of_15.explain
@@ -1,0 +1,131 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 15 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_15_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_15_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 15 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_16_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_16_of_23.explain
@@ -1,0 +1,138 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 16 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_17_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_17_of_23.explain
@@ -1,0 +1,182 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 17 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 8 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 10 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 13 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           └── 13 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_18_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_18_of_23.explain
@@ -1,0 +1,190 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 18 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    └── 12 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_19_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_19_of_23.explain
@@ -1,0 +1,190 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 19 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    └── 12 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_1_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_1_of_15.explain
@@ -1,0 +1,66 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 26 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+           │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+           │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+           │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+           │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+           └── 24 Mutation operations
+                ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+                ├── DiscardTableZoneConfig {"TableID":108}
+                ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+                ├── DiscardTableZoneConfig {"TableID":108}
+                ├── DiscardTableZoneConfig {"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_1_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_1_of_23.explain
@@ -1,0 +1,95 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 1 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      └── Stage 1 of 1 in PostCommitNonRevertiblePhase
+           ├── 4 elements transitioning toward PUBLIC
+           │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+           │    ├── ABSENT           → PUBLIC ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+           │    ├── WRITE_ONLY       → PUBLIC Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+           │    └── ABSENT           → PUBLIC ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+           ├── 35 elements transitioning toward ABSENT
+           │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY      → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── TRANSIENT_ABSENT → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+           │    ├── BACKFILL_ONLY    → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+           │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+           │    ├── DELETE_ONLY      → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC           → ABSENT ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+           │    ├── PUBLIC           → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC           → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+           │    ├── PUBLIC           → ABSENT IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+           │    └── PUBLIC           → ABSENT TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+           └── 38 Mutation operations
+                ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+                ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+                ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+                ├── DiscardTableZoneConfig {"TableID":108}
+                ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+                ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+                ├── DiscardTableZoneConfig {"TableID":108}
+                ├── DiscardTableZoneConfig {"TableID":108}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+                ├── RefreshStats {"TableID":108}
+                ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+                ├── RefreshStats {"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_20_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_20_of_23.explain
@@ -1,0 +1,190 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 20 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    └── 12 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_21_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_21_of_23.explain
@@ -1,0 +1,194 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 21 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    └── 14 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_22_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_22_of_23.explain
@@ -1,0 +1,194 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 22 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── MERGE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":3,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":5,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 12 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    └── DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    └── 14 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_23_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_23_of_23.explain
@@ -1,0 +1,190 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 23 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 52 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 55 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":4,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 10 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED   → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC      → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── DELETE_ONLY → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 8 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    └── 12 Mutation operations
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 15 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 9}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 3}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 5}
+           └── 15 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":3,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":9,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_2_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_2_of_15.explain
@@ -1,0 +1,79 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 2 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_2_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_2_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 2 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_3_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_3_of_15.explain
@@ -1,0 +1,79 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 3 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_3_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_3_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 3 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_4_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_4_of_15.explain
@@ -1,0 +1,79 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 4 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── DELETE_ONLY      → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_4_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_4_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 4 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── DELETE_ONLY      → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_5_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_5_of_15.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 5 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_5_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_5_of_23.explain
@@ -1,0 +1,110 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 5 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_6_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_6_of_15.explain
@@ -1,0 +1,81 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 6 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_6_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_6_of_23.explain
@@ -1,0 +1,110 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 6 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY       → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT           → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── MERGE_ONLY       → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY    → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY       → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC           → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC           → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 11 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_7_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_7_of_15.explain
@@ -1,0 +1,79 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 7 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_7_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_7_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 7 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_8_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_8_of_15.explain
@@ -1,0 +1,79 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 8 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 21 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 21 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 9 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           └── 9 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_8_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_8_of_23.explain
@@ -1,0 +1,108 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 8 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 4 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    └── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    ├── 29 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 34 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_9_of_15.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_9_of_15.explain
@@ -1,0 +1,123 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 9 of 15;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 2 in PostCommitNonRevertiblePhase
+      │    ├── 43 elements transitioning toward ABSENT
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 4 (j-)}
+      │    │    ├── VALIDATED             → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-), ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_j_key", IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 3}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 3, ConstraintID: 3, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 3}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 5 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      SecondaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-), ConstraintID: 4, TemporaryIndexID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-), RecreateSourceIndexID: 0}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_l_key", IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (crdb_region), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 5}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 5, ConstraintID: 5, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 5}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 39 Mutation operations
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":4,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":4,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── SetIndexName {"IndexID":2,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":3,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":3,"Kind":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── SetIndexName {"IndexID":4,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":5,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":5,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":2,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":2,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":4,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":4,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":4,"Kind":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":4,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":5,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 2 of 2 in PostCommitNonRevertiblePhase
+           ├── 11 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 4 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 4 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 2 (table_regional_by_row_j_key-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (l-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (l-), Expr: unique_rowid()}
+           │    └── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 4 (table_regional_by_row_l_key-)}
+           └── 11 Mutation operations
+                ├── RemoveColumnDefaultExpression {"ColumnID":4,"TableID":108}
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":2,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":4,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":4,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_9_of_23.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/add_column_multiple_regional_by_row/add_column_multiple_regional_by_row__rollback_9_of_23.explain
@@ -1,0 +1,134 @@
+/* setup */
+CREATE DATABASE multiregion_db PRIMARY REGION "us-east1" REGIONS "us-east2", "us-east3" SURVIVE REGION FAILURE;
+CREATE TABLE multiregion_db.public.table_regional_by_row (
+  k INT PRIMARY KEY,
+  V STRING,
+  m INT
+) LOCALITY REGIONAL BY ROW;
+
+/* test */
+ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT DEFAULT unique_rowid() UNIQUE, DROP COLUMN m, ADD COLUMN l INT DEFAULT unique_rowid() UNIQUE;
+EXPLAIN (DDL) rollback at post-commit stage 9 of 23;
+----
+Schema change plan for rolling back ALTER TABLE multiregion_db.public.table_regional_by_row DROP COLUMN v, ADD COLUMN j INT8 UNIQUE DEFAULT unique_rowid(), DROP COLUMN m, ADD COLUMN l INT8 UNIQUE DEFAULT unique_rowid();
+ └── PostCommitNonRevertiblePhase
+      ├── Stage 1 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward PUBLIC
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "v", ColumnID: 2 (v+)}
+      │    │    ├── WRITE_ONLY            → PUBLIC      Column:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+)}
+      │    │    ├── ABSENT                → PUBLIC      ColumnName:{DescID: 108 (table_regional_by_row), Name: "m", ColumnID: 3 (m+)}
+      │    │    ├── VALIDATED             → PUBLIC      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+), ConstraintID: 1}
+      │    │    ├── ABSENT                → PUBLIC      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    └── ABSENT                → PUBLIC      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 1 (table_regional_by_row_pkey+)}
+      │    ├── 30 elements transitioning toward ABSENT
+      │    │    ├── PUBLIC                → VALIDATED   PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC                → ABSENT      IndexName:{DescID: 108 (table_regional_by_row), Name: "table_regional_by_row_pkey", IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_DELETE_ONLY → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 7, ConstraintID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 7}
+      │    │    ├── BACKFILL_ONLY         → ABSENT      PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-), ConstraintID: 8, TemporaryIndexID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── DELETE_ONLY           → ABSENT      TemporaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 9, ConstraintID: 9, SourceIndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── TRANSIENT_ABSENT      → ABSENT      IndexPartitioning:{DescID: 108 (table_regional_by_row), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 9}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "j", ColumnID: 5 (j-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 1}
+      │    │    ├── WRITE_ONLY            → DELETE_ONLY Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      ColumnName:{DescID: 108 (table_regional_by_row), Name: "l", ColumnID: 6 (l-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 7}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 8 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC                → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 9}
+      │    │    ├── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 2}
+      │    │    └── PUBLIC                → ABSENT      TableZoneConfig:{DescID: 108 (table_regional_by_row), SeqNum: 3}
+      │    └── 37 Mutation operations
+      │         ├── SetColumnName {"ColumnID":2,"Name":"v","TableID":108}
+      │         ├── SetColumnName {"ColumnID":3,"Name":"m","TableID":108}
+      │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":1,"TableID":108}}
+      │         ├── SetIndexName {"IndexID":1,"Name":"table_regional_b...","TableID":108}
+      │         ├── MakePublicPrimaryIndexWriteOnly {"IndexID":6,"TableID":108}
+      │         ├── SetIndexName {"IndexID":6,"Name":"crdb_internal_in...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":7,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":7,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":8,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":9,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":5,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":5,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":7,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":8,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":9,"Kind":2,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnDeleteOnly {"ColumnID":6,"TableID":108}
+      │         ├── SetColumnName {"ColumnID":6,"Name":"crdb_internal_co...","TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":7,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":8,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":9,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── DiscardTableZoneConfig {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":2,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeWriteOnlyColumnPublic {"ColumnID":3,"TableID":108}
+      │         ├── RefreshStats {"TableID":108}
+      │         ├── MakeValidatedPrimaryIndexPublic {"IndexID":1,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":7,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":8,"TableID":108}
+      │         ├── MakeIndexAbsent {"IndexID":9,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      ├── Stage 2 of 3 in PostCommitNonRevertiblePhase
+      │    ├── 7 elements transitioning toward ABSENT
+      │    │    ├── VALIDATED → DELETE_ONLY PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 4 (crdb_region), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 1 (k), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 2 (v+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 3 (m+), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    ├── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    │    └── PUBLIC    → ABSENT      IndexColumn:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), IndexID: 6 (table_regional_by_row_pkey-)}
+      │    └── 9 Mutation operations
+      │         ├── MakeWriteOnlyIndexDeleteOnly {"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":4,"IndexID":6,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":2,"IndexID":6,"Kind":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":3,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":5,"IndexID":6,"Kind":2,"Ordinal":2,"TableID":108}
+      │         ├── RemoveColumnFromIndex {"ColumnID":6,"IndexID":6,"Kind":2,"Ordinal":3,"TableID":108}
+      │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
+      │         └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"PostCommitNonRev..."}
+      └── Stage 3 of 3 in PostCommitNonRevertiblePhase
+           ├── 10 elements transitioning toward ABSENT
+           │    ├── DELETE_ONLY → ABSENT PrimaryIndex:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-), ConstraintID: 6, TemporaryIndexID: 7, SourceIndexID: 1 (table_regional_by_row_pkey+)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 6 (table_regional_by_row_pkey-)}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 7}
+           │    ├── PUBLIC      → ABSENT IndexData:{DescID: 108 (table_regional_by_row), IndexID: 8 (table_regional_by_row_pkey-)}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 5 (j-), TypeName: "INT8"}
+           │    ├── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 5 (j-), Expr: unique_rowid()}
+           │    ├── DELETE_ONLY → ABSENT Column:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-)}
+           │    ├── PUBLIC      → ABSENT ColumnType:{DescID: 108 (table_regional_by_row), ColumnFamilyID: 0 (primary), ColumnID: 6 (l-), TypeName: "INT8"}
+           │    └── PUBLIC      → ABSENT ColumnDefaultExpression:{DescID: 108 (table_regional_by_row), ColumnID: 6 (l-), Expr: unique_rowid()}
+           └── 10 Mutation operations
+                ├── MakeIndexAbsent {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":6,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":7,"TableID":108}
+                ├── CreateGCJobForIndex {"IndexID":8,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":5,"TableID":108}
+                ├── RemoveColumnDefaultExpression {"ColumnID":6,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":5,"TableID":108}
+                ├── MakeDeleteOnlyColumnAbsent {"ColumnID":6,"TableID":108}
+                ├── RemoveJobStateFromDescriptor {"DescriptorID":108}
+                └── UpdateSchemaChangerJob {"IsNonCancelable":true,"RunningStatus":"all stages compl..."}

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table.go
@@ -241,7 +241,17 @@ func maybeRewriteIndexAndConstraintID(
 			}
 			return nil
 		})
+		// If there are references to the indexID in the subzones,
+		// then we should rewrite.
+		if zoneConfig, ok := e.(*scpb.TableZoneConfig); ok {
+			for subzoneIdx := range zoneConfig.ZoneConfig.Subzones {
+				if zoneConfig.ZoneConfig.Subzones[subzoneIdx].IndexID == uint32(indexID) {
+					zoneConfig.ZoneConfig.Subzones[subzoneIdx].IndexID = uint32(actualIndexID)
+				}
+			}
+		}
 	})
+
 	return true
 }
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql/schemachanger: update zone configs for multi stmt ALTER TABLE" (#146369)
  * 1/1 commits from "sql/schemachanger: apply zone configs to all pks during column changes" (#146460)

Please see individual PRs for details.

/cc @cockroachdb/release


Release justification:  low risk fixes for issues that can lead to incorrect zone configs