### PR TITLE
build: jj should use current revision in tag-custom-build.sh

### DIFF
--- a/scripts/tag-custom-build.sh
+++ b/scripts/tag-custom-build.sh
@@ -78,7 +78,7 @@ SHA="${1-}"
 
 if [ -z "$SHA" ] ; then
     if [ "$use_jj" = true ] ; then
-        SHA="$(jj log -n1 --template commit_id --no-graph)"
+        SHA="$(jj log -r@ -n1 --template commit_id --no-graph)"
     else
         SHA="$(git rev-parse HEAD)"
     fi


### PR DESCRIPTION
Using `-r@` makes it explicit, which commit is inspected. In some situation jj may fall back to a different commit.

Epic: none
Release note: none