### PR TITLE
sql: do not allow cascades to autocommit if there are AFTER triggers

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -4298,3 +4298,33 @@ statement ok
 DROP FUNCTION g;
 
 subtest end
+
+subtest regression_146889
+
+statement ok
+CREATE TABLE parent146889 (k INT PRIMARY KEY)
+
+statement ok
+CREATE TABLE child146889 (ref INT REFERENCES parent146889(k) ON DELETE CASCADE)
+
+statement ok
+INSERT INTO parent146889 VALUES (1);
+INSERT INTO child146889 VALUES (1);
+
+statement ok
+CREATE FUNCTION f146889() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', (SELECT count(*) FROM parent146889);
+    RETURN NULL;
+  END
+$$;
+
+statement ok
+CREATE TRIGGER t AFTER DELETE ON parent146889 FOR EACH ROW EXECUTE FUNCTION f146889();
+
+query T noticetrace
+DELETE FROM parent146889 WHERE k = 1;
+----
+NOTICE: 0
+
+subtest end

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2225,7 +2225,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 			}
 
 			// The cascading query is allowed to autocommit only if it is the last
-			// cascade and there are no check queries to run.
+			// cascade and there are no check queries or after-triggers to run.
 			//
 			// Note that even if it's the last cascade, we still might not be able
 			// to autocommit in case there are more checks to run during or after
@@ -2234,7 +2234,7 @@ func (dsp *DistSQLPlanner) PlanAndRunPostQueries(
 			// other words, allowAutoCommit = true here means that the plan _might_
 			// autocommit but doesn't guarantee that.
 			allowAutoCommit := planner.autoCommit
-			if len(plan.checkPlans) > 0 || cascadesIdx < len(plan.cascades)-1 {
+			if len(plan.checkPlans) > 0 || len(plan.triggers) > 0 || cascadesIdx < len(plan.cascades)-1 {
 				allowAutoCommit = false
 			}
 			evalCtx := evalCtxFactory(false /* usedConcurrently */)


### PR DESCRIPTION
This commit fixes an oversight from when AFTER triggers were introduced. Previously, the last FK cascade could autocommit if there were no checks even if there were still AFTER triggers to be executed. This could result in a `client already committed or rolled back the transaction` error when the trigger attempted to execute. The fix is simple - just check that there are no triggers before allowing autocommit.

Fixes #146889

Release note (bug fix): Fixed a bug that could cause an AFTER trigger to fail with `client already committed or rolled back the transaction` if the query also contained foreign-key cascades. The bug has existed since AFTER triggers were introduced in v24.3.