### PR TITLE
cli: improve tsdump upload time

### DIFF
--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -387,7 +387,7 @@ func (d *datadogWriter) flush(data []DatadogSeries) error {
 	}
 
 	retryOpts := base.DefaultRetryOptions()
-	retryOpts.MaxBackoff = 2 * time.Second
+	retryOpts.MaxBackoff = 100 * time.Millisecond
 	retryOpts.MaxRetries = 100
 	var req *http.Request
 	for retry := retry.Start(retryOpts); retry.Next(); {
@@ -460,9 +460,9 @@ func (d *datadogWriter) upload(fileName string) error {
 
 	// Note(davidh): This was previously set at 1000 and we'd get regular
 	// 400s from Datadog with the cryptic `Unable to decompress payload`
-	// error. I reduced this to 10 and was able to upload a 1.65GB tsdump
-	// in 3m10s without any errors (compared to 1m43s with 700 errors).
-	for i := 0; i < 10; i++ {
+	// error. We reduced this to 20 and was able to upload a 3.2GB tsdump
+	// in 6m20s without any errors.
+	for i := 0; i < 20; i++ {
 		go func() {
 			for data := range ch {
 				emittedMetrics, err := d.emitDataDogMetrics(data)


### PR DESCRIPTION
Previously, tsdump upload sub command had 10 workers which were uploading time series data to Datadog. The upload request had retry configuration with `100` max retries with max backoff of `2s`. This was resulting in high upload time for tsdump uploads. This patch updates worker count to `20` with max backoff of `100ms`.

Epic: None
Fixes: #146089
Release note: None

----
file size: 3.2GB
upload time before changes
<img width="994" alt="Screenshot 2025-05-27 at 11 04 01 AM" src="https://github.com/user-attachments/assets/e601d919-b082-4248-b409-eb2986ab2f55" />
upload time after changes (iteration 1)
<img width="979" alt="Screenshot 2025-05-27 at 11 02 57 AM" src="https://github.com/user-attachments/assets/de7d3302-0362-459c-b452-b3f1f5f6f4ec" />
upload time after changes (iteration 2)
<img width="991" alt="Screenshot 2025-05-27 at 11 03 20 AM" src="https://github.com/user-attachments/assets/e3a4f258-b83e-4b4e-b4ce-60c1a085bdaf" />