### PR TITLE
roachtest: use failure injection library for disk stalls 

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -48,6 +48,7 @@ go_library(
         "//pkg/roachprod/cloud",
         "//pkg/roachprod/config",
         "//pkg/roachprod/errors",
+        "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -42,6 +42,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
@@ -3310,4 +3311,21 @@ func (c *clusterImpl) RegisterClusterHook(
 	default:
 		panic(fmt.Sprintf("unknown test hook type %v", hookType))
 	}
+}
+
+// GetFailer returns a *failures.Failer for the given failure mode name. Used
+// for conducting failure injection on a cluster.
+func (c *clusterImpl) GetFailer(
+	l *logger.Logger,
+	nodes option.NodeListOption,
+	failureModeName string,
+	opts ...failures.ClusterOptionFunc,
+) (*failures.Failer, error) {
+	fr := failures.GetFailureRegistry()
+	clusterOpts := append(opts, failures.Secure(c.IsSecure()))
+	failer, err := fr.GetFailer(c.MakeNodes(nodes), failureModeName, l, clusterOpts...)
+	if err != nil {
+		return nil, err
+	}
+	return failer, err
 }

--- a/pkg/cmd/roachtest/cluster/BUILD.bazel
+++ b/pkg/cmd/roachtest/cluster/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/spec",
         "//pkg/roachprod",
+        "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
@@ -215,4 +216,6 @@ type Cluster interface {
 	GetPreemptedVMs(ctx context.Context, l *logger.Logger) ([]vm.PreemptedVM, error)
 
 	RegisterClusterHook(hookName string, hookType option.ClusterHookType, timeout time.Duration, hook func(context.Context) error)
+
+	GetFailer(l *logger.Logger, nodes option.NodeListOption, failureModeName string, opts ...failures.ClusterOptionFunc) (*failures.Failer, error)
 }

--- a/pkg/cmd/roachtest/clusterstats/BUILD.bazel
+++ b/pkg/cmd/roachtest/clusterstats/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         # Required for generated mocks
         "//pkg/roachprod",  #keep
         # Required for generated mocks
+        "//pkg/roachprod/failureinjection/failures",  #keep
         "//pkg/roachprod/install",  #keep
         "//pkg/roachprod/logger",
         "//pkg/roachprod/prometheus",

--- a/pkg/cmd/roachtest/clusterstats/mock_cluster_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_cluster_generated_test.go
@@ -16,6 +16,7 @@ import (
 	option "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	spec "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	roachprod "github.com/cockroachdb/cockroach/pkg/roachprod"
+	failures "github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	install "github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	logger "github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	prometheus "github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
@@ -361,6 +362,26 @@ func (mr *MockClusterMockRecorder) Get(arg0, arg1, arg2, arg3 interface{}, arg4 
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Get", reflect.TypeOf((*MockCluster)(nil).Get), varargs...)
+}
+
+// GetFailer mocks base method.
+func (m *MockCluster) GetFailer(arg0 *logger.Logger, arg1 option.NodeListOption, arg2 string, arg3 ...failures.ClusterOptionFunc) (*failures.Failer, error) {
+	m.ctrl.T.Helper()
+	varargs := []interface{}{arg0, arg1, arg2}
+	for _, a := range arg3 {
+		varargs = append(varargs, a)
+	}
+	ret := m.ctrl.Call(m, "GetFailer", varargs...)
+	ret0, _ := ret[0].(*failures.Failer)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// GetFailer indicates an expected call of GetFailer.
+func (mr *MockClusterMockRecorder) GetFailer(arg0, arg1, arg2 interface{}, arg3 ...interface{}) *gomock.Call {
+	mr.mock.ctrl.T.Helper()
+	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "GetFailer", reflect.TypeOf((*MockCluster)(nil).GetFailer), varargs...)
 }
 
 // GetPreemptedVMs mocks base method.

--- a/pkg/cmd/roachtest/roachtestutil/disk_stall.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_stall.go
@@ -7,18 +7,17 @@ package roachtestutil
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
-	"path/filepath"
-	"strconv"
-	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 )
 
+// TODO(darryl): Once the failure injection library is a first class citizen of roachtest,
+// i.e. synced with the monitor, test + cluster spec validation, observability into failure
+// modes, etc. we can remove this interface entirely.
 type DiskStaller interface {
 	Setup(ctx context.Context)
 	Cleanup(ctx context.Context)
@@ -48,20 +47,23 @@ type Fataler interface {
 }
 
 type cgroupDiskStaller struct {
-	f           Fataler
-	c           cluster.Cluster
-	readOrWrite []bandwidthReadWrite
-	logsToo     bool
+	*failures.Failer
+	f          Fataler
+	c          cluster.Cluster
+	stallReads bool
+	stallLogs  bool
 }
 
 var _ DiskStaller = (*cgroupDiskStaller)(nil)
 
-func MakeCgroupDiskStaller(f Fataler, c cluster.Cluster, readsToo bool, logsToo bool) DiskStaller {
-	bwRW := []bandwidthReadWrite{writeBandwidth}
-	if readsToo {
-		bwRW = append(bwRW, readBandwidth)
+func MakeCgroupDiskStaller(
+	f Fataler, c cluster.Cluster, stallReads bool, stallLogs bool,
+) DiskStaller {
+	diskStaller, err := c.GetFailer(f.L(), c.CRDBNodes(), failures.CgroupsDiskStallName)
+	if err != nil {
+		f.Fatalf("failed to get failer: %s", err)
 	}
-	return &cgroupDiskStaller{f: f, c: c, readOrWrite: bwRW, logsToo: logsToo}
+	return &cgroupDiskStaller{Failer: diskStaller, f: f, c: c, stallReads: stallReads, stallLogs: stallLogs}
 }
 
 func (s *cgroupDiskStaller) DataDir() string { return "{store-dir}" }
@@ -73,135 +75,65 @@ func (s *cgroupDiskStaller) Setup(ctx context.Context) {
 		// Safety measure.
 		s.f.Fatalf("cluster needs ReusePolicyNone to support disk stalls")
 	}
-	if s.logsToo {
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "mkdir -p {store-dir}/logs")
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "rm -f logs && ln -s {store-dir}/logs logs || true")
+	if err := s.Failer.Setup(ctx, s.f.L(), failures.DiskStallArgs{
+		StallLogs: s.stallLogs,
+		Nodes:     s.c.CRDBNodes().InstallNodes(),
+	}); err != nil {
+		s.f.Fatalf("failed to setup disk stall: %s", err)
 	}
 }
-func (s *cgroupDiskStaller) Cleanup(ctx context.Context) {}
+func (s *cgroupDiskStaller) Cleanup(ctx context.Context) {
+	err := s.Failer.Cleanup(ctx, s.f.L())
+	if err != nil {
+		s.f.Fatalf("failed to cleanup disk stall: %s", err)
+	}
+}
 
 func (s *cgroupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
-	// NB: I don't understand why, but attempting to set a bytesPerSecond={0,1}
-	// results in Invalid argument from the io.max cgroupv2 API.
-	s.Slow(ctx, nodes, 4)
+	if err := s.Failer.Inject(ctx, s.f.L(), failures.DiskStallArgs{
+		StallLogs:   s.stallLogs,
+		StallWrites: true,
+		StallReads:  s.stallReads,
+		Nodes:       nodes.InstallNodes(),
+	}); err != nil {
+		s.f.Fatalf("failed to stall disk: %s", err)
+	}
 }
 
 func (s *cgroupDiskStaller) Slow(
 	ctx context.Context, nodes option.NodeListOption, bytesPerSecond int,
 ) {
-	// Shuffle the order of read and write stall initiation.
-	rand.Shuffle(len(s.readOrWrite), func(i, j int) {
-		s.readOrWrite[i], s.readOrWrite[j] = s.readOrWrite[j], s.readOrWrite[i]
-	})
-	for _, rw := range s.readOrWrite {
-		if err := s.setThroughput(ctx, nodes, rw, throughput{limited: true, bytesPerSecond: bytesPerSecond}); err != nil {
-			s.f.Fatal(err)
-		}
+	if err := s.Failer.Inject(ctx, s.f.L(), failures.DiskStallArgs{
+		StallLogs:   s.stallLogs,
+		StallWrites: true,
+		StallReads:  s.stallReads,
+		Nodes:       nodes.InstallNodes(),
+		Throughput:  bytesPerSecond,
+	}); err != nil {
+		s.f.Fatalf("failed to slow disk: %s", err)
 	}
 }
 
 func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
-	for _, rw := range s.readOrWrite {
-		err := s.setThroughput(ctx, nodes, rw, throughput{limited: false})
-		if err != nil {
-			s.f.L().PrintfCtx(ctx, "error unstalling the disk; stumbling on: %v", err)
-		}
-		// NB: We log the error and continue on because unstalling may not
-		// succeed if the process has successfully exited.
+	if err := s.Failer.Recover(ctx, s.f.L()); err != nil {
+		s.f.Fatalf("failed to unstall disk: %s", err)
 	}
-}
-
-func (s *cgroupDiskStaller) device(nodes option.NodeListOption) (major, minor int) {
-	// TODO(jackson): Programmatically determine the device major,minor numbers.
-	// eg,:
-	//    deviceName := getDevice(s.t, s.c)
-	//    `cat /proc/partitions` and find `deviceName`
-	res, err := s.c.RunWithDetailsSingleNode(context.TODO(), s.f.L(), option.WithNodes(nodes[:1]), "lsblk | grep /mnt/data1 | awk '{print $2}'")
-	if err != nil {
-		s.f.Fatalf("error when determining block device: %s", err)
-		return 0, 0
-	}
-	parts := strings.Split(strings.TrimSpace(res.Stdout), ":")
-	if len(parts) != 2 {
-		s.f.Fatalf("unexpected output from lsblk: %s", res.Stdout)
-		return 0, 0
-	}
-	major, err = strconv.Atoi(parts[0])
-	if err != nil {
-		s.f.Fatalf("error when determining block device: %s", err)
-		return 0, 0
-	}
-	minor, err = strconv.Atoi(parts[1])
-	if err != nil {
-		s.f.Fatalf("error when determining block device: %s", err)
-		return 0, 0
-	}
-	return major, minor
-}
-
-type throughput struct {
-	limited        bool
-	bytesPerSecond int
-}
-
-type bandwidthReadWrite int8
-
-const (
-	readBandwidth bandwidthReadWrite = iota
-	writeBandwidth
-)
-
-func (rw bandwidthReadWrite) cgroupV2BandwidthProp() string {
-	switch rw {
-	case readBandwidth:
-		return "rbps"
-	case writeBandwidth:
-		return "wbps"
-	default:
-		panic("unreachable")
-	}
-}
-
-func (s *cgroupDiskStaller) setThroughput(
-	ctx context.Context, nodes option.NodeListOption, rw bandwidthReadWrite, bw throughput,
-) error {
-	maj, min := s.device(nodes)
-	cockroachIOController := filepath.Join("/sys/fs/cgroup/system.slice", SystemInterfaceSystemdUnitName()+".service", "io.max")
-
-	bytesPerSecondStr := "max"
-	if bw.limited {
-		bytesPerSecondStr = fmt.Sprintf("%d", bw.bytesPerSecond)
-	}
-	return s.c.RunE(ctx, option.WithNodes(nodes), "sudo", "/bin/bash", "-c", fmt.Sprintf(
-		`'echo %d:%d %s=%s > %s'`,
-		maj,
-		min,
-		rw.cgroupV2BandwidthProp(),
-		bytesPerSecondStr,
-		cockroachIOController,
-	))
-}
-
-func GetDiskDevice(f Fataler, c cluster.Cluster, nodes option.NodeListOption) string {
-	res, err := c.RunWithDetailsSingleNode(context.TODO(), f.L(), option.WithNodes(nodes[:1]), "lsblk | grep /mnt/data1 | awk '{print $1}'")
-	if err != nil {
-		f.Fatalf("error when determining block device: %s", err)
-		return ""
-	}
-	return "/dev/" + strings.TrimSpace(res.Stdout)
 }
 
 type dmsetupDiskStaller struct {
+	*failures.Failer
 	f Fataler
 	c cluster.Cluster
-
-	dev string // set in Setup; s.device() doesn't work when volume is not set up
 }
 
 var _ DiskStaller = (*dmsetupDiskStaller)(nil)
 
-func (s *dmsetupDiskStaller) device(nodes option.NodeListOption) string {
-	return GetDiskDevice(s.f, s.c, nodes)
+func MakeDmsetupDiskStaller(f Fataler, c cluster.Cluster) DiskStaller {
+	diskStaller, err := c.GetFailer(f.L(), c.CRDBNodes(), failures.DmsetupDiskStallName)
+	if err != nil {
+		f.Fatalf("failed to get failer: %s", err)
+	}
+	return &dmsetupDiskStaller{Failer: diskStaller, f: f, c: c}
 }
 
 func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
@@ -209,38 +141,23 @@ func (s *dmsetupDiskStaller) Setup(ctx context.Context) {
 		// We disable journaling and do all kinds of things below.
 		s.f.Fatalf("cluster needs ReusePolicyNone to support disk stalls")
 	}
-	s.dev = s.device(s.c.All())
-	// snapd will run "snapd auto-import /dev/dm-0" via udev triggers when
-	// /dev/dm-0 is created. This possibly interferes with the dmsetup create
-	// reload, so uninstall snapd.
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get purge -y snapd`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount -f /mnt/data1 || true`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
-	// See https://github.com/cockroachdb/cockroach/issues/129619#issuecomment-2316147244.
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo tune2fs -O ^has_journal `+s.dev)
-	err := s.c.RunE(ctx, option.WithNodes(s.c.All()), `echo "0 $(sudo blockdev --getsz `+s.dev+`) linear `+s.dev+` 0" | `+
-		`sudo dmsetup create data1`)
-	if err != nil {
-		// This has occasionally been seen to fail with "Device or resource busy",
-		// with no clear explanation. Try to find out who it is.
-		s.c.Run(ctx, option.WithNodes(s.c.All()), "sudo bash -c 'ps aux; dmsetup status; mount; lsof'")
-		s.f.Fatal(err)
+	if err := s.Failer.Setup(ctx, s.f.L(), failures.DiskStallArgs{Nodes: s.c.CRDBNodes().InstallNodes()}); err != nil {
+		s.f.Fatalf("failed to setup disk stall: %s", err)
 	}
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo mount /dev/mapper/data1 /mnt/data1`)
 }
 
 func (s *dmsetupDiskStaller) Cleanup(ctx context.Context) {
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup resume data1`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo umount /mnt/data1`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo dmsetup remove_all`)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo tune2fs -O has_journal `+s.dev)
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo mount /mnt/data1`)
-	// Reinstall snapd in case subsequent tests need it.
-	s.c.Run(ctx, option.WithNodes(s.c.All()), `sudo apt-get install -y snapd`)
+	if err := s.Failer.Cleanup(ctx, s.f.L()); err != nil {
+		s.f.Fatalf("failed to cleanup disk stall: %s", err)
+	}
 }
 
 func (s *dmsetupDiskStaller) Stall(ctx context.Context, nodes option.NodeListOption) {
-	s.c.Run(ctx, option.WithNodes(nodes), `sudo dmsetup suspend --noflush --nolockfs data1`)
+	if err := s.Failer.Inject(ctx, s.f.L(), failures.DiskStallArgs{
+		Nodes: nodes.InstallNodes(),
+	}); err != nil {
+		s.f.Fatalf("failed to stall disk: %s", err)
+	}
 }
 
 func (s *dmsetupDiskStaller) Slow(
@@ -251,12 +168,10 @@ func (s *dmsetupDiskStaller) Slow(
 }
 
 func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
-	s.c.Run(ctx, option.WithNodes(nodes), `sudo dmsetup resume data1`)
+	if err := s.Failer.Recover(ctx, s.f.L()); err != nil {
+		s.f.Fatalf("failed to unstall disk: %s", err)
+	}
 }
 
 func (s *dmsetupDiskStaller) DataDir() string { return "{store-dir}" }
 func (s *dmsetupDiskStaller) LogDir() string  { return "logs" }
-
-func MakeDmsetupDiskStaller(f Fataler, c cluster.Cluster) DiskStaller {
-	return &dmsetupDiskStaller{f: f, c: c}
-}

--- a/pkg/cmd/roachtest/roachtestutil/utils.go
+++ b/pkg/cmd/roachtest/roachtestutil/utils.go
@@ -21,7 +21,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
-	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util"
@@ -288,12 +287,4 @@ func PrefixCmdOutputWithTimestamp(cmd string) string {
 	// Don't prefix blank lines with timestamps.
 	awkCmd := `awk 'NF { cmd="date +\"%H:%M:%S\""; cmd | getline ts; close(cmd); print ts ":", $0; next } { print }'`
 	return fmt.Sprintf(`bash -c '%s' 2>&1 |`, cmd) + awkCmd
-}
-
-// GetFailer returns a *failures.Failer for the given failure mode name. Used
-// for conducting failure injection on a cluster.
-func GetFailer(
-	fr *failures.FailureRegistry, c cluster.Cluster, failureModeName string, l *logger.Logger,
-) (*failures.Failer, error) {
-	return fr.GetFailer(c.MakeNodes(c.CRDBNodes()), failureModeName, l, c.IsSecure())
 }

--- a/pkg/cmd/roachtest/tests/failure_injection.go
+++ b/pkg/cmd/roachtest/tests/failure_injection.go
@@ -557,6 +557,71 @@ var cgroupsDiskStallTests = func(c cluster.Cluster) []failureSmokeTest {
 	return tests
 }
 
+var cgroupStallLogsTest = func(c cluster.Cluster) failureSmokeTest {
+	nodes := c.CRDBNodes()
+	rand.Shuffle(len(nodes), func(i, j int) {
+		nodes[i], nodes[j] = nodes[j], nodes[i]
+	})
+	// We only want to stall one node for this test. If we stall writes on a quorum
+	// of nodes, then auth-session login will fail even if logs are not stalled.
+	stalledNode := c.Node(nodes[0])
+	unaffectedNode := c.Node(nodes[1])
+
+	getSessionCookie := func(
+		ctx context.Context,
+		l *logger.Logger,
+		c cluster.Cluster,
+		node option.NodeListOption,
+	) bool {
+		loginCmd := fmt.Sprintf(
+			"%s auth-session login root --url={pgurl%s} --certs-dir ./certs --only-cookie",
+			test.DefaultCockroachPath, node,
+		)
+		err := c.RunE(ctx, option.WithNodes(node), loginCmd)
+		return err == nil
+	}
+
+	return failureSmokeTest{
+		testName:    fmt.Sprintf("%s/WritesStalled=true/LogsStalled=true", failures.CgroupsDiskStallName),
+		failureName: failures.CgroupsDiskStallName,
+		args: failures.DiskStallArgs{
+			StallWrites:  true,
+			RestartNodes: true,
+			Nodes:        stalledNode.InstallNodes(),
+			StallLogs:    true,
+		},
+		validateFailure: func(ctx context.Context, l *logger.Logger, c cluster.Cluster, f *failures.Failer) error {
+			// Confirm symlink exists
+			if err := c.RunE(ctx, option.WithNodes(stalledNode), "test -L logs"); err != nil {
+				return errors.Wrapf(err, "`logs` is not a symlink on node %d", stalledNode)
+			}
+
+			// The cockroach-sql-auth.log file is appended to each time an authenticated session event
+			// occurs, e.g. a client logging in. If we attempt to fetch a cookie from the stalled node,
+			// we should expect to see our request time out, as it will be unable to write to the log.
+			if getSessionCookie(ctx, l, c, stalledNode) {
+				return errors.Errorf("was able to successfully get session cookie from stalled node %d", stalledNode)
+			}
+
+			// The unaffected node should be able to write to the log, so we should be able to
+			// get the session cookie with no issues.
+			if !getSessionCookie(ctx, l, c, unaffectedNode) {
+				return errors.Errorf("was unable to get session cookie from unaffected node %d", unaffectedNode)
+			}
+			return nil
+		},
+		validateRecover: func(ctx context.Context, l *logger.Logger, c cluster.Cluster, f *failures.Failer) error {
+			if !getSessionCookie(ctx, l, c, stalledNode) {
+				return errors.Errorf("was unable to get session cookie from stalled node %d", stalledNode)
+			}
+			return nil
+		},
+		workload: func(ctx context.Context, c cluster.Cluster, args ...string) error {
+			return nil
+		},
+	}
+}
+
 var dmsetupDiskStallTest = func(c cluster.Cluster) failureSmokeTest {
 	rng, _ := randutil.NewPseudoRand()
 	// SeededRandGroups only returns an error if the requested size is larger than the
@@ -776,9 +841,7 @@ func defaultFailureSmokeTestWorkload(ctx context.Context, c cluster.Cluster, arg
 	return c.RunE(ctx, option.WithNodes(c.WorkloadNode()), cmd)
 }
 
-func setupFailureSmokeTests(
-	ctx context.Context, t test.Test, c cluster.Cluster, fr *failures.FailureRegistry,
-) error {
+func setupFailureSmokeTests(ctx context.Context, t test.Test, c cluster.Cluster) error {
 	// Download any dependencies needed.
 	if err := c.Install(ctx, t.L(), c.CRDBNodes(), "nmap"); err != nil {
 		return err
@@ -804,7 +867,7 @@ func setupFailureSmokeTests(
 func runFailureSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster, noopFailer bool) {
 	fr := failures.NewFailureRegistry()
 	fr.Register()
-	if err := setupFailureSmokeTests(ctx, t, c, fr); err != nil {
+	if err := setupFailureSmokeTests(ctx, t, c); err != nil {
 		t.Error(err)
 	}
 
@@ -815,6 +878,7 @@ func runFailureSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster, no
 		latencyTest(c),
 		dmsetupDiskStallTest(c),
 		resetVMTests(c),
+		cgroupStallLogsTest(c),
 	}
 	failureSmokeTests = append(failureSmokeTests, cgroupsDiskStallTests(c)...)
 	failureSmokeTests = append(failureSmokeTests, processKillTests(c)...)

--- a/pkg/roachprod/failureinjection/failures/BUILD.bazel
+++ b/pkg/roachprod/failureinjection/failures/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
         "latency.go",
         "network_partition.go",
         "noop.go",
+        "option.go",
         "process_kill.go",
         "registry.go",
         "reset.go",

--- a/pkg/roachprod/failureinjection/failures/disk_stall.go
+++ b/pkg/roachprod/failureinjection/failures/disk_stall.go
@@ -29,8 +29,10 @@ type CGroupDiskStaller struct {
 	GenericFailure
 }
 
-func MakeCgroupDiskStaller(clusterName string, l *logger.Logger, secure bool) (FailureMode, error) {
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+func MakeCgroupDiskStaller(
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
+) (FailureMode, error) {
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(clusterOpts.secure))
 	if err != nil {
 		return nil, err
 	}
@@ -361,9 +363,9 @@ type DmsetupDiskStaller struct {
 }
 
 func MakeDmsetupDiskStaller(
-	clusterName string, l *logger.Logger, secure bool,
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
 ) (FailureMode, error) {
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(clusterOpts.secure))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/failureinjection/failures/disk_stall.go
+++ b/pkg/roachprod/failureinjection/failures/disk_stall.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -63,27 +64,58 @@ func (s *CGroupDiskStaller) Description() string {
 func (s *CGroupDiskStaller) Setup(ctx context.Context, l *logger.Logger, args FailureArgs) error {
 	diskStallArgs := args.(DiskStallArgs)
 
-	// To stall logs we need to create a symlink that points to our stalled
-	// store directory. In order to do that we need to temporarily move the
-	// existing logs directory and copy the contents over after. If a symlink
-	// already exists, don't attempt to recreate it.
+	// Cgroup throttles a specific disk device, however our logs directory
+	// is usually mounted on a different device than our cockroach data. To
+	// stall both logs and the cockroach process, they must both be mounted
+	// on the same device. To do so, we create a new logs directory in our
+	// stalled device, e.g. {store-dir}/logs, and create a symlink from logs
+	// to that directory.
+	//
+	// If the cluster is already running, we want to make sure we don't lose
+	// any existing logs. We first move our existing logs to a temporary
+	// directory, before copying them into the new symlinked directory.
 	if diskStallArgs.StallLogs {
-		createSymlinkCmd := `
+		// N.B. Because multiple FS operations aren't atomic, we must temporarily
+		// stop the cluster before moving the logs directory.
+		if diskStallArgs.RestartNodes {
+			if err := s.StopCluster(ctx, l, roachprod.DefaultStopOpts()); err != nil {
+				return err
+			}
+		}
+
+		tmpLogsDir := fmt.Sprintf("tmp-disk-stall-%d", timeutil.Now().Unix())
+		createSymlinkCmd := fmt.Sprintf(`
 if [ ! -L logs ]; then
-	echo "creating symlink";
-	mkdir -p {store-dir}/logs;
-	ln -s {store-dir}/logs logs;
+    if [ -e logs ]; then
+				echo "moving existing logs to tmp directory %[1]s"
+				mv logs %[1]s
+    fi
+    mkdir -p {store-dir}/logs
+		echo "creating symlink logs -> {store-dir}/logs";
+    ln -s {store-dir}/logs logs
+		if [ -e %[1]s ]; then
+				echo "copying tmp directory %[1]s to logs";
+				cp -va %[1]s/* logs/
+		fi
+else
+		echo "symlink already exists, not creating";
 fi
-`
+`, tmpLogsDir)
 		if err := s.Run(ctx, l, diskStallArgs.Nodes, createSymlinkCmd); err != nil {
 			return err
+		}
+		if diskStallArgs.RestartNodes {
+			if err := s.StartCluster(ctx, l); err != nil {
+				return err
+			}
 		}
 	}
 	return nil
 }
 func (s *CGroupDiskStaller) Cleanup(ctx context.Context, l *logger.Logger, args FailureArgs) error {
+	diskStallArgs := args.(DiskStallArgs)
 	stallType := []bandwidthType{readBandwidth, writeBandwidth}
-	nodes := args.(DiskStallArgs).Nodes
+	nodes := diskStallArgs.Nodes
 
 	// Setting cgroup limits is idempotent so attempt to unlimit reads/writes in case
 	// something went wrong in Recover.
@@ -92,8 +124,21 @@ func (s *CGroupDiskStaller) Cleanup(ctx context.Context, l *logger.Logger, args 
 		l.PrintfCtx(ctx, "error unstalling the disk; stumbling on: %v", err)
 	}
 	if args.(DiskStallArgs).StallLogs {
-		if err = s.Run(ctx, l, nodes, "unlink logs/logs"); err != nil {
+		// Cleanup our symlinked logs. Similar to Setup(), we must first stop the cluster
+		// to stop the cockroach process from concurrently writing to the logs directory.
+		if err = s.Run(ctx, l, nodes, "unlink logs"); err != nil {
 			return err
+		}
+		if diskStallArgs.RestartNodes {
+			if err = s.StopCluster(ctx, l, roachprod.DefaultStopOpts()); err != nil {
+				return err
+			}
+		}
+		if err = s.Run(ctx, l, nodes, "cp -r {store-dir}/logs logs"); err != nil {
+			return err
+		}
+		if diskStallArgs.RestartNodes {
+			return s.StartCluster(ctx, l)
 		}
 	}
 	return nil

--- a/pkg/roachprod/failureinjection/failures/failer_test.go
+++ b/pkg/roachprod/failureinjection/failures/failer_test.go
@@ -144,9 +144,8 @@ func runTransitionStep(
 }
 
 func Test_FailerLifecycle(t *testing.T) {
-	fr := NewFailureRegistry()
-	fr.Register()
-	f, err := fr.GetFailer("", NoopFailureName, nilLogger(), false /* secure */)
+	fr := GetFailureRegistry()
+	f, err := fr.GetFailer("", NoopFailureName, nilLogger(), Secure(false))
 	require.NoError(t, err)
 
 	rng, _ := randutil.NewTestRand()

--- a/pkg/roachprod/failureinjection/failures/latency.go
+++ b/pkg/roachprod/failureinjection/failures/latency.go
@@ -53,9 +53,9 @@ func registerNetworkLatencyFailure(r *FailureRegistry) {
 }
 
 func MakeNetworkLatencyFailure(
-	clusterName string, l *logger.Logger, secure bool,
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
 ) (FailureMode, error) {
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(clusterOpts.secure))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/failureinjection/failures/network_partition.go
+++ b/pkg/roachprod/failureinjection/failures/network_partition.go
@@ -50,9 +50,9 @@ type IPTablesPartitionFailure struct {
 }
 
 func MakeIPTablesPartitionFailure(
-	clusterName string, l *logger.Logger, secure bool,
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
 ) (FailureMode, error) {
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(clusterOpts.secure))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/failureinjection/failures/noop.go
+++ b/pkg/roachprod/failureinjection/failures/noop.go
@@ -17,7 +17,9 @@ func registerNoopFailure(r *FailureRegistry) {
 	r.add(NoopFailureName, NoopFailureArgs{}, MakeNoopFailure)
 }
 
-func MakeNoopFailure(clusterName string, l *logger.Logger, secure bool) (FailureMode, error) {
+func MakeNoopFailure(
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
+) (FailureMode, error) {
 	return &NoopFailureMode{}, nil
 }
 

--- a/pkg/roachprod/failureinjection/failures/option.go
+++ b/pkg/roachprod/failureinjection/failures/option.go
@@ -1,0 +1,14 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package failures
+
+type ClusterOptionFunc func(*ClusterOptions)
+
+func Secure(secure bool) ClusterOptionFunc {
+	return func(o *ClusterOptions) {
+		o.secure = secure
+	}
+}

--- a/pkg/roachprod/failureinjection/failures/process_kill.go
+++ b/pkg/roachprod/failureinjection/failures/process_kill.go
@@ -35,9 +35,9 @@ func registerProcessKillFailure(r *FailureRegistry) {
 }
 
 func MakeProcessKillFailure(
-	clusterName string, l *logger.Logger, secure bool,
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
 ) (FailureMode, error) {
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(clusterOpts.secure))
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/failureinjection/failures/reset.go
+++ b/pkg/roachprod/failureinjection/failures/reset.go
@@ -32,8 +32,10 @@ func registerResetVM(r *FailureRegistry) {
 	r.add(ResetVMFailureName, ResetVMArgs{}, MakeResetVMFailure)
 }
 
-func MakeResetVMFailure(clusterName string, l *logger.Logger, secure bool) (FailureMode, error) {
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(secure))
+func MakeResetVMFailure(
+	clusterName string, l *logger.Logger, clusterOpts ClusterOptions,
+) (FailureMode, error) {
+	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(clusterOpts.secure))
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This change switches the roachtestutil disk staller to using the failureinjection library instead. We keep the roachtestutil disk staller interface for now, as it still provides some additional cluster spec validation, but will be replaced completely in the future.

Informs: #138970
Release note: none