### PR TITLE
release-24.1: sqlsmith: harden skip of collated strings in some cases

### DIFF
--- a/pkg/internal/sqlsmith/scalar.go
+++ b/pkg/internal/sqlsmith/scalar.go
@@ -439,6 +439,25 @@ func makeFunc(s *Smither, ctx Context, typ *types.T, refs colRefs) (tree.TypedEx
 		// context.
 		return nil, false
 	}
+	if typ.Family() == types.CollatedStringFamily && s.disableNondeterministicLimits {
+		// 'concat_agg' and 'string_agg' functions can produce non-deterministic
+		// results for collated strings. The general issue is described in a
+		// comment within makeOrderByWithAllCols, but it appears that in some
+		// cases the skip in there doesn't work. One hypothesis is that this is
+		// due to not having the final type when the skip is attempted (and
+		// CollatedString and String types share the same oid). This block
+		// attempts to harden that skip by explicitly not generating these
+		// functions for collated strings.
+		//
+		// However, we might not have the final type in this block as well, in
+		// which case we would need to either completely skip these aggregates,
+		// or teach the unsortedMatricesDiff helpers to do SQL comparison as
+		// opposed to a text one.
+		switch fn.def.Name {
+		case "concat_agg", "string_agg":
+			return nil, false
+		}
+	}
 
 	args := make(tree.TypedExprs, 0)
 	for _, argTyp := range fn.overload.Types.Types() {


### PR DESCRIPTION
Backport 1/1 commits from #147123 on behalf of @yuzefovich.

----

About a year ago in 6573a538e270652416a5199fa3d1430585bfe598 we introduced the ability to generate queries with "deterministic limits" which we use in a couple of roachtests. Later, in 47694aad2f4c9ffcdc264e3ee5de40c89b557596, we found that collated strings can be equal in SQL sense while being different when comparing them as text (which we do in our helpers) which would make a false positive, so we adjusted the code to skip generating ORDER BY with all columns when the collated string is present in there.

We just saw a failure due to the same root cause where the stmt was somehow generated. Namely, it used `string_agg` aggregate with STRING type arguments, the result of which was cast to STRING COLLATE, which was used in a scalar subquery. I don't quite understand why that happened, but this commit attempts to harden the skip mentioned above.

Namely, now when picking a builtin function, if it happens to be either `string_agg` or `concat_agg` and we have the collated string as the desired type, we'll skip generating it in the "deterministic limits" context. It might be the case that this commit doesn't help, but I don't think it can hurt.

Fixes: #146872.

Release note: None

----

Release justification: test-only change.