### PR TITLE
sql: add support for LIKE, ILIKE, NOT LIKE, and NOT ILIKE aliases

### DIFF
--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -842,6 +842,38 @@ SELECT a FROM t WHERE a NOT ILIKE b -- literals removed
 SELECT _ FROM _ WHERE _ NOT ILIKE _ -- identifiers removed
 
 parse
+SELECT a ~~* b
+----
+SELECT a ILIKE b -- normalized!
+SELECT ((a) ILIKE (b)) -- fully parenthesized
+SELECT a ILIKE b -- literals removed
+SELECT _ ILIKE _ -- identifiers removed
+
+parse
+SELECT a ~~* 'foo'
+----
+SELECT a ILIKE 'foo' -- normalized!
+SELECT ((a) ILIKE ('foo')) -- fully parenthesized
+SELECT a ILIKE '_' -- literals removed
+SELECT _ ILIKE 'foo' -- identifiers removed
+
+parse
+SELECT a !~~* b
+----
+SELECT a NOT ILIKE b -- normalized!
+SELECT ((a) NOT ILIKE (b)) -- fully parenthesized
+SELECT a NOT ILIKE b -- literals removed
+SELECT _ NOT ILIKE _ -- identifiers removed
+
+parse
+SELECT a !~~* 'foo'
+----
+SELECT a NOT ILIKE 'foo' -- normalized!
+SELECT ((a) NOT ILIKE ('foo')) -- fully parenthesized
+SELECT a NOT ILIKE '_' -- literals removed
+SELECT _ NOT ILIKE 'foo' -- identifiers removed
+
+parse
 SELECT a FROM t WHERE a SIMILAR TO b
 ----
 SELECT a FROM t WHERE a SIMILAR TO b

--- a/pkg/sql/parser/testdata/select_clauses
+++ b/pkg/sql/parser/testdata/select_clauses
@@ -786,6 +786,46 @@ SELECT a FROM t WHERE a NOT LIKE b -- literals removed
 SELECT _ FROM _ WHERE _ NOT LIKE _ -- identifiers removed
 
 parse
+SELECT a ~~ b
+----
+SELECT a LIKE b -- normalized!
+SELECT ((a) LIKE (b)) -- fully parenthesized
+SELECT a LIKE b -- literals removed
+SELECT _ LIKE _ -- identifiers removed
+
+parse
+SELECT a ~~ 'foo'
+----
+SELECT a LIKE 'foo' -- normalized!
+SELECT ((a) LIKE ('foo')) -- fully parenthesized
+SELECT a LIKE '_' -- literals removed
+SELECT _ LIKE 'foo' -- identifiers removed
+
+parse
+SELECT a FROM t WHERE a ~ ~ b
+----
+SELECT a FROM t WHERE a ~ (~b) -- normalized!
+SELECT (a) FROM t WHERE ((a) ~ ((~(b)))) -- fully parenthesized
+SELECT a FROM t WHERE a ~ (~b) -- literals removed
+SELECT _ FROM _ WHERE _ ~ (~_) -- identifiers removed
+
+parse
+SELECT a !~~ b
+----
+SELECT a NOT LIKE b -- normalized!
+SELECT ((a) NOT LIKE (b)) -- fully parenthesized
+SELECT a NOT LIKE b -- literals removed
+SELECT _ NOT LIKE _ -- identifiers removed
+
+parse
+SELECT a !~~ 'foo'
+----
+SELECT a NOT LIKE 'foo' -- normalized!
+SELECT ((a) NOT LIKE ('foo')) -- fully parenthesized
+SELECT a NOT LIKE '_' -- literals removed
+SELECT _ NOT LIKE 'foo' -- identifiers removed
+
+parse
 SELECT a FROM t WHERE a ILIKE b
 ----
 SELECT a FROM t WHERE a ILIKE b

--- a/pkg/sql/parser/testdata/select_exprs
+++ b/pkg/sql/parser/testdata/select_exprs
@@ -112,7 +112,7 @@ SELECT _ - _ -- literals removed
 SELECT -0. - -1 -- identifiers removed
 
 parse
-SELECT~~+~++~bd(*)
+SELECT~+~+~++~bd(*)
 ----
 SELECT ~(~(~(~bd(*)))) -- normalized!
 SELECT (~((~((~((~(bd((*)))))))))) -- fully parenthesized

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -286,6 +286,10 @@ func (s *SQLScanner) Scan(lval ScanSymType) {
 				s.pos++
 				lval.SetID(lexbase.NOT_REGIMATCH)
 				return
+			case '~': // !~~
+				s.pos--
+				lval.SetID(lexbase.NOT)
+				return
 			}
 			lval.SetID(lexbase.NOT_REGMATCH)
 			return
@@ -423,6 +427,10 @@ func (s *SQLScanner) Scan(lval ScanSymType) {
 		case '*': // ~*
 			s.pos++
 			lval.SetID(lexbase.REGIMATCH)
+			return
+		case '~': // ~~
+			s.pos++
+			lval.SetID(lexbase.LIKE)
 			return
 		}
 		return

--- a/pkg/sql/scanner/scan.go
+++ b/pkg/sql/scanner/scan.go
@@ -286,7 +286,7 @@ func (s *SQLScanner) Scan(lval ScanSymType) {
 				s.pos++
 				lval.SetID(lexbase.NOT_REGIMATCH)
 				return
-			case '~': // !~~
+			case '~': // !~~ or !~~*
 				s.pos--
 				lval.SetID(lexbase.NOT)
 				return
@@ -430,6 +430,12 @@ func (s *SQLScanner) Scan(lval ScanSymType) {
 			return
 		case '~': // ~~
 			s.pos++
+			switch s.peek() {
+			case '*': // ~~*
+				s.pos++
+				lval.SetID(lexbase.ILIKE)
+				return
+			}
 			lval.SetID(lexbase.LIKE)
 			return
 		}

--- a/pkg/sql/sem/eval/testdata/eval/like
+++ b/pkg/sql/sem/eval/testdata/eval/like
@@ -20,6 +20,25 @@ eval
 ----
 false
 
+eval
+'TEST' ~~ 'TESTER'
+----
+false
+
+eval
+'TEST' ~ ~ 'TEST'
+----
+unsupported unary operator: ~ <string>
+
+eval
+'TEST' !~~ 'TESTER'
+----
+true
+
+eval
+'TEST' !~ ~ 'TEST'
+----
+unsupported unary operator: ~ <string>
 
 eval
 '' LIKE ''

--- a/pkg/sql/sem/eval/testdata/eval/like
+++ b/pkg/sql/sem/eval/testdata/eval/like
@@ -41,6 +41,16 @@ eval
 unsupported unary operator: ~ <string>
 
 eval
+'TEST' ~~* 'test'
+----
+true
+
+eval
+'TEST' !~~* 'test'
+----
+false
+
+eval
 '' LIKE ''
 ----
 true


### PR DESCRIPTION
#### sql: add support for LIKE and NOT LIKE aliases (`~~`, and `!~~`, respectively)

Fixes: cockroachdb/cockroach#95878
Epic: CRDB-25419
Release note (sql change): The `~~` and `!~~` are now supported aliases for
`LIKE` and `NOT LIKE`.

#### sql: add support for ILIKE and NOT ILIKE aliases (`~~*`, and `!~~*`, respectively)

Fixes: cockroachdb/cockroach#95878
Epic: CRDB-25419
Release note (sql change): The `~~*` and `!~~*` are now supported aliases for
`ILIKE` and `NOT ILIKE`.
