### PR TITLE
roachtest: update psycopg tests to use version 3.2.8

### DIFF
--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -19,7 +19,7 @@ import (
 )
 
 var psycopgReleaseTagRegex = regexp.MustCompile(`^(?P<major>\d+)(?:\.(?P<minor>\d+)(?:\.(?P<point>\d+)(?:\.(?P<subpoint>\d+))?)?)?$`)
-var supportedPsycopgTag = "3.2.6"
+var supportedPsycopgTag = "3.2.8"
 
 // This test runs psycopg full test suite against a single cockroach node.
 func registerPsycopg(r registry.Registry) {


### PR DESCRIPTION
The psycopg tests began failing due to memory leaks detected in the test_leak functions across various psycopg test files. These failures occurred after the release of Cython 3.1 on May 9, 2025, which introduced memory leaks. https://github.com/cython/cython/issues/6850

The psycopg maintainers fixed this issue in version 3.2.8 (released May 11, 2025) by restricting the Cython version to <3.1.0 in their dependencies. This commit updates our supported psycopg version from 3.2.6 to 3.2.8 to incorporate this fix. 
Fixes: #146425
Fixes: https://github.com/cockroachdb/cockroach/issues/146429
Release note: none