### PR TITLE
roachtest: added buffered write/sender cluster setting mutators to mixedversion

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -521,6 +521,28 @@ func DisableMutators(names ...string) CustomOption {
 	}
 }
 
+// DisableAllMutators will disable all available mutators.
+func DisableAllMutators() CustomOption {
+	return func(opts *testOptions) {
+		names := []string{}
+		for _, m := range planMutators {
+			names = append(names, m.Name())
+		}
+		DisableMutators(names...)(opts)
+	}
+}
+
+// DisableAllClusterSettingMutators will disable all available cluster setting mutators.
+func DisableAllClusterSettingMutators() CustomOption {
+	return func(opts *testOptions) {
+		names := []string{}
+		for _, m := range clusterSettingMutators {
+			names = append(names, m.Name())
+		}
+		DisableMutators(names...)(opts)
+	}
+}
+
 // WithTag allows callers give the mixedversion test instance a
 // `tag`. The tag is used as prefix in the log messages emitted by
 // this upgrade test. This is only useful when running multiple

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -211,11 +211,9 @@ const (
 	spanConfigTenantLimit = 50000
 )
 
-// planMutators includes a list of all known `mutator`
-// implementations. A subset of these mutations might be enabled in
-// any mixedversion test plan.
-var planMutators = []mutator{
-	preserveDowngradeOptionRandomizerMutator{},
+// clusterSettingMutators includes a list of all
+// cluster setting mutator implementations.
+var clusterSettingMutators = []mutator{
 	newClusterSettingMutator(
 		"kv.expiration_leases_only.enabled",
 		[]bool{true, false},
@@ -231,7 +229,32 @@ var planMutators = []mutator{
 		[]string{"snappy", "zstd"},
 		clusterSettingMinimumVersion("v24.1.0-alpha.0"),
 	),
+	// These two settings are newly introduced, so their probabilities
+	// are temporarily raised to increase testing on them specifically.
+	// The 50% matches the metamorphic probability of these settings
+	// being enabled in non mixed version tests.
+	newClusterSettingMutator(
+		"kv.transaction.write_buffering.enabled",
+		[]bool{true, false},
+		clusterSettingMinimumVersion("v25.2.0"),
+		clusterSettingProbability(0.5),
+	),
+	newClusterSettingMutator(
+		"kv.rangefeed.buffered_sender.enabled",
+		[]bool{true, false},
+		clusterSettingMinimumVersion("v25.2.0"),
+		clusterSettingProbability(0.5),
+	),
 }
+
+// planMutators includes a list of all known `mutator`
+// implementations. A subset of these mutations might be enabled in
+// any mixedversion test plan.
+var planMutators = append([]mutator{
+	preserveDowngradeOptionRandomizerMutator{},
+},
+	clusterSettingMutators...,
+)
 
 // Plan returns the TestPlan used to upgrade the cluster from the
 // first to the final version in the `versions` field. The test plan

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -940,8 +940,8 @@ func (r *testRunner) runWorker(
 					// 50% change of enabling buffered writes.
 					//
 					// Disabled by default. Disabled for mixed-version tests
-					// since these cluster settings are not supported in all
-					// versions.
+					// because they use a separate mechanism for metamorphic
+					// cluster settings.
 					for _, tc := range []struct {
 						setting string
 						label   string

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2750,11 +2750,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 				// TODO(renato): don't disable these mutators when the
 				// framework exposes some utility to provide mutual exclusion
 				// of concurrent steps.
-				mixedversion.DisableMutators(
-					mixedversion.ClusterSettingMutator("kv.expiration_leases_only.enabled"),
-					mixedversion.ClusterSettingMutator("storage.ingest_split.enabled"),
-					mixedversion.ClusterSettingMutator("storage.sstable.compression_algorithm"),
-				),
+				mixedversion.DisableAllClusterSettingMutators(),
 			)
 			testRNG := mvt.RNG()
 


### PR DESCRIPTION
Previously `kv.rangefeed.buffered_sender.enabled` and `kv.transaction.write_buffering.enabled` were disabled in mixedversion - this patch allows the mixedversion tests to enable these settings on supported version.

Informs: #146415
Fixes: https://github.com/cockroachdb/cockroach/issues/147009

Release note: None
TeamCity: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel?buildTypeTab=overview&branch=147225