### PR TITLE
schemachangerccl: increase polling duration for TestSubzonesRemovedByGCAfterIndexSwap

### DIFF
--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
@@ -248,7 +247,6 @@ CREATE TABLE person (
 	})
 
 	// Keep retrying until the old index and temporary index are removed by the GC job.
-	runner.SucceedsSoonDuration = 30 * time.Second
 	runner.CheckQueryResultsRetry(t, subzonesQuery, [][]string{
 		{"3", "north_america", "4", `/3/"CA"`, "NULL"},
 		{"3", "north_america", "4", `/3/"US"`, "NULL"},


### PR DESCRIPTION


The last attempt was 5af3b81742d6b69ab2642ec585c803834d909c54 but that doesn't seem to have been enough.

fixes https://github.com/cockroachdb/cockroach/issues/145524
Release note: None