### PR TITLE
release-23.1: cloud: redact azure secret keys in URI

### DIFF
--- a/pkg/cloud/azure/azure_storage.go
+++ b/pkg/cloud/azure/azure_storage.go
@@ -423,5 +423,11 @@ var _ base.ModuleTestingKnobs = &TestingKnobs{}
 
 func init() {
 	cloud.RegisterExternalStorageProvider(cloudpb.ExternalStorageProvider_azure,
-		parseAzureURL, makeAzureStorage, cloud.RedactedParams(AzureAccountKeyParam), scheme, deprecatedScheme, deprecatedExternalConnectionScheme)
+		parseAzureURL,
+		makeAzureStorage,
+		cloud.RedactedParams(AzureAccountKeyParam, AzureClientSecretParam),
+		scheme,
+		deprecatedScheme,
+		deprecatedExternalConnectionScheme,
+	)
 }


### PR DESCRIPTION
Backport 1/1 commits from #147022.

/cc @cockroachdb/release

---

When sanitizing Azure URIs, we redact account keys, but not the client secrets. This updates the sanitization rule to also redact the client secret.

Fixes: CRDB-50284

Release justification: Hiding client secrets in DB output.
