### PR TITLE
release-24.3: changefeedccl: fix premature shutdown due to schema change bug

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -849,7 +849,7 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (retu
 		return nil
 	}
 
-	advanced, err := ca.frontier.ForwardResolvedSpan(ca.Ctx(), resolved)
+	advanced, err := ca.frontier.ForwardResolvedSpan(resolved)
 	if err != nil {
 		return err
 	}
@@ -1614,7 +1614,7 @@ func (cf *changeFrontier) noteAggregatorProgress(d rowenc.EncDatum) error {
 }
 
 func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
-	frontierChanged, err := cf.frontier.ForwardResolvedSpan(cf.Ctx(), resolved)
+	frontierChanged, err := cf.frontier.ForwardResolvedSpan(resolved)
 	if err != nil {
 		return err
 	}
@@ -2034,22 +2034,38 @@ func makeSchemaChangeFrontier(
 
 // ForwardResolvedSpan advances the timestamp for a resolved span, taking care
 // of updating schema change boundary information.
+// The frontier is considered forwarded if either the frontier
+// timestamp advances or the current frontier timestamp becomes
+// a boundary timestamp (for some non-NONE boundary type)
+// and all the spans are at the boundary timestamp already.
 func (f *schemaChangeFrontier) ForwardResolvedSpan(
-	ctx context.Context, r jobspb.ResolvedSpan,
-) (bool, error) {
+	r jobspb.ResolvedSpan,
+) (forwarded bool, err error) {
+	forwarded, err = f.Forward(r.Span, r.Timestamp)
+	if err != nil {
+		return false, err
+	}
+	f.latestTs.Forward(r.Timestamp)
 	if r.BoundaryType != jobspb.ResolvedSpan_NONE {
 		// Boundary resolved events should be ingested from the schema feed
 		// serially, where the changefeed won't even observe a new schema change
 		// boundary until it has progressed past the current boundary.
-		if err := f.assertBoundaryNotEarlier(ctx, r); err != nil {
+		if err := f.assertBoundaryNotEarlier(r); err != nil {
 			return false, err
 		}
-		f.boundaryTime = r.Timestamp
-		f.boundaryType = r.BoundaryType
+		if r.Timestamp.After(f.boundaryTime) {
+			// Forward the boundary.
+			f.boundaryTime = r.Timestamp
+			f.boundaryType = r.BoundaryType
+			if !forwarded {
+				// The frontier is considered forwarded if the boundary type
+				// changes to non-NONE and all the spans are at the boundary
+				// timestamp already.
+				forwarded = f.schemaChangeBoundaryReached()
+			}
+		}
 	}
-
-	f.latestTs.Forward(r.Timestamp)
-	return f.Forward(r.Span, r.Timestamp)
+	return forwarded, nil
 }
 
 func (f *schemaChangeFrontier) ForwardLatestKV(ts time.Time) {
@@ -2128,20 +2144,16 @@ func (f *schemaChangeFrontier) InBackfill(r jobspb.ResolvedSpan) bool {
 
 // assertBoundaryNotEarlier is a helper method provided to assert that a
 // resolved span does not have an earlier boundary than the existing one.
-func (f *schemaChangeFrontier) assertBoundaryNotEarlier(
-	ctx context.Context, r jobspb.ResolvedSpan,
-) error {
+func (f *schemaChangeFrontier) assertBoundaryNotEarlier(r jobspb.ResolvedSpan) error {
 	boundaryType := r.BoundaryType
 	if boundaryType == jobspb.ResolvedSpan_NONE {
 		return errors.AssertionFailedf("assertBoundaryNotEarlier should not be called for NONE boundary")
 	}
 	boundaryTS := r.Timestamp
 	if f.boundaryTime.After(boundaryTS) {
-		err := errors.AssertionFailedf("received resolved span for %s "+
+		return errors.AssertionFailedf("received resolved span for %s "+
 			"with %v boundary (%v), which is earlier than previously received %v boundary (%v)",
 			r.Span, r.BoundaryType, r.Timestamp, f.boundaryType, f.boundaryTime)
-		log.Errorf(ctx, "error while forwarding boundary resolved span: %v", err)
-		return err
 	}
 	return nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -838,6 +838,10 @@ func (ca *changeAggregator) flushBufferedEvents() error {
 // changeAggregator node to the changeFrontier node to allow the changeFrontier
 // to persist the overall changefeed's progress
 func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (returnErr error) {
+	if log.V(2) {
+		log.Infof(ca.Ctx(), "resolved span from kv feed: %#v", resolved)
+	}
+
 	if resolved.Timestamp.IsEmpty() {
 		// @0.0 resolved timestamps could come in from rangefeed checkpoint.
 		// When rangefeed starts running, it emits @0.0 resolved timestamp.
@@ -933,6 +937,9 @@ func (ca *changeAggregator) emitResolved(batch jobspb.ResolvedSpans) error {
 		Stats: jobspb.ResolvedSpans_Stats{
 			RecentKvCount: ca.recentKVCount,
 		},
+	}
+	if log.V(2) {
+		log.Infof(ca.Ctx(), "progress update to be sent to change frontier: %#v", progressUpdate)
 	}
 	updateBytes, err := protoutil.Marshal(&progressUpdate)
 	if err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_processors_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors_test.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rangefeed"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
@@ -228,4 +229,74 @@ func TestGetCheckpointSpans(t *testing.T) {
 		catchup, len(cpSpans), numSpans, catchupFromCheckpoint, catchupFromHWM,
 		100*(1-float64(catchupFromCheckpoint.Nanoseconds())/float64(catchupFromHWM.Nanoseconds())))
 	require.Less(t, catchupFromCheckpoint, catchupFromHWM)
+}
+
+func makeTS(wt int64) hlc.Timestamp {
+	return hlc.Timestamp{WallTime: wt}
+}
+
+func makeResolvedSpan(
+	start, end string, ts hlc.Timestamp, boundaryType jobspb.ResolvedSpan_BoundaryType,
+) jobspb.ResolvedSpan {
+	return jobspb.ResolvedSpan{
+		Span:         makeSpan(start, end),
+		Timestamp:    ts,
+		BoundaryType: boundaryType,
+	}
+}
+
+func makeSpan(start, end string) roachpb.Span {
+	return roachpb.Span{
+		Key:    roachpb.Key(start),
+		EndKey: roachpb.Key(end),
+	}
+}
+
+func TestSchemaChangeFrontier_ForwardResolvedSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Create a fresh frontier with no progress.
+	f, err := makeSchemaChangeFrontier(
+		hlc.Timestamp{},
+		makeSpan("a", "f"),
+	)
+	require.NoError(t, err)
+	require.Zero(t, f.Frontier())
+
+	t.Run("advance frontier with no boundary", func(t *testing.T) {
+		// Forwarding part of the span space to 10 should not advance the frontier.
+		forwarded, err := f.ForwardResolvedSpan(
+			makeResolvedSpan("a", "b", makeTS(10), jobspb.ResolvedSpan_NONE))
+		require.NoError(t, err)
+		require.False(t, forwarded)
+		require.Zero(t, f.Frontier())
+
+		// Forwarding the rest of the span space to 10 should advance the frontier.
+		forwarded, err = f.ForwardResolvedSpan(
+			makeResolvedSpan("b", "f", makeTS(10), jobspb.ResolvedSpan_NONE))
+		require.NoError(t, err)
+		require.True(t, forwarded)
+		require.Equal(t, makeTS(10), f.Frontier())
+	})
+
+	t.Run("advance frontier with same timestamp and new boundary", func(t *testing.T) {
+		// Forwarding part of the span space to 10 again with a non-NONE boundary
+		// should be considered forwarding the frontier because we're learning
+		// about a new boundary.
+		forwarded, err := f.ForwardResolvedSpan(
+			makeResolvedSpan("c", "f", makeTS(10), jobspb.ResolvedSpan_RESTART))
+		require.NoError(t, err)
+		require.True(t, forwarded)
+		require.Equal(t, makeTS(10), f.Frontier())
+
+		// Forwarding the rest of the span space to 10 again with a non-NONE boundary
+		// should not be considered forwarding the frontier because we already
+		// know about the new boundary.
+		forwarded, err = f.ForwardResolvedSpan(
+			makeResolvedSpan("a", "c", makeTS(10), jobspb.ResolvedSpan_RESTART))
+		require.NoError(t, err)
+		require.False(t, forwarded)
+		require.Equal(t, makeTS(10), f.Frontier())
+	})
 }


### PR DESCRIPTION
Backport 3/3 commits from #144004.

/cc @cockroachdb/release

---

Fixes #144108

Test failures on master:
Fixes #143976
Fixes #144045
Fixes #144219

Test failures on release branches (won't be fixed until PR is backported):
Informs #144287
Informs #144291
Informs #144352

---

**changefeedccl: add more verbose logging around schema changes**

This patch adds more verbose logging to the change aggregator around
receiving and emitting resolved spans to help debug recurring changefeed
schema change test flakes.

Release note: None

---

**changefeedccl: fix premature shutdown due to schema change bug**

This patch fixes a bug that could potentially cause a changefeed
to erroneously complete when one of its watched tables encounters a
schema change has been fixed.

The root cause for the bug was that if we happened to get a rangefeed
checkpoint at precisely `ts.Prev()` for some schema change timestamp
`ts`, the kv feed would deliver a resolved span with `ts` and a NONE
boundary to the change aggregator, which would advance its frontier;
then when the resolved span with `ts` and a RESTART boundary was
sent to the change aggregator, the frontier would not be advanced and
so would not be flushed to the change frontier. The change frontier
would then read a nil row from the change aggregator and shut the
changefeed down as if it had completed successfully.

This bug has been fixed by modifying the resolved span frontier
forwarding logic to consider forwarding to the current timestamp
but with a non-NONE boundary type to be advancing the frontier.

Two alternative solutions that were ruled out were:
1. Unconditionally flushing the frontier when we get a non-NONE boundary
   instead of only flushing when the frontier is advanced.
     - Problem: We would flush the frontier O(spans) number of times.
2. Making the kv feed not emit resolved events for rangefeed checkpoints
   that are at a schema change boundary.
     - Problem: We wouldn't be able to save the per-span progress at the
       schema change boundary.

Release note (bug fix): A bug that could potentially cause a changefeed
to erroneously complete when one of its watched tables encounters a
schema change has been fixed.

---

**changefeedccl/resolvedspan: update assertion for forwarding boundary** 

This patch adds an assertion that the frontier will not forward the
boundary to a different type at the same time. This assertion is
important because if it's violated, the changefeed processors will not
shut down correctly during a schema change. One potential way this
could be violated in the future is a change to how boundary types are
determined on aggregators causing different boundaries to be sent from
aggregators in a mixed-version cluster for the same schema change.

Release note: None

---

Release justification: low-risk bug fix for high-priority bug