### PR TITLE
bench/tpcc: fix, refactor and add literal implementation

### DIFF
--- a/pkg/bench/tpcc/BUILD.bazel
+++ b/pkg/bench/tpcc/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "//pkg/util/syncutil",
         "//pkg/workload",
         "//pkg/workload/histogram",
         "//pkg/workload/tpcc",

--- a/pkg/bench/tpcc/subprocess_commands_test.go
+++ b/pkg/bench/tpcc/subprocess_commands_test.go
@@ -17,7 +17,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
-	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/histogram"
 	"github.com/cockroachdb/cockroach/pkg/workload/workloadsql"
@@ -55,7 +54,6 @@ var (
 		storeDir, ok := envutil.EnvString(storeDirEnvVar, 0)
 		require.True(t, ok)
 
-		defer log.Scope(t).Close(t)
 		srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
 			StoreSpecs: []base.StoreSpec{{Path: storeDir}},
 		})

--- a/pkg/bench/tpcc/subprocess_commands_test.go
+++ b/pkg/bench/tpcc/subprocess_commands_test.go
@@ -43,9 +43,9 @@ var (
 	benchmarkN        = envutil.EnvOrDefaultInt(nEnvVar, -1)
 	allowInternalTest = envutil.EnvOrDefaultBool(allowInternalTestEnvVar, false)
 
-	cloneEngine      = newCmd("TestInternalCloneEngine", TestInternalCloneEngine)
-	runClient        = newCmd("TestInternalRunClient", TestInternalRunClient)
-	generateStoreDir = newCmd("TestInternalGenerateStoreDir", TestInternalGenerateStoreDir)
+	cloneEngine      = makeCmd("TestInternalCloneEngine", TestInternalCloneEngine)
+	runClient        = makeCmd("TestInternalRunClient", TestInternalRunClient)
+	generateStoreDir = makeCmd("TestInternalGenerateStoreDir", TestInternalGenerateStoreDir)
 )
 
 func TestInternalCloneEngine(t *testing.T) {

--- a/pkg/bench/tpcc/subprocess_utils_test.go
+++ b/pkg/bench/tpcc/subprocess_utils_test.go
@@ -6,6 +6,7 @@
 package tpcc
 
 import (
+	"bytes"
 	"fmt"
 	"os"
 	"os/exec"
@@ -22,7 +23,7 @@ type cmd struct {
 	impl func(t *testing.T)
 }
 
-func (c *cmd) exec(env cmdEnv, args ...string) *exec.Cmd {
+func (c *cmd) exec(env cmdEnv, args ...string) (_ *exec.Cmd, stdout *bytes.Buffer) {
 	cmd := exec.Command(os.Args[0],
 		"--test.run=^TestInternal"+c.name+"$",
 		"--test.v")
@@ -33,7 +34,9 @@ func (c *cmd) exec(env cmdEnv, args ...string) *exec.Cmd {
 	cmd.Env = os.Environ()
 	cmd.Env = append(cmd.Env, fmt.Sprintf("%s=t", internalTestEnvVar))
 	cmd.Env = append(cmd.Env, env.toStrings()...)
-	return cmd
+	var buf bytes.Buffer
+	cmd.Stdout = &buf
+	return cmd, &buf
 }
 
 var isInternalTest = envutil.EnvOrDefaultBool(internalTestEnvVar, false)

--- a/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
@@ -45,9 +45,9 @@ func maybeGenerateStoreDir(b testing.TB) (_ vfs.FS, storeDir string, cleanup fun
 		}()
 	}
 
-	cmd, stdout := generateStoreDir.withEnv(storeDirEnvVar, storeDir).exec()
+	cmd, output := generateStoreDir.withEnv(storeDirEnvVar, storeDir).exec()
 	if err := cmd.Run(); err != nil {
-		b.Fatalf("failed to generate store dir: %s\n%s", err, stdout.String())
+		b.Fatalf("failed to generate store dir: %s\n%s", err, output.String())
 	}
 	return vfs.Default, storeDir, cleanup
 }

--- a/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
@@ -45,8 +45,11 @@ func maybeGenerateStoreDir(b testing.TB) (_ vfs.FS, storeDir string, cleanup fun
 		}()
 	}
 
-	require.NoError(b, generateStoreDir.exec(cmdEnv{
+	cmd, stdout := generateStoreDir.exec(cmdEnv{
 		{storeDirEnvVar, storeDir},
-	}).Run())
+	})
+	if err := cmd.Run(); err != nil {
+		b.Fatalf("failed to generate store dir: %s\n%s", err, stdout.String())
+	}
 	return vfs.Default, storeDir, cleanup
 }

--- a/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_generate_data_test.go
@@ -45,9 +45,7 @@ func maybeGenerateStoreDir(b testing.TB) (_ vfs.FS, storeDir string, cleanup fun
 		}()
 	}
 
-	cmd, stdout := generateStoreDir.exec(cmdEnv{
-		{storeDirEnvVar, storeDir},
-	})
+	cmd, stdout := generateStoreDir.withEnv(storeDirEnvVar, storeDir).exec()
 	if err := cmd.Run(); err != nil {
 		b.Fatalf("failed to generate store dir: %s\n%s", err, stdout.String())
 	}

--- a/pkg/bench/tpcc/tpcc_bench_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_test.go
@@ -64,12 +64,12 @@ func BenchmarkTPCC(b *testing.B) {
 			b testing.TB,
 		) (_ base.TestServerArgs, cleanup func()) {
 			td, cleanup := testutils.TempDir(b)
-			cmd, stdout := cloneEngine.
+			cmd, output := cloneEngine.
 				withEnv(srcEngineEnvVar, engPath).
 				withEnv(dstEngineEnvVar, td).
 				exec()
 			if err := cmd.Run(); err != nil {
-				b.Fatalf("failed to clone engine: %s\n%s", err, stdout.String())
+				b.Fatalf("failed to clone engine: %s\n%s", err, output.String())
 			}
 			return base.TestServerArgs{
 				StoreSpecs: []base.StoreSpec{{Path: td}},
@@ -170,12 +170,12 @@ func (bm *benchmark) startCockroach(b testing.TB) {
 }
 
 func (bm *benchmark) startClient(b *testing.B) (pid int, wait func() error) {
-	cmd, stdout := runClient.
+	cmd, output := runClient.
 		withEnv(nEnvVar, b.N).
 		withEnv(pgurlEnvVar, bm.pgURL).
 		exec(bm.workloadFlags...)
 	if err := cmd.Start(); err != nil {
-		b.Fatalf("failed to start client: %s\n%s", err, stdout.String())
+		b.Fatalf("failed to start client: %s\n%s", err, output.String())
 	}
 	bm.closers = append(bm.closers,
 		func() { _ = cmd.Process.Kill(); _ = cmd.Wait() },

--- a/pkg/bench/tpcc/tpcc_bench_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_test.go
@@ -55,6 +55,7 @@ import (
 // loader.
 func BenchmarkTPCC(b *testing.B) {
 	defer leaktest.AfterTest(b)()
+	defer log.Scope(b).Close(b)
 
 	_, engPath, cleanup := maybeGenerateStoreDir(b)
 	defer cleanup()
@@ -88,7 +89,6 @@ func BenchmarkTPCC(b *testing.B) {
 		{workloadFlag("mix", "newOrder=10,payment=10,orderStatus=1,delivery=1,stockLevel=1")},
 	} {
 		b.Run(opts.String(), func(b *testing.B) {
-			defer log.Scope(b).Close(b)
 			newBenchmark(append(opts, baseOptions...)).run(b)
 		})
 	}
@@ -110,6 +110,7 @@ func newBenchmark(opts ...options) *benchmark {
 
 func (bm *benchmark) run(b *testing.B) {
 	defer bm.close()
+
 	bm.startCockroach(b)
 	pid, wait := bm.startClient(b)
 

--- a/pkg/bench/tpcc/tpcc_bench_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_test.go
@@ -43,6 +43,14 @@ import (
 // with --store-dir will generate a new store directory at the specified path.
 // The combination of the two flags is how you bootstrap such a path initially.
 //
+// For example, generate the store directory with:
+//
+//	./dev bench pkg/bench/tpcc -f BenchmarkTPCC --test-args '--generate-store-dir --store-dir=/tmp/benchtpcc'
+//
+// Reuse the store directory with:
+//
+//	./dev bench pkg/bench/tpcc -f BenchmarkTPCC --test-args '--store-dir=/tmp/benchtpcc'
+//
 // TODO(ajwerner): Consider moving this all to CCL to leverage the import data
 // loader.
 func BenchmarkTPCC(b *testing.B) {

--- a/pkg/bench/tpcc/tpcc_bench_test.go
+++ b/pkg/bench/tpcc/tpcc_bench_test.go
@@ -64,10 +64,10 @@ func BenchmarkTPCC(b *testing.B) {
 			b testing.TB,
 		) (_ base.TestServerArgs, cleanup func()) {
 			td, cleanup := testutils.TempDir(b)
-			cmd, stdout := cloneEngine.exec(cmdEnv{
-				{srcEngineEnvVar, engPath},
-				{dstEngineEnvVar, td},
-			})
+			cmd, stdout := cloneEngine.
+				withEnv(srcEngineEnvVar, engPath).
+				withEnv(dstEngineEnvVar, td).
+				exec()
 			if err := cmd.Run(); err != nil {
 				b.Fatalf("failed to clone engine: %s\n%s", err, stdout.String())
 			}
@@ -161,10 +161,10 @@ func (bm *benchmark) startCockroach(b testing.TB) {
 }
 
 func (bm *benchmark) startClient(b *testing.B) (pid int, wait func() error) {
-	cmd, stdout := runClient.exec(cmdEnv{
-		{nEnvVar, b.N},
-		{pgurlEnvVar, bm.pgURL},
-	}, bm.workloadFlags...)
+	cmd, stdout := runClient.
+		withEnv(nEnvVar, b.N).
+		withEnv(pgurlEnvVar, bm.pgURL).
+		exec(bm.workloadFlags...)
 	if err := cmd.Start(); err != nil {
 		b.Fatalf("failed to start client: %s\n%s", err, stdout.String())
 	}

--- a/pkg/workload/workloadsql/dataload.go
+++ b/pkg/workload/workloadsql/dataload.go
@@ -66,6 +66,10 @@ func (l InsertsDataLoader) InitialDataLoad(
 		batchEnd := min(currentTable+maxTableBatchSize, len(tables))
 		nextBatch := tables[currentTable:batchEnd]
 		if err := crdb.ExecuteTx(ctx, db, &gosql.TxOptions{}, func(tx *gosql.Tx) error {
+			// Run the operations in a single txn so they complete more quickly.
+			if _, err := tx.Exec("SET LOCAL autocommit_before_ddl = false"); err != nil {
+				return err
+			}
 			currentDatabase := ""
 			for _, table := range nextBatch {
 				// Switch databases if one is explicitly specified for multi-region


### PR DESCRIPTION
#### bench/tpcc: uses signals instead of HTTP server for synchronization

Signals are now used instead of an HTTP server for synchronization
between the parent process (running the test cluster) and the child
process (running the workload). The two implementations behavior the
same, but signals are simpler.

Release note: None

#### bench/tpcc: print stdout of subprocesses if they fail

Previously, if a subprocess failed the benchmark would only print the
unhelpful message `exit status 1`. Now, the stdout of the subprocess is
also printed to make debugging easier.

Release note: None

#### workload/workloadsql: create tables in a single transaction

In #139871 the default value of `autocommit_before_ddl` became `true`.
This unintentionally made it such that workload `CREATE TABLE`
statements were executed in their own transactions. This commit disables
`autocommit_before_ddl` specifically for this case, similar to what was
done in #140462 for TPCC.

Release note: None

#### bench/tpcc: document example commands to run benchmarks

Release note: None

#### bench/tpcc: correctly suppress logs

This commit removes some noise in the benchmark output.

Release note: None

#### bench/tpcc: simplify internal test implementation

Release note: None

#### bench/tpcc: refactor command execution code

Release note: None

#### bench/tpcc: add benchmarks for TPC-C literal implementation

The literal implementation of the TPC-C workload follows the TPC-C spec
more literally. It performs worse than our hand optimized version:

```
TPCC/literal/mix=newOrder=1    114  9025016 ns/op  1804437 B/op  13002 allocs/op
TPCC/optimized/mix=newOrder=1  189  5907224 ns/op  1873704 B/op  12402 allocs/op
```

Release note: none

#### bench/tpcc: add synchronizedBuffer for subprocess STDOUT and STDERR

Release note: None
