### PR TITLE
roachtest: move task termination

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/task/manager.go
+++ b/pkg/cmd/roachtest/roachtestutil/task/manager.go
@@ -25,6 +25,7 @@ type (
 		Tasker
 		GroupProvider
 		Terminate(*logger.Logger)
+		Cancel()
 		CompletedEvents() <-chan Event
 	}
 
@@ -105,6 +106,11 @@ func (m *manager) Terminate(l *logger.Logger) {
 	}()
 
 	WaitForChannel(doneCh, "tasks", l)
+}
+
+// Cancel will cancel all tasks started by the manager.
+func (m *manager) Cancel() {
+	m.group.cancelAll()
 }
 
 // CompletedEvents returns a channel that will receive events for all tasks


### PR DESCRIPTION
Previously, the task manager was terminated during test teardown. The teardown
would happen directly after a test timeout as well. At this point the test code
could still be running, and new tasks could be initiated. This could result in
undefined behavior. This change moves the task termination to after the test has
returned.

Even though it's still possible to start new tasks after a test has timed out,
these tasks should be short-lived and should not cause any issues. When the test
code returns, the task manager is terminated and any stray tasks are cleaned up.

Fixes: https://github.com/cockroachdb/cockroach/issues/143973

Epic: None
Release note: None