### PR TITLE
release-25.2.1-rc: pkg/storage/disk: Add support for monitoring disk stats for unknown devices

### DIFF
--- a/pkg/storage/disk/BUILD.bazel
+++ b/pkg/storage/disk/BUILD.bazel
@@ -49,6 +49,7 @@ go_test(
         "linux_parse_test.go",
         "monitor_test.go",
         "monitor_tracer_test.go",
+        "platform_linux_test.go",
     ],
     data = glob(["testdata/**"]),
     embed = [":disk"],

--- a/pkg/storage/disk/monitor.go
+++ b/pkg/storage/disk/monitor.go
@@ -321,5 +321,5 @@ func getDeviceIDFromPath(fs vfs.FS, path string) (DeviceID, error) {
 	if err != nil {
 		return DeviceID{}, errors.Wrapf(err, "fstat(%s)", path)
 	}
-	return deviceIDFromFileInfo(finfo), nil
+	return deviceIDFromFileInfo(finfo, path), nil
 }

--- a/pkg/storage/disk/platform_darwin.go
+++ b/pkg/storage/disk/platform_darwin.go
@@ -26,7 +26,7 @@ func newStatsCollector(fs vfs.FS) (*darwinCollector, error) {
 	return &darwinCollector{}, nil
 }
 
-func deviceIDFromFileInfo(finfo fs.FileInfo) DeviceID {
+func deviceIDFromFileInfo(finfo fs.FileInfo, path string) DeviceID {
 	statInfo := finfo.Sys().(*sysutil.StatT)
 	id := DeviceID{
 		major: unix.Major(uint64(statInfo.Dev)),

--- a/pkg/storage/disk/platform_default.go
+++ b/pkg/storage/disk/platform_default.go
@@ -24,6 +24,6 @@ func newStatsCollector(fs vfs.FS) (*defaultCollector, error) {
 	return &defaultCollector{}, nil
 }
 
-func deviceIDFromFileInfo(fs.FileInfo) DeviceID {
+func deviceIDFromFileInfo(fs.FileInfo, string) DeviceID {
 	return DeviceID{}
 }

--- a/pkg/storage/disk/platform_linux.go
+++ b/pkg/storage/disk/platform_linux.go
@@ -18,7 +18,6 @@ import (
 	"os/exec"
 	"path/filepath"
 	"regexp"
-	"strconv"
 	"strings"
 	"time"
 
@@ -83,27 +82,46 @@ func deviceIDFromFileInfo(finfo fs.FileInfo, path string) DeviceID {
 	// Per /usr/include/linux/major.h and Documentation/admin-guide/devices.rst:
 	switch major {
 	case 0: // UNNAMED_MAJOR
+
 		// Perform additional lookups for unknown device types
 		var statfs sysutil.StatfsT
-		if err := sysutil.Statfs(path, &statfs); err != nil {
-			log.Warningf(ctx, "unable statfs(2) path %q: %v", path, err)
-		} else {
-			fsType := statfs.Type
-			switch strconv.FormatInt(fsType, 16) {
-			case "2fc12fc1": // ZFS_SUPER_MAGIC from include/sys/fs/zfs.h
-				if major, minor, err = deviceIDForZFS(path); err != nil {
-					log.Warningf(ctx, "unable to find device ID for %q: %v", path, err)
-				}
-			default:
-				log.Warningf(ctx, "unsupported file system type %q for path %q", fsType, path)
-			}
+		err := sysutil.Statfs(path, &statfs)
+		if err != nil {
+			maybeWarnf(ctx, "unable to statfs(2) path %q (%d:%d): %v", path, major, minor, err)
+			return DeviceID{major, minor}
 		}
-	case 259: //BLOCK_EXT_MAJOR=259
-		// noop
-	}
 
-	if major == 0 {
-		log.Warningf(ctx, "unsupported device type %q", path)
+		switch statfs.Type {
+		case 0x2fc12fc1: // ZFS_SUPER_MAGIC from include/sys/fs/zfs.h
+			major, minor, err = deviceIDForZFS(path)
+			if err != nil {
+				maybeWarnf(ctx, "zfs: unable to find device ID for %q: %v", path, err)
+			} else {
+				maybeInfof(ctx, "zfs: mapping %q to diskstats device %d:%d", path, major, minor)
+			}
+
+			id := DeviceID{
+				major: major,
+				minor: minor,
+			}
+			return id
+
+		case 0x58465342: // XFS_SUPER_MAGIC	from linux/magic.h "XFSB"
+			maybeWarnf(ctx, "xfs: unable to find device ID for %q: %v", path, err)
+
+		default:
+			maybeWarnf(ctx, "unsupported file system type %x for path (%d:%d) %q", statfs.Type, major, minor, path)
+		}
+
+	case 259: // BLOCK_EXT_MAJOR=259
+
+		// NOTE: Major device 259 is the happy path for ext4 and xfs filesystems: no
+		// additional handling is required.
+
+		maybeInfof(ctx, "mapping %q to diskstats device %d:%d", path, major, minor)
+
+	default:
+		maybeWarnf(ctx, "unsupported device type %d:%d for store at %q", major, minor, path)
 	}
 
 	id := DeviceID{
@@ -177,7 +195,7 @@ func getZPoolDevice(poolName _ZPoolName) (string, error) {
 			if devPart == "" {
 				devPart = stripDevicePartition(fields[0])
 			} else {
-				log.Warningf(ctx, "unsupported configuration: multiple devices (i.e. %q, %q) detected for zpool %q", devPart, fields[0], string(poolName))
+				maybeWarnf(ctx, "unsupported configuration: multiple devices (i.e. %q, %q) detected for zpool %q", devPart, fields[0], string(poolName))
 			}
 		}
 	}
@@ -188,17 +206,20 @@ func getZPoolDevice(poolName _ZPoolName) (string, error) {
 	return "", fmt.Errorf("no device found for zpool %q", poolName)
 }
 
+var (
+	nvmePartitionRegex = regexp.MustCompile(`^(nvme\d+n\d+)(p\d+)?$`)
+	scsiPartitionRegex = regexp.MustCompile(`^(ram|loop|fd|(h|s|v|xv)d[a-z])(\d+)?$`)
+)
+
 // stripDevicePartition removes partition suffix from a device path.
 func stripDevicePartition(devicePath string) string {
 	base := filepath.Base(devicePath)
 
-	var nvmePartitionRegex = regexp.MustCompile(`^(nvme\d+n\d+)(p\d+)?$`)
 	nvmeMatches := nvmePartitionRegex.FindStringSubmatch(base)
 	if len(nvmeMatches) == 3 {
 		return nvmeMatches[1]
 	}
 
-	var scsiPartitionRegex = regexp.MustCompile(`^(/dev/sd.*?)(\d+)$`)
 	scsiMatches := scsiPartitionRegex.FindStringSubmatch(base)
 	if len(scsiMatches) == 3 {
 		return scsiMatches[1]
@@ -230,4 +251,20 @@ func getDeviceID(devPath string) (uint32, uint32, error) {
 	}
 
 	return maj, min, nil
+}
+
+// maybeWarnf is a convenience function to prevent panicing during bootstrap
+// from using logging before it is setup.
+func maybeWarnf(ctx context.Context, format string, args ...interface{}) {
+	if active, _ := log.IsActive(); active {
+		log.Ops.WarningfDepth(ctx, 1, format, args...)
+	}
+}
+
+// maybeInfof is a convenience function to prevent panicing during bootstrap
+// from using logging before it is setup.
+func maybeInfof(ctx context.Context, format string, args ...interface{}) {
+	if active, _ := log.IsActive(); active {
+		log.Ops.InfofDepth(ctx, 1, format, args...)
+	}
 }

--- a/pkg/storage/disk/platform_linux.go
+++ b/pkg/storage/disk/platform_linux.go
@@ -8,10 +8,21 @@
 package disk
 
 import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
 	"io"
 	"io/fs"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strconv"
+	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/vfs"
@@ -63,11 +74,160 @@ func newStatsCollector(fs vfs.FS) (*linuxStatsCollector, error) {
 	}, nil
 }
 
-func deviceIDFromFileInfo(finfo fs.FileInfo) DeviceID {
+func deviceIDFromFileInfo(finfo fs.FileInfo, path string) DeviceID {
+	ctx := context.TODO()
 	statInfo := finfo.Sys().(*sysutil.StatT)
+	major := unix.Major(statInfo.Dev)
+	minor := unix.Minor(statInfo.Dev)
+
+	// Per /usr/include/linux/major.h and Documentation/admin-guide/devices.rst:
+	switch major {
+	case 0: // UNNAMED_MAJOR
+		// Perform additional lookups for unknown device types
+		var statfs sysutil.StatfsT
+		if err := sysutil.Statfs(path, &statfs); err != nil {
+			log.Warningf(ctx, "unable statfs(2) path %q: %v", path, err)
+		} else {
+			fsType := statfs.Type
+			switch strconv.FormatInt(fsType, 16) {
+			case "2fc12fc1": // ZFS_SUPER_MAGIC from include/sys/fs/zfs.h
+				if major, minor, err = deviceIDForZFS(path); err != nil {
+					log.Warningf(ctx, "unable to find device ID for %q: %v", path, err)
+				}
+			default:
+				log.Warningf(ctx, "unsupported file system type %q for path %q", fsType, path)
+			}
+		}
+	case 259: //BLOCK_EXT_MAJOR=259
+		// noop
+	}
+
+	if major == 0 {
+		log.Warningf(ctx, "unsupported device type %q", path)
+	}
+
 	id := DeviceID{
-		major: unix.Major(statInfo.Dev),
-		minor: unix.Minor(statInfo.Dev),
+		major: major,
+		minor: minor,
 	}
 	return id
+}
+
+type _ZPoolName string
+
+func deviceIDForZFS(path string) (uint32, uint32, error) {
+	zpoolName, err := getZFSPoolName(path)
+	if err != nil {
+		return 0, 0, errors.Newf("unable to find the zpool for %q: %v", path, err) // nolint:errwrap
+	}
+
+	devName, err := getZPoolDevice(zpoolName)
+	if err != nil {
+		return 0, 0, errors.Newf("unable to find the device for pool %q: %v", zpoolName, err) // nolint:errwrap
+	}
+
+	major, minor, err := getDeviceID(devName)
+	if err != nil {
+		return 0, 0, errors.Newf("unable to find the device numbers for device %q: %v", devName, err) // nolint:errwrap
+	}
+
+	return major, minor, nil
+}
+
+func getZFSPoolName(path string) (_ZPoolName, error) {
+	out, err := exec.Command("df", "--no-sync", "--output=source,fstype", path).Output()
+	if err != nil {
+		return "", errors.Newf("unable to exec df(1): %v", err) // nolint:errwrap
+	}
+
+	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	if len(lines) < 2 {
+		return "", fmt.Errorf("unexpected df(1) output: %q", out)
+	}
+
+	fields := strings.Fields(lines[1])
+	if len(fields) != 2 {
+		return "", fmt.Errorf("unexpected df(1) fields (expected 2, got %d): %q", len(fields), lines[1])
+	}
+
+	if fields[1] != "zfs" {
+		return "", fmt.Errorf("unexpected df(1) fields (expected 2, got %d): %q", len(fields), lines[1])
+	}
+
+	// Need to accept inputs formed like "data1" and "data1/crdb-logs"
+	poolName := strings.Split(fields[0], "/")[0]
+
+	return _ZPoolName(poolName), nil
+}
+
+func getZPoolDevice(poolName _ZPoolName) (string, error) {
+	ctx := context.TODO()
+
+	out, err := exec.Command("zpool", "status", "-pPL", string(poolName)).Output()
+	if err != nil {
+		return "", errors.Newf("unable to find the devices attached to pool %q: %v", poolName, err) // nolint:errwrap
+	}
+
+	scanner := bufio.NewScanner(bytes.NewReader(out))
+	var devPart string
+	for scanner.Scan() {
+		line := strings.TrimSpace(scanner.Text())
+		fields := strings.Fields(line)
+		if len(fields) >= 2 && fields[1] == "ONLINE" && strings.HasPrefix(fields[0], "/dev/") {
+			if devPart == "" {
+				devPart = stripDevicePartition(fields[0])
+			} else {
+				log.Warningf(ctx, "unsupported configuration: multiple devices (i.e. %q, %q) detected for zpool %q", devPart, fields[0], string(poolName))
+			}
+		}
+	}
+	if devPart != "" {
+		return devPart, nil
+	}
+
+	return "", fmt.Errorf("no device found for zpool %q", poolName)
+}
+
+// stripDevicePartition removes partition suffix from a device path.
+func stripDevicePartition(devicePath string) string {
+	base := filepath.Base(devicePath)
+
+	var nvmePartitionRegex = regexp.MustCompile(`^(nvme\d+n\d+)(p\d+)?$`)
+	nvmeMatches := nvmePartitionRegex.FindStringSubmatch(base)
+	if len(nvmeMatches) == 3 {
+		return nvmeMatches[1]
+	}
+
+	var scsiPartitionRegex = regexp.MustCompile(`^(/dev/sd.*?)(\d+)$`)
+	scsiMatches := scsiPartitionRegex.FindStringSubmatch(base)
+	if len(scsiMatches) == 3 {
+		return scsiMatches[1]
+	}
+
+	// If no match, return original device path
+	return devicePath
+}
+
+// getDeviceID takes a block device name (e.g., nvme5n1) and returns its major and minor numbers.
+func getDeviceID(devPath string) (uint32, uint32, error) {
+	devName := filepath.Base(devPath)
+	devFilePath := fmt.Sprintf("/sys/block/%s/dev", devName)
+	data, err := os.ReadFile(devFilePath)
+	if err != nil {
+		return 0, 0, errors.Newf("unable to read %q: %v", devFilePath, err) // nolint:errwrap
+	}
+
+	devStr := strings.TrimSpace(string(data))
+	parts := strings.Split(devStr, ":")
+	if len(parts) != 2 {
+		return 0, 0, fmt.Errorf("unexpected device string format in %q: %s", devFilePath, devStr)
+	}
+
+	var maj, min uint32
+	_, err = fmt.Sscanf(devStr, "%d:%d", &maj, &min)
+	if err != nil {
+		return 0, 0, errors.Newf("failed parsing device numbers: %v", err) // nolint:errwrap
+	}
+
+	return maj, min, nil
 }

--- a/pkg/storage/disk/platform_linux.go
+++ b/pkg/storage/disk/platform_linux.go
@@ -134,13 +134,16 @@ func deviceIDFromFileInfo(finfo fs.FileInfo, path string) DeviceID {
 type _ZPoolName string
 
 func deviceIDForZFS(path string) (uint32, uint32, error) {
-	zpoolName, err := getZFSPoolName(path)
+	zpoolName, err := zfsGetPoolName(path)
 	if err != nil {
 		return 0, 0, errors.Newf("unable to find the zpool for %q: %v", path, err) // nolint:errwrap
 	}
 
-	devName, err := getZPoolDevice(zpoolName)
-	if err != nil {
+	// If there are multiple devices for a zpool, an error is returned along with
+	// a device name.  Continue resolving the device's major:minor numbers,
+	// despite the multiple drives.
+	devName, err := zpoolGetDevice(zpoolName)
+	if err != nil && devName == "" {
 		return 0, 0, errors.Newf("unable to find the device for pool %q: %v", zpoolName, err) // nolint:errwrap
 	}
 
@@ -152,15 +155,19 @@ func deviceIDForZFS(path string) (uint32, uint32, error) {
 	return major, minor, nil
 }
 
-func getZFSPoolName(path string) (_ZPoolName, error) {
+func zfsGetPoolName(path string) (_ZPoolName, error) {
 	out, err := exec.Command("df", "--no-sync", "--output=source,fstype", path).Output()
 	if err != nil {
 		return "", errors.Newf("unable to exec df(1): %v", err) // nolint:errwrap
 	}
 
-	lines := strings.Split(strings.TrimSpace(string(out)), "\n")
+	return zfsParseDF(out)
+}
+
+func zfsParseDF(df []byte) (_ZPoolName, error) {
+	lines := strings.Split(strings.TrimSpace(string(df)), "\n")
 	if len(lines) < 2 {
-		return "", fmt.Errorf("unexpected df(1) output: %q", out)
+		return "", fmt.Errorf("unexpected df(1) output: %q", df)
 	}
 
 	fields := strings.Fields(lines[1])
@@ -178,7 +185,7 @@ func getZFSPoolName(path string) (_ZPoolName, error) {
 	return _ZPoolName(poolName), nil
 }
 
-func getZPoolDevice(poolName _ZPoolName) (string, error) {
+func zpoolGetDevice(poolName _ZPoolName) (string, error) {
 	ctx := context.TODO()
 
 	out, err := exec.Command("zpool", "status", "-pPL", string(poolName)).Output()
@@ -186,24 +193,34 @@ func getZPoolDevice(poolName _ZPoolName) (string, error) {
 		return "", errors.Newf("unable to find the devices attached to pool %q: %v", poolName, err) // nolint:errwrap
 	}
 
-	scanner := bufio.NewScanner(bytes.NewReader(out))
-	var devPart string
+	return zpoolParseStatus(ctx, poolName, out)
+}
+
+func zpoolParseStatus(ctx context.Context, poolName _ZPoolName, output []byte) (string, error) {
+	scanner := bufio.NewScanner(bytes.NewReader(output))
+	var devName string
+	var devCount int
 	for scanner.Scan() {
 		line := strings.TrimSpace(scanner.Text())
 		fields := strings.Fields(line)
 		if len(fields) >= 2 && fields[1] == "ONLINE" && strings.HasPrefix(fields[0], "/dev/") {
-			if devPart == "" {
-				devPart = stripDevicePartition(fields[0])
+			devCount++
+			if devName == "" {
+				devName = stripDevicePartition(fields[0])
 			} else {
-				maybeWarnf(ctx, "unsupported configuration: multiple devices (i.e. %q, %q) detected for zpool %q", devPart, fields[0], string(poolName))
+				maybeWarnf(ctx, "unsupported configuration: multiple devices (i.e. %q, %q) detected for zpool %q", devName, fields[0], string(poolName))
 			}
 		}
 	}
-	if devPart != "" {
-		return devPart, nil
-	}
 
-	return "", fmt.Errorf("no device found for zpool %q", poolName)
+	switch {
+	case devCount == 1:
+		return devName, nil
+	case devCount > 1:
+		return devName, errors.Newf("unsupported configuration: %d devices detected for zpool %q", devCount, string(poolName))
+	default:
+		return "", fmt.Errorf("no device found for zpool %q", poolName)
+	}
 }
 
 var (
@@ -221,7 +238,7 @@ func stripDevicePartition(devicePath string) string {
 	}
 
 	scsiMatches := scsiPartitionRegex.FindStringSubmatch(base)
-	if len(scsiMatches) == 3 {
+	if len(scsiMatches) >= 3 {
 		return scsiMatches[1]
 	}
 
@@ -238,6 +255,10 @@ func getDeviceID(devPath string) (uint32, uint32, error) {
 		return 0, 0, errors.Newf("unable to read %q: %v", devFilePath, err) // nolint:errwrap
 	}
 
+	return parseDeviceID(devFilePath, data)
+}
+
+func parseDeviceID(devFilePath string, data []byte) (uint32, uint32, error) {
 	devStr := strings.TrimSpace(string(data))
 	parts := strings.Split(devStr, ":")
 	if len(parts) != 2 {
@@ -245,7 +266,7 @@ func getDeviceID(devPath string) (uint32, uint32, error) {
 	}
 
 	var maj, min uint32
-	_, err = fmt.Sscanf(devStr, "%d:%d", &maj, &min)
+	_, err := fmt.Sscanf(devStr, "%d:%d", &maj, &min)
 	if err != nil {
 		return 0, 0, errors.Newf("failed parsing device numbers: %v", err) // nolint:errwrap
 	}

--- a/pkg/storage/disk/platform_linux_test.go
+++ b/pkg/storage/disk/platform_linux_test.go
@@ -1,0 +1,241 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build linux
+
+package disk
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func TestLinux_zfsParseDF(t *testing.T) {
+	testCases := []struct {
+		name        string
+		path        string
+		mockOutput  string
+		mockError   error
+		expectName  _ZPoolName
+		expectError bool
+	}{
+		{
+			name:       "valid ZFS pool with nested dataset",
+			path:       "/mnt/data1/",
+			mockOutput: "Filesystem     Type\ndata1/crdb1    zfs\n",
+			expectName: "data1",
+		},
+		{
+			name:       "valid ZFS pool without nested dataset",
+			path:       "/mnt/data2/",
+			mockOutput: "Filesystem     Type\ndata2    zfs\n",
+			expectName: "data2",
+		},
+		{
+			name:        "unexpected filesystem type",
+			path:        "/mnt/other/",
+			mockOutput:  "Filesystem     Type\n/dev/sda1    ext4\n",
+			expectError: true,
+		},
+		{
+			name:        "unexpected output format",
+			path:        "/mnt/bad/",
+			mockOutput:  "Filesystem\n",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			poolName, err := zfsParseDF([]byte(tc.mockOutput))
+			if tc.expectError {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectName, poolName)
+			}
+		})
+	}
+}
+
+func TestLinux_zpoolParseStatus(t *testing.T) {
+	ctx := context.Background()
+
+	testCases := []struct {
+		name        string
+		poolName    _ZPoolName
+		output      string
+		expectDev   string
+		expectError bool
+	}{
+		{
+			name:     "Valid single device",
+			poolName: "data1",
+			output: `
+  pool: data1
+ state: ONLINE
+  scan: resilvered 72.9G in 00:18:00 with 0 errors on Mon May 19 19:18:10 2025
+config:
+
+	NAME              STATE     READ WRITE CKSUM
+	data1             ONLINE       0     0     0
+	  /dev/nvme1n1p1  ONLINE       0     0     0
+
+errors: No known data errors
+`,
+			expectDev: "nvme1n1",
+		},
+		{
+			name:     "Invalid multiple devices",
+			poolName: "data1",
+			output: `
+  pool: data1
+ state: ONLINE
+status: One or more devices is currently being resilvered.
+	continue to function, possibly in a degraded state.
+action: Wait for the resilver to complete.
+  scan: resilver in progress since Tue May 20 22:22:02 2025
+	18.3G / 18.4G scanned, 2.10G / 17.9G issued at 79.8M/s
+	2.12G resilvered, 11.75% done, 00:03:22 to go
+config:
+
+	NAME                STATE     READ WRITE CKSUM
+	data1               ONLINE       0     0     0
+	  mirror-0          ONLINE       0     0     0
+	    /dev/nvme1n1p1  ONLINE       0     0     0
+	    /dev/nvme5n1p1  ONLINE       0     0     0  (resilvering)
+
+errors: No known data errors
+`,
+			expectDev:   "nvme1n1",
+			expectError: true,
+		},
+		{
+			name:     "Invalid output",
+			poolName: "data1",
+			output: `
+  pool: data1
+ state: ONLINE
+status: One or more devices is currently being resilvered.
+	continue to function, possibly in a degraded state.
+action: Wait for the resilver to complete.
+  scan: resilver in progress since Tue May 20 22:22:02 2025
+	18.3G / 18.4G scanned, 2.10G / 17.9G issued at 79.8M/s
+	2.12G resilvered, 11.75% done, 00:03:22 to go
+config:
+
+	NAME                STATE     READ WRITE CKSUM
+	data1               ONLINE       0     0     0
+	  mirror-0          ONLINE       0     0     0
+
+errors: No known data errors
+`,
+			expectDev:   "nvme1n1",
+			expectError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			device, err := zpoolParseStatus(ctx, tc.poolName, []byte(tc.output))
+			if tc.expectError && device != "" {
+				require.Error(t, err)
+				require.Equal(t, tc.expectDev, device)
+			} else if tc.expectError && device == "" {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.expectDev, device)
+			}
+		})
+	}
+}
+
+func TestLinux_stripDevicePartition(t *testing.T) {
+	tests := []struct {
+		name     string
+		input    string
+		expected string
+	}{
+		{"NVME with partition", "/dev/nvme0n1p1", "nvme0n1"},
+		{"NVME without partition", "/dev/nvme0n1", "nvme0n1"},
+		{"SCSI with partition", "/dev/sda1", "sda"},
+		{"SCSI without partition", "/dev/sda", "sda"},
+		{"RAM device with partition", "/dev/ram0", "ram"},
+		{"Loop device", "/dev/loop0", "loop"},
+		{"Invalid device", "/dev/randomdevice", "/dev/randomdevice"},
+		{"Empty string", "", ""},
+		{"Device path without prefix", "nvme0n1p3", "nvme0n1"},
+		{"Complex invalid input", "/dev/nvme0n1p1x", "/dev/nvme0n1p1x"},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := stripDevicePartition(test.input)
+			require.Equal(t, test.expected, got)
+		})
+	}
+}
+
+func TestLinux_parseDeviceID(t *testing.T) {
+	testCases := []struct {
+		name        string
+		devFilePath string
+		data        []byte
+		wantMaj     uint32
+		wantMin     uint32
+		wantErr     bool
+	}{
+		{
+			name:        "valid device numbers",
+			devFilePath: "/sys/block/sda/dev",
+			data:        []byte("8:0\n"),
+			wantMaj:     8,
+			wantMin:     0,
+			wantErr:     false,
+		},
+		{
+			name:        "valid device numbers with whitespace",
+			devFilePath: "/sys/block/nvme1n1/dev",
+			data:        []byte("  259:5\n"),
+			wantMaj:     259,
+			wantMin:     5,
+			wantErr:     false,
+		},
+		{
+			name:        "invalid format missing colon",
+			devFilePath: "/sys/block/sdc/dev",
+			data:        []byte("2593\n"),
+			wantErr:     true,
+		},
+		{
+			name:        "non-numeric values",
+			devFilePath: "/sys/block/sdd/dev",
+			data:        []byte("a:b\n"),
+			wantErr:     true,
+		},
+		{
+			name:        "empty data",
+			devFilePath: "/sys/block/sde/dev",
+			data:        []byte("\n"),
+			wantErr:     true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			maj, min, err := parseDeviceID(tc.devFilePath, tc.data)
+			if tc.wantErr {
+				require.Error(t, err)
+			} else {
+				require.NoError(t, err)
+				require.Equal(t, tc.wantMaj, maj)
+				require.Equal(t, tc.wantMin, min)
+			}
+		})
+	}
+}

--- a/pkg/testutils/lint/passes/fmtsafe/functions.go
+++ b/pkg/testutils/lint/passes/fmtsafe/functions.go
@@ -80,6 +80,9 @@ var requireConstFmt = map[string]bool{
 
 	"(*github.com/cockroachdb/cockroach/pkg/internal/rsg/yacc.Tree).errorf": true,
 
+	"github.com/cockroachdb/cockroach/pkg/storage/disk.maybeInfof": true,
+	"github.com/cockroachdb/cockroach/pkg/storage/disk.maybeWarnf": true,
+
 	"(github.com/cockroachdb/cockroach/pkg/storage.pebbleLogger).Infof":  true,
 	"(github.com/cockroachdb/cockroach/pkg/storage.pebbleLogger).Fatalf": true,
 	"(github.com/cockroachdb/cockroach/pkg/storage.pebbleLogger).Errorf": true,

--- a/pkg/util/sysutil/sysutil_unix.go
+++ b/pkg/util/sysutil/sysutil_unix.go
@@ -20,6 +20,9 @@ import (
 // StatT is syscall.Stat_t.
 type StatT = syscall.Stat_t
 
+// StatfsT is syscall.Statfs_t.
+type StatfsT = syscall.Statfs_t
+
 // ProcessIdentity returns a string describing the user and group that this
 // process is running as.
 func ProcessIdentity() redact.RedactableString {
@@ -42,4 +45,8 @@ func TerminateSelf() error {
 		return nil //nolint:returnerrcheck
 	}
 	return pr.Signal(unix.SIGTERM)
+}
+
+func Statfs(path string, stat *StatfsT) (err error) {
+	return syscall.Statfs(path, stat)
 }


### PR DESCRIPTION
Previously, crdb couldn't monitor stores running on unknown devices.  Now the
code attempts to resolve the underlying device based on the fstype.  Any
failures fallback to the current behavior.

Epic: none
Release note: None
Fixes: #146336

----

Release justification: Resolves ZD 26731 (and probably many other tickets)
