### PR TITLE
sql: verify correct query vector length when building a vector search

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -456,6 +456,9 @@ CREATE TABLE exec_test (
   FAMILY (a, b, vec1)
 )
 
+query error pgcode 22000 different vector dimensions 1 and 3
+SELECT a FROM exec_test ORDER BY vec1 <-> '[1]' LIMIT 1;
+
 statement ok
 INSERT INTO exec_test (a, b, vec1) VALUES
   (1, 1, '[1, 2, 3]'),
@@ -467,6 +470,12 @@ INSERT INTO exec_test (a, b, vec1) VALUES
   (7, NULL, '[1, 1, 1]'),
   (8, NULL, NULL),
   (9, 3, NULL);
+
+statement error pgcode 22000 pq: expected 3 dimensions, not 1
+INSERT INTO exec_test (a, b, vec1) VALUES (10, 1, '[1]');
+
+query error pgcode 22000 different vector dimensions 1 and 3
+SELECT a FROM exec_test ORDER BY vec1 <-> '[1]' LIMIT 1;
 
 # Get all rows that do not have NULL vector values.
 query IT rowsort


### PR DESCRIPTION
Previously the vector search operator was missing a check to ensure that the query vector had the right number of dimensions to search a given table. This patch adds a verification of query vector size when building a search node.

Fixes: #146693
Release note (bug fix): Fixed an issue where searching a vector with a query vector that doesn't match the dimensions of the vector column in the table would cause a node to crash.