### PR TITLE
cdc: fix fine grained checkpointing test network issue

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1224,7 +1224,7 @@ func runCDCFineGrainedCheckpointingBenchmark(
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
 	m := c.NewMonitor(ctx, c.All())
 
-	db := c.Conn(ctx, t.L(), 1)
+	db := c.Conn(ctx, t.L(), c.Spec().NodeCount)
 
 	startTime := timeutil.Now()
 
@@ -1376,10 +1376,12 @@ func runCDCFineGrainedCheckpointingBenchmark(
 	testutils.SucceedsWithin(t, func() error {
 		unique, err := get("/unique")
 		if err != nil {
+			t.L().Errorf("error getting unique count: %v", err)
 			return err
 		}
 		dupes, err = get("/dupes")
 		if err != nil {
+			t.L().Errorf("error getting dupes count: %v", err)
 			return err
 		}
 		t.L().Printf("sink got %d unique, %d dupes", unique, dupes)


### PR DESCRIPTION
We were seeing a network issue where the changefeed node was unable to connect to the webhook server running on the coordinator node on teamcity. By running the changefeed on a node 4, the same node as the sink, we ensure that the changefeed node can reach the sink.

Fixes: #146862
Epic: none
Release note: None