### PR TITLE
release-25.1: roachtest: harden tpchbench

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -294,7 +294,6 @@ go_library(
         "//pkg/workload/debug",
         "//pkg/workload/histogram",
         "//pkg/workload/histogram/exporter",
-        "//pkg/workload/querybench",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpcds",
         "//pkg/workload/tpch",

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -8,8 +8,6 @@ package tests
 import (
 	"context"
 	"fmt"
-	"io"
-	"os"
 	"strings"
 	"time"
 
@@ -20,16 +18,16 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
-	"github.com/cockroachdb/cockroach/pkg/util/httputil"
-	"github.com/cockroachdb/cockroach/pkg/workload/querybench"
 )
 
 type tpchBenchSpec struct {
-	Nodes           int
-	CPUs            int
-	ScaleFactor     int
-	benchType       string
-	url             string
+	Nodes       int
+	CPUs        int
+	ScaleFactor int
+	benchType   string
+	url         string
+	// numQueries must match the number of queries in the file specified in url.
+	numQueries      int
 	numRunsPerQuery int
 	// maxLatency is the expected maximum time that a query will take to execute
 	// needed to correctly initialize histograms.
@@ -71,17 +69,13 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 
 		t.L().Printf("running %s benchmark on tpch scale-factor=%d", filename, b.ScaleFactor)
 
-		numQueries, err := getNumQueriesInFile(filename, b.url)
-		if err != nil {
-			t.Fatal(err)
-		}
 		// maxOps flag will allow us to exit the workload once all the queries were
 		// run b.numRunsPerQuery number of times.
-		maxOps := b.numRunsPerQuery * numQueries
+		maxOps := b.numRunsPerQuery * b.numQueries
 
 		labels := map[string]string{
 			"max_ops":     fmt.Sprintf("%d", maxOps),
-			"num_queries": fmt.Sprintf("%d", numQueries),
+			"num_queries": fmt.Sprintf("%d", b.numQueries),
 		}
 
 		// Run with only one worker to get best-case single-query performance.
@@ -101,50 +95,6 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 		return nil
 	})
 	m.Wait()
-}
-
-// getNumQueriesInFile downloads a file that url points to, stores it at a
-// temporary location, parses it using querybench, and deletes the file. It
-// returns the number of queries in the file.
-func getNumQueriesInFile(filename, url string) (int, error) {
-	tempFile, err := downloadFile(filename, url)
-	if err != nil {
-		return 0, err
-	}
-	// Use closure to make linter happy about unchecked error.
-	defer func() {
-		_ = os.Remove(tempFile.Name())
-	}()
-
-	queries, err := querybench.GetQueries(tempFile.Name(), "")
-	if err != nil {
-		return 0, err
-	}
-	return len(queries), nil
-}
-
-// downloadFile will download a url as a local temporary file.
-func downloadFile(filename string, url string) (*os.File, error) {
-	// These files may be a bit large, so give ourselves
-	// some room before the timeout expires.
-	httpClient := httputil.NewClientWithTimeout(30 * time.Second)
-	// Get the data.
-	resp, err := httpClient.Get(context.TODO(), url)
-	if err != nil {
-		return nil, err
-	}
-	defer resp.Body.Close()
-
-	// Create the file.
-	out, err := os.CreateTemp(`` /* dir */, filename)
-	if err != nil {
-		return nil, err
-	}
-	defer out.Close()
-
-	// Write the body to file.
-	_, err = io.Copy(out, resp.Body)
-	return out, err
 }
 
 func registerTPCHBenchSpec(r registry.Registry, b tpchBenchSpec) {
@@ -183,6 +133,7 @@ func registerTPCHBench(r registry.Registry) {
 			ScaleFactor:     1,
 			benchType:       `sql20`,
 			url:             `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/workload/querybench/2.1-sql-20`,
+			numQueries:      14,
 			numRunsPerQuery: 3,
 			maxLatency:      100 * time.Second,
 		},
@@ -192,6 +143,7 @@ func registerTPCHBench(r registry.Registry) {
 			ScaleFactor:     1,
 			benchType:       `tpch`,
 			url:             `https://raw.githubusercontent.com/cockroachdb/cockroach/master/pkg/workload/querybench/tpch-queries`,
+			numQueries:      22,
 			numRunsPerQuery: 3,
 			maxLatency:      500 * time.Second,
 		},

--- a/pkg/workload/querybench/query_bench.go
+++ b/pkg/workload/querybench/query_bench.go
@@ -88,7 +88,7 @@ func (g *queryBench) Hooks() workload.Hooks {
 			if g.queryFile == "" {
 				return errors.Errorf("Missing required argument '--query-file'")
 			}
-			stmts, err := GetQueries(g.queryFile, g.separator)
+			stmts, err := getQueries(g.queryFile, g.separator)
 			if err != nil {
 				return err
 			}
@@ -148,9 +148,9 @@ func (g *queryBench) Ops(
 	return ql, nil
 }
 
-// GetQueries returns the queries in a file as a slice of named statements. If
+// getQueries returns the queries in a file as a slice of named statements. If
 // no separator is given, splits by newlines.
-func GetQueries(path, separator string) ([]namedStmt, error) {
+func getQueries(path, separator string) ([]namedStmt, error) {
 	file, err := os.Open(path)
 	if err != nil {
 		return nil, err


### PR DESCRIPTION
Backport 1/1 commits from #146904 on behalf of @yuzefovich.

----

tpchbench currently does the following:
- curl's a target query file to be passed into `workload run` command
later
- downloads the same file via HTTP GET to get the number of queries in the file. This number is multiplied by `num-runs` to come up with `max-ops` parameter
- issues `workload run querybench --query-file=... --num-runs=3 --max-ops=...`
- `querybench` itself will parse the target file on its own to come up with its internal "max-ops" for each worker.

We just saw a couple of timeout failures in this roachtest that occurred due to `--max-ops=0` being passed. The querybench worker correctly computed its own "max-ops" as 66, yet because the main workload loop had max-ops of 0, the external loop never exited, yet the querybench worker simply short-circuited its `run` method.

I'm not quite sure why we passed `--max-ops=0`. Perhaps there was some hiccup in downloading the query file via HTTP request.

This commit switches the roachtest to using the hard-coded number of queries in the test file which removes the HTTP GET / parse step altogether.

Fixes: #146903.

Release note: None

----

Release justification: test-only change.