### PR TITLE
kvserver: fix kv.rangefeed.closed_timestamp.slow_ranges metric

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -866,11 +866,13 @@ func (r *Replica) handleClosedTimestampUpdateRaftMuLocked(
 	// update to the leaseholder so that it will eventually begin to progress
 	// again. Or, if the closed timestamp has been lagging by more than the
 	// cancel threshold for a while, cancel the rangefeed.
-	if signal := r.raftMu.rangefeedCTLagObserver.observeClosedTimestampUpdate(ctx,
+	signal := r.raftMu.rangefeedCTLagObserver.observeClosedTimestampUpdate(ctx,
 		closedTS.GoTime(),
 		r.Clock().PhysicalTime(),
 		&r.store.cfg.Settings.SV,
-	); signal.exceedsNudgeLagThreshold {
+	)
+	exceedsSlowLagThresh = signal.exceedsNudgeLagThreshold
+	if exceedsSlowLagThresh {
 		m := r.store.metrics.RangeFeedMetrics
 		expensiveLog := m.RangeFeedSlowClosedTimestampLogN.ShouldLog()
 		if expensiveLog {


### PR DESCRIPTION
In #137531, which began cancelling chronically behind rangefeeds, the `kv.rangefeed.closed_timestamp.slow_ranges` metric stopped being incremented after a rangefeed exceeded the slow rangefeed lag threshold (> 5 x target closed timestamp).

Begin incrementing the metric again.

Epic: none
Release note (bug fix): The `kv.rangefeed.closed_timestamp.slow_ranges` would erroneously not be incremented when a rangefeed closed timestamp was slower than the target threshold. This is now fixed.