### PR TITLE
release-25.2.1-rc: sql: improve IMPORTs and index backfills on very large clusters

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -30,7 +30,6 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/importer",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/base",
         "//pkg/cloud",
         "//pkg/clusterversion",
         "//pkg/col/coldata",

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -100,6 +100,14 @@ var processorsPerNode = settings.RegisterIntSetting(
 	settings.PositiveInt,
 )
 
+var initialSplitsPerProcessor = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"bulkio.import.initial_splits_per_processor",
+	"number of initial splits each import processor with enough data will create",
+	3,
+	settings.NonNegativeInt,
+)
+
 var performConstraintValidation = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"bulkio.import.constraint_validation.unsafe.enabled",
@@ -306,9 +314,12 @@ func (r *importResumer) Resume(ctx context.Context, execCtx interface{}) error {
 	}
 
 	procsPerNode := int(processorsPerNode.Get(&p.ExecCfg().Settings.SV))
+	initialSplitsPerProc := int(initialSplitsPerProcessor.Get(&p.ExecCfg().Settings.SV))
 
-	res, err := ingestWithRetry(ctx, p, r.job, tables, typeDescs, files, format, details.Walltime,
-		r.testingKnobs, procsPerNode)
+	res, err := ingestWithRetry(
+		ctx, p, r.job, tables, typeDescs, files, format, details.Walltime,
+		r.testingKnobs, procsPerNode, initialSplitsPerProc,
+	)
 	if err != nil {
 		return err
 	}
@@ -1287,6 +1298,7 @@ func ingestWithRetry(
 	walltime int64,
 	testingKnobs importTestingKnobs,
 	procsPerNode int,
+	initialSplitsPerProc int,
 ) (kvpb.BulkOpSummary, error) {
 	ctx, sp := tracing.ChildSpan(ctx, "importer.ingestWithRetry")
 	defer sp.Finish()
@@ -1308,7 +1320,7 @@ func ingestWithRetry(
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		for {
 			res, err = distImport(
-				ctx, execCtx, job, tables, typeDescs, from, format, walltime, testingKnobs, procsPerNode,
+				ctx, execCtx, job, tables, typeDescs, from, format, walltime, testingKnobs, procsPerNode, initialSplitsPerProc,
 			)
 			// If we got a re-planning error, then do at least one more attempt
 			// regardless of the retry duration.


### PR DESCRIPTION
Backport 1/1 commits from #146980 on behalf of @yuzefovich.

----

This commit fixes an oversight of the behavior introduced in
c9ca8bdc4037e63f82a3181a2dbb9e0cf09aef5c as it pertains to very large
(200+ node) clusters. In particular, in that change we introduced the logic to
create initial splits via the BulkAdder when it is flushed due to
reaching the maximum size (128MiB for IMPORT into PKs, and 512MiB for IMPORT
into secondary indexes as well as index backfills). The rationale for
having _some_ initial splits is sound; however, in that change we made
it so that _each processor_ can create N initial split points where N is
the number of nodes in the cluster. In other words, a single bulk
operation could result in N^2 number of splits, which could overwhelm
the node that happened to be the leaseholder for the initial empty range
for the ingest.

I think the intention was that we would create a total number of splits
that is linearly dependent on the number of nodes in the cluster, so
this commit introduces a couple of cluster settings that control the
multiple for the linear function. I did a few runs of IMPORT of TPCC 50k
and TPCC 100k on 100 node cluster, and it looks like a few numbers in
[2, 16] range behave roughly the same, so I picked 3 as the default
value for both cluster settings. In other words, IMPORTs and index
backfills will now create N x 3 number of initial split points by
default.

An alternative strategy could have been to assign one (or small number)
processor to do some number of splits based on its first SST file.
I decided to not pursue this alternative under the assumption that we'll
get better initial split point distribution if they are created across
all nodes. With just one processor doing the splits, we could over-split
a part of the key space that that particular node happens to write.

I decided to not include a release note given that we expect this to
have noticeable impact only on 200+ node clusters.

Fixes: #143076.

Release note: None

----

Release justification: bug fix.