### PR TITLE
release-23.2: changefeedccl: fix mvcc_timestamp being zero when used with cdc queries

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/projection.go
+++ b/pkg/ccl/changefeedccl/cdcevent/projection.go
@@ -116,5 +116,7 @@ func (p *Projection) Project(r Row) (Row, error) {
 		return Row{}, err
 	}
 
+	p.MvccTimestamp = r.MvccTimestamp
+
 	return Row(*p), nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9812,3 +9812,30 @@ func TestParallelIOMetrics(t *testing.T) {
 	}
 	cdcTest(t, testFn, feedTestForceSink("pubsub"))
 }
+
+func TestChangefeedMVCCTimestampWithQueries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY);`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1);`)
+
+		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp AS SELECT * FROM foo`)
+		require.NoError(t, err)
+		defer closeFeed(t, feed)
+
+		msgs, err := readNextMessages(ctx, feed, 1)
+		require.NoError(t, err)
+
+		var m map[string]any
+		require.NoError(t, gojson.Unmarshal(msgs[0].Value, &m))
+		ts := m["__crdb__"].(map[string]any)["mvcc_timestamp"].(string)
+		assertReasonableMVCCTimestamp(t, ts)
+	}
+
+	cdcTest(t, testFn)
+}


### PR DESCRIPTION
Backport 1/1 commits from #146836 on behalf of @asg0451.

----

Fix a bug where the mvcc_timestamp was emitted as zero
when used with cdc queries.

Fixes: #146823

Release note (bug fix): The mvcc_timestamp is now
emitted correctly when used with cdc queries.


----

Release justification: