### PR TITLE
release-25.2: fix spurious LDR DLQ entries

### DIFF
--- a/pkg/crosscluster/logical/BUILD.bazel
+++ b/pkg/crosscluster/logical/BUILD.bazel
@@ -119,6 +119,7 @@ go_library(
 go_test(
     name = "logical_test",
     srcs = [
+        "batch_handler_test.go",
         "create_logical_replication_stmt_test.go",
         "dead_letter_queue_test.go",
         "logical_replication_job_test.go",
@@ -153,6 +154,7 @@ go_test(
         "//pkg/crosscluster/streamclient/randclient",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
@@ -171,6 +173,7 @@ go_test(
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/lease",
         "//pkg/sql/catalog/resolver",
+        "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/execinfra",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
@@ -199,6 +202,7 @@ go_test(
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",

--- a/pkg/crosscluster/logical/batch_handler_test.go
+++ b/pkg/crosscluster/logical/batch_handler_test.go
@@ -183,8 +183,7 @@ func TestBatchHandlerExhaustive(t *testing.T) {
 	if uniqueConstraint {
 		runner.Exec(t, `ALTER TABLE test_table ADD CONSTRAINT unique_value UNIQUE (value)`)
 	}
-	// TODO(jeffswenson): enable this metamorphic option after fixing #146465.
-	if false && addAndRemoveColumn {
+	if addAndRemoveColumn {
 		runner.Exec(t, `ALTER TABLE test_table ADD COLUMN temp_col INT`)
 		runner.Exec(t, `ALTER TABLE test_table DROP COLUMN temp_col`)
 	}

--- a/pkg/crosscluster/logical/batch_handler_test.go
+++ b/pkg/crosscluster/logical/batch_handler_test.go
@@ -1,0 +1,391 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package logical
+
+import (
+	"context"
+	"fmt"
+	"math/rand"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
+	"github.com/stretchr/testify/require"
+)
+
+// EventBuilder helps construct StreamEvent_KV events for testing.
+type EventBuilder struct {
+	t         *testing.T
+	tableDesc catalog.TableDescriptor
+	colMap    catalog.TableColMap
+	codec     keys.SQLCodec
+}
+
+// newEventBuilder creates a new EventBuilder for the given table descriptor.
+func newKvEventBuilder(t *testing.T, desc *descpb.TableDescriptor) *EventBuilder {
+	tableDesc := tabledesc.NewBuilder(desc).BuildImmutableTable()
+	var colMap catalog.TableColMap
+	for i, col := range tableDesc.PublicColumns() {
+		colMap.Set(col.GetID(), i)
+	}
+	return &EventBuilder{
+		t:         t,
+		tableDesc: tableDesc,
+		colMap:    colMap,
+		codec:     keys.SystemSQLCodec,
+	}
+}
+
+func (b *EventBuilder) encodeRow(timestamp hlc.Timestamp, row tree.Datums) roachpb.KeyValue {
+	indexEntries, err := rowenc.EncodePrimaryIndex(
+		b.codec,
+		b.tableDesc,
+		b.tableDesc.GetPrimaryIndex(),
+		b.colMap,
+		row,
+		false,
+	)
+	require.NoError(b.t, err)
+	require.Len(b.t, indexEntries, 1)
+	kv := roachpb.KeyValue{
+		Key:   indexEntries[0].Key,
+		Value: indexEntries[0].Value,
+	}
+	kv.Value.Timestamp = timestamp
+	kv.Value.InitChecksum(kv.Key)
+	return kv
+}
+
+// insertEvent creates an insert event for the given row at the specified timestamp.
+func (b *EventBuilder) insertEvent(time hlc.Timestamp, row tree.Datums) streampb.StreamEvent_KV {
+	event := streampb.StreamEvent_KV{
+		KeyValue: b.encodeRow(time, row),
+	}
+	return event
+}
+
+// updateEvent creates an update event for the given row and previous values at the specified timestamp.
+func (b *EventBuilder) updateEvent(
+	time hlc.Timestamp, row tree.Datums, prevValue tree.Datums,
+) streampb.StreamEvent_KV {
+	kv := b.encodeRow(time, row)
+	kvPrev := b.encodeRow(time, prevValue)
+	return streampb.StreamEvent_KV{
+		KeyValue:  kv,
+		PrevValue: kvPrev.Value,
+	}
+}
+
+// deleteEvent creates a delete event for the given row at the specified timestamp.
+func (b *EventBuilder) deleteEvent(
+	time hlc.Timestamp, prevValue tree.Datums,
+) streampb.StreamEvent_KV {
+	kv := b.encodeRow(time, prevValue)
+	return streampb.StreamEvent_KV{
+		KeyValue: roachpb.KeyValue{
+			Key:   kv.Key,
+			Value: roachpb.Value{Timestamp: time},
+		},
+		PrevValue: kv.Value,
+	}
+}
+
+// newKvBatchHandler creates a new batch handler for testing.
+func newKvBatchHandler(
+	t *testing.T, s serverutils.ApplicationLayerInterface, tableName string,
+) (*kvRowProcessor, catalog.TableDescriptor) {
+	ctx := context.Background()
+	desc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), tree.Name(tableName))
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	handler, err := newKVRowProcessor(
+		ctx,
+		&execinfra.ServerConfig{
+			DB:           s.InternalDB().(descs.DB),
+			LeaseManager: s.LeaseManager(),
+			Settings:     s.ClusterSettings(),
+		},
+		&eval.Context{
+			Codec:            s.Codec(),
+			Settings:         s.ClusterSettings(),
+			SessionDataStack: sessiondata.NewStack(sd),
+		},
+		execinfrapb.LogicalReplicationWriterSpec{},
+		map[descpb.ID]sqlProcessorTableConfig{
+			desc.GetID(): {
+				srcDesc: desc,
+			},
+		},
+	)
+	require.NoError(t, err)
+	return handler, desc
+}
+
+// addAndRemoveColumn is a metamorphic test option that randomly decides whether
+// to add and remove a column to trigger a rebuild of the primary key.
+var addAndRemoveColumn = metamorphic.ConstantWithTestBool("batch-handler-exhaustive-rebuild-primary-index", false)
+
+// uniqueConstraint is a metamorphic test option that randomly decides whether
+// to add a unique constraint to the table.
+var uniqueConstraint = metamorphic.ConstantWithTestBool("batch-handler-exhaustive-unique-constraint", false)
+
+func TestBatchHandlerExhaustive(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// This test is an "exhaustive" test of the batch handler. It tries to test
+	// cross product of every possible (replication event type, local value,
+	// previous value, lww win).
+	//
+	// This doesn't test
+	// 1. Batches containing multiple rows or multiple events for the same row.
+	// 2. Events that are supposed to be DLQ'd, like unique constraint
+	// violations or foreign key violations.
+
+	ctx := context.Background()
+	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(ctx)
+	s := srv.ApplicationLayer()
+	runner := sqlutils.MakeSQLRunner(sqlDB)
+
+	// TODO(jeffswenson): improve this test so that it uses a random schema.
+
+	// Create a test table with an index
+	runner.Exec(t, `
+		CREATE TABLE test_table (
+			id INT PRIMARY KEY,
+			value STRING
+		)
+	`)
+
+	if uniqueConstraint {
+		runner.Exec(t, `ALTER TABLE test_table ADD CONSTRAINT unique_value UNIQUE (value)`)
+	}
+	// TODO(jeffswenson): enable this metamorphic option after fixing #146465.
+	if false && addAndRemoveColumn {
+		runner.Exec(t, `ALTER TABLE test_table ADD COLUMN temp_col INT`)
+		runner.Exec(t, `ALTER TABLE test_table DROP COLUMN temp_col`)
+	}
+
+	handler, desc := newKvBatchHandler(t, s, "test_table")
+	defer handler.ReleaseLeases(ctx)
+
+	// TODO(jeffswenson): test the other handler types.
+	eventBuilder := newKvEventBuilder(t, desc.TableDesc())
+
+	type previousValue string
+	const (
+		previousValuePresent previousValue = "present"
+		previousValueAbsent  previousValue = "absent"
+	)
+	previousValues := []previousValue{
+		previousValuePresent,
+		previousValueAbsent,
+	}
+
+	type localValue string
+	const (
+		// The local value is the same as the previous value supplied by the
+		// event.
+		localValueMatch localValue = "previous-value"
+		// The local value is different from the previous value supplied by the
+		// event.
+		localValueMismatch localValue = "different-value"
+		// The local value never existed in the database.
+		localValueNull localValue = "null-value"
+		// The local value is a tombstone.
+		localValueTombstone localValue = "tombstone-value"
+		// The local value is the same as the replication value supplied by the
+		// event.
+		localValueReplay localValue = "replay-value"
+	)
+	localValues := []localValue{
+		localValueMatch,
+		localValueMismatch,
+		localValueNull,
+		localValueTombstone,
+		localValueReplay,
+	}
+
+	type replicationType string
+	const (
+		replicationTypeUpdate replicationType = "update"
+		replicationTypeInsert replicationType = "insert"
+		replicationTypeDelete replicationType = "delete"
+	)
+	replicationTypes := []replicationType{
+		replicationTypeUpdate,
+		replicationTypeInsert,
+		replicationTypeDelete,
+	}
+
+	start := s.Clock().Now()
+
+	type testCase struct {
+		id              int
+		previousValue   previousValue
+		localValue      localValue
+		replicationType replicationType
+		winLww          bool
+	}
+	testCaseName := func(tc testCase) string {
+		return fmt.Sprintf("replication-type=%s:previous-value=%s:local-value=%s:win-lww=%t", tc.replicationType, tc.previousValue, tc.localValue, tc.winLww)
+	}
+	getPreviousValue := func(tc testCase) string {
+		if tc.previousValue == previousValuePresent {
+			return fmt.Sprintf("previous-value-%s", testCaseName(tc))
+		}
+		return ""
+	}
+	getEventValue := func(tc testCase) string {
+		if tc.replicationType == replicationTypeDelete {
+			return ""
+		}
+		return fmt.Sprintf("new-value-%s", testCaseName(tc))
+	}
+	getEvent := func(tc testCase) streampb.StreamEvent_KV {
+		origin := start
+		if tc.winLww {
+			origin = s.Clock().Now()
+		}
+		switch tc.replicationType {
+		case replicationTypeUpdate:
+			return eventBuilder.updateEvent(
+				origin,
+				[]tree.Datum{tree.NewDInt(tree.DInt(tc.id)), tree.NewDString(getEventValue(tc))},
+				[]tree.Datum{tree.NewDInt(tree.DInt(tc.id)), tree.NewDString(getPreviousValue(tc))},
+			)
+		case replicationTypeInsert:
+			return eventBuilder.insertEvent(
+				origin,
+				[]tree.Datum{tree.NewDInt(tree.DInt(tc.id)), tree.NewDString(getEventValue(tc))},
+			)
+		case replicationTypeDelete:
+			return eventBuilder.deleteEvent(
+				origin,
+				[]tree.Datum{tree.NewDInt(tree.DInt(tc.id)), tree.NewDString(getPreviousValue(tc))},
+			)
+		default:
+			panic(fmt.Sprintf("unknown replication type: %s", tc.replicationType))
+		}
+	}
+	getLocalValue := func(tc testCase) string {
+		switch tc.localValue {
+		case localValueMatch:
+			return getPreviousValue(tc)
+		case localValueMismatch:
+			return fmt.Sprintf("value-mismatch-%d", tc.id)
+		case localValueReplay:
+			return getEventValue(tc)
+		}
+		return ""
+	}
+
+	// Construct the Cartesian product of all the possible test cases.
+	var testCases []testCase
+	id := rand.Intn(10000) // Start at a non-zero value to avoid bugs that are papered over by ordered ids.
+	for _, previousValue := range previousValues {
+		for _, localValue := range localValues {
+			for _, replicationType := range replicationTypes {
+				for _, winLww := range []bool{true, false} {
+
+					if !winLww {
+						if localValue == localValueNull {
+							// If there is no tombstone or local row, then its
+							// impossible to lose lww. So skip the test case.
+							continue
+						}
+						if localValue == localValueMatch && previousValue == previousValueAbsent {
+							// If the local value matches the previous value,
+							// but the replication event does not have a
+							// previous value, then it's impossible to lose lww.
+							// So skip the test case.
+							continue
+						}
+					}
+
+					testCases = append(testCases, testCase{
+						id:              id,
+						previousValue:   previousValue,
+						localValue:      localValue,
+						replicationType: replicationType,
+						winLww:          winLww,
+					})
+					id++
+				}
+			}
+		}
+	}
+
+	// Initialize the database with the specified local values.
+	for _, tc := range testCases {
+		switch tc.localValue {
+		case localValueNull:
+			// Do nothing
+		case localValueTombstone:
+			runner.Exec(t, fmt.Sprintf(`INSERT INTO test_table (id, value) VALUES (%d, 'old-value-%d')`, tc.id, rand.Int()))
+			runner.Exec(t, fmt.Sprintf(`DELETE FROM test_table WHERE id = %d`, tc.id))
+		default:
+			value := getLocalValue(tc)
+			if value == "" {
+				continue
+			}
+			runner.Exec(t, fmt.Sprintf(`INSERT INTO test_table (id, value) VALUES (%d, '%s')`, tc.id, value))
+		}
+	}
+
+	// TODO(jeffswenson): metamorphically enable batching
+	for _, tc := range testCases {
+		_, err := handler.HandleBatch(ctx, []streampb.StreamEvent_KV{getEvent(tc)})
+		require.NoError(t, err)
+	}
+
+	found := map[string]string{}
+	results := runner.QueryStr(t, `SELECT id, value FROM test_table`)
+	for _, row := range results {
+		found[row[0]] = row[1]
+	}
+
+	for _, tc := range testCases {
+		id := fmt.Sprintf("%d", tc.id)
+		var expected string
+		switch {
+		case tc.winLww && tc.replicationType != replicationTypeDelete:
+			expected = getEventValue(tc)
+		case !tc.winLww:
+			expected = getLocalValue(tc)
+		}
+		caseDesc := testCaseName(tc) // Get test case description for assertion messages
+		if expected == "" {
+			require.NotContains(t, found, id, "expected row %s to be deleted. Test case: %s", id, caseDesc)
+		} else {
+			require.Contains(t, found, id, "expected row %s to exist, but it was not found. Test case: %s", id, caseDesc)
+			require.Equal(t, expected, found[id], "mismatch for row %s. Test case: %s", id, caseDesc)
+		}
+	}
+
+	// TODO(jeffswenson): find a way to validate that all indexes are in a valid
+	// state.
+}

--- a/pkg/crosscluster/logical/table_batch_handler_test.go
+++ b/pkg/crosscluster/logical/table_batch_handler_test.go
@@ -7,89 +7,60 @@ package logical
 
 import (
 	"context"
-	"fmt"
-	"math/rand"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/desctestutils"
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog/lease"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
-	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
-	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/stretchr/testify/require"
 )
 
-type eventBuilder struct {
-	descID descpb.ID
-}
-
-func newEventBuilder(
-	t *testing.T, runner *sqlutils.SQLRunner, s serverutils.ApplicationLayerInterface,
-) *eventBuilder {
-	runner.Exec(t, `
-		CREATE TABLE test_table (
-			id STRING PRIMARY KEY,
-			value STRING
-		);
-	`)
-
-	// Get the actual table descriptor
-	desc := desctestutils.TestingGetPublicTableDescriptor(s.DB(), s.Codec(), "defaultdb", "test_table")
-
-	return &eventBuilder{
-		descID: desc.GetID(),
-	}
-}
-
-func (e *eventBuilder) makeInsert(id string, value string, timestamp hlc.Timestamp) decodedEvent {
-	return decodedEvent{
-		dstDescID:       e.descID,
-		isDelete:        false,
-		originTimestamp: timestamp,
-		row:             tree.Datums{tree.NewDString(id), tree.NewDString(value)},
-	}
-}
-
-func (e *eventBuilder) makeUpdate(
-	id string, old, new string, timestamp hlc.Timestamp,
-) decodedEvent {
-	return decodedEvent{
-		dstDescID:       e.descID,
-		isDelete:        false,
-		originTimestamp: timestamp,
-		row:             tree.Datums{tree.NewDString(id), tree.NewDString(new)},
-		prevRow:         tree.Datums{tree.NewDString(id), tree.NewDString(old)},
-	}
-}
-
-func (e *eventBuilder) makeDelete(id string, value string, timestamp hlc.Timestamp) decodedEvent {
-	return decodedEvent{
-		dstDescID:       e.descID,
-		isDelete:        true,
-		originTimestamp: timestamp,
-		row:             tree.Datums{tree.NewDString(id), tree.DNull},
-		prevRow:         tree.Datums{tree.NewDString(id), tree.NewDString(value)},
-	}
-}
-
-func newTestTableHandler(
-	t *testing.T, descID descpb.ID, s serverutils.ApplicationLayerInterface,
-) *tableHandler {
-	sd := sql.NewInternalSessionData(context.Background(), s.ClusterSettings(), "" /* opName */)
-	handler, err := newTableHandler(context.Background(), descID, s.InternalDB().(descs.DB), s.Codec(), sd, 1337, s.LeaseManager().(*lease.Manager), s.ClusterSettings())
+func newCrudBatchHandler(
+	t *testing.T, s serverutils.ApplicationLayerInterface, tableName string,
+) (*sqlCrudWriter, catalog.TableDescriptor) {
+	ctx := context.Background()
+	desc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), tree.Name(tableName))
+	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)
+	handler, err := newCrudSqlWriter(
+		ctx,
+		&execinfra.ServerConfig{
+			DB:           s.InternalDB().(descs.DB),
+			Codec:        s.Codec(),
+			LeaseManager: s.LeaseManager(),
+			Settings:     s.ClusterSettings(),
+		},
+		&eval.Context{
+			Codec:            s.Codec(),
+			Settings:         s.ClusterSettings(),
+			SessionDataStack: sessiondata.NewStack(sd),
+		},
+		sd,
+		jobspb.LogicalReplicationDetails_DiscardNothing,
+		map[descpb.ID]sqlProcessorTableConfig{
+			desc.GetID(): {
+				srcDesc: desc,
+			},
+		},
+		0, // jobID
+	)
 	require.NoError(t, err)
-	return handler
+	return handler, desc
 }
 
-func TestTableHandlerFastPath(t *testing.T) {
+func TestBatchHandlerFastPath(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -98,87 +69,144 @@ func TestTableHandlerFastPath(t *testing.T) {
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 	runner := sqlutils.MakeSQLRunner(sqlDB)
-	eb := newEventBuilder(t, runner, s)
-	handler := newTestTableHandler(t, eb.descID, s)
 
-	// Apply a batch with inserts to popluate some data
-	stats, err := handler.handleDecodedBatch(ctx, []decodedEvent{
-		eb.makeInsert("1", "foo", s.Clock().Now()),
-		eb.makeInsert("2", "bar", s.Clock().Now()),
+	// Create a test table with an index
+	runner.Exec(t, `
+		CREATE TABLE test_table (
+			id INT PRIMARY KEY,
+			value STRING
+		)
+	`)
+
+	handler, desc := newCrudBatchHandler(t, s, "test_table")
+	defer handler.ReleaseLeases(ctx)
+	eb := newKvEventBuilder(t, desc.TableDesc())
+
+	// Apply a batch with inserts to populate some data
+	_, err := handler.HandleBatch(ctx, []streampb.StreamEvent_KV{
+		eb.insertEvent(s.Clock().Now(), []tree.Datum{
+			tree.NewDInt(tree.DInt(1)),
+			tree.NewDString("foo"),
+		}),
+		eb.insertEvent(s.Clock().Now(), []tree.Datum{
+			tree.NewDInt(tree.DInt(2)),
+			tree.NewDString("bar"),
+		}),
 	})
 	require.NoError(t, err)
-	require.Equal(t, tableBatchStats{inserts: 2}, stats)
+	// TODO(jeffswenson): fix stats
+	//require.Equal(t, batchStats{inserts: 2}, stats)
 	runner.CheckQueryResults(t, `SELECT id, value FROM test_table`, [][]string{
 		{"1", "foo"},
 		{"2", "bar"},
 	})
 
 	// Apply a batch with updates and deletes for the previously written rows
-	stats, err = handler.handleDecodedBatch(ctx, []decodedEvent{
-		eb.makeUpdate("1", "foo", "foo-update", s.Clock().Now()),
-		eb.makeDelete("2", "bar", s.Clock().Now()),
+	_, err = handler.HandleBatch(ctx, []streampb.StreamEvent_KV{
+		eb.updateEvent(s.Clock().Now(),
+			[]tree.Datum{tree.NewDInt(tree.DInt(1)), tree.NewDString("foo-update")},
+			[]tree.Datum{tree.NewDInt(tree.DInt(1)), tree.NewDString("foo")},
+		),
+		eb.deleteEvent(s.Clock().Now(), []tree.Datum{
+			tree.NewDInt(tree.DInt(2)),
+			tree.NewDString("bar"),
+		}),
 	})
 	require.NoError(t, err)
-	require.Equal(t, tableBatchStats{updates: 1, deletes: 1}, stats)
+	// TODO(jeffswenson): fix stats
+	//require.Equal(t, batchStats{updates: 1, deletes: 1}, stats)
 	runner.CheckQueryResults(t, `SELECT id, value FROM test_table`, [][]string{
 		{"1", "foo-update"},
 	})
-
 }
 
-func TestTableHandlerSlowPath(t *testing.T) {
+func TestBatchHandlerSlowPath(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 
-	eb := newEventBuilder(t, runner, s)
+	// Create a test table with an index
+	runner.Exec(t, `
+		CREATE TABLE test_table (
+			id INT PRIMARY KEY,
+			value STRING
+		)
+	`)
 
-	handler := newTestTableHandler(t, eb.descID, s)
+	handler, desc := newCrudBatchHandler(t, s, "test_table")
+	defer handler.ReleaseLeases(ctx)
+	eb := newKvEventBuilder(t, desc.TableDesc())
 
 	runner.Exec(t, `
 		INSERT INTO test_table (id, value) VALUES 
-		('a', 'alpha'), ('b', 'beta'), ('c', 'gamma');
+		(1, 'alpha'), (2, 'beta'), (3, 'gamma');
 	`)
 
-	stats, err := handler.handleDecodedBatch(ctx, []decodedEvent{
-		eb.makeInsert("a", "alpha-update", s.Clock().Now()),
-		eb.makeUpdate("b", "wrong", "beta-update", s.Clock().Now()),
-		eb.makeDelete("c", "wrong", s.Clock().Now()),
-		// TODO(jeffswenson): add tombstone case
-		eb.makeDelete("d", "never-existed", s.Clock().Now()),
-		eb.makeUpdate("e", "never-existed", "omega-insert", s.Clock().Now()),
+	_, err := handler.HandleBatch(ctx, []streampb.StreamEvent_KV{
+		eb.insertEvent(s.Clock().Now(), []tree.Datum{
+			tree.NewDInt(tree.DInt(1)),
+			tree.NewDString("alpha-update"),
+		}),
+		eb.updateEvent(s.Clock().Now(),
+			[]tree.Datum{tree.NewDInt(tree.DInt(2)), tree.NewDString("beta-update")},
+			[]tree.Datum{tree.NewDInt(tree.DInt(2)), tree.NewDString("wrong")},
+		),
+		eb.deleteEvent(s.Clock().Now(), []tree.Datum{
+			tree.NewDInt(tree.DInt(3)),
+			tree.NewDString("wrong"),
+		}),
+		eb.deleteEvent(s.Clock().Now(), []tree.Datum{
+			tree.NewDInt(tree.DInt(4)),
+			tree.NewDString("never-existed"),
+		}),
+		eb.updateEvent(s.Clock().Now(),
+			[]tree.Datum{tree.NewDInt(tree.DInt(5)), tree.NewDString("omega-insert")},
+			[]tree.Datum{tree.NewDInt(tree.DInt(5)), tree.NewDString("never-existed")},
+		),
 	})
 	require.NoError(t, err)
-	require.Equal(t,
-		tableBatchStats{inserts: 1, updates: 2, deletes: 1, tombstoneUpdates: 1, refreshedRows: 5},
-		stats)
+	// TODO(jeffswenson): fix stats
+	//require.Equal(t,
+	//	batchStats{inserts: 1, updates: 2, deletes: 1, tombstoneUpdates: 1, refreshedRows: 5},
+	//	stats)
 
 	runner.CheckQueryResults(t, `SELECT id, value FROM test_table`, [][]string{
-		{"a", "alpha-update"}, // a was processed as an update
-		{"b", "beta-update"},  // b was processed as an update
-		// c is deleted, so it should not be in the result
-		// d has an update tombstone
-		{"e", "omega-insert"}, // e was processed as an insert
+		{"1", "alpha-update"}, // 1 was processed as an update
+		{"2", "beta-update"},  // 2 was processed as an update
+		// 3 is deleted, so it should not be in the result
+		// 4 has an update tombstone
+		{"5", "omega-insert"}, // 5 was processed as an insert
 	})
 }
 
-func TestTableHandlerDuplicateBatchEntries(t *testing.T) {
+func TestBatchHandlerDuplicateBatchEntries(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
 	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
+
 	defer srv.Stopper().Stop(ctx)
 	s := srv.ApplicationLayer()
 	runner := sqlutils.MakeSQLRunner(sqlDB)
 
-	eb := newEventBuilder(t, runner, s)
-	handler := newTestTableHandler(t, eb.descID, s)
+	// Create a test table with an index
+	runner.Exec(t, `
+		CREATE TABLE test_table (
+			id INT PRIMARY KEY,
+			value STRING
+		)
+	`)
+
+	handler, desc := newCrudBatchHandler(t, s, "test_table")
+	defer handler.ReleaseLeases(ctx)
+	eb := newKvEventBuilder(t, desc.TableDesc())
 
 	before := s.Clock().Now()
 	after := s.Clock().Now()
@@ -186,206 +214,18 @@ func TestTableHandlerDuplicateBatchEntries(t *testing.T) {
 	// TODO(jeffswenson): think about the different weird grouped batches that
 	// could exist. Is it sensitive to order? What happens when an update chain
 	// hits a refresh?
-	_, err := handler.handleDecodedBatch(ctx, []decodedEvent{
-		eb.makeUpdate("a", "wrong-value", "insert-followed-by-delete", before),
-		eb.makeDelete("a", "insert-followed-by-delete", after),
+	_, err := handler.HandleBatch(ctx, []streampb.StreamEvent_KV{
+		eb.updateEvent(before,
+			[]tree.Datum{tree.NewDInt(tree.DInt(1)), tree.NewDString("insert-followed-by-delete")},
+			[]tree.Datum{tree.NewDInt(tree.DInt(1)), tree.NewDString("wrong-value")},
+		),
+		eb.deleteEvent(after, []tree.Datum{
+			tree.NewDInt(tree.DInt(1)),
+			tree.NewDString("insert-followed-by-delete"),
+		}),
 	})
 	// The update causes a refresh and then after the refresh, the delete ends up
 	// taking the update tombstone path because there is no local row, but the
 	// cput fails because it observes the insert/delete.
 	require.ErrorContains(t, err, "unexpected value")
-}
-
-func TestTableHandlerExhaustive(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	// TODO(jeffswenson): re-enable this test
-	skip.WithIssue(t, 146217, "crud writer does not correctly implement lww")
-
-	// This test is an "exhaustive" test of the table handler. It tries to test
-	// cross product of every possible (replication event type, local value,
-	// previous value, lww win).
-	//
-	// Some things that aren't tested:
-	// 1. Batches containing multiple events of the same row.
-	// 2. The optimistic path. Since the batch is guaranteed to fail the first
-	//    apply attempt, it always takes the read refresh path.
-
-	ctx := context.Background()
-	srv, sqlDB, _ := serverutils.StartServer(t, base.TestServerArgs{})
-	defer srv.Stopper().Stop(ctx)
-	s := srv.ApplicationLayer()
-	runner := sqlutils.MakeSQLRunner(sqlDB)
-
-	eb := newEventBuilder(t, runner, s)
-
-	handler := newTestTableHandler(t, eb.descID, s)
-
-	type previousValue string
-	const (
-		previousValuePresent previousValue = "present"
-		previousValueAbsent  previousValue = "absent"
-	)
-	previousValues := []previousValue{
-		previousValuePresent,
-		previousValueAbsent,
-	}
-
-	type localValue string
-	const (
-		// The local value is the same as the previous value supplied by the
-		// event.
-		localValueMatch localValue = "previous-value"
-		// The local value is different from the previous value supplied by the
-		// event.
-		localValueMismatch localValue = "different-value"
-		// The local value never existed in the database.
-		localValueNull localValue = "null-value"
-		// The local value is a tombstone.
-		localValueTombstone localValue = "tombstone-value"
-	)
-	localValues := []localValue{
-		localValueMatch,
-		localValueMismatch,
-		localValueNull,
-		localValueTombstone,
-	}
-
-	type replicationType string
-	const (
-		replicationTypeUpdate replicationType = "update"
-		replicationTypeInsert replicationType = "insert"
-		replicationTypeDelete replicationType = "delete"
-	)
-	replicationTypes := []replicationType{
-		replicationTypeUpdate,
-		replicationTypeInsert,
-		replicationTypeDelete,
-	}
-
-	start := s.Clock().Now()
-
-	type testCase struct {
-		id              int
-		previousValue   previousValue
-		localValue      localValue
-		replicationType replicationType
-		winLww          bool
-	}
-	testCaseName := func(tc testCase) string {
-		return fmt.Sprintf("replication-type=%s:previous-value=%s:local-value=%s:win-lww=%t", tc.replicationType, tc.previousValue, tc.localValue, tc.winLww)
-	}
-	getPreviousValue := func(tc testCase) string {
-		if tc.previousValue == previousValuePresent {
-			return fmt.Sprintf("previous-value-%s", testCaseName(tc))
-		}
-		return ""
-	}
-	getNewValue := func(tc testCase) string {
-		return fmt.Sprintf("new-value-%s", testCaseName(tc))
-	}
-	getDecodedEvent := func(tc testCase) decodedEvent {
-		origin := start
-		if tc.winLww {
-			origin = s.Clock().Now()
-		}
-		switch tc.replicationType {
-		case replicationTypeUpdate:
-			return eb.makeUpdate(fmt.Sprintf("%d", tc.id), getPreviousValue(tc), getNewValue(tc), origin)
-		case replicationTypeInsert:
-			return eb.makeInsert(fmt.Sprintf("%d", tc.id), getNewValue(tc), origin)
-		case replicationTypeDelete:
-			return eb.makeDelete(fmt.Sprintf("%d", tc.id), getPreviousValue(tc), origin)
-		default:
-			panic(fmt.Sprintf("unknown replication type: %s", tc.replicationType))
-		}
-	}
-	getLocalValue := func(tc testCase) string {
-		switch tc.localValue {
-		case localValueMatch:
-			return getPreviousValue(tc)
-		case localValueMismatch:
-			return fmt.Sprintf("value-mismatch-%d", tc.id)
-		}
-		return ""
-	}
-
-	// Construct the Cartesian product of all the possible test cases.
-	var testCases []testCase
-	id := 1337 // Start at a non-zero value to avoid bugs that are papered over by ordered ids.
-	for _, previousValue := range previousValues {
-		for _, localValue := range localValues {
-			for _, replicationType := range replicationTypes {
-				for _, winLww := range []bool{true, false} {
-
-					if !winLww {
-						// If there is no tombstone or local row, then its
-						// impossible to lose lww. So skip the test case.
-						if localValue == localValueNull {
-							continue
-						}
-						if localValue == localValueMatch && previousValue == previousValueAbsent {
-							continue
-						}
-					}
-
-					testCases = append(testCases, testCase{
-						id:              id,
-						previousValue:   previousValue,
-						localValue:      localValue,
-						replicationType: replicationType,
-						winLww:          winLww,
-					})
-					id++
-				}
-			}
-		}
-	}
-
-	// Initialize the database with the specified local values.
-	for _, tc := range testCases {
-		switch tc.localValue {
-		case localValueMatch, localValueMismatch:
-			value := getLocalValue(tc)
-			if value == "" {
-				continue
-			}
-			runner.Exec(t, fmt.Sprintf(`INSERT INTO test_table (id, value) VALUES ('%d', '%s')`, tc.id, value))
-		case localValueNull:
-			// Do nothing
-		case localValueTombstone:
-			runner.Exec(t, fmt.Sprintf(`INSERT INTO test_table (id, value) VALUES ('%d', 'old-value-%d')`, tc.id, rand.Int()))
-			runner.Exec(t, fmt.Sprintf(`DELETE FROM test_table WHERE id = '%d'`, tc.id))
-		}
-	}
-
-	batch := make([]decodedEvent, 0, len(testCases))
-	for _, tc := range testCases {
-		batch = append(batch, getDecodedEvent(tc))
-	}
-	_, err := handler.handleDecodedBatch(ctx, batch)
-	require.NoError(t, err)
-
-	found := map[string]string{}
-	results := runner.QueryStr(t, `SELECT id, value FROM test_table`)
-	for _, row := range results {
-		found[row[0]] = row[1]
-	}
-
-	for _, tc := range testCases {
-		id := fmt.Sprintf("%d", tc.id)
-		var expected string
-		switch {
-		case tc.winLww && tc.replicationType != replicationTypeDelete:
-			expected = getNewValue(tc)
-		case !tc.winLww:
-			expected = getLocalValue(tc)
-		}
-		if expected == "" {
-			require.NotContains(t, found, id, "expected row %s to be deleted", id)
-		} else {
-			require.Equal(t, expected, found[id], "expected row %s to be %s", id, expected)
-		}
-	}
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1678,9 +1678,19 @@ func maybeSwapErrorIndex(pErr *kvpb.Error, a, b int) {
 }
 
 // mergeErrors merges the two errors, combining their transaction state and
-// returning the error with the highest priority.
+// returning the error with the highest priority. If errors have the same
+// priority, the error with the lowest request index is preferred. This allows
+// a caller issuing multiple cputs to control which ConditionFailedError is
+// returned. Specifically, it allows returning a primary key cput failure
+// instead of a unique index conflict.
 func mergeErrors(pErr1, pErr2 *kvpb.Error) *kvpb.Error {
 	ret, drop := pErr1, pErr2
+
+	hasIndex := ret.Index != nil && drop.Index != nil
+	if hasIndex && drop.Index.Index < ret.Index.Index {
+		ret, drop = drop, ret
+	}
+
 	if kvpb.ErrPriority(drop.GoError()) > kvpb.ErrPriority(ret.GoError()) {
 		ret, drop = drop, ret
 	}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "logical: batch handler exhaustive test" (#147001)
  * 1/1 commits from "kvcoord: deterministic error ordering" (#147117)

Please see individual PRs for details.

Release justification: fixes #145994 which was discovered in customer environments. 

/cc @cockroachdb/release
