### PR TITLE
split: patch decider logs to prevent redaction and duplication

### DIFF
--- a/pkg/kv/kvserver/split/decider.go
+++ b/pkg/kv/kvserver/split/decider.go
@@ -278,20 +278,28 @@ func (d *Decider) recordLocked(
 				if now.Sub(d.mu.lastNoSplitKeyLoggingMetrics) > minNoSplitKeyLoggingMetricsInterval {
 					d.mu.lastNoSplitKeyLoggingMetrics = now
 					if causeMsg := d.mu.splitFinder.NoSplitKeyCauseLogMsg(); causeMsg != "" {
-						popularKeyFrequency := d.mu.splitFinder.PopularKey().Frequency
-						log.KvDistribution.Infof(ctx, "%s, most popular key occurs in %d%% of samples",
-							causeMsg, int(popularKeyFrequency*100))
 						log.KvDistribution.VInfof(ctx, 3, "splitter_state=%v", (*lockedDecider)(d))
+						popularKeyDetected := ", no popular key"
+						clearDirectionDetected := ", no clear direction"
+
+						popularKeyFrequency := d.mu.splitFinder.PopularKey().Frequency
 						if popularKeyFrequency >= splitKeyThreshold {
+							popularKeyDetected = ", popular key detected"
 							d.loadSplitterMetrics.PopularKeyCount.Inc(1)
 						}
+
 						accessDirection := d.mu.splitFinder.AccessDirection()
 						direction := directionStr(accessDirection)
-						log.KvDistribution.Infof(ctx, "%s, access balance between left and right for sampled keys: %s-biased %d%%",
-							causeMsg, direction, int(math.Abs(accessDirection)*100))
 						if math.Abs(accessDirection) >= clearDirectionThreshold {
+							clearDirectionDetected = ", clear direction detected"
 							d.loadSplitterMetrics.ClearDirectionCount.Inc(1)
 						}
+
+						log.KvDistribution.Infof(
+							ctx, "%s, most popular key occurs in %d%% of samples, access balance %s-biased %d%%%s%s",
+							causeMsg, int(popularKeyFrequency*100), direction, int(math.Abs(accessDirection)*100),
+							redact.SafeString(popularKeyDetected), redact.SafeString(clearDirectionDetected),
+						)
 						d.loadSplitterMetrics.NoSplitKeyCount.Inc(1)
 					}
 				}
@@ -554,7 +562,7 @@ func (t *maxStatTracker) windowWidth() time.Duration {
 
 // Returns the absolute percentage and direction of accesses
 // as a string to be used in a log statement.
-func directionStr(direction float64) string {
+func directionStr(direction float64) redact.SafeString {
 	dstr := "right"
 	if direction == 0 {
 		dstr = "even"
@@ -562,5 +570,5 @@ func directionStr(direction float64) string {
 	if direction < 0 {
 		dstr = "left"
 	}
-	return dstr
+	return redact.SafeString(dstr)
 }


### PR DESCRIPTION
split: patch decider logs to prevent redaction and duplication

Prior to this change, the decider would, upon looking for a split key and not finding one, do two things which need to be changed:
 1. Log the direction if accesses as redacted, so users would be unable to see which direction accesses were going.
 2. Under certain circumstances log both the popular key log, and the clear direction logs, indicating (incorrectly) multiple causes to a missing split key.

This change patches these items.

Fixes: #146816
Epic: CRDB-43150

Release note: none