### PR TITLE
roachtest-operations: fix node-kill

### DIFF
--- a/pkg/cmd/roachtest/operations/node_kill.go
+++ b/pkg/cmd/roachtest/operations/node_kill.go
@@ -20,19 +20,10 @@ import (
 )
 
 type cleanupNodeKill struct {
-	nodes    option.NodeListOption
-	downtime time.Duration
+	nodes option.NodeListOption
 }
 
 func (cl *cleanupNodeKill) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
-	o.Status(fmt.Sprintf("waiting for %s before restarting node %s", cl.downtime, cl.nodes))
-	select {
-	case <-time.After(cl.downtime):
-	case <-ctx.Done():
-		o.Status("cleanup context cancelled during wait")
-		return
-	}
-
 	db, err := c.ConnE(ctx, o.L(), cl.nodes[0])
 	if err != nil {
 		err = c.RunE(ctx, option.WithNodes(cl.nodes), "./cockroach.sh")
@@ -56,20 +47,15 @@ func (cl *cleanupNodeKill) Cleanup(ctx context.Context, o operation.Operation, c
 }
 
 func nodeKillRunner(
-	signal int, drain bool, downtime time.Duration,
+	signal int, drain bool,
 ) func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 	return func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
-		return runNodeKill(ctx, o, c, signal, drain, downtime)
+		return runNodeKill(ctx, o, c, signal, drain)
 	}
 }
 
 func runNodeKill(
-	ctx context.Context,
-	o operation.Operation,
-	c cluster.Cluster,
-	signal int,
-	drain bool,
-	downtime time.Duration,
+	ctx context.Context, o operation.Operation, c cluster.Cluster, signal int, drain bool,
 ) registry.OperationCleanup {
 	rng, _ := randutil.NewPseudoRand()
 	node := c.All().SeededRandNode(rng)
@@ -101,17 +87,7 @@ func runNodeKill(
 		time.Sleep(1 * time.Second)
 	}
 
-	// Schedule the cleanup instead of returning it
-	go func() {
-		cleanup := cleanupNodeKill{
-			nodes:    node,
-			downtime: downtime,
-		}
-		cleanup.Cleanup(ctx, o, c)
-	}()
-
-	// return nil to avoid the hardcoded 5s + random [0s, 24h] wait
-	return nil
+	return &cleanupNodeKill{nodes: node}
 }
 
 func registerNodeKill(r registry.Registry) {
@@ -149,7 +125,8 @@ func registerNodeKill(r registry.Registry) {
 			CompatibleClouds:   registry.AllClouds,
 			CanRunConcurrently: registry.OperationCannotRunConcurrently,
 			Dependencies:       []registry.OperationDependency{registry.OperationRequiresZeroUnderreplicatedRanges},
-			Run:                nodeKillRunner(spec.signal, spec.drain, spec.downtime),
+			WaitBeforeCleanup:  spec.downtime,
+			Run:                nodeKillRunner(spec.signal, spec.drain),
 		})
 	}
 }

--- a/pkg/cmd/roachtest/registry/operation_spec.go
+++ b/pkg/cmd/roachtest/registry/operation_spec.go
@@ -85,6 +85,11 @@ type OperationSpec struct {
 	// and will have CanRunConcurrently = false.
 	CanRunConcurrently OperationIsolation
 
+	// WaitBeforeCleanup specifies the amount of time to wait before running
+	// the cleanup function. This overrides the default wait time set by the flag
+	// --wait-before-cleanup.
+	WaitBeforeCleanup time.Duration
+
 	// Run is the operation function. It returns an OperationCleanup if this
 	// operation requires additional cleanup steps afterwards (eg. dropping an
 	// extra column that was created). A nil return value indicates no cleanup


### PR DESCRIPTION
In a recent change, a bug was introduced in the node kill operations where the cleanup was failing due to context cancel. The issue happened because cleanup was run in a go routine and the calling function cancels the context. This PR fixes the issue.

Epic: None
Release: None