### PR TITLE
release-25.2: server: allow for filtering hot ranges by node id

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3598,6 +3598,7 @@ of ranges currently considered “hot” by the node(s).
 | page_size | [int32](#cockroach.server.serverpb.HotRangesRequest-int32) |  |  | [reserved](#support-status) |
 | page_token | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 | tenant_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
+| nodes | [string](#cockroach.server.serverpb.HotRangesRequest-string) | repeated |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -543,6 +543,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -497,7 +497,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 		requestedNodes = []roachpb.NodeID{requestedNodeID}
 	}
 
-	remoteRequest := serverpb.HotRangesRequest{NodeID: "local"}
+	remoteRequest := serverpb.HotRangesRequest{Nodes: []string{"local"}}
 	nodeFn := func(ctx context.Context, status serverpb.StatusClient, nodeID roachpb.NodeID) ([]hotRangeInfo, error) {
 		resp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil || resp == nil {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1383,6 +1383,10 @@ message HotRangesRequest {
     (gogoproto.customname) = "TenantID",
     (gogoproto.nullable) = true
   ];
+  repeated string nodes = 5 [
+    (gogoproto.customname) = "Nodes",
+    (gogoproto.nullable) = true
+  ];
 }
 
 // HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -147,11 +147,14 @@ func (s *hotRangesLoggingScheduler) shouldLog() bool {
 // logHotRanges collects the hot ranges from this node's status server and
 // sends them to the TELEMETRY log channel.
 func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	req := &serverpb.HotRangesRequest{NodeID: "local", PageSize: ReportTopHottestRanges}
+	req := &serverpb.HotRangesRequest{}
+
 	// if we are running in single tenant mode, only log the ranges on the status server.
 	if !s.multiTenant {
-		req.NodeID = "local"
+		req.Nodes = []string{"local"}
+		req.PageSize = ReportTopHottestRanges
 	}
+
 	resp, err := s.sServer.HotRangesV2(ctx, req)
 	if err != nil {
 		log.Warningf(ctx, "failed to get hot ranges: %s", err)

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -30,7 +30,7 @@ const HotRanges = (props: HotRangesProps) => {
 
   useEffect(() => {
     const request = new cockroach.server.serverpb.HotRangesRequest({
-      node_id: nodeId,
+      nodes: [nodeId],
       page_size: pageSize,
       page_token: pageToken,
     });


### PR DESCRIPTION
Backport 1/1 commits from #143904.

/cc @cockroachdb/release

---

server: allow for filtering hot ranges by node id

Right now, each call within the Hot Ranges page relies on front end filtering to prune out the nodes which are specified in the page's filter.

This filter should be applied on the back end, to minimize the number of outbound calls the system needs to make.

Fixes: #142594
Epic: CRDB-43150

Release note: none
Release justification: Required performance improvement to the hot ranges page required for 25.2.1 release.
