### PR TITLE
sql: remove old hyperloglog version

### DIFF
--- a/DEPS.bzl
+++ b/DEPS.bzl
@@ -784,16 +784,6 @@ def go_deps():
         ],
     )
     go_repository(
-        name = "com_github_axiomhq_hyperloglog_000",
-        build_file_proto_mode = "disable_global",
-        importpath = "github.com/axiomhq/hyperloglog/000",
-        sha256 = "812834322ee2ca50dc36f91f9ac3f2cde4631af2f9c330b1271c78b46024a540",
-        strip_prefix = "github.com/axiomhq/hyperloglog@v0.0.0-20181223111420-4b99d0c2c99e",
-        urls = [
-            "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/axiomhq/hyperloglog/com_github_axiomhq_hyperloglog-v0.0.0-20181223111420-4b99d0c2c99e.zip",
-        ],
-    )
-    go_repository(
         name = "com_github_aymanbagabas_go_osc52",
         build_file_proto_mode = "disable_global",
         importpath = "github.com/aymanbagabas/go-osc52",

--- a/build/bazelutil/distdir_files.bzl
+++ b/build/bazelutil/distdir_files.bzl
@@ -288,7 +288,6 @@ DISTDIR_FILES = {
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/aws/aws-sdk-go-v2/service/sts/com_github_aws_aws_sdk_go_v2_service_sts-v1.33.17.zip": "87aca25fafd483a1eac29c5baaab05ad485422a9aa1ccc5db0d39733c2d71cd2",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/aws/aws-sdk-go/com_github_aws_aws_sdk_go-v1.40.37.zip": "c0c481d28af88f621fb3fdeacc1e5d32f69a1bb83d0ee959f95ce89e4e2d0494",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/aws/smithy-go/com_github_aws_smithy_go-v1.22.3.zip": "572df48de9133d57f45909d3067b2053b97230268c2d28e4e44ea9644009ef11",
-    "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/axiomhq/hyperloglog/com_github_axiomhq_hyperloglog-v0.0.0-20181223111420-4b99d0c2c99e.zip": "812834322ee2ca50dc36f91f9ac3f2cde4631af2f9c330b1271c78b46024a540",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/axiomhq/hyperloglog/com_github_axiomhq_hyperloglog-v0.2.5.zip": "6125b12664bb5dd8614e82f0fe7528242dcb11649e1d7e051aabf3da471e14e1",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/aymanbagabas/go-osc52/com_github_aymanbagabas_go_osc52-v1.0.3.zip": "138e75a51599c2a8e4afe2bd6acdeaddbb73eb9ec796dfa2f577b16201660d9e",
     "https://storage.googleapis.com/cockroach-godeps/gomod/github.com/aymerick/douceur/com_github_aymerick_douceur-v0.2.0.zip": "dcbf69760cc1a8b32384495438e1086e4c3d669b2ebc0debd92e1865ffd6be60",

--- a/go.mod
+++ b/go.mod
@@ -122,7 +122,6 @@ require (
 	github.com/aws/aws-sdk-go-v2/service/secretsmanager v1.35.1
 	github.com/aws/smithy-go v1.22.3
 	github.com/axiomhq/hyperloglog v0.2.5
-	github.com/axiomhq/hyperloglog/000 v0.0.0-20181223111420-4b99d0c2c99e
 	github.com/bazelbuild/rules_go v0.26.0
 	github.com/biogo/store v0.0.0-20160505134755-913427a1d5e8
 	github.com/blevesearch/snowballstem v0.9.0
@@ -506,10 +505,6 @@ replace golang.org/x/time => github.com/cockroachdb/x-time v0.3.1-0.202305251236
 replace github.com/gogo/protobuf => github.com/cockroachdb/gogoproto v1.3.3-0.20241216150617-2358cdb156a1
 
 replace storj.io/drpc => github.com/cockroachdb/drpc v0.0.0-20250507084558-a793c5c40d3d
-
-// TODO(yuzefovich): remove this version once compatibility with 24.3 is no
-// longer needed.
-replace github.com/axiomhq/hyperloglog/000 => github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e
 
 // Note: This forked dependency adds a commit that opens up some
 // private APIs to enable us to make some perf improvements to

--- a/go.sum
+++ b/go.sum
@@ -451,8 +451,6 @@ github.com/aws/aws-sdk-go-v2/service/sts v1.33.17/go.mod h1:cQnB8CUnxbMU82JvlqjK
 github.com/aws/smithy-go v1.13.5/go.mod h1:Tg+OJXh4MB2R/uN61Ko2f6hTZwB/ZYGOtib8J3gBHzA=
 github.com/aws/smithy-go v1.22.3 h1:Z//5NuZCSW6R4PhQ93hShNbyBbn8BWCmCVCt+Q8Io5k=
 github.com/aws/smithy-go v1.22.3/go.mod h1:t1ufH5HMublsJYulve2RKmHDC15xu1f26kHCp/HgceI=
-github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e h1:190ugM9MsyFauTkR/UqcHG/mn5nmFe6SvHJqEHIrtrA=
-github.com/axiomhq/hyperloglog v0.0.0-20181223111420-4b99d0c2c99e/go.mod h1:IOXAcuKIFq/mDyuQ4wyJuJ79XLMsmLM+5RdQ+vWrL7o=
 github.com/axiomhq/hyperloglog v0.2.5 h1:Hefy3i8nAs8zAI/tDp+wE7N+Ltr8JnwiW3875pvl0N8=
 github.com/axiomhq/hyperloglog v0.2.5/go.mod h1:DLUK9yIzpU5B6YFLjxTIcbHu1g4Y1WQb1m5RH3radaM=
 github.com/aymanbagabas/go-osc52 v1.0.3 h1:DTwqENW7X9arYimJrPeGZcV0ln14sGMt3pHZspWD+Mg=

--- a/pkg/sql/distsql_plan_stats.go
+++ b/pkg/sql/distsql_plan_stats.go
@@ -410,7 +410,6 @@ func (dsp *DistSQLPlanner) createPartialStatsPlan(
 
 	sampledColumnIDs := make([]descpb.ColumnID, len(scan.catalogCols))
 	spec := execinfrapb.SketchSpec{
-		SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
 		GenerateHistogram:   reqStat.histogram,
 		HistogramMaxBuckets: reqStat.histogramMaxBuckets,
 		Columns:             make([]uint32, len(reqStat.columns)),
@@ -656,7 +655,6 @@ func (dsp *DistSQLPlanner) createStatsPlan(
 	sampledColumnIDs := make([]descpb.ColumnID, len(requestedCols))
 	for _, s := range reqStats {
 		spec := execinfrapb.SketchSpec{
-			SketchType:          execinfrapb.SketchType_HLL_PLUS_PLUS_V1,
 			GenerateHistogram:   s.histogram,
 			HistogramMaxBuckets: s.histogramMaxBuckets,
 			Columns:             make([]uint32, len(s.columns)),

--- a/pkg/sql/execinfrapb/processors_table_stats.proto
+++ b/pkg/sql/execinfrapb/processors_table_stats.proto
@@ -17,18 +17,9 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
 import "sql/catalog/descpb/structured.proto";
 import "gogoproto/gogo.proto";
 
-// TODO(yuzefovich): this can be removed once compatibility with 24.3 is no
-// longer needed.
-enum SketchType {
-  // This is the github.com/axiomhq/hyperloglog binary format (as of commit
-  // 730eea1) for a sketch with precision 14. Values are encoded using their key
-  // encoding, except integers which are encoded in 8 bytes (little-endian).
-  HLL_PLUS_PLUS_V1 = 0;
-}
-
 // SketchSpec contains the specification for a generated statistic.
 message SketchSpec {
-  optional SketchType sketch_type = 1 [(gogoproto.nullable) = false];
+  reserved 1;
 
   // Each value is an index identifying a column in the input stream.
   // TODO(radu): currently only one column is supported.

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -115,7 +115,6 @@ go_library(
         "//pkg/util/tracing/tracingpb",
         "//pkg/util/vector",
         "@com_github_axiomhq_hyperloglog//:hyperloglog",
-        "@com_github_axiomhq_hyperloglog_000//:000",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -10,14 +10,12 @@ import (
 	"math"
 	"time"
 
-	hllNew "github.com/axiomhq/hyperloglog"
-	hllOld "github.com/axiomhq/hyperloglog/000"
+	"github.com/axiomhq/hyperloglog"
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/execversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -103,7 +101,6 @@ func newSampleAggregator(
 			return nil, errors.Errorf("histograms require one column")
 		}
 	}
-	useNewHLL := execversion.FromContext(ctx) >= execversion.V25_1
 
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
@@ -144,13 +141,9 @@ func newSampleAggregator(
 	for i := range spec.Sketches {
 		s.sketches[i] = sketchInfo{
 			spec:     spec.Sketches[i],
+			sketch:   hyperloglog.New14(),
 			numNulls: 0,
 			numRows:  0,
-		}
-		if useNewHLL {
-			s.sketches[i].sketchNew = hllNew.New14()
-		} else {
-			s.sketches[i].sketchOld = hllOld.New14()
 		}
 		if spec.Sketches[i].GenerateHistogram {
 			sampleCols.Add(int(spec.Sketches[i].Columns[0]))
@@ -173,13 +166,9 @@ func newSampleAggregator(
 		s.invSr[col] = &sr
 		s.invSketch[col] = &sketchInfo{
 			spec:     spec.InvertedSketches[i],
+			sketch:   hyperloglog.New14(),
 			numNulls: 0,
 			numRows:  0,
-		}
-		if useNewHLL {
-			s.invSketch[col].sketchNew = hllNew.New14()
-		} else {
-			s.invSketch[col].sketchOld = hllOld.New14()
 		}
 	}
 
@@ -372,6 +361,8 @@ func (s *sampleAggregator) mainLoop(
 func (s *sampleAggregator) processSketchRow(
 	sketch *sketchInfo, row rowenc.EncDatumRow, da *tree.DatumAlloc,
 ) error {
+	var tmpSketch hyperloglog.Sketch
+
 	numRows, err := row[s.numRowsCol].GetInt()
 	if err != nil {
 		return err
@@ -398,22 +389,11 @@ func (s *sampleAggregator) processSketchRow(
 	if d == tree.DNull {
 		return errors.AssertionFailedf("NULL sketch data")
 	}
-	if sketch.sketchNew != nil {
-		var tmpSketch hllNew.Sketch
-		if err := tmpSketch.UnmarshalBinary([]byte(*d.(*tree.DBytes))); err != nil {
-			return err
-		}
-		if err := sketch.sketchNew.Merge(&tmpSketch); err != nil {
-			return errors.NewAssertionErrorWithWrappedErrf(err, "merging sketch data")
-		}
-	} else {
-		var tmpSketch hllOld.Sketch
-		if err := tmpSketch.UnmarshalBinary([]byte(*d.(*tree.DBytes))); err != nil {
-			return err
-		}
-		if err := sketch.sketchOld.Merge(&tmpSketch); err != nil {
-			return errors.NewAssertionErrorWithWrappedErrf(err, "merging sketch data")
-		}
+	if err := tmpSketch.UnmarshalBinary([]byte(*d.(*tree.DBytes))); err != nil {
+		return err
+	}
+	if err := sketch.sketch.Merge(&tmpSketch); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "merging sketch data")
 	}
 	return nil
 }
@@ -631,12 +611,7 @@ func (s *sampleAggregator) getAvgSize(si *sketchInfo) int64 {
 // getDistinctCount returns the number of distinct values in the given sketch,
 // optionally including null values.
 func (s *sampleAggregator) getDistinctCount(si *sketchInfo, includeNulls bool) int64 {
-	var distinctCount int64
-	if si.sketchNew != nil {
-		distinctCount = int64(si.sketchNew.Estimate())
-	} else {
-		distinctCount = int64(si.sketchOld.Estimate())
-	}
+	distinctCount := int64(si.sketch.Estimate())
 	if si.numNulls > 0 && !includeNulls {
 		// Nulls are included in the estimate, so reduce the count by 1 if nulls are
 		// not requested.


### PR DESCRIPTION
This was only needed for compatibility with 24.3 nodes to ensure that table stats collection worked in mixed-version state. We no longer need compatibility with that version. Additionally remove no longer used sketch type field from the processor spec.

We've bumped the min version as well as removed mixed-version 24.3 logic test config, so this should now be safe.

Epic: None
Release note: None