### PR TITLE
reelase: add new formulas to homebrew

### DIFF
--- a/pkg/cmd/release/update_brew.go
+++ b/pkg/cmd/release/update_brew.go
@@ -24,6 +24,7 @@ func updateBrew(workDir string, version *semver.Version, latestMajor bool) error
 		commands = append(commands, exec.Command("make", fmt.Sprintf("VERSION=%s", version.String()), "PRODUCT=cockroach"))
 		commands = append(commands, exec.Command("make", fmt.Sprintf("VERSION=%s", version.String()), "PRODUCT=cockroach-sql"))
 	}
+	commands = append(commands, exec.Command("git", "add", "Formula"))
 	for _, cmd := range commands {
 		cmd.Dir = workDir
 		out, err := cmd.CombinedOutput()


### PR DESCRIPTION
Previously, the update_brew command did not add the new formulas to the git index. This lead to missing files in the homebrew repository after adding a new major version.

This commit adds a `git add Formula` command to ensure that the new formulas are added to PRs.

Release note: none
Epic: none