### PR TITLE
release-25.2: sql/ttl: restart job on node topology change

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -197,6 +197,7 @@ go_library(
         "tpchbench.go",
         "tpchvec.go",
         "ts_util.go",
+        "ttl_restart.go",
         "typeorm.go",
         "unoptimized_query_oracle.go",
         "validate_system_schema_after_version_upgrade.go",

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -172,5 +172,6 @@ func RegisterTests(r registry.Registry) {
 	registerMultiRegionSystemDatabase(r)
 	registerSqlStatsMixedVersion(r)
 	registerDbConsole(r)
+	registerTTLRestart(r)
 	perturbation.RegisterTests(r)
 }

--- a/pkg/cmd/roachtest/tests/ttl_restart.go
+++ b/pkg/cmd/roachtest/tests/ttl_restart.go
@@ -1,0 +1,505 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tests
+
+import (
+	"context"
+	gosql "database/sql"
+	"fmt"
+	"sort"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/errors"
+)
+
+// registerTTLRestart will register the TTL restart job. This is a test that
+// verifies the restart behavior of the TTL job. It ensures that the TTL job will
+// restart if a node goes down or a new one comes online.
+func registerTTLRestart(r registry.Registry) {
+	for numRestartNodes := 1; numRestartNodes <= 2; numRestartNodes++ {
+		r.Add(registry.TestSpec{
+			Name:             fmt.Sprintf("ttl-restart/num-restart-nodes=%d", numRestartNodes),
+			Owner:            registry.OwnerSQLFoundations,
+			Cluster:          r.MakeClusterSpec(3),
+			Leases:           registry.MetamorphicLeases,
+			CompatibleClouds: registry.AllClouds,
+			Suites:           registry.Suites(registry.Nightly),
+			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+				runTTLRestart(ctx, t, c, numRestartNodes)
+			},
+		})
+	}
+}
+
+const showRangesQuery = "with r as (show ranges from table ttldb.tab1 with details) select range_id, lease_holder from r"
+const jobCheckSQL = `
+  SELECT
+        coordinator_id,
+        job_id,
+        status
+  FROM [SHOW JOBS]
+  WHERE job_type = 'ROW LEVEL TTL' AND description LIKE '%ttldb.public.tab1%'
+  ORDER BY created DESC LIMIT 1
+`
+
+type ttlJobInfo struct {
+	JobID          int
+	CoordinatorID  int
+	Status         string
+	JobResumeCount int
+}
+
+type leaseInfo struct {
+	RangeID     int
+	LeaseHolder int
+}
+type leaseInfoSlice []leaseInfo
+
+// runTTLRestart will run the test. It ensures that the TTL job will restart
+// if node(s) restart. The numRestartNodes parameter indicates the number of
+// nodes to restart. It must be positive, but less than the total number of nodes
+// in the cluster, since we always want the TTL job coorindator to continue
+// running.
+func runTTLRestart(ctx context.Context, t test.Test, c cluster.Cluster, numRestartNodes int) {
+	if numRestartNodes <= 0 {
+		t.Fatalf("the test must stop at least one node: %d", numRestartNodes)
+	}
+	if numRestartNodes >= c.Spec().NodeCount {
+		t.Fatalf("the test cannot stop all of the nodes: %d >= %d", numRestartNodes, c.Spec().NodeCount)
+	}
+
+	startOpts := option.NewStartOpts()
+	settings := install.MakeClusterSettings()
+	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
+
+	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m.Go(func(ctx context.Context) error {
+		db := c.Conn(ctx, t.L(), 1)
+		defer db.Close()
+
+		t.Status("create the table")
+		setup := []string{
+			// Speed up the test by doing the replan check often and with a low threshold.
+			"SET CLUSTER SETTING sql.ttl.replan_flow_frequency = '15s'",
+			"SET CLUSTER SETTING sql.ttl.replan_flow_threshold = '0.1'",
+			// Add additional logging to help debug the test on failure.
+			"SET CLUSTER SETTING server.debug.default_vmodule = 'ttljob_processor=1,distsql_plan_bulk=1'",
+			// Create the schema to be used in the test
+			"CREATE DATABASE IF NOT EXISTS ttldb",
+			"CREATE TABLE IF NOT EXISTS ttldb.tab1 (pk INT8 NOT NULL PRIMARY KEY, ts TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP)",
+		}
+		for _, stmt := range setup {
+			if _, err := db.ExecContext(ctx, stmt); err != nil {
+				return errors.Wrapf(err, "error with statement: %s", stmt)
+			}
+		}
+
+		t.Status("add manual splits so that ranges are distributed evenly across the cluster")
+		if _, err := db.ExecContext(ctx, "ALTER TABLE ttldb.tab1 SPLIT AT VALUES (6000), (12000)"); err != nil {
+			return errors.Wrapf(err, "error adding manual splits")
+		}
+
+		t.Status("insert data")
+		if _, err := db.ExecContext(ctx, "INSERT INTO ttldb.tab1 (pk) SELECT generate_series(1, 18000)"); err != nil {
+			return errors.Wrapf(err, "error ingesting data")
+		}
+
+		t.Status("relocate ranges to distribute across nodes")
+		// Moving ranges is put under a SucceedsSoon to account for errors like:
+		// "lease target replica not found in RangeDescriptor"
+		testutils.SucceedsSoon(t, func() error { return distributeLeases(ctx, t, db) })
+		leases, err := gatherLeaseDistribution(ctx, t, db)
+		if err != nil {
+			return errors.Wrapf(err, "error gathering lease distribution")
+		}
+		showLeaseDistribution(t, leases)
+
+		t.Status("enable TTL")
+		ts := db.QueryRowContext(ctx, "SELECT EXTRACT(HOUR FROM now() + INTERVAL '2 minutes') AS hour, EXTRACT(MINUTE FROM now() + INTERVAL '2 minutes') AS minute")
+		var hour, minute int
+		if err := ts.Scan(&hour, &minute); err != nil {
+			return errors.Wrapf(err, "error generating cron expression")
+		}
+		ttlCronExpression := fmt.Sprintf("%d %d * * *", minute, hour)
+		t.L().Printf("using a cron expression of '%s'", ttlCronExpression)
+		ttlJobSettingSQL := fmt.Sprintf(`ALTER TABLE ttldb.tab1
+			SET (ttl_expiration_expression = $$(ts::timestamptz + '1 minutes')$$,
+           ttl_select_batch_size=100,
+           ttl_delete_batch_size=100,
+           ttl_select_rate_limit=100,
+           ttl_job_cron='%s')`,
+			ttlCronExpression)
+		if _, err := db.ExecContext(ctx, ttlJobSettingSQL); err != nil {
+			return errors.Wrapf(err, "error setting TTL attributes")
+		}
+
+		t.Status("wait for the TTL job to start")
+		var jobInfo ttlJobInfo
+		waitForTTLJob := func() error {
+			var err error
+			jobInfo, err = findRunningJob(ctx, t, c, db, nil,
+				false /* expectJobRestart */, false /* allowJobSucceeded */)
+			return err
+		}
+		// The ttl job is scheduled to run in about 2 minutes. Wait for a little
+		// while longer to give the job system enough time to start the job in case
+		// the system is slow.
+		testutils.SucceedsWithin(t, waitForTTLJob, 8*time.Minute)
+		t.L().Printf("TTL job (ID %d) is running at node %d", jobInfo.JobID, jobInfo.CoordinatorID)
+		// Reset the connection so that we query from the coordinator as this is the
+		// only node that will stay up.
+		if err := db.Close(); err != nil {
+			return errors.Wrapf(err, "error closing connection")
+		}
+		db = c.Conn(ctx, t.L(), jobInfo.CoordinatorID)
+
+		t.Status("wait for TTL deletions to start happening")
+		waitForTTLProgressAcrossAllNodes := func() error {
+			if err := waitForTTLProgressAcrossAllRanges(ctx, db); err != nil {
+				return errors.Wrapf(err, "error waiting for TTL progress after restart")
+			}
+			return nil
+		}
+		testutils.SucceedsWithin(t, waitForTTLProgressAcrossAllNodes, 1*time.Minute)
+
+		t.Status("stop non-coordinator nodes")
+		nonCoordinatorCount := c.Spec().NodeCount - 1
+		stoppingAllNonCoordinators := numRestartNodes == nonCoordinatorCount
+		var ttlNodes map[int]struct{}
+		if !stoppingAllNonCoordinators {
+			// We need to stop a node that actually executed part of the TTL job.
+			// Relying on SQL isn't fully reliable due to potential cache staleness.
+			// Instead, we scan cockroach.log files for known TTL job log markers to
+			// identify nodes that were truly involved in the job execution.
+			ttlNodes, err = findNodesWithJobLogs(ctx, t, c, jobInfo.JobID)
+			if err != nil {
+				return errors.Wrapf(err, "error finding nodes with job logs")
+			}
+		}
+		stoppedNodes := make([]int, 0)
+		for node := 1; node <= c.Spec().NodeCount && len(stoppedNodes) < numRestartNodes; node++ {
+			if node == jobInfo.CoordinatorID {
+				continue
+			}
+			if !stoppingAllNonCoordinators {
+				// Only stop this node if it was confirmed to have executed the TTL job,
+				// based on presence of job log markers.
+				if _, found := ttlNodes[node]; !found {
+					continue
+				}
+			}
+			m.ExpectDeath()
+			t.L().Printf("stopping node %d", node)
+			c.Stop(ctx, t.L(), option.DefaultStopOpts(), c.Nodes(node))
+			stoppedNodes = append(stoppedNodes, node)
+		}
+
+		// If we haven't lost quorum, then the TTL job should restart and continue
+		// working before restarting the down nodes.
+		if numRestartNodes <= c.Spec().NodeCount/2 {
+			t.Status("ensure TTL job restarts")
+			testutils.SucceedsWithin(t, func() error {
+				jobInfo, err = findRunningJob(ctx, t, c, db, &jobInfo,
+					true /* expectJobRestart */, false /* allowJobSucceeded */)
+				if err != nil {
+					return err
+				}
+				return nil
+			}, 6*time.Minute)
+		}
+
+		t.Status("restart the down nodes")
+		nodesRestarted := 0
+		for _, node := range stoppedNodes {
+			t.L().Printf("starting node %d", node)
+			c.Start(ctx, t.L(), startOpts, settings, c.Node(node))
+			nodesRestarted++
+		}
+		m.ResetDeaths()
+
+		// In some cases, the TTL job can complete successfully before a restart is
+		// observed. To handle this, we tolerate either a job restart or successful
+		// completion.
+		t.Status("ensure TTL job restarts again or finishes")
+		testutils.SucceedsWithin(t, func() error {
+			jobInfo, err = findRunningJob(ctx, t, c, db, &jobInfo,
+				true /* expectJobRestart */, true /* allowJobSucceeded */)
+			if err != nil {
+				return err
+			}
+			return nil
+		}, 6*time.Minute)
+
+		return nil
+	})
+	m.Wait()
+}
+
+// gatherLeaseDistribution returns a slice of leaseInfo structs, one for each
+// range in the cluster. Each struct contains the rangeID and the leaseholder
+// for that range.
+func gatherLeaseDistribution(
+	ctx context.Context, t test.Test, db *gosql.DB,
+) (leaseInfoSlice, error) {
+	leases := make(leaseInfoSlice, 0)
+	ranges, err := db.QueryContext(ctx, showRangesQuery)
+	if err != nil {
+		return leases, errors.Wrapf(err, "error querying the ranges")
+	}
+	defer ranges.Close()
+	for ranges.Next() {
+		var rangeID, leaseHolder int
+		if err := ranges.Scan(&rangeID, &leaseHolder); err != nil {
+			return leases, err
+		}
+		leases = append(leases, leaseInfo{RangeID: rangeID, LeaseHolder: leaseHolder})
+	}
+	return leases, nil
+}
+
+// showLeaseDistribution pretty prints leaseInfoSlice, which is collected from
+// gatherLeaseDistribution.
+func showLeaseDistribution(t test.Test, leases leaseInfoSlice) {
+	for _, lease := range leases {
+		t.L().Printf("Range %d lease holder is %d", lease.RangeID, lease.LeaseHolder)
+	}
+}
+
+// distributeLeases redistributes the ranges evenly across the cluster.
+func distributeLeases(ctx context.Context, t test.Test, db *gosql.DB) error {
+	ranges, err := db.QueryContext(ctx, showRangesQuery)
+	if err != nil {
+		return errors.Wrapf(err, "error querying the ranges")
+	}
+	defer ranges.Close()
+	var nextLeaseHolder int
+	for nextLeaseHolder = 1; ranges.Next(); nextLeaseHolder++ {
+		var rangeID, leaseHolder int
+		if err := ranges.Scan(&rangeID, &leaseHolder); err != nil {
+			return err
+		}
+		if leaseHolder != nextLeaseHolder {
+			alterStmt := fmt.Sprintf("ALTER RANGE %d RELOCATE LEASE TO %d", rangeID, nextLeaseHolder)
+			row := db.QueryRowContext(ctx, alterStmt)
+			var pretty, result string
+			if err := row.Scan(&rangeID, &pretty, &result); err != nil {
+				return err
+			}
+			if result != "ok" {
+				return errors.Newf("failed to alter range %d: %s", rangeID, result)
+			}
+			t.L().Printf("Relocated lease of range %d to node %d", rangeID, nextLeaseHolder)
+		}
+	}
+	const expectedLeaseHolders = 3
+	if actual := nextLeaseHolder - 1; actual != expectedLeaseHolders {
+		return errors.Newf("expected %d leaseholders, but got %d", expectedLeaseHolders, actual)
+	}
+	return nil
+
+}
+
+// waitForTTLProgressAcrossAllRanges ensures that TTL deletions are happening across
+// all ranges. It builds a baseline of key counts for each leaseholder's ranges,
+// and later checks that each leaseholder made progress on at least one of those ranges,
+// regardless of current leaseholder assignment.
+func waitForTTLProgressAcrossAllRanges(ctx context.Context, db *gosql.DB) error {
+	query := `
+		WITH r AS (
+			SHOW RANGES FROM TABLE ttldb.tab1 WITH DETAILS
+		)
+		SELECT
+		  range_id,
+			lease_holder,
+			count(*) AS key_count
+		FROM
+			r,
+			LATERAL crdb_internal.list_sql_keys_in_range(range_id)
+		GROUP BY
+		  range_id,
+			lease_holder
+		ORDER BY
+		  range_id`
+
+	// Map of leaseholder -> rangeID -> keyCount
+	baseline := make(map[int]map[int]int)
+
+	rows, err := db.QueryContext(ctx, query)
+	if err != nil {
+		return err
+	}
+	defer rows.Close()
+
+	for rows.Next() {
+		var rangeID, leaseHolder, keyCount int
+		if err := rows.Scan(&rangeID, &leaseHolder, &keyCount); err != nil {
+			return err
+		}
+		if _, ok := baseline[leaseHolder]; !ok {
+			baseline[leaseHolder] = make(map[int]int)
+		}
+		baseline[leaseHolder][rangeID] = keyCount
+	}
+
+	compareWithBaseline := func() error {
+		current := make(map[int]int) // rangeID -> keyCount
+
+		rows, err := db.QueryContext(ctx, query)
+		if err != nil {
+			return err
+		}
+		defer rows.Close()
+
+		for rows.Next() {
+			var rangeID, leaseHolder, keyCount int
+			if err := rows.Scan(&rangeID, &leaseHolder, &keyCount); err != nil {
+				return err
+			}
+			current[rangeID] = keyCount
+		}
+
+		for leaseHolder, ranges := range baseline {
+			madeProgress := false
+			for rangeID, oldCount := range ranges {
+				newCount, ok := current[rangeID]
+				if !ok {
+					return errors.Newf("range %d (from leaseholder %d) not found in follow-up check", rangeID, leaseHolder)
+				}
+				if newCount < oldCount {
+					madeProgress = true
+					break
+				}
+			}
+			if !madeProgress {
+				return errors.Newf("leaseholder %d made no progress on any of their original ranges", leaseHolder)
+			}
+		}
+
+		return nil
+	}
+
+	return testutils.SucceedsWithinError(compareWithBaseline, 20*time.Second)
+}
+
+// findRunningJob checks the current state of the TTL job and returns metadata
+// about it. If a previous job state (lastJob) is provided, and expectJobRestart
+// is true, the function verifies that the job has restarted by comparing resume
+// counts. If allowJobSucceeded is true, it tolerates the job having already
+// succeeded without requiring a restart.
+//
+// The function also logs TTL job metadata, including any observed coordinator
+// changes and job completion status.
+func findRunningJob(
+	ctx context.Context,
+	t test.Test,
+	c cluster.Cluster,
+	db *gosql.DB,
+	lastJob *ttlJobInfo,
+	expectJobRestart bool,
+	allowJobSucceeded bool,
+) (newJobInfo ttlJobInfo, err error) {
+	var coordinatorID gosql.NullInt64
+	if err := db.QueryRowContext(ctx, jobCheckSQL).Scan(&coordinatorID, &newJobInfo.JobID, &newJobInfo.Status); err != nil {
+		return newJobInfo, errors.Wrapf(err, "error querying status of TTL job")
+	}
+	// When the TTL job restarts, the coordinator_id can be temporarily NULL
+	// if the job hasn't been rescheduled yet.
+	if !coordinatorID.Valid {
+		return newJobInfo, errors.Newf("TTL coordinator is NULL")
+	}
+	newJobInfo.CoordinatorID = int(coordinatorID.Int64)
+
+	// Count the number of job resumes by looking in the logs on each node.
+	const ttlResumeLogMarker = "ROW LEVEL TTL job %d: stepping through state running"
+	cmd := fmt.Sprintf("grep -c '"+ttlResumeLogMarker+"' {log-dir}/cockroach.log", newJobInfo.JobID)
+	results, err := c.RunWithDetails(ctx, nil, option.WithNodes(c.CRDBNodes()), cmd)
+	if err != nil {
+		return newJobInfo, errors.Wrapf(err, "error running command: %s", cmd)
+	}
+
+	newJobInfo.JobResumeCount = 0
+	for i := range results {
+		resumeCount, err := strconv.Atoi(strings.TrimSpace(results[i].Stdout))
+		if err != nil {
+			return newJobInfo, errors.Wrapf(err, "error converting command output from node %d to int: %s",
+				results[i].Node, results[i].Stdout)
+		}
+		newJobInfo.JobResumeCount += resumeCount
+	}
+
+	if lastJob != nil && lastJob.JobID != newJobInfo.JobID {
+		return newJobInfo, errors.Newf("TTL job ID changed from %d to %d", lastJob.JobID, newJobInfo.JobID)
+	}
+	// Handle timing scenario where the job started, according to the job infra,
+	// but we haven't yet logged the resume log message.
+	if newJobInfo.Status == "running" && newJobInfo.JobResumeCount == 0 {
+		return newJobInfo, errors.Newf("TTL job is running but resume count is 0")
+	}
+	if lastJob != nil && lastJob.CoordinatorID != newJobInfo.CoordinatorID {
+		t.L().Printf("TTL job (ID %d) is running now at node %d", newJobInfo.JobID, newJobInfo.CoordinatorID)
+	}
+
+	if lastJob != nil {
+		jobRestarted := newJobInfo.JobResumeCount > lastJob.JobResumeCount
+		if expectJobRestart && !jobRestarted {
+			if newJobInfo.Status == "succeeded" && allowJobSucceeded {
+				t.L().Printf("TTL job (ID %d) has already succeeded; treating as successful", newJobInfo.JobID)
+				return newJobInfo, nil
+			}
+			return newJobInfo, errors.Newf("TTL job did not restart, resume count is %d", newJobInfo.JobResumeCount)
+		}
+	}
+	t.L().Printf("TTL job (ID %d) resume count is %d", newJobInfo.JobID, newJobInfo.JobResumeCount)
+
+	return newJobInfo, nil
+}
+
+// findNodesWithJobLogs returns the IDs of nodes whose logs contain entries for
+// the given TTL job ID.
+func findNodesWithJobLogs(
+	ctx context.Context, t test.Test, c cluster.Cluster, jobID int,
+) (map[int]struct{}, error) {
+	// Log marker to search for
+	const ttlLogMarker = "id=%d"
+	cmd := fmt.Sprintf("grep -q '"+ttlLogMarker+"' {log-dir}/cockroach.log", jobID)
+
+	// Run grep command across all nodes
+	results, err := c.RunWithDetails(ctx, nil, option.WithNodes(c.CRDBNodes()), cmd)
+	if err != nil && !testutils.IsError(err, "exit status") {
+		// Only fail on non-grep errors (exit status from grep is expected if pattern not found)
+		return nil, errors.Wrapf(err, "error running grep command for job %d", jobID)
+	}
+
+	nodesWithJob := make(map[int]struct{})
+	for _, res := range results {
+		if res.Err == nil {
+			// grep -q succeeded, meaning the log marker was found
+			nodesWithJob[int(res.Node)] = struct{}{}
+		}
+	}
+
+	if len(nodesWithJob) == 0 {
+		return nil, errors.Newf("TTL job %d was not found in any node logs", jobID)
+	}
+
+	// Extract and sort node IDs
+	var nodeList []int
+	for node := range nodesWithJob {
+		nodeList = append(nodeList, node)
+	}
+	sort.Ints(nodeList)
+	t.L().Printf("TTL job %d found on nodes: %v", jobID, nodeList)
+
+	return nodesWithJob, nil
+}

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
@@ -33,6 +34,22 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+var replanThreshold = settings.RegisterFloatSetting(
+	settings.ApplicationLevel,
+	"sql.ttl.replan_flow_threshold",
+	"the fraction of flow instances that must change (added or updated) before the TTL job is replanned; set to 0 to disable",
+	0.1,
+	settings.FloatInRange(0, 1),
+)
+
+var replanFrequency = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"sql.ttl.replan_flow_frequency",
+	"how frequently the TTL job checks whether to replan its physical execution flow",
+	time.Minute*2,
+	settings.PositiveDuration,
+)
+
 // rowLevelTTLResumer implements the TTL job. The job can run on any node, but
 // the job node distributes SELECT/DELETE work via DistSQL to ttlProcessor
 // nodes. DistSQL divides work into spans that each ttlProcessor scans in a
@@ -49,7 +66,7 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 	defer func() {
 		if retErr == nil {
 			return
-		} else if joberror.IsPermanentBulkJobError(retErr) {
+		} else if joberror.IsPermanentBulkJobError(retErr) && !errors.Is(retErr, sql.ErrPlanChanged) {
 			retErr = jobs.MarkAsPermanentJobError(retErr)
 		} else {
 			retErr = jobs.MarkAsRetryJobError(retErr)
@@ -127,51 +144,51 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 	statsCtx, statsCancel := context.WithCancelCause(ctx)
 	defer statsCancel(nil)
 	statsGroup := ctxgroup.WithContext(statsCtx)
-	err := func() error {
-		if rowLevelTTL.RowStatsPollInterval != 0 {
-			defer statsCancel(errors.New("cancelling TTL stats query because TTL job completed"))
-			metrics := execCfg.JobRegistry.MetricsStruct().RowLevelTTL.(*RowLevelTTLAggMetrics).loadMetrics(
-				labelMetrics,
-				relationName,
-			)
+	if rowLevelTTL.RowStatsPollInterval != 0 {
+		metrics := execCfg.JobRegistry.MetricsStruct().RowLevelTTL.(*RowLevelTTLAggMetrics).loadMetrics(
+			labelMetrics,
+			relationName,
+		)
 
-			statsGroup.GoCtx(func(ctx context.Context) error {
-				// Do once initially to ensure we have some base statistics.
-				if err := metrics.fetchStatistics(ctx, execCfg, relationName, details, aostDuration, ttlExpr); err != nil {
-					return err
-				}
-				// Wait until poll interval is reached, or early exit when we are done
-				// with the TTL job.
-				for {
-					select {
-					case <-ctx.Done():
-						return nil
-					case <-time.After(rowLevelTTL.RowStatsPollInterval):
-						if err := metrics.fetchStatistics(ctx, execCfg, relationName, details, aostDuration, ttlExpr); err != nil {
-							return err
-						}
+		statsGroup.GoCtx(func(ctx context.Context) error {
+			// Do once initially to ensure we have some base statistics.
+			if err := metrics.fetchStatistics(ctx, execCfg, relationName, details, aostDuration, ttlExpr); err != nil {
+				return err
+			}
+			// Wait until poll interval is reached, or early exit when we are done
+			// with the TTL job.
+			for {
+				select {
+				case <-ctx.Done():
+					return nil
+				case <-time.After(rowLevelTTL.RowStatsPollInterval):
+					if err := metrics.fetchStatistics(ctx, execCfg, relationName, details, aostDuration, ttlExpr); err != nil {
+						return err
 					}
 				}
-			})
-		}
+			}
+		})
+	}
 
-		distSQLPlanner := jobExecCtx.DistSQLPlanner()
+	distSQLPlanner := jobExecCtx.DistSQLPlanner()
 
+	jobSpanCount := 0
+	makePlan := func(ctx context.Context, distSQLPlanner *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 		// We don't return the compatible nodes here since PartitionSpans will
 		// filter out incompatible nodes.
 		planCtx, _, err := distSQLPlanner.SetupAllNodesPlanning(ctx, jobExecCtx.ExtendedEvalContext(), execCfg)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		spanPartitions, err := distSQLPlanner.PartitionSpans(ctx, planCtx, []roachpb.Span{entirePKSpan}, sql.PartitionSpansBoundDefault)
 		if err != nil {
-			return err
+			return nil, nil, err
 		}
 		expectedNumSpanPartitions := knobs.ExpectedNumSpanPartitions
 		if expectedNumSpanPartitions != 0 {
 			actualNumSpanPartitions := len(spanPartitions)
 			if expectedNumSpanPartitions != actualNumSpanPartitions {
-				return errors.AssertionFailedf(
+				return nil, nil, errors.AssertionFailedf(
 					"incorrect number of span partitions expected=%d actual=%d",
 					expectedNumSpanPartitions, actualNumSpanPartitions,
 				)
@@ -202,25 +219,9 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 			}
 		}
 
-		jobSpanCount := 0
+		jobSpanCount = 0
 		for _, spanPartition := range spanPartitions {
 			jobSpanCount += len(spanPartition.Spans)
-		}
-
-		if err := t.job.NoTxn().Update(ctx,
-			func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-				progress := md.Progress
-				rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
-				rowLevelTTL.JobTotalSpanCount = int64(jobSpanCount)
-				rowLevelTTL.JobProcessedSpanCount = 0
-				progress.Progress = &jobspb.Progress_FractionCompleted{
-					FractionCompleted: 0,
-				}
-				ju.UpdateProgress(progress)
-				return nil
-			},
-		); err != nil {
-			return err
 		}
 
 		sqlInstanceIDToTTLSpec := make(map[base.SQLInstanceID]*execinfrapb.TTLSpec, len(spanPartitions))
@@ -250,9 +251,51 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 		physicalPlan.PlanToStreamColMap = []int{}
 
 		sql.FinalizePlan(ctx, planCtx, physicalPlan)
+		return physicalPlan, planCtx, nil
+	}
 
-		metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter()
+	metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter()
 
+	physicalPlan, planCtx, err := makePlan(ctx, distSQLPlanner)
+	if err != nil {
+		return err
+	}
+
+	if err := t.job.NoTxn().Update(ctx,
+		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			progress := md.Progress
+			rowLevelTTL := progress.Details.(*jobspb.Progress_RowLevelTTL).RowLevelTTL
+			rowLevelTTL.JobTotalSpanCount = int64(jobSpanCount)
+			rowLevelTTL.JobProcessedSpanCount = 0
+			progress.Progress = &jobspb.Progress_FractionCompleted{
+				FractionCompleted: 0,
+			}
+			ju.UpdateProgress(progress)
+			return nil
+		},
+	); err != nil {
+		return err
+	}
+
+	// Get a function to be used in a goroutine to monitor whether a replan is
+	// needed due to changes in node membership. This is important because if
+	// there are idle nodes that become available, it's more efficient to restart
+	// the TTL job to utilize those nodes for parallel work.
+	replanChecker, cancelReplanner := sql.PhysicalPlanChangeChecker(
+		ctx, physicalPlan, makePlan, jobExecCtx,
+		sql.ReplanOnChangedFraction(func() float64 { return replanThreshold.Get(&execCfg.Settings.SV) }),
+		func() time.Duration { return replanFrequency.Get(&execCfg.Settings.SV) },
+	)
+
+	// Create a separate context group to run the replanner and the TTL distSQL driver.
+	// Note: this is distinct from the stats collection group, as errors from stats
+	// collection are non-fatal and treated as warnings.
+	g := ctxgroup.WithContext(ctx)
+	g.GoCtx(func(ctx context.Context) error {
+		defer cancelReplanner()
+		if rowLevelTTL.RowStatsPollInterval != 0 {
+			defer statsCancel(errors.New("cancelling TTL stats query because TTL job completed"))
+		}
 		distSQLReceiver := sql.MakeDistSQLReceiver(
 			ctx,
 			metadataCallbackWriter,
@@ -277,8 +320,11 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 		)
 
 		return metadataCallbackWriter.Err()
-	}()
-	if err != nil {
+	})
+
+	g.GoCtx(replanChecker)
+
+	if err := g.Wait(); err != nil {
 		return err
 	}
 

--- a/pkg/sql/ttl/ttljob/ttljob_processor.go
+++ b/pkg/sql/ttl/ttljob/ttljob_processor.go
@@ -128,7 +128,6 @@ func getTableInfo(
 }
 
 func (t *ttlProcessor) work(ctx context.Context) error {
-
 	ttlSpec := t.ttlSpec
 	flowCtx := t.FlowCtx
 	serverCfg := flowCtx.Cfg
@@ -138,6 +137,10 @@ func (t *ttlProcessor) work(ctx context.Context) error {
 	tableID := details.TableID
 	cutoff := details.Cutoff
 	ttlExpr := ttlSpec.TTLExpr
+
+	// Note: the ttl-restart test depends on this message to know what nodes are
+	// involved in a TTL job.
+	log.Infof(ctx, "TTL processor started processorID=%d tableID=%d", t.ProcessorID, tableID)
 
 	selectRateLimit := ttlSpec.SelectRateLimit
 	// Default 0 value to "unlimited" in case job started on node <= v23.2.


### PR DESCRIPTION
Backport 1/1 commits from #145214 on behalf of @spilchen.

----

Previously, TTL jobs did not respond promptly to node failures. If a node participating in a TTL job went down, the remaining nodes would continue execution without compensating for the lost parallelism, leading to suboptimal job performance.

This change improves fault tolerance and job efficiency by introducing a mechanism to better react to topology changes. The TTL coordinator monitors for topology changes and can restart the job to leverage any newly available nodes, restoring or enhancing parallelism.

The change introduces new goroutines to control the various work units in the TTL coordinator. A summary of the goroutines involved in the TTL at the coorinadotr are as follows:

## TTL Coordinator
  - Stats collector (goroutine, preexisting)
    - Periodically collects row-level statistics for the job
  - Replan Checker (goroutine, new)
    - Periodically evaluates whether the physical plan needs replanning
    - If a significant node change is detected, the job is failed and retried
  - DistSQL execution (goroutine, new)
    - Drives overall job execution
    - Cancels the stats group and replan checker on completion
  - TTL Job Runner (control loop)
    - Waits for replan checker and DistSQL execution
    - Will log any warnings from the stats collector
    
Fixes #140513
Fixes #138999

Epic: none
Release note (performance improvement): TTL jobs now respond to node topology changes by restarting and rebalancing across available nodes.

----

Release justification: backporting since it originated from a support escalation.