### PR TITLE
stateloader: mv ReplicaID to state machine loader

### DIFF
--- a/pkg/kv/kvserver/kvstorage/BUILD.bazel
+++ b/pkg/kv/kvserver/kvstorage/BUILD.bazel
@@ -44,7 +44,7 @@ go_test(
     deps = [
         "//pkg/clusterversion",
         "//pkg/keys",
-        "//pkg/kv/kvserver/logstore",
+        "//pkg/kv/kvserver/stateloader",
         "//pkg/raft/raftpb",
         "//pkg/roachpb",
         "//pkg/settings/cluster",

--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/keys"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -64,7 +64,7 @@ func (e *env) handleNewReplica(
 	skipRaftReplicaID bool,
 	k, ek roachpb.RKey,
 ) *roachpb.RangeDescriptor {
-	sl := logstore.NewStateLoader(id.RangeID)
+	sl := stateloader.Make(id.RangeID)
 	require.NoError(t, sl.SetHardState(ctx, e.eng, raftpb.HardState{}))
 	if !skipRaftReplicaID && id.ReplicaID != 0 {
 		require.NoError(t, sl.SetRaftReplicaID(ctx, e.eng, id.ReplicaID))

--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -9,7 +9,6 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -103,7 +102,7 @@ func DestroyReplica(
 	nextReplicaID roachpb.ReplicaID,
 	opts ClearRangeDataOptions,
 ) error {
-	diskReplicaID, err := logstore.NewStateLoader(rangeID).LoadRaftReplicaID(ctx, reader)
+	diskReplicaID, err := stateloader.Make(rangeID).LoadRaftReplicaID(ctx, reader)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -206,35 +206,3 @@ func (sl StateLoader) SynthesizeHardState(
 	err := sl.SetHardState(ctx, writer, newHS)
 	return errors.Wrapf(err, "writing HardState %+v", &newHS)
 }
-
-// SetRaftReplicaID overwrites the RaftReplicaID.
-func (sl StateLoader) SetRaftReplicaID(
-	ctx context.Context, writer storage.Writer, replicaID roachpb.ReplicaID,
-) error {
-	rid := kvserverpb.RaftReplicaID{ReplicaID: replicaID}
-	// "Blind" because opts.Stats == nil and timestamp.IsEmpty().
-	return storage.MVCCBlindPutProto(
-		ctx,
-		writer,
-		sl.RaftReplicaIDKey(),
-		hlc.Timestamp{}, /* timestamp */
-		&rid,
-		storage.MVCCWriteOptions{}, /* opts */
-	)
-}
-
-// LoadRaftReplicaID loads the RaftReplicaID.
-func (sl StateLoader) LoadRaftReplicaID(
-	ctx context.Context, reader storage.Reader,
-) (*kvserverpb.RaftReplicaID, error) {
-	var replicaID kvserverpb.RaftReplicaID
-	found, err := storage.MVCCGetProto(ctx, reader, sl.RaftReplicaIDKey(),
-		hlc.Timestamp{}, &replicaID, storage.MVCCGetOptions{ReadCategory: fs.ReplicationReadCategory})
-	if err != nil {
-		return nil, err
-	}
-	if !found {
-		return nil, errors.AssertionFailedf("no replicaID persisted")
-	}
-	return &replicaID, nil
-}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -568,7 +568,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 
 		st:       st,
 		todoEng:  r.store.TODOEngine(),
-		logSL:    &r.raftMu.stateLoader.StateLoader,
+		sl:       r.raftMu.stateLoader,
 		writeSST: inSnap.SSTStorageScratch.WriteSST,
 
 		truncState:    truncState,

--- a/pkg/kv/kvserver/split_queue_test.go
+++ b/pkg/kv/kvserver/split_queue_test.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -94,7 +94,7 @@ func TestSplitQueueShouldQueue(t *testing.T) {
 		cpy.EndKey = test.end
 		replicaID := cpy.Replicas().VoterDescriptors()[0].ReplicaID
 		require.NoError(t,
-			logstore.NewStateLoader(cpy.RangeID).SetRaftReplicaID(ctx, tc.store.TODOEngine(), replicaID))
+			stateloader.Make(cpy.RangeID).SetRaftReplicaID(ctx, tc.store.TODOEngine(), replicaID))
 		repl, err := loadInitializedReplicaForTesting(ctx, tc.store, &cpy, replicaID)
 		if err != nil {
 			t.Fatal(err)

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -372,17 +372,17 @@ func (rsl StateLoader) SetForceFlushIndex(
 // LoadRaftReplicaID loads the RaftReplicaID.
 func (rsl StateLoader) LoadRaftReplicaID(
 	ctx context.Context, reader storage.Reader,
-) (*kvserverpb.RaftReplicaID, error) {
+) (kvserverpb.RaftReplicaID, error) {
 	var replicaID kvserverpb.RaftReplicaID
-	found, err := storage.MVCCGetProto(ctx, reader, rsl.RaftReplicaIDKey(),
-		hlc.Timestamp{}, &replicaID, storage.MVCCGetOptions{ReadCategory: fs.ReplicationReadCategory})
-	if err != nil {
-		return nil, err
+	if found, err := storage.MVCCGetProto(
+		ctx, reader, rsl.RaftReplicaIDKey(), hlc.Timestamp{}, &replicaID,
+		storage.MVCCGetOptions{ReadCategory: fs.ReplicationReadCategory},
+	); err != nil {
+		return kvserverpb.RaftReplicaID{}, err
+	} else if !found {
+		return kvserverpb.RaftReplicaID{}, errors.AssertionFailedf("no replicaID persisted")
 	}
-	if !found {
-		return nil, errors.AssertionFailedf("no replicaID persisted")
-	}
-	return &replicaID, nil
+	return replicaID, nil
 }
 
 // SetRaftReplicaID overwrites the RaftReplicaID.

--- a/pkg/kv/kvserver/stateloader/stateloader.go
+++ b/pkg/kv/kvserver/stateloader/stateloader.go
@@ -369,6 +369,38 @@ func (rsl StateLoader) SetForceFlushIndex(
 		hlc.Timestamp{}, ffIndex, storage.MVCCWriteOptions{Stats: ms})
 }
 
+// LoadRaftReplicaID loads the RaftReplicaID.
+func (rsl StateLoader) LoadRaftReplicaID(
+	ctx context.Context, reader storage.Reader,
+) (*kvserverpb.RaftReplicaID, error) {
+	var replicaID kvserverpb.RaftReplicaID
+	found, err := storage.MVCCGetProto(ctx, reader, rsl.RaftReplicaIDKey(),
+		hlc.Timestamp{}, &replicaID, storage.MVCCGetOptions{ReadCategory: fs.ReplicationReadCategory})
+	if err != nil {
+		return nil, err
+	}
+	if !found {
+		return nil, errors.AssertionFailedf("no replicaID persisted")
+	}
+	return &replicaID, nil
+}
+
+// SetRaftReplicaID overwrites the RaftReplicaID.
+func (rsl StateLoader) SetRaftReplicaID(
+	ctx context.Context, writer storage.Writer, replicaID roachpb.ReplicaID,
+) error {
+	rid := kvserverpb.RaftReplicaID{ReplicaID: replicaID}
+	// "Blind" because opts.Stats == nil and timestamp.IsEmpty().
+	return storage.MVCCBlindPutProto(
+		ctx,
+		writer,
+		rsl.RaftReplicaIDKey(),
+		hlc.Timestamp{}, /* timestamp */
+		&rid,
+		storage.MVCCWriteOptions{}, /* opts */
+	)
+}
+
 // LoadRangeTombstone loads the RangeTombstone of the range.
 func (rsl StateLoader) LoadRangeTombstone(
 	ctx context.Context, reader storage.Reader,

--- a/pkg/kv/kvserver/store_pool_test.go
+++ b/pkg/kv/kvserver/store_pool_test.go
@@ -14,8 +14,8 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/replicastats"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -263,7 +263,7 @@ func TestStorePoolUpdateLocalStoreBeforeGossip(t *testing.T) {
 
 	const replicaID = 1
 	require.NoError(t,
-		logstore.NewStateLoader(rg.RangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+		stateloader.Make(rg.RangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
 	replica, err := loadInitializedReplicaForTesting(ctx, store, &rg, replicaID)
 	if err != nil {
 		t.Fatalf("make replica error : %+v", err)

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -39,7 +39,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness"
@@ -899,8 +898,7 @@ func TestMarkReplicaInitialized(t *testing.T) {
 
 	newRangeID := roachpb.RangeID(3)
 	const replicaID = 1
-	require.NoError(t,
-		logstore.NewStateLoader(newRangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+	require.NoError(t, stateloader.Make(newRangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
 
 	r, err := newUninitializedReplica(store, newRangeID, replicaID)
 	require.NoError(t, err)
@@ -4125,7 +4123,7 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 	require.True(t, created)
 	replicaID, err := repl.mu.stateLoader.LoadRaftReplicaID(ctx, tc.store.TODOEngine())
 	require.NoError(t, err)
-	require.Equal(t, &kvserverpb.RaftReplicaID{ReplicaID: 7}, replicaID)
+	require.Equal(t, kvserverpb.RaftReplicaID{ReplicaID: 7}, replicaID)
 }
 
 func BenchmarkStoreGetReplica(b *testing.B) {

--- a/pkg/kv/kvserver/stores_test.go
+++ b/pkg/kv/kvserver/stores_test.go
@@ -14,7 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/gossip"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/storage/disk"
@@ -154,8 +154,7 @@ func TestStoresGetReplicaForRangeID(t *testing.T) {
 			},
 		}
 
-		require.NoError(t,
-			logstore.NewStateLoader(desc.RangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+		require.NoError(t, stateloader.Make(desc.RangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
 		replica, err := loadInitializedReplicaForTesting(ctx, store, desc, replicaID)
 		if err != nil {
 			t.Fatalf("unexpected error when creating replica: %+v", err)


### PR DESCRIPTION
The knowledge about an existing replica is specific to the state machine, along with `RangeTombstone` which communicates absence of a replica. Later, knowledge about the current and removed `LogID` will also be in this category.

Epic: CRDB-46488