### PR TITLE
release-25.2: add job tracing support to changefeeds

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -128,6 +128,7 @@ go_library(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/bufalloc",
         "//pkg/util/buildutil",
+        "//pkg/util/bulk",
         "//pkg/util/cache",
         "//pkg/util/cancelchecker",
         "//pkg/util/cidr",

--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -392,6 +392,9 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 	}
 
 	tryFlushBatch := func(topic string) error {
+		ctx, sp := tracing.ChildSpan(ctx, "changefeed.batching_sink.try_flush_batch")
+		defer sp.Finish()
+
 		batchBuffer, ok := topicBatches[topic]
 		if !ok || batchBuffer.isEmpty() {
 			return nil

--- a/pkg/ccl/changefeedccl/batching_sink.go
+++ b/pkg/ccl/changefeedccl/batching_sink.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -349,6 +350,9 @@ func (s *batchingSink) runBatchingWorker(ctx context.Context) {
 	// Once finalized, batches are sent to a parallelIO struct which handles
 	// performing multiple Flushes in parallel while maintaining Keys() ordering.
 	ioHandler := func(ctx context.Context, req IORequest) error {
+		ctx, sp := tracing.ChildSpan(ctx, "changefeed.batching_sink.io_handler")
+		defer sp.Finish()
+
 		batch, _ := req.(*sinkBatch)
 		defer s.metrics.recordSinkIOInflightChange(int64(-batch.numMessages))
 		s.metrics.recordSinkIOInflightChange(int64(batch.numMessages))
@@ -570,6 +574,9 @@ func makeBatchingSink(
 	}
 
 	sink.wg.GoCtx(func(ctx context.Context) error {
+		ctx, sp := tracing.ChildSpan(ctx, "changefeed.batching_sink.worker")
+		defer sp.Finish()
+
 		sink.runBatchingWorker(ctx)
 		return nil
 	})

--- a/pkg/ccl/changefeedccl/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeed.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/protoreflect"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/gogo/protobuf/jsonpb"
 )
 
@@ -88,6 +89,9 @@ const (
 func emitResolvedTimestamp(
 	ctx context.Context, encoder Encoder, sink ResolvedTimestampSink, resolved hlc.Timestamp,
 ) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.emit_resolved_timestamp")
+	defer sp.Finish()
+
 	// TODO(dan): Emit more fine-grained (table level) resolved
 	// timestamps.
 	if err := sink.EmitResolvedTimestamp(ctx, encoder, resolved); err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -82,6 +82,7 @@ func distChangefeedFlow(
 	description string,
 	localState *cachedState,
 	resultsCh chan<- tree.Datums,
+	onTracingEvent func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents),
 ) error {
 	opts := changefeedbase.MakeStatementOptions(details.Opts)
 	progress := localState.progress
@@ -135,7 +136,7 @@ func distChangefeedFlow(
 		}
 	}
 	return startDistChangefeed(
-		ctx, execCtx, jobID, schemaTS, details, description, initialHighWater, localState, resultsCh)
+		ctx, execCtx, jobID, schemaTS, details, description, initialHighWater, localState, resultsCh, onTracingEvent)
 }
 
 func fetchTableDescriptors(
@@ -234,6 +235,7 @@ func startDistChangefeed(
 	initialHighWater hlc.Timestamp,
 	localState *cachedState,
 	resultsCh chan<- tree.Datums,
+	onTracingEvent func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents),
 ) error {
 	execCfg := execCtx.ExecCfg()
 	tableDescs, err := fetchTableDescriptors(ctx, execCfg, AllTargets(details), schemaTS)
@@ -291,6 +293,9 @@ func startDistChangefeed(
 						localState.drainingNodes = append(localState.drainingNodes, meta.Changefeed.DrainInfo.NodeID)
 					}
 					localState.aggregatorFrontier = append(localState.aggregatorFrontier, meta.Changefeed.Checkpoint...)
+				}
+				if meta.AggregatorEvents != nil && onTracingEvent != nil {
+					onTracingEvent(ctx, meta.AggregatorEvents)
 				}
 				return nil
 			},

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -826,7 +826,7 @@ func (ca *changeAggregator) computeTrailingMetadata(meta *execinfrapb.Changefeed
 	// elements; but we are not interested in flushing potentially large number of events;
 	// all we want to ensure is that any previously observed event (such as resolved timestamp)
 	// has been fully processed.
-	if err := ca.flushBufferedEvents(); err != nil {
+	if err := ca.flushBufferedEvents(ca.Ctx()); err != nil {
 		// This method may be invoked during shutdown when the context already canceled.
 		// Regardless for the cause of this error, there is nothing we can do with it anyway.
 		// All we want to ensure is that if any error occurs we still return correct checkpoint,
@@ -879,23 +879,28 @@ func (ca *changeAggregator) tick() error {
 		}
 		return ca.noteResolvedSpan(resolved)
 	case kvevent.TypeFlush:
-		return ca.flushBufferedEvents()
+		return ca.flushBufferedEvents(ca.Ctx())
 	}
 
 	return nil
 }
 
-func (ca *changeAggregator) flushBufferedEvents() error {
-	if err := ca.eventConsumer.Flush(ca.Ctx()); err != nil {
+func (ca *changeAggregator) flushBufferedEvents(ctx context.Context) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.aggregator.flush_buffered_events")
+	defer sp.Finish()
+	if err := ca.eventConsumer.Flush(ctx); err != nil {
 		return err
 	}
-	return ca.sink.Flush(ca.Ctx())
+	return ca.sink.Flush(ctx)
 }
 
 // noteResolvedSpan periodically flushes Frontier progress from the current
 // changeAggregator node to the changeFrontier node to allow the changeFrontier
 // to persist the overall changefeed's progress
 func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (returnErr error) {
+	ctx, sp := tracing.ChildSpan(ca.Ctx(), "changefeed.aggregator.note_resolved_span")
+	defer sp.Finish()
+
 	if log.V(2) {
 		log.Infof(ca.Ctx(), "resolved span from kv feed: %#v", resolved)
 	}
@@ -915,7 +920,7 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (retu
 
 	defer func(ctx context.Context) {
 		maybeLogBehindSpan(ctx, "aggregator", ca.frontier, advanced, sv)
-	}(ca.Ctx())
+	}(ctx)
 
 	// The resolved sliMetric data backs the aggregator_progress metric
 	if advanced {
@@ -941,7 +946,7 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (retu
 				returnErr = errors.CombineErrors(returnErr, err)
 			}
 		}()
-		return ca.flushFrontier()
+		return ca.flushFrontier(ctx)
 	}
 
 	// At a lower frequency, we checkpoint specific spans in the job progress
@@ -954,18 +959,20 @@ func (ca *changeAggregator) noteResolvedSpan(resolved jobspb.ResolvedSpan) (retu
 		defer func() {
 			ca.lastSpanFlush = timeutil.Now()
 		}()
-		return ca.flushFrontier()
+		return ca.flushFrontier(ctx)
 	}
 	return returnErr
 }
 
 // flushFrontier flushes sink and emits resolved spans to the change frontier.
-func (ca *changeAggregator) flushFrontier() error {
+func (ca *changeAggregator) flushFrontier(ctx context.Context) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.aggregator.flush_frontier")
+	defer sp.Finish()
 	// Make sure to flush the sink before forwarding resolved spans,
 	// otherwise, we could lose buffered messages and violate the
 	// at-least-once guarantee. This is also true for checkpointing the
 	// resolved spans in the job progress.
-	if err := ca.flushBufferedEvents(); err != nil {
+	if err := ca.flushBufferedEvents(ctx); err != nil {
 		return err
 	}
 
@@ -1662,7 +1669,7 @@ func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 			continue
 		}
 
-		if err := cf.noteAggregatorProgress(row[0]); err != nil {
+		if err := cf.noteAggregatorProgress(cf.Ctx(), row[0]); err != nil {
 			if log.V(2) {
 				log.Infof(cf.Ctx(), "change frontier moving to draining after error while processing aggregator progress: %v", err)
 			}
@@ -1673,7 +1680,10 @@ func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 	return nil, cf.DrainHelper()
 }
 
-func (cf *changeFrontier) noteAggregatorProgress(d rowenc.EncDatum) error {
+func (cf *changeFrontier) noteAggregatorProgress(ctx context.Context, d rowenc.EncDatum) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.frontier.note_aggregator_progress")
+	defer sp.Finish()
+
 	if err := d.EnsureDecoded(changefeedResultTypes[0], &cf.a); err != nil {
 		return err
 	}
@@ -1688,7 +1698,7 @@ func (cf *changeFrontier) noteAggregatorProgress(d rowenc.EncDatum) error {
 			`unmarshalling aggregator progress update: %x`, raw)
 	}
 	if log.V(2) {
-		log.Infof(cf.Ctx(), "progress update from aggregator: %#v", resolvedSpans)
+		log.Infof(ctx, "progress update from aggregator: %#v", resolvedSpans)
 	}
 
 	cf.maybeMarkJobIdle(resolvedSpans.Stats.RecentKvCount)
@@ -1741,7 +1751,7 @@ func (cf *changeFrontier) forwardFrontier(resolved jobspb.ResolvedSpan) error {
 		// all feeds in the scope.
 		cf.sliMetrics.setCheckpoint(cf.sliMetricsID, newResolved)
 
-		return cf.maybeEmitResolved(newResolved)
+		return cf.maybeEmitResolved(cf.Ctx(), newResolved)
 	}
 
 	return nil
@@ -1768,6 +1778,9 @@ func (cf *changeFrontier) maybeMarkJobIdle(recentKVCount uint64) {
 func (cf *changeFrontier) maybeCheckpointJob(
 	resolvedSpan jobspb.ResolvedSpan, frontierChanged bool,
 ) (bool, error) {
+	ctx, sp := tracing.ChildSpan(cf.Ctx(), "changefeed.frontier.maybe_checkpoint_job")
+	defer sp.Finish()
+
 	// When in a Backfill, the frontier remains unchanged at the backfill boundary
 	// as we receive spans from the scan request at the Backfill Timestamp
 	inBackfill := !frontierChanged && cf.frontier.InBackfill(resolvedSpan)
@@ -1797,11 +1810,11 @@ func (cf *changeFrontier) maybeCheckpointJob(
 			return false, nil
 		}
 		checkpointStart := timeutil.Now()
-		updated, err := cf.checkpointJobProgress(cf.frontier.Frontier(), checkpoint, cf.evalCtx.Settings.Version)
+		updated, err := cf.checkpointJobProgress(ctx, cf.frontier.Frontier(), checkpoint, cf.evalCtx.Settings.Version)
 		if err != nil {
 			return false, err
 		}
-		cf.js.checkpointCompleted(cf.Ctx(), timeutil.Since(checkpointStart))
+		cf.js.checkpointCompleted(ctx, timeutil.Since(checkpointStart))
 		return updated, nil
 	}
 
@@ -1811,8 +1824,13 @@ func (cf *changeFrontier) maybeCheckpointJob(
 const changefeedJobProgressTxnName = "changefeed job progress"
 
 func (cf *changeFrontier) checkpointJobProgress(
-	frontier hlc.Timestamp, spanLevelCheckpoint *jobspb.TimestampSpansMap, cv clusterversion.Handle,
+	ctx context.Context,
+	frontier hlc.Timestamp,
+	spanLevelCheckpoint *jobspb.TimestampSpansMap,
+	cv clusterversion.Handle,
 ) (bool, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.frontier.checkpoint_job_progress")
+	defer sp.Finish()
 	defer cf.sliMetrics.Timers.CheckpointJobProgress.Start()()
 
 	if cf.knobs.RaiseRetryableError != nil {
@@ -1854,8 +1872,8 @@ func (cf *changeFrontier) checkpointJobProgress(
 				checkpointStr = legacyCheckpoint.String()
 			}
 
-			if ptsUpdated, err = cf.manageProtectedTimestamps(cf.Ctx(), txn, changefeedProgress); err != nil {
-				log.Warningf(cf.Ctx(), "error managing protected timestamp record: %v", err)
+			if ptsUpdated, err = cf.manageProtectedTimestamps(ctx, txn, changefeedProgress); err != nil {
+				log.Warningf(ctx, "error managing protected timestamp record: %v", err)
 				return err
 			}
 
@@ -1893,6 +1911,9 @@ func (cf *changeFrontier) checkpointJobProgress(
 func (cf *changeFrontier) manageProtectedTimestamps(
 	ctx context.Context, txn isql.Txn, progress *jobspb.ChangefeedProgress,
 ) (updated bool, err error) {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.frontier.manage_protected_timestamps")
+	defer sp.Finish()
+
 	ptsUpdateInterval := changefeedbase.ProtectTimestampInterval.Get(&cf.FlowCtx.Cfg.Settings.SV)
 	ptsUpdateLag := changefeedbase.ProtectTimestampLag.Get(&cf.FlowCtx.Cfg.Settings.SV)
 	if timeutil.Since(cf.lastProtectedTimestampUpdate) < ptsUpdateInterval {
@@ -1982,7 +2003,7 @@ func (cf *changeFrontier) remakePTSRecord(
 	return nil
 }
 
-func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {
+func (cf *changeFrontier) maybeEmitResolved(ctx context.Context, newResolved hlc.Timestamp) error {
 	if cf.freqEmitResolved == emitNoResolved || newResolved.IsEmpty() {
 		return nil
 	}
@@ -1992,7 +2013,7 @@ func (cf *changeFrontier) maybeEmitResolved(newResolved hlc.Timestamp) error {
 	if !shouldEmit {
 		return nil
 	}
-	if err := emitResolvedTimestamp(cf.Ctx(), cf.encoder, cf.sink, newResolved); err != nil {
+	if err := emitResolvedTimestamp(ctx, cf.encoder, cf.sink, newResolved); err != nil {
 		return err
 	}
 	cf.lastEmitResolved = newResolved.GoTime()

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	bulkutil "github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/cancelchecker"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -47,6 +48,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -106,6 +108,11 @@ type changeAggregator struct {
 	// frontier keeps track of resolved timestamps for spans along with schema change
 	// boundary information.
 	frontier *resolvedspan.AggregatorFrontier
+
+	// Aggregator that aggregates StructuredEvents emitted in the
+	// changeAggregator's trace recording.
+	agg      *tracing.TracingAggregator
+	aggTimer timeutil.Timer
 
 	metrics                *Metrics
 	sliMetrics             *sliMetrics
@@ -225,6 +232,12 @@ func newChangeAggregatorProcessor(
 					producerMeta = []execinfrapb.ProducerMetadata{{Changefeed: &meta}}
 				}
 
+				if ca.agg != nil {
+					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
+						ca.FlowCtx.NodeID.SQLInstanceID(), ca.FlowCtx.ID, ca.agg)
+					producerMeta = append(producerMeta, *meta)
+				}
+
 				ca.close()
 				return producerMeta
 			},
@@ -302,8 +315,9 @@ func (ca *changeAggregator) wrapMetricsRecorderWithTelemetry(
 }
 
 const (
-	changeAggregatorLogTag = "change-aggregator"
-	changeFrontierLogTag   = "change-frontier"
+	changeAggregatorLogTag  = "change-aggregator"
+	changeFrontierLogTag    = "change-frontier"
+	tracingAggTimerInterval = 15 * time.Second
 )
 
 // Start is part of the RowSource interface.
@@ -316,7 +330,13 @@ func (ca *changeAggregator) Start(ctx context.Context) {
 	}
 	ctx = logtags.RemoveTag(ctx, changeFrontierLogTag)
 	ctx = logtags.AddTag(ctx, changeAggregatorLogTag, nil /* value */)
-	ctx = ca.StartInternal(ctx, changeAggregatorProcName)
+
+	ca.agg = tracing.TracingAggregatorForContext(ctx)
+	if ca.agg != nil {
+		ca.aggTimer.Reset(tracingAggTimerInterval)
+	}
+
+	ctx = ca.StartInternal(ctx, changeAggregatorProcName, ca.agg)
 
 	spans, err := ca.setupSpansAndFrontier()
 	if err != nil {
@@ -758,6 +778,15 @@ func (ca *changeAggregator) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMet
 			break
 		}
 
+		select {
+		case <-ca.aggTimer.C:
+			ca.aggTimer.Read = true
+			ca.aggTimer.Reset(tracingAggTimerInterval)
+			return nil, bulkutil.ConstructTracingAggregatorProducerMeta(ca.Ctx(),
+				ca.FlowCtx.NodeID.SQLInstanceID(), ca.FlowCtx.ID, ca.agg)
+		default:
+		}
+
 		if err := ca.tick(); err != nil {
 			var e kvevent.ErrBufferClosed
 			if errors.As(err, &e) {
@@ -1052,6 +1081,11 @@ type changeFrontier struct {
 	metricsID    int
 	sliMetricsID int64
 
+	// Aggregator that aggregates StructuredEvents emitted in the
+	// changeFrontier's trace recording.
+	agg      *tracing.TracingAggregator
+	aggTimer timeutil.Timer
+
 	knobs TestingKnobs
 
 	usageWg       sync.WaitGroup
@@ -1233,11 +1267,17 @@ func newChangeFrontierProcessor(
 		processorID,
 		memMonitor,
 		execinfra.ProcStateOpts{
+			InputsToDrain: []execinfra.RowSource{cf.input},
 			TrailingMetaCallback: func() []execinfrapb.ProducerMetadata {
 				cf.close()
+
+				if cf.agg != nil {
+					meta := bulkutil.ConstructTracingAggregatorProducerMeta(ctx,
+						cf.FlowCtx.NodeID.SQLInstanceID(), cf.FlowCtx.ID, cf.agg)
+					return []execinfrapb.ProducerMetadata{*meta}
+				}
 				return nil
 			},
-			InputsToDrain: []execinfra.RowSource{cf.input},
 		},
 	); err != nil {
 		return nil, err
@@ -1297,9 +1337,16 @@ func (cf *changeFrontier) Start(ctx context.Context) {
 		ctx = logtags.AddTag(ctx, "job", cf.spec.JobID)
 	}
 	ctx = logtags.AddTag(ctx, changeFrontierLogTag, nil /* value */)
+
+	cf.agg = tracing.TracingAggregatorForContext(ctx)
+	if cf.agg != nil {
+		cf.aggTimer.Reset(1 * time.Second)
+	}
+
 	// StartInternal called at the beginning of the function because there are
 	// early returns if errors are detected.
-	ctx = cf.StartInternal(ctx, changeFrontierProcName)
+	ctx = cf.StartInternal(ctx, changeFrontierProcName, cf.agg)
+
 	cf.input.Start(ctx)
 
 	// The job registry has a set of metrics used to monitor the various jobs it
@@ -1538,6 +1585,15 @@ func (cf *changeFrontier) Next() (rowenc.EncDatumRow, *execinfrapb.ProducerMetad
 			return cf.ProcessRowHelper(cf.passthroughBuf.Pop()), nil
 		} else if !cf.resolvedBuf.IsEmpty() {
 			return cf.ProcessRowHelper(cf.resolvedBuf.Pop()), nil
+		}
+
+		select {
+		case <-cf.aggTimer.C:
+			cf.aggTimer.Read = true
+			cf.aggTimer.Reset(1 * time.Second)
+			return nil, bulkutil.ConstructTracingAggregatorProducerMeta(cf.Ctx(),
+				cf.FlowCtx.NodeID.SQLInstanceID(), cf.FlowCtx.ID, cf.agg)
+		default:
 		}
 
 		if ok, boundaryType, boundaryTime := cf.frontier.AtBoundary(); ok &&

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -38,6 +38,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/exprutil"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -48,6 +49,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/bulk"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -55,6 +57,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/severity"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
@@ -75,7 +78,9 @@ func init() {
 	jobs.RegisterConstructor(
 		jobspb.TypeChangefeed,
 		func(job *jobs.Job, _ *cluster.Settings) jobs.Resumer {
-			return &changefeedResumer{job: job}
+			r := &changefeedResumer{job: job}
+			r.mu.perNodeAggregatorStats = make(bulk.ComponentAggregatorStats)
+			return r
 		},
 		jobs.UsesTenantCostControl,
 	)
@@ -417,7 +422,7 @@ func coreChangefeed(
 			knobs.BeforeDistChangefeed()
 		}
 
-		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh)
+		err := distChangefeedFlow(ctx, p, 0 /* jobID */, details, description, localState, resultsCh, nil)
 		if err == nil {
 			log.Infof(ctx, "core changefeed completed with no error")
 			return nil
@@ -1211,7 +1216,26 @@ func validateAndNormalizeChangefeedExpression(
 
 type changefeedResumer struct {
 	job *jobs.Job
+
+	mu struct {
+		syncutil.Mutex
+		// perNodeAggregatorStats is a per component running aggregate of trace
+		// driven AggregatorStats emitted by the processors.
+		perNodeAggregatorStats bulk.ComponentAggregatorStats
+	}
 }
+
+// DumpTraceAfterRun implements jobs.TraceableJob.
+func (b *changefeedResumer) DumpTraceAfterRun() bool {
+	return true
+}
+
+// ForceRealSpan implements jobs.TraceableJob.
+func (b *changefeedResumer) ForceRealSpan() bool {
+	return true
+}
+
+var _ jobs.TraceableJob = &changefeedResumer{}
 
 func (b *changefeedResumer) setJobStatusMessage(
 	ctx context.Context, lastUpdate time.Time, fmtOrMsg string, args ...interface{},
@@ -1405,6 +1429,17 @@ func (b *changefeedResumer) resumeWithRetries(
 		log.Warningf(ctx, "failed to resolve destination details for change monitoring: %v", err)
 	}
 
+	onTracingEvent := func(ctx context.Context, meta *execinfrapb.TracingAggregatorEvents) {
+		componentID := execinfrapb.ComponentID{
+			FlowID:        meta.FlowID,
+			SQLInstanceID: meta.SQLInstanceID,
+		}
+
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		b.mu.perNodeAggregatorStats[componentID] = *meta
+	}
+
 	for r := getRetry(ctx); r.Next(); {
 		flowErr := maybeUpgradePreProductionReadyExpression(ctx, jobID, details, jobExec)
 
@@ -1422,7 +1457,7 @@ func (b *changefeedResumer) resumeWithRetries(
 			g := ctxgroup.WithContext(ctx)
 			g.GoCtx(func(ctx context.Context) error {
 				defer close(confPoller)
-				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh)
+				return distChangefeedFlow(ctx, jobExec, jobID, details, description, localState, startedCh, onTracingEvent)
 			})
 			g.GoCtx(func(ctx context.Context) error {
 				t := time.NewTicker(15 * time.Second)
@@ -1654,8 +1689,17 @@ func (b *changefeedResumer) OnFailOrCancel(
 }
 
 // CollectProfile is part of the jobs.Resumer interface.
-func (b *changefeedResumer) CollectProfile(_ context.Context, _ interface{}) error {
-	return nil
+func (b *changefeedResumer) CollectProfile(ctx context.Context, execCtx interface{}) error {
+	p := execCtx.(sql.JobExecContext)
+	var aggStatsCopy bulk.ComponentAggregatorStats
+	func() {
+		b.mu.Lock()
+		defer b.mu.Unlock()
+		aggStatsCopy = b.mu.perNodeAggregatorStats.DeepCopy()
+	}()
+
+	return bulk.FlushTracingAggregatorStats(ctx, b.job.ID(),
+		p.ExecCfg().InternalDB, aggStatsCopy)
 }
 
 // Try to clean up a protected timestamp created by the changefeed.

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -685,6 +686,9 @@ func (c *parallelEventConsumer) startWorkers() error {
 		id := i
 		consumer := consumers[i]
 		workerClosure := func(ctx2 context.Context) error {
+			ctx2, sp := tracing.ChildSpan(ctx2, "changefeed.parallel_event_consumer.worker")
+			defer sp.Finish()
+
 			return c.workerLoop(ctx2, consumer, id)
 		}
 		c.g.GoCtx(workerClosure)

--- a/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/kvfeed/BUILD.bazel
@@ -36,6 +36,7 @@ go_library(
         "//pkg/util/retry",
         "//pkg/util/span",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
     ],

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/span"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
 )
@@ -329,6 +330,8 @@ func newKVFeed(
 var errChangefeedCompleted = errors.New("changefeed completed")
 
 func (f *kvFeed) run(ctx context.Context) (err error) {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.kvfeed.run")
+	defer sp.Finish()
 	log.Infof(ctx, "kv feed run starting")
 
 	emitResolved := func(ts hlc.Timestamp, boundary jobspb.ResolvedSpan_BoundaryType) error {
@@ -356,6 +359,7 @@ func (f *kvFeed) run(ctx context.Context) (err error) {
 	for i := 0; ; i++ {
 		initialScan := i == 0
 		initialScanOnly := f.endTime == f.initialHighWater
+
 		scannedSpans, scannedTS, err := f.scanIfShould(ctx, initialScan, initialScanOnly, rangeFeedResumeFrontier.Frontier())
 		if err != nil {
 			return err
@@ -486,6 +490,9 @@ func filterCheckpointSpans(
 func (f *kvFeed) scanIfShould(
 	ctx context.Context, initialScan bool, initialScanOnly bool, highWater hlc.Timestamp,
 ) ([]roachpb.Span, hlc.Timestamp, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.kvfeed.scan_if_should")
+	defer sp.Finish()
+
 	scanTime := highWater.Next()
 
 	events, err := f.tableFeed.Peek(ctx, scanTime)
@@ -578,6 +585,9 @@ func (f *kvFeed) scanIfShould(
 // If the function returns a nil error, resumeFrontier.Frontier() will be
 // ts.Prev() where ts is the schema change timestamp.
 func (f *kvFeed) runUntilTableEvent(ctx context.Context, resumeFrontier span.Frontier) (err error) {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.kvfeed.run_until_table_event")
+	defer sp.Finish()
+
 	startFrom := resumeFrontier.Frontier()
 
 	// Determine whether to request the previous value of each update from
@@ -709,6 +719,9 @@ func copyFromSourceToDestUntilTableEvent(
 	knobs TestingKnobs,
 	st *timers.ScopedTimers,
 ) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.kvfeed.copy_from_source_to_dest_until_table_event")
+	defer sp.Finish()
+
 	// Initially, the only copy boundary is the end time if one is specified.
 	// Once we discover a table event (which is before the end time), that will
 	// become the new boundary.

--- a/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
+++ b/pkg/ccl/changefeedccl/kvfeed/physical_kv_feed.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -62,6 +63,9 @@ type rangefeed struct {
 
 // Run implements the physicalFeedFactory interface.
 func (p rangefeedFactory) Run(ctx context.Context, sink kvevent.Writer, cfg rangeFeedConfig) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.physical_kv_feed.run")
+	defer sp.Finish()
+
 	// To avoid blocking raft, RangeFeed puts all entries in a server side
 	// buffer. But to keep things simple, it's a small fixed-sized buffer. This
 	// means we need to ingest everything we get back as quickly as possible, so
@@ -131,6 +135,9 @@ func quantizeTS(ts hlc.Timestamp, granularity time.Duration) hlc.Timestamp {
 // addEventsToBuffer consumes rangefeed events from `p.eventCh`, transforms
 // them to kvevent.Event's, and pushes them into `p.memBuf`.
 func (p *rangefeed) addEventsToBuffer(ctx context.Context) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.physical_kv_feed.add_events_to_buffer")
+	defer sp.Finish()
+
 	for {
 		select {
 		case e := <-p.eventCh:

--- a/pkg/ccl/changefeedccl/kvfeed/scanner.go
+++ b/pkg/ccl/changefeedccl/kvfeed/scanner.go
@@ -30,6 +30,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 )
 
@@ -56,6 +57,9 @@ type scanRequestScanner struct {
 var _ kvScanner = (*scanRequestScanner)(nil)
 
 func (p *scanRequestScanner) Scan(ctx context.Context, sink kvevent.Writer, cfg scanConfig) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.kvfeed.scanner.scan")
+	defer sp.Finish()
+
 	ctx, cancel := context.WithCancel(ctx)
 	defer cancel()
 
@@ -173,6 +177,9 @@ func (p *scanRequestScanner) exportSpan(
 	sink kvevent.Writer,
 	knobs TestingKnobs,
 ) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.kvfeed.scanner.export_span")
+	defer sp.Finish()
+
 	txn := p.db.NewTxn(ctx, "changefeed backfill")
 	if log.V(2) {
 		log.Infof(ctx, `sending ScanRequest %s at %s`, span, ts)

--- a/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/schemafeed/BUILD.bazel
@@ -37,7 +37,9 @@ go_library(
         "//pkg/util/metric",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_logtags//:logtags",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/google/btree"
 	// Placeholder for pgzip and zdstd.
@@ -764,6 +765,9 @@ var logQueueDepth = log.Every(30 * time.Second)
 // flushFile flushes file to the cloud storage.
 // file should not be used after flushing.
 func (s *cloudStorageSink) flushFile(ctx context.Context, file *cloudStorageSinkFile) error {
+	ctx, sp := tracing.ChildSpan(ctx, "changefeed.cloudstorage_sink.flush_file")
+	defer sp.Finish()
+
 	asyncFlushEnabled := enableAsyncFlush.Get(&s.settings.SV)
 	if s.asyncFlushActive && !asyncFlushEnabled {
 		// Async flush behavior was turned off --  drain any active flush requests


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: add job tracing support to changefeeds" (#144412)
  * 1/1 commits from "changefeedccl: add more tracing spans" (#146216)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: better supportability