### PR TITLE
workload/tpcc: remove --deprecated-fk-indexes flag

### DIFF
--- a/pkg/workload/tpcc/ddls.go
+++ b/pkg/workload/tpcc/ddls.go
@@ -93,9 +93,6 @@ const (
 		h_amount decimal(6,2),
 		h_data   varchar(24),
 		primary key (h_w_id, rowid)`
-	deprecatedTpccHistorySchemaFkSuffix = `
-		index history_customer_fk_idx (h_c_w_id, h_c_d_id, h_c_id),
-		index history_district_fk_idx (h_w_id, h_d_id)`
 
 	// ORDER table.
 	tpccOrderSchemaBase = `(
@@ -149,8 +146,6 @@ const (
 		s_remote_cnt integer,
 		s_data       varchar(50),
 		primary key (s_w_id, s_i_id)`
-	deprecatedTpccStockSchemaFkSuffix = `
-		index stock_item_fk_idx (s_i_id)`
 
 	// ORDER-LINE table.
 	tpccOrderLineSchemaBase = `(
@@ -165,8 +160,6 @@ const (
 		ol_amount       decimal(6,2),
 		ol_dist_info    char(24),
 		primary key (ol_w_id, ol_d_id, ol_o_id DESC, ol_number)`
-	deprecatedTpccOrderLineSchemaFkSuffix = `
-		index order_line_stock_fk_idx (ol_supply_w_id, ol_i_id)`
 
 	localityRegionalByRowSuffix = `
 		locality regional by row`
@@ -177,21 +170,12 @@ const (
 )
 
 type schemaOptions struct {
-	fkClause       string
 	familyClause   string
 	columnClause   string
 	localityClause string
 }
 
 type makeSchemaOption func(o *schemaOptions)
-
-func maybeAddFkSuffix(fks bool, suffix string) makeSchemaOption {
-	return func(o *schemaOptions) {
-		if fks {
-			o.fkClause = suffix
-		}
-	}
-}
 
 func maybeAddColumnFamiliesSuffix(separateColumnFamilies bool, suffix string) makeSchemaOption {
 	return func(o *schemaOptions) {
@@ -233,9 +217,6 @@ func makeSchema(base string, opts ...makeSchemaOption) string {
 		opt(&o)
 	}
 	ret := base
-	if o.fkClause != "" {
-		ret += "," + o.fkClause
-	}
 	if o.familyClause != "" {
 		ret += "," + o.familyClause
 	}


### PR DESCRIPTION
This commit is effectively a revert of b52aefc3ba2d54b52a17807a4cf07538c775ab1a. For context, long time ago (until about 20.2 version) we required that the origin side of the FK constraint had an index on the foreign key column. That requirement has been removed, yet we needed to keep the support for the schema with those indexes to allow the workload to run against 20.1 and prior versions. We don't need that ability anymore, so it should be safe to delete this.

Epic: None
Release note: None