### PR TITLE
multiregionccl: deflake TestMultiRegionTenantRegions

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -350,6 +350,7 @@ func TestMultiRegionTenantRegions(t *testing.T) {
 
 	// Shorten the sqlliveness TTL to speed up the test.
 	tenEast1SQLDB.Exec(t, "SET CLUSTER SETTING server.sqlliveness.ttl = '5s'")
+	tenEast1SQLDB.Exec(t, "SET CLUSTER SETTING server.sqlliveness.heartbeat = '1s'")
 
 	// Update system database with regions.
 	checkRegions := func(t *testing.T, regions ...string) {


### PR DESCRIPTION
Since we used a shorter TTL, we need a shorter heartbeat also.

fixes https://github.com/cockroachdb/cockroach/issues/146760
Release note: None