### PR TITLE
ci: deadmansnitch for code-cover-gen GH action

### DIFF
--- a/.github/workflows/code-cover-gen.yml
+++ b/.github/workflows/code-cover-gen.yml
@@ -113,7 +113,7 @@ jobs:
             jq -n --arg err "$msg" '{error: $err}' > artifacts/cover-${PR}-${HEAD_SHA}.json 
             BASE_SHA=${{ env.BASE_SHA }}
             if [ -n "$BASE_SHA" ]; then
-              jq -n --arg err "$msg" '{error: $err}' > artifacts/cover-${PR}-${BASE_SHA}.json 
+              jq -n --arg err "$msg" '{error: $err}' > artifacts/cover-${PR}-${BASE_SHA}.json
             fi
           fi
 
@@ -122,3 +122,8 @@ jobs:
         with:
           name: cover
           path: artifacts/cover-*.json
+
+      - name: 'Call DeadManSnitch'
+        if: env.ERROR == ''
+        run: |
+          curl -X GET 'https://nosnch.in/54f81030dc' -d 'message=Code coverage generated'


### PR DESCRIPTION
Previously, we had added active monitoring for
`code-cover-publish` [1]. However, this time
`code-cover-gen` kept failing during build [2].
The latter workflow has `continue-on-error` in
order to report the (failure) status to Reviewable.io. Effectively, it was silently failing.

This change adds active monitoring for `code-cover-gen`. 
DMS will alert testeng in case any of the workflow steps fail repeatedly 
during the 24h interval.

[1] https://github.com/cockroachdb/cockroach/pull/137412
[2] https://github.com/cockroachdb/cockroach/issues/147052

Epic: none
Release note: None