### PR TITLE
release-24.3: changefeedccl: fix mvcc_timestamp being zero when used with cdc queries

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/projection.go
+++ b/pkg/ccl/changefeedccl/cdcevent/projection.go
@@ -116,5 +116,7 @@ func (p *Projection) Project(r Row) (Row, error) {
 		return Row{}, err
 	}
 
+	p.MvccTimestamp = r.MvccTimestamp
+
 	return Row(*p), nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -10,6 +10,7 @@ import (
 	gosql "database/sql"
 	"encoding/base64"
 	"encoding/json"
+	gojson "encoding/json"
 	"fmt"
 	"math"
 	"math/rand"
@@ -2729,7 +2730,7 @@ func TestChangefeedSchemaChangeAllowBackfill_Legacy(t *testing.T) {
 			// the backfill) occurs before the schema-change backfill for a drop
 			// column, the order in which the sink receives both backfills is
 			// uncertain. the only guarantee here is per-key ordering guarantees,
-			// so we must check both backfills in the same assertion.
+			// so we must check both backfills in the same assertion
 			assertPayloadsPerKeyOrderedStripTs(t, dropColumn, []string{
 				// Changefeed level backfill for DROP COLUMN b.
 				`drop_column: [1]->{"after": {"a": 1}}`,
@@ -9932,4 +9933,67 @@ func TestCDCQuerySelectSingleRow(t *testing.T) {
 		}
 	}
 	cdcTest(t, testFn, withKnobsFn(knobsFn))
+}
+
+func assertReasonableMVCCTimestamp(t *testing.T, ts string) {
+	epochNanos := parseTimeToHLC(t, ts).WallTime
+	now := timeutil.Now()
+	require.GreaterOrEqual(t, epochNanos, now.Add(-1*time.Hour).UnixNano())
+}
+
+func assertEqualTSNSHLCWalltime(t *testing.T, tsns int64, tshlc string) {
+	tsHLCWallTimeNano := parseTimeToHLC(t, tshlc).WallTime
+	require.EqualValues(t, tsns, tsHLCWallTimeNano)
+}
+
+// TestChangefeedAsSelectForEmptyTable verifies that a changefeed
+// yields a proper user error on an empty table and in the same
+// allows hidden columns to be selected.
+func TestChangefeedAsSelectForEmptyTable(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE empty()`)
+		sqlDB.Exec(t, `INSERT INTO empty DEFAULT VALUES`)
+		// Should fail when no columns are selected.
+		// Use expectErrCreatingFeed which handles sinkless feeds correctly by
+		// attempting to read from the feed if no error occurs at creation time
+		expectErrCreatingFeed(t, f, `CREATE CHANGEFEED AS SELECT * FROM empty`, `SELECT yields no columns`)
+
+		// Should succeed when a rowid column is explicitly selected.
+		feed, err := f.Feed(`CREATE CHANGEFEED AS SELECT rowid FROM empty`)
+		require.NoError(t, err)
+		defer closeFeed(t, feed)
+	}
+
+	cdcTest(t, testFn)
+}
+
+func TestChangefeedMVCCTimestampWithQueries(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY);`)
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1);`)
+
+		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp, format=json, envelope=bare AS SELECT * FROM foo`)
+		require.NoError(t, err)
+		defer closeFeed(t, feed)
+
+		msgs, err := readNextMessages(ctx, feed, 1)
+		require.NoError(t, err)
+
+		var m map[string]any
+		require.NoError(t, gojson.Unmarshal(msgs[0].Value, &m))
+		ts := m["__crdb__"].(map[string]any)["mvcc_timestamp"].(string)
+		assertReasonableMVCCTimestamp(t, ts)
+	}
+
+	cdcTest(t, testFn)
 }


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: fix mvcc_timestamp being zero when used with cdc queries" (#146836)
  * 1/1 commits from "changefeedccl: fix mvcc timestamp test" (#146880)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: O-support bug fix