### PR TITLE
release-25.2: roachtest: fix unsortedMatricesDiffWithFloatComp helper for numerics

### DIFF
--- a/pkg/cmd/roachtest/tests/query_comparison_util.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util.go
@@ -620,9 +620,18 @@ func isFloatArray(colType string) bool {
 	}
 }
 
+func isDecimal(colType string) bool {
+	switch colType {
+	case "DECIMAL", "NUMERIC":
+		return true
+	default:
+		return false
+	}
+}
+
 func isDecimalArray(colType string) bool {
 	switch colType {
-	case "[]DECIMAL", "_DECIMAL":
+	case "[]DECIMAL", "_DECIMAL", "[]NUMERIC", "_NUMERIC":
 		return true
 	default:
 		return false
@@ -633,7 +642,7 @@ func needApproximateMatch(colType string) bool {
 	// On s390x, check that values for both float and decimal coltypes are
 	// approximately equal to take into account platform differences in floating
 	// point calculations. On other architectures, check float values only.
-	return (runtime.GOARCH == "s390x" && (colType == "DECIMAL" || isDecimalArray(colType))) ||
+	return (runtime.GOARCH == "s390x" && (isDecimal(colType) || isDecimalArray(colType))) ||
 		colType == "FLOAT4" || colType == "FLOAT8" || isFloatArray(colType)
 }
 
@@ -714,7 +723,7 @@ func unsortedMatricesDiffWithFloatComp(
 	}
 	var needCustomMatch bool
 	for _, colType := range colTypes {
-		if needApproximateMatch(colType) || colType == "DECIMAL" || isDecimalArray(colType) {
+		if needApproximateMatch(colType) || isDecimal(colType) || isDecimalArray(colType) {
 			needCustomMatch = true
 			break
 		}
@@ -748,7 +757,7 @@ func unsortedMatricesDiffWithFloatComp(
 				}
 			} else {
 				switch {
-				case colType == "DECIMAL":
+				case isDecimal(colType):
 					// For decimals, remove any trailing zeroes.
 					row1[j] = trimDecimalTrailingZeroes(row1[j])
 					row2[j] = trimDecimalTrailingZeroes(row2[j])

--- a/pkg/cmd/roachtest/tests/query_comparison_util_test.go
+++ b/pkg/cmd/roachtest/tests/query_comparison_util_test.go
@@ -156,6 +156,30 @@ func TestUnsortedMatricesDiff(t *testing.T) {
 			exactMatch:  false,
 			approxMatch: true,
 		},
+		{
+			name:        "decimals as numerics with trailing zeroes",
+			colTypes:    []string{"NUMERIC"},
+			t1:          [][]string{{"1.20"}, {"1.000"}},
+			t2:          [][]string{{"1.200"}, {"1"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
+		{
+			name:        "decimals as numerics with non-trailing zeroes",
+			colTypes:    []string{"NUMERIC"},
+			t1:          [][]string{{"10"}, {"1.000"}},
+			t2:          [][]string{{"1.0"}, {"1000"}},
+			exactMatch:  false,
+			approxMatch: false,
+		},
+		{
+			name:        "decimals as numerics with trailing zeroes in array",
+			colTypes:    []string{"_NUMERIC"}, // this is how []DECIMAL can be named in lib/pq driver
+			t1:          [][]string{{"1.0,1.000"}, {"3.0,4.000"}},
+			t2:          [][]string{{"1.00,1"}, {"3.00,4"}},
+			exactMatch:  false,
+			approxMatch: true,
+		},
 	}
 	for _, tc := range tcs {
 		t.Run(tc.name, func(t *testing.T) {


### PR DESCRIPTION
Backport 1/1 commits from #147051 on behalf of @yuzefovich.

----

This commit is similar in spirit to 261cae955c48493ff14003e927b9bccd23bec1f6. We use `T_numeric` and `T__numeric` oids for decimals and decimal arrays, respectively. These oids have "NUMERIC" and "_NUMERIC" names in lib/pq when stringified, so we need to teach our custom logic for ignoring trailizing zeroes to also apply whenever it sees the numeric column types.

Fixes: #146524.

Release note: None

----

Release justification: test-only change.