### PR TITLE
drtprod: Update Cockroach binary in PUA

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_pua_9.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_9.yaml
@@ -142,8 +142,7 @@ targets:
       - command: stage
         args:
           - $WORKLOAD_CLUSTER
-          - release
-          - $COCKROACH_VERSION
+          - cockroach
       - command: stage
         args:
           - $WORKLOAD_CLUSTER

--- a/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
@@ -160,8 +160,7 @@ targets:
       - command: stage
         args:
           - $WORKLOAD_CLUSTER
-          - release
-          - $COCKROACH_VERSION
+          - cockroach
       - command: stage
         args:
           - $WORKLOAD_CLUSTER


### PR DESCRIPTION
This change updates the Cockroach binary used by the workload cluster to the latest master version. The previous binary had a bug causing workloads to perform a runtime stack collection via Stop the World (STW), negatively affecting PUA benchmark results.

Epic: none

Release note: None