### PR TITLE
changefeedccl: set default changefeed quantization to 1s

### DIFF
--- a/pkg/ccl/changefeedccl/changefeedbase/settings.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/settings.go
@@ -346,5 +346,6 @@ var Quantize = settings.RegisterDurationSettingWithExplicitUnit(
 	settings.ApplicationLevel,
 	"changefeed.resolved_timestamp.granularity",
 	"the granularity at which changefeed progress is quantized to make tracking more efficient",
-	time.Duration(metamorphic.ConstantWithTestRange("changefeed.resolved_timestamp.granularity", 0, 0, 10))*time.Second,
+	time.Duration(metamorphic.ConstantWithTestRange("changefeed.resolved_timestamp.granularity", 1, 0, 10))*time.Second,
+	settings.DurationWithMinimum(0),
 )


### PR DESCRIPTION
This PR sets the setting changefeed.resolved_timestamp.granularity default to 1s.

Epic: none
Fixes: #144631

Release note (general change): Changefeeds now round down the progress of each range to 1 second, in order to cover more ranges in fine-grained checkpointing.