### PR TITLE
import: remove deprecated fields from ImportDetails proto

### DIFF
--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -701,8 +701,6 @@ message ImportDetails {
   repeated string uris = 2 [(gogoproto.customname) = "URIs"];
   roachpb.IOFileFormat format = 3 [(gogoproto.nullable) = false];
 
-  int64 sst_size = 4 [(gogoproto.customname) = "SSTSize"];
-  int64 oversample = 9;
   bool skip_fks = 10 [(gogoproto.customname) = "SkipFKs"];
 
   // walltime is the time at which an import job will write KVs.
@@ -711,35 +709,12 @@ message ImportDetails {
     (gogoproto.customname) = "ParentID",
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"
   ];
-  string backup_path = 7;
-
-  // samples is a sampling of cockroach KV keys generated from the input data.
-  // It is populated with the sampling phase's results. These must be
-  // used if a job is resumed to guarantee that AddSSTable will not attempt
-  // to add ranges with an old split point within them.
-  repeated bytes samples = 8;
-
-  // ingest_directly means the Import job directly ingests the data as readers
-  // produce it instead of sampling it and then setting up a distsql shuffle and
-  // sort that produced sorted, non-overlapping data to ingest. When ingesting
-  // directly, many other fields like samples, oversample, sst_size are ignored.
-  bool ingest_directly = 11;
 
   bool prepare_complete = 12;
   bool schemas_published = 24;
   bool tables_published = 13;
 
   bool parse_bundle_schema = 14;
-
-  // ProtectedTimestampRecord is the ID of the protected timestamp record
-  // corresponding to this job. While the job ought to clean up the record
-  // when it enters a terminal state, there may be cases where it cannot or
-  // does not run the code to do so. To deal with this there is a background
-  // reconciliation loop to ensure that protected timestamps are cleaned up.
-  bytes protected_timestamp_record = 22 [
-    (gogoproto.customname) = "ProtectedTimestampRecord",
-    (gogoproto.customtype) = "github.com/cockroachdb/cockroach/pkg/util/uuid.UUID"
-  ];
 
   // DefaultIntSize is the integer type that a "naked" int will be resolved
   // to during the import. This is set based on the session variable DefaultIntSize
@@ -751,6 +726,8 @@ message ImportDetails {
   string database_primary_region = 27 [
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb.RegionName"
   ];
+
+  reserved 4, 7, 8, 9, 11, 22;
 
   // next val: 28
 }

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -472,7 +472,6 @@ func (b *BufferingAdder) createInitialSplits(ctx context.Context) error {
 	log.Infof(ctx, "%s adder scattered %d initial split spans in %v",
 		b.name, len(toScatter), timing(scattersWait))
 
-	b.sink.initialSplitDone = true
 	return nil
 }
 

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -132,8 +132,6 @@ type SSTBatcher struct {
 	// writeAtBatchTS is passed to the writeAtBatchTs argument to db.AddSStable.
 	writeAtBatchTS bool
 
-	initialSplitDone bool
-
 	// disableScatters controls scatters of the as-we-fill split ranges.
 	disableScatters bool
 

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -46,7 +46,6 @@ go_library(
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",
-        "//pkg/kv/kvserver/protectedts",
         "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/server/telemetry",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/protectedts"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
@@ -357,20 +356,6 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		return err
 	}
 
-	// As of 21.2 we do not write a protected timestamp record during IMPORT INTO.
-	// In case of a mixed version cluster with 21.1 and 21.2 nodes, it is possible
-	// that the job was planned on an older node and then resumed on a 21.2 node.
-	// Thus, we still need to clear the timestamp record that was written when the
-	// IMPORT INTO was planned on the older node.
-	//
-	// TODO(adityamaru): Remove in 22.1.
-	if err := p.ExecCfg().InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
-		return r.releaseProtectedTimestamp(
-			ctx, p.ExecCfg().ProtectedTimestampProvider.WithTxn(txn),
-		)
-	}); err != nil {
-		log.Errorf(ctx, "failed to release protected timestamp: %v", err)
-	}
 	emitImportJobEvent(ctx, p, jobs.StateSucceeded, r.job)
 
 	addToFileFormatTelemetry(details.Format.Format.String(), "succeeded")
@@ -1511,12 +1496,7 @@ func (r *importResumer) OnFailOrCancel(
 		// schema before dropping the descriptor.
 		var err error
 		jobsToRunAfterTxnCommit, err = r.dropSchemas(ctx, txn, descsCol, cfg, p)
-		if err != nil {
-			return err
-		}
-		// TODO(adityamaru): Remove in 22.1 since we do not write PTS records during
-		// IMPORT INTO from 21.2+.
-		return r.releaseProtectedTimestamp(ctx, cfg.ProtectedTimestampProvider.WithTxn(txn))
+		return err
 	}); err != nil {
 		return err
 	}
@@ -1781,25 +1761,6 @@ func (r *importResumer) dropSchemas(
 	queuedJob = append(queuedJob, job.ID())
 
 	return queuedJob, nil
-}
-
-func (r *importResumer) releaseProtectedTimestamp(
-	ctx context.Context, pts protectedts.Storage,
-) error {
-	details := r.job.Details().(jobspb.ImportDetails)
-	ptsID := details.ProtectedTimestampRecord
-	// If the job doesn't have a protected timestamp then there's nothing to do.
-	if ptsID == nil {
-		return nil
-	}
-	err := pts.Release(ctx, *ptsID)
-	if errors.Is(err, protectedts.ErrNotExists) {
-		// No reason to return an error which might cause problems if it doesn't
-		// seem to exist.
-		log.Warningf(ctx, "failed to release protected which seems not to exist: %v", err)
-		err = nil
-	}
-	return err
 }
 
 // ReportResults implements JobResultsReporter interface.

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -95,7 +95,8 @@ var _ jobs.Resumer = &importResumer{}
 var processorsPerNode = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"bulkio.import.processors_per_node",
-	"number of input processors to run on each sql instance", 1,
+	"number of input processors to run on each sql instance",
+	1,
 	settings.PositiveInt,
 )
 

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -69,9 +69,7 @@ const (
 	mysqlOutfileEnclose  = "fields_enclosed_by"
 	mysqlOutfileEscape   = "fields_escaped_by"
 
-	importOptionSSTSize          = "sstsize"
 	importOptionDecompress       = "decompress"
-	importOptionOversample       = "oversample"
 	importOptionSkipFKs          = "skip_foreign_keys"
 	importOptionDisableGlobMatch = "disable_glob_matching"
 	importOptionSaveRejected     = "experimental_save_rejected"
@@ -119,9 +117,7 @@ var importOptionExpectValues = map[string]exprutil.KVStringOptValidate{
 	mysqlOutfileEnclose:  exprutil.KVStringOptRequireValue,
 	mysqlOutfileEscape:   exprutil.KVStringOptRequireValue,
 
-	importOptionSSTSize:      exprutil.KVStringOptRequireValue,
 	importOptionDecompress:   exprutil.KVStringOptRequireValue,
-	importOptionOversample:   exprutil.KVStringOptRequireValue,
 	importOptionSaveRejected: exprutil.KVStringOptRequireNoValue,
 
 	importOptionSkipFKs:          exprutil.KVStringOptRequireNoValue,
@@ -161,8 +157,8 @@ func makeStringSet(opts ...string) map[string]struct{} {
 
 // Options common to all formats.
 var allowedCommonOptions = makeStringSet(
-	importOptionSSTSize, importOptionDecompress, importOptionOversample,
-	importOptionSaveRejected, importOptionDisableGlobMatch, importOptionDetached)
+	importOptionDecompress, importOptionSaveRejected, importOptionDisableGlobMatch, importOptionDetached,
+)
 
 // Format specific allowed options.
 var avroAllowedOptions = makeStringSet(
@@ -752,26 +748,6 @@ func importPlanHook(
 			return unimplemented.Newf("import.format", "unsupported import format: %q", importStmt.FileFormat)
 		}
 
-		// sstSize, if 0, will be set to an appropriate default by the specific
-		// implementation (local or distributed) since each has different optimal
-		// settings.
-		var sstSize int64
-		if override, ok := opts[importOptionSSTSize]; ok {
-			sz, err := humanizeutil.ParseBytes(override)
-			if err != nil {
-				return err
-			}
-			sstSize = sz
-		}
-		var oversample int64
-		if override, ok := opts[importOptionOversample]; ok {
-			os, err := strconv.ParseInt(override, 10, 64)
-			if err != nil {
-				return err
-			}
-			oversample = os
-		}
-
 		var skipFKs bool
 		if _, ok := opts[importOptionSkipFKs]; ok {
 			skipFKs = true
@@ -967,8 +943,6 @@ func importPlanHook(
 			ParentID:              db.GetID(),
 			Tables:                tableDetails,
 			Types:                 typeDetails,
-			SSTSize:               sstSize,
-			Oversample:            oversample,
 			SkipFKs:               skipFKs,
 			ParseBundleSchema:     importStmt.Bundle,
 			DefaultIntSize:        p.SessionData().DefaultIntSize,

--- a/pkg/sql/importer/import_processor.go
+++ b/pkg/sql/importer/import_processor.go
@@ -50,45 +50,33 @@ const readImportDataProcessorName = "readImportDataProcessor"
 
 var progressUpdateInterval = time.Second * 10
 
-var importPKAdderBufferSize = func() *settings.ByteSizeSetting {
-	s := settings.RegisterByteSizeSetting(
-		settings.ApplicationLevel,
-		"kv.bulk_ingest.pk_buffer_size",
-		"the initial size of the BulkAdder buffer handling primary index imports",
-		32<<20,
-	)
-	return s
-}()
+var importPKAdderBufferSize = settings.RegisterByteSizeSetting(
+	settings.ApplicationLevel,
+	"kv.bulk_ingest.pk_buffer_size",
+	"the initial size of the BulkAdder buffer handling primary index imports",
+	32<<20,
+)
 
-var importPKAdderMaxBufferSize = func() *settings.ByteSizeSetting {
-	s := settings.RegisterByteSizeSetting(
-		settings.ApplicationLevel,
-		"kv.bulk_ingest.max_pk_buffer_size",
-		"the maximum size of the BulkAdder buffer handling primary index imports",
-		128<<20,
-	)
-	return s
-}()
+var importPKAdderMaxBufferSize = settings.RegisterByteSizeSetting(
+	settings.ApplicationLevel,
+	"kv.bulk_ingest.max_pk_buffer_size",
+	"the maximum size of the BulkAdder buffer handling primary index imports",
+	128<<20,
+)
 
-var importIndexAdderBufferSize = func() *settings.ByteSizeSetting {
-	s := settings.RegisterByteSizeSetting(
-		settings.ApplicationLevel,
-		"kv.bulk_ingest.index_buffer_size",
-		"the initial size of the BulkAdder buffer handling secondary index imports",
-		32<<20,
-	)
-	return s
-}()
+var importIndexAdderBufferSize = settings.RegisterByteSizeSetting(
+	settings.ApplicationLevel,
+	"kv.bulk_ingest.index_buffer_size",
+	"the initial size of the BulkAdder buffer handling secondary index imports",
+	32<<20,
+)
 
-var importIndexAdderMaxBufferSize = func() *settings.ByteSizeSetting {
-	s := settings.RegisterByteSizeSetting(
-		settings.ApplicationLevel,
-		"kv.bulk_ingest.max_index_buffer_size",
-		"the maximum size of the BulkAdder buffer handling secondary index imports",
-		512<<20,
-	)
-	return s
-}()
+var importIndexAdderMaxBufferSize = settings.RegisterByteSizeSetting(
+	settings.ApplicationLevel,
+	"kv.bulk_ingest.max_index_buffer_size",
+	"the maximum size of the BulkAdder buffer handling secondary index imports",
+	512<<20,
+)
 
 var readerParallelismSetting = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
@@ -98,7 +86,7 @@ var readerParallelismSetting = settings.RegisterIntSetting(
 	settings.NonNegativeInt,
 )
 
-// ImportBufferConfigSizes determines the minimum, maximum and step size for the
+// importBufferConfigSizes determines the minimum, maximum and step size for the
 // BulkAdder buffer used in import.
 func importBufferConfigSizes(st *cluster.Settings, isPKAdder bool) (int64, func() int64) {
 	if isPKAdder {

--- a/pkg/sql/importer/read_import_avro.go
+++ b/pkg/sql/importer/read_import_avro.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/timeofday"
 	"github.com/cockroachdb/errors"
 	"github.com/linkedin/goavro/v2"
@@ -516,8 +515,6 @@ func newAvroInputReader(
 		opts: avroOpts,
 	}, nil
 }
-
-func (a *avroInputReader) start(group ctxgroup.Group) {}
 
 func (a *avroInputReader) readFiles(
 	ctx context.Context,

--- a/pkg/sql/importer/read_import_csv.go
+++ b/pkg/sql/importer/read_import_csv.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/encoding/csv"
 	"github.com/cockroachdb/errors"
 )
@@ -65,9 +64,6 @@ func newCSVInputReader(
 		numExpectedDataCols: numExpectedDataCols,
 		opts:                opts,
 	}
-}
-
-func (c *csvInputReader) start(group ctxgroup.Group) {
 }
 
 func (c *csvInputReader) readFiles(

--- a/pkg/sql/importer/read_import_mysql.go
+++ b/pkg/sql/importer/read_import_mysql.go
@@ -33,7 +33,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -89,9 +88,6 @@ func newMysqldumpReader(
 	}
 	res.tables = converters
 	return res, nil
-}
-
-func (m *mysqldumpReader) start(ctx ctxgroup.Group) {
 }
 
 func (m *mysqldumpReader) readFiles(

--- a/pkg/sql/importer/read_import_mysqlout.go
+++ b/pkg/sql/importer/read_import_mysqlout.go
@@ -20,7 +20,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/row"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/errors"
 )
 
@@ -55,9 +54,6 @@ func newMysqloutfileReader(
 		},
 		opts: opts,
 	}, nil
-}
-
-func (d *mysqloutfileReader) start(ctx ctxgroup.Group) {
 }
 
 func (d *mysqloutfileReader) readFiles(

--- a/pkg/sql/importer/read_import_pgcopy.go
+++ b/pkg/sql/importer/read_import_pgcopy.go
@@ -23,7 +23,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/errors"
 )
 
@@ -62,9 +61,6 @@ func newPgCopyReader(
 		},
 		opts: opts,
 	}, nil
-}
-
-func (d *pgCopyReader) start(ctx ctxgroup.Group) {
 }
 
 func (d *pgCopyReader) readFiles(

--- a/pkg/sql/importer/read_import_pgdump.go
+++ b/pkg/sql/importer/read_import_pgdump.go
@@ -38,7 +38,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
@@ -1024,9 +1023,6 @@ func newPgDumpReader(
 		jobID:      jobID,
 		evalCtx:    evalCtx,
 	}, nil
-}
-
-func (m *pgDumpReader) start(ctx ctxgroup.Group) {
 }
 
 func (m *pgDumpReader) readFiles(

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -54,9 +54,6 @@ func newWorkloadReader(
 	return &workloadReader{semaCtx: semaCtx, evalCtx: evalCtx, table: table, kvCh: kvCh, parallelism: parallelism, db: db}
 }
 
-func (w *workloadReader) start(ctx ctxgroup.Group) {
-}
-
 // makeDatumFromColOffset tries to fast-path a few workload-generated types into
 // directly datums, to dodge making a string and then the parsing it.
 func makeDatumFromColOffset(

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4147,7 +4147,6 @@ alter_unsupported_stmt:
 //
 // Options:
 //    distributed = '...'
-//    sstsize = '...'
 //    temp = '...'
 //
 // Use CREATE TABLE followed by IMPORT INTO to create and import into a table

--- a/pkg/sql/sem/tree/pretty_test.go
+++ b/pkg/sql/sem/tree/pretty_test.go
@@ -39,7 +39,7 @@ var (
 	}()
 )
 
-// TestPrettyData reads in a single SQL statement from a file, formats
+// TestPrettyDataShort reads in a single SQL statement from a file, formats
 // it at 40 characters width, and compares that output to a known-good
 // output file. It is most useful when changing or implementing the
 // doc interface for a node, and should be used to compare and verify

--- a/pkg/sql/sem/tree/testdata/pretty/import2.align-deindent.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.align-deindent.golden
@@ -6,24 +6,22 @@ IMPORT
 PGDUMP
 	'http://test'
 WITH
-	skip = '2',
-	sstsize = '30MB'
+	skip = '2'
 
 6:
 ------
 IMPORT
 PGDUMP 'http://test'
-  WITH skip = '2',
-       sstsize = '30MB'
+  WITH skip = '2'
 
 35:
 -----------------------------------
 IMPORT
 PGDUMP 'http://test'
-  WITH skip = '2', sstsize = '30MB'
+  WITH skip = '2'
 
 61:
 -------------------------------------------------------------
-IMPORT PGDUMP 'http://test' WITH skip = '2', sstsize = '30MB'
+IMPORT PGDUMP 'http://test' WITH skip = '2'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/import2.align-deindent.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.align-deindent.golden.short
@@ -4,6 +4,6 @@
 -
 IMPORT
 PGDUMP 'http://test'
-  WITH skip = '2', sstsize = '30MB'
+  WITH skip = '2'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/import2.align-only.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.align-only.golden
@@ -6,24 +6,22 @@ IMPORT
 PGDUMP
 	'http://test'
 WITH
-	skip = '2',
-	sstsize = '30MB'
+	skip = '2'
 
 6:
 ------
 IMPORT
 PGDUMP 'http://test'
-  WITH skip = '2',
-       sstsize = '30MB'
+  WITH skip = '2'
 
 35:
 -----------------------------------
 IMPORT
 PGDUMP 'http://test'
-  WITH skip = '2', sstsize = '30MB'
+  WITH skip = '2'
 
 61:
 -------------------------------------------------------------
-IMPORT PGDUMP 'http://test' WITH skip = '2', sstsize = '30MB'
+IMPORT PGDUMP 'http://test' WITH skip = '2'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/import2.align-only.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.align-only.golden.short
@@ -4,6 +4,6 @@
 -
 IMPORT
 PGDUMP 'http://test'
-  WITH skip = '2', sstsize = '30MB'
+  WITH skip = '2'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/import2.ref.golden
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.ref.golden
@@ -6,8 +6,7 @@ IMPORT
 PGDUMP
 	'http://test'
 WITH
-	skip = '2',
-	sstsize = '30MB'
+	skip = '2'
 
 32:
 --------------------------------
@@ -15,10 +14,10 @@ IMPORT
 PGDUMP
 	'http://test'
 WITH
-	skip = '2', sstsize = '30MB'
+	skip = '2'
 
 61:
 -------------------------------------------------------------
-IMPORT PGDUMP 'http://test' WITH skip = '2', sstsize = '30MB'
+IMPORT PGDUMP 'http://test' WITH skip = '2'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/import2.ref.golden.short
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.ref.golden.short
@@ -6,6 +6,6 @@ IMPORT
 PGDUMP
 	'http://test'
 WITH
-	skip = '2', sstsize = '30MB'
+	skip = '2'
 
 

--- a/pkg/sql/sem/tree/testdata/pretty/import2.sql
+++ b/pkg/sql/sem/tree/testdata/pretty/import2.sql
@@ -1,1 +1,1 @@
-import pgdump 'http://test' with skip = '2', sstsize = '30MB'
+import pgdump 'http://test' with skip = '2'


### PR DESCRIPTION
**import: remove deprecated fields from ImportDetails proto**

The following no longer used fields are removed from the ImportDetails proto:
- SSTSize: this option stopped having any effect in 8790323d2d8bd6daff61cdb1566e04a38791d252. This WITH option of the IMPORT stmt was already skipped from documentation (or was never documented).
- Oversample
- BackupPath
- Samples
- IngestDirectly
- ProtectedTimestampRecord: this was deprecated in 4c9455048921eeb0d38af00e011cbfba321e1fc6.

**import: address some nits**

This commit addresses a few nits (like typos in the comments and removing a no longer used method from an interface).

`SSTBatcher.initialSplitDone` is unused as of e4e41efda5854763a5f90626bec633ec2ce3f57e.

Epic: None
Release note: None