### PR TITLE
logstore: decouple state loaders

### DIFF
--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -34,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	raft "github.com/cockroachdb/cockroach/pkg/raft"
@@ -5316,7 +5317,7 @@ func TestProcessSplitAfterRightHandSideHasBeenRemoved(t *testing.T) {
 		getHardState := func(
 			t *testing.T, store *kvserver.Store, rangeID roachpb.RangeID,
 		) raftpb.HardState {
-			hs, err := stateloader.Make(rangeID).LoadHardState(ctx, store.TODOEngine())
+			hs, err := logstore.NewStateLoader(rangeID).LoadHardState(ctx, store.LogEngine())
 			require.NoError(t, err)
 			return hs
 		}

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -51,14 +51,18 @@ func LoadReplicaState(
 			"r%d: loaded RaftReplicaID %d does not match %d", desc.RangeID, loaded, replicaID)
 	}
 
+	// TODO(pav-kv): donate the buffer from one stateloader to the other when
+	// done, to avoid the second allocation.
+	logSL := logstore.NewStateLoader(desc.RangeID)
+
 	ls := LoadedReplicaState{ReplicaID: replicaID}
-	if ls.hardState, err = sl.LoadHardState(ctx, eng); err != nil {
+	if ls.hardState, err = logSL.LoadHardState(ctx, eng); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.TruncState, err = sl.LoadRaftTruncatedState(ctx, eng); err != nil {
+	if ls.TruncState, err = logSL.LoadRaftTruncatedState(ctx, eng); err != nil {
 		return LoadedReplicaState{}, err
 	}
-	if ls.LastEntryID, err = sl.LoadLastEntryID(ctx, eng, ls.TruncState); err != nil {
+	if ls.LastEntryID, err = logSL.LoadLastEntryID(ctx, eng, ls.TruncState); err != nil {
 		return LoadedReplicaState{}, err
 	}
 	if ls.ReplState, err = sl.Load(ctx, eng, desc); err != nil {

--- a/pkg/kv/kvserver/logstore/BUILD.bazel
+++ b/pkg/kv/kvserver/logstore/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "logstore",
     srcs = [
         "bytes_tracker.go",
+        "keys.go",
         "logstore.go",
         "sideload.go",
         "sideload_disk.go",

--- a/pkg/kv/kvserver/logstore/keys.go
+++ b/pkg/kv/kvserver/logstore/keys.go
@@ -1,0 +1,44 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logstore
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+)
+
+// KeyBuf provides methods for generating storage engine keys for raft state.
+// The keys are generated in the in-place buffer, and are only valid until the
+// next call to one of the methods.
+type KeyBuf roachpb.Key
+
+// MakeKeyBuf creates a KeyBuf set to generate raft state keys within the
+// RangeID-local unreplicated keyspace.
+// TODO(pav-kv): support LogID.
+func MakeKeyBuf(rangeID roachpb.RangeID) KeyBuf {
+	return KeyBuf(keys.MakeRangeIDUnreplicatedPrefix(rangeID))
+}
+
+// RaftHardStateKey returns the key for raft HardState.
+func (b KeyBuf) RaftHardStateKey() roachpb.Key {
+	return roachpb.Key(append(b, keys.LocalRaftHardStateSuffix...))
+}
+
+// RaftTruncatedStateKey returns the key for RaftTruncatedState.
+func (b KeyBuf) RaftTruncatedStateKey() roachpb.Key {
+	return roachpb.Key(append(b, keys.LocalRaftTruncatedStateSuffix...))
+}
+
+// RaftLogPrefix returns the key prefix shared by all entries in the raft log.
+func (b KeyBuf) RaftLogPrefix() roachpb.Key {
+	return roachpb.Key(append(b, keys.LocalRaftLogSuffix...))
+}
+
+// RaftLogKey returns the key for a raft log entry.
+func (b KeyBuf) RaftLogKey(index kvpb.RaftIndex) roachpb.Key {
+	return keys.RaftLogKeyFromPrefix(b.RaftLogPrefix(), index)
+}

--- a/pkg/kv/kvserver/logstore/stateloader.go
+++ b/pkg/kv/kvserver/logstore/stateloader.go
@@ -38,14 +38,12 @@ import (
 // TODO(pavelkalinnikov): understand the split between logstore and raftlog
 // packages, reshuffle or merge them, including this StateLoader.
 type StateLoader struct {
-	keys.RangeIDPrefixBuf
+	KeyBuf
 }
 
 // NewStateLoader creates a log StateLoader for the given range.
 func NewStateLoader(rangeID roachpb.RangeID) StateLoader {
-	return StateLoader{
-		RangeIDPrefixBuf: keys.MakeRangeIDPrefixBuf(rangeID),
-	}
+	return StateLoader{KeyBuf: MakeKeyBuf(rangeID)}
 }
 
 // EntryID is an (index, term) pair identifying a raft log entry.

--- a/pkg/kv/kvserver/loqrecovery/BUILD.bazel
+++ b/pkg/kv/kvserver/loqrecovery/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/kv/kvserver/kvstorage",
         "//pkg/kv/kvserver/liveness",
         "//pkg/kv/kvserver/liveness/livenesspb",
+        "//pkg/kv/kvserver/logstore",
         "//pkg/kv/kvserver/loqrecovery/loqrecoverypb",
         "//pkg/kv/kvserver/raftlog",
         "//pkg/kv/kvserver/stateloader",

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/loqrecovery/loqrecoverypb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/raftlog"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -185,12 +186,11 @@ func visitStoreReplicas(
 	send func(info loqrecoverypb.ReplicaInfo) error,
 ) error {
 	if err := kvstorage.IterateRangeDescriptorsFromDisk(ctx, reader, func(desc roachpb.RangeDescriptor) error {
-		rsl := stateloader.Make(desc.RangeID)
-		rstate, err := rsl.Load(ctx, reader, &desc)
+		rstate, err := stateloader.Make(desc.RangeID).Load(ctx, reader, &desc)
 		if err != nil {
 			return err
 		}
-		hstate, err := rsl.LoadHardState(ctx, reader)
+		hstate, err := logstore.NewStateLoader(desc.RangeID).LoadHardState(ctx, reader)
 		if err != nil {
 			return err
 		}

--- a/pkg/kv/kvserver/raft_log_truncator.go
+++ b/pkg/kv/kvserver/raft_log_truncator.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/storage"
@@ -260,6 +261,7 @@ type replicaForTruncator interface {
 	sideloadedStats(
 		_ context.Context, _ kvpb.RaftSpan) (entries uint64, size int64, _ error)
 	getStateLoader() stateloader.StateLoader
+	getLogStateLoader() logstore.StateLoader
 	// NB: Setting the persistent raft state is via the Engine exposed by
 	// storeForTruncator.
 }
@@ -549,7 +551,7 @@ func (t *raftLogTruncator) tryEnactTruncations(
 	defer batch.Close()
 	if err := handleTruncatedStateBelowRaftPreApply(ctx, truncState,
 		pendingTruncs.mu.truncs[enactIndex].RaftTruncatedState,
-		stateLoader.StateLoader, batch,
+		r.getLogStateLoader(), batch,
 	); err != nil {
 		log.Errorf(ctx, "while attempting to truncate raft log: %+v", err)
 		pendingTruncs.reset()

--- a/pkg/kv/kvserver/raft_truncator_replica.go
+++ b/pkg/kv/kvserver/raft_truncator_replica.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/logstore"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 )
@@ -52,4 +53,11 @@ func (r *raftTruncatorReplica) getStateLoader() stateloader.StateLoader {
 	// the duration of the existence of replicaForTruncator, so we return the
 	// r.raftMu.stateloader (and not r.mu.stateLoader).
 	return r.raftMu.stateLoader
+}
+
+func (r *raftTruncatorReplica) getLogStateLoader() logstore.StateLoader {
+	// NB: the replicaForTruncator contract says that Replica.raftMu is held for
+	// the duration of the existence of replicaForTruncator, so we return the
+	// raftMu loader.
+	return r.logStorage.raftMu.loader
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1971,7 +1971,9 @@ func (r *Replica) assertStateRaftMuLockedReplicaMuRLocked(
 ) {
 	if ts := r.shMu.state.TruncatedState; ts != nil {
 		log.Fatalf(ctx, "non-empty RaftTruncatedState in ReplicaState: %+v", ts)
-	} else if loaded, err := r.raftMu.stateLoader.LoadRaftTruncatedState(ctx, reader); err != nil {
+	} else if loaded, err := r.asLogStorage().raftMu.loader.LoadRaftTruncatedState(
+		ctx, reader,
+	); err != nil {
 		log.Fatalf(ctx, "%s", err)
 	} else if ts := r.asLogStorage().shMu.trunc; loaded != ts {
 		log.Fatalf(ctx, "on-disk and in-memory RaftTruncatedState diverged: %s",

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -509,7 +509,7 @@ func (b *replicaAppBatch) stageTruncation(
 	// into the batch, and compute metadata used after applying it.
 	if err := handleTruncatedStateBelowRaftPreApply(
 		ctx, b.truncState, *truncatedState,
-		b.r.raftMu.stateLoader.StateLoader, b.batch,
+		b.r.asLogStorage().raftMu.loader, b.batch,
 	); err != nil {
 		return errors.Wrap(err, "unable to handle truncated state")
 	}
@@ -710,8 +710,7 @@ func (b *replicaAppBatch) ApplyToStateMachine(ctx context.Context) error {
 func (b *replicaAppBatch) addAppliedStateKeyToBatch(ctx context.Context) error {
 	// Set the range applied state, which includes the last applied raft and
 	// lease index along with the mvcc stats, all in one key.
-	loader := &b.r.raftMu.stateLoader
-	return loader.SetRangeAppliedState(
+	return b.r.raftMu.stateLoader.SetRangeAppliedState(
 		ctx, b.batch, b.state.RaftAppliedIndex, b.state.LeaseAppliedIndex, b.state.RaftAppliedIndexTerm,
 		b.state.Stats, b.state.RaftClosedTimestamp, &b.asAlloc,
 	)

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -229,11 +229,12 @@ func newUninitializedReplicaWithoutRaftGroup(
 	}
 	r.logStorage.mu.RWMutex = (*syncutil.RWMutex)(&r.mu.ReplicaMutex)
 	r.logStorage.raftMu.Mutex = &r.raftMu.Mutex
+	r.logStorage.raftMu.loader = logstore.NewStateLoader(rangeID)
 	r.logStorage.ls = &logstore.LogStore{
 		RangeID:     rangeID,
 		Engine:      store.LogEngine(),
 		Sideload:    sideloaded,
-		StateLoader: r.raftMu.stateLoader.StateLoader,
+		StateLoader: r.logStorage.raftMu.loader,
 		// NOTE: use the same SyncWaiter loop for all raft log writes performed by a
 		// given range ID, to ensure that callbacks are processed in order.
 		SyncWaiter: store.syncWaiters[int(rangeID)%len(store.syncWaiters)],

--- a/pkg/kv/kvserver/replica_raft_truncation_test.go
+++ b/pkg/kv/kvserver/replica_raft_truncation_test.go
@@ -39,7 +39,6 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 	datadriven.Walk(t, datapathutils.TestDataPath(t, "truncated_state"), func(t *testing.T, path string) {
 		const rangeID = 12
 		loader := logstore.NewStateLoader(rangeID)
-		prefixBuf := &loader.RangeIDPrefixBuf
 		eng := storage.NewDefaultInMemForTesting()
 		defer eng.Close()
 
@@ -93,7 +92,7 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 						binary.BigEndian.PutUint64(meta.RawBytes, uint64(idx))
 						value, err := protoutil.Marshal(&meta)
 						require.NoError(t, err)
-						require.NoError(t, eng.PutUnversioned(prefixBuf.RaftLogKey(idx), value))
+						require.NoError(t, eng.PutUnversioned(loader.RaftLogKey(idx), value))
 					}
 				}
 
@@ -112,8 +111,8 @@ func TestHandleTruncatedStateBelowRaft(t *testing.T) {
 
 				// Find the first untruncated log entry (the log head).
 				res, err := storage.MVCCScan(ctx, eng,
-					prefixBuf.RaftLogPrefix().Clone(),
-					prefixBuf.RaftLogPrefix().PrefixEnd(),
+					loader.RaftLogPrefix().Clone(),
+					loader.RaftLogPrefix().PrefixEnd(),
 					hlc.Timestamp{},
 					storage.MVCCScanOptions{MaxKeys: 1})
 				require.NoError(t, err)

--- a/pkg/kv/kvserver/replica_raftlog.go
+++ b/pkg/kv/kvserver/replica_raftlog.go
@@ -46,6 +46,7 @@ type replicaLogStorage struct {
 	// points to Replica.raftMu, and shares its semantics and locking order.
 	raftMu struct {
 		*syncutil.Mutex
+		loader logstore.StateLoader
 		// bytesAccount accounts bytes used by various Raft components, like entries
 		// to be applied. Currently, it only tracks bytes used by committed entries
 		// being applied to the state machine.

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -123,7 +123,7 @@ func (r *replicaRaftStorage) InitialState() (raftpb.HardState, raftpb.ConfState,
 	r.mu.AssertHeld()
 
 	ctx := r.AnnotateCtx(context.TODO())
-	hs, err := r.raftMu.stateLoader.LoadHardState(ctx, r.store.TODOEngine())
+	hs, err := r.logStorage.raftMu.loader.LoadHardState(ctx, r.store.LogEngine())
 	if err != nil {
 		r.reportRaftStorageError(err)
 		return raftpb.HardState{}, raftpb.ConfState{}, err
@@ -569,6 +569,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 		st:       st,
 		todoEng:  r.store.TODOEngine(),
 		sl:       r.raftMu.stateLoader,
+		logSL:    r.logStorage.raftMu.loader,
 		writeSST: inSnap.SSTStorageScratch.WriteSST,
 
 		truncState:    truncState,

--- a/pkg/kv/kvserver/stateloader/BUILD.bazel
+++ b/pkg/kv/kvserver/stateloader/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/keys",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverpb",
         "//pkg/kv/kvserver/logstore",


### PR DESCRIPTION
This commit removes coupling between the state machine `StateLoader` and the log storage `StateLoader`. The log engine `StateLoader` will be able to read from `LogID`-aware keys, and will have a different key prefix than the state machine loader.

Epic: CRDB-46488