### PR TITLE
roachtest: collect CPU, Allocs, Mutex profiles after sysbench runs

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -41,6 +41,8 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/workload/histogram/exporter",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_google_pprof//profile",
+        "@com_github_pkg_errors//:errors",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_stretchr_testify//require",

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -42,7 +42,6 @@ go_library(
         "//pkg/workload/histogram/exporter",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_google_pprof//profile",
-        "@com_github_pkg_errors//:errors",
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_stretchr_testify//require",

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "@com_github_prometheus_common//expfmt",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/cmd/roachtest/roachtestutil/profile.go
+++ b/pkg/cmd/roachtest/roachtestutil/profile.go
@@ -417,19 +417,19 @@ func GetProfile(
 
 	// profileWg is used to wait for all the profiles to be collected.
 	profileWg := sync.WaitGroup{}
-	for _, nodeId := range nodes {
+	for i, nodeId := range nodes {
 		profileWg.Add(1)
-		go func(nodeID int) {
+		go func(nodeID int, sliceIdx int) {
 			defer profileWg.Done()
 			var err error
-			profiles[nodeID-1], err = getProfileSingleNode(ctx, cluster, logger, profileType,
+			profiles[sliceIdx], err = getProfileSingleNode(ctx, cluster, logger, profileType,
 				nodeID, duration)
 
 			if err != nil {
 				logger.Printf("error getting profile for node %d: %s", nodeID, err)
-				errors[nodeID-1] = err
+				errors[sliceIdx] = err
 			}
-		}(nodeId)
+		}(nodeId, i)
 	}
 	profileWg.Wait()
 

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -327,6 +327,7 @@ go_library(
         "@com_github_codahale_hdrhistogram//:hdrhistogram",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_google_go_cmp//cmp",
+        "@com_github_google_pprof//profile",
         "@com_github_ibm_sarama//:sarama",
         "@com_github_jackc_pgtype//:pgtype",
         "@com_github_jackc_pgx_v5//:pgx",

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -264,7 +264,13 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 
 		t.Status("running 75 second workload to collect profiles")
 		{
-			m := t.NewGroup(task.WithContext(ctx))
+			// Create the profiles directory in the artifacts directory.
+			profilesDir := filepath.Join(t.ArtifactsDir(), "profiles")
+			require.NoError(t, os.MkdirAll(profilesDir, 0755))
+
+			// Start a short sysbench test in order to collect the profiles from an
+			// active cluster.
+			m := t.NewErrorGroup(task.WithContext(ctx))
 			m.Go(
 				func(ctx context.Context, l *logger.Logger) error {
 					opts := opts
@@ -274,7 +280,6 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 
 					if msg, crashed := detectSysbenchCrash(result); crashed {
 						t.L().Printf("%s; sysbench run to collect profiles failed", msg)
-						return nil
 					}
 					return err
 				},
@@ -283,7 +288,34 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 			// Wait for 30 seconds to give a chance to the workload to start, and then
 			// collect CPU, mutex diffs, allocs diffs profiles.
 			time.Sleep(30 * time.Second)
-			collectSysbenchProfiles(t, m, c, 30*time.Second /* duration */)
+			collectionDuration := 30 * time.Second
+			profiles, err := collectSysbenchProfiles(m, c, collectionDuration, profilesDir)
+
+			// If there is an error generating one or more profiles, we need to clean
+			// up the profiles directory and return the error to avoid leaving
+			// potentially corrupt profiles in the directory.
+			if err != nil {
+				require.NoError(t, os.RemoveAll(profilesDir))
+				return err
+			}
+
+			// If there is a problem executing the workload, or , we need to clean up
+			// the directory and return the error.
+			if err := m.WaitE(); err != nil {
+				require.NoError(t, os.RemoveAll(profilesDir))
+				return err
+			}
+
+			// At this point we know that the workload has not crashed, and we have
+			// collected all the individual profiles. We can now merge and export
+			// them. If exporting or merging fails for some reason, we clean up the
+			// profiles directory and return the error to avoid leaving potentially
+			// corrupt profiles.
+			if err := mergeAndExportSysbenchProfiles(c, collectionDuration, profiles,
+				profilesDir); err != nil {
+				require.NoError(t, os.RemoveAll(profilesDir))
+				return err
+			}
 		}
 
 		return nil
@@ -624,10 +656,24 @@ func exportSysbenchResults(
 }
 
 // collectSysbenchProfiles collects cpu, mutex, and allocs profiles from the
-// cluster `c` for the duration specified.
-func collectSysbenchProfiles(t test.Test, m task.Group, c cluster.Cluster, duration time.Duration) {
+// cluster `c` for the duration specified. It returns a map of profiles for each
+// type and for each node. It returns an error if any of the profiles couldn't
+// be collected.
+//
+// Example of returned map:
+//
+//	{
+//	  "cpu":    [node1Profile, node2Profile, node3Profile],
+//	  "allocs": [node1Profile, node2Profile, node3Profile],
+//	  "mutex":  [node1Profile, node2Profile, node3Profile],
+//	}
+//
+// where each profile is a *profile.Profile and the slice indices correspond to
+// the node indices in c.CRDBNodes().
+func collectSysbenchProfiles(
+	m task.ErrorGroup, c cluster.Cluster, duration time.Duration, profilesDir string,
+) (map[string][]*profile.Profile, error) {
 	profiles := map[string][]*profile.Profile{"cpu": {}, "allocs": {}, "mutex": {}}
-	mergedProfiles := map[string]*profile.Profile{"cpu": {}, "allocs": {}, "mutex": {}}
 	for typ := range profiles {
 		m.Go(
 			func(ctx context.Context, l *logger.Logger) error {
@@ -639,38 +685,47 @@ func collectSysbenchProfiles(t test.Test, m task.Group, c cluster.Cluster, durat
 		)
 	}
 
-	m.Wait()
+	return profiles, nil
+}
 
+// mergeAndExportSysbenchProfiles accepts a map of individual profiles of each
+// node of different types (cpu, allocs, mutex), and exports them to the
+// specified directory. Also, it merges them and exports the merged profiles
+// to the same directory.
+func mergeAndExportSysbenchProfiles(
+	c cluster.Cluster,
+	duration time.Duration,
+	profiles map[string][]*profile.Profile,
+	profilesDir string,
+) error {
 	// Merge the profiles.
+	mergedProfiles := map[string]*profile.Profile{"cpu": {}, "allocs": {}, "mutex": {}}
 	for typ := range mergedProfiles {
 		var err error
-		mergedProfiles[typ], err = profile.Merge(profiles[typ])
-		require.NoError(t, err)
-	}
-
-	// Create the profiles directory in the artifacts directory.
-	profilesDir := filepath.Join(t.ArtifactsDir(), "profiles")
-	require.NoError(t, os.MkdirAll(profilesDir, 0755))
-
-	// exportProfile exports a profile to the artifacts' directory.
-	exportProfile := func(profile *profile.Profile, filename string) {
-		buf := bytes.Buffer{}
-		require.NoError(t, profile.Write(&buf))
-		err := os.WriteFile(filepath.Join(profilesDir, filename), buf.Bytes(), 0644)
-		require.NoError(t, err)
-	}
-
-	// Export individual profiles.
-	for i := range len(c.CRDBNodes()) {
-		for typ := range profiles {
-			exportProfile(profiles[typ][i], fmt.Sprintf("n%d.%s%s.pb.gz", i+1, typ, duration))
+		if mergedProfiles[typ], err = profile.Merge(profiles[typ]); err != nil {
+			return errors.Wrapf(err, "failed to merge profiles type: %s", typ)
 		}
 	}
 
-	// Export merged profiles.
+	// Export the merged profiles.
 	for typ := range mergedProfiles {
-		exportProfile(mergedProfiles[typ], fmt.Sprintf("merged.%s.pb.gz", typ))
+		if err := roachtestutil.ExportProfile(mergedProfiles[typ], profilesDir,
+			fmt.Sprintf("merged.%s.pb.gz", typ)); err != nil {
+			return errors.Wrapf(err, "failed to export merged profiles: %s", typ)
+		}
 	}
+
+	// Export the individual profiles as well.
+	for i := range len(c.CRDBNodes()) {
+		for typ := range profiles {
+			if err := roachtestutil.ExportProfile(profiles[typ][i], profilesDir,
+				fmt.Sprintf("n%d.%s%s.pb.gz", i+1, typ, duration)); err != nil {
+				return errors.Wrapf(err, "failed to export individual profile type: %s", typ)
+			}
+		}
+	}
+
+	return nil
 }
 
 // Add sysbenchMetrics to the openmetricsMap

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -273,7 +273,8 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 						opts.cmd(useHAProxy)+" run")
 
 					if msg, crashed := detectSysbenchCrash(result); crashed {
-						t.Skipf("%s; skipping test", msg)
+						t.L().Printf("%s; sysbench run to collect profiles failed", msg)
+						return nil
 					}
 					return err
 				},
@@ -282,7 +283,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 			// Wait for 30 seconds to give a chance to the workload to start, and then
 			// collect CPU, mutex diffs, allocs diffs profiles.
 			time.Sleep(30 * time.Second)
-			collectSysbenchProfiles(t, m, c, time.Second*30 /* duration */)
+			collectSysbenchProfiles(t, m, c, 30*time.Second /* duration */)
 		}
 
 		return nil


### PR DESCRIPTION
This commit makes sysbench{-settings} runs perform a short sysbench run at the end of the benchmark. During that run, we will collect CPU, Allocs, Mutex profiles. These profiles could feed into PGO, also they can be useful to investigate the performance of a specific run.

Release note: None

Epic: None