### PR TITLE
release-24.3: changefeedccl: deflake pts update test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -9860,6 +9860,9 @@ func TestChangefeedProtectedTimestampUpdate(t *testing.T) {
 		changefeedbase.ProtectTimestampLag.Override(
 			context.Background(), &s.Server.ClusterSettings().SV, 10*time.Millisecond)
 
+		// Ensure that the resolved timestamp advances at least once
+		// since the PTS lag override.
+		testutils.SucceedsSoon(t, checkHWM)
 		testutils.SucceedsSoon(t, checkHWM)
 
 		sqlDB.QueryRow(t, ptsQry).Scan(&ts2)


### PR DESCRIPTION
Backport 1/1 commits from #140707 on behalf of @rharding6373.

----

This PR deflakes TestChangefeedProtectedTimestampUpdate by checking that the resolved timestamp advances at least once after the PTS lag cluster setting override. Otherwise it's possible that the resolved timestamp advanced before the override went into effect.

Epic: none

Fixes: #140681

Release note: none

----

Release justification: test fix