### PR TITLE
drt: update YAML configurations and scripts for 300-node scale cluster

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_scale_300.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_300.yaml
@@ -8,19 +8,17 @@ environment:
   ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
   CLUSTER: drt-scale-300
   WORKLOAD_CLUSTER: workload-scale-300
-  CLUSTER_NODES: 150
-  TOTAL_PARTITIONS: 30
+  CLUSTER_NODES: 90
+  TOTAL_PARTITIONS: 15
   WORKLOAD_NODES: 15
 
 dependent_file_locations:
   - pkg/cmd/drtprod/scripts/setup_datadog_cluster
   - pkg/cmd/drtprod/scripts/setup_datadog_workload
-  - pkg/cmd/drtprod/scripts/ycsb_init.sh
-  - pkg/cmd/drtprod/scripts/generate_ycsb_run.sh
   - pkg/cmd/drtprod/scripts/tpcc_init.sh
   - pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
-  - pkg/cmd/drtprod/scripts/ycsb_init.sh
-  - pkg/cmd/drtprod/scripts/generate_ycsb_run.sh
+  - artifacts/roachtest
+  - artifacts/drtprod
 
 targets:
   # crdb cluster specs
@@ -33,13 +31,13 @@ targets:
           clouds: gce
           gce-managed: true
           gce-enable-multiple-stores: true
-          gce-zones: "us-central1-a:50,us-central1-b:50,us-central1-c:50"
+          gce-zones: "us-central1-a:30,us-central1-b:30,us-central1-c:30"
           nodes: $CLUSTER_NODES
           gce-machine-type: n2-standard-16
           local-ssd: false
-          gce-pd-volume-size: 1024
+          gce-pd-volume-size: 2048
           gce-pd-volume-type: pd-ssd
-          gce-pd-volume-count: 4
+          gce-pd-volume-count: 2
           os-volume-size: 100
           username: drt
           lifetime: 8760h
@@ -51,7 +49,12 @@ targets:
         args:
           - $CLUSTER
           - release
-          - v25.1.1
+          - v25.2.0-rc.1 # for libgeos
+      - command: stage
+        args:
+          - $CLUSTER
+          - cockroach
+          - release-25.2.1-rc
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:
@@ -61,7 +64,7 @@ targets:
         flags:
           # add flag to set provisioned throughput on each store according to their cloud provider limits
           enable-fluent-sink: true
-          store-count: 4
+          store-count: 2
           args: --wal-failover=among-stores
           restart: false
           sql-port: 26257
@@ -84,7 +87,7 @@ targets:
           - $WORKLOAD_CLUSTER
         flags:
           clouds: gce
-          gce-zones: "us-central1-f"
+          gce-zones: "us-central1-a"
           nodes: $WORKLOAD_NODES
           gce-machine-type: n2-standard-8
           os-volume-size: 100
@@ -102,6 +105,15 @@ targets:
         args:
           - $WORKLOAD_CLUSTER
           - cockroach
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - artifacts/roachtest
+          - roachtest-operations
+      - command: put
+        args:
+          - $WORKLOAD_CLUSTER
+          - artifacts/drtprod
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_workload"
   - target_name: post_tasks
     dependent_targets:
@@ -129,18 +141,14 @@ targets:
           - chmod
           - 600
           - './certs/*'
-      - command: put
-        args:
-          - $WORKLOAD_CLUSTER
-          - artifacts/drtprod
-          - drtprod
       - script: "pkg/cmd/drtprod/scripts/tpcc_init.sh"
         args:
-          - cct_tpcc_6M
+          - cct_tpcc
           - false
         flags:
-          warehouses: 6000000
-          db: cct_tpcc_6M
+          warehouses: 4000000
+          db: cct_tpcc
+      - script: pkg/cmd/drtprod/scripts/populate_workload_keys.sh
   - target_name: tpcc_run
     dependent_targets:
       - $CLUSTER
@@ -148,38 +156,16 @@ targets:
     steps:
       - script: "pkg/cmd/drtprod/scripts/generate_tpcc_run.sh"
         args:
-          - cct_tpcc_6M # suffix added to script name tpcc_run_400k.sh
-          - false # determines whether to execute the script immediately on workload node
+          - cct_tpcc
+          - false
         flags:
-          db: cct_tpcc_6M
-          warehouses: 6000000
+          db: cct_tpcc
+          warehouses: 4000000
           active-warehouses: 500000
-          conns: 33333
+          active-workers: 2000
+          conns: 2000
           max-rate: 2500
-          workers: 166666
+          workers: 500000
           duration: 12h
           ramp: 1h
           wait: 0
-      - script: "pkg/cmd/drtprod/scripts/ycsb_init.sh"
-        args:
-          - 20M
-          - true
-        flags:
-          splits: 200
-          insert-count: 20000000
-  - target_name: ycsb_run
-    dependent_targets:
-      - post_tasks
-    steps:
-      - script: "pkg/cmd/drtprod/scripts/generate_ycsb_run.sh"
-        args:
-          - 20M
-          - false
-        flags:
-          max-rate: 66666
-          read-freq: 0.8
-          insert-freq: 0.1
-          update-freq: 0.05
-          delete-freq: 0.05
-          duration: 0
-          ramp: 5s

--- a/pkg/cmd/drtprod/configs/drt_scale_300_grow.yaml
+++ b/pkg/cmd/drtprod/configs/drt_scale_300_grow.yaml
@@ -6,7 +6,7 @@ environment:
   ROACHPROD_GCE_DNS_DOMAIN: drt.crdb.io
   ROACHPROD_GCE_DNS_ZONE: drt
   ROACHPROD_GCE_DEFAULT_PROJECT: cockroach-drt
-  CLUSTER: drt-scale-300:151-300
+  CLUSTER: drt-scale-300:211-300
 
 targets:
   - target_name: $CLUSTER
@@ -15,7 +15,12 @@ targets:
         args:
           - $CLUSTER
           - release
-          - v25.1.1
+          - v25.2.0-rc.1 # for libgeos
+      - command: stage
+        args:
+          - $CLUSTER
+          - cockroach
+          - release-25.2.1-rc
       - script: "pkg/cmd/drtprod/scripts/setup_datadog_cluster"
       - command: start
         args:
@@ -25,7 +30,7 @@ targets:
         flags:
           # add flag to set provisioned throughput on each store according to their cloud provider limits
           enable-fluent-sink: true
-          store-count: 4
+          store-count: 2
           args: --wal-failover=among-stores
           restart: false
           sql-port: 26257

--- a/pkg/cmd/drtprod/scripts/create_decommission_node.sh
+++ b/pkg/cmd/drtprod/scripts/create_decommission_node.sh
@@ -12,6 +12,8 @@ if [ -z "${CLUSTER}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 absolute_path=$(drtprod run "${CLUSTER}":1 -- "realpath ./cockroach")
 pwd=$(drtprod run "${CLUSTER}":1 -- "dirname ${absolute_path}")
 

--- a/pkg/cmd/drtprod/scripts/create_run_operation.sh
+++ b/pkg/cmd/drtprod/scripts/create_run_operation.sh
@@ -32,6 +32,8 @@ if [ -z "${DD_API_KEY}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 # sync cluster is needed for operations
 drtprod ssh ${WORKLOAD_CLUSTER} -- "ROACHPROD_GCE_DEFAULT_PROJECT=${ROACHPROD_GCE_DEFAULT_PROJECT} ./roachprod sync"
 

--- a/pkg/cmd/drtprod/scripts/generate_kv_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_kv_run.sh
@@ -29,6 +29,8 @@ if [ -z "${WORKLOAD_NODES}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 PGURLS=$(drtprod pgurl $CLUSTER --external | sed s/\'//g)
 
 # Loop through each node

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_drop.sh
@@ -29,6 +29,8 @@ if [ -z "${WORKLOAD_NODES}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 PG_URL_N1=$(drtprod pgurl $CLUSTER:1  --external | sed s/\'//g)
 PGURLS=$(drtprod pgurl $CLUSTER --external  | sed s/\'//g)
 

--- a/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpcc_run.sh
@@ -52,6 +52,8 @@ if [ -n "${TOTAL_PARTITIONS}" ] && [ "${TOTAL_PARTITIONS}" -lt "${WORKLOAD_NODES
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 get_partitions_in_range() {
     local start=$(($1 - 1))
     local end=$(($2 - 1))
@@ -99,6 +101,7 @@ for ((NODE=0; NODE<WORKLOAD_NODES; NODE++)); do
   cat <<EOF >/tmp/tpcc_run_${suffix}.sh
 #!/usr/bin/env bash
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
 export ROACHPROD_GCE_DEFAULT_PROJECT=$ROACHPROD_GCE_DEFAULT_PROJECT
 ./drtprod sync
 $([ "$execute_script" = "true" ] && [ "$NODE" -eq 0 ] && echo "${pwd}/tpcc_init_${suffix}.sh")

--- a/pkg/cmd/drtprod/scripts/generate_tpch_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_tpch_run.sh
@@ -25,6 +25,8 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
 pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
 PGURLS=$(drtprod pgurl "${CLUSTER}":1)

--- a/pkg/cmd/drtprod/scripts/generate_ycsb_run.sh
+++ b/pkg/cmd/drtprod/scripts/generate_ycsb_run.sh
@@ -44,6 +44,8 @@ if [ -z "${CLUSTER_NODES}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
 pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
 

--- a/pkg/cmd/drtprod/scripts/mixed_version.sh
+++ b/pkg/cmd/drtprod/scripts/mixed_version.sh
@@ -37,6 +37,8 @@ if [ -z "$CLUSTER" ]; then
     exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 /home/ubuntu/drtprod sync
 
 # Set optional release versions

--- a/pkg/cmd/drtprod/scripts/populate_workload_keys.sh
+++ b/pkg/cmd/drtprod/scripts/populate_workload_keys.sh
@@ -5,6 +5,8 @@
 # Use of this software is governed by the CockroachDB Software License
 # included in the /LICENSE file.
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 if [ -z "${CLUSTER}" ]; then
   echo "environment CLUSTER is not set"
   exit 1
@@ -16,5 +18,4 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
 fi
 
 # the ssh keys of all workload nodes should be setup on the crdb nodes for the operations
-drtprod ssh ${CLUSTER} -- "echo \"$(drtprod run ${WORKLOAD_CLUSTER} -- cat ./.ssh/id_rsa.pub|grep ssh-rsa)\" >> ./.ssh/authorized_keys"
-
+drtprod ssh ${CLUSTER} -- "echo \"$(drtprod run ${WORKLOAD_CLUSTER}:1 -- cat ./.ssh/id_rsa.pub|grep ssh-rsa)\" >> ./.ssh/authorized_keys"

--- a/pkg/cmd/drtprod/scripts/tpcc_init.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_init.sh
@@ -36,6 +36,8 @@ if [ -z "${WORKLOAD_CLUSTER}" ]; then
   exit 1
 fi
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 absolute_path=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "realpath ./cockroach")
 pwd=$(drtprod run "${WORKLOAD_CLUSTER}":1 -- "dirname ${absolute_path}")
 PGURLS=$(drtprod pgurl "${CLUSTER}":1)

--- a/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
@@ -28,6 +28,8 @@ for var in "${env_vars[@]}"; do
   fi
 done
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
+
 for NODE in $(seq 1 $NUM_REGIONS)
 do
   NODE_OFFSET=$(($(($(($NODE - 1))*$NODES_PER_REGION))+1))
@@ -45,6 +47,7 @@ do
   cat <<EOF >/tmp/tpcc_run.sh
 #!/usr/bin/env bash
 
+export ROACHPROD_DISABLED_PROVIDERS=IBM
 export ROACHPROD_GCE_DEFAULT_PROJECT=$ROACHPROD_GCE_DEFAULT_PROJECT
 ./roachprod sync
 PGURLS=\$(./roachprod load-balancer pgurl $CLUSTER | sed s/\'//g)


### PR DESCRIPTION
Add support for disabling IBM provider in drtprod scripts

Exported `ROACHPROD_DISABLED_PROVIDERS=IBM` across multiple drtprod scripts to disable usage of the IBM cloud provider. Updated configuration files to adjust cluster size, storage parameters, and workload distributions, removing YCSB references and streamlining TPCC operations.

Epic: None
Release: None