### PR TITLE
vecindex: fix bugs and clean up

### DIFF
--- a/pkg/sql/vecindex/cspann/commontest/utils.go
+++ b/pkg/sql/vecindex/cspann/commontest/utils.go
@@ -72,7 +72,7 @@ func ValidatePartitionsEqual(t *testing.T, l, r *cspann.Partition) {
 	require.Equal(t, l.Level(), r.Level(), "levels do not match")
 	require.Equal(t, l.ChildKeys(), r.ChildKeys(), "childKeys do not match")
 	require.Equal(t, l.ValueBytes(), r.ValueBytes(), "valueBytes do not match")
-	require.Equal(t, q1.GetCentroid(), q2.GetCentroid(), "centroids do not match")
+	require.Equal(t, l.Centroid, r.Centroid, "centroids do not match")
 	require.Equal(t, q1.GetCount(), q2.GetCount(), "counts do not match")
 	if eq, ok := q1.(equaler); ok {
 		require.True(t, eq.Equal(q2))

--- a/pkg/sql/vecindex/cspann/memstore/memstore.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore.go
@@ -695,9 +695,11 @@ func Load(data []byte) (*Store, error) {
 
 		var quantizer quantize.Quantizer
 		var quantizedSet quantize.QuantizedVectorSet
+		var centroid vector.T
 		if partitionProto.RaBitQ != nil {
 			quantizer = raBitQuantizer
 			quantizedSet = partitionProto.RaBitQ
+			centroid = partitionProto.RaBitQ.Centroid
 		} else {
 			quantizer = unquantizer
 			quantizedSet = partitionProto.UnQuantized
@@ -705,7 +707,7 @@ func Load(data []byte) (*Store, error) {
 
 		metadata := cspann.PartitionMetadata{
 			Level:    partitionProto.Metadata.Level,
-			Centroid: quantizedSet.GetCentroid(),
+			Centroid: centroid,
 			StateDetails: cspann.PartitionStateDetails{
 				State:   partitionProto.Metadata.State,
 				Target1: partitionProto.Metadata.Target1,

--- a/pkg/sql/vecindex/cspann/memstore/memstore_test.go
+++ b/pkg/sql/vecindex/cspann/memstore/memstore_test.go
@@ -253,7 +253,6 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 		cspann.MakeReadyPartitionMetadata(1, centroid),
 		unquantizer,
 		&quantize.UnQuantizedVectorSet{
-			Centroid: centroid,
 			Vectors: vector.Set{
 				Dims:  2,
 				Count: 3,
@@ -270,7 +269,6 @@ func TestInMemoryStoreMarshalling(t *testing.T) {
 		cspann.MakeReadyPartitionMetadata(2, centroid),
 		raBitQuantizer,
 		&quantize.UnQuantizedVectorSet{
-			Centroid: centroid,
 			Vectors: vector.Set{
 				Dims:  2,
 				Count: 3,

--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -127,7 +127,7 @@ func (p *Partition) QuantizedSet() quantize.QuantizedVectorSet {
 // Centroid is the full-sized centroid vector for this partition.
 // NOTE: The centroid is immutable and therefore this method is thread-safe.
 func (p *Partition) Centroid() vector.T {
-	return p.quantizedSet.GetCentroid()
+	return p.metadata.Centroid
 }
 
 // ChildKeys point to the location of the full-size vectors that are quantized
@@ -271,7 +271,7 @@ func (p *Partition) Find(childKey ChildKey) int {
 // vectors that were cleared. The centroid stays the same.
 func (p *Partition) Clear() int {
 	count := len(p.childKeys)
-	p.quantizedSet.Clear(p.quantizedSet.GetCentroid())
+	p.quantizedSet.Clear(p.metadata.Centroid)
 	clear(p.childKeys)
 	p.childKeys = p.childKeys[:0]
 	clear(p.valueBytes)

--- a/pkg/sql/vecindex/cspann/partition_test.go
+++ b/pkg/sql/vecindex/cspann/partition_test.go
@@ -55,7 +55,7 @@ func TestPartition(t *testing.T) {
 		quantizedSet := quantizer.Quantize(&workspace, vectors)
 		childKeys := []ChildKey{childKey10, childKey20, childKey30}
 		valueBytes := []ValueBytes{valueBytes10, valueBytes20, valueBytes30}
-		metadata := MakeReadyPartitionMetadata(1, quantizedSet.GetCentroid())
+		metadata := MakeReadyPartitionMetadata(1, vectors.Centroid(make(vector.T, vectors.Dims)))
 		return NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
 	}
 

--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -64,15 +64,6 @@ message RaBitQuantizedVectorSet {
 message UnQuantizedVectorSet {
   option (gogoproto.equal) = true;
 
-  // Centroid is the average of vectors in the set, representing its "center of
-  // mass". Note that the centroid is computed when a vector set is created and
-  // is not updated when vectors are added or removed.
-  // NOTE: By default, this is the mean centroid for the L2Squared distance
-  // metric, but is the spherical centroid for InnerProduct and Cosine metrics.
-  // The spherical centroid is simply the mean centroid, but normalized.
-  // NOTE: The centroid should be treated as immutable.
-  repeated float centroid = 1;
-  reserved 2; // CentroidDistances
   // Vectors is the set of original full-size vectors.
-  cockroach.util.vector.Set vectors = 3 [(gogoproto.nullable) = false];
+  cockroach.util.vector.Set vectors = 1 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/vecindex/cspann/quantize/quantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer.go
@@ -70,16 +70,6 @@ type QuantizedVectorSet interface {
 	// GetCount returns the number of quantized vectors in the set.
 	GetCount() int
 
-	// GetCentroid returns the full-size centroid vector for the set. The
-	// centroid is the average of the vectors across all dimensions.
-	// NOTE: By default, this is the mean centroid for the L2Squared distance
-	// metric, but is the spherical centroid for InnerProduct and Cosine metrics.
-	// The spherical centroid is simply the mean centroid, but normalized.
-	// NOTE: This centroid is calculated once, when the set is first created. It
-	// is not updated when quantized vectors are added to or removed from the set.
-	// Since it is immutable, this method is thread-safe.
-	GetCentroid() vector.T
-
 	// ReplaceWithLast removes the quantized vector at the given offset from the
 	// set, replacing it with the last quantized vector in the set. The modified
 	// set has one less element and the last quantized vector's position changes.

--- a/pkg/sql/vecindex/cspann/quantize/rabitq.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq.go
@@ -390,8 +390,9 @@ func (q *RaBitQuantizer) quantizeHelper(
 
 	// L2Squared doesn't use this, so don't store it.
 	if q.distanceMetric != vecdist.L2Squared {
+		centroidDotProducts := qs.CentroidDotProducts[oldCount:]
 		for i := range count {
-			qs.CentroidDotProducts[i] = num32.Dot(vectors.At(i), qs.Centroid)
+			centroidDotProducts[i] = num32.Dot(vectors.At(i), qs.Centroid)
 		}
 	}
 

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
@@ -114,11 +114,6 @@ func (vs *RaBitQuantizedVectorSet) GetCount() int {
 	return len(vs.CodeCounts)
 }
 
-// GetCentroid implements the QuantizedVectorSet interface.
-func (vs *RaBitQuantizedVectorSet) GetCentroid() vector.T {
-	return vs.Centroid
-}
-
 // ReplaceWithLast implements the QuantizedVectorSet interface.
 func (vs *RaBitQuantizedVectorSet) ReplaceWithLast(offset int) {
 	lastOffset := len(vs.CodeCounts) - 1

--- a/pkg/sql/vecindex/cspann/quantize/unquantizedpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizedpb.go
@@ -12,23 +12,15 @@ func (vs *UnQuantizedVectorSet) GetCount() int {
 	return vs.Vectors.Count
 }
 
-// GetCentroid implements the QuantizedVectorSet interface.
-func (vs *UnQuantizedVectorSet) GetCentroid() vector.T {
-	return vs.Centroid
-}
-
 // Clone implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) Clone() QuantizedVectorSet {
 	return &UnQuantizedVectorSet{
-		Centroid: vs.Centroid, // Centroid is immutable
-		Vectors:  vs.Vectors.Clone(),
+		Vectors: vs.Vectors.Clone(),
 	}
 }
 
 // Clear implements the QuantizedVectorSet interface.
 func (vs *UnQuantizedVectorSet) Clear(centroid vector.T) {
-	// vs.Centroid is immutable, so do not try to reuse its memory.
-	vs.Centroid = centroid
 	vs.Vectors.Clear()
 }
 

--- a/pkg/sql/vecindex/cspann/quantize/unquantizedpb_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizedpb_test.go
@@ -16,13 +16,11 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	quantizedSet := UnQuantizedVectorSet{
 		Vectors: vector.MakeSet(2),
 	}
-	quantizedSet.Centroid = []float32{4, 2}
 
 	// Add vectors.
 	vectors := vector.MakeSetFromRawData([]float32{1, 2, 3, 4, 5, 6}, 2)
 	quantizedSet.AddSet(vectors)
 	require.Equal(t, 3, quantizedSet.GetCount())
-	require.Equal(t, vector.T{4, 2}, quantizedSet.GetCentroid())
 
 	vectors = vector.MakeSetFromRawData([]float32{7, 8, 9, 10}, 2)
 	quantizedSet.AddSet(vectors)
@@ -38,6 +36,5 @@ func TestUnQuantizedVectorSet(t *testing.T) {
 	require.Equal(t, 4, quantizedSet.GetCount())
 
 	// Check that clone is unaffected.
-	require.Equal(t, []float32{4, 2}, cloned.Centroid)
 	require.Equal(t, vector.Set{Dims: 2, Count: 4, Data: []float32{0, 0, 9, 10, 5, 6, 7, 8}}, cloned.Vectors)
 }

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer.go
@@ -49,18 +49,9 @@ func (q *UnQuantizer) Quantize(w *workspace.T, vectors vector.Set) QuantizedVect
 	}
 
 	unquantizedSet := &UnQuantizedVectorSet{
-		Centroid: make(vector.T, q.dims),
-		Vectors:  vector.MakeSet(q.dims),
+		Vectors: vector.MakeSet(q.dims),
 	}
-	if vectors.Count != 0 {
-		unquantizedSet.AddSet(vectors)
-		vectors.Centroid(unquantizedSet.Centroid)
-		if q.distanceMetric == vecdist.InnerProduct || q.distanceMetric == vecdist.Cosine {
-			// Use spherical centroid for inner product and cosine distances,
-			// which is the mean centroid, but normalized.
-			num32.Normalize(unquantizedSet.Centroid)
-		}
-	}
+	unquantizedSet.AddSet(vectors)
 	return unquantizedSet
 }
 
@@ -84,8 +75,7 @@ func (q *UnQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) Qua
 
 	dataBuffer := make([]float32, 0, capacity*q.GetDims())
 	unquantizedSet := &UnQuantizedVectorSet{
-		Centroid: centroid,
-		Vectors:  vector.MakeSetFromRawData(dataBuffer, q.GetDims()),
+		Vectors: vector.MakeSetFromRawData(dataBuffer, q.GetDims()),
 	}
 	return unquantizedSet
 }

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer_test.go
@@ -8,7 +8,6 @@ package quantize
 import (
 	"testing"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/testutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/vecdist"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/workspace"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
@@ -24,12 +23,11 @@ func TestUnQuantizerSimple(t *testing.T) {
 	// Quantize empty set.
 	vectors := vector.MakeSet(2)
 	quantizedSet := quantizer.Quantize(&workspace, vectors)
-	require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
+	require.Equal(t, 0, quantizedSet.GetCount())
 
 	// Add 3 vectors and verify centroid and centroid distances.
 	vectors = vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
 	quantizedSet = quantizer.Quantize(&workspace, vectors)
-	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
 
 	// Add 2 more vectors to existing set.
 	vectors = vector.MakeSetFromRawData([]float32{4, 3, 6, 5}, 2)
@@ -43,7 +41,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 		&workspace, quantizedSet, vector.T{1, 1}, distances, errorBounds)
 	require.Equal(t, []float32{17, 1, 41, 13, 41}, distances)
 	require.Equal(t, []float32{0, 0, 0, 0, 0}, errorBounds)
-	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
 
 	// Query vector is centroid.
 	quantizer.EstimateDistances(
@@ -67,7 +64,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 	quantizedSet.ReplaceWithLast(0)
 	quantizedSet.ReplaceWithLast(0)
 	require.Equal(t, 0, quantizedSet.GetCount())
-	require.Equal(t, vector.T{4, 3}, quantizedSet.GetCentroid())
 	distances = distances[:0]
 	errorBounds = errorBounds[:0]
 	quantizer.EstimateDistances(
@@ -76,7 +72,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 	// Empty quantized set.
 	vectors = vector.MakeSet(2)
 	quantizedSet = quantizer.Quantize(&workspace, vectors)
-	require.Equal(t, vector.T{0, 0}, quantizedSet.GetCentroid())
 
 	// Add single vector to quantized set.
 	vectors = vector.T{4, 4}.AsSet()
@@ -93,7 +88,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 	quantizer = NewUnQuantizer(2, vecdist.InnerProduct)
 	vectors = vector.MakeSetFromRawData([]float32{5, 2, 1, 2, 6, 5}, 2)
 	quantizedSet = quantizer.Quantize(&workspace, vectors)
-	require.Equal(t, vector.T{0.8, 0.6}, quantizedSet.GetCentroid())
 
 	distances = distances[:3]
 	errorBounds = errorBounds[:3]
@@ -106,7 +100,6 @@ func TestUnQuantizerSimple(t *testing.T) {
 	quantizer = NewUnQuantizer(2, vecdist.Cosine)
 	vectors = vector.MakeSetFromRawData([]float32{-1, 0, 0, 1, 0.70710678, 0.70710678}, 2)
 	quantizedSet = quantizer.Quantize(&workspace, vectors)
-	require.Equal(t, []float32{-0.1691, 0.9856}, testutils.RoundFloats(quantizedSet.GetCentroid(), 4))
 
 	distances = distances[:3]
 	errorBounds = errorBounds[:3]

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -74,7 +74,7 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 					}
 					metadata := cspann.PartitionMetadata{
 						Level:    level,
-						Centroid: quantizedSet.GetCentroid(),
+						Centroid: set.Centroid(make(vector.T, set.Dims)),
 					}
 					metadata.StateDetails.MakeSplitting(10, 20)
 					originalPartition := cspann.NewPartition(metadata, quantizer, quantizedSet, childKeys, valueBytes)
@@ -146,7 +146,7 @@ func testingAssertPartitionsEqual(t *testing.T, l, r *cspann.Partition) {
 	require.Equal(t, l.ChildKeys(), r.ChildKeys(), "childKeys do not match")
 	require.Equal(t, l.ValueBytes(), r.ValueBytes(), "valueBytes do not match")
 	q1, q2 := l.QuantizedSet(), r.QuantizedSet()
-	require.Equal(t, q1.GetCentroid(), q2.GetCentroid(), "centroids do not match")
+	require.Equal(t, l.Centroid(), r.Centroid(), "centroids do not match")
 	require.Equal(t, q1.GetCount(), q2.GetCount(), "counts do not match")
 	switch leftSet := q1.(type) {
 	case *quantize.UnQuantizedVectorSet:


### PR DESCRIPTION
#### quantize: fix calculation when vectors are added incrementally

The quantization code is mis-calculating the centroid dot product when
vectors are added incrementally to a quantized set that uses a non-Euclidean
distance metric. Rather than appending the dot products to the end of the
CentroidDotProducts slice, it was overwriting the initial elements of the
slice. Fix the bug and add more tests that ensure it won't happen again.

#### kmeans: fix small issue with convergence calculation

Update the convergence calculation to match the logic in scikit-learn, which
sums the shifts across all centroids before comparing to the tolerance value.
Also improve comments and add an interesting test case.

#### quantize: remove the QuantizedVectorSet.GetCentroid method

Remove GetCentroid method from the QuantizedVectorSet interface. Having
it present on the interface forces every quantizer to store it, even
those (like UnQuantizer) that don't need it. It's also redundant in most
contexts with Partition.Centroid(), so it's cleaner to have code use
that consistently.