### PR TITLE
rpc: replace dprcpool.Conn usage with dprc.Conn 

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -94,8 +94,10 @@ func newDRPCServer(_ context.Context, rpcCtx *Context) (*DRPCServer, error) {
 	}, nil
 }
 
-func dialDRPC(rpcCtx *Context) func(ctx context.Context, target string) (drpcpool.Conn, error) {
-	return func(ctx context.Context, target string) (drpcpool.Conn, error) {
+func dialDRPC(
+	rpcCtx *Context,
+) func(ctx context.Context, target string, _ ConnectionClass) (drpc.Conn, error) {
+	return func(ctx context.Context, target string, _ ConnectionClass) (drpc.Conn, error) {
 		// TODO(server): could use connection class instead of empty key here.
 		pool := drpcpool.New[struct{}, drpcpool.Conn](drpcpool.Options{
 			Expiration: defaultDRPCConnIdleTimeout,
@@ -151,7 +153,7 @@ func dialDRPC(rpcCtx *Context) func(ctx context.Context, target string) (drpcpoo
 }
 
 type closeEntirePoolConn struct {
-	drpcpool.Conn
+	drpc.Conn
 	pool *drpcpool.Pool[struct{}, drpcpool.Conn]
 }
 

--- a/pkg/rpc/nodedialer/BUILD.bazel
+++ b/pkg/rpc/nodedialer/BUILD.bazel
@@ -23,7 +23,7 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
-        "@io_storj_drpc//drpcpool",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -25,7 +25,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
-	"storj.io/drpc/drpcpool"
+	"storj.io/drpc"
 )
 
 // An AddressResolver translates NodeIDs into addresses.
@@ -187,7 +187,7 @@ func (n *Dialer) dial(
 	locality roachpb.Locality,
 	checkBreaker bool,
 	class rpc.ConnectionClass,
-) (*grpc.ClientConn, *rpc.BatchStreamPool, drpcpool.Conn, *rpc.DRPCBatchStreamPool, error) {
+) (*grpc.ClientConn, *rpc.BatchStreamPool, drpc.Conn, *rpc.DRPCBatchStreamPool, error) {
 	const ctxWrapMsg = "dial"
 	// Don't trip the breaker if we're already canceled.
 	if ctxErr := ctx.Err(); ctxErr != nil {


### PR DESCRIPTION
`drpc.Conn` is the connection interface and `drpcpool.Conn` is a wrapper interface to provide connection pool functionality. Currently we use `drpcpool.Conn` across our codebase.

This change replaces all references to `drpcpool.Conn` with the more generic `drpc.Conn`, allowing us to plug in either a plain connection or a pooled connection without touching call sites. In the future, we will be able to introduce connection multiplexing on `drpc.Conn` without touching existing code. Pooled connections can still be used simply by passing in a `drpcpool.Conn` implementation.

Fixes: https://github.com/cockroachdb/cockroach/issues/147199
Epic: CRDB-48923
Release note: none