### PR TITLE
sqlstats: fix data race between collector and ingester

### DIFF
--- a/pkg/sql/sqlstats/sslocal/BUILD.bazel
+++ b/pkg/sql/sqlstats/sslocal/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "sslocal",
     srcs = [
         "cluster_settings.go",
+        "doc.go",
         "sql_stats.go",
         "sql_stats_ingestor.go",
         "sslocal_iterator.go",

--- a/pkg/sql/sqlstats/sslocal/doc.go
+++ b/pkg/sql/sqlstats/sslocal/doc.go
@@ -1,0 +1,83 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+/*
+This package is used to collect SQL Activity Statistics from the SQL subsystem.
+
+# The recording of SQL Activity is managed through the following components:
+
+ 1. Conn Executor: SQL Execution is managed here and stats are collected and sent
+    to the Stats Collector.
+ 2. (sslocal) Stats Collector: Receives stats from the Conn Executor and buffers them into
+    the `ssmemstorage.Container`
+ 3. (sslocal) SQL Stats Ingester: Receives stats from the Stats Collector and
+    flushes them to the registry.
+ 4. Container: A per-application container that holds stats for a given
+    application. The Ingester flushes
+
+# Sequence of Operations
+
+The diagram below illustrates how stats flow through the StatsCollector and
+StatsIngester as a transaction executes.
+
+	+---------------+           +-----------------+                                   +---------------+                                        +-----------+
+	| ConnExecutor  |           | StatsCollector  |                                   | StatsIngester |                                        | Container |
+	+---------------+           +-----------------+                                   +---------------+                                        +-----------+
+			|                            |                                                    |                                                      |
+			| RecordStatement            |                                                    |                                                      |
+			|--------------------------->|                                                    |                                                      |
+			|                            | -------------------------------------------\       |                                                      |
+			|                            |-| *RecordedStmtStats accumulates in buffer |       |                                                      |
+			|                            | |------------------------------------------|       |                                                      |
+			|                            |                                                    |                                                      |
+			| EndTransaction             |                                                    |                                                      |
+			|--------------------------->|                                                    |                                                      |
+			|                            | ------------------------------------------\        |                                                      |
+			|                            |-| set TransactionID on *RecordedStmtStats |        |                                                      |
+			|                            | |-----------------------------------------|        |                                                      |
+			|                            |                                                    |                                                      |
+			|                            | IngestStatement                                    |                                                      |
+			|                            |--------------------------------------------------->|                                                      |
+			|                            |                                                    | -------------------------------------------\         |
+			|                            |                                                    |-| *RecordedStmtStats accumulates in buffer |         |
+			|                            |                                                    | |------------------------------------------|         |
+			|                            |                                                    |                                                      |
+			|                            | RecordStatement                                    |                                                      |
+			|                            |---------------------------------------------------------------------------------------------------------->|
+			|                            |                                                    |                                                      |
+			| RecordTransaction          |                                                    |                                                      |
+			|--------------------------->|                                                    |                                                      |
+			|                            |                                                    |                                                      |
+			|                            | IngestTransaction                                  |                                                      |
+			|                            |--------------------------------------------------->|                                                      |
+			|                            |                                                    |                                                      |
+			|                            | RecordTransaction                                  |                                                      |
+			|                            |---------------------------------------------------------------------------------------------------------->|
+			|                            |                                                    | -----------------------------------------------\     |
+			|                            |                                                    |-| all *RecordedStmtStats in buffer are flushed |     |
+			|                            |                                                    | |----------------------------------------------|     |
+			|                            |                                                    |                                                      | ----------------------------------------\
+			|                            |                                                    |                                                      |-| eventually flushed to persisted stats |
+			|                            |                                                    |                                                      | |---------------------------------------|
+			|                            |                                                    |                                                      |
+*/
+package sslocal
+
+// Input to sequence diagram generator:
+/*
+object ConnExecutor StatsCollector StatsIngester Container
+ConnExecutor -> StatsCollector: RecordStatement
+note right of StatsCollector: *RecordedStmtStats accumulates in buffer
+ConnExecutor -> StatsCollector: EndTransaction
+note right of StatsCollector: set TransactionID on *RecordedStmtStats
+StatsCollector -> StatsIngester: IngestStatement
+note right of StatsIngester: *RecordedStmtStats accumulates in buffer
+StatsCollector -> Container: RecordStatement
+ConnExecutor -> StatsCollector: RecordTransaction
+StatsCollector -> StatsIngester: IngestTransaction
+StatsCollector -> Container: RecordTransaction
+note right of StatsIngester: all *RecordedStmtStats in buffer are flushed
+note right of Container: eventually flushed to persisted stats
+*/

--- a/pkg/sql/sqlstats/sslocal/sql_stats_ingestor.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_ingestor.go
@@ -315,11 +315,6 @@ func (i *SQLStatsIngester) flushBuffer(
 		return
 	}
 
-	// Set the transaction fingerprint ID for each statement.
-	for _, s := range *statements {
-		s.TransactionFingerprintID = transaction.FingerprintID
-	}
-
 	for _, sink := range i.sinks {
 		sink.ObserveTransaction(ctx, transaction, *statements)
 	}


### PR DESCRIPTION
I've admittedly not been able to reproduce the data race observed in the same `*sqlstats.RecordedStmtStats` object in two different locations. One of these is now redunant. The transactionID set in the `StatsCollector` happens before the data is processed by the `SQLStatsIngester` so the setting of the transactionID in the ingester is removed. If it happens to get statements without corresponding transactionIDs, that should be a bug.

The reason this was introduced was likely
https://github.com/cockroachdb/cockroach/pull/141767 which unified the types used by the two components. Previously, they were different structs and ownership was clear and required editing the transactionID twice.

This PR also introduces a `doc.go` file to the `sslocal` package in an effort to guide the reviewer and provide context for future work. The diagram reflects the changes in this commit.

Resolves: #146796

Release note: None