### PR TITLE
kvserver: log lease info when co-operatively transferring lease

### DIFF
--- a/pkg/kv/kvserver/lease_queue.go
+++ b/pkg/kv/kvserver/lease_queue.go
@@ -133,7 +133,8 @@ func (lq *leaseQueue) process(
 	}
 
 	if transferOp, ok := change.Op.(plan.AllocationTransferLeaseOp); ok {
-		log.KvDistribution.Infof(ctx, "transferring lease to s%d usage=%v", transferOp.Target, transferOp.Usage)
+		lease, _ := repl.GetLease()
+		log.KvDistribution.Infof(ctx, "transferring lease to s%d usage=%v, lease=[%v type=%v]", transferOp.Target, transferOp.Usage, lease, lease.Type())
 		lq.lastLeaseTransfer.Store(timeutil.Now())
 		if err := repl.AdminTransferLease(ctx, transferOp.Target, false /* bypassSafetyChecks */); err != nil {
 			return false, errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, transferOp.Target)


### PR DESCRIPTION
Previously, we wouldn't log the lease details and type when co-operatively transferring leases.

This commit adds this information, which can be useful when observing the lease history over time.

Sample log line:
```
transferring lease to s2 usage=[...], lease=[repl=(n1,s1):1 seq=1 start=0,0 exp=1748360418.445624000,0 pro=1748360412.445624000,0 acq=Request type=LeaseExpiration]
```

Resolves: #122186
Epic: CRDB-37522
Release note: None