### PR TITLE
kv/bulk: remove misleading warning on Scatter in SSTBatcher

### DIFF
--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"math"
+	"strings"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
@@ -643,9 +644,12 @@ func (b *SSTBatcher) doFlush(ctx context.Context, reason int) error {
 					resp, err := b.db.AdminScatter(ctx, splitAt, maxScatterSize)
 					b.currentStats.ScatterWait += timeutil.Since(beforeScatter)
 					if err != nil {
-						// err could be a max size violation, but this is unexpected since we
-						// split before, so a warning is probably ok.
-						log.Warningf(ctx, "%s failed to scatter	: %v", b.name, err)
+						// TODO(dt): switch to a typed error.
+						if strings.Contains(err.Error(), "existing range size") {
+							log.VEventf(ctx, 1, "%s scattered non-empty range rejected: %v", b.name, err)
+						} else {
+							log.Warningf(ctx, "%s failed to scatter	: %v", b.name, err)
+						}
 					} else {
 						b.currentStats.Scatters++
 						b.currentStats.ScatterMoved += resp.ReplicasScatteredBytes


### PR DESCRIPTION
When SSTBatcher needs to create a new range, it inserts a split point and then attempts to scatter that range. The scatter operation is performed with 4MiB as max size (meaning if RHS already contains more than 4MiB of data, the scatter fails), and previously we would log all scatter errors as warnings. However, I don't think that we should do that if we hit the max size limit because in some cases (like in multi-node IMPORTs) other nodes might have written into the RHS already, so this commit removes the warning.

The relevant code is reverted to the state before 6c942fa3fb2b577e4e8f3cb7685f35980612dd8d.

Epic: None
Release note: None