### PR TITLE
roachtest: harden tpchbench

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -303,7 +303,6 @@ go_library(
         "//pkg/workload/debug",
         "//pkg/workload/histogram",
         "//pkg/workload/histogram/exporter",
-        "//pkg/workload/querybench",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpcds",
         "//pkg/workload/tpch",

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -88,7 +88,7 @@ func (g *queryBench) Hooks() workload.Hooks {
 			if g.queryFile == "" {
 				return errors.Errorf("Missing required argument '--query-file'")
 			}
-			stmts, err := GetQueries(g.queryFile, g.separator)
+			stmts, err := getQueries(g.queryFile, g.separator)
 			if err != nil {
 				return err
 			}
@@ -148,9 +148,9 @@ func (g *queryBench) Ops(
 	return ql, nil
 }
 
-// GetQueries returns the queries in a file as a slice of named statements. If
+// getQueries returns the queries in a file as a slice of named statements. If
 // no separator is given, splits by newlines.
-func GetQueries(path, separator string) ([]namedStmt, error) {
+func getQueries(path, separator string) ([]namedStmt, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
tpchbench currently does the following:
- curl's a target query file to be passed into `workload run` command
later
- downloads the same file via HTTP GET to get the number of queries in the file. This number is multiplied by `num-runs` to come up with `max-ops` parameter
- issues `workload run querybench --query-file=... --num-runs=3 --max-ops=...`
- `querybench` itself will parse the target file on its own to come up with its internal "max-ops" for each worker.

We just saw a couple of timeout failures in this roachtest that occurred due to `--max-ops=0` being passed. The querybench worker correctly computed its own "max-ops" as 66, yet because the main workload loop had max-ops of 0, the external loop never exited, yet the querybench worker simply short-circuited its `run` method.

I'm not quite sure why we passed `--max-ops=0`. Perhaps there was some hiccup in downloading the query file via HTTP request.

This commit switches the roachtest to using the hard-coded number of queries in the test file which removes the HTTP GET / parse step altogether.

Fixes: #146903.

Release note: None