### PR TITLE
release-25.1: ui: fix broken sql activity pages when app name contains "#"

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/package.json
+++ b/pkg/ui/workspaces/cluster-ui/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@cockroachlabs/cluster-ui",
-  "version": "25.1.2",
+  "version": "25.1.3",
   "description": "Cluster UI is a library of large features shared between CockroachDB and CockroachCloud",
   "repository": {
     "type": "git",

--- a/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/statementsApi.ts
@@ -120,7 +120,7 @@ export const getStatementDetails = (
     end: req.end.toInt(),
   });
   for (const app of req.app_names) {
-    queryStr += `&appNames=${app}`;
+    queryStr += `&appNames=${encodeURIComponent(app)}`;
   }
   return fetchData(
     cockroach.server.serverpb.StatementDetailsResponse,

--- a/pkg/ui/workspaces/db-console/src/util/api.ts
+++ b/pkg/ui/workspaces/db-console/src/util/api.ts
@@ -730,7 +730,7 @@ export function getStatementDetails(
     end: req.end.toInt(),
   });
   for (const app of req.app_names) {
-    queryStr += `&appNames=${app}`;
+    queryStr += `&appNames=${encodeURIComponent(app)}`;
   }
   return timeoutFetch(
     serverpb.StatementDetailsResponse,


### PR DESCRIPTION
Backport 1/1 commits from #147021 on behalf of @kyle-a-wong.

----

This commit fixes a bug sql activity statement details pages fails to load sql activity for a statement if the app name used to run the statement contains a "#".

This was happening because the application names weren't being properly url encoded. Now these will be encoded correctly.

Epic: None
Release note (bug fix): Fixes a bug in the sql activity statement details page where details would fail to load of the application name used to execute the query contained a "#" character.

----

Release justification: