### PR TITLE
ui: fix broken sql activity pages when app name contains "#"

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -120,7 +120,7 @@ export const getStatementDetails = (
     end: req.end.toInt(),
   });
   for (const app of req.app_names) {
-    queryStr += `&appNames=${app}`;
+    queryStr += `&appNames=${encodeURIComponent(app)}`;
   }
   return fetchData(
     cockroach.server.serverpb.StatementDetailsResponse,

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -730,7 +730,7 @@ export function getStatementDetails(
     end: req.end.toInt(),
   });
   for (const app of req.app_names) {
-    queryStr += `&appNames=${app}`;
+    queryStr += `&appNames=${encodeURIComponent(app)}`;
   }
   return timeoutFetch(
     serverpb.StatementDetailsResponse,


### PR DESCRIPTION
This commit fixes a bug sql activity statement details pages fails to load sql activity for a statement if the app name used to run the statement contains a "#".

This was happening because the application names weren't being properly url encoded. Now these will be encoded correctly.

Epic: None
Release note (bug fix): Fixes a bug in the sql activity statement details page where details would fail to load of the application name used to execute the query contained a "#" character.

Fixes: #145586