### PR TITLE
release-24.3: changefeedccl: fix mvcc_timestamp being zero when used with cdc queries 

### DIFF
--- a/pkg/ccl/changefeedccl/cdcevent/projection.go
+++ b/pkg/ccl/changefeedccl/cdcevent/projection.go
@@ -116,5 +116,7 @@ func (p *Projection) Project(r Row) (Row, error) {
 		return Row{}, err
 	}
 
+	p.MvccTimestamp = r.MvccTimestamp
+
 	return Row(*p), nil
 }

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -2729,7 +2729,7 @@ func TestChangefeedSchemaChangeAllowBackfill_Legacy(t *testing.T) {
 			// the backfill) occurs before the schema-change backfill for a drop
 			// column, the order in which the sink receives both backfills is
 			// uncertain. the only guarantee here is per-key ordering guarantees,
-			// so we must check both backfills in the same assertion
+			// so we must check both backfills in the same assertion.
 			assertPayloadsPerKeyOrderedStripTs(t, dropColumn, []string{
 				// Changefeed level backfill for DROP COLUMN b.
 				`drop_column: [1]->{"after": {"a": 1}}`,
@@ -9954,8 +9954,16 @@ func TestChangefeedMVCCTimestampWithQueries(t *testing.T) {
 		sqlDB.Exec(t, `CREATE TABLE foo (key INT PRIMARY KEY);`)
 		sqlDB.Exec(t, `INSERT INTO foo VALUES (1);`)
 
-		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp AS SELECT * FROM foo`)
+		feed, err := f.Feed(`CREATE CHANGEFEED WITH mvcc_timestamp, format=json, envelope=bare AS SELECT * FROM foo`)
 		require.NoError(t, err)
+
+		// Bypass some bad heuristics checks in these testfeeds.
+		if wf, ok := feed.(*webhookFeed); ok {
+			wf.isBare = true
+		} else if cf, ok := feed.(*cloudFeed); ok {
+			cf.isBare = true
+		}
+
 		defer closeFeed(t, feed)
 
 		msgs, err := readNextMessages(ctx, feed, 1)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "changefeedccl: fix mvcc_timestamp being zero when used with cdc queries" (#146836)
  * 1/1 commits from "changefeedccl: fix mvcc timestamp test" (#146880)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: O-support important bug fix 