### PR TITLE
release-24.1: changefeedccl: reduce max backoff

### DIFF
--- a/pkg/ccl/changefeedccl/retry.go
+++ b/pkg/ccl/changefeedccl/retry.go
@@ -20,9 +20,9 @@ var useFastRetry = envutil.EnvOrDefaultBool(
 // getRetry returns retry object for changefeed.
 func getRetry(ctx context.Context) Retry {
 	opts := retry.Options{
-		InitialBackoff: 5 * time.Second,
+		InitialBackoff: 1 * time.Second,
 		Multiplier:     2,
-		MaxBackoff:     10 * time.Minute,
+		MaxBackoff:     1 * time.Minute,
 	}
 
 	if useFastRetry {


### PR DESCRIPTION
Backport 1/1 commits from #146448 on behalf of @asg0451.

----

Reduce max backoff to 1 minute from 10 minutes.
This should improve behaviour during transient
errors and rolling restarts.

Epic: none

Release note (enterprise change): Reduced the
maximum backoff for changefeed retries from 10
minutes to 1 minute, resulting in faster recovery
from transient errors.


----

Release justification: improve usability