### PR TITLE
explain: skip TestCPUTimeEndToEnd under deadlock

### DIFF
--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -155,6 +155,7 @@ func TestCPUTimeEndToEnd(t *testing.T) {
 
 	skip.UnderStress(t, "multinode cluster setup times out under stress")
 	skip.UnderRace(t, "multinode cluster setup times out under race")
+	skip.UnderDeadlock(t, "lock verification can timeout")
 
 	if !grunning.Supported {
 		return


### PR DESCRIPTION
See linked issue, susceptible to lock verification timeout.

Fixes: #146512
Release note: None