### PR TITLE
sql/schemachanger: fix trigger dependencies on self

### DIFF
--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -218,14 +218,14 @@ pq: cannot drop table tbl1 because other objects depend on it
 exec-sql
 ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
 ----
-pq: cannot rename relation "sc1.tbl1" because table "tbl2" depends on it
-HINT: consider dropping "tbl2" first.
+pq: cannot rename relation "sc1.tbl1" because table "tbl1" depends on it
+HINT: consider dropping "tbl1" first.
 
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because table "tbl2" depends on it
-HINT: consider dropping "tbl2" first.
+pq: cannot set schema on relation "tbl1" because table "tbl1" depends on it
+HINT: consider dropping "tbl1" first.
 
 exec-sql
 DROP TYPE sc1.enum1

--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -218,14 +218,12 @@ pq: cannot drop table tbl1 because other objects depend on it
 exec-sql
 ALTER TABLE sc1.tbl1 RENAME TO tbl1_new
 ----
-pq: cannot rename relation "sc1.tbl1" because table "tbl1" depends on it
-HINT: consider dropping "tbl1" first.
+pq: cannot rename relation "sc1.tbl1" because trigger "tr1" on table "tbl1" depends on it
 
 exec-sql
 ALTER TABLE sc1.tbl1 SET SCHEMA sc2;
 ----
-pq: cannot set schema on relation "tbl1" because table "tbl1" depends on it
-HINT: consider dropping "tbl1" first.
+pq: cannot set schema on relation "tbl1" because trigger "tr1" on table "tbl1" depends on it
 
 exec-sql
 DROP TYPE sc1.enum1

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -925,7 +925,7 @@ statement ok
 CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION trigger_func();
 
 # Relations are referenced by name, so renaming the table is not allowed.
-statement error pgcode 2BP01 cannot rename relation "t" because table "xy" depends on it
+statement error pgcode 2BP01 cannot rename relation "t" because trigger "foo" on table "xy" depends on it
 ALTER TABLE t RENAME TO t2;
 
 # Sequences are remapped to their IDs, so renaming is allowed.
@@ -4505,37 +4505,37 @@ ALTER TABLE t1 SET (schema_locked = false);
 statement ok
 ALTER TABLE other SET (schema_locked = false);
 
-statement error pq: cannot alter type of column "j" because table "t1" depends on it
+statement error pq: cannot alter type of column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table t1 alter column j set data type text;
 
-statement error pq: cannot alter type of column "j" because table "t1" depends on it
+statement error pq: cannot alter type of column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table other alter column j set data type text;
 
-statement error pq: cannot rename column "j" because table "t1" depends on it
+statement error pq: cannot rename column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table t1 rename column j to j2;
 
-statement error pq: cannot rename column "j" because table "t1" depends on it
+statement error pq: cannot rename column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table other rename column j to j2;
 
-statement error pq: cannot drop column "j" because table "t1" depends on it
+statement error pq: cannot drop column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table t1 drop column j;
 
 statement error pq: unimplemented: drop column cascade is not supported with triggers
 alter table t1 drop column j cascade;
 
-statement error pq: cannot drop column "j" because table "t1" depends on it
+statement error pq: cannot drop column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table other drop column j;
 
 statement error pq: unimplemented: drop column cascade is not supported with triggers
 alter table other drop column j cascade;
 
-statement error pq: cannot drop index "i1" because table "t1" depends on it
+statement error pq: cannot drop index "i1" because trigger "audit_trigger" on table "t1" depends on it
 drop index t1@i1;
 
 statement error pq: unimplemented: drop index cascade is not supported with triggers
 drop index t1@i1 CASCADE;
 
-statement error pq: cannot drop index "i1" because table "t1" depends on it
+statement error pq: cannot drop index "i1" because trigger "audit_trigger" on table "t1" depends on it
 drop index other@i1;
 
 statement error pq: unimplemented: drop index cascade is not supported with triggers
@@ -4553,7 +4553,7 @@ DROP TYPE e;
 statement error pq: unimplemented: DROP TYPE CASCADE is not yet supported
 DROP TYPE e CASCADE;
 
-statement error pq: cannot drop relation "other" because table "t1" depends on it
+statement error pq: cannot drop relation "other" because trigger "audit_trigger" on table "t1" depends on it
 DROP TABLE other;
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -1024,7 +1024,7 @@ DROP TABLE t;
 # Test cascading drops with a trigger.
 # ==============================================================================
 
-subtest cascade
+subtest cascade_dsc
 
 statement ok
 CREATE DATABASE db;
@@ -1033,13 +1033,13 @@ statement ok
 USE db;
 
 statement ok
-CREATE FUNCTION i() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NULL; END; $$;
+CREATE FUNCTION i() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN SELECT 1 FROM t; RETURN NULL; END; $$;
 
 statement ok
 CREATE TABLE t (a INT, b INT);
 
 statement ok
-CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NULL; END; $$;
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN SELECT a, b FROM t; RETURN NULL; END; $$;
 
 statement ok
 CREATE TRIGGER foo AFTER INSERT ON t FOR EACH ROW EXECUTE FUNCTION g();
@@ -1060,13 +1060,79 @@ statement ok
 CREATE TABLE s.t (a INT, b INT);
 
 statement ok
-CREATE FUNCTION s.g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN RETURN NULL; END; $$;
+CREATE FUNCTION s.g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN SELECT * FROM s.t; RETURN NULL; END; $$;
 
 statement ok
 CREATE TRIGGER foo AFTER INSERT ON s.t FOR EACH ROW EXECUTE FUNCTION s.g();
 
 statement ok
 DROP SCHEMA s CASCADE;
+
+# Like cascade_dsc, but the DROP is doing with the legacy schema changer
+subtest cascade_legacy
+
+let $use_decl_sc
+SHOW use_declarative_schema_changer
+
+statement ok
+CREATE DATABASE db;
+
+statement ok
+USE db;
+
+statement ok
+CREATE FUNCTION i() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN SELECT 1 FROM other; RETURN NULL; END; $$;
+
+statement ok
+CREATE TABLE t (a INT, b INT);
+
+statement ok
+CREATE TABLE other (n INT PRIMARY KEY, j INT);
+
+statement ok
+CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN SELECT a, b FROM t; RETURN NULL; END; $$;
+
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON t FOR EACH ROW EXECUTE FUNCTION g();
+
+statement ok
+CREATE TRIGGER bar AFTER INSERT ON t FOR EACH ROW EXECUTE FUNCTION i();
+
+statement ok
+USE test;
+
+statement ok
+set use_declarative_schema_changer = 'off';
+
+statement ok
+DROP DATABASE db CASCADE;
+
+statement ok
+SET use_declarative_schema_changer = $use_decl_sc;
+
+statement ok
+CREATE SCHEMA s;
+
+statement ok
+CREATE TABLE s.t (a INT, b INT);
+
+statement ok
+CREATE TABLE s.other (n INT PRIMARY KEY);
+
+statement ok
+CREATE FUNCTION s.g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$ BEGIN SELECT * FROM s.t; SELECT 1 FROM s.other; RETURN NULL; END; $$;
+
+statement ok
+CREATE TRIGGER foo AFTER INSERT ON s.t FOR EACH ROW EXECUTE FUNCTION s.g();
+
+statement ok
+set use_declarative_schema_changer = 'off';
+
+statement ok
+DROP SCHEMA s CASCADE;
+
+statement ok
+SET use_declarative_schema_changer = $use_decl_sc;
 
 # ==============================================================================
 # Test references across schemas and databases.
@@ -4379,8 +4445,14 @@ CREATE TRIGGER audit_trigger AFTER INSERT OR UPDATE OR DELETE ON t1 FOR EACH ROW
 statement error pq: cannot drop column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table t1 drop column j;
 
+statement error pq: unimplemented: ALTER TABLE DROP COLUMN cascade not supported with triggers
+alter table other drop column j cascade;
+
 statement error pq: cannot drop column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table other drop column j;
+
+statement error pq: unimplemented: ALTER TABLE DROP COLUMN cascade not supported with triggers
+alter table other drop column j cascade;
 
 statement error pq: cannot alter type of column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table t1 alter column j set data type text;
@@ -4388,9 +4460,7 @@ alter table t1 alter column j set data type text;
 statement error pq: cannot alter type of column "j" because trigger "audit_trigger" on table "t1" depends on it
 alter table other alter column j set data type text;
 
-# TODO(142370): This should be blocked because the trigger references the table,
-# but we currently don't detect self-dependencies.
-statement ok
+statement error pq: cannot drop index "i1" because trigger "audit_trigger" on table "t1" depends on it
 drop index t1@i1;
 
 statement error pq: cannot drop index "i1" because trigger "audit_trigger" on table "t1" depends on it
@@ -4415,12 +4485,8 @@ statement error pq: cannot drop table other because other objects depend on it
 DROP TABLE other;
 
 # Verify the trigger still works
-# TODO(142370): this fails for now because we were allowed to drop the index earlier.
-statement error pq: while building trigger expression: index "i1" not found
-INSERT INTO t1 VALUES (0,0,0);
-
 statement ok
-create index i1 on t1(k);
+INSERT INTO t1 VALUES (0,0,0);
 
 # This test doesn't run with the legacy schema config because CREATE/DROP
 # trigger isn't implemented there. We enable legacy to run DDL to verify
@@ -4439,28 +4505,41 @@ ALTER TABLE t1 SET (schema_locked = false);
 statement ok
 ALTER TABLE other SET (schema_locked = false);
 
-statement error pq: ALTER COLUMN TYPE is only implemented in the declarative schema changer
+statement error pq: cannot alter type of column "j" because table "t1" depends on it
 alter table t1 alter column j set data type text;
 
 statement error pq: cannot alter type of column "j" because table "t1" depends on it
 alter table other alter column j set data type text;
 
-# TODO(142370): allowed because we don't pick up self-dependencies yet
-statement ok
+statement error pq: cannot rename column "j" because table "t1" depends on it
+alter table t1 rename column j to j2;
+
+statement error pq: cannot rename column "j" because table "t1" depends on it
+alter table other rename column j to j2;
+
+statement error pq: cannot drop column "j" because table "t1" depends on it
 alter table t1 drop column j;
+
+statement error pq: unimplemented: drop column cascade is not supported with triggers
+alter table t1 drop column j cascade;
 
 statement error pq: cannot drop column "j" because table "t1" depends on it
 alter table other drop column j;
 
-# TODO(142370): allowed because we don't pick up self-dependencies yet
-statement ok
+statement error pq: unimplemented: drop column cascade is not supported with triggers
+alter table other drop column j cascade;
+
+statement error pq: cannot drop index "i1" because table "t1" depends on it
 drop index t1@i1;
 
-statement error pq: index "i1" does not exist
+statement error pq: unimplemented: drop index cascade is not supported with triggers
 drop index t1@i1 CASCADE;
 
 statement error pq: cannot drop index "i1" because table "t1" depends on it
 drop index other@i1;
+
+statement error pq: unimplemented: drop index cascade is not supported with triggers
+drop index other@i1 CASCADE;
 
 statement error pq: cannot drop function "f1" because other objects \(\[test.public.t1\]\) still depend on it
 DROP FUNCTION f1;
@@ -4481,8 +4560,7 @@ statement ok
 set use_declarative_schema_changer = $use_decl_sc;
 
 # Verify the trigger still works
-# TODO(142370): this fails because we were wrongly allowed to drop index i1 earlier
-statement error pq: while building trigger expression: index "i1" not found
+statement ok
 INSERT INTO t1(n,k) VALUES (1,1);
 
 statement ok

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.explain
@@ -23,7 +23,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │         │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
- │         └── 9 Mutation operations
+ │         └── 10 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── AddTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
  │              ├── SetTriggerName {"Name":{"Name":"tr","TableID":104,"TriggerID":1}}
@@ -32,6 +32,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │              ├── SetTriggerEvents {"Events":{"TableID":104,"TriggerID":1}}
  │              ├── SetTriggerFunctionCall {"FunctionCall":{"FuncBody":"BEGIN\nRAISE NOTI...","FuncID":105,"TableID":104,"TriggerID":1}}
  │              ├── SetTriggerForwardReferences {"Deps":{"TableID":104,"TriggerID":1}}
+ │              ├── UpdateTableBackReferencesInRelations {"TableID":104}
  │              └── AddTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
@@ -58,7 +59,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │         │    └── ABSENT → PUBLIC TriggerDeps:{DescID: 104 (t), TriggerID: 1}
  │         ├── 1 element transitioning toward TRANSIENT_PUBLIC
  │         │    └── PUBLIC → ABSENT TableSchemaLocked:{DescID: 104 (t)}
- │         └── 12 Mutation operations
+ │         └── 13 Mutation operations
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── AddTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
  │              ├── SetTriggerName {"Name":{"Name":"tr","TableID":104,"TriggerID":1}}
@@ -67,6 +68,7 @@ Schema change plan for CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR DELETE ON �
  │              ├── SetTriggerEvents {"Events":{"TableID":104,"TriggerID":1}}
  │              ├── SetTriggerFunctionCall {"FunctionCall":{"FuncBody":"BEGIN\nRAISE NOTI...","FuncID":105,"TableID":104,"TriggerID":1}}
  │              ├── SetTriggerForwardReferences {"Deps":{"TableID":104,"TriggerID":1}}
+ │              ├── UpdateTableBackReferencesInRelations {"TableID":104}
  │              ├── AddTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":105,"Initialize":true}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger.side_effects
@@ -25,8 +25,15 @@ write *eventpb.CreateTrigger to event log:
     user: root
   tableName: defaultdb.public.t
   triggerName: tr
-## StatementPhase stage 1 of 1 with 9 MutationType ops
+## StatementPhase stage 1 of 1 with 10 MutationType ops
 upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  +  dependedOnBy:
+  +  - id: 104
+     families:
+     - columnIds:
   ...
      nextIndexId: 2
      nextMutationId: 1
@@ -39,6 +46,8 @@ upsert descriptor #104
   -  schemaLocked: true
   +  triggers:
   +  - actionTime: BEFORE
+  +    dependsOn:
+  +    - 104
   +    dependsOnRoutines:
   +    - 105
   +    enabled: true
@@ -81,7 +90,7 @@ upsert descriptor #105
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 12 MutationType ops
+## PreCommitPhase stage 2 of 2 with 13 MutationType ops
 upsert descriptor #104
   ...
      createAsOfTime:
@@ -114,6 +123,8 @@ upsert descriptor #104
   +    revertible: true
   +    targetRanks: <redacted>
   +    targets: <redacted>
+  +  dependedOnBy:
+  +  - id: 104
      families:
      - columnIds:
   ...
@@ -128,6 +139,8 @@ upsert descriptor #104
   -  schemaLocked: true
   +  triggers:
   +  - actionTime: BEFORE
+  +    dependsOn:
+  +    - 104
   +    dependsOnRoutines:
   +    - 105
   +    enabled: true
@@ -216,8 +229,8 @@ upsert descriptor #104
   -    revertible: true
   -    targetRanks: <redacted>
   -    targets: <redacted>
-     families:
-     - columnIds:
+     dependedOnBy:
+     - id: 104
   ...
      replacementOf:
        time: {}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger__rollback_1_of_1.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/create_trigger/create_trigger__rollback_1_of_1.explain
@@ -22,13 +22,14 @@ Schema change plan for rolling back CREATE TRIGGER tr BEFORE INSERT OR UPDATE OR
       │    │    ├── PUBLIC → ABSENT TriggerEvents:{DescID: 104 (t), TriggerID: 1}
       │    │    ├── PUBLIC → ABSENT TriggerFunctionCall:{DescID: 104 (t), TriggerID: 1}
       │    │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
-      │    └── 10 Mutation operations
+      │    └── 11 Mutation operations
       │         ├── RemoveTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
       │         ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerName","TriggerID":1}
       │         ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerEnab...","TriggerID":1}
       │         ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerTimi...","TriggerID":1}
       │         ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerEven...","TriggerID":1}
       │         ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerFunc...","TriggerID":1}
+      │         ├── UpdateTableBackReferencesInRelations {"TableID":104}
       │         ├── RemoveTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
       │         ├── SetJobStateOnDescriptor {"DescriptorID":105}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.explain
@@ -50,7 +50,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │         │    ├── PUBLIC → ABSENT  TriggerFunctionCall:{DescID: 104 (t-), TriggerID: 1}
  │         │    ├── PUBLIC → ABSENT  TriggerDeps:{DescID: 104 (t-), TriggerID: 1}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 104 (t-)}
- │         └── 52 Mutation operations
+ │         └── 53 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}
  │              ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":104}
@@ -74,6 +74,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerTimi...","TriggerID":1}
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerEven...","TriggerID":1}
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerFunc...","TriggerID":1}
+ │              ├── UpdateTableBackReferencesInRelations {"TableID":104}
  │              ├── RemoveTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":101}}
@@ -194,7 +195,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │         │    ├── PUBLIC → ABSENT  TriggerFunctionCall:{DescID: 104 (t-), TriggerID: 1}
  │         │    ├── PUBLIC → ABSENT  TriggerDeps:{DescID: 104 (t-), TriggerID: 1}
  │         │    └── PUBLIC → ABSENT  TableSchemaLocked:{DescID: 104 (t-)}
- │         └── 55 Mutation operations
+ │         └── 56 Mutation operations
  │              ├── MarkDescriptorAsDropped {"DescriptorID":104}
  │              ├── RemoveObjectParent {"ObjectID":104,"ParentSchemaID":101}
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":1,"TableID":104}
@@ -218,6 +219,7 @@ Schema change plan for DROP TABLE ‹defaultdb›.‹public›.‹t›;
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerTimi...","TriggerID":1}
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerEven...","TriggerID":1}
  │              ├── NotImplementedForPublicObjects {"DescID":104,"ElementType":"scpb.TriggerFunc...","TriggerID":1}
+ │              ├── UpdateTableBackReferencesInRelations {"TableID":104}
  │              ├── RemoveTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}
  │              ├── SetTableSchemaLocked {"TableID":104}
  │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":100,"DescriptorID":104,"Name":"t","SchemaID":101}}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_table_trigger/drop_table_trigger.side_effects
@@ -17,12 +17,15 @@ write *eventpb.DropTable to event log:
     tag: DROP TABLE
     user: root
   tableName: defaultdb.public.t
-## StatementPhase stage 1 of 1 with 52 MutationType ops
+## StatementPhase stage 1 of 1 with 53 MutationType ops
 delete object namespace entry {100 101 t} -> 104
 upsert descriptor #104
   ...
      createAsOfTime:
        wallTime: "1640995200000000000"
+  -  dependedOnBy:
+  -  - id: 104
+  +  dependedOnBy: []
   +  dropTime: <redacted>"
      families:
      - columnIds:
@@ -32,6 +35,8 @@ upsert descriptor #104
   -  schemaLocked: true
   -  triggers:
   -  - actionTime: BEFORE
+  -    dependsOn:
+  -    - 104
   -    dependsOnRoutines:
   -    - 105
   -    enabled: true
@@ -72,12 +77,14 @@ upsert descriptor #105
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 55 MutationType ops
+## PreCommitPhase stage 2 of 2 with 56 MutationType ops
 delete object namespace entry {100 101 t} -> 104
 upsert descriptor #104
   ...
      createAsOfTime:
        wallTime: "1640995200000000000"
+  -  dependedOnBy:
+  -  - id: 104
   +  declarativeSchemaChangerState:
   +    authorization:
   +      userName: root
@@ -93,6 +100,7 @@ upsert descriptor #104
   +        statementTag: DROP TABLE
   +    targetRanks: <redacted>
   +    targets: <redacted>
+  +  dependedOnBy: []
   +  dropTime: <redacted>"
      families:
      - columnIds:
@@ -102,6 +110,8 @@ upsert descriptor #104
   -  schemaLocked: true
   -  triggers:
   -  - actionTime: BEFORE
+  -    dependsOn:
+  -    - 104
   -    dependsOnRoutines:
   -    - 105
   -    enabled: true
@@ -174,8 +184,8 @@ upsert descriptor #104
   -        statementTag: DROP TABLE
   -    targetRanks: <redacted>
   -    targets: <redacted>
+     dependedOnBy: []
      dropTime: <redacted>"
-     families:
   ...
      triggers: []
      unexposedParentSchemaId: 101

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.explain
@@ -10,8 +10,9 @@ Schema change plan for DROP TRIGGER ‹tr› ON ‹defaultdb›.‹t›;
  │         ├── 2 elements transitioning toward ABSENT
  │         │    ├── PUBLIC → ABSENT Trigger:{DescID: 104 (t), TriggerID: 1}
  │         │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
- │         └── 2 Mutation operations
+ │         └── 3 Mutation operations
  │              ├── RemoveTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
+ │              ├── UpdateTableBackReferencesInRelations {"TableID":104}
  │              └── RemoveTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}
  └── PreCommitPhase
       ├── Stage 1 of 2 in PreCommitPhase
@@ -24,6 +25,7 @@ Schema change plan for DROP TRIGGER ‹tr› ON ‹defaultdb›.‹t›;
            ├── 2 elements transitioning toward ABSENT
            │    ├── PUBLIC → ABSENT Trigger:{DescID: 104 (t), TriggerID: 1}
            │    └── PUBLIC → ABSENT TriggerDeps:{DescID: 104 (t), TriggerID: 1}
-           └── 2 Mutation operations
+           └── 3 Mutation operations
                 ├── RemoveTrigger {"Trigger":{"TableID":104,"TriggerID":1}}
+                ├── UpdateTableBackReferencesInRelations {"TableID":104}
                 └── RemoveTriggerBackReferencesInRoutines {"BackReferencedTableID":104,"BackReferencedTriggerID":1}

--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.side_effects
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/drop_trigger/drop_trigger.side_effects
@@ -17,13 +17,23 @@ write *eventpb.DropTrigger to event log:
     user: root
   tableName: defaultdb.public.t
   triggerName: tr
-## StatementPhase stage 1 of 1 with 2 MutationType ops
+## StatementPhase stage 1 of 1 with 3 MutationType ops
 upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  dependedOnBy:
+  -  - id: 104
+  +  dependedOnBy: []
+     families:
+     - columnIds:
   ...
        time: {}
      schemaLocked: true
   -  triggers:
   -  - actionTime: BEFORE
+  -    dependsOn:
+  -    - 104
   -    dependsOnRoutines:
   -    - 105
   -    enabled: true
@@ -63,13 +73,23 @@ upsert descriptor #105
 ## PreCommitPhase stage 1 of 2 with 1 MutationType op
 undo all catalog changes within txn #1
 persist all catalog changes to storage
-## PreCommitPhase stage 2 of 2 with 2 MutationType ops
+## PreCommitPhase stage 2 of 2 with 3 MutationType ops
 upsert descriptor #104
+  ...
+     createAsOfTime:
+       wallTime: "1640995200000000000"
+  -  dependedOnBy:
+  -  - id: 104
+  +  dependedOnBy: []
+     families:
+     - columnIds:
   ...
        time: {}
      schemaLocked: true
   -  triggers:
   -  - actionTime: BEFORE
+  -    dependsOn:
+  -    - 104
   -    dependsOnRoutines:
   -    - 105
   -    enabled: true

--- a/pkg/sql/alter_column_type.go
+++ b/pkg/sql/alter_column_type.go
@@ -50,7 +50,7 @@ func AlterColumnType(
 		}
 		if found {
 			return params.p.dependentError(
-				ctx, objType, col.GetName(), tableDesc.ParentID, tableRef.ID, op,
+				ctx, objType, col.GetName(), tableDesc.ParentID, tableRef.ID, tableDesc.ID, op,
 			)
 		}
 	}

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -879,7 +879,8 @@ func (p *planner) disallowDroppingPrimaryIndexReferencedInUDFOrView(
 		if tableRef.IndexID == currentPrimaryIndex.GetID() {
 			// canRemoveDependent with `DropDefault` will return the right error.
 			err := p.canRemoveDependent(
-				ctx, "index", currentPrimaryIndex.GetName(), tableDesc.ParentID, tableRef, tree.DropDefault)
+				ctx, "index", currentPrimaryIndex.GetName(), tableDesc.ID, tableDesc.ParentID, tableRef, tree.DropDefault,
+				true /* blockOnTriggerDependency */)
 			if err != nil {
 				return errors.WithDetail(err, sqlerrors.PrimaryIndexSwapDetail)
 			}

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1928,7 +1928,8 @@ func dropColumnImpl(
 			continue
 		}
 		err := params.p.canRemoveDependent(
-			params.ctx, "column", string(t.Column), tableDesc.ParentID, ref, t.DropBehavior,
+			params.ctx, "column", string(t.Column), tableDesc.ID, tableDesc.ParentID, ref, t.DropBehavior,
+			true, /* blockOnTriggerDependency */
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -839,7 +839,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 			depViewRenameError := func(objType string, refTableID descpb.ID) error {
 				return params.p.dependentError(params.ctx,
-					objType, tree.ErrString(&t.NewName), n.tableDesc.ParentID, refTableID, "rename",
+					objType, tree.ErrString(&t.NewName), n.tableDesc.ParentID, refTableID, n.tableDesc.ID, "rename",
 				)
 			}
 

--- a/pkg/sql/alter_table_set_schema.go
+++ b/pkg/sql/alter_table_set_schema.go
@@ -79,7 +79,7 @@ func (p *planner) AlterTableSetSchema(
 		if !dependent.ByID {
 			return nil, p.dependentError(
 				ctx, string(tableDesc.DescriptorType()), tableDesc.Name,
-				tableDesc.ParentID, dependent.ID, "set schema on",
+				tableDesc.ParentID, dependent.ID, tableDesc.ID, "set schema on",
 			)
 		}
 	}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -430,9 +430,10 @@ func (p *planner) dropIndexByName(
 	var depsToDrop catalog.DescriptorIDSet
 	for _, tableRef := range tableDesc.DependedOnBy {
 		if tableRef.IndexID == idx.GetID() {
-			// Ensure that we have DROP privilege on all dependent views
+			// Ensure that we have DROP privilege on all dependent relations
 			err := p.canRemoveDependent(
-				ctx, "index", idx.GetName(), tableDesc.ParentID, tableRef, behavior)
+				ctx, "index", idx.GetName(), tableDesc.ID, tableDesc.ParentID,
+				tableRef, behavior, true /* blockOnTriggerDependency */)
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/drop_index.go
+++ b/pkg/sql/drop_index.go
@@ -530,7 +530,7 @@ func (p *planner) removeDependents(
 ) (droppedViews []string, err error) {
 	for _, descId := range depsToDrop.Ordered() {
 		depDesc, err := p.getDescForCascade(
-			ctx, typeName, objName, tableDesc.ParentID, descId, dropBehavior,
+			ctx, typeName, objName, tableDesc.ParentID, descId, tableDesc.ID, dropBehavior,
 		)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -304,7 +304,7 @@ func (p *planner) dropTableImpl(
 	dependedOnBy := append([]descpb.TableDescriptor_Reference(nil), tableDesc.DependedOnBy...)
 	for _, ref := range dependedOnBy {
 		depDesc, err := p.getDescForCascade(
-			ctx, string(tableDesc.DescriptorType()), tableDesc.Name, tableDesc.ParentID, ref.ID, tree.DropCascade,
+			ctx, string(tableDesc.DescriptorType()), tableDesc.Name, tableDesc.ParentID, ref.ID, tableDesc.ID, tree.DropCascade,
 		)
 		if err != nil {
 			return droppedViews, err

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -235,6 +235,11 @@ func (p *planner) dropTableImpl(
 	if catalog.HasConcurrentDeclarativeSchemaChange(tableDesc) {
 		return nil, scerrors.ConcurrentSchemaChangeError(tableDesc)
 	}
+	// Early out if the table is already dropped. This can happen during a cascade
+	// with a trigger.
+	if tableDesc.Dropped() {
+		return droppedViews, nil
+	}
 	// Remove foreign key back references from tables that this table has foreign
 	// keys to.
 	// Copy out the set of outbound fks as it may be overwritten in the loop.
@@ -311,9 +316,17 @@ func (p *planner) dropTableImpl(
 
 		switch t := depDesc.(type) {
 		case *tabledesc.Mutable:
-			cascadedViews, err := p.dropViewImpl(ctx, t, !droppingParent, "dropping dependent view", tree.DropCascade)
-			if err != nil {
-				return droppedViews, err
+			var cascadedViews []string
+			if t.IsTable() {
+				cascadedViews, err = p.dropTableImpl(ctx, t, !droppingParent, "dropping dependent table", tree.DropCascade)
+				if err != nil {
+					return droppedViews, err
+				}
+			} else {
+				cascadedViews, err = p.dropViewImpl(ctx, t, !droppingParent, "dropping dependent view", tree.DropCascade)
+				if err != nil {
+					return droppedViews, err
+				}
 			}
 
 			qualifiedView, err := p.getQualifiedTableName(ctx, t)

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 type dropViewNode struct {
@@ -144,7 +145,7 @@ func descInSlice(descID descpb.ID, td []toDelete) bool {
 // or other supported object type.
 func (p *planner) canRemoveDependent(
 	ctx context.Context,
-	typeName string,
+	typeName redact.SafeString,
 	objName string,
 	targetID descpb.ID,
 	parentID descpb.ID,
@@ -161,7 +162,7 @@ func (p *planner) canRemoveDependent(
 	case *tabledesc.Mutable:
 		return p.canRemoveDependentViewGeneric(ctx, typeName, objName, targetID, parentID, t, behavior, blockOnTriggerDependency)
 	case *funcdesc.Mutable:
-		return p.canRemoveDependentFunctionGeneric(ctx, typeName, objName, t, behavior)
+		return p.canRemoveDependentFunctionGeneric(ctx, string(typeName), objName, t, behavior)
 	default:
 		return errors.AssertionFailedf(
 			"unexpected dependent %s %s on %s %s",
@@ -191,7 +192,7 @@ func (p *planner) canRemoveDependentFromTable(
 	// TODO(146722): we pass false for blockOnTriggerDependency to allow proceeding
 	// even if a table has a trigger-based dependency. This is needed when we're
 	// here as part of dropping a database.
-	return p.canRemoveDependent(ctx, string(from.DescriptorType()), from.Name, from.GetID(), from.ParentID,
+	return p.canRemoveDependent(ctx, redact.SafeString(from.DescriptorType()), from.Name, from.GetID(), from.ParentID,
 		ref, behavior, false /* blockOnTriggerDependency */)
 }
 
@@ -207,22 +208,22 @@ func (p *planner) canRemoveDependentFromTable(
 // trigger that depends on the target.
 func (p *planner) canRemoveDependentViewGeneric(
 	ctx context.Context,
-	typeName string,
+	typeName redact.SafeString,
 	objName string,
 	targetID descpb.ID,
 	parentID descpb.ID,
-	viewDesc *tabledesc.Mutable,
+	desc *tabledesc.Mutable,
 	behavior tree.DropBehavior,
 	blockOnTriggerDependency bool,
 ) error {
 	if behavior != tree.DropCascade {
-		return p.dependentRelationError(ctx, typeName, objName, parentID, viewDesc, "drop")
+		return p.dependentRelationError(ctx, typeName, objName, parentID, desc, targetID, "drop")
 	}
 
 	// In general, drop cascade is only support with triggers for drop table/database.
 	if blockOnTriggerDependency {
-		for i := range viewDesc.Triggers {
-			trigger := &viewDesc.Triggers[i]
+		for i := range desc.Triggers {
+			trigger := &desc.Triggers[i]
 			for _, id := range trigger.DependsOn {
 				if id == targetID {
 					return unimplemented.NewWithIssuef(
@@ -232,12 +233,12 @@ func (p *planner) canRemoveDependentViewGeneric(
 		}
 	}
 
-	if err := p.CheckPrivilege(ctx, viewDesc, privilege.DROP); err != nil {
+	if err := p.CheckPrivilege(ctx, desc, privilege.DROP); err != nil {
 		return err
 	}
-	// If this view is depended on by other views, we have to check them as well.
-	for _, ref := range viewDesc.DependedOnBy {
-		if err := p.canRemoveDependentFromTable(ctx, viewDesc, ref, behavior); err != nil {
+	// If this relation is depended on by other relations, we have to check them as well.
+	for _, ref := range desc.DependedOnBy {
+		if err := p.canRemoveDependentFromTable(ctx, desc, ref, behavior); err != nil {
 			return err
 		}
 	}
@@ -326,7 +327,7 @@ func (p *planner) dropViewImpl(
 		dependedOnBy := append([]descpb.TableDescriptor_Reference(nil), viewDesc.DependedOnBy...)
 		for _, ref := range dependedOnBy {
 			depDesc, err := p.getDescForCascade(
-				ctx, string(viewDesc.DescriptorType()), viewDesc.Name, viewDesc.ParentID, ref.ID, behavior,
+				ctx, string(viewDesc.DescriptorType()), viewDesc.Name, viewDesc.ParentID, ref.ID, viewDesc.ID, behavior,
 			)
 			if err != nil {
 				return cascadeDroppedViews, err
@@ -374,7 +375,7 @@ func (p *planner) getDescForCascade(
 	ctx context.Context,
 	typeName string,
 	objName string,
-	parentID, descID descpb.ID,
+	parentID, descID, targetID descpb.ID,
 	behavior tree.DropBehavior,
 ) (catalog.MutableDescriptor, error) {
 	desc, err := p.Descriptors().MutableByID(p.txn).Desc(ctx, descID)
@@ -383,7 +384,7 @@ func (p *planner) getDescForCascade(
 		return nil, errors.Wrapf(err, "error resolving dependent ID %d", descID)
 	}
 	if behavior != tree.DropCascade {
-		return nil, p.dependentError(ctx, typeName, objName, parentID, descID, "drop")
+		return nil, p.dependentError(ctx, typeName, objName, parentID, descID, targetID, "drop")
 	}
 	return desc, nil
 }

--- a/pkg/sql/rename_column.go
+++ b/pkg/sql/rename_column.go
@@ -117,7 +117,7 @@ func (p *planner) findColumnToRename(
 		}
 		if found {
 			return nil, p.dependentError(
-				ctx, "column", oldName.String(), tableDesc.ParentID, tableRef.ID, "rename",
+				ctx, "column", oldName.String(), tableDesc.ParentID, tableRef.ID, tableDesc.ID, "rename",
 			)
 		}
 	}

--- a/pkg/sql/rename_index.go
+++ b/pkg/sql/rename_index.go
@@ -87,7 +87,7 @@ func (n *renameIndexNode) startExec(params runParams) error {
 			continue
 		}
 		return p.dependentError(
-			ctx, "index", n.n.Index.Index.String(), tableDesc.ParentID, tableRef.ID, "rename",
+			ctx, "index", n.n.Index.Index.String(), tableDesc.ParentID, tableRef.ID, tableDesc.ID, "rename",
 		)
 	}
 

--- a/pkg/sql/rename_table.go
+++ b/pkg/sql/rename_table.go
@@ -83,7 +83,7 @@ func (p *planner) RenameTable(ctx context.Context, n *tree.RenameTable) (planNod
 		if !dependent.ByID {
 			return nil, p.dependentError(
 				ctx, string(tableDesc.DescriptorType()), oldTn.String(),
-				tableDesc.ParentID, dependent.ID, "rename",
+				tableDesc.ParentID, dependent.ID, tableDesc.ID, "rename",
 			)
 		}
 	}
@@ -259,18 +259,32 @@ func (n *renameTableNode) Next(runParams) (bool, error) { return false, nil }
 func (n *renameTableNode) Values() tree.Datums          { return tree.Datums{} }
 func (n *renameTableNode) Close(context.Context)        {}
 
+// dependentError returns an error indicating that an operation on a target object
+// (e.g., rename or drop) cannot proceed because it is depended on by another object.
+//
+// The dependent object is identified by dependentID, and the target object is the one
+// being operated on. parentID refers to the database containing the target. The function
+// dispatches to a specific error formatter based on the dependent's descriptor type.
+//
 // TODO(a-robinson): Support renaming objects depended on by views once we have
 // a better encoding for view queries (#10083).
 func (p *planner) dependentError(
-	ctx context.Context, typeName string, objName string, parentID descpb.ID, id descpb.ID, op string,
+	ctx context.Context,
+	typeName string,
+	objName string,
+	parentID descpb.ID,
+	dependentID descpb.ID,
+	targetID descpb.ID,
+	op string,
 ) error {
-	desc, err := p.Descriptors().ByIDWithLeased(p.txn).WithoutNonPublic().Get().Desc(ctx, id)
+	desc, err := p.Descriptors().ByIDWithLeased(p.txn).WithoutNonPublic().Get().Desc(ctx, dependentID)
 	if err != nil {
 		return err
 	}
 	switch desc.DescriptorType() {
 	case catalog.Table:
-		return p.dependentRelationError(ctx, typeName, objName, parentID, desc.(catalog.TableDescriptor), op)
+		return p.dependentRelationError(ctx, redact.SafeString(typeName), objName, parentID, desc.(catalog.TableDescriptor),
+			targetID, redact.SafeString(op))
 	case catalog.Function:
 		return p.dependentFunctionError(typeName, objName, desc.(catalog.FunctionDescriptor), op)
 	default:
@@ -289,23 +303,38 @@ func (p *planner) dependentFunctionError(
 
 func (p *planner) dependentRelationError(
 	ctx context.Context,
-	typeName, objName string,
+	typeName redact.SafeString,
+	objName string,
 	parentID descpb.ID,
 	desc catalog.TableDescriptor,
-	op string,
+	targetID descpb.ID,
+	op redact.SafeString,
 ) error {
-	viewName := desc.GetName()
+	// Check if any triggers on the table depend on the target object.
+	for i := range desc.GetTriggers() {
+		trigger := &desc.GetTriggers()[i]
+		for _, id := range trigger.DependsOn {
+			if id == targetID {
+				return sqlerrors.NewDependentObjectErrorf(
+					"cannot %s %s %q because trigger %q on table %q depends on it",
+					op, typeName, objName, trigger.Name, desc.GetName(),
+				)
+			}
+		}
+	}
+
+	relationName := desc.GetName()
 	if desc.GetParentID() != parentID {
 		viewFQName, err := p.getQualifiedTableName(ctx, desc)
 		if err != nil {
 			log.Warningf(ctx, "unable to retrieve name of relation %d: %v", desc.GetID(), err)
 			return sqlerrors.NewDependentObjectErrorf(
 				"cannot %s %s %q because a %s depends on it",
-				redact.SafeString(op), redact.SafeString(typeName), objName, redact.SafeString(desc.GetObjectTypeString()))
+				op, typeName, objName, redact.SafeString(desc.GetObjectTypeString()))
 		}
-		viewName = viewFQName.FQString()
+		relationName = viewFQName.FQString()
 	}
-	return sqlerrors.NewDependentBlocksOpError(op, typeName, objName, desc.GetObjectTypeString(), viewName)
+	return sqlerrors.NewDependentBlocksOpError(string(op), string(typeName), objName, desc.GetObjectTypeString(), relationName)
 }
 
 // checkForCrossDbReferences validates if any cross DB references

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_trigger.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_trigger.go
@@ -146,12 +146,6 @@ func buildRelationDeps(
 ) []scpb.TriggerDeps_RelationReference {
 	usesRelations := make([]scpb.TriggerDeps_RelationReference, 0)
 	if err := refProvider.ForEachTableReference(func(tblID descpb.ID, idxID descpb.IndexID, colIDs descpb.ColumnIDs) error {
-		// It is possible for the trigger function to reference the table on which the
-		// trigger is defined. In that case, we need to remove the table from the list
-		// of referenced relations to avoid a circular dependency.
-		if tblID == tableID {
-			return nil
-		}
 		usesRelations = append(usesRelations, scpb.TriggerDeps_RelationReference{
 			ID:        tblID,
 			IndexID:   idxID,

--- a/pkg/sql/schemachanger/scplan/testdata/create_trigger
+++ b/pkg/sql/schemachanger/scplan/testdata/create_trigger
@@ -11,7 +11,7 @@ $$;
 ops
 CREATE TRIGGER t1_tg BEFORE INSERT OR UPDATE OR DELETE ON defaultdb.t1 FOR EACH ROW EXECUTE FUNCTION g();
 ----
-StatementPhase stage 1 of 1 with 8 MutationType ops
+StatementPhase stage 1 of 1 with 9 MutationType ops
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
     [[TriggerName:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
@@ -67,9 +67,18 @@ StatementPhase stage 1 of 1 with 8 MutationType ops
       Deps:
         TableID: 104
         TriggerID: 1
-        UsesRelations: []
+        UsesRelations:
+        - id: 104
+          columnids: []
+          indexid: 0
         UsesRoutineIDs:
         - 105
+    *scop.UpdateTableBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
     *scop.AddTriggerBackReferencesInRoutines
       BackReferencedTableID: 104
       BackReferencedTriggerID: 1
@@ -87,7 +96,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 8 MutationType ops
+PreCommitPhase stage 2 of 2 with 9 MutationType ops
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
     [[TriggerName:{DescID: 104, TriggerID: 1}, PUBLIC], ABSENT] -> PUBLIC
@@ -143,9 +152,18 @@ PreCommitPhase stage 2 of 2 with 8 MutationType ops
       Deps:
         TableID: 104
         TriggerID: 1
-        UsesRelations: []
+        UsesRelations:
+        - id: 104
+          columnids: []
+          indexid: 0
         UsesRoutineIDs:
         - 105
+    *scop.UpdateTableBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
     *scop.AddTriggerBackReferencesInRoutines
       BackReferencedTableID: 104
       BackReferencedTriggerID: 1

--- a/pkg/sql/schemachanger/scplan/testdata/drop_table
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_table
@@ -42,7 +42,7 @@ CREATE TRIGGER foo BEFORE INSERT OR UPDATE ON shipments FOR EACH ROW EXECUTE FUN
 ops
 DROP TABLE defaultdb.shipments CASCADE;
 ----
-StatementPhase stage 1 of 1 with 141 MutationType ops
+StatementPhase stage 1 of 1 with 142 MutationType ops
   transitions:
     [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
@@ -449,6 +449,12 @@ StatementPhase stage 1 of 1 with 141 MutationType ops
       DescID: 109
       ElementType: scpb.TriggerFunctionCall
       TriggerID: 1
+    *scop.UpdateTableBackReferencesInRelations
+      RelationReferences:
+      - id: 109
+        columnids: []
+        indexid: 0
+      TableID: 109
     *scop.UpdateTableBackReferencesInTypes
       BackReferencedTableID: 109
       TypeIDs:
@@ -751,7 +757,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 152 MutationType ops
+PreCommitPhase stage 2 of 2 with 153 MutationType ops
   transitions:
     [[Namespace:{DescID: 109, Name: shipments, ReferencedDescID: 100}, ABSENT], PUBLIC] -> ABSENT
     [[Owner:{DescID: 109}, ABSENT], PUBLIC] -> ABSENT
@@ -1158,6 +1164,12 @@ PreCommitPhase stage 2 of 2 with 152 MutationType ops
       DescID: 109
       ElementType: scpb.TriggerFunctionCall
       TriggerID: 1
+    *scop.UpdateTableBackReferencesInRelations
+      RelationReferences:
+      - id: 109
+        columnids: []
+        indexid: 0
+      TableID: 109
     *scop.UpdateTableBackReferencesInTypes
       BackReferencedTableID: 109
       TypeIDs:

--- a/pkg/sql/schemachanger/scplan/testdata/drop_trigger
+++ b/pkg/sql/schemachanger/scplan/testdata/drop_trigger
@@ -13,7 +13,7 @@ CREATE TRIGGER t1_tg_2 AFTER INSERT OR UPDATE ON defaultdb.t1 FOR EACH ROW EXECU
 ops
 DROP TRIGGER t1_tg ON defaultdb.t1;
 ----
-StatementPhase stage 1 of 1 with 2 MutationType ops
+StatementPhase stage 1 of 1 with 3 MutationType ops
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerDeps:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -22,6 +22,12 @@ StatementPhase stage 1 of 1 with 2 MutationType ops
       Trigger:
         TableID: 104
         TriggerID: 1
+    *scop.UpdateTableBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
     *scop.RemoveTriggerBackReferencesInRoutines
       BackReferencedTableID: 104
       BackReferencedTriggerID: 1
@@ -34,7 +40,7 @@ PreCommitPhase stage 1 of 2 with 1 MutationType op
   ops:
     *scop.UndoAllInTxnImmediateMutationOpSideEffects
       {}
-PreCommitPhase stage 2 of 2 with 2 MutationType ops
+PreCommitPhase stage 2 of 2 with 3 MutationType ops
   transitions:
     [[Trigger:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
     [[TriggerDeps:{DescID: 104, TriggerID: 1}, ABSENT], PUBLIC] -> ABSENT
@@ -43,6 +49,12 @@ PreCommitPhase stage 2 of 2 with 2 MutationType ops
       Trigger:
         TableID: 104
         TriggerID: 1
+    *scop.UpdateTableBackReferencesInRelations
+      RelationReferences:
+      - id: 104
+        columnids: []
+        indexid: 0
+      TableID: 104
     *scop.RemoveTriggerBackReferencesInRoutines
       BackReferencedTableID: 104
       BackReferencedTriggerID: 1


### PR DESCRIPTION
## Fix trigger dependencies on self

This change corrects an issue where a trigger on a table that referenced the same table did not properly record its dependency. Previously, such dependencies were missing.

The fix ensures that self-referential trigger dependencies are properly tracked in both the declarative schema changer and the legacy schema changer. 

Fixes #142370.

Release note (bug fix): Fixed an issue where self-referencing triggers did not have their dependencies properly recorded, which could lead to broken dependencies.

## Include trigger name in dependency error message

Previously, when an operation failed due to a dependency, the error message would mention the dependent table but not the specific trigger causing the dependency. This made it harder to understand what exactly was blocking the operation.

This change improves the error message by including the trigger name. This makes the errors more consistent with errors coming from the DSC, which already include the trigger name. For example:

Before:
```
pq: cannot rename relation "sc1.tbl1" because table "tbl1" depends on it
```

After:
```
pq: cannot rename relation "sc1.tbl1" because trigger "tr1" on table "tbl1" depends on it
```

Epic: none
Release note: none