### PR TITLE
roachtest: only run splits/load roachtest on gce

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -146,10 +146,12 @@ func registerLoadSplits(r registry.Registry) {
 	cSpec := r.MakeClusterSpec(numNodes, spec.WorkloadNode())
 
 	r.Add(registry.TestSpec{
-		Name:             fmt.Sprintf("splits/load/uniform/nodes=%d", numRoachNodes),
-		Owner:            registry.OwnerKV,
-		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		Name:    fmt.Sprintf("splits/load/uniform/nodes=%d", numRoachNodes),
+		Owner:   registry.OwnerKV,
+		Cluster: cSpec,
+		// The tests assert on the CPU usage indirectly via the number of splits,
+		// only GCE was intended to be used with the hardcoded split numbers.
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -197,7 +199,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/uniform/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -219,7 +221,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/sequential/nodes=%d", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -245,7 +247,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/sequential/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -272,7 +274,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/spanning/nodes=%d", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -293,7 +295,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/spanning/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -323,7 +325,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/ycsb/a/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -348,7 +350,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/ycsb/b/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -372,7 +374,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/ycsb/d/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
@@ -397,7 +399,7 @@ func registerLoadSplits(r registry.Registry) {
 		Name:             fmt.Sprintf("splits/load/ycsb/e/nodes=%d/obj=cpu", numRoachNodes),
 		Owner:            registry.OwnerKV,
 		Cluster:          cSpec,
-		CompatibleClouds: registry.AllExceptAWS,
+		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {


### PR DESCRIPTION
`splits/load/*` roachtests were only ever intended to be run on GCE, as the number of splits is asserted on directly and is susceptible to different architectures.

This is fine because we only want to assert there isn't runaway behavior or no splits at all occurring.

Fixes: #146925
Release note: None