### PR TITLE
sql: improve IMPORTs and index backfills on very large clusters

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/importer",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/col/coldata",


### PR DESCRIPTION
This commit fixes an oversight of the behavior introduced in
c9ca8bdc4037e63f82a3181a2dbb9e0cf09aef5c as it pertains to very large
(200+ node) clusters. In particular, in that change we introduced the logic to
create initial splits via the BulkAdder when it is flushed due to
reaching the maximum size (128MiB for IMPORT into PKs, and 512MiB for IMPORT
into secondary indexes as well as index backfills). The rationale for
having _some_ initial splits is sound; however, in that change we made
it so that _each processor_ can create N initial split points where N is
the number of nodes in the cluster. In other words, a single bulk
operation could result in N^2 number of splits, which could overwhelm
the node that happened to be the leaseholder for the initial empty range
for the ingest.

I think the intention was that we would create a total number of splits
that is linearly dependent on the number of nodes in the cluster, so
this commit introduces a couple of cluster settings that control the
multiple for the linear function. I did a few runs of IMPORT of TPCC 50k
and TPCC 100k on 100 node cluster, and it looks like a few numbers in
[2, 16] range behave roughly the same, so I picked 3 as the default
value for both cluster settings. In other words, IMPORTs and index
backfills will now create N x 3 number of initial split points by
default.

An alternative strategy could have been to assign one (or small number)
processor to do some number of splits based on its first SST file.
I decided to not pursue this alternative under the assumption that we'll
get better initial split point distribution if they are created across
all nodes. With just one processor doing the splits, we could over-split
a part of the key space that that particular node happens to write.

I decided to not include a release note given that we expect this to
have noticeable impact only on 200+ node clusters.

Fixes: #143076.

Release note: None