### PR TITLE
row/fetcher: clean up and harden TestRowFetcherMVCCMetadata

### DIFF
--- a/pkg/sql/row/BUILD.bazel
+++ b/pkg/sql/row/BUILD.bazel
@@ -127,6 +127,7 @@ go_test(
         "//pkg/sql",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/bootstrap",
+        "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/descs",
         "//pkg/sql/catalog/desctestutils",

--- a/pkg/sql/row/fetcher.go
+++ b/pkg/sql/row/fetcher.go
@@ -1284,12 +1284,6 @@ func (rf *Fetcher) NextRowDecodedInto(
 	return true, spanID, nil
 }
 
-// RowLastModified may only be called after NextRow has returned a non-nil row
-// and returns the timestamp of the last modification to that row.
-func (rf *Fetcher) RowLastModified() hlc.Timestamp {
-	return rf.table.rowLastModified
-}
-
 // RowIsDeleted may only be called after NextRow has returned a non-nil row and
 // returns true if that row was most recently deleted. This method is only
 // meaningful when the configured KVBatchFetcher returns deletion tombstones, which
@@ -1306,7 +1300,7 @@ func (rf *Fetcher) finalizeRow() error {
 		// TODO (rohany): Datums are immutable, so we can't store a DDecimal on the
 		//  fetcher and change its contents with each row. If that assumption gets
 		//  lifted, then we can avoid an allocation of a new decimal datum here.
-		dec := rf.args.Alloc.NewDDecimal(tree.DDecimal{Decimal: eval.TimestampToDecimal(rf.RowLastModified())})
+		dec := rf.args.Alloc.NewDDecimal(tree.DDecimal{Decimal: eval.TimestampToDecimal(rf.table.rowLastModified)})
 		table.row[table.timestampOutputIdx] = rowenc.EncDatum{Datum: dec}
 	}
 	if table.oidOutputIdx != noOutputColumn {


### PR DESCRIPTION
This commit refactors `TestRowFetcherMVCCMetadata` a bit to explicitly request `crdb_internal_mvcc_timestamp` as opposed to fishing it out of the fetcher, which allows removing an exported method from the latter.

This commit also hardens the test to de-flake it when write buffering is enabled. The test scans the storage engine directly, so we need to tweak a testing knob to ensure that COMMIT blocks until the writes are committed into pebble.

Fixes: #147174.

Release note: None