### PR TITLE
workload: remove some nested txns in schemachange workload

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -72,12 +72,6 @@ func (og *operationGenerator) tableHasRows(
 	return og.scanBool(ctx, tx, fmt.Sprintf(`SELECT EXISTS (SELECT * FROM %s)`, tableName.String()))
 }
 
-func (og *operationGenerator) scanInt(
-	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
-) (i int, err error) {
-	return Scan[int](ctx, og, tx, query, args...)
-}
-
 func (og *operationGenerator) scanBool(
 	ctx context.Context, tx pgx.Tx, query string, args ...interface{},
 ) (b bool, err error) {
@@ -1030,66 +1024,6 @@ func (og *operationGenerator) constraintExists(
 	return og.scanBool(ctx, tx, `SELECT EXISTS(
 		SELECT * FROM information_schema.table_constraints WHERE table_name = $1 AND constraint_name = $2
 	 )`, string(tableName), string(constraintName))
-}
-
-func (og *operationGenerator) rowsSatisfyFkConstraint(
-	ctx context.Context,
-	tx pgx.Tx,
-	parentTable *tree.TableName,
-	parentColumn *column,
-	childTable *tree.TableName,
-	childColumn *column,
-) (bool, error) {
-	// Self referential foreign key constraints are acceptable.
-	selfReferential, err := og.scanBool(ctx, tx,
-		`SELECT $1:::REGCLASS=$2:::REGCLASS`,
-		parentTable.String(), childTable.String())
-	if err != nil {
-		return false, err
-	}
-	if selfReferential && parentColumn.name == childColumn.name {
-		return true, nil
-	}
-
-	// Validate the parent table has rows.
-	childRows, err := og.scanInt(ctx, tx,
-		fmt.Sprintf(`
-SELECT count(*) FROM %s
-		`, childTable.String()),
-	)
-	if err != nil {
-		return false, err
-	}
-
-	// If child table is empty then no violation can exist.
-	if childRows == 0 {
-		return true, nil
-	}
-
-	q := fmt.Sprintf(`
-	  SELECT count(*)
-	    FROM %s as t1
-		  LEFT JOIN %s as t2
-				     ON t1.%s = t2.%s
-			WHERE t2.%s IS NOT NULL
-`, childTable.String(), parentTable.String(), childColumn.name.String(), parentColumn.name.String(), parentColumn.name.String())
-
-	joinTx, err := tx.Begin(ctx)
-	if err != nil {
-		return false, err
-	}
-	numJoinRows, err := og.scanInt(ctx, joinTx, q)
-	if err != nil {
-		rbkErr := joinTx.Rollback(ctx)
-		// UndefinedFunction errors mean that the column type is not comparable.
-		if pgErr := new(pgconn.PgError); errors.As(err, &pgErr) &&
-			((pgcode.MakeCode(pgErr.Code) == pgcode.UndefinedFunction) ||
-				(pgcode.MakeCode(pgErr.Code) == pgcode.UndefinedColumn)) {
-			return false, rbkErr
-		}
-		return false, errors.WithSecondaryError(err, rbkErr)
-	}
-	return numJoinRows == childRows, joinTx.Commit(ctx)
 }
 
 var (

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -898,15 +898,6 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	if err != nil {
 		return nil, err
 	}
-	// If we are intentionally using an invalid child type, then it doesn't make
-	// sense to validate if the rows validate the constraint.
-	rowsSatisfyConstraint := true
-	if !fetchInvalidChild {
-		rowsSatisfyConstraint, err = og.rowsSatisfyFkConstraint(ctx, tx, parentTable, parentColumn, childTable, childColumn)
-		if err != nil {
-			return nil, err
-		}
-	}
 
 	stmt := makeOpStmt(OpStmtDDL)
 	stmt.expectedExecErrors.addAll(codesWithConditions{
@@ -923,7 +914,6 @@ func (og *operationGenerator) addForeignKeyConstraint(
 	// separate job validating the constraint, we can't at transaction time predict,
 	// perfectly if an error is expected. We can confirm post transaction with a time
 	// travel query.
-	_ = rowsSatisfyConstraint
 	stmt.potentialExecErrors.add(pgcode.ForeignKeyViolation)
 	og.potentialCommitErrors.add(pgcode.ForeignKeyViolation)
 
@@ -3623,22 +3613,12 @@ func (og *operationGenerator) randParentColumnForFkRelation(
 	var typName string
 	var nullable string
 
-	nestedTxn, err := tx.Begin(ctx)
-	if err != nil {
-		return nil, nil, err
-	}
-	err = nestedTxn.QueryRow(ctx, fmt.Sprintf(`
+	err := tx.QueryRow(ctx, fmt.Sprintf(`
 	SELECT table_schema, table_name, column_name, crdb_sql_type, is_nullable FROM (
 		%s
 	)`, subQuery.String())).Scan(&tableSchema, &tableName, &columnName, &typName, &nullable)
 	if err != nil {
-		if rbErr := nestedTxn.Rollback(ctx); rbErr != nil {
-			err = errors.CombineErrors(rbErr, err)
-		}
 		return nil, nil, err
-	}
-	if err = nestedTxn.Commit(ctx); err != nil {
-		return nil, nil, errors.WithStack(err)
 	}
 
 	columnToReturn := column{


### PR DESCRIPTION
Remove the rowsSatisfyFkConstraint helper, since its result was never actaully used. Also remove a nested transaction usage that was not needed.

These changes should reduce the chance of seeing a "cannot create or release savepoint after an error has occurred" error.

fixes https://github.com/cockroachdb/cockroach/issues/146050
Release note: None