### PR TITLE
kvcoord: deterministic error ordering

### DIFF
--- a/pkg/crosscluster/logical/batch_handler_test.go
+++ b/pkg/crosscluster/logical/batch_handler_test.go
@@ -183,8 +183,7 @@ func TestBatchHandlerExhaustive(t *testing.T) {
 	if uniqueConstraint {
 		runner.Exec(t, `ALTER TABLE test_table ADD CONSTRAINT unique_value UNIQUE (value)`)
 	}
-	// TODO(jeffswenson): enable this metamorphic option after fixing #146465.
-	if false && addAndRemoveColumn {
+	if addAndRemoveColumn {
 		runner.Exec(t, `ALTER TABLE test_table ADD COLUMN temp_col INT`)
 		runner.Exec(t, `ALTER TABLE test_table DROP COLUMN temp_col`)
 	}


### PR DESCRIPTION
DistSender splits requests up in range order and collects errors in the order requests were dispatched. If there are multiple errors, the highest priority error is returned and ties are broken by dispatch order. Now, the merge logic consults the index of the request that generated the error. This is particularly useful for CPuts as it allows the caller to observe the first cput in the batch that failed.

The deterministic order allows LDR, `deleteSwap`, and `updateSwap` to guarantee the cput error is for the primary key. This property is essential because they are using cput to optimistically guess at the value of the row in the database. The batches may also contain cput failures for unique indexes, but those errors should only be raised to the user if the primary key cput succeeded.

This is still a bit of a hack. In a perfect world, the cput failure would be treated as a result instead of an error. That would allow the caller to inspect each cput result independently and would make it clear that cput failures do not poison any of the other requests in the batch.

Informs: https://github.com/cockroachdb/cockroach/issues/146117
Release note: fixes an issue with LDR where the presence of a unique
index may cause spurious DLQ entries if the unique index has a smaller
index id than the primary key index.