### PR TITLE
cspann: set quantizers when loading memstore

### DIFF
--- a/pkg/sql/vecindex/cspann/memstore/memstore.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.go
@@ -665,10 +665,15 @@ func Load(data []byte) (*Store, error) {
 		return nil, err
 	}
 
+	raBitQuantizer := quantize.NewRaBitQuantizer(storeProto.Dims, storeProto.Seed, vecdist.L2Squared)
+	unquantizer := quantize.NewUnQuantizer(storeProto.Dims, vecdist.L2Squared)
+
 	// Construct the InMemoryStore object.
 	inMemStore := &Store{
-		dims: storeProto.Dims,
-		seed: storeProto.Seed,
+		dims:          storeProto.Dims,
+		seed:          storeProto.Seed,
+		rootQuantizer: unquantizer,
+		quantizer:     raBitQuantizer,
 	}
 	inMemStore.mu.clock = 2
 	inMemStore.mu.partitions = make(map[qualifiedPartitionKey]*memPartition, len(storeProto.Partitions))
@@ -676,9 +681,6 @@ func Load(data []byte) (*Store, error) {
 	inMemStore.mu.vectors = make(map[string]vector.T, len(storeProto.Vectors))
 	inMemStore.mu.stats = storeProto.Stats
 	inMemStore.mu.pending.Init()
-
-	raBitQuantizer := quantize.NewRaBitQuantizer(storeProto.Dims, storeProto.Seed, vecdist.L2Squared)
-	unquantizer := quantize.NewUnQuantizer(storeProto.Dims, vecdist.L2Squared)
 
 	// Construct the Partition objects.
 	for i := range storeProto.Partitions {

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -299,6 +299,8 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 	store2, err := Load(data)
 	require.NoError(t, err)
 
+	require.NotNil(t, store2.rootQuantizer)
+	require.NotNil(t, store2.quantizer)
 	require.Len(t, store2.mu.partitions, 2)
 	require.Equal(t, qkey10, store2.mu.partitions[qkey10].key)
 	require.Equal(t, uint64(1), store2.mu.partitions[qkey10].lock.created)


### PR DESCRIPTION
Previously, we were not setting the quantizers in the memstore in the Load method (only used in benchmarking). This caused nil-reference exceptions after loading the store from disk. The fix is simply to set the quantizers.

Epic: CRDB-42943
Release note: None