### PR TITLE
cloud: redact azure secret keys in URI

### DIFF
--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -427,7 +427,7 @@ func init() {
 		cloud.RegisteredProvider{
 			EarlyBootConstructFn: makeAzureStorage,
 			EarlyBootParseFn:     parseAzureURL,
-			RedactedParams:       cloud.RedactedParams(AzureAccountKeyParam),
+			RedactedParams:       cloud.RedactedParams(AzureAccountKeyParam, AzureClientSecretParam),
 			Schemes:              []string{scheme, deprecatedScheme, deprecatedExternalConnectionScheme},
 		})
 }


### PR DESCRIPTION
When sanitizing Azure URIs, we redact account keys, but not the client secrets. This updates the sanitization rule to also redact the client secret.

Fixes: CRDB-50284