### PR TITLE
release-25.2: xform: increase pool size for "heavy" configs

### DIFF
--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -80,6 +80,10 @@ go_test(
         "//pkg/sql/opt/testutils/opttester:testfixtures",
     ],
     embed = [":xform"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/config/zonepb",
         "//pkg/roachpb",


### PR DESCRIPTION
Backport 1/1 commits from #147087 on behalf of @yuzefovich.

----

We just saw an engflow failure that looks like an OOM under deadlock config, so let's bump the size.

Fixes: #146867.

Release note: None

----

Release justification: test-only change.