### PR TITLE
release-23.2: changefeedccl: fix mvcc_timestamp being zero when used with cdc queries

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/projection.go
+++ b/pkg/ccl/changefeedccl/cdcevent/projection.go
@@ -116,5 +116,7 @@ func (p *Projection) Project(r Row) (Row, error) {
 		return Row{}, err
 	}
 
+	p.MvccTimestamp = r.MvccTimestamp
+
 	return Row(*p), nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9813,6 +9813,33 @@ func TestParallelIOMetrics(t *testing.T) {
 	cdcTest(t, testFn, feedTestForceSink("pubsub"))
 }
 
+func TestChangefeedMVCCTimestampWithQueries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY);`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1);`)
+
+		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp AS SELECT * FROM foo`)
+		require.NoError(t, err)
+		defer closeFeed(t, feed)
+
+		msgs, err := readNextMessages(ctx, feed, 1)
+		require.NoError(t, err)
+
+		var m map[string]any
+		require.NoError(t, gojson.Unmarshal(msgs[0].Value, &m))
+		ts := m["__crdb__"].(map[string]any)["mvcc_timestamp"].(string)
+		assertReasonableMVCCTimestamp(t, ts)
+	}
+
+	cdcTest(t, testFn)
+}
+
 func TestCloudstorageParallelCompression(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9824,20 +9824,32 @@ func TestChangefeedMVCCTimestampWithQueries(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY);`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1);`)
 
-		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp AS SELECT * FROM foo`)
+		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp, format=json, envelope=bare AS SELECT * FROM foo`)
 		require.NoError(t, err)
+		// Bypass some bad heuristics checks in these testfeeds.
+		if wf, ok := feed.(*webhookFeed); ok {
+			wf.isBare = true
+		} else if cf, ok := feed.(*cloudFeed); ok {
+			cf.isBare = true
+		}
 		defer closeFeed(t, feed)
 
 		msgs, err := readNextMessages(ctx, feed, 1)
 		require.NoError(t, err)
 
 		var m map[string]any
-		require.NoError(t, gojson.Unmarshal(msgs[0].Value, &m))
+		require.NoError(t, json.Unmarshal(msgs[0].Value, &m))
 		ts := m["__crdb__"].(map[string]any)["mvcc_timestamp"].(string)
 		assertReasonableMVCCTimestamp(t, ts)
 	}
 
 	cdcTest(t, testFn)
+}
+
+func assertReasonableMVCCTimestamp(t *testing.T, ts string) {
+	epochNanos := parseTimeToHLC(t, ts).WallTime
+	now := timeutil.Now()
+	require.GreaterOrEqual(t, epochNanos, now.Add(-1*time.Hour).UnixNano())
 }
 
 func TestCloudstorageParallelCompression(t *testing.T) {


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: fix mvcc_timestamp being zero when used with cdc queries" (#146836)
  * 1/1 commits from "changefeedccl: fix mvcc timestamp test" (#146880)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: O-support bug fix
