### PR TITLE
server: avoid allocation while creating gRPC heartbeat client

### DIFF
--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -46,12 +46,10 @@ func (g *grpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
 	return ch
 }
 
-type grpcHeartbeatClient struct {
-	c HeartbeatClient
-}
+type grpcHeartbeatClient heartbeatClient
 
 func (g *grpcHeartbeatClient) Ping(ctx context.Context, in *PingRequest) (*PingResponse, error) {
-	return g.c.Ping(ctx, in)
+	return (*heartbeatClient)(g).Ping(ctx, in)
 }
 
 type GRPCConnection = Connection[*grpc.ClientConn]

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -251,9 +251,7 @@ func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc
 		},
 		dialDRPC: dialDRPC(rpcCtx),
 		newHeartbeatClient: func(cc *grpc.ClientConn) rpcHeartbeatClient {
-			return &grpcHeartbeatClient{
-				c: NewHeartbeatClient(cc),
-			}
+			return &grpcHeartbeatClient{cc: cc}
 		},
 		newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
 			return kvpb.NewInternalClient(cc).BatchStream(ctx)


### PR DESCRIPTION
Avoid allocation while creating gRPC heartbeat client.

Fixes: none
Epic: CRDB-48923
Release note: none