### PR TITLE
sql/rls: prevent leak of hidden rows in RLS due to predicate reordering

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -5522,3 +5522,116 @@ statement ok
 DROP ROLE can_createdb_global;
 
 subtest end
+
+subtest filter_pushdown_leaks
+
+statement ok
+CREATE ROLE alice;
+
+statement ok
+CREATE TABLE t (x INT PRIMARY KEY, y INT, alice_has_access BOOL);
+
+statement ok
+CREATE INDEX ON t(y);
+
+statement ok
+INSERT INTO t VALUES (1, 10, true), (2, 20, false);
+
+statement ok
+GRANT SELECT, INSERT, UPDATE, DELETE ON t TO alice;
+
+statement ok
+ALTER TABLE t ENABLE ROW LEVEL SECURITY;
+
+statement ok
+CREATE POLICY select_policy_alice
+ON t
+FOR SELECT
+TO alice
+USING (alice_has_access);
+
+statement ok
+SET ROLE alice;
+
+# Attempt various runtime errors to test whether the system leaks the existence
+# of a row with y = 20, which is hidden from the user by the RLS policy.
+
+# Division by zero
+query IIB
+SELECT * FROM t WHERE y = 20 AND y/0 = 0;
+----
+
+# Out of range error
+query IIB
+SELECT * FROM t WHERE y = 20 AND ARRAY[1,2,3][10] = 1;
+----
+
+# Out of range error
+query IIB
+UPDATE t SET y = y WHERE y = 20 AND ARRAY[1,2,3][10] = 1 RETURNING *;
+----
+
+# Custom function that raise an exception.
+statement ok
+CREATE FUNCTION fail() RETURNS INT AS $$ BEGIN RAISE EXCEPTION 'fail'; END; $$ LANGUAGE plpgsql;
+
+query IIB
+DELETE FROM t WHERE y = 20 AND fail() = 1 RETURNING *;
+----
+
+# Custom function that is designated as leakproof
+statement ok
+CREATE FUNCTION divbyzero() RETURNS INT IMMUTABLE LEAKPROOF
+AS $$
+ BEGIN
+   SELECT 20 / 0;
+   RETURN 1;
+ END;
+$$ LANGUAGE plpgsql;
+
+# Show that queries on rows we can see will cause the query to fail
+statement error pq: division by zero
+SELECT * FROM t WHERE y = 10 AND divbyzero() = 1;
+
+# But queries on rows we cannot see won't see any error.
+query IIB
+SELECT * FROM t WHERE y = 20 AND divbyzero() = 1;
+----
+
+# Invalid regular expression
+query IIB
+SELECT * FROM t WHERE y = 20 AND 'a' ~ '(';
+----
+
+# Unicode errors
+query IIB
+UPDATE t SET y = y WHERE y = 20 AND power(1e400, 1) > 0 RETURNING *;
+----
+
+# CTEs
+query IIB
+WITH rows AS (
+  SELECT x FROM t WHERE y = 20 AND y/0 = 0
+)
+DELETE FROM t WHERE x IN (SELECT x FROM rows) RETURNING *;
+----
+
+# INSERT w/ ON CONFLICT. This leaks information because the update attempts
+# to modify a row that is filtered out by RLS, and fails. Postgres behaves the
+# same, so this is left here as an example of that behaviour.
+statement error pq: new row violates row-level security policy for table "t"
+INSERT INTO t VALUES (2, 20, false) ON CONFLICT(x) DO UPDATE SET y = 20;
+
+statement ok
+RESET ROLE;
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP FUNCTION fail, divbyzero;
+
+statement ok
+DROP ROLE alice;
+
+subtest end

--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -174,10 +174,13 @@ select t1.c1 from t1, t2 where t1.c1 = t2.c1 and t1.c1 = 1;
 ----
 • cross join
 │
-├── • scan
-│     table: t1@t1_idx
-│     spans: 1+ spans
-│     policies: policy 1, p2, p3, r1, r2
+├── • index join
+│   │ table: t1@t1_pkey
+│   │
+│   └── • scan
+│         table: t1@t1_idx
+│         spans: 1+ spans
+│         policies: policy 1, p2, p3, r1, r2
 │
 └── • filter
     │ filter: c1 = _
@@ -303,6 +306,9 @@ exec-ddl
 CREATE POLICY p_update2 ON writer FOR UPDATE WITH CHECK (value IN ('updater: a', 'updater: b', 'updater: c'))
 ----
 
+# TODO(mgartner): We used to record the locking strength in this plan, but it
+# appears that optimization no longer applies since introducing the barrier for
+# the RLS expression.
 plan
 UPDATE writer SET key = key * 11;
 ----
@@ -317,7 +323,6 @@ UPDATE writer SET key = key * 11;
     └── • scan
           table: writer@writer_pkey
           spans: 1+ spans
-          locking strength: for update
           policies: p_select, p_update1
 
 plan
@@ -353,7 +358,6 @@ UPDATE writer SET value = 'updated' WHERE key between 1 and 100;
     └── • scan
           table: writer@writer_pkey
           spans: 1+ spans
-          locking strength: for update
           policies: p_select, p_update1
 
 plan
@@ -370,7 +374,6 @@ UPDATE writer SET value = value WHERE key = 5;
     └── • scan
           table: writer@writer_pkey
           spans: 1+ spans
-          locking strength: for update
           policies: p_select, p_update1
 
 # Should not apply select policy for the new row because columns weren't
@@ -389,7 +392,6 @@ UPDATE writer SET key = 10 WHERE true;
     └── • scan
           table: writer@writer_pkey
           spans: 1+ spans
-          locking strength: for update
           policies: p_select, p_update1
 
 
@@ -434,11 +436,14 @@ CREATE POLICY p_delete ON writer FOR DELETE USING (key = 1);
 plan
 DELETE FROM writer WHERE key = 1;
 ----
-• delete range
-  from: writer
-  auto commit
-  spans: 1+ spans
-  policies: p_select, p_delete
+• delete
+│ from: writer
+│ auto commit
+│
+└── • scan
+      table: writer@writer_pkey
+      spans: 1+ spans
+      policies: p_select, p_delete
 
 plan
 DELETE FROM writer WHERE value = 'some-val' or value = 'other-val';

--- a/pkg/sql/opt/memo/testdata/logprops/tail-calls
+++ b/pkg/sql/opt/memo/testdata/logprops/tail-calls
@@ -444,14 +444,13 @@ values
                                     │              └── const: '00000'
                                     └── project
                                          ├── barrier
-                                         │    └── barrier
-                                         │         └── values
-                                         │              └── tuple
-                                         │                   └── udf: nested
-                                         │                        └── body
-                                         │                             └── values
-                                         │                                  └── tuple
-                                         │                                       └── const: 1
+                                         │    └── values
+                                         │         └── tuple
+                                         │              └── udf: nested
+                                         │                   └── body
+                                         │                        └── values
+                                         │                             └── tuple
+                                         │                                  └── const: 1
                                          └── projections
                                               └── udf: _stmt_raise_3
                                                    ├── tail-call

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "norm",
     srcs = [
+        "barrier_funcs.go",
         "bool_funcs.go",
         "comp_funcs.go",
         "decorrelate_funcs.go",

--- a/pkg/sql/opt/norm/barrier_funcs.go
+++ b/pkg/sql/opt/norm/barrier_funcs.go
@@ -1,0 +1,16 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package norm
+
+import "github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+
+// BarriersEqual returns true if the two BarrierPrivate structs are the same.
+func (c *CustomFuncs) BarriersEqual(left, right *memo.BarrierPrivate) bool {
+	if left == nil || right == nil {
+		return left == right // true if both nil, false otherwise
+	}
+	return *left == *right
+}

--- a/pkg/sql/opt/norm/rules/barrier.opt
+++ b/pkg/sql/opt/norm/rules/barrier.opt
@@ -1,0 +1,16 @@
+# =============================================================================
+# barrier.opt contains normalization rules for Barrier operators.
+# =============================================================================
+
+# EliminateRedundantBarrier removes a Barrier operator when it wraps another
+# identical Barrier. This deduplication avoids unnecessary nesting of
+# equivalent Barriers. The rule applies only when both Barrier operators have
+# the same configuration.
+[EliminateRedundantBarrier, Normalize]
+(Barrier
+    (Barrier $input:* $innerBarrierPrivate:*)
+    $outerBarrierPrivate:* &
+        (BarriersEqual $innerBarrierPrivate $outerBarrierPrivate)
+)
+=>
+(Barrier $input $outerBarrierPrivate)

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -448,3 +448,32 @@ $input
     )
     (RemoveFiltersItem $filter $item)
 )
+
+# PushLeakproofFiltersIntoPermeableBarrier splits filter expressions based on
+# leakproofness and pushes only the leakproof filters beneath a permeable
+# Barrier. The remaining filters stay above the Barrier.
+#
+# This allows safe reordering of leakproof expressions while preserving the
+# Barrier to block unsafe transformations involving non-leakproof filters.
+# The Barrier must be marked as LeakproofPermeable to allow this behavior.
+[PushLeakproofFiltersIntoPermeableBarrier, Normalize]
+(Select
+    (Barrier
+        $input:*
+        $private:* & (IsBarrierLeakproofPermeable $private)
+    )
+    $filters:* &
+        (Let
+            (
+                $leakproofFilters
+                $remainingFilters
+                $ok
+            ):(SplitLeakproofFilters $filters)
+            $ok
+        )
+)
+=>
+(Select
+    (Barrier (Select $input $leakproofFilters) $private)
+    $remainingFilters
+)

--- a/pkg/sql/opt/norm/testdata/rules/barrier
+++ b/pkg/sql/opt/norm/testdata/rules/barrier
@@ -1,0 +1,72 @@
+exec-ddl
+CREATE TABLE xy (x INT PRIMARY KEY, y INT);
+----
+
+# --------------------------------------------------
+# EliminateRedundantBarrier
+# --------------------------------------------------
+
+# TODO(sql-queries): for simplicity, we should eliminate the barrier expression
+# at the root in this case. It serves no purpose because the filters were able
+# to permeate it.
+exprnorm expect=EliminateRedundantBarrier
+(Barrier
+  (Barrier
+     (Barrier
+          (Select
+             (Scan [ (Table "xy") (Cols "x,y") ])
+             [ (Eq (Var "y") (Const 3 "int")) ]
+          )
+          [ (LeakproofPermeable "true") ]
+     )
+     [ (LeakproofPermeable "true") ]
+  )
+  [ (LeakproofPermeable "true") ]
+)
+----
+barrier
+ ├── columns: x:1!null y:2!null
+ ├── key: (1)
+ ├── fd: ()-->(2)
+ └── select
+      ├── columns: x:1!null y:2!null
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan xy
+      │    ├── columns: x:1!null y:2
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2)
+      └── filters
+           └── y:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]
+
+# Don't eliminate the barriers because they aren't equal.
+exprnorm expect-not=EliminateRedundantBarrier
+(Barrier
+     (Barrier
+          (Select
+             (Scan [ (Table "xy") (Cols "x,y") ])
+             [ (Eq (Var "y") (Const 3 "int")) ]
+          )
+          [ (LeakproofPermeable "true") ]
+     )
+  [ (LeakproofPermeable "false") ]
+)
+----
+barrier
+ ├── columns: x:1!null y:2!null
+ ├── key: (1)
+ ├── fd: ()-->(2)
+ └── barrier
+      ├── columns: x:1!null y:2!null
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      └── select
+           ├── columns: x:1!null y:2!null
+           ├── key: (1)
+           ├── fd: ()-->(2)
+           ├── scan xy
+           │    ├── columns: x:1!null y:2
+           │    ├── key: (1)
+           │    └── fd: (1)-->(2)
+           └── filters
+                └── y:2 = 3 [outer=(2), constraints=(/2: [/3 - /3]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -25,6 +25,30 @@ CREATE TABLE e
 )
 ----
 
+exec-ddl
+CREATE TABLE rls (x INT PRIMARY KEY, y INT, alice_has_access BOOL);
+----
+
+exec-ddl
+CREATE INDEX ON rls(y);
+----
+
+exec-ddl
+ALTER TABLE rls ENABLE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY select_policy_alice
+ON rls
+FOR SELECT
+TO alice
+USING (alice_has_access);
+----
+
+exec-ddl
+CREATE ROLE alice;
+----
+
 # --------------------------------------------------
 # SimplifySelectFilters
 # --------------------------------------------------
@@ -2477,3 +2501,68 @@ project
       │         └── row-number [as=row_num:25]
       └── filters
            └── row_num:25 <= 100 [outer=(25), constraints=(/25: (/NULL - /100]; tight)]
+
+# --------------------------------------------------
+# PushLeakproofFiltersIntoPermeableBarrier
+# --------------------------------------------------
+
+exec-ddl
+SET ROLE alice;
+----
+
+# The 'y/0 = 0' predicate is not leakproof, so it should exist outside of the
+# barrier that includes the injected RLS filter.
+norm expect=PushLeakproofFiltersIntoPermeableBarrier
+SELECT * FROM rls WHERE y = 20 AND y/0 = 0;
+----
+project
+ ├── columns: x:1!null y:2!null alice_has_access:3!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── select
+      ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── immutable
+      ├── key: (1)
+      ├── fd: ()-->(2,3), (1)-->(4,5)
+      ├── barrier
+      │    ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,3), (1)-->(4,5)
+      │    └── select
+      │         ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         ├── key: (1)
+      │         ├── fd: ()-->(2,3), (1)-->(4,5)
+      │         ├── scan rls
+      │         │    ├── columns: x:1!null y:2 alice_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         │    ├── key: (1)
+      │         │    └── fd: (1)-->(2-5)
+      │         └── filters
+      │              ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+      │              └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
+      └── filters
+           └── (20 / 0) = 0 [immutable]
+
+# All filters are leakproof, so barrier pushed entirely out of the select.
+norm expect=PushLeakproofFiltersIntoPermeableBarrier
+SELECT * FROM rls WHERE y = 20;
+----
+project
+ ├── columns: x:1!null y:2!null alice_has_access:3!null
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── barrier
+      ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── key: (1)
+      ├── fd: ()-->(2,3), (1)-->(4,5)
+      └── select
+           ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── key: (1)
+           ├── fd: ()-->(2,3), (1)-->(4,5)
+           ├── scan rls
+           │    ├── columns: x:1!null y:2 alice_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           │    ├── key: (1)
+           │    └── fd: (1)-->(2-5)
+           └── filters
+                ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+                └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -1535,6 +1535,16 @@ define VectorMutationSearchPrivate {
 [Relational]
 define Barrier {
     Input RelExpr
+    _ BarrierPrivate
+}
+
+[Private]
+define BarrierPrivate {
+    # LeakproofPermeable indicates that leakproof expressions are allowed to
+    # move across this barrier. This enables the optimizer to reorder or push
+    # leakproof filters and projections past the barrier, while still
+    # preserving it to block unsafe (non-leakproof) expressions.
+    LeakproofPermeable bool
 }
 
 # FakeRel is a mock relational operator used for testing and as a dummy binding

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -34,12 +34,14 @@ SELECT c1 FROM T1;
 ----
 project
  ├── columns: c1:1
- └── select
+ └── barrier
       ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── scan t1
-      │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      └── filters
-           └── false
+      └── select
+           ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           ├── scan t1
+           │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           └── filters
+                └── false
 
 # Add a policy with a USING expression to see that a SELECT will include that
 # expression in its filter.
@@ -53,12 +55,14 @@ SELECT c1 FROM T1;
 ----
 project
  ├── columns: c1:1!null
- └── select
+ └── barrier
       ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── scan t1
-      │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      └── filters
-           └── c1:1 > 0
+      └── select
+           ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           ├── scan t1
+           │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           └── filters
+                └── c1:1 > 0
 
 # Introduce a contradiction with the policy expression to verify that
 # the optimizer eliminates the scan.
@@ -69,12 +73,14 @@ project
  ├── columns: c1:1!null
  └── select
       ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── select
+      ├── barrier
       │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    ├── scan t1
-      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── filters
-      │         └── c1:1 > 0
+      │    └── select
+      │         ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         ├── scan t1
+      │         │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         └── filters
+      │              └── c1:1 > 0
       └── filters
            └── c1:1 < 0
 
@@ -109,13 +115,15 @@ update t1
       │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
       │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── select
+      │    │    ├── barrier
       │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    ├── scan t1
-      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    └── filters
-      │    │    │         └── ((c1:7 % 2) = 0) AND false
+      │    │    │    └── select
+      │    │    │         ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         ├── scan t1
+      │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         │    └── flags: avoid-full-scan
+      │    │    │         └── filters
+      │    │    │              └── ((c1:7 % 2) = 0) AND false
       │    │    └── filters
       │    │         └── c1:7 > 0
       │    └── projections
@@ -142,13 +150,15 @@ update t1
       │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
       │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── select
+      │    │    ├── barrier
       │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    ├── scan t1
-      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    └── filters
-      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    └── select
+      │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         ├── scan t1
+      │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         │    └── flags: avoid-full-scan
+      │    │    │         └── filters
+      │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    └── filters
       │    │         └── c1:7 > 0
       │    └── projections
@@ -174,13 +184,15 @@ update t1
       │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
       │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── select
+      │    │    ├── barrier
       │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    ├── scan t1
-      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    └── filters
-      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    └── select
+      │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         ├── scan t1
+      │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         │    └── flags: avoid-full-scan
+      │    │    │         └── filters
+      │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    └── filters
       │    │         └── true
       │    └── projections
@@ -210,13 +222,15 @@ project
  │         │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
  │         │    ├── select
  │         │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
- │         │    │    ├── select
+ │         │    │    ├── barrier
  │         │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
- │         │    │    │    ├── scan t1
- │         │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
- │         │    │    │    │    └── flags: avoid-full-scan
- │         │    │    │    └── filters
- │         │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+ │         │    │    │    └── select
+ │         │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    │         ├── scan t1
+ │         │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+ │         │    │    │         │    └── flags: avoid-full-scan
+ │         │    │    │         └── filters
+ │         │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
  │         │    │    └── filters
  │         │    │         └── true
  │         │    └── projections
@@ -241,13 +255,15 @@ update t1
       │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
       │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── select
+      │    │    ├── barrier
       │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    ├── scan t1
-      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    └── filters
-      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    └── select
+      │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         ├── scan t1
+      │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         │    └── flags: avoid-full-scan
+      │    │    │         └── filters
+      │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    └── filters
       │    │         └── true
       │    └── projections
@@ -270,13 +286,15 @@ update t1
       │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    ├── select
       │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── select
+      │    │    ├── barrier
       │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    ├── scan t1
-      │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    └── filters
-      │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    └── select
+      │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         ├── scan t1
+      │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │    │         │    └── flags: avoid-full-scan
+      │    │    │         └── filters
+      │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    └── filters
       │    │         └── c1:7 > 0
       │    └── projections
@@ -306,13 +324,15 @@ project
            │    ├── columns: c1_new:13!null c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
            │    ├── select
            │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-           │    │    ├── select
+           │    │    ├── barrier
            │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-           │    │    │    ├── scan t1
-           │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-           │    │    │    │    └── flags: avoid-full-scan
-           │    │    │    └── filters
-           │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+           │    │    │    └── select
+           │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+           │    │    │         ├── scan t1
+           │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+           │    │    │         │    └── flags: avoid-full-scan
+           │    │    │         └── filters
+           │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
            │    │    └── filters
            │    │         └── true
            │    └── projections
@@ -345,13 +365,15 @@ update t1
       │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
       │    │    ├── inner-join (cross)
       │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
-      │    │    │    ├── select
+      │    │    │    ├── barrier
       │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
-      │    │    │    │    ├── scan t1
-      │    │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
-      │    │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    │    └── filters
-      │    │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │         ├── scan t1
+      │    │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │         │    └── flags: avoid-full-scan
+      │    │    │    │         └── filters
+      │    │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    │    ├── scan other
       │    │    │    │    └── columns: k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
       │    │    │    └── filters (true)
@@ -402,13 +424,15 @@ update t1
       │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
       │    │    │    ├── inner-join (cross)
       │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
-      │    │    │    │    ├── select
+      │    │    │    │    ├── barrier
       │    │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
-      │    │    │    │    │    ├── scan t1
-      │    │    │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
-      │    │    │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    │    │    └── filters
-      │    │    │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+      │    │    │    │    │    └── select
+      │    │    │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │    │         ├── scan t1
+      │    │    │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+      │    │    │    │    │         │    └── flags: avoid-full-scan
+      │    │    │    │    │         └── filters
+      │    │    │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
       │    │    │    │    ├── scan other
       │    │    │    │    │    └── columns: k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
       │    │    │    │    └── filters (true)
@@ -466,13 +490,15 @@ project
            │    │    ├── grouping columns: rowid:10!null
            │    │    ├── inner-join (cross)
            │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12 k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
-           │    │    │    ├── select
+           │    │    │    ├── barrier
            │    │    │    │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
-           │    │    │    │    ├── scan t1
-           │    │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
-           │    │    │    │    │    └── flags: avoid-full-scan
-           │    │    │    │    └── filters
-           │    │    │    │         └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
+           │    │    │    │    └── select
+           │    │    │    │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+           │    │    │    │         ├── scan t1
+           │    │    │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null t1.crdb_internal_mvcc_timestamp:11 t1.tableoid:12
+           │    │    │    │         │    └── flags: avoid-full-scan
+           │    │    │    │         └── filters
+           │    │    │    │              └── ((c1:7 % 2) = 0) AND (c1:7 < 100)
            │    │    │    ├── scan other
            │    │    │    │    └── columns: k:13!null a:14 other.crdb_internal_mvcc_timestamp:15 other.tableoid:16
            │    │    │    └── filters (true)
@@ -510,13 +536,15 @@ delete t1
  ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
  └── select
       ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      ├── select
+      ├── barrier
       │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    ├── scan t1
-      │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: avoid-full-scan
-      │    └── filters
-      │         └── ((c1:7 % 2) = 0) AND false
+      │    └── select
+      │         ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │         ├── scan t1
+      │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │         │    └── flags: avoid-full-scan
+      │         └── filters
+      │              └── ((c1:7 % 2) = 0) AND false
       └── filters
            └── (c1:7 >= 0) AND (c1:7 <= 20)
 
@@ -532,13 +560,15 @@ delete t1
  ├── fetch columns: c1:7 c2:8 c3:9 rowid:10
  └── select
       ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      ├── select
+      ├── barrier
       │    ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    ├── scan t1
-      │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    └── flags: avoid-full-scan
-      │    └── filters
-      │         └── ((c1:7 % 2) = 0) AND ((c1:7 >= 8) AND (c1:7 <= 12))
+      │    └── select
+      │         ├── columns: c1:7!null c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │         ├── scan t1
+      │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │         │    └── flags: avoid-full-scan
+      │         └── filters
+      │              └── ((c1:7 % 2) = 0) AND ((c1:7 >= 8) AND (c1:7 <= 12))
       └── filters
            └── (c1:7 >= 0) AND (c1:7 <= 20)
 
@@ -571,12 +601,14 @@ project
  ├── columns: c1:1!null
  └── select
       ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── select
+      ├── barrier
       │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    ├── scan t1
-      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── filters
-      │         └── false
+      │    └── select
+      │         ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         ├── scan t1
+      │         │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         └── filters
+      │              └── false
       └── filters
            └── (c1:1 >= 0) AND (c1:1 <= 9)
 
@@ -591,12 +623,14 @@ project
  ├── columns: c1:1!null
  └── select
       ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── select
+      ├── barrier
       │    ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    ├── scan t1
-      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── filters
-      │         └── c1:1 > 0
+      │    └── select
+      │         ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         ├── scan t1
+      │         │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         └── filters
+      │              └── c1:1 > 0
       └── filters
            └── (c1:1 >= 0) AND (c1:1 <= 9)
 
@@ -719,13 +753,15 @@ update t1
       ├── columns: rls:14 c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c2_new:13!null
       ├── project
       │    ├── columns: c2_new:13!null c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    ├── select
+      │    ├── barrier
       │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── scan t1
-      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    └── flags: avoid-full-scan
-      │    │    └── filters
-      │    │         └── (true OR ((c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24'))) AND ((c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24'))
+      │    │    └── select
+      │    │         ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         ├── scan t1
+      │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         │    └── flags: avoid-full-scan
+      │    │         └── filters
+      │    │              └── (true OR ((c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24'))) AND ((c2:8 = 'Hello, World') OR (c3:9 = '2024-12-24'))
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections
@@ -775,13 +811,15 @@ update t1
       ├── columns: rls:14!null c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c2_new:13!null
       ├── project
       │    ├── columns: c2_new:13!null c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    ├── select
+      │    ├── barrier
       │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── scan t1
-      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    └── flags: avoid-full-scan
-      │    │    └── filters
-      │    │         └── true AND false
+      │    │    └── select
+      │    │         ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         ├── scan t1
+      │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         │    └── flags: avoid-full-scan
+      │    │         └── filters
+      │    │              └── true AND false
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections
@@ -819,12 +857,14 @@ insert t1
       │    ├── columns: rowid_default:13 c1:7 c2:8 c3:9!null
       │    ├── project
       │    │    ├── columns: c1:7 c2:8 c3:9!null
-      │    │    └── select
+      │    │    └── barrier
       │    │         ├── columns: c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │         ├── scan t1
-      │    │         │    └── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │         └── filters
-      │    │              └── c3:9 IN ('2013-06-02', '1988-07-01')
+      │    │         └── select
+      │    │              ├── columns: c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │              ├── scan t1
+      │    │              │    └── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │              └── filters
+      │    │                   └── c3:9 IN ('2013-06-02', '1988-07-01')
       │    └── projections
       │         └── unique_rowid() [as=rowid_default:13]
       └── projections
@@ -1028,13 +1068,15 @@ update t1
       ├── columns: rls:14 c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12 c1_new:13
       ├── project
       │    ├── columns: c1_new:13 c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    ├── select
+      │    ├── barrier
       │    │    ├── columns: c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    ├── scan t1
-      │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
-      │    │    │    └── flags: avoid-full-scan
-      │    │    └── filters
-      │    │         └── true AND (c3:9 IN ('2025-01-01', '2024-12-31'))
+      │    │    └── select
+      │    │         ├── columns: c1:7 c2:8 c3:9!null rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         ├── scan t1
+      │    │         │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
+      │    │         │    └── flags: avoid-full-scan
+      │    │         └── filters
+      │    │              └── true AND (c3:9 IN ('2025-01-01', '2024-12-31'))
       │    └── projections
       │         └── c1:7 + 1 [as=c1_new:13]
       └── projections
@@ -1046,26 +1088,30 @@ SELECT c2 FROM t1 FOR SHARE
 ----
 project
  ├── columns: c2:2
- └── select
+ └── barrier
       ├── columns: c1:1 c2:2 c3:3!null rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── scan t1
-      │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── locking: for-share
-      └── filters
-           └── true AND (c3:3 IN ('2025-01-01', '2024-12-31'))
+      └── select
+           ├── columns: c1:1 c2:2 c3:3!null rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           ├── scan t1
+           │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           │    └── locking: for-share
+           └── filters
+                └── true AND (c3:3 IN ('2025-01-01', '2024-12-31'))
 
 build
 SELECT c3 FROM t1 FOR UPDATE
 ----
 project
  ├── columns: c3:3!null
- └── select
+ └── barrier
       ├── columns: c1:1 c2:2 c3:3!null rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── scan t1
-      │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── locking: for-update
-      └── filters
-           └── true AND (c3:3 IN ('2025-01-01', '2024-12-31'))
+      └── select
+           ├── columns: c1:1 c2:2 c3:3!null rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           ├── scan t1
+           │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+           │    └── locking: for-update
+           └── filters
+                └── true AND (c3:3 IN ('2025-01-01', '2024-12-31'))
 
 exec-ddl
 DROP POLICY p_update on t1;
@@ -1318,12 +1364,14 @@ project
  ├── columns: c2:2
  └── select
       ├── columns: c1:1!null c2:2 c3:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
-      ├── select
+      ├── barrier
       │    ├── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-      │    ├── scan t1_explicit_pk
-      │    │    └── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-      │    └── filters
-      │         └── ((((((c2:2 = '(c2) p_select policy') OR (c1:1 = 1)) OR (c1:1 = 2)) OR (c1:1 = 3)) OR (c1:1 = 4)) AND ((c1:1 % 2) = 0)) AND ((c1:1 % 3) = 0)
+      │    └── select
+      │         ├── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         ├── scan t1_explicit_pk
+      │         │    └── columns: c1:1!null c2:2 c3:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         └── filters
+      │              └── ((((((c2:2 = '(c2) p_select policy') OR (c1:1 = 1)) OR (c1:1 = 2)) OR (c1:1 = 3)) OR (c1:1 = 4)) AND ((c1:1 % 2) = 0)) AND ((c1:1 % 3) = 0)
       └── filters
            └── c3:3 >= '2025-01-01'
 
@@ -1360,13 +1408,15 @@ update t1_explicit_pk
       │    ├── columns: c3_new:11!null c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
       │    ├── select
       │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    ├── select
+      │    │    ├── barrier
       │    │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    ├── scan t1_explicit_pk
-      │    │    │    │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
-      │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    └── filters
-      │    │    │         └── (((((((c2:7 = '(c2) p_select policy') OR (c1:6 = 1)) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0))
+      │    │    │    └── select
+      │    │    │         ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │         ├── scan t1_explicit_pk
+      │    │    │         │    ├── columns: c1:6!null c2:7 c3:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    │         │    └── flags: avoid-full-scan
+      │    │    │         └── filters
+      │    │    │              └── (((((((c2:7 = '(c2) p_select policy') OR (c1:6 = 1)) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0)) AND ((((((c1:6 = 1) OR (c1:6 = 2)) OR (c1:6 = 3)) OR (c1:6 = 4)) AND ((c1:6 % 2) = 0)) AND ((c1:6 % 3) = 0))
       │    │    └── filters
       │    │         └── c1:6 = 18
       │    └── projections
@@ -1439,12 +1489,14 @@ project
  ├── columns: c1:1!null
  └── select
       ├── columns: c1:1!null c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      ├── select
+      ├── barrier
       │    ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    ├── scan t1
-      │    │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
-      │    └── filters
-      │         └── true OR (c2:2 != 'out of policy')
+      │    └── select
+      │         ├── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         ├── scan t1
+      │         │    └── columns: c1:1 c2:2 c3:3 rowid:4!null crdb_internal_mvcc_timestamp:5 tableoid:6
+      │         └── filters
+      │              └── true OR (c2:2 != 'out of policy')
       └── filters
            └── (c1:1 >= 0) AND (c1:1 <= 9)
 
@@ -1518,19 +1570,21 @@ SELECT * FROM t
 ----
 project
  ├── columns: k:1!null a:2 b:3 c:4 v:5!null
- └── select
+ └── barrier
       ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-      ├── project
-      │    ├── columns: v:5 k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    ├── scan t
-      │    │    ├── columns: k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    │    └── computed column expressions
-      │    │         └── v:5
-      │    │              └── c:4 + 1
-      │    └── projections
-      │         └── c:4 + 1 [as=v:5]
-      └── filters
-           └── v:5 > 0
+      └── select
+           ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+           ├── project
+           │    ├── columns: v:5 k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+           │    ├── scan t
+           │    │    ├── columns: k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+           │    │    └── computed column expressions
+           │    │         └── v:5
+           │    │              └── c:4 + 1
+           │    └── projections
+           │         └── c:4 + 1 [as=v:5]
+           └── filters
+                └── v:5 > 0
 
 # Do a SELECT that doesn't reference the virtual column.
 build
@@ -1540,19 +1594,21 @@ project
  ├── columns: k:1!null c:4
  └── select
       ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-      ├── select
+      ├── barrier
       │    ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    ├── project
-      │    │    ├── columns: v:5 k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    │    ├── scan t
-      │    │    │    ├── columns: k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    │    │    └── computed column expressions
-      │    │    │         └── v:5
-      │    │    │              └── c:4 + 1
-      │    │    └── projections
-      │    │         └── c:4 + 1 [as=v:5]
-      │    └── filters
-      │         └── v:5 > 0
+      │    └── select
+      │         ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      │         ├── project
+      │         │    ├── columns: v:5 k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │         │    ├── scan t
+      │         │    │    ├── columns: k:1!null a:2 b:3 c:4 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │         │    │    └── computed column expressions
+      │         │    │         └── v:5
+      │         │    │              └── c:4 + 1
+      │         │    └── projections
+      │         │         └── c:4 + 1 [as=v:5]
+      │         └── filters
+      │              └── v:5 > 0
       └── filters
            └── a:2 IS NULL
 
@@ -1598,20 +1654,22 @@ update t
       │    │    ├── columns: c_new:15!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    ├── select
       │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    ├── select
+      │    │    │    ├── barrier
       │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    ├── project
-      │    │    │    │    │    ├── columns: v:12 k:8!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    │    ├── scan t
-      │    │    │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    │    │    └── v:12
-      │    │    │    │    │    │    │         └── c:11 + 1
-      │    │    │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    │    │    └── projections
-      │    │    │    │    │         └── c:11 + 1 [as=v:12]
-      │    │    │    │    └── filters
-      │    │    │    │         └── (v:12 > 0) AND (v:12 > 5)
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │         ├── project
+      │    │    │    │         │    ├── columns: v:12 k:8!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │         │    ├── scan t
+      │    │    │    │         │    │    ├── columns: k:8!null a:9 b:10 c:11 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │         │    │    ├── computed column expressions
+      │    │    │    │         │    │    │    └── v:12
+      │    │    │    │         │    │    │         └── c:11 + 1
+      │    │    │    │         │    │    └── flags: avoid-full-scan
+      │    │    │    │         │    └── projections
+      │    │    │    │         │         └── c:11 + 1 [as=v:12]
+      │    │    │    │         └── filters
+      │    │    │    │              └── (v:12 > 0) AND (v:12 > 5)
       │    │    │    └── filters
       │    │    │         └── k:8 = 1
       │    │    └── projections
@@ -1670,15 +1728,17 @@ SELECT * FROM t
 ----
 project
  ├── columns: k:1!null a:2 b:3 c:4 v:5!null
- └── select
+ └── barrier
       ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-      ├── scan t
-      │    ├── columns: k:1!null a:2 b:3 c:4 v:5 crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    └── computed column expressions
-      │         └── v:5
-      │              └── c:4 + 1
-      └── filters
-           └── v:5 > 0
+      └── select
+           ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+           ├── scan t
+           │    ├── columns: k:1!null a:2 b:3 c:4 v:5 crdb_internal_mvcc_timestamp:6 tableoid:7
+           │    └── computed column expressions
+           │         └── v:5
+           │              └── c:4 + 1
+           └── filters
+                └── v:5 > 0
 
 # Do a SELECT that doesn't reference the stored column.
 build
@@ -1688,15 +1748,17 @@ project
  ├── columns: k:1!null c:4
  └── select
       ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-      ├── select
+      ├── barrier
       │    ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    ├── scan t
-      │    │    ├── columns: k:1!null a:2 b:3 c:4 v:5 crdb_internal_mvcc_timestamp:6 tableoid:7
-      │    │    └── computed column expressions
-      │    │         └── v:5
-      │    │              └── c:4 + 1
-      │    └── filters
-      │         └── v:5 > 0
+      │    └── select
+      │         ├── columns: k:1!null a:2 b:3 c:4 v:5!null crdb_internal_mvcc_timestamp:6 tableoid:7
+      │         ├── scan t
+      │         │    ├── columns: k:1!null a:2 b:3 c:4 v:5 crdb_internal_mvcc_timestamp:6 tableoid:7
+      │         │    └── computed column expressions
+      │         │         └── v:5
+      │         │              └── c:4 + 1
+      │         └── filters
+      │              └── v:5 > 0
       └── filters
            └── a:2 IS NULL
 
@@ -1742,16 +1804,18 @@ update t
       │    │    ├── columns: c_new:15!null k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
       │    │    ├── select
       │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    ├── select
+      │    │    │    ├── barrier
       │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    ├── scan t
-      │    │    │    │    │    ├── columns: k:8!null a:9 b:10 c:11 v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
-      │    │    │    │    │    ├── computed column expressions
-      │    │    │    │    │    │    └── v:12
-      │    │    │    │    │    │         └── c:11 + 1
-      │    │    │    │    │    └── flags: avoid-full-scan
-      │    │    │    │    └── filters
-      │    │    │    │         └── (v:12 > 0) AND (v:12 > 5)
+      │    │    │    │    └── select
+      │    │    │    │         ├── columns: k:8!null a:9 b:10 c:11 v:12!null crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │         ├── scan t
+      │    │    │    │         │    ├── columns: k:8!null a:9 b:10 c:11 v:12 crdb_internal_mvcc_timestamp:13 tableoid:14
+      │    │    │    │         │    ├── computed column expressions
+      │    │    │    │         │    │    └── v:12
+      │    │    │    │         │    │         └── c:11 + 1
+      │    │    │    │         │    └── flags: avoid-full-scan
+      │    │    │    │         └── filters
+      │    │    │    │              └── (v:12 > 0) AND (v:12 > 5)
       │    │    │    └── filters
       │    │    │         └── k:8 = 1
       │    │    └── projections
@@ -1788,12 +1852,14 @@ SELECT id, customer_id FROM orders
 ----
 project
  ├── columns: id:1!null customer_id:2
- └── select
+ └── barrier
       ├── columns: id:1!null customer_id:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      ├── scan orders
-      │    └── columns: id:1!null customer_id:2 crdb_internal_mvcc_timestamp:3 tableoid:4
-      └── filters
-           └── false
+      └── select
+           ├── columns: id:1!null customer_id:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           ├── scan orders
+           │    └── columns: id:1!null customer_id:2 crdb_internal_mvcc_timestamp:3 tableoid:4
+           └── filters
+                └── false
 
 # Update the customer ID. This should cascade the update to orders, bypassing
 # RLS on orders.
@@ -2019,3 +2085,90 @@ root
                 └── filters
                      ├── customer_id:14 = 2
                      └── customer_id:14 IS DISTINCT FROM CAST(NULL AS INT8)
+
+# Show that optimization barriers are added to prevent reordering of predicates if
+# we use any non-leakproof functions in the WHERE clause.
+
+exec-ddl
+CREATE TABLE ob (x INT PRIMARY KEY, y INT, user_has_access BOOL);
+----
+
+exec-ddl
+CREATE INDEX ON ob(y);
+----
+
+exec-ddl
+ALTER TABLE ob ENABLE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY p1 ON ob USING (user_has_access);
+----
+
+# No barrier needed since expressions are all leakproof. Barrier will be
+# in the plan, but at the outer most part of the tree.
+norm
+SELECT * FROM ob WHERE y = 20;
+----
+project
+ ├── columns: x:1!null y:2!null user_has_access:3!null
+ └── barrier
+      ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      └── select
+           ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+           ├── scan ob
+           │    └── columns: x:1!null y:2 user_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+           └── filters
+                ├── user_has_access:3
+                └── y:2 = 20
+
+# Barrier needed. Try to expose with a division by zero error.
+norm
+SELECT * FROM ob WHERE y = 20 AND y/0 = 0;
+----
+project
+ ├── columns: x:1!null y:2!null user_has_access:3!null
+ └── select
+      ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      ├── barrier
+      │    ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── select
+      │         ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         ├── scan ob
+      │         │    └── columns: x:1!null y:2 user_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         └── filters
+      │              ├── user_has_access:3
+      │              └── y:2 = 20
+      └── filters
+           └── (20 / 0) = 0
+
+# Barrier needed. Filters are added outside of a WHERE (as JOIN predicates).
+norm
+SELECT * FROM ob t1 INNER JOIN ob t2 ON t1.y = 20 AND t2.y/0 = 0;
+----
+project
+ ├── columns: x:1!null y:2!null user_has_access:3!null x:6!null y:7 user_has_access:8!null
+ └── inner-join (cross)
+      ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5 x:6!null y:7 user_has_access:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      ├── barrier
+      │    ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │    └── select
+      │         ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         ├── scan ob
+      │         │    └── columns: x:1!null y:2 user_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+      │         └── filters
+      │              ├── user_has_access:3
+      │              └── y:2 = 20
+      ├── select
+      │    ├── columns: x:6!null y:7 user_has_access:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    ├── barrier
+      │    │    ├── columns: x:6!null y:7 user_has_access:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │    └── select
+      │    │         ├── columns: x:6!null y:7 user_has_access:8!null crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │         ├── scan ob
+      │    │         │    └── columns: x:6!null y:7 user_has_access:8 crdb_internal_mvcc_timestamp:9 tableoid:10
+      │    │         └── filters
+      │    │              └── user_has_access:8
+      │    └── filters
+      │         └── (y:7 / 0) = 0
+      └── filters (true)

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -80,7 +80,7 @@ func (mb *mutationBuilder) buildRowLevelBeforeTriggers(
 	canModifyRows := true
 	for i := range triggers {
 		trigger := triggers[i]
-		triggerScope.expr = f.ConstructBarrier(triggerScope.expr)
+		triggerScope.expr = f.ConstructBarrier(triggerScope.expr, &memo.BarrierPrivate{})
 
 		// Resolve the trigger function and build the invocation.
 		args := mb.buildTriggerFunctionArgs(trigger, eventType, oldColID, newColID)
@@ -133,7 +133,7 @@ func (mb *mutationBuilder) buildRowLevelBeforeTriggers(
 			newColID = triggerFnColID
 		}
 	}
-	triggerScope.expr = f.ConstructBarrier(triggerScope.expr)
+	triggerScope.expr = f.ConstructBarrier(triggerScope.expr, &memo.BarrierPrivate{})
 
 	// INSERT and UPDATE triggers can modify the row to be inserted or updated
 	// via the return value of the trigger function.
@@ -357,7 +357,7 @@ func (mb *mutationBuilder) ensureNoRowsModifiedByTrigger(
 		f.ConstructNull(types.Int),
 	)
 	mb.b.projectColWithMetadataName(triggerScope, "check-rows", types.Int, check)
-	triggerScope.expr = f.ConstructBarrier(triggerScope.expr)
+	triggerScope.expr = f.ConstructBarrier(triggerScope.expr, &memo.BarrierPrivate{})
 }
 
 // recomputeComputedColsForTrigger resets all computed columns and builds new
@@ -686,7 +686,7 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 			for i, trigger := range tb.triggers {
 				if i > 0 {
 					// No need to place a barrier below the first trigger.
-					triggerScope.expr = f.ConstructBarrier(triggerScope.expr)
+					triggerScope.expr = f.ConstructBarrier(triggerScope.expr, &memo.BarrierPrivate{})
 				}
 
 				tgName := tree.NewDName(string(trigger.Name()))
@@ -757,7 +757,7 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 			}
 			// Always wrap the expression in a barrier, or else the projections will be
 			// pruned and the triggers will not be executed.
-			return f.ConstructBarrier(triggerScope.expr)
+			return f.ConstructBarrier(triggerScope.expr, &memo.BarrierPrivate{})
 		})
 }
 

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -799,7 +799,7 @@ func tableOrdinals(tab cat.Table, k columnKinds) []int {
 // addBarrier adds an optimization barrier to the given scope, in order to
 // prevent side effects from being duplicated, eliminated, or reordered.
 func (b *Builder) addBarrier(s *scope) {
-	s.expr = b.factory.ConstructBarrier(s.expr)
+	s.expr = b.factory.ConstructBarrier(s.expr, &memo.BarrierPrivate{})
 }
 
 // projectColWithMetadataName projects a new anonymous column with the given

--- a/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
+++ b/pkg/sql/opt/optgen/lang/support/textmate/OptGen/Syntaxes/optgen.tmLanguage
@@ -124,6 +124,7 @@
                         AggregationsItem |
                         Filters |
                         FiltersItem |
+                        Barrier |
                         Zip |
                         ZipItem |
                         ZipItemPrivate |

--- a/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
+++ b/pkg/sql/opt/optgen/lang/support/vim/cropt.vim
@@ -35,7 +35,7 @@ syn keyword define contained define
 syn match func contained '(A-Za-z0-9_)*'
 
 syn keyword operator Subquery SubqueryPrivate Any Exists Variable Const Null True False Placeholder
-syn keyword operator Tuple Projections ColPrivate Aggregations AggregationsItem Filters FiltersItem
+syn keyword operator Tuple Projections ColPrivate Aggregations AggregationsItem Filters FiltersItem Barrier
 syn keyword operator Zip ZipItem ZipItemPrivate And Or Not Eq Lt Gt Le Ge Ne In NotIn
 syn keyword operator Like NotLike ILike NotILike SimilarTo NotSimilarTo RegMatch NotRegMatch
 syn keyword operator RegIMatch NotRegIMatch Is IsNot Contains JsonExists JsonAllExists


### PR DESCRIPTION
RLS policies are applied as filters to scan operations before any user-defined predicates. Previously, the optimizer could reorder these predicates freely, which could result in information leakage: users could infer the existence of hidden rows based on query behavior.

This change wraps the RLS filter in a Barrier operator, which prevents it from being reordered across non-leak-proof expressions. This ensures that evaluation order is preserved and RLS protections remain intact.

 The Barrier is marked as permeable, allowing optgen rules to push the Barrier up the plan tree for expressions that are leakproof. Only optgen rules for the Select operator were added in this change. Subsequent changes will handle joins and projections.

Informs #146952

Epic: CRDB-48807
Release note (bug fix): Fixed a security issue where optimizer predicate reordering could leak information about hidden rows protected by RLS policies.