### PR TITLE
roachpb: remove WriteTooOld bit from Transaction 

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2030,8 +2030,7 @@ func (rsr *ReverseScanRequest) flags() flag {
 }
 
 // EndTxn updates the timestamp cache to prevent replays.
-// Replays for the same transaction key and timestamp will have
-// Txn.WriteTooOld=true and must retry on EndTxn.
+// Replays for the same transaction key and timestamp must retry on EndTxn.
 func (*EndTxnRequest) flags() flag              { return isWrite | isTxn | isAlone | updatesTSCache }
 func (*AdminSplitRequest) flags() flag          { return isAdmin | isAlone }
 func (*AdminUnsplitRequest) flags() flag        { return isAdmin | isAlone }

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -938,11 +938,6 @@ func (ba *BatchRequest) ValidateForEvaluation() error {
 	if _, ok := ba.GetArg(EndTxn); ok && ba.Txn == nil {
 		return errors.AssertionFailedf("EndTxn request without transaction")
 	}
-	if ba.Txn != nil {
-		if ba.Txn.WriteTooOld && ba.Txn.ReadTimestamp == ba.Txn.WriteTimestamp {
-			return errors.AssertionFailedf("WriteTooOld set but no offset in timestamps. txn: %s", ba.Txn)
-		}
-	}
 	return nil
 }
 

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -182,7 +182,7 @@ func TestErrorRedaction(t *testing.T) {
 		var s redact.StringBuilder
 		s.Print(r)
 		act := s.RedactableString().Redact()
-		const exp = "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered previous write with future timestamp 0.000000002,0 (local=0.000000001,2) within uncertainty interval `t <= (local=0.000000002,2, global=0.000000003,0)`; observed timestamps: [{12 0.000000004,0}]: \"foo\" meta={id=00000000 key=‹×› iso=Serializable pri=0.00005746 epo=0 ts=0.000000001,0 min=0.000000001,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 wto=false gul=0.000000002,0 obs={n1@0.000000111,1 n2@0.000000222,2}"
+		const exp = "ReadWithinUncertaintyIntervalError: read at time 0.000000001,0 encountered previous write with future timestamp 0.000000002,0 (local=0.000000001,2) within uncertainty interval `t <= (local=0.000000002,2, global=0.000000003,0)`; observed timestamps: [{12 0.000000004,0}]: \"foo\" meta={id=00000000 key=‹×› iso=Serializable pri=0.00005746 epo=0 ts=0.000000001,0 min=0.000000001,0 seq=0} lock=true stat=PENDING rts=0.000000001,0 gul=0.000000002,0 obs={n1@0.000000111,1 n2@0.000000222,2}"
 		require.Equal(t, exp, string(act))
 	})
 
@@ -215,7 +215,7 @@ func TestErrorRedaction(t *testing.T) {
 		},
 		{
 			err:    &TransactionPushError{},
-			expect: "failed to push meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 wto=false gul=0,0",
+			expect: "failed to push meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0",
 		},
 		{
 			err:    &TransactionRetryError{},
@@ -304,7 +304,7 @@ func TestErrorRedaction(t *testing.T) {
 		},
 		{
 			err:    &IndeterminateCommitError{},
-			expect: "found txn in indeterminate STAGING state meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 wto=false gul=0,0",
+			expect: "found txn in indeterminate STAGING state meta={id=00000000 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=false stat=PENDING rts=0,0 gul=0,0",
 		},
 		{
 			err:    &InvalidLeaseError{},

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction.go
@@ -585,11 +585,6 @@ func IsEndTxnExceedingDeadline(commitTS hlc.Timestamp, deadline hlc.Timestamp) b
 func IsEndTxnTriggeringRetryError(
 	txn *roachpb.Transaction, deadline hlc.Timestamp,
 ) (retry bool, reason kvpb.TransactionRetryReason, extraMsg redact.RedactableString) {
-	if txn.WriteTooOld {
-		// If we saw any WriteTooOldErrors, we must restart to avoid lost
-		// update anomalies.
-		return true, kvpb.RETRY_WRITE_TOO_OLD, ""
-	}
 	if !txn.IsoLevel.ToleratesWriteSkew() && txn.WriteTimestamp != txn.ReadTimestamp {
 		// Return a transaction retry error if the commit timestamp isn't equal to
 		// the txn timestamp.

--- a/pkg/kv/kvserver/replica_evaluate.go
+++ b/pkg/kv/kvserver/replica_evaluate.go
@@ -215,15 +215,6 @@ func evaluateBatch(
 	evalPath batchEvalPath,
 	omitInRangefeeds bool, // only relevant for transactional writes
 ) (_ *kvpb.BatchResponse, _ result.Result, retErr *kvpb.Error) {
-	defer func() {
-		// Ensure that errors don't carry the WriteTooOld flag set. The client
-		// handles non-error responses with the WriteTooOld flag set, and errors
-		// with this flag set confuse it.
-		if retErr != nil && retErr.GetTxn() != nil {
-			retErr.GetTxn().WriteTooOld = false
-		}
-	}()
-
 	// NB: Don't mutate BatchRequest directly.
 	baReqs := ba.Requests
 

--- a/pkg/kv/kvserver/replica_tscache.go
+++ b/pkg/kv/kvserver/replica_tscache.go
@@ -385,8 +385,7 @@ func init() {
 
 // applyTimestampCache moves the batch timestamp forward depending on
 // the presence of overlapping entries in the timestamp cache. If the
-// batch is transactional, the txn timestamp and the txn.WriteTooOld
-// bool are updated.
+// batch is transactional the txn timestamp is updated.
 //
 // Two important invariants of Cockroach: 1) encountering a more
 // recently written value means transaction restart. 2) values must

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1537,10 +1537,8 @@ func (t Transaction) SafeFormat(w redact.SafePrinter, _ rune) {
 	if len(t.Name) > 0 {
 		w.Printf("%q ", redact.SafeString(t.Name))
 	}
-	// TODO(ssd): Remove wto from this log output. We avoid that for now to avoid
-	// updating many many tests that include this log line.
-	w.Printf("meta={%s} lock=%t stat=%s rts=%s wto=%t gul=%s",
-		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, false, t.GlobalUncertaintyLimit)
+	w.Printf("meta={%s} lock=%t stat=%s rts=%s gul=%s",
+		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, t.GlobalUncertaintyLimit)
 
 	// Print observed timestamps (limited to 5 for readability).
 	if obsCount := len(t.ObservedTimestamps); obsCount > 0 {

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -1326,7 +1326,6 @@ func (t *Transaction) Restart(
 	t.UpgradePriority(upgradePriority)
 	// Reset all epoch-scoped state.
 	t.Sequence = 0
-	t.WriteTooOld = false
 	t.ReadTimestampFixed = false
 	t.LockSpans = nil
 	t.InFlightWrites = nil
@@ -1367,8 +1366,6 @@ func (t *Transaction) BumpEpoch() {
 func (t *Transaction) BumpReadTimestamp(timestamp hlc.Timestamp) {
 	t.ReadTimestamp.Forward(timestamp)
 	t.WriteTimestamp.Forward(t.ReadTimestamp)
-	// TODO(nvanbenschoten): remove this when the WriteTooOld flag is removed.
-	t.WriteTooOld = false
 }
 
 // Update ratchets priority, timestamp and original timestamp values (among
@@ -1403,7 +1400,6 @@ func (t *Transaction) Update(o *Transaction) {
 		}
 		// Replace all epoch-scoped state.
 		t.Epoch = o.Epoch
-		t.WriteTooOld = o.WriteTooOld
 		t.ReadTimestampFixed = o.ReadTimestampFixed
 		t.Sequence = o.Sequence
 		t.LockSpans = o.LockSpans
@@ -1433,21 +1429,10 @@ func (t *Transaction) Update(o *Transaction) {
 		}
 
 		if t.ReadTimestamp == o.ReadTimestamp {
-			// If neither of the transactions has a bumped ReadTimestamp, then the
-			// WriteTooOld flag is cumulative.
-			t.WriteTooOld = t.WriteTooOld || o.WriteTooOld
 			t.ReadTimestampFixed = t.ReadTimestampFixed || o.ReadTimestampFixed
 		} else if t.ReadTimestamp.Less(o.ReadTimestamp) {
-			// If `o` has a higher ReadTimestamp (i.e. it's the result of a refresh,
-			// which refresh generally clears the WriteTooOld field), then it dictates
-			// the WriteTooOld field. This relies on refreshes not being performed
-			// concurrently with any requests whose response's WriteTooOld field
-			// matters.
-			t.WriteTooOld = o.WriteTooOld
 			t.ReadTimestampFixed = o.ReadTimestampFixed
 		}
-		// If t has a higher ReadTimestamp, than it gets to dictate the
-		// WriteTooOld field - so there's nothing to update.
 
 		if t.Sequence < o.Sequence {
 			t.Sequence = o.Sequence
@@ -1552,8 +1537,10 @@ func (t Transaction) SafeFormat(w redact.SafePrinter, _ rune) {
 	if len(t.Name) > 0 {
 		w.Printf("%q ", redact.SafeString(t.Name))
 	}
+	// TODO(ssd): Remove wto from this log output. We avoid that for now to avoid
+	// updating many many tests that include this log line.
 	w.Printf("meta={%s} lock=%t stat=%s rts=%s wto=%t gul=%s",
-		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, t.WriteTooOld, t.GlobalUncertaintyLimit)
+		t.TxnMeta, t.IsLocking(), t.Status, t.ReadTimestamp, false, t.GlobalUncertaintyLimit)
 
 	// Print observed timestamps (limited to 5 for readability).
 	if obsCount := len(t.ObservedTimestamps); obsCount > 0 {

--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -133,7 +133,7 @@ message SplitTrigger {
   // UseEstimatesBecauseExternalBytesArePresent is true if we should consider estimating MVCC
   // stats when calculating them in the splitTrigger.
   bool use_estimates_because_external_bytes_are_present = 7;
-  
+
   // ManualSplit indicates that this split is manually triggered via an AdminSplitRequest by a sql client.
   bool manualSplit = 8;
 }
@@ -449,35 +449,7 @@ message Transaction {
   // slice should be treated as immutable and all updates should be performed
   // on a copy of the slice.
   repeated ObservedTimestamp observed_timestamps = 8 [(gogoproto.nullable) = false];
-  // If set, a write performed by the transaction could not be performed at the
-  // transaction's read timestamp because a newer value was present. Had our
-  // write been performed, it would have overwritten the other value even though
-  // that value might not have been read by a previous read in the transaction
-  // (i.e. lost update anomaly). The write is still performed, but this flag is
-  // set and the txn's write timestamp is bumped, so the client will not be able
-  // to commit without performing a refresh.
-  //
-  // Since 20.1, errors do not carry this flag; only successful BatchResponses
-  // do. When possible, such a BatchResponse is preferred to a WriteTooOldError
-  // because the former leaves intents behind to act as locks.
-  //
-  // On the client, the txnSpanRefresher terminates this flag by refreshing
-  // eagerly when the flag is set. If the key that generated the write too old
-  // condition had been previously read by the transaction, a refresh of the
-  // transaction's read span will surely fail. The client is not currently smart
-  // enough to avoid hopeless refreshes, though.
-  //
-  // Historically, this field was also important for SNAPSHOT transactions which
-  // could commit in other situations when the write timestamp is bumped, but
-  // not when this flag is set (since lost updates cannot be tolerated even in
-  // SNAPSHOT). In SERIALIZABLE isolation, transactions generally don't commit
-  // with a bumped write timestamp, so this flag is only telling us that a
-  // refresh is less likely to succeed than in other cases where
-  // ReadTimestamp != WriteTimestamp.
-  //
-  // TODO(nvanbenschoten): this flag is no longer assigned by v23.2 nodes.
-  // Remove it when compatibility with v23.1 nodes is no longer a concern.
-  bool write_too_old = 12;
+
   // Set of spans that the transaction has acquired locks within. These are
   // spans which must be resolved on txn completion. Note that these spans
   // may be condensed to cover aggregate spans if the keys locked by the
@@ -493,6 +465,7 @@ message Transaction {
   // treated as immutable and all updates should be performed on a copy
   // of the slice.
   repeated Span lock_spans = 11 [(gogoproto.nullable) = false];
+
   // Set of in-flight intent writes that have been issued by the transaction but
   // which may not have succeeded yet. If any in-flight writes are provided, a
   // committing EndTxn request will move a PENDING transaction to the STAGING
@@ -534,7 +507,7 @@ message Transaction {
   // choose which writes are exported on a per-transaction basis.
   bool omit_in_rangefeeds = 20;
 
-  reserved 3, 6, 9, 13, 14;
+  reserved 3, 6, 9, 12, 13, 14;
 }
 
 // A TransactionRecord message contains the subset of the fields in a

--- a/pkg/roachpb/data_test.go
+++ b/pkg/roachpb/data_test.go
@@ -514,12 +514,10 @@ func TestTransactionBumpReadTimestamp(t *testing.T) {
 			var txn Transaction
 			txn.ReadTimestamp = origReadTs
 			txn.WriteTimestamp = origWriteTs
-			txn.WriteTooOld = true
 
 			txn.BumpReadTimestamp(c.bumpTs)
 			require.Equal(t, c.expReadTs, txn.ReadTimestamp)
 			require.Equal(t, c.expWriteTs, txn.WriteTimestamp)
-			require.False(t, txn.WriteTooOld)
 		})
 	}
 }
@@ -604,7 +602,6 @@ var nonZeroTxn = Transaction{
 			Logical:  2,
 		},
 	}},
-	WriteTooOld:        true,
 	LockSpans:          []Span{{Key: []byte("a"), EndKey: []byte("b")}},
 	InFlightWrites:     []SequencedWrite{{Key: []byte("c"), Sequence: 1}},
 	ReadTimestampFixed: true,
@@ -656,30 +653,6 @@ func TestTransactionUpdate(t *testing.T) {
 	expTxn4.Sequence = txn.Sequence + 10
 	require.Equal(t, expTxn4, txn4)
 
-	// Test the updates to the WriteTooOld field. The WriteTooOld field is
-	// supposed to be dictated by the transaction with the higher ReadTimestamp,
-	// or it's cumulative when the ReadTimestamps are equal.
-	{
-		txn2 := txn
-		txn2.ReadTimestamp = txn2.ReadTimestamp.Add(-1, 0)
-		txn2.WriteTooOld = false
-		txn2.Update(&txn)
-		require.True(t, txn2.WriteTooOld)
-	}
-	{
-		txn2 := txn
-		txn2.WriteTooOld = false
-		txn2.Update(&txn)
-		require.True(t, txn2.WriteTooOld)
-	}
-	{
-		txn2 := txn
-		txn2.ReadTimestamp = txn2.ReadTimestamp.Add(1, 0)
-		txn2.WriteTooOld = false
-		txn2.Update(&txn)
-		require.False(t, txn2.WriteTooOld)
-	}
-
 	// Updating a Transaction at a future epoch ignores all epoch-scoped fields.
 	var txn5 Transaction
 	txn5.ID = txn.ID
@@ -699,7 +672,6 @@ func TestTransactionUpdate(t *testing.T) {
 	expTxn5.LockSpans = nil
 	expTxn5.InFlightWrites = nil
 	expTxn5.IgnoredSeqNums = nil
-	expTxn5.WriteTooOld = false
 	expTxn5.ReadTimestampFixed = false
 	require.Equal(t, expTxn5, txn5)
 
@@ -881,7 +853,6 @@ func TestTransactionRestart(t *testing.T) {
 	expTxn.Sequence = 0
 	expTxn.WriteTimestamp = makeTS(25, 1)
 	expTxn.ReadTimestamp = makeTS(25, 1)
-	expTxn.WriteTooOld = false
 	expTxn.ReadTimestampFixed = false
 	expTxn.LockSpans = nil
 	expTxn.InFlightWrites = nil
@@ -896,7 +867,6 @@ func TestTransactionRefresh(t *testing.T) {
 	expTxn := nonZeroTxn
 	expTxn.WriteTimestamp = makeTS(25, 1)
 	expTxn.ReadTimestamp = makeTS(25, 1)
-	expTxn.WriteTooOld = false
 	require.Equal(t, expTxn, txn)
 }
 

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -41,7 +41,7 @@ func TestTransactionString(t *testing.T) {
 		GlobalUncertaintyLimit: hlc.Timestamp{WallTime: 40, Logical: 41},
 	}
 	expStr := `"name" meta={id=d7aa0f5e key="foo" iso=Serializable pri=44.58039917 epo=2 ts=0.000000020,21 min=0.000000010,11 seq=15}` +
-		` lock=true stat=COMMITTED rts=0.000000030,31 wto=false gul=0.000000040,41`
+		` lock=true stat=COMMITTED rts=0.000000030,31 gul=0.000000040,41`
 
 	if str := txn.String(); str != expStr {
 		t.Errorf(

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -19,7 +19,7 @@ with t=A k=a
 put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+89
 >> at end:
-txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 lock_count=1 lock_age=89
@@ -33,7 +33,7 @@ with t=A k=a
 >> put v=first t=A k=a
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 lock_count=1 lock_age=89
@@ -58,7 +58,7 @@ with t=B k=k
 initput: lock acquisition = {k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+100
 >> at end:
-txn: "B" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+txn: "B" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,1 -> /BYTES/k1
@@ -85,7 +85,7 @@ with t=C k=k
 cput: lock acquisition = {k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+100
 >> at end:
-txn: "C" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
+txn: "C" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} ts=0,2 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,2 -> /BYTES/k2
@@ -127,7 +127,7 @@ with t=D k=k
 put: lock acquisition = {k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+97
 >> at end:
-txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -143,7 +143,7 @@ with t=D k=k
 >> put v=k3 ambiguousReplay t=D k=k
 stats: no change
 >> at end:
-txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -179,7 +179,7 @@ del: lock acquisition = {k id=00000005 key="k" iso=Serializable pri=0.00000000 e
 resolve_intent: "k" -> resolved key = true
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
 >> at end:
-txn: "E" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+txn: "E" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 data: "k"/4.000000000,0 -> /<empty>
 data: "k"/3.000000000,0 -> /BYTES/k3
@@ -220,7 +220,7 @@ with t=F k=k
 put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+95
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/5.000000000,0 -> /BYTES/k5
@@ -241,7 +241,7 @@ del: "k": found key true
 del: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1 Replicated Intent []}
 stats: val_bytes=+6 live_count=-1 live_bytes=-72 gc_bytes_age=+7410 intent_bytes=-7
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/5.000000000,0 -> /<empty>
@@ -260,7 +260,7 @@ with t=F k=k
 >> put v=k5 ambiguousReplay t=F k=k
 stats: no change
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/5.000000000,0 -> /<empty>
@@ -279,7 +279,7 @@ with t=F k=k
 >> del ambiguousReplay t=F k=k
 stats: no change
 >> at end:
-txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,1 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,1 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
 meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} ts=5.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/k5}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/5.000000000,0 -> /<empty>
@@ -328,7 +328,7 @@ del_range: returned "a"
 del_range: returned "k"
 stats: key_bytes=+24 val_count=+2 val_bytes=+106 live_count=-2 live_bytes=-58 gc_bytes_age=+16544 intent_count=+2 intent_bytes=+24 lock_count=+2 lock_age=+176
 >> at end:
-txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 gul=0,0
 meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/12.000000000,1 -> /<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
@@ -353,7 +353,7 @@ del_range: returned "a"
 del_range: returned "k"
 stats: no change
 >> at end:
-txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,2 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,2 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 gul=0,0
 meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/12.000000000,1 -> /<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first
@@ -375,7 +375,7 @@ with t=G k=k
 >> del_range k=a end=z ambiguousReplay returnKeys t=G k=k
 stats: no change
 >> at end:
-txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,3 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 wto=false gul=0,0
+txn: "G" meta={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,3 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,1 gul=0,0
 meta: "a"/0,0 -> txn={id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0} ts=12.000000000,1 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/12.000000000,1 -> /<empty>
 data: "a"/12.000000000,0 -> {localTs=11.000000000,0}/BYTES/first

--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -20,7 +20,7 @@ resolve_intent: "b/123" -> resolved key = true
 put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
 resolve_intent: "c" -> resolved key = true
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 gul=0,0
 data: "a"/44.000000000,0 -> /BYTES/abc
 data: "a/123"/44.000000000,0 -> /BYTES/abc
 data: "b"/44.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -2,7 +2,7 @@ run ok
 txn_begin t=A ts=123
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=123.000000000,0 gul=0,0
 
 # Write value1.
 
@@ -15,7 +15,7 @@ with t=A
 cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=-23
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/123.000000000,0 -> /BYTES/v
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=58 live_count=1 live_bytes=72 intent_count=1 intent_bytes=18 lock_count=1 lock_age=-23
@@ -32,7 +32,7 @@ with t=A
 cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2 Replicated Intent []}
 stats: val_bytes=+11 live_bytes=+11 intent_bytes=+1
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} ts=123.000000000,0 del=false klen=12 vlen=7 ih={{1 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/123.000000000,0 -> /BYTES/v2
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=69 live_count=1 live_bytes=83 intent_count=1 intent_bytes=19 lock_count=1 lock_age=-23
@@ -49,7 +49,7 @@ with t=A
 cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1 Replicated Intent []}
 stats: val_bytes=-10 live_bytes=-10
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} ts=123.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/123.000000000,0 -> /BYTES/v3
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=59 live_count=1 live_bytes=73 intent_count=1 intent_bytes=19 lock_count=1 lock_age=-23
@@ -106,7 +106,7 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+10 live_count=+1 live_
 cput: lock acquisition = {c id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+49 gc_bytes_age=+2156 intent_count=+1 intent_bytes=+21 lock_count=+1 lock_age=+98
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 meta: "c"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "c"/2.000000000,0 -> /BYTES/cput
 data: "c"/1.000000000,0 -> /BYTES/value
@@ -121,9 +121,9 @@ with t=A
   cput k=c v=cput cond=value
 ----
 >> txn_restart ts=3 t=A
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 >> cput k=c v=cput cond=value t=A
 cput: lock acquisition = {c id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
 meta: "c"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_write_too_old
@@ -32,7 +32,7 @@ with t=a
   cput k=k v=v2 cond=v1
 ----
 >> at end:
-txn: "a" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 data: "k"/10.000000000,0 -> /BYTES/v1
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k" at timestamp 1.000000000,0 too old; must write at or above 10.000000000,1
 

--- a/pkg/storage/testdata/mvcc_histories/delete_range
+++ b/pkg/storage/testdata/mvcc_histories/delete_range
@@ -121,7 +121,7 @@ with t=A
   txn_remove
 ----
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=46.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=46.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=46.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=46.000000000,0 gul=0,0
 data: "a"/45.000000000,0 -> /<empty>
 data: "a"/44.000000000,0 -> /BYTES/abc
 data: "a/123"/45.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -32,7 +32,7 @@ del: "a": found key true
 del: "g": found key true
 put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2

--- a/pkg/storage/testdata/mvcc_histories/deletes
+++ b/pkg/storage/testdata/mvcc_histories/deletes
@@ -99,7 +99,7 @@ with t=A
 ----
 del: "a": found key false
 >> at end:
-txn: "A" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=43.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=43.000000000,0 gul=0,0
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -128,7 +128,7 @@ with t=A
 ----
 del: "a": found key false
 >> at end:
-txn: "A" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 gul=0,0
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -157,7 +157,7 @@ with t=A
 ----
 del: "a": found key false
 >> at end:
-txn: "A" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=46.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=46.000000000,0 gul=0,0
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -186,7 +186,7 @@ with t=A
 ----
 del: "a": found key false
 >> at end:
-txn: "A" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=47.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=47.000000000,0 gul=0,0
 data: "a"/48.000000000,0 -> /<empty>
 data: "a"/47.000000000,0 -> /<empty>
 data: "a"/46.000000000,0 -> /BYTES/abc
@@ -216,7 +216,7 @@ with t=A
 del: "a": found key false
 del: lock acquisition = {a id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=49.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=49.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/50.000000000,0 -> /<empty>
 data: "a"/48.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/empty_key
+++ b/pkg/storage/testdata/mvcc_histories/empty_key
@@ -28,6 +28,6 @@ txn_begin t=A
 resolve_intent t=A k=
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=true stat=PENDING rts=0,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,0 min=0,0 seq=0} lock=true stat=PENDING rts=0,0 gul=0,0
 <no data>
 error: (*withstack.withStack:) attempted access to empty key

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -49,7 +49,7 @@ put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0={localTs=4.000000000,0}/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -49,7 +49,7 @@ put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0={localTs=4.000000000,0}/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
@@ -109,7 +109,7 @@ with t=A
 ----
 put: lock acquisition = {B id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 meta: "B"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "B"/10.000000000,0 -> /BYTES/O
 

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -112,7 +112,7 @@ with t=A k=c
 ----
 put: lock acquisition = {c id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 gul=0,0
 data: "a"/5.000000000,0 -> /BYTES/12
 data: "a"/2.000000000,0 -> /BYTES/11
 meta: "c"/0,0 -> txn={id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
@@ -26,7 +26,7 @@ with t=A k=a
 ----
 put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/4.000000000,0 -> /BYTES/1
 

--- a/pkg/storage/testdata/mvcc_histories/idempotent_transactions
+++ b/pkg/storage/testdata/mvcc_histories/idempotent_transactions
@@ -12,7 +12,7 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_
 >> put v=first t=a k=a
 stats: no change
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/first
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=22 lock_count=1 lock_age=89
@@ -47,7 +47,7 @@ stats: val_bytes=+17 live_bytes=+17 intent_bytes=+1
 stats: no change
 meta: "a" -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=78 live_count=1 live_bytes=92 intent_count=1 intent_bytes=23 lock_count=1 lock_age=89
@@ -59,7 +59,7 @@ with t=a k=a
   put v=second
 ----
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=-1} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=-1} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
 error: (*issuelink.withIssueLink:) transaction 00000001-0000-0000-0000-000000000000 with sequence 1 missing an intent with lower sequence -1
@@ -88,7 +88,7 @@ stats: no change
 inc: current value = 1
 stats: no change
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -129,7 +129,7 @@ stats: no change
 inc: current value = 1
 stats: no change
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{2 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -175,7 +175,7 @@ stats: no change
 inc: current value = 2
 stats: no change
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{2 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -219,7 +219,7 @@ stats: no change
 inc: current value = 2
 stats: no change
 >> at end:
-txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1} ts=11.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/11.000000000,0 -> /BYTES/second
 meta: "i"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{2 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -22,7 +22,7 @@ put: lock acquisition = {k/20 id=00000001 key=/Min iso=Serializable pri=0.000000
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
 put: lock acquisition = {k/30 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -52,7 +52,7 @@ get: "k" -> /BYTES/b @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # Mask a write in the middle.
 
@@ -68,7 +68,7 @@ scan: "k/10" -> /BYTES/10 @11.000000000,0
 scan: "k/30" -> /BYTES/30 @11.000000000,0
 get: "k" -> /BYTES/c @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # Mask all the writes.
 
@@ -82,7 +82,7 @@ with t=A
 scan: "k"-"l" -> <no data>
 get: "k" -> <no data>
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # Disjoint masks.
 
@@ -97,7 +97,7 @@ scan: "k" -> /BYTES/b @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=2
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=2
 
 # A historical read before the ignored range should retrieve the
 # historical value visible at that point.
@@ -113,7 +113,7 @@ scan: "k" -> /BYTES/a @11.000000000,0
 scan: "k/10" -> /BYTES/10 @11.000000000,0
 get: "k" -> /BYTES/a @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=12} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=12} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # A historical read with an ignored range before it should hide
 # the historical value hidden at that point.
@@ -129,7 +129,7 @@ scan: "k" -> /BYTES/b @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=22} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=22} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # A historical read with an ignored range that overlaps should hide
 # the historical value hidden at that point.
@@ -146,7 +146,7 @@ scan: "k/10" -> /BYTES/10 @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=32} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=32} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # Do an intent push by advancing the transaction timestamp, while also having
 # a range of ignored seqnums. This should permanently delete the value at seqnum
@@ -171,7 +171,7 @@ resolve_intent: "k" -> resolved key = true
 meta: "k" -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=20} ts=14.000000000,0 del=false klen=12 vlen=19 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=32} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=32} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=20} ts=14.000000000,0 del=false klen=12 vlen=19 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -196,7 +196,7 @@ scan: "k/10" -> /BYTES/10 @11.000000000,0
 scan: "k/30" -> /BYTES/30 @11.000000000,0
 get: "k" -> /BYTES/a @14.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 run ok
 with t=A
@@ -218,7 +218,7 @@ scan: "k/10" -> /BYTES/10 @11.000000000,0
 scan: "k/20" -> /BYTES/20 @11.000000000,0
 get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 
 # Call mvccResolveWriteIntent with status=COMMITTED. This should fold the
 # intent while leaving the value unmodified.
@@ -236,7 +236,7 @@ meta: "k" -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=
 resolve_intent: "k" -> resolved key = true
 get: "k" -> /BYTES/b @14.000000000,0
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -265,7 +265,7 @@ put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 
 meta: "l" -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30} ts=20.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "l" -> /BYTES/c @20.000000000,0
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -293,7 +293,7 @@ meta: "l" -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=
 get: "l" -> <no data>
 resolve_intent: "l" -> resolved key = true
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=35} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0 isn=1
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=35} lock=true stat=PENDING rts=20.000000000,0 gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -311,7 +311,7 @@ with t=C
 ----
 get: "l" -> <no data>
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=30.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=30.000000000,0 gul=0,0
 
 
 # Put some values, then ignore all except the first, then do a commit. The
@@ -334,7 +334,7 @@ put: lock acquisition = {m id=00000003 key=/Min iso=Serializable pri=0.00000000 
 meta: "m" -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} ts=30.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "m" -> /BYTES/c @30.000000000,0
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -357,7 +357,7 @@ meta: "m" -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=
 get: "m" -> /BYTES/a @30.000000000,0
 resolve_intent: "m" -> resolved key = true
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 wto=false gul=0,0 isn=1
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=30.000000000,0 gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -388,7 +388,7 @@ put: lock acquisition = {n id=00000004 key=/Min iso=Serializable pri=0.00000000 
 meta: "n" -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30} ts=40.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "n" -> /BYTES/c @40.000000000,0
 >> at end:
-txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=40.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -417,7 +417,7 @@ resolve_intent: "n" -> resolved key = true
 meta: "n" -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} ts=45.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "n" -> /BYTES/c @45.000000000,0
 >> at end:
-txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=40.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -446,7 +446,7 @@ get: "n" -> /BYTES/c @45.000000000,0
 resolve_intent: "n" -> resolved key = true
 get: "n" -> /BYTES/c @45.000000000,0
 >> at end:
-txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -484,7 +484,7 @@ put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 Replicated Intent []}
 put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 Replicated Intent []}
 >> at end:
-txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -513,7 +513,7 @@ get: "o" -> <no data>
 resolve_intent: "n" -> resolved key = true
 resolve_intent: "o" -> resolved key = true
 >> at end:
-txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -564,7 +564,7 @@ put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 Replicated Intent [{5 6}]}
 meta: "o" -> txn={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
-txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -588,7 +588,7 @@ with t=E
 resolve_intent: "o" -> resolved key = true
 get: "o" -> <no data>
 >> at end:
-txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=55.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=55.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -623,7 +623,7 @@ put: lock acquisition = {o id=00000006 key="o" iso=Serializable pri=0.00000000 e
 meta: "o" -> txn={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "o" -> /BYTES/b @50.000000000,0
 >> at end:
-txn: "F" meta={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0
+txn: "F" meta={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=40.000000000,0 gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -653,7 +653,7 @@ resolve_intent: "o" -> resolved key = true
 meta: "o" -> txn={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10} ts=50.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "o" -> /BYTES/a @50.000000000,0
 >> at end:
-txn: "F" meta={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=40.000000000,0 wto=false gul=0,0 isn=1
+txn: "F" meta={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=45.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=40.000000000,0 gul=0,0 isn=1
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
 meta: "k/10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k/10"/11.000000000,0 -> /BYTES/10
@@ -690,7 +690,7 @@ put: lock acquisition = {p id=00000007 key="p" iso=Serializable pri=0.00000000 e
 meta: "p" -> txn={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "p" -> /BYTES/b @50.000000000,0
 >> at end:
-txn: "G" meta={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+txn: "G" meta={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 gul=0,0
 meta: "p"/0,0 -> txn={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "p"/50.000000000,0 -> /BYTES/b
 
@@ -704,7 +704,7 @@ with t=G k=p
 resolve_intent: "p" -> resolved key = true
 get: "p" -> <no data>
 >> at end:
-txn: "G" meta={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "G" meta={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 <no data>
 logical op: *enginepb.MVCCAbortIntentOp
 
@@ -734,7 +734,7 @@ put: lock acquisition = {q id=00000008 key="q" iso=Serializable pri=0.00000000 e
 meta: "q" -> txn={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "q" -> /BYTES/b @50.000000000,0
 >> at end:
-txn: "H" meta={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+txn: "H" meta={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 gul=0,0
 meta: "q"/0,0 -> txn={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "q"/50.000000000,0 -> /BYTES/b
 
@@ -748,7 +748,7 @@ with t=H k=q
 resolve_intent: "q" -> resolved key = false
 meta: "q" -> txn={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
-txn: "H" meta={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "H" meta={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 meta: "q"/0,0 -> txn={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "q"/50.000000000,0 -> /BYTES/b
 
@@ -778,7 +778,7 @@ put: lock acquisition = {r id=00000009 key="r" iso=Serializable pri=0.00000000 e
 meta: "r" -> txn={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "r" -> /BYTES/b @50.000000000,0
 >> at end:
-txn: "I" meta={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+txn: "I" meta={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=50.000000000,0 gul=0,0
 meta: "r"/0,0 -> txn={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "r"/50.000000000,0 -> /BYTES/b
 
@@ -793,7 +793,7 @@ with t=I k=r
 resolve_intent: "r" -> resolved key = true
 meta: "r" -> txn={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=20} ts=60.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
-txn: "I" meta={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=0 ts=60.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "I" meta={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=0 ts=60.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 meta: "r"/0,0 -> txn={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=60.000000000,0 min=0,0 seq=20} ts=60.000000000,0 del=false klen=12 vlen=20 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "r"/60.000000000,0 -> {localTs=50.000000000,0}/BYTES/b
 logical op: *enginepb.MVCCUpdateIntentOp

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
@@ -19,7 +19,7 @@ put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 e
 resolve_intent: "k" -> resolved key = true
 get: "k" -> <no data>
 >> at end:
-txn: "A" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 <no data>
 logical op: *enginepb.MVCCWriteIntentOp
 logical op: *enginepb.MVCCUpdateIntentOp

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -53,7 +53,7 @@ stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=
 resolve_intent: "k/30" -> resolved key = true
 stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_bytes=-74 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/b
 data: "k/10"/11.000000000,0 -> /BYTES/10
 data: "k/20"/11.000000000,0 -> /BYTES/20
@@ -125,7 +125,7 @@ stats: key_count=-1 key_bytes=-17 val_count=-1 val_bytes=-57 live_count=-1 live_
 resolve_intent: "k/30" -> resolved key = true
 stats: val_bytes=-50 live_bytes=-50 intent_count=-1 intent_bytes=-19 lock_count=-1 lock_age=-89
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/c
 data: "k/10"/11.000000000,0 -> /BYTES/10
 data: "k/30"/11.000000000,0 -> /BYTES/30
@@ -157,7 +157,7 @@ put: lock acquisition = {b id=00000003 key="b" iso=Serializable pri=0.00000000 e
 meta: "b" -> txn={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} ts=12.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "b" -> /BYTES/b @12.000000000,0
 >> at end:
-txn: "B" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=12.000000000,0 gul=0,0
 meta: "b"/0,0 -> txn={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} ts=12.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "b"/12.000000000,0 -> /BYTES/b
 data: "k"/11.000000000,0 -> /BYTES/c
@@ -175,7 +175,7 @@ with t=B k=b
 resolve_intent: "b" -> resolved key = true
 get: "b" -> <no data>
 >> at end:
-txn: "B" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=1 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0 isn=1
+txn: "B" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=1 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/c
 data: "k/10"/11.000000000,0 -> /BYTES/10
 data: "k/30"/11.000000000,0 -> /BYTES/30

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
@@ -19,7 +19,7 @@ with t=A
 ----
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/11.000000000,0 -> /BYTES/a
 data: "k"/1.000000000,0 -> /BYTES/first
@@ -68,7 +68,7 @@ with t=B
 put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
 put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/b
 data: "k"/1.000000000,0 -> /BYTES/first
@@ -120,7 +120,7 @@ put: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
 put: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c
 data: "k"/1.000000000,0 -> /BYTES/first
@@ -179,7 +179,7 @@ with t=D
 put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
 put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
 >> at end:
-txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/b
 data: "k"/1.000000000,0 -> /BYTES/first

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_delete
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_delete
@@ -30,7 +30,7 @@ stats: val_bytes=+4 live_count=-1 live_bytes=-70 gc_bytes_age=+6586 intent_bytes
 resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-54 live_count=+1 live_bytes=+20 gc_bytes_age=-6586 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-89
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/a
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=6 live_count=1 live_bytes=20
 
@@ -71,7 +71,7 @@ stats: val_bytes=+10 live_count=+1 live_bytes=+74 gc_bytes_age=-5696 intent_byte
 resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-60 live_count=-1 live_bytes=-74 gc_bytes_age=+1246 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-89
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /<empty>
 stats: key_count=1 key_bytes=14 val_count=1 gc_bytes_age=1246
 
@@ -113,7 +113,7 @@ stats: val_bytes=+4 gc_bytes_age=+356
 resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-54 gc_bytes_age=-4806 intent_count=-1 intent_bytes=-12 lock_count=-1 lock_age=-89
 >> at end:
-txn: "A" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /<empty>
 stats: key_count=1 key_bytes=14 val_count=1 gc_bytes_age=1246
 
@@ -164,7 +164,7 @@ stats: val_bytes=+12 live_bytes=+12
 resolve_intent: "k" -> resolved key = true
 stats: val_bytes=-78 live_bytes=-78 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-89
 >> at end:
-txn: "A" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=50} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=50} lock=true stat=PENDING rts=11.000000000,0 gul=0,0 isn=1
 data: "k"/11.000000000,0 -> /BYTES/c
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=6 live_count=1 live_bytes=20
 

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
@@ -14,7 +14,7 @@ put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 {localTs=15.000000000,0}/BYTES/a}{20 {localTs=20.000000000,0}/BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/50.000000000,0 -> {localTs=25.000000000,0}/BYTES/c
 
@@ -32,7 +32,7 @@ get: "k" -> /BYTES/b @50.000000000,0
 resolve_intent: "k" -> resolved key = true
 get: "k" -> /BYTES/b @50.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 {localTs=15.000000000,0}/BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/50.000000000,0 -> {localTs=20.000000000,0}/BYTES/b
 
@@ -47,5 +47,5 @@ with t=A
 ----
 resolve_intent: "k" -> resolved key = true
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 gul=0,0 isn=1
 data: "k"/50.000000000,0 -> {localTs=15.000000000,0}/BYTES/a

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -45,7 +45,7 @@ inc: current value = 2
 inc: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2 Replicated Intent []}
 stats: val_bytes=+10 live_bytes=+10
 >> at end:
-txn: "a" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+txn: "a" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} lock=true stat=PENDING rts=0,1 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/0,1 -> /INT/2
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=61 live_count=1 live_bytes=75 intent_count=1 intent_bytes=18 lock_count=1 lock_age=100
@@ -83,7 +83,7 @@ with t=r
   increment k=r
 ----
 >> at end:
-txn: "r" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "r" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} ts=0,1 del=false klen=12 vlen=6 ih={{1 /INT/1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/0,1 -> /INT/2
 data: "r"/3.000000000,0 -> /INT/2

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -30,7 +30,7 @@ with t=A
   resolve_intent
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> put v=first k=a t=A
 put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -38,7 +38,7 @@ data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+46 gc_bytes_age=+2352 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+98
 >> txn_step k=a t=A
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> put v=second k=a t=A
 put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1 Replicated Intent []}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -46,7 +46,7 @@ data: "a"/2.000000000,0 -> /BYTES/second
 data: "a"/1.000000000,0 -> /BYTES/default
 stats: val_bytes=+17 live_bytes=+17 intent_bytes=+1
 >> txn_step n=2 k=a t=A
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> del k=a t=A
 del: "a": found key true
 del: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3 Replicated Intent []}
@@ -55,7 +55,7 @@ data: "a"/2.000000000,0 -> /<empty>
 data: "a"/1.000000000,0 -> /BYTES/default
 stats: val_bytes=+6 live_count=-1 live_bytes=-89 gc_bytes_age=+9310 intent_bytes=-11
 >> txn_step n=6 k=a t=A
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> put v=first k=a t=A
 put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9 Replicated Intent []}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}} mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -4,7 +4,7 @@ with t=A
   put k=k1 v=v1
 ----
 >> txn_begin ts=2 t=A
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> put k=k1 v=v1 t=A
 put: lock acquisition = {k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -20,9 +20,9 @@ with t=A
   put k=k2 v=v2
 ----
 >> txn_advance ts=3 t=A
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> txn_step t=A
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
 >> put k=k1 v=v1 t=A
 put: lock acquisition = {k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/is_span_empty
+++ b/pkg/storage/testdata/mvcc_histories/is_span_empty
@@ -20,7 +20,7 @@ del_range_ts k=d end=f ts=2
 del: "b": found key false
 put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 rangekey: {d-f}/[2.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /BYTES/a4
 data: "a"/2.000000000,0 -> /BYTES/a2

--- a/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
+++ b/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
@@ -40,7 +40,7 @@ with t=A
 put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {c-e}/[6.000000000,0=/<empty>]
 data: "a"/5.000000000,0 -> /BYTES/a5
 data: "a"/4.000000000,0 -> /BYTES/a4

--- a/pkg/storage/testdata/mvcc_histories/local_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/local_timestamp
@@ -291,7 +291,7 @@ stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_
 put: lock acquisition = {k12 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k1"/20.000000000,0 -> {localTs=10.000000000,0}/BYTES/v
 meta: "k10"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=19 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -324,7 +324,7 @@ with t=A
   txn_advance ts=30
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 
 run stats ok
 with t=A localTs=20
@@ -457,7 +457,7 @@ stats: val_bytes=-73 live_bytes=-73 intent_count=-1 intent_bytes=-32 lock_count=
 resolve_intent: "k12" -> resolved key = true
 stats: val_bytes=-86 live_bytes=-86 intent_count=-1 intent_bytes=-32 lock_count=-1 lock_age=-70
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k10"/40.000000000,0 -> {localTs=20.000000000,0}/BYTES/v2
 data: "k11"/40.000000000,0 -> {localTs=30.000000000,0}/BYTES/v2
 data: "k12"/40.000000000,0 -> /BYTES/v2

--- a/pkg/storage/testdata/mvcc_histories/max_keys
+++ b/pkg/storage/testdata/mvcc_histories/max_keys
@@ -146,7 +146,7 @@ scan: "m" -> /BYTES/b @11.000000000,0
 scan: "l" -> /BYTES/b @11.000000000,0
 scan: resume span ["k","k\x00") RESUME_KEY_LIMIT nextBytes=0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 data: "a"/1.000000000,0 -> /BYTES/val-a
 data: "aa"/2.000000000,0 -> /<empty>
 data: "aa"/1.000000000,0 -> /BYTES/val-aa
@@ -180,7 +180,7 @@ resolve_intent: "l" -> resolved key = true
 resolve_intent: "m" -> resolved key = true
 resolve_intent: "n" -> resolved key = true
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 data: "a"/1.000000000,0 -> /BYTES/val-a
 data: "aa"/2.000000000,0 -> /<empty>
 data: "aa"/1.000000000,0 -> /BYTES/val-aa
@@ -231,7 +231,7 @@ scan: "l" -> /BYTES/b @12.000000000,0
 scan: "m" -> /BYTES/b @12.000000000,0
 scan: resume span ["n","o") RESUME_KEY_LIMIT nextBytes=0
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=12.000000000,0 gul=0,0
 data: "a"/1.000000000,0 -> /BYTES/val-a
 data: "aa"/2.000000000,0 -> /<empty>
 data: "aa"/1.000000000,0 -> /BYTES/val-aa

--- a/pkg/storage/testdata/mvcc_histories/merges
+++ b/pkg/storage/testdata/mvcc_histories/merges
@@ -38,4 +38,4 @@ with t=A
 ----
 get: "a" -> /BYTES/defghi @0,0
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
@@ -8,7 +8,7 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=22 t=A k=a
-txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 gul=0,0
 >> put v=cde t=A k=a
 put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0 Replicated Intent []}
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/testdata/mvcc_histories/put_after_rollback
@@ -19,7 +19,7 @@ stats: val_bytes=-2 live_bytes=-2
 get: "k2" -> /BYTES/b @1.000000000,0
 get: "k2" -> <no data>
 >> at end:
-txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=1.000000000,0 gul=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/1.000000000,0 -> /BYTES/b
 stats: key_count=1 key_bytes=15 val_count=1 val_bytes=58 live_count=1 live_bytes=73 intent_count=1 intent_bytes=18 lock_count=1 lock_age=99
@@ -40,7 +40,7 @@ del: "k3": found key false
 del: lock acquisition = {k3 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40 Replicated Intent [{5 35}]}
 stats: val_bytes=-8 live_count=-1 live_bytes=-75 gc_bytes_age=+6633 intent_bytes=-6
 >> at end:
-txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=1.000000000,0 gul=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/1.000000000,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} ts=1.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -67,7 +67,7 @@ stats: val_bytes=+10 live_bytes=+10
 cput: lock acquisition = {k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60 Replicated Intent [{5 55}]}
 stats: val_bytes=-12 live_bytes=-12
 >> at end:
-txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60} lock=true stat=PENDING rts=1.000000000,0 gul=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/1.000000000,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} ts=1.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -114,7 +114,7 @@ meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts
 resolve_intent: "k5" -> resolved key = true
 stats: val_bytes=-64 live_bytes=-64 intent_count=-1 intent_bytes=-18 lock_count=-1 lock_age=-95
 >> at end:
-txn: "B" meta={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0 isn=1
+txn: "B" meta={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=5.000000000,0 gul=0,0 isn=1
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/1.000000000,0 -> /BYTES/b
 meta: "k3"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} ts=1.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
@@ -21,7 +21,7 @@ put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5 Replicated Intent []}
 get: "k" -> /BYTES/v2 @1.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{4 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v2
 
@@ -31,7 +31,7 @@ with t=A
   txn_step n=4
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=1.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=1.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 
 
 # We're operating at a higher epoch but a lower seqnum.

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_timestamp
@@ -20,7 +20,7 @@ with t=A
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4 Replicated Intent []}
 get: "k" -> /BYTES/v @5.000000000,0
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4} ts=5.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/5.000000000,0 -> /BYTES/v
 
@@ -30,7 +30,7 @@ with t=A
   txn_restart
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 
 
 # We're operating at a higher epoch but a lower timestamp.

--- a/pkg/storage/testdata/mvcc_histories/put_out_of_order
+++ b/pkg/storage/testdata/mvcc_histories/put_out_of_order
@@ -13,7 +13,7 @@ with t=A
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+98
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0} ts=2.000000000,1 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/2.000000000,1 -> /BYTES/v
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=56 live_count=1 live_bytes=70 intent_count=1 intent_bytes=18 lock_count=1 lock_age=98
@@ -29,7 +29,7 @@ with t=A
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=1 Replicated Intent []}
 stats: val_bytes=+13 live_bytes=+13 intent_bytes=+1
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=1} ts=2.000000000,1 del=false klen=12 vlen=7 ih={{0 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/2.000000000,1 -> /BYTES/v2
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=69 live_count=1 live_bytes=83 intent_count=1 intent_bytes=19 lock_count=1 lock_age=98
@@ -53,7 +53,7 @@ with t=A
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=2 Replicated Intent []}
 stats: val_bytes=+13 live_bytes=+13
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=2} ts=2.000000000,1 del=false klen=12 vlen=7 ih={{0 /BYTES/v}{1 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/2.000000000,1 -> /BYTES/v2
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=82 live_count=1 live_bytes=96 intent_count=1 intent_bytes=19 lock_count=1 lock_age=98

--- a/pkg/storage/testdata/mvcc_histories/put_with_txn
+++ b/pkg/storage/testdata/mvcc_histories/put_with_txn
@@ -13,7 +13,7 @@ get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1
 >> at end:
-txn: "A" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,1 -> /BYTES/v
 stats: key_count=1 key_bytes=14 val_count=1 val_bytes=49 live_count=1 live_bytes=63 intent_count=1 intent_bytes=18 lock_count=1 lock_age=100

--- a/pkg/storage/testdata/mvcc_histories/range_key_clear
+++ b/pkg/storage/testdata/mvcc_histories/range_key_clear
@@ -46,7 +46,7 @@ put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 
 put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace_nometamorphiciter
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace_nometamorphiciter
@@ -21,7 +21,7 @@ put_rangekey k=e end=g ts=5
 put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 rangekey: {b-d}/[5.000000000,0=/<empty>]
 rangekey: {e-g}/[5.000000000,0=/<empty>]
 meta: "c"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -48,7 +48,7 @@ stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2
 put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+54 live_count=+1 live_bytes=+68 gc_bytes_age=-194 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "d"/1.000000000,0 -> /BYTES/d1
@@ -240,7 +240,7 @@ with t=A ts=7
 >> cput k=g v=g7 cond=g1 t=A ts=7
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=7.000000000,0 gul=0,0 isn=1
 rangekey: {a-c}/[3.000000000,0=/<empty>]
 rangekey: {c-k}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "d"/1.000000000,0 -> /BYTES/d1

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
@@ -34,7 +34,7 @@ del: "b": found key false
 del: "a": found key false
 put: lock acquisition = {e id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 gul=0,0
 rangekey: {a-c}/[2.000000000,0=/<empty>]
 rangekey: {c-e}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
 rangekey: {e-i}/[4.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_complex
@@ -91,7 +91,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+176
 put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
@@ -98,7 +98,7 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_
 put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -101,7 +101,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_
 put: lock acquisition = {m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+92
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
@@ -23,7 +23,7 @@ with t=A
 ----
 put: lock acquisition = {b id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 data: "a"/2.000000000,0 -> /BYTES/a2
 meta: "b"/0,0 -> txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -149,7 +149,7 @@ with t=A
 ----
 put: lock acquisition = {b id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 rangekey: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
 meta: "b"/0,0 -> txn={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "b"/3.000000000,0 -> /BYTES/b3

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -32,7 +32,7 @@ del: "b": found key false
 del: "a": found key false
 put: lock acquisition = {e id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 gul=0,0
 rangekey: {a-c}/[2.000000000,0=/<empty>]
 rangekey: {c-e}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
 rangekey: {e-i}/[4.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
@@ -91,7 +91,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+176
 put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 rangekey: {b-c}/[3.000000000,0=/<empty> 1.000000000,0=/<empty>]
 rangekey: {c-d}/[5.000000000,0=/<empty> 3.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_reverse_skip_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_reverse_skip_regression
@@ -31,7 +31,7 @@ with t=A
 ----
 put: lock acquisition = {b id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
 data: "a"/2.000000000,0 -> /BYTES/a2
 meta: "b"/0,0 -> txn={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -60,7 +60,7 @@ with t=A
 ----
 put: lock acquisition = {b id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 gul=0,0
 rangekey: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
 meta: "b"/0,0 -> txn={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "b"/3.000000000,0 -> /BYTES/b3
@@ -96,7 +96,7 @@ with t=A
 ----
 put: lock acquisition = {b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 rangekey: {a-b}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
 data: "a"/3.000000000,0 -> /BYTES/a3
 meta: "b"/0,0 -> txn={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -148,7 +148,7 @@ with t=A
 ----
 put: lock acquisition = {b id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 rangekey: {a-b}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "a"/2.000000000,0 -> /BYTES/a2
 meta: "b"/0,0 -> txn={id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -309,7 +309,7 @@ stats: val_bytes=-35 gc_bytes_age=-3301 intent_count=-1 intent_bytes=-12 lock_co
 resolve_intent: "r" -> resolved key = true
 stats: val_bytes=-48 gc_bytes_age=-4491 intent_count=-1 intent_bytes=-25 lock_count=-1 lock_age=-93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -382,7 +382,7 @@ stats: no change
 resolve_intent: "j" -> resolved key = false
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -240,7 +240,7 @@ resolve_intent_range t=A k=a end=z status=COMMITTED
 resolve_intent_range: "a"-"z" -> resolved 18 key(s)
 stats: val_bytes=-669 live_bytes=-315 gc_bytes_age=-33241 intent_count=-18 intent_bytes=-318 lock_count=-18 lock_age=-1674
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -291,7 +291,7 @@ resolve_intent_range t=A k=a end=z status=COMMITTED
 resolve_intent_range: "a"-"z" -> resolved 0 key(s)
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
@@ -172,7 +172,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -320,7 +320,7 @@ del: "r": found key false
 del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -468,7 +468,7 @@ stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes
 put: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=9.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=9.000000000,0 gul=0,0
 rangekey: g{-gg}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {ggg-i}/[5.000000000,0=/<empty> 4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 rangekey: {i-jjj}/[5.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
@@ -32,7 +32,7 @@ del: "g": found key true
 put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 gul=0,0
 rangekey: {k-p}/[4.000000000,0=/<empty>]
 data: "a"/4.000000000,0 -> /<empty>
 data: "a"/2.000000000,0 -> /BYTES/a2

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -34,7 +34,7 @@ del: "f": found key false
 del: "n": found key false
 put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 gul=0,0
 rangekey: {a-d}/[3.000000000,0=/<empty>]
 rangekey: {k-m}/[4.000000000,0=/<empty>]
 rangekey: {m-o}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
@@ -9,7 +9,7 @@ with t=A
     resolve_intent
 ----
 >> txn_begin ts=11 t=A
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 >> put v=abc k=a t=A
 put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -53,7 +53,7 @@ with t=A
 ----
 get: "a" -> /BYTES/abc @11.000000000,0
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 
 run trace ok
 with t=A
@@ -96,5 +96,5 @@ with t=A k=a
   txn_remove
 ----
 >> txn_begin ts=1 t=A k=a
-txn: "A" meta={id=00000003 key="a" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000003 key="a" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 >> txn_remove t=A k=a

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -15,7 +15,7 @@ with t=A
 ----
 put: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 data: "k1"/10.000000000,0 -> /BYTES/v
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k2"/10.000000000,0 -> /BYTES/v

--- a/pkg/storage/testdata/mvcc_histories/replace_point_tombstones_with_range_tombstones
+++ b/pkg/storage/testdata/mvcc_histories/replace_point_tombstones_with_range_tombstones
@@ -49,7 +49,7 @@ put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 
 del: "g": found key false
 del: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 rangekey: {h-o}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/1.000000000,0 -> /<empty>
@@ -149,7 +149,7 @@ put: lock acquisition = {f id=00000002 key=/Min iso=Serializable pri=0.00000000 
 del: "g": found key false
 del: lock acquisition = {g id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=0,0
 rangekey: {h-o}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
 data: "b"/1.000000000,0 -> /BYTES/b1
 data: "c"/1.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -20,7 +20,7 @@ txn_begin t=A ts=10,0
 txn_begin t=B ts=11,0
 ----
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 
 run stats ok
 with t=A
@@ -92,7 +92,7 @@ stats: no change
 >> acquire_lock k=k3 str=shared t=A
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -122,7 +122,7 @@ stats: no change
 >> acquire_lock k=k3 str=shared t=A
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -153,7 +153,7 @@ stats: lock_bytes=+2
 >> acquire_lock k=k3 str=shared t=A
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -364,7 +364,7 @@ with t=A
 put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2 Replicated Intent [{0 0}]}
 stats: val_bytes=+17 live_bytes=+17 intent_bytes=+6
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 data: "k1"/5.000000000,0 -> /BYTES/v1
 data: "k2"/5.000000000,0 -> /BYTES/v2
 data: "k3"/5.000000000,0 -> /BYTES/v3
@@ -380,7 +380,7 @@ with t=A
 >> acquire_lock k=k4 str=shared t=A
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -394,7 +394,7 @@ with t=A
   acquire_lock k=k4 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -407,7 +407,7 @@ with t=A
   acquire_lock k=k4 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 lock (Replicated): "k1"/Shared -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 lock (Replicated): "k2"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -611,7 +611,7 @@ del: "k3": found key true
 del: lock acquisition = {k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4 Replicated Intent [{1 2}]}
 stats: val_bytes=+4 live_count=-1 live_bytes=-74 gc_bytes_age=+7020 intent_bytes=-7
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/10.000000000,0 -> /<empty>
@@ -630,7 +630,7 @@ run stats ok
 txn_ignore_seqs t=A seqs
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 
 # Pending resolution without epoch bump or savepoint rollback is a no-op.
 run stats ok
@@ -748,7 +748,7 @@ resolve_intent: "k1" -> resolved key = true
 resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-71 lock_age=-90
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/10.000000000,0 -> /<empty>
@@ -791,7 +791,7 @@ with t=A
 resolve_intent: "k1" -> resolved key = false
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/10.000000000,0 -> /<empty>
@@ -818,7 +818,7 @@ with t=A
 resolve_intent: "k1" -> resolved key = false
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/10.000000000,0 -> /<empty>
@@ -847,7 +847,7 @@ with t=A
 resolve_intent: "k1" -> resolved key = false
 stats: no change
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/10.000000000,0 -> /<empty>
@@ -877,7 +877,7 @@ resolve_intent: "k1" -> resolved key = true
 resolve_intent: released shared or exclusive locks
 stats: lock_count=-1 lock_bytes=-69 lock_age=-90
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} ts=10.000000000,0 del=true klen=12 vlen=0 ih={{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k2"/10.000000000,0 -> /<empty>
@@ -930,7 +930,7 @@ run stats ok
 txn_begin t=C ts=12,0
 ----
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=12.000000000,0 gul=0,0
 
 # Replay lock acquisition in batch with no other operations.
 run stats ok
@@ -946,7 +946,7 @@ stats: lock_count=+1 lock_bytes=+69 lock_age=+88
 >> acquire_lock k=k1 str=shared t=C
 stats: no change
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=12.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=1} ts=12.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 stats: key_count=3 key_bytes=45 val_count=3 val_bytes=21 live_count=3 live_bytes=66 lock_count=1 lock_bytes=69 lock_age=88
 
@@ -973,7 +973,7 @@ stats: no change
 >> acquire_lock k=k1 str=exclusive t=C
 stats: no change
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=12.000000000,0 gul=0,0
 lock (Replicated): "k1"/Exclusive -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2} ts=12.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k1"/Shared -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=1} ts=12.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 stats: key_count=3 key_bytes=45 val_count=3 val_bytes=21 live_count=3 live_bytes=66 lock_count=2 lock_bytes=138 lock_age=176
@@ -1001,7 +1001,7 @@ stats: no change
 >> put k=k2 v=v2_2 t=C
 stats: no change
 >> at end:
-txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=12.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=12.000000000,0 gul=0,0
 data: "k1"/5.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2} ts=12.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k2"/12.000000000,0 -> /BYTES/v2_2

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks_errors
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks_errors
@@ -10,7 +10,7 @@ run ok
 txn_begin t=A ts=10,0
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 
 run error
 check_for_acquire_lock t=A k=k1 str=none
@@ -43,7 +43,7 @@ with t=A
   acquire_lock t=A k=k1 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 
 run error
@@ -52,7 +52,7 @@ with t=A
   acquire_lock t=A k=k1 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 error: (*withstack.withStack:) cannot acquire lock with strength Shared at seq number 5, already held at higher seq number 10
 
@@ -62,7 +62,7 @@ with t=A
   acquire_lock t=A k=k1 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 
 run error
@@ -71,6 +71,6 @@ with t=A
   acquire_lock t=A k=k1 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=false
 error: (*withstack.withStack:) locking request with epoch 1 came after lock had already been acquired at epoch 2 in txn 00000001-0000-0000-0000-000000000000

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks_max_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks_max_conflicts
@@ -12,7 +12,7 @@ txn_begin t=C ts=12,0
 txn_begin t=D ts=13,0
 ----
 >> at end:
-txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=13.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=13.000000000,0 gul=0,0
 
 run ok
 acquire_lock t=A k=k1 str=shared

--- a/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
+++ b/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
@@ -18,7 +18,7 @@ put: lock acquisition = {dddddddddddddddddddddddddddddddddddddddddddddddddd id=0
 put: lock acquisition = {eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/1.000000000,0 -> /BYTES/a
 meta: "b"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -184,7 +184,7 @@ with t=B
 put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
 put: lock acquisition = {b id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/1.000000000,0 -> /BYTES/a
 meta: "b"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -23,7 +23,7 @@ txn_begin t=D ts=15,0
 txn_begin t=E ts=16,0
 ----
 >> at end:
-txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=16.000000000,0 wto=false gul=0,0
+txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=16.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=16.000000000,0 gul=0,0
 
 run ok
 put k=k1 v=v1 ts=11,0

--- a/pkg/storage/testdata/mvcc_histories/target_bytes
+++ b/pkg/storage/testdata/mvcc_histories/target_bytes
@@ -594,7 +594,7 @@ scan: "n" -> /BYTES/b @11.000000000,0
 scan: resume span ["k","m\x00") RESUME_BYTE_LIMIT nextBytes=25
 scan: 25 bytes (target 32)
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 data: "a"/123.000000000,45 -> /BYTES/abcdef
 data: "a"/1.000000000,0 -> /BYTES/nevergoingtobeseen
 data: "aa"/250.000000000,1 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval
@@ -24,7 +24,7 @@ with k=k2
 ----
 put: lock acquisition = {k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v
 meta: "k2"/0,0 -> txn={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} ts=20.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -45,7 +45,7 @@ run ok
 txn_begin t=txn1 ts=5,0 globalUncertaintyLimit=5,0
 ----
 >> at end:
-txn: "txn1" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=5.000000000,0
+txn: "txn1" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=5.000000000,0
 
 run ok
 get t=txn1 k=k1
@@ -72,7 +72,7 @@ run ok
 txn_begin t=txn2 ts=5,0 globalUncertaintyLimit=10,0
 ----
 >> at end:
-txn: "txn2" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=10.000000000,0
+txn: "txn2" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=10.000000000,0
 
 run error
 get t=txn2 k=k1
@@ -103,7 +103,7 @@ run ok
 txn_begin t=txn3 ts=5,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn3" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+txn: "txn3" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=15.000000000,0
 
 run error
 get t=txn3 k=k1
@@ -134,7 +134,7 @@ run ok
 txn_begin t=txn4 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn4" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn4" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn4 k=k1
@@ -165,7 +165,7 @@ run ok
 txn_begin t=txn5 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn5" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn5" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn5 k=k1
@@ -196,7 +196,7 @@ run ok
 txn_begin t=txn6 ts=10,0 globalUncertaintyLimit=10,0
 ----
 >> at end:
-txn: "txn6" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=10.000000000,0
+txn: "txn6" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=10.000000000,0
 
 run ok
 get t=txn6 k=k1
@@ -223,7 +223,7 @@ run ok
 txn_begin t=txn7 ts=10,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn7" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=15.000000000,0
+txn: "txn7" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=15.000000000,0
 
 run ok
 get t=txn7 k=k1
@@ -250,7 +250,7 @@ run ok
 txn_begin t=txn8 ts=10,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn8" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+txn: "txn8" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn8 k=k1
@@ -281,7 +281,7 @@ run ok
 txn_begin t=txn9 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn9" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn9" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn9 k=k1
@@ -312,7 +312,7 @@ run ok
 txn_begin t=txn10 ts=15,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn10" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=15.000000000,0
+txn: "txn10" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=15.000000000,0
 
 run ok
 get t=txn10 k=k1
@@ -339,7 +339,7 @@ run ok
 txn_begin t=txn11 ts=15,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn11" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=20.000000000,0
+txn: "txn11" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn11 k=k1
@@ -370,7 +370,7 @@ run ok
 txn_begin t=txn12 ts=15,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn12" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+txn: "txn12" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn12 k=k1
@@ -401,7 +401,7 @@ run ok
 txn_begin t=txn13 ts=20,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn13" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=20.000000000,0
+txn: "txn13" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn13 k=k1
@@ -430,7 +430,7 @@ run ok
 txn_begin t=txn14 ts=20,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn14" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=25.000000000,0
+txn: "txn14" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn14 k=k1
@@ -459,7 +459,7 @@ run ok
 txn_begin t=txn15 ts=25,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn15" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=25.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=25.000000000,0 wto=false gul=25.000000000,0
+txn: "txn15" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=25.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=25.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn15 k=k1

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
@@ -81,7 +81,7 @@ with k=k5
 ----
 put: lock acquisition = {k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -102,7 +102,7 @@ with k=k6
 ----
 put: lock acquisition = {k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -126,7 +126,7 @@ with k=k7
 ----
 put: lock acquisition = {k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -153,7 +153,7 @@ with k=k8
 ----
 put: lock acquisition = {k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -192,7 +192,7 @@ run ok
 txn_begin t=txn1 ts=5,0 globalUncertaintyLimit=10,0
 ----
 >> at end:
-txn: "txn1" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=10.000000000,0
+txn: "txn1" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=10.000000000,0
 
 run ok
 get t=txn1 k=k1 localUncertaintyLimit=5,0
@@ -287,7 +287,7 @@ run ok
 txn_begin t=txn2 ts=5,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn2" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+txn: "txn2" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=15.000000000,0
 
 run ok
 get t=txn2 k=k1 localUncertaintyLimit=5,0
@@ -382,7 +382,7 @@ run ok
 txn_begin t=txn3 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn3" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn3" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn3 k=k1 localUncertaintyLimit=5,0
@@ -477,7 +477,7 @@ run ok
 txn_begin t=txn4 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn4" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn4" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn4 k=k1 localUncertaintyLimit=5,0
@@ -572,7 +572,7 @@ run ok
 txn_begin t=txn5 ts=5,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn5" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+txn: "txn5" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=15.000000000,0
 
 run error
 get t=txn5 k=k1 localUncertaintyLimit=10,0
@@ -675,7 +675,7 @@ run ok
 txn_begin t=txn6 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn6" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn6" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn6 k=k1 localUncertaintyLimit=10,0
@@ -778,7 +778,7 @@ run ok
 txn_begin t=txn7 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn7" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn7" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn7 k=k1 localUncertaintyLimit=10,0
@@ -881,7 +881,7 @@ run ok
 txn_begin t=txn8 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn8" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn8" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn8 k=k1 localUncertaintyLimit=15,0
@@ -984,7 +984,7 @@ run ok
 txn_begin t=txn9 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn9" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn9" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn9 k=k1 localUncertaintyLimit=15,0
@@ -1087,7 +1087,7 @@ run ok
 txn_begin t=txn10 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn10" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn10" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn10 k=k1 localUncertaintyLimit=20,0
@@ -1190,7 +1190,7 @@ run ok
 txn_begin t=txn11 ts=10,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn11" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=15.000000000,0
+txn: "txn11" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=15.000000000,0
 
 run ok
 get t=txn11 k=k1 localUncertaintyLimit=10,0
@@ -1277,7 +1277,7 @@ run ok
 txn_begin t=txn12 ts=10,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn12" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+txn: "txn12" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn12 k=k1 localUncertaintyLimit=10,0
@@ -1372,7 +1372,7 @@ run ok
 txn_begin t=txn13 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn13" meta={id=00000011 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn13" meta={id=00000011 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn13 k=k1 localUncertaintyLimit=10,0
@@ -1467,7 +1467,7 @@ run ok
 txn_begin t=txn14 ts=10,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn14" meta={id=00000012 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+txn: "txn14" meta={id=00000012 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn14 k=k1 localUncertaintyLimit=15,0
@@ -1562,7 +1562,7 @@ run ok
 txn_begin t=txn15 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn15" meta={id=00000013 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn15" meta={id=00000013 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn15 k=k1 localUncertaintyLimit=15,0
@@ -1657,7 +1657,7 @@ run ok
 txn_begin t=txn16 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn16" meta={id=00000014 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn16" meta={id=00000014 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn16 k=k1 localUncertaintyLimit=20,0
@@ -1760,7 +1760,7 @@ run ok
 txn_begin t=txn17 ts=15,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn17" meta={id=00000015 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=20.000000000,0
+txn: "txn17" meta={id=00000015 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn17 k=k1 localUncertaintyLimit=15,0
@@ -1855,7 +1855,7 @@ run ok
 txn_begin t=txn18 ts=15,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn18" meta={id=00000016 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+txn: "txn18" meta={id=00000016 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn18 k=k1 localUncertaintyLimit=15,0
@@ -1950,7 +1950,7 @@ run ok
 txn_begin t=txn19 ts=15,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn19" meta={id=00000017 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+txn: "txn19" meta={id=00000017 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn19 k=k1 localUncertaintyLimit=20,0
@@ -2053,7 +2053,7 @@ run ok
 txn_begin t=txn20 ts=20,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn20" meta={id=00000018 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=25.000000000,0
+txn: "txn20" meta={id=00000018 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn20 k=k1 localUncertaintyLimit=20,0

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
@@ -81,7 +81,7 @@ with k=k5
 ----
 put: lock acquisition = {k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -102,7 +102,7 @@ with k=k6
 ----
 put: lock acquisition = {k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -126,7 +126,7 @@ with k=k7
 ----
 put: lock acquisition = {k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -153,7 +153,7 @@ with k=k8
 ----
 put: lock acquisition = {k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
+txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
 data: "k1"/10.000000000,0 -> /BYTES/v1
 data: "k2"/20.000000000,0 -> /BYTES/v4
@@ -192,7 +192,7 @@ run ok
 txn_begin t=txn1 ts=5,0 globalUncertaintyLimit=10,0
 ----
 >> at end:
-txn: "txn1" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=10.000000000,0
+txn: "txn1" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=10.000000000,0
 
 run ok
 get t=txn1 k=k1 localUncertaintyLimit=5,0
@@ -279,7 +279,7 @@ run ok
 txn_begin t=txn2 ts=5,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn2" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+txn: "txn2" meta={id=00000006 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=15.000000000,0
 
 run ok
 get t=txn2 k=k1 localUncertaintyLimit=5,0
@@ -366,7 +366,7 @@ run ok
 txn_begin t=txn3 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn3" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn3" meta={id=00000007 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn3 k=k1 localUncertaintyLimit=5,0
@@ -453,7 +453,7 @@ run ok
 txn_begin t=txn4 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn4" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn4" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn4 k=k1 localUncertaintyLimit=5,0
@@ -540,7 +540,7 @@ run ok
 txn_begin t=txn5 ts=5,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn5" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=15.000000000,0
+txn: "txn5" meta={id=00000009 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=15.000000000,0
 
 run error
 get t=txn5 k=k1 localUncertaintyLimit=10,0
@@ -643,7 +643,7 @@ run ok
 txn_begin t=txn6 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn6" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn6" meta={id=0000000a key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn6 k=k1 localUncertaintyLimit=10,0
@@ -746,7 +746,7 @@ run ok
 txn_begin t=txn7 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn7" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn7" meta={id=0000000b key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn7 k=k1 localUncertaintyLimit=10,0
@@ -849,7 +849,7 @@ run ok
 txn_begin t=txn8 ts=5,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn8" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=20.000000000,0
+txn: "txn8" meta={id=0000000c key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=20.000000000,0
 
 run error
 get t=txn8 k=k1 localUncertaintyLimit=15,0
@@ -952,7 +952,7 @@ run ok
 txn_begin t=txn9 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn9" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn9" meta={id=0000000d key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn9 k=k1 localUncertaintyLimit=15,0
@@ -1055,7 +1055,7 @@ run ok
 txn_begin t=txn10 ts=5,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn10" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=25.000000000,0
+txn: "txn10" meta={id=0000000e key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn10 k=k1 localUncertaintyLimit=20,0
@@ -1158,7 +1158,7 @@ run ok
 txn_begin t=txn11 ts=10,0 globalUncertaintyLimit=15,0
 ----
 >> at end:
-txn: "txn11" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=15.000000000,0
+txn: "txn11" meta={id=0000000f key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=15.000000000,0
 
 run ok
 get t=txn11 k=k1 localUncertaintyLimit=10,0
@@ -1245,7 +1245,7 @@ run ok
 txn_begin t=txn12 ts=10,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn12" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+txn: "txn12" meta={id=00000010 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn12 k=k1 localUncertaintyLimit=10,0
@@ -1332,7 +1332,7 @@ run ok
 txn_begin t=txn13 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn13" meta={id=00000011 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn13" meta={id=00000011 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn13 k=k1 localUncertaintyLimit=10,0
@@ -1419,7 +1419,7 @@ run ok
 txn_begin t=txn14 ts=10,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn14" meta={id=00000012 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=20.000000000,0
+txn: "txn14" meta={id=00000012 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn14 k=k1 localUncertaintyLimit=15,0
@@ -1506,7 +1506,7 @@ run ok
 txn_begin t=txn15 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn15" meta={id=00000013 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn15" meta={id=00000013 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn15 k=k1 localUncertaintyLimit=15,0
@@ -1593,7 +1593,7 @@ run ok
 txn_begin t=txn16 ts=10,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn16" meta={id=00000014 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=25.000000000,0
+txn: "txn16" meta={id=00000014 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn16 k=k1 localUncertaintyLimit=20,0
@@ -1696,7 +1696,7 @@ run ok
 txn_begin t=txn17 ts=15,0 globalUncertaintyLimit=20,0
 ----
 >> at end:
-txn: "txn17" meta={id=00000015 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=20.000000000,0
+txn: "txn17" meta={id=00000015 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=20.000000000,0
 
 run ok
 get t=txn17 k=k1 localUncertaintyLimit=15,0
@@ -1783,7 +1783,7 @@ run ok
 txn_begin t=txn18 ts=15,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn18" meta={id=00000016 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+txn: "txn18" meta={id=00000016 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn18 k=k1 localUncertaintyLimit=15,0
@@ -1870,7 +1870,7 @@ run ok
 txn_begin t=txn19 ts=15,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn19" meta={id=00000017 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 wto=false gul=25.000000000,0
+txn: "txn19" meta={id=00000017 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=15.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=15.000000000,0 gul=25.000000000,0
 
 run error
 get t=txn19 k=k1 localUncertaintyLimit=20,0
@@ -1973,7 +1973,7 @@ run ok
 txn_begin t=txn20 ts=20,0 globalUncertaintyLimit=25,0
 ----
 >> at end:
-txn: "txn20" meta={id=00000018 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=25.000000000,0
+txn: "txn20" meta={id=00000018 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 gul=25.000000000,0
 
 run ok
 get t=txn20 k=k1 localUncertaintyLimit=20,0

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
@@ -11,7 +11,7 @@ with t=B
 ----
 put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} ts=33.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/33.000000000,0 -> /BYTES/xyz
 error: (*kvpb.LockConflictError:) conflicting locks on "a"

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_in_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_in_txn
@@ -5,7 +5,7 @@ with t=A
 ----
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k"/0,1 -> /BYTES/v
 
@@ -20,6 +20,6 @@ with t=A
 ----
 put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1 Replicated Intent []}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=0,1 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} ts=1.000000000,0 del=false klen=12 vlen=6 ih={{0 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v

--- a/pkg/storage/testdata/mvcc_histories/verify_locks
+++ b/pkg/storage/testdata/mvcc_histories/verify_locks
@@ -36,7 +36,7 @@ txn_begin t=A ts=10,0
 txn_begin t=B ts=11,0
 ----
 >> at end:
-txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
+txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 gul=0,0
 
 run stats ok
 with t=A
@@ -59,7 +59,7 @@ stats: lock_count=+1 lock_bytes=+69 lock_age=+90
 put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10 Replicated Intent []}
 stats: key_bytes=+12 val_count=+1 val_bytes=+60 live_bytes=+53 gc_bytes_age=+1710 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+90
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 data: "k1"/5.000000000,0 -> /BYTES/v1
 data: "k2"/5.000000000,0 -> /BYTES/v2
 data: "k3"/5.000000000,0 -> /BYTES/v3
@@ -99,7 +99,7 @@ found: true
 found: false
 found: false
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 
 # A different transaction shouldn't be able to verify TxnA's locks.
 run stats ok
@@ -154,7 +154,7 @@ found: true
 found: false
 found: false
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=15} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=15} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 
 # Lower:
 run stats ok
@@ -182,7 +182,7 @@ found: true
 found: false
 found: false
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 gul=0,0
 
 # Ensure if a lock is held at a sequence number that's ignored it'll be
 # considered not found.
@@ -212,7 +212,7 @@ found: false
 found: false
 found: false
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 
 # Test that if a lock is held at a sequence number that's ignored, but it's also
 # held at a lock strength that's stronger at a sequence number that's not
@@ -233,7 +233,7 @@ with t=A
   acquire_lock k=k7 str=shared
 ----
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 lock (Replicated): "k1"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k2"/Shared -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
 lock (Replicated): "k3"/Exclusive -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} ts=10.000000000,0 del=false klen=0 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -255,7 +255,7 @@ found: true
 found: true
 found: false
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 
 # Test that the intent history is consulted when verifying locks.
 run ok
@@ -271,7 +271,7 @@ put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000
 put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=25 Replicated Intent [{5 15}]}
 put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30 Replicated Intent [{5 15}]}
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=1
 data: "k1"/5.000000000,0 -> /BYTES/v1
 data: "k2"/5.000000000,0 -> /BYTES/v2
 data: "k3"/5.000000000,0 -> /BYTES/v3
@@ -312,4 +312,4 @@ found: true
 found: false
 found: false
 >> at end:
-txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=3
+txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 gul=0,0 isn=3

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -23,7 +23,7 @@ with t=A
 ----
 del: "a": found key false
 >> at end:
-txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 wto=false gul=0,0
+txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 gul=0,0
 data: "a"/44.000000000,0 -> /BYTES/abc
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; must write at or above 44.000000000,1
 
@@ -45,7 +45,7 @@ with t=B
   cput   k=a v=def
 ----
 >> at end:
-txn: "B" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 wto=false gul=55.000000000,0
+txn: "B" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=33.000000000,0 gul=55.000000000,0
 data: "a"/44.000000000,0 -> /BYTES/abc
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "a" at timestamp 33.000000000,0 too old; must write at or above 44.000000000,1
 

--- a/pkg/storage/testdata/mvcc_histories/write_with_sequence
+++ b/pkg/storage/testdata/mvcc_histories/write_with_sequence
@@ -21,7 +21,7 @@ put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 e
 put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "t" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v2
 error: (*issuelink.withIssueLink:) transaction 00000001-0000-0000-0000-000000000000 with sequence 3 missing an intent with lower sequence 1
@@ -49,7 +49,7 @@ put: lock acquisition = {k id=00000002 key="k" iso=Serializable pri=0.00000000 e
 put: lock acquisition = {k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "t" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v2
 
@@ -76,7 +76,7 @@ put: lock acquisition = {k id=00000003 key="k" iso=Serializable pri=0.00000000 e
 put: lock acquisition = {k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "t" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v2
 error: (*assert.withAssertionFailure:) transaction 00000003-0000-0000-0000-000000000000 with sequence 2 has a different value [0 0 0 0 3 118 50] after recomputing from what was written: [0 0 0 0 3 118 49]
@@ -104,7 +104,7 @@ put: lock acquisition = {k id=00000004 key="k" iso=Serializable pri=0.00000000 e
 put: lock acquisition = {k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "t" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v2
 
@@ -131,7 +131,7 @@ put: lock acquisition = {k id=00000005 key="k" iso=Serializable pri=0.00000000 e
 put: lock acquisition = {k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
 put: batch after write is empty
 >> at end:
-txn: "t" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "t" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v2
 error: (*assert.withAssertionFailure:) transaction 00000005-0000-0000-0000-000000000000 with sequence 3 has a different value [0 0 0 0 3 118 51] after recomputing from what was written: [0 0 0 0 3 118 50]
@@ -162,7 +162,7 @@ put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 e
 put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4 Replicated Intent []}
 put: batch after write is non-empty
 >> at end:
-txn: "t" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
+txn: "t" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 gul=0,0
 meta: "k"/0,0 -> txn={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4} ts=1.000000000,0 del=false klen=12 vlen=7 ih={{2 /BYTES/v1}{3 /BYTES/v2}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/1.000000000,0 -> /BYTES/v4
 

--- a/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/sessions/sessionsPage.fixture.ts
@@ -75,7 +75,7 @@ export const idleTransactionSession: SessionInfo = {
         nanos: 134293000,
       },
       txn_description:
-        '"sql txn" meta={id=2c3ce6bc key=/Min pri=0.04688813 epo=0 ts=1596816673.134285000,0 min=1596816673.134285000,0 seq=0} lock=false stat=PENDING rts=1596816673.134285000,0 wto=false max=1596816673.634285000,0',
+        '"sql txn" meta={id=2c3ce6bc key=/Min pri=0.04688813 epo=0 ts=1596816673.134285000,0 min=1596816673.134285000,0 seq=0} lock=false stat=PENDING rts=1596816673.134285000,0 max=1596816673.634285000,0',
       num_statements_executed: 2,
       deadline: {
         seconds: Long.fromNumber(-62135596800),
@@ -130,7 +130,7 @@ export const activeSession: SessionInfo = {
         nanos: 320351000,
       },
       txn_description:
-        '"sql txn" meta={id=7bc353be key=/Min pri=0.05293838 epo=0 ts=1596816677.320344000,0 min=1596816677.320344000,0 seq=0} lock=false stat=PENDING rts=1596816677.320344000,0 wto=false max=1596816677.820344000,0',
+        '"sql txn" meta={id=7bc353be key=/Min pri=0.05293838 epo=0 ts=1596816677.320344000,0 min=1596816677.320344000,0 seq=0} lock=false stat=PENDING rts=1596816677.320344000,0 max=1596816677.820344000,0',
       num_statements_executed: 4,
       deadline: {
         seconds: Long.fromNumber(-62135596800),


### PR DESCRIPTION
In 8323322, we removed the mechanism that set WriteTooOld to
true. Here, we remove the option completely as we no longer require
support for nodes on 23.1 or earlier.

Epic: None

Release note: None