### PR TITLE
roachtest: fix restore test fixture sizes

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -295,13 +295,13 @@ func registerRestore(r registry.Registry) {
 		},
 		{
 			hardware: makeHardwareSpecs(hardwareSpecs{ebsThroughput: 250 /* MB/s */}),
-			backup:   backupSpecs{cloud: spec.AWS, fixture: MediumFixture},
+			backup:   backupSpecs{cloud: spec.AWS, fixture: SmallFixture},
 			timeout:  1 * time.Hour,
 			suites:   registry.Suites(registry.Nightly),
 		},
 		{
 			hardware: makeHardwareSpecs(hardwareSpecs{}),
-			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			backup:   backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
 			timeout:  1 * time.Hour,
 			suites:   registry.Suites(registry.Nightly),
 		},
@@ -309,7 +309,7 @@ func registerRestore(r registry.Registry) {
 			// Benchmarks using a low memory per core ratio - we don't expect ideal
 			// performance but nodes should not OOM.
 			hardware: makeHardwareSpecs(hardwareSpecs{mem: spec.Low}),
-			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			backup:   backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
 			timeout:  1 * time.Hour,
 			suites:   registry.Suites(registry.Nightly),
 		},
@@ -317,7 +317,7 @@ func registerRestore(r registry.Registry) {
 			// Benchmarks if per node throughput remains constant if the number of
 			// nodes doubles relative to default.
 			hardware: makeHardwareSpecs(hardwareSpecs{nodes: 8}),
-			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			backup:   backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
 			timeout:  1 * time.Hour,
 			suites:   registry.Suites(registry.Nightly),
 		},
@@ -327,7 +327,7 @@ func registerRestore(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{
 				nodes: 9, ebsThroughput: 250, /* MB/s */
 				zones: []string{"us-east-2b", "us-west-2b", "eu-west-1b"}}), // These zones are AWS-specific.
-			backup:  backupSpecs{cloud: spec.AWS, fixture: MediumFixture},
+			backup:  backupSpecs{cloud: spec.AWS, fixture: SmallFixture},
 			timeout: 90 * time.Minute,
 			suites:  registry.Suites(registry.Nightly),
 		},
@@ -335,7 +335,7 @@ func registerRestore(r registry.Registry) {
 			// Benchmarks if per node throughput doubles if the vcpu count doubles
 			// relative to default.
 			hardware: makeHardwareSpecs(hardwareSpecs{cpus: 16}),
-			backup:   backupSpecs{cloud: spec.GCE, fixture: MediumFixture},
+			backup:   backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
 			timeout:  1 * time.Hour,
 			suites:   registry.Suites(registry.Nightly),
 		},
@@ -346,7 +346,7 @@ func registerRestore(r registry.Registry) {
 			timeout:  24 * time.Hour,
 			suites:   registry.Suites(registry.Weekly),
 		},
-		// Following three tests are just used to benchmark classic restore against
+		// Following two tests are just used to benchmark classic restore against
 		// OR with the exact same fixtures and hardware.
 		{
 			hardware:       makeHardwareSpecs(hardwareSpecs{}),
@@ -354,14 +354,6 @@ func registerRestore(r registry.Registry) {
 			timeout:        1 * time.Hour,
 			suites:         registry.Suites(registry.Nightly),
 			fullBackupOnly: true,
-			skip:           "used for adhoc benchmarking against OR",
-		},
-		{
-			hardware:       makeHardwareSpecs(hardwareSpecs{}),
-			backup:         backupSpecs{cloud: spec.GCE, fixture: SmallFixture},
-			fullBackupOnly: false,
-			timeout:        1 * time.Hour,
-			suites:         registry.Suites(registry.Nightly),
 			skip:           "used for adhoc benchmarking against OR",
 		},
 		{

--- a/pkg/cmd/roachtest/tests/restore_test.go
+++ b/pkg/cmd/roachtest/tests/restore_test.go
@@ -6,14 +6,9 @@
 package tests
 
 import (
-	"slices"
-	"testing"
-
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
-	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/prometheus/client_golang/prometheus/promauto"
-	"github.com/stretchr/testify/require"
 )
 
 type mockRegistry struct {
@@ -44,28 +39,3 @@ func (m *mockRegistry) Cloud() string {
 }
 
 var _ registry.Registry = &mockRegistry{}
-
-func TestRestoreRegisteredNames(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	r := &mockRegistry{}
-	registerRestore(r)
-	registerRestoreNodeShutdown(r)
-	expectedRestoreTests := []string{
-		"restore/nodeShutdown/coordinator",
-		"restore/nodeShutdown/worker",
-		"restore/pause/tpcc-5k/gce/nodes=4/cpus=8",
-		"restore/tpcc-10/gce/nodes=4/cpus=8",
-		"restore/tpcc-300k/gce/nodes=15/cpus=16",
-		"restore/tpcc-30k/aws/nodes=4/cpus=8",
-		"restore/tpcc-30k/aws/nodes=9/cpus=8/zones=us-east-2b,us-west-2b,eu-west-1b",
-		"restore/tpcc-30k/gce/fullOnly/nodes=10/cpus=8",
-		"restore/tpcc-30k/gce/nodes=4/cpus=16",
-		"restore/tpcc-30k/gce/nodes=4/cpus=8",
-		"restore/tpcc-30k/gce/nodes=4/cpus=8/lowmem",
-		"restore/tpcc-30k/gce/nodes=8/cpus=8",
-		"restore/tpcc-5k/gce/fullOnly/nodes=4/cpus=8",
-		"restore/tpcc-5k/gce/nodes=4/cpus=8",
-	}
-	slices.Sort(r.testNames)
-	require.Equal(t, expectedRestoreTests, r.testNames)
-}


### PR DESCRIPTION
The previous PR #146555 updates the restore roachtests to restore from the new fixture framework, but erroneously switched the restore roachtests that restored from a 400 GiB fixture to a 2 TB fixture. This resulted in several roachtest timeouts. This patch updates the tests to restore from the more sensible 350 GiB fixtures.

Epic: None

Release note: None