### PR TITLE
Add `jj` support for tag-custom-build.sh

### DIFF
--- a/scripts/tag-custom-build.sh
+++ b/scripts/tag-custom-build.sh
@@ -26,6 +26,10 @@
 #
 #      ./scripts/tag-custom-build.sh "$SHA"
 #
+#    Use the --jj flag to get the current SHA from jj instead of git:
+#
+#      ./scripts/tag-custom-build.sh --jj
+#
 # Note the Tag Name and Build ID (printed at the end of the script output).
 #
 # Verify the SHA on the GitHub page for the tag (it should open automatically
@@ -40,10 +44,44 @@
 
 set -euo pipefail
 
+use_jj=false
+
+# Parse command line options
+while getopts ":j-:" opt; do
+  case $opt in
+    j)
+      use_jj=true
+      ;;
+    -)
+      case "${OPTARG}" in
+        jj)
+          use_jj=true
+          ;;
+        *)
+          echo "Invalid option: --${OPTARG}" >&2
+          exit 1
+          ;;
+      esac
+      ;;
+    \?)
+      echo "Invalid option: -$OPTARG" >&2
+      exit 1
+      ;;
+  esac
+done
+
+# Shift past the processed options
+shift $((OPTIND-1))
+
+# Get SHA from positional parameter if provided
 SHA="${1-}"
 
 if [ -z "$SHA" ] ; then
-    SHA="$(git rev-parse HEAD)"
+    if [ "$use_jj" = true ] ; then
+        SHA="$(jj log -n1 --template commit_id --no-graph)"
+    else
+        SHA="$(git rev-parse HEAD)"
+    fi
 fi
 
 # Ensure all the latest tags are downloaded locally
@@ -52,8 +90,7 @@ git fetch -t
 ID="$(git describe --tags --match=v[0-9]* "$SHA")"
 TAG="custombuild-$ID"
 
-git tag "$TAG" "$SHA"
-git push git@github.com:cockroachdb/cockroach.git "$TAG"
+git push git@github.com:cockroachdb/cockroach.git "$SHA:refs/tags/$TAG"
 
 TAG_URL="https://github.com/cockroachdb/cockroach/releases/tag/${TAG}"
 TEAMCITY_URL="https://teamcity.cockroachdb.com/buildConfiguration/Internal_Cockroach_Release_Customized_MakeAndPublishCustomizedBuild?mode=builds&branch=${TAG}"


### PR DESCRIPTION
Previously, if you use jj for local development, running `scripts/tag-custom-build.sh` would create a lot of hassle. The scripts calls `git tag`, which makes the jj changeset immutable. Also it leaves local tags behind, which is not what we want.

This commit adds a `--jj` flag to the script, which will use `jj` to identify the SHA. Also, it skips the `git tag` command, and instead pushes to `refs/tags/$TAG`.

Epic: none
Release note: none