### PR TITLE
roachprod: fix unattended service on startup

### DIFF
--- a/pkg/roachprod/vm/aws/testdata/startup_script
+++ b/pkg/roachprod/vm/aws/testdata/startup_script
@@ -117,10 +117,15 @@ if [ -e /mnt/data1/.roachprod-initialized ]; then
 	exit 0
 fi
 
-# Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
-systemctl stop unattended-upgrades
-sudo rm -rf /var/log/unattended-upgrades
-apt-get purge -y unattended-upgrades
+# Uninstall some packages to prevent them running cronjobs and similar jobs in
+# parallel Check if the service exists before trying to stop it, because it may
+# have been removed during a previous invocation of this script.
+if systemctl list-unit-files | grep -q '^unattended-upgrades.service'; then
+    echo "unattended-upgrades service exists. Proceeding with uninstallation."
+    systemctl stop unattended-upgrades
+    sudo rm -rf /var/log/unattended-upgrades
+    apt-get purge -y unattended-upgrades
+fi
 
 
 

--- a/pkg/roachprod/vm/azure/testdata/startup_script
+++ b/pkg/roachprod/vm/azure/testdata/startup_script
@@ -49,10 +49,15 @@ if [ -e /mnt/data1/.roachprod-initialized ]; then
 	exit 0
 fi
 
-# Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
-systemctl stop unattended-upgrades
-sudo rm -rf /var/log/unattended-upgrades
-apt-get purge -y unattended-upgrades
+# Uninstall some packages to prevent them running cronjobs and similar jobs in
+# parallel Check if the service exists before trying to stop it, because it may
+# have been removed during a previous invocation of this script.
+if systemctl list-unit-files | grep -q '^unattended-upgrades.service'; then
+    echo "unattended-upgrades service exists. Proceeding with uninstallation."
+    systemctl stop unattended-upgrades
+    sudo rm -rf /var/log/unattended-upgrades
+    apt-get purge -y unattended-upgrades
+fi
 
 
 

--- a/pkg/roachprod/vm/gce/testdata/startup_script
+++ b/pkg/roachprod/vm/gce/testdata/startup_script
@@ -115,10 +115,15 @@ if [ -e /mnt/data1/.roachprod-initialized ]; then
 	exit 0
 fi
 
-# Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
-systemctl stop unattended-upgrades
-sudo rm -rf /var/log/unattended-upgrades
-apt-get purge -y unattended-upgrades
+# Uninstall some packages to prevent them running cronjobs and similar jobs in
+# parallel Check if the service exists before trying to stop it, because it may
+# have been removed during a previous invocation of this script.
+if systemctl list-unit-files | grep -q '^unattended-upgrades.service'; then
+    echo "unattended-upgrades service exists. Proceeding with uninstallation."
+    systemctl stop unattended-upgrades
+    sudo rm -rf /var/log/unattended-upgrades
+    apt-get purge -y unattended-upgrades
+fi
 
 
 

--- a/pkg/roachprod/vm/ibm/testdata/startup_script
+++ b/pkg/roachprod/vm/ibm/testdata/startup_script
@@ -93,10 +93,15 @@ if [ -e /mnt/data1/.roachprod-initialized ]; then
 	exit 0
 fi
 
-# Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
-systemctl stop unattended-upgrades
-sudo rm -rf /var/log/unattended-upgrades
-apt-get purge -y unattended-upgrades
+# Uninstall some packages to prevent them running cronjobs and similar jobs in
+# parallel Check if the service exists before trying to stop it, because it may
+# have been removed during a previous invocation of this script.
+if systemctl list-unit-files | grep -q '^unattended-upgrades.service'; then
+    echo "unattended-upgrades service exists. Proceeding with uninstallation."
+    systemctl stop unattended-upgrades
+    sudo rm -rf /var/log/unattended-upgrades
+    apt-get purge -y unattended-upgrades
+fi
 
 
 

--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -194,10 +194,15 @@ if [ -e {{ .DisksInitializedFile }} ]; then
 	exit 0
 fi
 
-# Uninstall some packages to prevent them running cronjobs and similar jobs in parallel
-systemctl stop unattended-upgrades
-sudo rm -rf /var/log/unattended-upgrades
-apt-get purge -y unattended-upgrades`
+# Uninstall some packages to prevent them running cronjobs and similar jobs in
+# parallel Check if the service exists before trying to stop it, because it may
+# have been removed during a previous invocation of this script.
+if systemctl list-unit-files | grep -q '^unattended-upgrades.service'; then
+    echo "unattended-upgrades service exists. Proceeding with uninstallation."
+    systemctl stop unattended-upgrades
+    sudo rm -rf /var/log/unattended-upgrades
+    apt-get purge -y unattended-upgrades
+fi`
 
 const startupScriptHostname = `
 # set hostname according to the name used by roachprod. There's host


### PR DESCRIPTION
Previously on GCE, the unattended-upgrade service was stopped and removed before
the OS initialisation check. On a managed cluster where the VM can be restarted
this would cause start-up to fail since it tries to stop a non-existent service.
This change moves the stop/remove to after the OS initialisation check.

Fixes: https://github.com/cockroachdb/cockroach/issues/147044

Epic: None
Release note: None