### PR TITLE
rpc: unify Peer for DRPC and gRPC connections

### DIFF
--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -750,7 +750,7 @@ func visitNodeWithRetry(
 		// Note that we use ConnectNoBreaker here to avoid any race with probe
 		// running on current node and target node restarting. Errors from circuit
 		// breaker probes could confuse us and present node as unavailable.
-		conn, _, err = rpcCtx.GRPCDialNode(addr.String(), node.NodeID, node.Locality, rpc.DefaultClass).ConnectNoBreaker(ctx)
+		conn, err = rpcCtx.GRPCDialNode(addr.String(), node.NodeID, node.Locality, rpc.DefaultClass).ConnectNoBreaker(ctx)
 		// Nodes would contain dead nodes that we don't need to visit. We can skip
 		// them and let caller handle incomplete info.
 		if err != nil {
@@ -803,7 +803,7 @@ func makeVisitNode(g *gossip.Gossip, loc roachpb.Locality, rpcCtx *rpc.Context) 
 			// Note that we use ConnectNoBreaker here to avoid any race with probe
 			// running on current node and target node restarting. Errors from circuit
 			// breaker probes could confuse us and present node as unavailable.
-			conn, _, err = rpcCtx.GRPCDialNode(addr.String(), node.NodeID, node.Locality, rpc.DefaultClass).ConnectNoBreaker(ctx)
+			conn, err = rpcCtx.GRPCDialNode(addr.String(), node.NodeID, node.Locality, rpc.DefaultClass).ConnectNoBreaker(ctx)
 			if err != nil {
 				if grpcutil.IsClosedConnection(err) {
 					log.Infof(ctx, "can't dial node n%d because connection is permanently closed: %s",

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -17,11 +17,11 @@ import (
 	"storj.io/drpc"
 )
 
-// rpcConn defines a lightweight interface that both grpc.ClientConn and drpc.Conn
+// RPCConn defines a lightweight interface that both grpc.ClientConn and drpc.Conn
 // must implement. It is used as a type constraint for rpc connections and allows
 // the Connection and Peer structs to work seamlessly with both gRPC and DRPC
 // connections.
-type rpcConn interface {
+type RPCConn interface {
 	io.Closer
 	comparable
 }
@@ -35,7 +35,7 @@ type rpcHeartbeatClient interface {
 // heartbeatClientConstructor is a function type that creates a HeartbeatClient
 // for a given rpc connection. This allows us to use different implementations of
 // HeartbeatClient for different types of connections (e.g., gRPC and DRPC).
-type heartbeatClientConstructor[Conn rpcConn] func(Conn) rpcHeartbeatClient
+type heartbeatClientConstructor[Conn RPCConn] func(Conn) rpcHeartbeatClient
 
 // closeNotifier signals via a channel when its underlying gRPC or DRPC connection closes.
 type closeNotifier interface {
@@ -46,12 +46,12 @@ type closeNotifier interface {
 // closeNotifierConstructor is a function type that creates a closeNotifier
 // for a given rpc connection. This allows us to use different implementations of
 // closeNotifier for different types of connections (e.g., gRPC and DRPC).
-type closeNotifierConstructor[Conn rpcConn] func(*stop.Stopper, Conn) closeNotifier
+type closeNotifierConstructor[Conn RPCConn] func(*stop.Stopper, Conn) closeNotifier
 
 // Connection is a wrapper around an rpc connection (ex: grpc.ClientConn or
 // drpc.Conn). It prevents the underlying rpc connection from being used until
 // it has been validated via heartbeat.
-type Connection[Conn rpcConn] struct {
+type Connection[Conn RPCConn] struct {
 	// Fields in this struct are only ever mutated from the circuit breaker probe,
 	// but they may be read widely (many callers hold a *Connection).
 
@@ -83,7 +83,7 @@ type Connection[Conn rpcConn] struct {
 
 // newConnectionToNodeID makes a Connection for the given node, class, and nontrivial Signal
 // that should be queried in Connect().
-func newConnectionToNodeID[Conn rpcConn](
+func newConnectionToNodeID[Conn RPCConn](
 	opts *ContextOptions,
 	k peerKey,
 	breakerSignal func() circuit.Signal,
@@ -232,7 +232,7 @@ func (c *Connection[Conn]) DRPCBatchStreamPool() *DRPCBatchStreamPool {
 	return &c.drpcBatchStreamPool
 }
 
-type connFuture[Conn rpcConn] struct {
+type connFuture[Conn RPCConn] struct {
 	ready chan struct{}
 	cc    Conn
 	dc    drpc.Conn

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -14,17 +14,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
-	"storj.io/drpc"
 )
 
 // RPCConn defines a lightweight interface that both grpc.ClientConn and drpc.Conn
 // must implement. It is used as a type constraint for rpc connections and allows
 // the Connection and Peer structs to work seamlessly with both gRPC and DRPC
 // connections.
-type RPCConn interface {
-	io.Closer
-	comparable
-}
+type RPCConn io.Closer
+
+// dialFunc is a generic function type used to establish an RPC connection.
+// It takes a context for cancellation/timeouts, a target string (e.g., address),
+// and a ConnectionClass to categorize the connection's purpose or priority.
+// It returns the established connection (of type Conn) or an error if dialing fails.
+type dialFunc[Conn RPCConn] func(ctx context.Context, target string, class ConnectionClass) (Conn, error)
 
 // rpcHeartbeatClient offers a unified Ping interface compatible with both
 // gRPC and DRPC.
@@ -41,6 +43,23 @@ type heartbeatClientConstructor[Conn RPCConn] func(Conn) rpcHeartbeatClient
 type closeNotifier interface {
 	// CloseNotify returns a channel that will be closed once the connection is terminated.
 	CloseNotify(ctx context.Context) <-chan struct{}
+}
+
+// ConnectionOptions allow for customization of connection behaviors such as:
+//   - Establishing a new connection.
+//   - Client constuctors for clients like batch streams.
+//   - Comparing two connections for equivalence.
+type ConnectionOptions[Conn RPCConn] struct {
+	// dial function to open a new connection.
+	dial dialFunc[Conn]
+	// connEquals defines the equivalence function for two RPC connections.
+	connEquals equalsFunc[Conn]
+	// newBatchStreamClient is a constructor function for creating a new batch
+	// stream client associated with a specific RPC connection.
+	newBatchStreamClient streamConstructor[*kvpb.BatchRequest, *kvpb.BatchResponse, Conn]
+	// newCloseNotifier is a constructor function for creating a new
+	// closeNotifier associated with a specific RPC connection.
+	newCloseNotifier closeNotifierConstructor[Conn]
 }
 
 // closeNotifierConstructor is a function type that creates a closeNotifier
@@ -76,9 +95,6 @@ type Connection[Conn RPCConn] struct {
 	//
 	// The pool is only initialized once the rpc connection is resolved.
 	batchStreamPool streamPool[*kvpb.BatchRequest, *kvpb.BatchResponse, Conn]
-	// TODO(server): remove this once the code is consolidated to use generic
-	// Connection and Pool for drpc.Conn.
-	drpcBatchStreamPool DRPCBatchStreamPool
 }
 
 // newConnectionToNodeID makes a Connection for the given node, class, and nontrivial Signal
@@ -87,7 +103,7 @@ func newConnectionToNodeID[Conn RPCConn](
 	opts *ContextOptions,
 	k peerKey,
 	breakerSignal func() circuit.Signal,
-	newBatchStreamClient streamConstructor[*kvpb.BatchRequest, *kvpb.BatchResponse, Conn],
+	connOptions *ConnectionOptions[Conn],
 ) *Connection[Conn] {
 	c := &Connection[Conn]{
 		breakerSignalFn: breakerSignal,
@@ -95,8 +111,7 @@ func newConnectionToNodeID[Conn RPCConn](
 		connFuture: connFuture[Conn]{
 			ready: make(chan struct{}),
 		},
-		batchStreamPool:     makeStreamPool(opts.Stopper, newBatchStreamClient),
-		drpcBatchStreamPool: makeStreamPool(opts.Stopper, newDRPCBatchStream),
+		batchStreamPool: makeStreamPool(opts.Stopper, connOptions.newBatchStreamClient, connOptions.connEquals),
 	}
 	return c
 }
@@ -108,15 +123,15 @@ func newConnectionToNodeID[Conn RPCConn](
 // block but fall back to defErr in this case.
 func (c *Connection[Conn]) waitOrDefault(
 	ctx context.Context, defErr error, sig circuit.Signal,
-) (Conn, drpc.Conn, error) {
+) (Conn, error) {
 	// Check the circuit breaker first. If it is already tripped now, we
 	// want it to take precedence over connFuture below (which is closed in
 	// the common case of a connection going bad after having been healthy
 	// for a while).
-	var cc Conn
+	var nilConn Conn
 	select {
 	case <-sig.C():
-		return cc, nil, sig.Err()
+		return nilConn, sig.Err()
 	default:
 	}
 
@@ -127,26 +142,26 @@ func (c *Connection[Conn]) waitOrDefault(
 		select {
 		case <-c.connFuture.C():
 		case <-sig.C():
-			return cc, nil, sig.Err()
+			return nilConn, sig.Err()
 		case <-ctx.Done():
-			return cc, nil, errors.Wrapf(ctx.Err(), "while connecting to n%d at %s", c.k.NodeID, c.k.TargetAddr)
+			return nilConn, errors.Wrapf(ctx.Err(), "while connecting to n%d at %s", c.k.NodeID, c.k.TargetAddr)
 		}
 	} else {
 		select {
 		case <-c.connFuture.C():
 		case <-sig.C():
-			return cc, nil, sig.Err()
+			return nilConn, sig.Err()
 		case <-ctx.Done():
-			return cc, nil, errors.Wrapf(ctx.Err(), "while connecting to n%d at %s", c.k.NodeID, c.k.TargetAddr)
+			return nilConn, errors.Wrapf(ctx.Err(), "while connecting to n%d at %s", c.k.NodeID, c.k.TargetAddr)
 		default:
-			return cc, nil, defErr
+			return nilConn, defErr
 		}
 	}
 
 	// Done waiting, c.connFuture has resolved, return the result. Note that this
 	// conn could be unhealthy (or there may not even be a conn, i.e. Err() !=
 	// nil), if that's what the caller wanted (ConnectNoBreaker).
-	return c.connFuture.Conn(), c.connFuture.DRPCConn(), c.connFuture.Err()
+	return c.connFuture.Conn(), c.connFuture.Err()
 }
 
 // Connect returns the underlying rpc connection after it has been validated,
@@ -156,7 +171,7 @@ func (c *Connection[Conn]) waitOrDefault(
 // an error. In rare cases, this behavior is undesired and ConnectNoBreaker may
 // be used instead.
 func (c *Connection[Conn]) Connect(ctx context.Context) (Conn, error) {
-	cc, _, err := c.waitOrDefault(ctx, nil /* defErr */, c.breakerSignalFn())
+	cc, err := c.waitOrDefault(ctx, nil /* defErr */, c.breakerSignalFn())
 	return cc, err
 }
 
@@ -164,7 +179,7 @@ func (c *Connection[Conn]) Connect(ctx context.Context) (Conn, error) {
 // returns underlying drpc connection after it has been validated.
 // TODO(server): remove this once the code is consolidated to use generic
 // Connection and Pool for drpc.Conn.
-func (c *Connection[Conn]) ConnectEx(ctx context.Context) (Conn, drpc.Conn, error) {
+func (c *Connection[Conn]) ConnectEx(ctx context.Context) (Conn, error) {
 	return c.waitOrDefault(ctx, nil /* defErr */, c.breakerSignalFn())
 }
 
@@ -186,7 +201,7 @@ func (s *neverTripSignal) IsTripped() bool {
 // that it will latch onto (or start) an existing connection attempt even if
 // previous attempts have not succeeded. This may be preferable to Connect
 // if the caller is already certain that a peer is available.
-func (c *Connection[Conn]) ConnectNoBreaker(ctx context.Context) (Conn, drpc.Conn, error) {
+func (c *Connection[Conn]) ConnectNoBreaker(ctx context.Context) (Conn, error) {
 	// For ConnectNoBreaker we don't use the default Signal but pass a dummy one
 	// that never trips. (The probe tears down the Conn on quiesce so we don't rely
 	// on the Signal for that).
@@ -210,7 +225,7 @@ func (c *Connection[Conn]) ConnectNoBreaker(ctx context.Context) (Conn, drpc.Con
 // latest heartbeat. Returns ErrNotHeartbeated if the peer was just contacted for
 // the first time and the first heartbeat has not occurred yet.
 func (c *Connection[Conn]) Health() error {
-	_, _, err := c.waitOrDefault(context.Background(), ErrNotHeartbeated, c.breakerSignalFn())
+	_, err := c.waitOrDefault(context.Background(), ErrNotHeartbeated, c.breakerSignalFn())
 	return err
 }
 
@@ -225,17 +240,9 @@ func (c *Connection[Conn]) BatchStreamPool() *streamPool[*kvpb.BatchRequest, *kv
 	return &c.batchStreamPool
 }
 
-func (c *Connection[Conn]) DRPCBatchStreamPool() *DRPCBatchStreamPool {
-	if !c.connFuture.Resolved() {
-		panic("DRPCBatchStreamPool called on unresolved connection")
-	}
-	return &c.drpcBatchStreamPool
-}
-
 type connFuture[Conn RPCConn] struct {
 	ready chan struct{}
 	cc    Conn
-	dc    drpc.Conn
 	err   error
 }
 
@@ -263,14 +270,6 @@ func (s *connFuture[Conn]) Conn() Conn {
 	return s.cc
 }
 
-// DRPCConn must only be called after C() has been closed.
-func (s *connFuture[Conn]) DRPCConn() drpc.Conn {
-	if s.err != nil {
-		return nil
-	}
-	return s.dc
-}
-
 func (s *connFuture[Conn]) Resolved() bool {
 	select {
 	case <-s.ready:
@@ -282,12 +281,12 @@ func (s *connFuture[Conn]) Resolved() bool {
 
 // Resolve is idempotent. Only the first call has any effect.
 // Not thread safe.
-func (s *connFuture[Conn]) Resolve(cc Conn, dc drpc.Conn, err error) {
+func (s *connFuture[Conn]) Resolve(cc Conn, err error) {
 	select {
 	case <-s.ready:
 		// Already resolved, noop.
 	default:
-		s.cc, s.dc, s.err = cc, dc, err
+		s.cc, s.err = cc, err
 		close(s.ready)
 	}
 }

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2064,7 +2064,7 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 		conns.mu.m = map[peerKey]*peer[*grpc.ClientConn]{}
 	}
 
-	p := rpcCtx.newPeer(k, remoteLocality)
+	p := newPeer(rpcCtx, k, newGRPCPeerOptions(rpcCtx, k, remoteLocality))
 	// (Asynchronously) Start the probe (= heartbeat loop). The breaker is healthy
 	// right now (it was just created) but the call to `.Probe` will launch the
 	// probe[1] regardless.

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -8,6 +8,8 @@ package rpc
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -53,3 +55,31 @@ func (g *grpcHeartbeatClient) Ping(ctx context.Context, in *PingRequest) (*PingR
 }
 
 type GRPCConnection = Connection[*grpc.ClientConn]
+
+func newGRPCPeerOptions(rpcCtx *Context, k peerKey, locality roachpb.Locality) *peerOptions[*grpc.ClientConn] {
+	pm, lm := rpcCtx.metrics.acquire(k, locality)
+	return &peerOptions[*grpc.ClientConn]{
+		locality: locality,
+		peers:    &rpcCtx.peers,
+		connOptions: &ConnectionOptions[*grpc.ClientConn]{
+			dial: func(ctx context.Context, target string, class ConnectionClass) (*grpc.ClientConn, error) {
+				additionalDialOpts := []grpc.DialOption{grpc.WithStatsHandler(&statsTracker{lm})}
+				additionalDialOpts = append(additionalDialOpts, rpcCtx.testingDialOpts...)
+				return rpcCtx.grpcDialRaw(ctx, target, class, additionalDialOpts...)
+			},
+			connEquals: func(a, b *grpc.ClientConn) bool {
+				return a == b
+			},
+			newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
+				return kvpb.NewInternalClient(cc).BatchStream(ctx)
+			},
+			newCloseNotifier: func(stopper *stop.Stopper, cc *grpc.ClientConn) closeNotifier {
+				return &grpcCloseNotifier{stopper: stopper, conn: cc}
+			},
+		},
+		newHeartbeatClient: func(cc *grpc.ClientConn) rpcHeartbeatClient {
+			return (*grpcHeartbeatClient)(&heartbeatClient{cc: cc})
+		},
+		pm: pm,
+	}
+}

--- a/pkg/rpc/nodedialer/BUILD.bazel
+++ b/pkg/rpc/nodedialer/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
         "//pkg/util/stop",
         "//pkg/util/tracing",
         "@com_github_cockroachdb_errors//:errors",
-        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -25,7 +25,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
-	"storj.io/drpc"
 )
 
 // An AddressResolver translates NodeIDs into addresses.
@@ -101,7 +100,7 @@ func (n *Dialer) Dial(
 		err = errors.Wrapf(err, "failed to resolve n%d", nodeID)
 		return nil, err
 	}
-	conn, _, _, _, err := n.dial(ctx, nodeID, addr, locality, true, class)
+	conn, _, err := n.dial(ctx, nodeID, addr, locality, true, class)
 	return conn, err
 }
 
@@ -118,7 +117,7 @@ func (n *Dialer) DialNoBreaker(
 	if err != nil {
 		return nil, err
 	}
-	conn, _, _, _, err := n.dial(ctx, nodeID, addr, locality, false, class)
+	conn, _, err := n.dial(ctx, nodeID, addr, locality, false, class)
 	return conn, err
 }
 
@@ -148,7 +147,7 @@ func (n *Dialer) DialInternalClient(
 		return nil, errors.Wrap(err, "resolver error")
 	}
 	log.VEventf(ctx, 2, "sending request to %s", addr)
-	conn, pool, dconn, drpcBatchStreamPool, err := n.dial(ctx, nodeID, addr, locality, true, class)
+	conn, pool, err := n.dial(ctx, nodeID, addr, locality, true, class)
 	if err != nil {
 		return nil, err
 	}
@@ -167,8 +166,6 @@ func (n *Dialer) DialInternalClient(
 		client = &unaryDRPCBatchServiceToInternalAdapter{
 			useStreamPoolClient:      useStreamPoolClient,
 			RestrictedInternalClient: client, // for RangeFeed only
-			drpcClient:               kvpb.NewDRPCBatchClient(dconn),
-			drpcStreamPool:           drpcBatchStreamPool,
 		}
 		return client, nil
 	}
@@ -187,29 +184,28 @@ func (n *Dialer) dial(
 	locality roachpb.Locality,
 	checkBreaker bool,
 	class rpc.ConnectionClass,
-) (*grpc.ClientConn, *rpc.BatchStreamPool, drpc.Conn, *rpc.DRPCBatchStreamPool, error) {
+) (*grpc.ClientConn, *rpc.BatchStreamPool, error) {
 	const ctxWrapMsg = "dial"
 	// Don't trip the breaker if we're already canceled.
 	if ctxErr := ctx.Err(); ctxErr != nil {
-		return nil, nil, nil, nil, errors.Wrap(ctxErr, ctxWrapMsg)
+		return nil, nil, errors.Wrap(ctxErr, ctxWrapMsg)
 	}
 	rpcConn := n.rpcContext.GRPCDialNode(addr.String(), nodeID, locality, class)
 	connect := rpcConn.ConnectEx
 	if !checkBreaker {
 		connect = rpcConn.ConnectNoBreaker
 	}
-	conn, dconn, err := connect(ctx)
+	conn, err := connect(ctx)
 	if err != nil {
 		// If we were canceled during the dial, don't trip the breaker.
 		if ctxErr := ctx.Err(); ctxErr != nil {
-			return nil, nil, nil, nil, errors.Wrap(ctxErr, ctxWrapMsg)
+			return nil, nil, errors.Wrap(ctxErr, ctxWrapMsg)
 		}
 		err = errors.Wrapf(err, "failed to connect to n%d at %v", nodeID, addr)
-		return nil, nil, nil, nil, err
+		return nil, nil, err
 	}
 	pool := rpcConn.BatchStreamPool()
-	drpcStreamPool := rpcConn.DRPCBatchStreamPool()
-	return conn, pool, dconn, drpcStreamPool, nil
+	return conn, pool, nil
 }
 
 // ConnHealth returns nil if we have an open connection of the request

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -118,7 +118,7 @@ func (p *peer[Conn]) releaseMetricsLocked() {
 // of its surrounding rpc.Context and will no longer probe; see
 // (*peer).maybeDelete.
 // See (*peer).launch for details on the probe (heartbeat loop) itself.
-type peer[Conn rpcConn] struct {
+type peer[Conn RPCConn] struct {
 	peerMetrics
 	k                    peerKey
 	opts                 *ContextOptions
@@ -151,7 +151,7 @@ type peer[Conn rpcConn] struct {
 }
 
 // PeerSnap is the state of a peer.
-type PeerSnap[Conn rpcConn] struct {
+type PeerSnap[Conn RPCConn] struct {
 	c *Connection[Conn] // never nil, only mutated in the breaker probe
 
 	// Timestamp of latest successful initial heartbeat on `c`. This
@@ -634,7 +634,7 @@ func (p *peer[Conn]) onSubsequentHeartbeatSucceeded(_ context.Context, now time.
 	// ConnectionFailures is not updated here.
 }
 
-func maybeLogOnFailedHeartbeat[Conn rpcConn](
+func maybeLogOnFailedHeartbeat[Conn RPCConn](
 	ctx context.Context,
 	now time.Time,
 	err, prevErr error,
@@ -792,7 +792,7 @@ func (p PeerSnap[Conn]) deletable(now time.Time) bool {
 // In both cases, if such a conn exists that became healthy *after* ours became
 // unhealthy, `healthy` will be true. If no such conn exists, (false, false) is
 // returned.
-func hasSiblingConn[Conn rpcConn](peers map[peerKey]*peer[Conn], self peerKey) (healthy, ok bool) {
+func hasSiblingConn[Conn RPCConn](peers map[peerKey]*peer[Conn], self peerKey) (healthy, ok bool) {
 	for other, otherPeer := range peers {
 		if self == other {
 			continue // exclude self
@@ -879,7 +879,7 @@ func (peers *peerMap[Conn]) shouldDeleteAfter(myKey peerKey, err error) time.Dur
 	return deleteAfter
 }
 
-func touchOldPeers[Conn rpcConn](peers *peerMap[Conn], now time.Time) {
+func touchOldPeers[Conn RPCConn](peers *peerMap[Conn], now time.Time) {
 	sigs := func() (sigs []circuit.Signal) {
 		peers.mu.RLock()
 		defer peers.mu.RUnlock()

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -18,15 +18,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
-	"storj.io/drpc"
 )
 
 type peerStatus int
@@ -120,15 +117,12 @@ func (p *peer[Conn]) releaseMetricsLocked() {
 // See (*peer).launch for details on the probe (heartbeat loop) itself.
 type peer[Conn RPCConn] struct {
 	peerMetrics
-	k                    peerKey
-	opts                 *ContextOptions
-	heartbeatInterval    time.Duration
-	heartbeatTimeout     time.Duration
-	dial                 func(ctx context.Context, target string, class ConnectionClass) (Conn, error)
-	dialDRPC             func(ctx context.Context, target string, class ConnectionClass) (drpc.Conn, error)
-	newHeartbeatClient   heartbeatClientConstructor[Conn]
-	newBatchStreamClient streamConstructor[*kvpb.BatchRequest, *kvpb.BatchResponse, Conn]
-	newCloseNotifier     closeNotifierConstructor[Conn]
+	k                  peerKey
+	opts               *ContextOptions
+	newHeartbeatClient heartbeatClientConstructor[Conn]
+	heartbeatInterval  time.Duration
+	heartbeatTimeout   time.Duration
+	connOptions        *ConnectionOptions[Conn]
 	// b maintains connection health. This breaker's async probe is always
 	// active - it is the heartbeat loop and manages `mu.c.` (including
 	// recreating it after the connection fails and has to be redialed).
@@ -209,6 +203,14 @@ func (p *peer[Conn]) snap() PeerSnap[Conn] {
 	return p.mu.PeerSnap
 }
 
+type peerOptions[Conn RPCConn] struct {
+	locality           roachpb.Locality
+	pm                 peerMetrics
+	newHeartbeatClient heartbeatClientConstructor[Conn]
+	connOptions        *ConnectionOptions[Conn]
+	peers              *peerMap[Conn]
+}
+
 // newPeer returns circuit breaker that trips when connection (associated
 // with provided peerKey) is failed. The breaker's probe *is* the heartbeat loop
 // and is thus running at all times. The exception is a decommissioned node, for
@@ -228,7 +230,9 @@ func (p *peer[Conn]) snap() PeerSnap[Conn] {
 // map, the next attempt to dial the node will start from a blank slate. In
 // other words, even with this theoretical race, the situation will sort itself
 // out quickly.
-func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc.ClientConn] {
+func newPeer[Conn RPCConn](
+	rpcCtx *Context, k peerKey, peerOpts *peerOptions[Conn],
+) *peer[Conn] {
 	// Initialization here is a bit circular. The peer holds the breaker. The
 	// breaker probe references the peer because it needs to replace the one-shot
 	// Connection when it makes a new connection in the probe. And (all but the
@@ -236,31 +240,17 @@ func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc
 	// Connect method needs to do the short-circuiting (if a Connection is created
 	// while the breaker is tripped, we want to block in Connect only once we've
 	// seen the first heartbeat succeed).
-	pm, lm := rpcCtx.metrics.acquire(k, locality)
-	p := &peer[*grpc.ClientConn]{
-		peerMetrics:        pm,
+	p := &peer[Conn]{
+		peerMetrics:        peerOpts.pm,
 		logDisconnectEvery: log.Every(time.Minute),
 		k:                  k,
 		remoteClocks:       rpcCtx.RemoteClocks,
 		opts:               &rpcCtx.ContextOptions,
-		peers:              &rpcCtx.peers,
-		dial: func(ctx context.Context, target string, class ConnectionClass) (*grpc.ClientConn, error) {
-			additionalDialOpts := []grpc.DialOption{grpc.WithStatsHandler(&statsTracker{lm})}
-			additionalDialOpts = append(additionalDialOpts, rpcCtx.testingDialOpts...)
-			return rpcCtx.grpcDialRaw(ctx, target, class, additionalDialOpts...)
-		},
-		dialDRPC: dialDRPC(rpcCtx),
-		newHeartbeatClient: func(cc *grpc.ClientConn) rpcHeartbeatClient {
-			return &grpcHeartbeatClient{cc: cc}
-		},
-		newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
-			return kvpb.NewInternalClient(cc).BatchStream(ctx)
-		},
-		newCloseNotifier: func(stopper *stop.Stopper, cc *grpc.ClientConn) closeNotifier {
-			return &grpcCloseNotifier{stopper: stopper, conn: cc}
-		},
-		heartbeatInterval: rpcCtx.RPCHeartbeatInterval,
-		heartbeatTimeout:  rpcCtx.RPCHeartbeatTimeout,
+		peers:              peerOpts.peers,
+		connOptions:        peerOpts.connOptions,
+		newHeartbeatClient: peerOpts.newHeartbeatClient,
+		heartbeatInterval:  rpcCtx.RPCHeartbeatInterval,
+		heartbeatTimeout:   rpcCtx.RPCHeartbeatTimeout,
 	}
 	var b *circuit.Breaker
 
@@ -274,8 +264,8 @@ func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc
 		},
 	})
 	p.b = b
-	c := newConnectionToNodeID(p.opts, k, b.Signal, p.newBatchStreamClient)
-	p.mu.PeerSnap = PeerSnap[*grpc.ClientConn]{c: c}
+	c := newConnectionToNodeID(p.opts, k, b.Signal, p.connOptions)
+	p.mu.PeerSnap = PeerSnap[Conn]{c: c}
 
 	return p
 }
@@ -374,7 +364,7 @@ func (p *peer[Conn]) run(ctx context.Context, report func(error), done func()) {
 		func() {
 			p.mu.Lock()
 			defer p.mu.Unlock()
-			p.mu.c = newConnectionToNodeID(p.opts, p.k, p.mu.c.breakerSignalFn, p.newBatchStreamClient)
+			p.mu.c = newConnectionToNodeID(p.opts, p.k, p.mu.c.breakerSignalFn, p.connOptions)
 		}()
 
 		if p.snap().deleteAfter != 0 {
@@ -387,25 +377,18 @@ func (p *peer[Conn]) run(ctx context.Context, report func(error), done func()) {
 }
 
 func (p *peer[Conn]) runOnce(ctx context.Context, report func(error)) error {
-	cc, err := p.dial(ctx, p.k.TargetAddr, p.k.Class)
+	cc, err := p.connOptions.dial(ctx, p.k.TargetAddr, p.k.Class)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		_ = cc.Close() // nolint:grpcconnclose
 	}()
-	dc, err := p.dialDRPC(ctx, p.k.TargetAddr, p.k.Class)
-	if err != nil {
-		return err
-	}
-	defer func() {
-		_ = dc.Close()
-	}()
 
 	// Set up notifications on a channel when gRPC tears down, so that we
 	// can trigger another instant heartbeat for expedited circuit breaker
 	// tripping.
-	connClosedCh := p.newCloseNotifier(p.opts.Stopper, cc).CloseNotify(ctx)
+	connClosedCh := p.connOptions.newCloseNotifier(p.opts.Stopper, cc).CloseNotify(ctx)
 
 	if p.remoteClocks != nil {
 		p.remoteClocks.OnConnect(ctx, p.k.NodeID)
@@ -425,7 +408,7 @@ func (p *peer[Conn]) runOnce(ctx context.Context, report func(error)) error {
 		return err
 	}
 
-	p.onInitialHeartbeatSucceeded(ctx, p.opts.Clock.Now(), cc, dc, report)
+	p.onInitialHeartbeatSucceeded(ctx, p.opts.Clock.Now(), cc, report)
 
 	return p.runHeartbeatUntilFailure(ctx, connClosedCh)
 }
@@ -588,7 +571,7 @@ func logOnHealthy(ctx context.Context, disconnected, now time.Time) {
 }
 
 func (p *peer[Conn]) onInitialHeartbeatSucceeded(
-	ctx context.Context, now time.Time, cc Conn, dc drpc.Conn, report func(err error),
+	ctx context.Context, now time.Time, cc Conn, report func(err error),
 ) {
 	// First heartbeat succeeded. By convention we update the breaker
 	// before updating the peer. The other way is fine too, just the
@@ -611,11 +594,10 @@ func (p *peer[Conn]) onInitialHeartbeatSucceeded(
 	// ahead of signaling the connFuture, so that the stream pool is ready for use
 	// by the time the connFuture is resolved.
 	p.mu.c.batchStreamPool.Bind(ctx, cc)
-	p.mu.c.drpcBatchStreamPool.Bind(ctx, dc)
 
 	// Close the channel last which is helpful for unit tests that
 	// first waitOrDefault for a healthy conn to then check metrics.
-	p.mu.c.connFuture.Resolve(cc, dc, nil /* err */)
+	p.mu.c.connFuture.Resolve(cc, nil /* err */)
 
 	logOnHealthy(ctx, p.mu.disconnected, now)
 }
@@ -733,7 +715,7 @@ func (p *peer[Conn]) onHeartbeatFailed(
 		// attention to the circuit breaker.
 		err = &netutil.InitialHeartbeatFailedError{WrappedErr: err}
 		var nilConn Conn
-		ls.c.connFuture.Resolve(nilConn, nil /* dc */, err)
+		ls.c.connFuture.Resolve(nilConn, err)
 	}
 
 	// Close down the stream pool that was bound to this connection.
@@ -774,7 +756,7 @@ func (p *peer[Conn]) onQuiesce(report func(error)) {
 	// NB: it's important that connFuture is resolved, or a caller sitting on
 	// `c.ConnectNoBreaker` would never be unblocked; after all, the probe won't
 	// start again in the future.
-	p.snap().c.connFuture.Resolve(cc, nil, errQuiescing)
+	p.snap().c.connFuture.Resolve(cc, errQuiescing)
 }
 
 func (p PeerSnap[Conn]) deletable(now time.Time) bool {

--- a/pkg/rpc/peer_map.go
+++ b/pkg/rpc/peer_map.go
@@ -37,7 +37,7 @@ func (c peerKey) SafeFormat(p redact.SafePrinter, _ rune) {
 	p.Printf("{n%d: %s (%v)}", c.NodeID, c.TargetAddr, c.Class)
 }
 
-type peerMap[Conn rpcConn] struct {
+type peerMap[Conn RPCConn] struct {
 	mu struct {
 		syncutil.RWMutex
 		m map[peerKey]*peer[Conn]

--- a/pkg/rpc/stream_pool.go
+++ b/pkg/rpc/stream_pool.go
@@ -29,7 +29,7 @@ type streamClient[Req, Resp any] interface {
 
 // streamConstructor creates a new gRPC stream client over the provided client
 // connection, using the provided call options.
-type streamConstructor[Req, Resp any, Conn rpcConn] func(
+type streamConstructor[Req, Resp any, Conn RPCConn] func(
 	context.Context, Conn,
 ) (streamClient[Req, Resp], error)
 
@@ -67,7 +67,7 @@ const defaultPooledStreamIdleTimeout = 10 * time.Second
 //
 // A pooledStream must only be returned to the pool for reuse after a successful
 // Send call. If the Send call fails, the pooledStream must not be reused.
-type pooledStream[Req, Resp any, Conn rpcConn] struct {
+type pooledStream[Req, Resp any, Conn RPCConn] struct {
 	pool         *streamPool[Req, Resp, Conn]
 	stream       streamClient[Req, Resp]
 	streamCtx    context.Context
@@ -77,7 +77,7 @@ type pooledStream[Req, Resp any, Conn rpcConn] struct {
 	respC chan result[Resp]
 }
 
-func newPooledStream[Req, Resp any, Conn rpcConn](
+func newPooledStream[Req, Resp any, Conn RPCConn](
 	pool *streamPool[Req, Resp, Conn],
 	stream streamClient[Req, Resp],
 	streamCtx context.Context,
@@ -190,7 +190,7 @@ func (s *pooledStream[Req, Resp, Conn]) Send(ctx context.Context, req Req) (Resp
 // manner that mimics unary RPC invocation. Pooling these streams allows for
 // reuse of gRPC resources across calls, as opposed to native unary RPCs, which
 // create a new stream and throw it away for each request (see grpc.invoke).
-type streamPool[Req, Resp any, Conn rpcConn] struct {
+type streamPool[Req, Resp any, Conn RPCConn] struct {
 	stopper     *stop.Stopper
 	idleTimeout time.Duration
 	newStream   streamConstructor[Req, Resp, Conn]
@@ -206,7 +206,7 @@ type streamPool[Req, Resp any, Conn rpcConn] struct {
 	}
 }
 
-func makeStreamPool[Req, Resp any, Conn rpcConn](
+func makeStreamPool[Req, Resp any, Conn RPCConn](
 	stopper *stop.Stopper, newStream streamConstructor[Req, Resp, Conn],
 ) streamPool[Req, Resp, Conn] {
 	return streamPool[Req, Resp, Conn]{


### PR DESCRIPTION
This commit unifies the Peer's functionality for both dRPC and gRPC connections. It achieves this by introducing an interface for connection-specific behavior and injecting the appropriate dRPC or gRPC implementations.

Fixes: none
Epic: CRDB-48923
Release note: none