### PR TITLE
sql: disable auto stats in TestDistSQLReceiverReportsContention

### DIFF
--- a/pkg/sql/distsql_running_test.go
+++ b/pkg/sql/distsql_running_test.go
@@ -502,6 +502,9 @@ func TestDistSQLReceiverReportsContention(t *testing.T) {
 		// Otherwise, we're subject to flakes when internal queries experience contention.
 		_, err := db.Exec("SET CLUSTER SETTING sql.txn_stats.sample_rate = 0")
 		require.NoError(t, err)
+		// Also disable auto stats just in case.
+		_, err = db.Exec("SET CLUSTER SETTING sql.stats.automatic_collection.enabled = false")
+		require.NoError(t, err)
 
 		sqlutils.CreateTable(
 			t, db, "test", "x INT PRIMARY KEY", 1, sqlutils.ToRowFn(sqlutils.RowIdxFn),


### PR DESCRIPTION
We just saw a failure in this test where the contended queries metric reported some contention even though the test didn't produce it deliberately. The only thing that stood out to me in the artifacts is the stats collection goroutine, so let's just disable auto stats collection just in case (I doubt this will have any effect given that we use AOST and inconsistent scans that shouldn't contend with foreground traffic).

Fixes: #146569.

Release note: None