### PR TITLE
server, rpc: register `Heartbeat`, `PerReplica`, `PerStore` services with DPRC server

### DIFF
--- a/pkg/server/drpc_server.go
+++ b/pkg/server/drpc_server.go
@@ -31,8 +31,6 @@ type drpcServer struct {
 
 // newDRPCServer creates and configures a new drpcServer instance. It enables
 // DRPC if the experimental setting is on, otherwise returns a dummy server.
-//
-// TODO: Register DRPC Heartbeat service
 func newDRPCServer(ctx context.Context, rpcCtx *rpc.Context) (*drpcServer, error) {
 	drpcServer := &drpcServer{}
 	if rpc.ExperimentalDRPCEnabled.Get(&rpcCtx.Settings.SV) {
@@ -54,6 +52,10 @@ func newDRPCServer(ctx context.Context, rpcCtx *rpc.Context) (*drpcServer, error
 
 	drpcServer.tlsCfg = tlsCfg
 	drpcServer.setMode(modeInitializing)
+
+	if err := rpc.DRPCRegisterHeartbeat(drpcServer, rpcCtx.NewHeartbeatService()); err != nil {
+		return nil, err
+	}
 
 	return drpcServer, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -987,7 +987,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		return nil, err
 	}
 	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)
+	if err := kvserver.DRPCRegisterPerReplica(drpcServer, node.perReplicaServer); err != nil {
+		return nil, err
+	}
 	kvserver.RegisterPerStoreServer(grpcServer.Server, node.perReplicaServer)
+	if err := kvserver.DRPCRegisterPerStore(drpcServer, node.perReplicaServer); err != nil {
+		return nil, err
+	}
 	ctpb.RegisterSideTransportServer(grpcServer.Server, ctReceiver)
 
 	// Create blob service for inter-node file sharing.


### PR DESCRIPTION
`` rpc: register `Heartbeat` service with DPRC server ``

Enable Heartbeat service on the DRPC server in addition to gRPC. Controlled
by `rpc.experimental_drpc.enabled` (off by default).

Fixes: #146471

`` kvserver: register `PerReplica`/`PerStore` service with DRPC server ``

Enable the `PerReplica` and `PerStore` service on the DRPC server in
addition to gRPC. This is controlled by `rpc.experimental_drpc.enabled`
(off by default).

This change is part of a series and is similar to: #146926

Note: This only registers the service; the client is not updated to use the
DRPC client, so this service will not have any functional effect.

Epic: CRDB-48925
Release note: None