### PR TITLE
release-25.2.1-rc: Backport hot range logging & filtering BE functionality

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3599,6 +3599,8 @@ of ranges currently considered “hot” by the node(s).
 | page_token | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 | tenant_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 | nodes | [string](#cockroach.server.serverpb.HotRangesRequest-string) | repeated |  | [reserved](#support-status) |
+| per_node_limit | [int32](#cockroach.server.serverpb.HotRangesRequest-int32) |  | per_node_limit indicates the maximum number of hot ranges to return for each node. If left empty, the default is 128. | [reserved](#support-status) |
+| stats_only | [bool](#cockroach.server.serverpb.HotRangesRequest-bool) |  | stats_only indicates whether to return only the stats for the hot ranges, without pulling descriptor information. | [reserved](#support-status) |
 
 
 

--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -3598,6 +3598,7 @@ of ranges currently considered “hot” by the node(s).
 | page_size | [int32](#cockroach.server.serverpb.HotRangesRequest-int32) |  |  | [reserved](#support-status) |
 | page_token | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
 | tenant_id | [string](#cockroach.server.serverpb.HotRangesRequest-string) |  |  | [reserved](#support-status) |
+| nodes | [string](#cockroach.server.serverpb.HotRangesRequest-string) | repeated |  | [reserved](#support-status) |
 
 
 

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -543,6 +543,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/appstatspb",
         "//pkg/sql/catalog/descs",
+        "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/systemschema",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -497,7 +497,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 		requestedNodes = []roachpb.NodeID{requestedNodeID}
 	}
 
-	remoteRequest := serverpb.HotRangesRequest{NodeID: "local"}
+	remoteRequest := serverpb.HotRangesRequest{Nodes: []string{"local"}}
 	nodeFn := func(ctx context.Context, status serverpb.StatusClient, nodeID roachpb.NodeID) ([]hotRangeInfo, error) {
 		resp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil || resp == nil {

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1387,6 +1387,18 @@ message HotRangesRequest {
     (gogoproto.customname) = "Nodes",
     (gogoproto.nullable) = true
   ];
+  // per_node_limit indicates the maximum number of hot ranges
+  // to return for each node. If left empty, the default is 128.
+  int32 per_node_limit = 6 [
+    (gogoproto.customname) = "PerNodeLimit",
+    (gogoproto.nullable) = true
+  ];
+  // stats_only indicates whether to return only the stats
+  // for the hot ranges, without pulling descriptor information.
+  bool stats_only = 7 [
+    (gogoproto.customname) = "StatsOnly",
+    (gogoproto.nullable) = true
+  ];
 }
 
 // HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -1383,6 +1383,10 @@ message HotRangesRequest {
     (gogoproto.customname) = "TenantID",
     (gogoproto.nullable) = true
   ];
+  repeated string nodes = 5 [
+    (gogoproto.customname) = "Nodes",
+    (gogoproto.nullable) = true
+  ];
 }
 
 // HotRangesResponseV2 is a response payload returned by `HotRangesV2` service.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3042,6 +3042,7 @@ func (s *systemStatusServer) localHotRanges(
 	slices.SortFunc(resp.Ranges, func(a, b *serverpb.HotRangesResponseV2_HotRange) int {
 		return cmp.Compare(a.CPUTimePerSecond, b.CPUTimePerSecond)
 	})
+
 	// truncate the response if localLimit is set
 	if localLimit != 0 && localLimit < len(resp.Ranges) {
 		resp.Ranges = resp.Ranges[:localLimit]

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -7,6 +7,7 @@ package server
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"crypto/ecdsa"
 	"crypto/rsa"
@@ -19,6 +20,7 @@ import (
 	"os/exec"
 	"reflect"
 	"regexp"
+	"slices"
 	"sort"
 	"strconv"
 	"strings"
@@ -2846,7 +2848,7 @@ func (t *statusServer) HotRangesV2(
 	}
 
 	ti, _ := t.sqlServer.tenantConnect.TenantInfo()
-	if ti.TenantID.IsSet() {
+	if ti.TenantID.IsSet() && !req.StatsOnly {
 		err = t.addDescriptorsToHotRanges(ctx, resp)
 		if err != nil {
 			return nil, err
@@ -2906,13 +2908,13 @@ func (s *systemStatusServer) HotRangesV2(
 				return nil, errors.New("cannot call 'local' mixed with other nodes")
 			}
 
-			resp, err := s.localHotRanges(ctx, tenantID, requestedNodeID)
+			resp, err := s.localHotRanges(tenantID, requestedNodeID, int(req.PerNodeLimit))
 			if err != nil {
 				return nil, err
 			}
 
-			// If operating as the system tenant, add descriptor data to the reposnse.
-			if !tenantID.IsSet() {
+			// If explicitly set as the system tenant, or unset, add descriptor data to the reposnse.
+			if !tenantID.IsSet() && !req.StatsOnly {
 				err = s.addDescriptorsToHotRanges(ctx, resp)
 				if err != nil {
 					return nil, err
@@ -2926,7 +2928,12 @@ func (s *systemStatusServer) HotRangesV2(
 		requestedNodes = append(requestedNodes, requestedNodeID)
 	}
 
-	remoteRequest := serverpb.HotRangesRequest{Nodes: []string{"local"}, TenantID: req.TenantID}
+	remoteRequest := serverpb.HotRangesRequest{
+		Nodes:        []string{"local"},
+		TenantID:     req.TenantID,
+		PerNodeLimit: req.PerNodeLimit,
+		StatsOnly:    req.StatsOnly,
+	}
 	nodeFn := func(ctx context.Context, status serverpb.StatusClient, nodeID roachpb.NodeID) ([]*serverpb.HotRangesResponseV2_HotRange, error) {
 		nodeResp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil {
@@ -2973,7 +2980,7 @@ func (s *systemStatusServer) HotRangesV2(
 // Returns a HotRangesResponseV2 containing detailed information about each hot range,
 // or an error if the operation fails.
 func (s *systemStatusServer) localHotRanges(
-	ctx context.Context, tenantID roachpb.TenantID, requestedNodeID roachpb.NodeID,
+	tenantID roachpb.TenantID, requestedNodeID roachpb.NodeID, localLimit int,
 ) (*serverpb.HotRangesResponseV2, error) {
 	// Initialize response object
 	var resp serverpb.HotRangesResponseV2
@@ -3029,6 +3036,15 @@ func (s *systemStatusServer) localHotRanges(
 
 	if err != nil {
 		return nil, err
+	}
+
+	// sort the slices by cpu
+	slices.SortFunc(resp.Ranges, func(a, b *serverpb.HotRangesResponseV2_HotRange) int {
+		return cmp.Compare(a.CPUTimePerSecond, b.CPUTimePerSecond)
+	})
+	// truncate the response if localLimit is set
+	if localLimit != 0 && localLimit < len(resp.Ranges) {
+		resp.Ranges = resp.Ranges[:localLimit]
 	}
 
 	return &resp, nil

--- a/pkg/server/structlogging/BUILD.bazel
+++ b/pkg/server/structlogging/BUILD.bazel
@@ -41,9 +41,11 @@ go_test(
         "//pkg/base",
         "//pkg/kv/kvserver",
         "//pkg/kv/kvserver/allocator/plan",
+        "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",
+        "//pkg/settings/cluster",
         "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/skip",
@@ -54,5 +56,6 @@ go_test(
         "//pkg/util/log/logpb",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -147,11 +147,14 @@ func (s *hotRangesLoggingScheduler) shouldLog() bool {
 // logHotRanges collects the hot ranges from this node's status server and
 // sends them to the TELEMETRY log channel.
 func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	req := &serverpb.HotRangesRequest{NodeID: "local", PageSize: ReportTopHottestRanges}
+	req := &serverpb.HotRangesRequest{}
+
 	// if we are running in single tenant mode, only log the ranges on the status server.
 	if !s.multiTenant {
-		req.NodeID = "local"
+		req.Nodes = []string{"local"}
+		req.PageSize = ReportTopHottestRanges
 	}
+
 	resp, err := s.sServer.HotRangesV2(ctx, req)
 	if err != nil {
 		log.Warningf(ctx, "failed to get hot ranges: %s", err)

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -25,7 +25,16 @@ import (
 )
 
 // ReportTopHottestRanges limits the number of ranges to be reported per iteration
-const ReportTopHottestRanges = 5
+var ReportTopHottestRanges int32 = 5
+
+// CheckInterval is the interval at which the system checks
+// whether or not to log the hot ranges.
+var CheckInterval = time.Second
+
+// TestLoopChannel triggers the hot ranges logging loop to start again.
+// It's useful in the context of a test, where we don't want to wait
+// for whatever the last time the interval was.
+var TestLoopChannel = make(chan struct{}, 1)
 
 var TelemetryHotRangesStatsInterval = settings.RegisterDurationSetting(
 	settings.ApplicationLevel,
@@ -50,18 +59,38 @@ var TelemetryHotRangesStatsLoggingDelay = settings.RegisterDurationSetting(
 	settings.NonNegativeDuration,
 )
 
+// TelemetryHotRangesStatsCPUThreshold defines the cpu duration
+// per second which needs to be exceeded for the system to automatically
+// log the hot ranges. It tracks the reasoning that the kv layer
+// uses to determine when to begin sampling reads for a given
+// range in the keyspace, more information found where the cluster
+// setting SplitByLoadCPUThreshold is defined.
+var TelemetryHotRangesStatsCPUThreshold = settings.RegisterDurationSetting(
+	settings.SystemOnly,
+	"server.telemetry.hot_ranges_stats.cpu_threshold",
+	"the cpu time over which the system will automatically begin logging hot ranges",
+	time.Second/4,
+)
+
 // hotRangesLoggingScheduler is responsible for logging index usage stats
 // on a scheduled interval.
 type hotRangesLoggingScheduler struct {
-	ie          sql.InternalExecutor
 	sServer     serverpb.TenantStatusServer
 	st          *cluster.Settings
 	stopper     *stop.Stopper
 	job         *jobs.Job
 	multiTenant bool
+	lastLogged  time.Time
 }
 
-// StartHotRangesLoggingScheduler starts the capture index usage statistics logging scheduler.
+// StartHotRangesLoggingScheduler starts the hot range log task
+// or job.
+//
+// For system tenants, or single tenant deployments, it runs as
+// a task on each node, logging only the ranges on the node in
+// which it runs. For app tenants in a multi-tenant deployment,
+// it runs on a single node in the sql cluster, applying a fanout
+// to the kv layer to collect the hot ranges from all nodes.
 func StartHotRangesLoggingScheduler(
 	ctx context.Context,
 	stopper *stop.Stopper,
@@ -70,22 +99,24 @@ func StartHotRangesLoggingScheduler(
 	st *cluster.Settings,
 	ti *tenantcapabilities.Entry,
 ) error {
-	multiTenant := ti != nil && !ti.TenantID.IsSystem()
+	multiTenant := ti != nil && ti.TenantID.IsSet() && !ti.TenantID.IsSystem()
 	scheduler := hotRangesLoggingScheduler{
-		ie:          ie,
 		sServer:     sServer,
 		st:          st,
 		stopper:     stopper,
 		multiTenant: multiTenant,
+		lastLogged:  timeutil.Now(),
 	}
 
 	if multiTenant {
-		return scheduler.startJob(ctx, stopper)
+		return scheduler.startJob()
 	}
 
 	return scheduler.startTask(ctx, stopper)
 }
 
+// startTask is for usage in a system-tenant or non-multi-tenant
+// installation.
 func (s *hotRangesLoggingScheduler) startTask(ctx context.Context, stopper *stop.Stopper) error {
 	return stopper.RunAsyncTask(ctx, "hot-ranges-stats", func(ctx context.Context) {
 		err := s.start(ctx, stopper)
@@ -93,7 +124,7 @@ func (s *hotRangesLoggingScheduler) startTask(ctx context.Context, stopper *stop
 	})
 }
 
-func (s *hotRangesLoggingScheduler) startJob(ctx context.Context, stopper *stop.Stopper) error {
+func (s *hotRangesLoggingScheduler) startJob() error {
 	jobs.RegisterConstructor(
 		jobspb.TypeHotRangesLogger,
 		func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
@@ -105,27 +136,20 @@ func (s *hotRangesLoggingScheduler) startJob(ctx context.Context, stopper *stop.
 }
 
 func (s *hotRangesLoggingScheduler) start(ctx context.Context, stopper *stop.Stopper) error {
-	intervalChangedChan := make(chan struct{})
-	// We have to register this callback first. Otherwise we may run into
-	// an unlikely but possible scenario where we've started the ticker,
-	// and the setting is changed before we register the callback and the
-	// ticker will not be reset to the new value.
-	TelemetryHotRangesStatsInterval.SetOnChange(&s.st.SV, func(ctx context.Context) {
-		intervalChangedChan <- struct{}{}
-	})
-
-	ticker := time.NewTicker(TelemetryHotRangesStatsInterval.Get(&s.st.SV))
-
 	for {
+		ci := CheckInterval
+		if s.multiTenant {
+			ci *= 5
+		}
 		select {
 		case <-stopper.ShouldQuiesce():
 			return nil
 		case <-ctx.Done():
 			return nil
-		case <-ticker.C:
+		case <-time.After(ci):
 			s.maybeLogHotRanges(ctx, stopper)
-		case <-intervalChangedChan:
-			ticker.Reset(TelemetryHotRangesStatsInterval.Get(&s.st.SV))
+		case <-TestLoopChannel:
+			continue
 		}
 	}
 }
@@ -133,29 +157,78 @@ func (s *hotRangesLoggingScheduler) start(ctx context.Context, stopper *stop.Sto
 // maybeLogHotRanges is a small helper function which couples the
 // functionality of checking whether to log and logging.
 func (s *hotRangesLoggingScheduler) maybeLogHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	if s.shouldLog() {
+	if s.shouldLog(ctx) {
 		s.logHotRanges(ctx, stopper)
+		s.lastLogged = timeutil.Now()
 	}
 }
 
-// shouldLog checks the below conditions to see whether it should emit logs.
-//   - Is the cluster setting server.telemetry.hot_ranges_stats.enabled true?
-func (s *hotRangesLoggingScheduler) shouldLog() bool {
-	return TelemetryHotRangesStatsEnabled.Get(&s.st.SV)
+// shouldLog checks the below conditions to see whether it
+// should emit logs.
+//
+//		To return true, we verify that both:
+//		 - The logging setting is enabled.
+//	   - One of the following conditions is met:
+//		   -- It's been greater than the log interval since we last logged.
+//		   -- One of the replicas see exceeds our cpu threshold.
+func (s *hotRangesLoggingScheduler) shouldLog(ctx context.Context) bool {
+	enabled := TelemetryHotRangesStatsEnabled.Get(&s.st.SV)
+	if !enabled {
+		return false
+	}
+
+	logInterval := TelemetryHotRangesStatsInterval.Get(&s.st.SV)
+	if timeutil.Since(s.lastLogged) > logInterval {
+		return true
+	}
+
+	// Getting the hot ranges with the statsOnly flag will
+	// ensure the call doesn't touch the keyspace. Therefore
+	// drastically lightening the overhead of fetching them.
+	resp, err := s.getHotRanges(context.Background(), true)
+	if err != nil {
+		log.Warningf(ctx, "failed to get hot ranges: %s", err)
+		return false
+	}
+	cpuThreshold := TelemetryHotRangesStatsCPUThreshold.Get(&s.st.SV)
+	return maxCPU(resp.Ranges) > cpuThreshold
 }
 
-// logHotRanges collects the hot ranges from this node's status server and
-// sends them to the TELEMETRY log channel.
-func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
-	req := &serverpb.HotRangesRequest{}
+func maxCPU(ranges []*serverpb.HotRangesResponseV2_HotRange) time.Duration {
+	maxSeen := float64(0)
+	for _, r := range ranges {
+		if r.CPUTimePerSecond > maxSeen {
+			maxSeen = r.CPUTimePerSecond
+		}
+	}
+	return time.Duration(maxSeen)
+}
+
+// getHotRanges is a simple utility function for making a hot ranges
+// request to the status server. It can be used to fetch only the
+// stats for ranges requested, or everything. It also determines
+// whether to limit the request to only the local node, or to
+// issue a fanout for multi-tenant apps.
+func (s *hotRangesLoggingScheduler) getHotRanges(
+	ctx context.Context, statsOnly bool,
+) (*serverpb.HotRangesResponseV2, error) {
+	req := &serverpb.HotRangesRequest{
+		PerNodeLimit: ReportTopHottestRanges,
+		StatsOnly:    statsOnly,
+	}
 
 	// if we are running in single tenant mode, only log the ranges on the status server.
 	if !s.multiTenant {
 		req.Nodes = []string{"local"}
-		req.PageSize = ReportTopHottestRanges
 	}
 
-	resp, err := s.sServer.HotRangesV2(ctx, req)
+	return s.sServer.HotRangesV2(ctx, req)
+}
+
+// logHotRanges collects the hot ranges from this node's status server and
+// sends them to the HEALTH log channel.
+func (s *hotRangesLoggingScheduler) logHotRanges(ctx context.Context, stopper *stop.Stopper) {
+	resp, err := s.getHotRanges(ctx, false)
 	if err != nil {
 		log.Warningf(ctx, "failed to get hot ranges: %s", err)
 		return

--- a/pkg/server/structlogging/hot_ranges_log.go
+++ b/pkg/server/structlogging/hot_ranges_log.go
@@ -29,7 +29,7 @@ var ReportTopHottestRanges int32 = 5
 
 // CheckInterval is the interval at which the system checks
 // whether or not to log the hot ranges.
-var CheckInterval = time.Second
+var CheckInterval = time.Minute
 
 // TestLoopChannel triggers the hot ranges logging loop to start again.
 // It's useful in the context of a test, where we don't want to wait

--- a/pkg/server/structlogging/hot_ranges_log_job.go
+++ b/pkg/server/structlogging/hot_ranges_log_job.go
@@ -13,6 +13,14 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
+// hot_ranges_log_job.go adds the required functions to satisfy
+// the jobs.Scheduler interface for the hot ranges logging job.
+// This is only required for app tenants in a multi-tenant deployment
+// as the app tenants have no notion of "local" ranges, and therefore
+// require a fanout to be performed to collect the hot ranges.
+// It's run as a job, as since fanout is required, only one node
+// needs to run it at any given time, as opposed to the every
+// node task behavior otherwise.
 func (s *hotRangesLoggingScheduler) Resume(ctx context.Context, execCtxI interface{}) error {
 	// This job is a forever running background job, and it is always safe to
 	// terminate the SQL pod whenever the job is running, so mark it as idle.

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -9,15 +9,17 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"regexp"
-	"slices"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator/plan"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/structlogging"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
@@ -26,13 +28,127 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/stretchr/testify/require"
 )
+
+// setup an impossibly low cpu threshold, test clusters
+// do not seem to record cpu utilization per replica.
+const lowCPUThreshold = time.Duration(-1)
+const highCPUThreshold = time.Second
+const defaultTestWait = time.Second
+const lowDelay = 50 * time.Millisecond
+const highDelay = time.Minute
+
+// TestHotRangeLogger tests that hot ranges stats are logged per node.
+// It uses system ranges to verify behavior.
+func TestHotRangeLoggerSettings(t *testing.T) {
+	skip.UnderRace(t)
+	skip.UnderStress(t)
+	ctx := context.Background()
+
+	// We only want to run this once within the suite, as the
+	// subsystem we depend on takes on the order of whole seconds
+	// to warm.
+	s, spy, teardown := setupTestServer(t, ctx)
+	defer teardown()
+
+	for _, test := range []struct {
+		enabled            bool
+		tickerInterval     time.Duration
+		logSettingInterval time.Duration
+		waitFor            time.Duration
+		logCPUThreshold    time.Duration
+		hasLogs            bool
+	}{
+		// Tests the straightforward use case, where we expect no threshold,
+		// a minimal interval, minimal loop, and zero threshold should
+		// result in multiple logs.
+		{true, lowDelay, lowDelay, defaultTestWait, lowCPUThreshold, true},
+
+		// This test is the same as the default case, except the
+		// cluster setting which controls logging is off.
+		{false, lowDelay, lowDelay, defaultTestWait, lowCPUThreshold, false},
+
+		// This test validates that even when we check on a low cadance,
+		// if the threshold is not passed and the interval is long,
+		// no logs will appear.
+		{true, lowDelay, highDelay, defaultTestWait, highCPUThreshold, false},
+
+		// This test validates that even if the interval is long,
+		// if the cpu threshold is low, and its checked, the system
+		// will produce logs.
+		{true, lowDelay, highDelay, defaultTestWait, lowCPUThreshold, true},
+
+		// This test validates with a high check cadance, no logs
+		// will appear, even if the interval and thresholds are low.
+		{true, highDelay, lowDelay, defaultTestWait, lowCPUThreshold, false},
+
+		// This test checks that if there's a low logging interval
+		// if the cpuThreshold is high, logs will still appear.
+		{true, lowDelay, lowDelay, defaultTestWait, highCPUThreshold, true},
+	} {
+		t.Run(fmt.Sprintf("settings tests %v", test), func(t *testing.T) {
+			setupTest(ctx, s.ClusterSettings(), test.enabled, test.logSettingInterval, test.tickerInterval, test.logCPUThreshold, spy)
+			time.Sleep(test.waitFor)
+			require.Equal(t, test.hasLogs, hasNonZeroQPSRange(spy.Logs()))
+		})
+	}
+
+	t.Run("the per node restriction limits the number of unique logs", func(t *testing.T) {
+		countSeenRanges := func(logs []testLog) int {
+			counts := make(map[int64]int)
+			for _, l := range logs {
+				counts[l.Stats.RangeID]++
+			}
+			return len(counts)
+		}
+
+		// without a limit set, we should see many ranges.
+		setupTest(ctx, s.ClusterSettings(), true, lowDelay, lowDelay, lowCPUThreshold, spy)
+		time.Sleep(time.Second)
+		require.Greater(t, countSeenRanges(spy.Logs()), 1)
+
+		// with a limit, only one range should show up.
+		structlogging.ReportTopHottestRanges = 1
+		setupTest(ctx, s.ClusterSettings(), true, lowDelay, lowDelay, lowCPUThreshold, spy)
+		time.Sleep(time.Second)
+		require.Equal(t, countSeenRanges(spy.Logs()), 1)
+	})
+}
+
+// For multi-tenancy, we want to test the differing behavior.
+// Specifically, we want to test the following:
+//   - Logs are written separately for system and app tenants.
+//   - For app tenants, the interval at which logs are collected
+//     is longer.
+//   - For app tenants, a job is initialized for the hot ranges
+//     logger, whereas for the system tenant it runs as a task.
+func TestHotRangeLoggerMultitenant(t *testing.T) {
+	skip.UnderRace(t)
+	ctx := context.Background()
+	s, spy, teardown := setupTestServer(t, ctx)
+	tenantID := roachpb.MustMakeTenantID(2)
+	tt, err := s.TenantController().StartTenant(ctx, base.TestTenantArgs{
+		TenantID: tenantID,
+	})
+	spy.Logs()
+	require.NoError(t, err)
+	require.NotNil(t, tt)
+	// TODO (brian): the jobs system isn't registering this correctly,
+	// this will be fixed in a short follow pr.
+	defer teardown()
+}
+
+type testLog struct {
+	TenantID string
+	Stats    eventpb.HotRangesStats
+}
 
 type hotRangesLogSpy struct {
 	t  *testing.T
 	mu struct {
 		syncutil.RWMutex
-		logs []eventpb.HotRangesStats
+		logs []testLog
 	}
 }
 
@@ -54,13 +170,13 @@ func (spy *hotRangesLogSpy) Intercept(e []byte) {
 		spy.t.Fatal(err)
 	}
 
-	spy.mu.logs = append(spy.mu.logs, rangesLog)
+	spy.mu.logs = append(spy.mu.logs, testLog{entry.TenantID, rangesLog})
 }
 
-func (spy *hotRangesLogSpy) Logs() []eventpb.HotRangesStats {
+func (spy *hotRangesLogSpy) Logs() []testLog {
 	spy.mu.RLock()
 	defer spy.mu.RUnlock()
-	logs := make([]eventpb.HotRangesStats, len(spy.mu.logs))
+	logs := make([]testLog, len(spy.mu.logs))
 	copy(logs, spy.mu.logs)
 	return logs
 }
@@ -71,20 +187,27 @@ func (spy *hotRangesLogSpy) Reset() {
 	spy.mu.logs = nil
 }
 
-func setupHotRangesLogTest(
+// setupTestServer is a somewhat lengthy warmup process
+// to ensure that the hot ranges tests are ready to run.
+// It sets up a cluster, runs it until the hot range stats are
+// warm by dialing the knobs to noisy, and checking for output,
+// then redials the knobs back to quiet so the test can take over.
+func setupTestServer(
 	t *testing.T, ctx context.Context,
-) (serverutils.ApplicationLayerInterface, *hotRangesLogSpy, func()) {
+) (serverutils.TestServerInterface, *hotRangesLogSpy, func()) {
 	sc := log.ScopeWithoutShowLogs(t)
 	spy := &hotRangesLogSpy{t: t}
-	tc := serverutils.StartCluster(t, 1, base.TestClusterArgs{
-		ReplicationMode: base.ReplicationManual,
-		ServerArgs: base.TestServerArgs{
-			DefaultTestTenant: base.TestControlsTenantsExplicitly,
-			Knobs: base.TestingKnobs{
-				Store: &kvserver.StoreTestingKnobs{
-					ReplicaPlannerKnobs: plan.ReplicaPlannerTestingKnobs{
-						DisableReplicaRebalancing: true,
-					},
+
+	// override internal settings.
+	structlogging.ReportTopHottestRanges = 1000
+	structlogging.CheckInterval = 100 * time.Millisecond
+
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestControlsTenantsExplicitly,
+		Knobs: base.TestingKnobs{
+			Store: &kvserver.StoreTestingKnobs{
+				ReplicaPlannerKnobs: plan.ReplicaPlannerTestingKnobs{
+					DisableReplicaRebalancing: true,
 				},
 			},
 		},
@@ -92,7 +215,7 @@ func setupHotRangesLogTest(
 
 	leakChecker := leaktest.AfterTest(t)
 	logInterceptor := log.InterceptWith(ctx, spy)
-	stopper := tc.Stopper()
+	stopper := s.Stopper()
 	teardown := func() {
 		stopper.Stop(ctx)
 		sc.Close(t)
@@ -100,39 +223,57 @@ func setupHotRangesLogTest(
 		leakChecker()
 	}
 
-	ts := tc.ApplicationLayer(0)
-	return ts, spy, teardown
-}
+	ts := s.ApplicationLayer()
 
-// TestHotRangeLogger tests that hot ranges stats are logged per node.
-// The test will ensure each node contains 5 distinct range replicas for hot
-// ranges logging. Each node should thus log 5 distinct range ids.
-func TestHotRangeLogger(t *testing.T) {
-	skip.UnderRace(t)
-	ctx := context.Background()
-	ts, spy, teardown := setupHotRangesLogTest(t, ctx)
-	defer teardown()
-
+	// lower settings so that we can wait for the stats to warm.
 	structlogging.TelemetryHotRangesStatsEnabled.Override(ctx, &ts.ClusterSettings().SV, true)
 	structlogging.TelemetryHotRangesStatsInterval.Override(ctx, &ts.ClusterSettings().SV, time.Millisecond)
 	structlogging.TelemetryHotRangesStatsLoggingDelay.Override(ctx, &ts.ClusterSettings().SV, 0*time.Millisecond)
 
+	// simulate some queries.
+	for range 1000 {
+		_, err := ts.SQLConn(t).Exec("SELECT * FROM system.namespace")
+		require.NoError(t, err)
+	}
+
 	testutils.SucceedsSoon(t, func() error {
 		logs := spy.Logs()
 
-		// Look for a descriptor, which we always expect to exist in the system.
-		for _, l := range logs {
-			if !slices.Equal(l.Databases, []string{"‹system›"}) {
-				continue
-			}
-			if !slices.Equal(l.Tables, []string{"‹sqlliveness›"}) {
-				continue
-			}
-			if !slices.Equal(l.Indexes, []string{"‹primary›"}) {
-				continue
-			}
+		if hasNonZeroQPSRange(logs) {
 			return nil
 		}
 		return errors.New("waited too long for the synthetic data")
 	})
+
+	return s, spy, teardown
+}
+
+// Utility function which generally indicates that the hot ranges
+// are being logged.
+func hasNonZeroQPSRange(logs []testLog) bool {
+	for _, l := range logs {
+		if l.Stats.Qps == 0 {
+			continue
+		}
+		return true
+	}
+	return false
+}
+
+func setupTest(
+	ctx context.Context,
+	st *cluster.Settings,
+	enabled bool,
+	logInterval, tickerInterval time.Duration,
+	logCPUThreshold time.Duration,
+	spy *hotRangesLogSpy,
+) {
+	structlogging.TelemetryHotRangesStatsEnabled.Override(ctx, &st.SV, enabled)
+	structlogging.TelemetryHotRangesStatsInterval.Override(ctx, &st.SV, logInterval)
+	structlogging.TelemetryHotRangesStatsCPUThreshold.Override(ctx, &st.SV, logCPUThreshold)
+	structlogging.CheckInterval = tickerInterval
+	// wait for the activity from the previous test to drain.
+	time.Sleep(100 * time.Millisecond)
+	structlogging.TestLoopChannel <- struct{}{}
+	spy.Reset()
 }

--- a/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/reports/containers/hotranges/index.tsx
@@ -30,7 +30,7 @@ const HotRanges = (props: HotRangesProps) => {
 
   useEffect(() => {
     const request = new cockroach.server.serverpb.HotRangesRequest({
-      node_id: nodeId,
+      nodes: [nodeId],
       page_size: pageSize,
       page_token: pageToken,
     });


### PR DESCRIPTION
Note, all of the PRs build on each other. It's tough to backport the prs separately, however I can do them sequentially if preferred.

Backport:
  * 1/1 commits from "server: allow for filtering hot ranges by node id" (#143904)
  * 1/1 commits from "server: add information filtering to hot ranges endpoint" (#144091)
  * 1/1 commits from "structlogging: conditionally log hot ranges if the node is burdened" (#144414)
  * 1/1 commits from "structlogging: hot ranges log modify interval loop check to be 1m" (#146280)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: required hotspot telemetry changes