### PR TITLE
kv: break down Internal service

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3695,39 +3695,24 @@ service RangeFeed {
 }
 
 // TODO: add comment
-service Batch {
+service KVBatch {
   rpc Batch(BatchRequest) returns (BatchResponse) {}
-}
-
-// BatchStream provides the specific RPC for the stream pool implementation.
-// It is not intended for direct client consumption.
-//
-// Rationale for this specific service:
-// - Isolates the stream pooling mechanism's specific RPC.
-// - The `BatchStreamPoolClient` (used when stream pooling is enabled)
-//   consumes this service to provide a unary 'Batch' method interface,
-//   abstracting away the streaming complexity.
-//
-// TODO: Remove these methods from the 'Internal' service once the DRPC
-// migration for tenant connector is complete.
-service BatchStream {
-  // BatchStream is a streaming variant of Batch. There is a 1:1 correspondence
-  // between requests and responses. The method is used to facilitate pooling of
-  // gRPC streams to avoid the overhead of creating and discarding a new stream
-  // for each unary Batch RPC invocation. See rpc.BatchStreamPool.
   rpc BatchStream(stream BatchRequest) returns (stream BatchResponse) {}
 }
 
-// TODO: **do better** job with naming/split here. We can split it further as
-// service TenantSettings and service GossipSubscription.
-//
 // TODO: add comment
-service SystemTenant {
+service TenantService {
   // TenantSettings is used by tenants to obtain and stay up to date with tenant
   // setting overrides.
   rpc TenantSettings(TenantSettingsRequest) returns (stream TenantSettingsEvent) {}
 
   rpc GossipSubscription(GossipSubscriptionRequest) returns (stream GossipSubscriptionEvent) {}
+
+  rpc RangeLookup(RangeLookupRequest) returns (RangeLookupResponse) {}
+
+  // GetRangeDescriptors is used by tenants to get range descriptors for their
+  // own ranges.
+  rpc GetRangeDescriptors(GetRangeDescriptorsRequest) returns (stream GetRangeDescriptorsResponse) {}
 }
 
 // TODO: add comment
@@ -3738,23 +3723,14 @@ service TenantUsage {
 }
 
 // TODO: add comment
-service Node {
+service Cluster {
   // Join a bootstrapped cluster. If the target node is itself not part of a
   // bootstrapped cluster, an appropriate error is returned.
   rpc Join (JoinNodeRequest) returns (JoinNodeResponse) {}
 }
 
 // TODO: add comment
-service Range {
-  rpc RangeLookup(RangeLookupRequest) returns (RangeLookupResponse) {}
-
-  // GetRangeDescriptors is used by tenants to get range descriptors for their
-  // own ranges.
-  rpc GetRangeDescriptors(GetRangeDescriptorsRequest) returns (stream GetRangeDescriptorsResponse) {}
-}
-
-// TODO: add comment
-service SpanConfig {
+service TenantSpanConfig {
   // GetSpanConfigs is used to fetch the span configurations over a given
   // keyspan.
   rpc GetSpanConfigs(GetSpanConfigsRequest) returns (GetSpanConfigsResponse) {}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3689,6 +3689,79 @@ message JoinNodeResponse {
   roachpb.Version active_version = 4;
 }
 
+// DistSender defines a subset of the Internal service RPCs, specifically for
+// DRPC usage within the DistSender subsystem.
+//
+// During the gRPC to DRPC migration:
+// - gRPC clients will continue to use the full 'Internal' service client.
+// - DRPC clients targeting DistSender functionalities will use clients
+//   generated from this 'DistSender' service.
+// - The 'RestrictedInternalClient' interface ensures that components like
+//   DistSender can operate with either the gRPC 'Internal' client or this new
+//   DRPC 'DistSender' client.
+//
+// TODO: Remove these methods from the 'Internal' service once the DRPC
+// migration for DistSender is complete, making this service the sole
+// definition.
+service DistSender {
+  rpc Batch(BatchRequest) returns (BatchResponse) {}
+
+  rpc MuxRangeFeed(stream RangeFeedRequest) returns (stream MuxRangeFeedEvent) {}
+}
+
+// BatchStream provides the specific RPC for the stream pool implementation.
+// It is not intended for direct client consumption.
+//
+// Rationale for this specific service:
+// - Isolates the stream pooling mechanism's specific RPC.
+// - The `BatchStreamPoolClient` (used when stream pooling is enabled)
+//   consumes this service to provide a unary 'Batch' method interface,
+//   abstracting away the streaming complexity.
+//
+// TODO: Remove these methods from the 'Internal' service once the DRPC
+// migration for tenant connector is complete.
+service BatchStream {
+  // BatchStream is a streaming variant of Batch. There is a 1:1 correspondence
+  // between requests and responses. The method is used to facilitate pooling of
+  // gRPC streams to avoid the overhead of creating and discarding a new stream
+  // for each unary Batch RPC invocation. See rpc.BatchStreamPool.
+  rpc BatchStream(stream BatchRequest) returns (stream BatchResponse) {}
+}
+
+// TenantConnector groups RPCs specific to tenant connectors.
+//
+// TODO: Remove these methods from the 'Internal' service once the DRPC
+// migration for tenant connector is complete.
+service TenantConnector {
+  rpc RangeLookup(RangeLookupRequest) returns (RangeLookupResponse) {}
+
+  rpc GossipSubscription(GossipSubscriptionRequest) returns (stream GossipSubscriptionEvent) {}
+
+  // TenantSettings is used by tenants to obtain and stay up to date with tenant
+  // setting overrides.
+  rpc TenantSettings(TenantSettingsRequest) returns (stream TenantSettingsEvent) {}
+
+  // GetSpanConfigs is used to fetch the span configurations over a given
+  // keyspan.
+  rpc GetSpanConfigs(GetSpanConfigsRequest) returns (GetSpanConfigsResponse) {}
+
+  // GetAllSystemSpanConfigsThatApply is used to fetch all system span
+  // configurations that apply over a tenant's ranges.
+  rpc GetAllSystemSpanConfigsThatApply(GetAllSystemSpanConfigsThatApplyRequest) returns (GetAllSystemSpanConfigsThatApplyResponse) {}
+
+  // UpdateSpanConfigs is used to update the span configurations over given
+  // keyspans.
+  rpc UpdateSpanConfigs(UpdateSpanConfigsRequest) returns (UpdateSpanConfigsResponse) {}
+
+  // SpanConfigConformance is used to determine whether ranges backing the given
+  // keyspans conform to span configs that apply over them.
+  rpc SpanConfigConformance(SpanConfigConformanceRequest) returns (SpanConfigConformanceResponse) {}
+
+  // GetRangeDescriptors is used by tenants to get range descriptors for their
+  // own ranges.
+  rpc GetRangeDescriptors(GetRangeDescriptorsRequest) returns (stream GetRangeDescriptorsResponse) {}
+}
+
 // Batch and RangeFeed service implemented by nodes for KV API requests.
 service Internal {
   rpc Batch (BatchRequest) returns (BatchResponse) {}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3689,24 +3689,14 @@ message JoinNodeResponse {
   roachpb.Version active_version = 4;
 }
 
-// DistSender defines a subset of the Internal service RPCs, specifically for
-// DRPC usage within the DistSender subsystem.
-//
-// During the gRPC to DRPC migration:
-// - gRPC clients will continue to use the full 'Internal' service client.
-// - DRPC clients targeting DistSender functionalities will use clients
-//   generated from this 'DistSender' service.
-// - The 'RestrictedInternalClient' interface ensures that components like
-//   DistSender can operate with either the gRPC 'Internal' client or this new
-//   DRPC 'DistSender' client.
-//
-// TODO: Remove these methods from the 'Internal' service once the DRPC
-// migration for DistSender is complete, making this service the sole
-// definition.
-service DistSender {
-  rpc Batch(BatchRequest) returns (BatchResponse) {}
-
+// TODO: add comment
+service RangeFeed {
   rpc MuxRangeFeed(stream RangeFeedRequest) returns (stream MuxRangeFeedEvent) {}
+}
+
+// TODO: add comment
+service Batch {
+  rpc Batch(BatchRequest) returns (BatchResponse) {}
 }
 
 // BatchStream provides the specific RPC for the stream pool implementation.
@@ -3728,19 +3718,43 @@ service BatchStream {
   rpc BatchStream(stream BatchRequest) returns (stream BatchResponse) {}
 }
 
-// TenantConnector groups RPCs specific to tenant connectors.
+// TODO: **do better** job with naming/split here. We can split it further as
+// service TenantSettings and service GossipSubscription.
 //
-// TODO: Remove these methods from the 'Internal' service once the DRPC
-// migration for tenant connector is complete.
-service TenantConnector {
-  rpc RangeLookup(RangeLookupRequest) returns (RangeLookupResponse) {}
-
-  rpc GossipSubscription(GossipSubscriptionRequest) returns (stream GossipSubscriptionEvent) {}
-
+// TODO: add comment
+service SystemTenant {
   // TenantSettings is used by tenants to obtain and stay up to date with tenant
   // setting overrides.
   rpc TenantSettings(TenantSettingsRequest) returns (stream TenantSettingsEvent) {}
 
+  rpc GossipSubscription(GossipSubscriptionRequest) returns (stream GossipSubscriptionEvent) {}
+}
+
+// TODO: add comment
+service TenantUsage {
+  // TokenBucket is used by tenants to obtain Request Units and report
+  // consumption.
+  rpc TokenBucket (TokenBucketRequest) returns (TokenBucketResponse) {}
+}
+
+// TODO: add comment
+service Node {
+  // Join a bootstrapped cluster. If the target node is itself not part of a
+  // bootstrapped cluster, an appropriate error is returned.
+  rpc Join (JoinNodeRequest) returns (JoinNodeResponse) {}
+}
+
+// TODO: add comment
+service Range {
+  rpc RangeLookup(RangeLookupRequest) returns (RangeLookupResponse) {}
+
+  // GetRangeDescriptors is used by tenants to get range descriptors for their
+  // own ranges.
+  rpc GetRangeDescriptors(GetRangeDescriptorsRequest) returns (stream GetRangeDescriptorsResponse) {}
+}
+
+// TODO: add comment
+service SpanConfig {
   // GetSpanConfigs is used to fetch the span configurations over a given
   // keyspan.
   rpc GetSpanConfigs(GetSpanConfigsRequest) returns (GetSpanConfigsResponse) {}
@@ -3756,10 +3770,6 @@ service TenantConnector {
   // SpanConfigConformance is used to determine whether ranges backing the given
   // keyspans conform to span configs that apply over them.
   rpc SpanConfigConformance(SpanConfigConformanceRequest) returns (SpanConfigConformanceResponse) {}
-
-  // GetRangeDescriptors is used by tenants to get range descriptors for their
-  // own ranges.
-  rpc GetRangeDescriptors(GetRangeDescriptorsRequest) returns (stream GetRangeDescriptorsResponse) {}
 }
 
 // Batch and RangeFeed service implemented by nodes for KV API requests.


### PR DESCRIPTION
We've split the large `Internal` Protobuf service into three smaller ones: `DistSender`, `BatchStream`, and `TenantConnector`.

The main reasons for this are:
- Easier Maintenance: Smaller services are simpler to manage and update.
- Smoother DRPC Rollout: We can move to DRPC step-by-step with these smaller API surfaces, rather than doing `Internal` all at once.
- Subsystems get client interfaces focused only on what they need.

(Edit: Ignore the below overview, see the final proto file and discussion in the comments and reviews)

Here is high level overview of this split,
- `DistSender`: A set of RPCs for DistSender needs. gRPC clients stick with `Internal` for now; new DRPC clients use this. `RestrictedInternalClient` helps bridge the two.
- `BatchStream`: This is just for the stream pool's internal RPC. `rpc.BatchStreamPoolClient` uses it to offer a simple unary `Batch` method. Clients don't call this service directly.
- `TenantConnector`: Bundles RPCs for tenant interactions. This gives new DRPC clients a clear API for tenant stuff, while gRPC clients keep using `Internal` for now.

TODOs in the new service definitions track the eventual removal of these methods from `Internal` once their DRPC migrations are complete.

Epic: CRDB-48925
Release note: None