### PR TITLE
base: fix configuration of WAL failover encryption

### DIFF
--- a/pkg/base/store_spec.go
+++ b/pkg/base/store_spec.go
@@ -471,7 +471,7 @@ func PopulateWithEncryptionOpts(
 			break
 		}
 
-		for _, externalPath := range [2]storagepb.ExternalPath{walFailoverConfig.Path, walFailoverConfig.PrevPath} {
+		for _, externalPath := range [2]*storagepb.ExternalPath{&walFailoverConfig.Path, &walFailoverConfig.PrevPath} {
 			if !externalPath.IsSet() || !es.PathMatches(externalPath.Path) {
 				continue
 			}


### PR DESCRIPTION
In 6721617 the configuration of stores was refactored to make use of protocol buffers. In this change, a bug was introduced in the logic mapping encryption-at-rest configuration to the failover directory. The logic began saving the encryption-at-rest configuration to a local loop variable, rather than the actual WAL failover configuration struct.

Epic: none
Release note: none