### PR TITLE
roachtest: unconditionally save clusters that show raft fatal errors

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1109,6 +1109,12 @@ func (c *clusterImpl) Save(ctx context.Context, msg string, l *logger.Logger) {
 	c.destroyState.mu.Unlock()
 }
 
+func (c *clusterImpl) saved() bool {
+	c.destroyState.mu.Lock()
+	defer c.destroyState.mu.Unlock()
+	return c.destroyState.mu.saved
+}
+
 var errClusterNotFound = errors.New("cluster not found")
 
 // validateCluster takes a cluster and checks that the reality corresponds to

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -152,12 +152,20 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	ctx, cancel := context.WithCancel(context.Background())
 	defer cancel()
 	CtrlC(ctx, l, cancel, cr)
-	// Install goroutine leak checker and run it at the end of the entire test
-	// run. If a test is leaking a goroutine, then it will likely be still around.
-	// We could diff goroutine snapshots before/after each executed test, but that
-	// could yield false positives; e.g., user-specified test teardown goroutines
-	// may still be running long after the test has completed.
-	defer leaktest.AfterTest(l)()
+	if false {
+		// Install goroutine leak checker and run it at the end of the entire test
+		// run. If a test is leaking a goroutine, then it will likely be still around.
+		// We could diff goroutine snapshots before/after each executed test, but that
+		// could yield false positives; e.g., user-specified test teardown goroutines
+		// may still be running long after the test has completed.
+		//
+		// NB: we currently don't do this since it's been firing for a long time and
+		// nobody has cleaned up the leaks. While there are leaks, the leaktest
+		// output pollutes stdout and makes roachtest annoying to use.
+		//
+		// Tracking issue: https://github.com/cockroachdb/cockroach/issues/148196
+		defer leaktest.AfterTest(l)()
+	}
 
 	// We allow roachprod users to set a default auth-mode through the
 	// ROACHPROD_DEFAULT_AUTH_MODE env var. However, roachtests shouldn't

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1615,6 +1615,11 @@ func (r *testRunner) postTestAssertions(
 func (r *testRunner) teardownTest(
 	ctx context.Context, t *testImpl, c *clusterImpl, timedOut bool,
 ) error {
+	// Check for rare conditions (such as storage durability crashes) at this
+	// point. This may still mark the test as failed (so that we enter artifacts
+	// collection below).
+	r.maybeSaveClusterDueToInvariantProblems(ctx, t, c)
+
 	if timedOut || t.Failed() || roachtestflags.AlwaysCollectArtifacts {
 		err := r.collectArtifacts(ctx, t, c, timedOut, time.Hour)
 		if err != nil {
@@ -1667,6 +1672,43 @@ func (r *testRunner) teardownTest(
 		getCpuProfileArtifacts(ctx, c, t)
 	}
 	return nil
+}
+
+// maybeSaveClusterDueToInvariantProblems detects rare conditions (such as
+// storage durability crashes) on the cluster and if one is detected,
+// unconditionally preserves the cluster for future debugging. It also creates
+// volume snapshots so that the durable state close to the incident is
+// preserved.
+func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
+	ctx context.Context, t *testImpl, c *clusterImpl,
+) {
+	if len(c.Nodes()) == 0 {
+		return // test only
+	}
+	dets, err := c.RunWithDetails(ctx, t.L(), option.WithNodes(c.All()),
+		"([ -d logs ] && grep -RE '^F.*raft' logs) || true",
+	)
+	for _, det := range dets {
+		err = errors.CombineErrors(err, det.Err)
+	}
+	if err != nil {
+		t.L().Printf(
+			"failed to check whether to save cluster due to invariant problems: %s",
+			err,
+		)
+		return
+	}
+
+	for _, det := range dets {
+		if det.Stdout != "" {
+			_ = c.Extend(ctx, 7*24*time.Hour, t.L())
+			snapName := "invariant-problem-" + c.Name() + "-" + strconv.Itoa(rand.Int())
+			_, _ = c.CreateSnapshot(ctx, snapName)
+			c.Save(ctx, "invariant problem - snap name "+snapName, t.L())
+			t.Error("invariant problem - snap name " + snapName + ":\n" + det.Stdout)
+			return
+		}
+	}
 }
 
 func (r *testRunner) collectArtifacts(

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -987,10 +987,12 @@ func (r *testRunner) runWorker(
 					// Continue with a fresh cluster.
 					c = nil
 				case NoDebug:
-					// On any test failure or error, we destroy the cluster. We could be
-					// more selective, but this sounds safer.
-					l.PrintfCtx(ctx, "destroying cluster %s because: %s", c, failureMsg)
-					c.Destroy(context.Background(), closeLogger, l)
+					if !c.saved() {
+						// On any test failure or error, we destroy the cluster. We could be
+						// more selective, but this sounds safer.
+						l.PrintfCtx(ctx, "destroying cluster %s because: %s", c, failureMsg)
+						c.Destroy(context.Background(), closeLogger, l)
+					}
 					c = nil
 				}
 			}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1686,7 +1686,7 @@ func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 		return // test only
 	}
 	dets, err := c.RunWithDetails(ctx, t.L(), option.WithNodes(c.All()),
-		"([ -d logs ] && grep -RE '^F.*raft' logs) || true",
+		"([ -d logs ] && grep -RE '^F.*Was the raft log corrupted' logs) || true",
 	)
 	for _, det := range dets {
 		err = errors.CombineErrors(err, det.Err)

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1702,8 +1702,12 @@ func (r *testRunner) maybeSaveClusterDueToInvariantProblems(
 	for _, det := range dets {
 		if det.Stdout != "" {
 			_ = c.Extend(ctx, 7*24*time.Hour, t.L())
-			snapName := "invariant-problem-" + c.Name() + "-" + strconv.Itoa(rand.Int())
-			_, _ = c.CreateSnapshot(ctx, snapName)
+			timestamp := timeutil.Now().Format("20060102_150405")
+			snapName := fmt.Sprintf("invariant-problem-%s-%s", c.Name(), timestamp)
+			if _, err := c.CreateSnapshot(ctx, snapName); err != nil {
+				t.L().Printf("failed to create snapshot %q: %s", snapName, err)
+				snapName = "<failed>"
+			}
 			c.Save(ctx, "invariant problem - snap name "+snapName, t.L())
 			t.Error("invariant problem - snap name " + snapName + ":\n" + det.Stdout)
 			return

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -2275,6 +2275,7 @@ func logTestParameters(l *logger.Logger, params map[string]string) {
 
 func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) map[string]string {
 	spec := t.spec
+
 	clusterParams := map[string]string{
 		"cloud":                  roachtestflags.Cloud.String(),
 		"cpu":                    fmt.Sprintf("%d", spec.Cluster.CPUs),
@@ -2282,6 +2283,7 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 		"runtimeAssertionsBuild": fmt.Sprintf("%t", roachtestutil.UsingRuntimeAssertions(t)),
 		"coverageBuild":          fmt.Sprintf("%t", t.goCoverEnabled),
 	}
+
 	// Emit CPU architecture only if it was specified; otherwise, it's captured below, assuming cluster was created.
 	if spec.Cluster.Arch != "" {
 		clusterParams["arch"] = string(spec.Cluster.Arch)
@@ -2299,6 +2301,13 @@ func getTestParameters(t *testImpl, c *clusterImpl, createOpts *vm.CreateOpts) m
 			// N.B. when Arch is specified, it cannot differ from cluster's arch.
 			// Hence, we only emit when arch was unspecified.
 			clusterParams["arch"] = string(c.arch)
+		}
+
+		c.destroyState.mu.Lock()
+		saved, savedMsg := c.destroyState.mu.saved, c.destroyState.mu.savedMsg
+		c.destroyState.mu.Unlock()
+		if saved {
+			clusterParams["saved"] = savedMsg
 		}
 	}
 

--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -90,6 +90,7 @@ go_library(
         "import_cancellation.go",
         "inconsistency.go",
         "indexes.go",
+        "invariant_check_detection.go",
         "inverted_index.go",
         "jasyncsql.go",
         "jasyncsql_blocklist.go",

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -11,10 +11,13 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
 )
 
 func registerAcceptance(r registry.Registry) {
@@ -81,6 +84,22 @@ func registerAcceptance(r registry.Registry) {
 				// and version upgrade is impossible to test as of 05/2025.
 				incompatibleClouds: registry.OnlyIBM,
 			},
+			// Tests for maybeSaveClusterDueToInvariantProblems. These don't verify
+			// that everything works as it should, but they can be run to verify
+			// manually that the cluster is saved correctly and the log output is
+			// helpful.
+			{
+				name:    "invariant-check-detection/failed=true",
+				fn:      runInvariantCheckDetectionFailed,
+				timeout: time.Hour,
+				skip:    "manual only",
+			},
+			{
+				name:    "invariant-check-detection/failed=false",
+				fn:      runInvariantCheckDetectionSuccess,
+				timeout: time.Hour,
+				skip:    "manual only",
+			},
 		},
 		registry.OwnerDisasterRecovery: {
 			{
@@ -145,7 +164,9 @@ func registerAcceptance(r registry.Registry) {
 					tc.name,
 				))
 			}
-			suites := append([]string{registry.Nightly, registry.Quick, registry.Acceptance}, tc.suites...)
+			var suites []string
+			suites = append(suites, registry.Nightly, registry.Quick, registry.Acceptance)
+			suites = append(suites, tc.suites...)
 			testSpec := registry.TestSpec{
 				Name:              "acceptance/" + tc.name,
 				Owner:             owner,
@@ -169,5 +190,26 @@ func registerAcceptance(r registry.Registry) {
 			}
 			r.Add(testSpec)
 		}
+	}
+}
+
+func runInvariantCheckDetectionFailed(ctx context.Context, t test.Test, c cluster.Cluster) {
+	runInvariantCheckDetection(ctx, t, c, true)
+}
+
+func runInvariantCheckDetectionSuccess(ctx context.Context, t test.Test, c cluster.Cluster) {
+	runInvariantCheckDetection(ctx, t, c, false)
+}
+
+func runInvariantCheckDetection(ctx context.Context, t test.Test, c cluster.Cluster, failed bool) {
+	c.Put(ctx, t.Cockroach(), "cockroach")
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 3))
+	require.NoError(t, c.PutString(ctx, `
+foo br baz
+F250502 11:37:20.387424 1036 raft/raft.go:2411 ⋮ [T1,Vsystem,n1,s1,r155/1:‹/Table/113/1/{43/578…-51/201…}›] 80 match(30115) is out of range [lastIndex(30114)]. Was the raft log corrupted, truncated, or lost?
+asdasds
+`, "logs/foo.log", 0644, c.Node(2)))
+	if failed {
+		t.Error("boom")
 	}
 }

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -202,7 +202,6 @@ func runInvariantCheckDetectionSuccess(ctx context.Context, t test.Test, c clust
 }
 
 func runInvariantCheckDetection(ctx context.Context, t test.Test, c cluster.Cluster, failed bool) {
-	c.Put(ctx, t.Cockroach(), "cockroach")
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Range(1, 3))
 	require.NoError(t, c.PutString(ctx, `
 foo br baz

--- a/pkg/cmd/roachtest/tests/invariant_check_detection.go
+++ b/pkg/cmd/roachtest/tests/invariant_check_detection.go
@@ -1,0 +1,51 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/stretchr/testify/require"
+)
+
+func registerInvariantCheckDetection(r registry.Registry) {
+	// Tests for maybeSaveClusterDueToInvariantProblems. These don't verify
+	// that everything works as it should, but they can be run to verify
+	// manually that the cluster is saved correctly and the log output is
+	// helpful.
+
+	for _, failed := range []bool{false, true} {
+		r.Add(registry.TestSpec{
+			CompatibleClouds: registry.AllClouds,
+			Name:             fmt.Sprintf("invariant-check-detection/failed=%t", failed),
+			Owner:            registry.OwnerTestEng,
+			Suites:           registry.ManualOnly,
+			Cluster:          spec.ClusterSpec{NodeCount: 1, CPUs: 4, ReusePolicy: spec.ReusePolicyNone{}},
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runInvariantCheckDetection(ctx, t, c, failed)
+			},
+		})
+	}
+}
+
+func runInvariantCheckDetection(ctx context.Context, t test.Test, c cluster.Cluster, failed bool) {
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.Node(1))
+	require.NoError(t, c.PutString(ctx, `
+foo br baz
+F250502 11:37:20.387424 1036 raft/raft.go:2411 ⋮ [T1,Vsystem,n1,s1,r155/1:‹/Table/113/1/{43/578…-51/201…}›] 80 match(30115) is out of range [lastIndex(30114)]. Was the raft log corrupted, truncated, or lost?
+asdasds
+`, "logs/foo.log", 0644, c.Node(1)))
+	if failed {
+		t.Error("boom")
+	}
+}

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -77,6 +77,7 @@ func RegisterTests(r registry.Registry) {
 	registerImportTPCH(r)
 	registerInconsistency(r)
 	registerIndexes(r)
+	registerInvariantCheckDetection(r)
 	registerJasyncSQL(r)
 	registerJepsen(r)
 	registerJobs(r)


### PR DESCRIPTION
When a cluster's logs contain a raft panic, it will be extended (by a week),
volume snapshots will be taken, and the cluster will not be destroyed. This
gives us the artifacts for a thorough investigation.

Verified manually via:

```
run --local acceptance/invariant-check-detection/failed=true
```

Here is the (editorialized) output:

```
test-teardown: 2025/05/20 08:15:15 cluster.go:2559: running cmd `([ -d logs ] && grep -RE '^...` on nodes [:1-4]; details in run_081515.744363000_n1-4_d-logs-grep-RE-Fraft.log
test-teardown: 2025/05/20 08:15:16 cluster.go:2995: extending cluster by 168h0m0s
test-teardown: 2025/05/20 08:15:16 cluster.go:1104: saving cluster local [tag:] (4 nodes) for debugging (--debug specified)
test-teardown: 2025/05/20 08:15:16 test_impl.go:478: test failure https://github.com/cockroachdb/cockroach/pull/2: full stack retained in failure_2.log: (test_runner.go:1705).maybeSaveClusterDueToInvariantProblems: invariant problem - snap name invariant-problem-local-8897676895823393049:
logs/foo.log:F250502 11:37:20.387424 1036 raft/raft.go:2411 ⋮ [T1,Vsystem,n1,s1,r155/1:?/Table/113/1/{43/578…-51/201…}?] 80 match(30115) is out of range [lastIndex(30114)]. Was the raft log corrupted, truncated, or lost?
```

Closes https://github.com/cockroachdb/cockroach/issues/145953.
Informs https://github.com/cockroachdb/cockroach/issues/146617.
Informs https://github.com/cockroachdb/cockroach/issues/138028.

Fixes #146355.

Epic: none