### PR TITLE
sql: maintain backref during restore of trigger

### DIFF
--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -2044,7 +2044,9 @@ func doRestorePlan(
 	if newDBName != "" {
 		overrideDBName = newDBName
 	}
-	if err := rewrite.TableDescs(tables, descriptorRewrites, overrideDBName); err != nil {
+	var typeBackrefsToRemove map[descpb.ID]map[descpb.ID]struct{}
+	typeBackrefsToRemove, err = rewrite.TableDescs(tables, descriptorRewrites, overrideDBName)
+	if err != nil {
 		return errors.Wrapf(err, "table descriptor rewrite failed")
 	}
 	if err := rewrite.DatabaseDescs(databases, descriptorRewrites, map[descpb.ID]struct{}{}); err != nil {
@@ -2053,7 +2055,7 @@ func doRestorePlan(
 	if err := rewrite.SchemaDescs(schemas, descriptorRewrites); err != nil {
 		return errors.Wrapf(err, "schema descriptor rewrite failed")
 	}
-	if err := rewrite.TypeDescs(types, descriptorRewrites); err != nil {
+	if err := rewrite.TypeDescs(types, descriptorRewrites, typeBackrefsToRemove); err != nil {
 		return errors.Wrapf(err, "type descriptor rewrite failed")
 	}
 	if err := rewrite.FunctionDescs(functions, descriptorRewrites, overrideDBName); err != nil {

--- a/pkg/backup/testdata/backup-restore/triggers
+++ b/pkg/backup/testdata/backup-restore/triggers
@@ -33,6 +33,7 @@ CREATE FUNCTION sc1.f1() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
     foobar sc1.enum1;
   BEGIN
     SELECT a FROM sc1.tbl1;
+    SELECT a FROM sc2.tbl2;
     SELECT 'Good'::sc1.enum1;
     RAISE NOTICE '%', nextval('sc1.sq1');
     RETURN NEW;
@@ -291,7 +292,7 @@ RESTORE TABLE sc1.tbl1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2'
 regex matches error
 
 exec-sql
-RESTORE TABLE sc1.tbl1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2', skip_missing_udfs;
+RESTORE TABLE sc1.tbl1,sc2.tbl2,sc1.sq1 FROM LATEST IN 'nodelocal://1/test/' WITH into_db = 'db2', skip_missing_udfs;
 ----
 
 exec-sql
@@ -312,4 +313,30 @@ SELECT relname, t.name FROM descs, LATERAL (
   SELECT value->'name' FROM jsonb_array_elements(descs.triggers)
 ) AS t(name)
 ORDER BY relname, t.name
+----
+
+# Do DDLs to validate the the dependencies were properly maintained when the
+# trigger was dropped by restore.
+exec-sql
+ALTER TABLE sc2.tbl2 RENAME TO table2;
+----
+
+exec-sql
+DROP TABLE sc1.tbl1
+----
+
+exec-sql
+DROP SEQUENCE sc1.sq1;
+----
+
+exec-sql
+DROP DATABASE db1_new;
+----
+
+exec-sql
+DROP TYPE sc1.enum1;
+----
+
+exec-sql
+ALTER TABLE sc2.table2 RENAME TO tbl2;
 ----

--- a/pkg/sql/importer/import_job.go
+++ b/pkg/sql/importer/import_job.go
@@ -583,7 +583,7 @@ func prepareNewTablesForIngestion(
 		}
 		seqVals[id] = tableDesc.SeqVal
 	}
-	if err := rewrite.TableDescs(
+	if _, err := rewrite.TableDescs(
 		newMutableTableDescriptors, tableRewrites, "",
 	); err != nil {
 		return nil, err


### PR DESCRIPTION
When doing a restore, we have code that removes triggers if there are any missing dependencies. Every reference has a forward reference and a backward reference. Removal of the triggers was only accounting for removal of the forward reference. This left dangling backreferences whenever trigger removal was done during restore.

This change corrects that by properly cleaning up any back reference that existed because of triggers.

It handles the following cases:
- if the removal of the trigger removes the last forward reference to a user defined type, update the types backref
- consider removal of any relation backref if the trigger had a forward ref to a relation. Generally, we remove all backrefs except in cases where the relation was for a sequence

Epic: none
Fixes: #147155