### PR TITLE
workload/version: add version query interface

### DIFF
--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2842,6 +2842,7 @@ GO_TARGETS = [
     "//pkg/workload/ttllogger:ttllogger",
     "//pkg/workload/vecann:vecann",
     "//pkg/workload/vecann:vecann_test",
+    "//pkg/workload/version:version",
     "//pkg/workload/workloadimpl:workloadimpl",
     "//pkg/workload/workloadimpl:workloadimpl_test",
     "//pkg/workload/workloadsql:workloadsql",

--- a/pkg/workload/schemachange/BUILD.bazel
+++ b/pkg/workload/schemachange/BUILD.bazel
@@ -23,7 +23,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
-        "//pkg/roachpb",
         "//pkg/security/username",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
@@ -43,6 +42,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/workload",
         "//pkg/workload/histogram",
+        "//pkg/workload/version",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_jackc_pgx_v5//:pgx",
         "@com_github_jackc_pgx_v5//pgconn",

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -152,7 +152,7 @@ func (og *operationGenerator) resetTxnState() {
 
 // getSupportedDeclarativeOp generates declarative operations until,
 // a fully supported one is found. This is required for mixed version testing
-// support, where statements may be partially supproted.
+// support, where statements may be partially supported.
 func (og *operationGenerator) getSupportedDeclarativeOp(
 	ctx context.Context, tx pgx.Tx,
 ) (opType, error) {

--- a/pkg/workload/version/BUILD.bazel
+++ b/pkg/workload/version/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "version",
+    srcs = ["version.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/workload/version",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "@com_github_jackc_pgx_v5//:pgx",
+    ],
+)

--- a/pkg/workload/version/version.go
+++ b/pkg/workload/version/version.go
@@ -1,0 +1,76 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package version
+
+import (
+	"context"
+	gosql "database/sql"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/jackc/pgx/v5"
+)
+
+type VersionQuery interface {
+	IsClusterVersionLessThan(ctx context.Context, targetVersion roachpb.Version) (bool, error)
+	Compare(ctx context.Context, compareFn func(roachpb.Version) bool) (bool, error)
+}
+
+type versionQuery struct {
+	getVersion func(ctx context.Context) (string, error)
+}
+
+func WithPGX(tx pgx.Tx) VersionQuery {
+	return &versionQuery{
+		getVersion: func(ctx context.Context) (string, error) {
+			var clusterVersionStr string
+			row := tx.QueryRow(ctx, `SHOW CLUSTER SETTING version`)
+			if err := row.Scan(&clusterVersionStr); err != nil {
+				return "", err
+			}
+			return clusterVersionStr, nil
+		},
+	}
+}
+
+func WithGoSQL(db *gosql.DB) VersionQuery {
+	return &versionQuery{
+		getVersion: func(ctx context.Context) (string, error) {
+			var clusterVersionStr string
+			row := db.QueryRowContext(ctx, `SHOW CLUSTER SETTING version`)
+			if err := row.Scan(&clusterVersionStr); err != nil {
+				return "", err
+			}
+			return clusterVersionStr, nil
+		},
+	}
+}
+
+// IsClusterVersionLessThan compares the the cluster version against the given
+// target version, returns true if the cluster version is less than the target
+// version. This can be used in mixed version environments to prevent using
+// features that are not supported by the cluster version.
+func (q *versionQuery) IsClusterVersionLessThan(
+	ctx context.Context, targetVersion roachpb.Version,
+) (bool, error) {
+	return q.Compare(ctx, func(v roachpb.Version) bool {
+		return v.Less(targetVersion)
+	})
+}
+
+// Compare compares the cluster version against the given function.
+func (q *versionQuery) Compare(
+	ctx context.Context, compareFn func(roachpb.Version) bool,
+) (bool, error) {
+	clusterVersionStr, err := q.getVersion(ctx)
+	if err != nil {
+		return false, err
+	}
+	clusterVersion, err := roachpb.ParseVersion(clusterVersionStr)
+	if err != nil {
+		return false, err
+	}
+	return compareFn(clusterVersion), nil
+}

--- a/pkg/workload/workloadsql/BUILD.bazel
+++ b/pkg/workload/workloadsql/BUILD.bazel
@@ -9,6 +9,8 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/workloadsql",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
+        "//pkg/roachpb",
         "//pkg/sql/lexbase",
         "//pkg/sql/sem/tree",
         "//pkg/util/ctxgroup",
@@ -16,6 +18,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/workload",
+        "//pkg/workload/version",
         "@com_github_cockroachdb_cockroach_go_v2//crdb",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_version//:version",


### PR DESCRIPTION
Previously, the cluster version was only queried by the schemachange workload.
But in order to support mixed version environments better this has now been
moved to a package that is accessible by the rest of workload and supports
multiple query methods.

Epic: None
Release note: None

Fixes: #147250