### PR TITLE
multiregionccl: skip test under deadlock

### DIFF
--- a/pkg/ccl/multiregionccl/regional_by_row_test.go
+++ b/pkg/ccl/multiregionccl/regional_by_row_test.go
@@ -174,6 +174,7 @@ func TestAlterTableLocalityRegionalByRowError(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderRace(t, "takes >400s under race")
+	skip.UnderDeadlock(t, "skipping as per issue #146428")
 
 	var chunkSize int64 = 100
 	var maxValue = 4000


### PR DESCRIPTION
This change skips TestAlterTableLocalityRegionalByRowError under deadlock detection to prevent test failures.

Fixes: #146428
Release note: none