### PR TITLE
roachtest: add test for online restore recovery on missing ssts

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
@@ -95,6 +96,25 @@ func registerBackupRestoreRoundTrip(r registry.Registry) {
 			},
 		})
 	}
+}
+
+func registerOnlineRestoreRecovery(r registry.Registry) {
+	r.Add(registry.TestSpec{
+		Name:                       "backup-restore/online-restore-recovery",
+		Timeout:                    4 * time.Hour,
+		Owner:                      registry.OwnerDisasterRecovery,
+		Cluster:                    r.MakeClusterSpec(4, spec.WorkloadNode()),
+		EncryptionSupport:          registry.EncryptionMetamorphic,
+		NativeLibs:                 registry.LibGEOS,
+		CompatibleClouds:           registry.Clouds(spec.GCE, spec.Local),
+		Suites:                     registry.Suites(registry.Nightly),
+		TestSelectionOptOutSuites:  registry.Suites(registry.Nightly),
+		Randomized:                 true,
+		RequiresDeprecatedWorkload: true, // uses schemachange
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			testOnlineRestoreRecovery(ctx, t, c)
+		},
+	})
 }
 
 // backup-restore/round-trip tests that a round trip of creating a backup and
@@ -415,4 +435,138 @@ func createDriversForBackupRestore(
 		return nil, nil, nil, err
 	}
 	return d, runBackgroundWorkload, tables, nil
+}
+
+func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Cluster) {
+	testRNG, seed := randutil.NewLockedPseudoRand()
+	t.L().Printf("random seed: %d", seed)
+
+	c.Start(ctx, t.L(), roachtestutil.MaybeUseMemoryBudget(t, 50), install.MakeClusterSettings(), c.CRDBNodes())
+	m := c.NewMonitor(ctx, c.CRDBNodes())
+	const jobStatusWait = time.Minute * 5
+
+	m.Go(func(ctx context.Context) error {
+		testUtils, err := setupBackupRestoreTestUtils(
+			ctx, t, c, m, testRNG,
+			withOnlineRestore(true), withCompaction(true),
+		)
+		if err != nil {
+			return err
+		}
+		defer testUtils.CloseConnections()
+
+		dbs := []string{"bank", "tpcc", schemaChangeDB}
+		d, runBackgroundWorkload, _, err := createDriversForBackupRestore(
+			ctx, t, c, m, testRNG, testUtils, dbs,
+		)
+		if err != nil {
+			return err
+		}
+
+		stopBackgroundCommands, err := runBackgroundWorkload()
+		if err != nil {
+			return err
+		}
+		defer stopBackgroundCommands()
+
+		dbConn := c.Conn(ctx, t.L(), c.CRDBNodes().RandNode()[0])
+		defer dbConn.Close()
+
+		allNodes := labeledNodes{Nodes: c.CRDBNodes(), Version: clusterupgrade.CurrentVersion().String()}
+		bspec := backupSpec{
+			Plan:    allNodes,
+			Execute: allNodes,
+		}
+
+		t.L().Printf("starting backup")
+		collection, err := d.createBackupCollection(
+			ctx, t.L(), t, testRNG, bspec, bspec, "online-restore-recovery-backup",
+			true /* internalSystemsJobs */, false, /* isMultitenant */
+		)
+		if err != nil {
+			return err
+		}
+
+		// If we're running a cluster backup, we need to reset the cluster
+		// to restore it. We also intentionally stop background commands so
+		// the workloads don't report errors.
+		if _, ok := collection.btype.(*clusterBackup); ok {
+			t.L().Printf("resetting cluster before restoring full cluster backup")
+			stopBackgroundCommands()
+			expectDeathsFn := func(n int) {
+				m.ExpectDeaths(int32(n))
+			}
+
+			// Between each reset grab a debug zip from the cluster.
+			zipPath := fmt.Sprintf("debug-%d.zip", timeutil.Now().Unix())
+			if err := testUtils.cluster.FetchDebugZip(ctx, t.L(), zipPath); err != nil {
+				t.L().Printf("failed to fetch a debug zip: %v", err)
+			}
+			if err := testUtils.resetCluster(
+				ctx, t.L(), clusterupgrade.CurrentVersion(), expectDeathsFn, []install.ClusterSettingOption{},
+			); err != nil {
+				return err
+			}
+		}
+
+		// We set this pausepoint so that the download job is paused before it
+		// begins downloading external files. This allows us to guarantee that when
+		// we delete an SST file, it won't have already been downloaded by the
+		// download phase and therefore not trigger a failure.
+		if _, err := dbConn.ExecContext(
+			ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = 'restore.before_download'",
+		); err != nil {
+			return errors.Wrap(err, "failed to set pausepoint for online restore")
+		}
+
+		t.L().Printf("performing online restore of backup")
+		if _, _, err := d.runRestore(
+			ctx, t.L(), testRNG, collection, false /* checkFiles */, true, /* internalSystemJobs */
+		); err != nil {
+			return err
+		}
+		downloadJobID, err := d.getORDownloadJobID(ctx, t.L(), testRNG)
+		if err != nil {
+			return err
+		}
+		if err := WaitForPaused(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
+			return errors.Wrapf(
+				err, "waiting for download job %v to reach paused state", downloadJobID,
+			)
+		}
+
+		if _, err := dbConn.ExecContext(
+			ctx, "SET CLUSTER SETTING jobs.debug.pausepoints = ''",
+		); err != nil {
+			return errors.Wrap(err, "failed to remove pausepoint for online restore")
+		}
+
+		t.L().Printf("deleting sst from backup")
+		if err := d.deleteRandomSST(ctx, t.L(), dbConn, collection); err != nil {
+			return err
+		}
+		if _, err := dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID); err != nil {
+			return errors.Wrapf(
+				err, "failed to resume download job %v after deleting sst", downloadJobID,
+			)
+		}
+		if err := WaitForResume(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait); err != nil {
+			return errors.Wrapf(
+				err, "waiting for download job %v to reach resumed state", downloadJobID,
+			)
+		}
+		if err := errors.Wrapf(
+			WaitForFailed(ctx, dbConn, jobspb.JobID(downloadJobID), jobStatusWait),
+			"waiting for download job %v to reach failed state", downloadJobID,
+		); err != nil {
+			return errors.Wrapf(
+				err, "waiting for download job %v to reach failed state", downloadJobID,
+			)
+		}
+		return errors.Wrapf(
+			checkNoExternalBytesRemaining(ctx, dbConn),
+			"cluster did not cleanup all external files after download phase failure",
+		)
+	})
+	m.Wait()
 }

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -223,6 +223,8 @@ func WaitForRunning(
 		}, maxWait)
 }
 
+// WaitForSucceeded waits for a job to reach the succeeded state from a running
+// state.
 func WaitForSucceeded(
 	ctx context.Context, db *gosql.DB, jobID jobspb.JobID, maxWait time.Duration,
 ) error {
@@ -232,6 +234,61 @@ func WaitForSucceeded(
 			case jobs.StateSucceeded:
 				return true, false
 			case jobs.StateRunning:
+				return false, false
+			default:
+				return false, true
+			}
+		}, maxWait)
+}
+
+// WaitForPaused waits for a job to reach the paused state from a running state.
+func WaitForPaused(
+	ctx context.Context, db *gosql.DB, jobID jobspb.JobID, maxWait time.Duration,
+) error {
+	return WaitForState(ctx, db, jobID,
+		func(status jobs.State) (success bool, unexpected bool) {
+			switch status {
+			case jobs.StatePaused:
+				return true, false
+			case jobs.StateRunning:
+				return false, false
+			case jobs.StatePauseRequested:
+				return false, false
+			default:
+				return false, true
+			}
+		}, maxWait)
+}
+
+// WaitForResume waits for a job to reach the resumed state from a paused state.
+func WaitForResume(
+	ctx context.Context, db *gosql.DB, jobID jobspb.JobID, maxWait time.Duration,
+) error {
+	return WaitForState(ctx, db, jobID,
+		func(status jobs.State) (success bool, unexpected bool) {
+			switch status {
+			case jobs.StateRunning:
+				return true, false
+			case jobs.StatePaused:
+				return false, false
+			default:
+				return false, true
+			}
+		}, maxWait)
+}
+
+// WaitForFailed waits for a job to reach the failed state from a running state.
+func WaitForFailed(
+	ctx context.Context, db *gosql.DB, jobID jobspb.JobID, maxWait time.Duration,
+) error {
+	return WaitForState(ctx, db, jobID,
+		func(state jobs.State) (success bool, unexpected bool) {
+			switch state {
+			case jobs.StateFailed:
+				return true, false
+			case jobs.StateRunning:
+				return false, false
+			case jobs.StateReverting:
 				return false, false
 			default:
 				return false, true

--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -25,6 +25,7 @@ func RegisterTests(r registry.Registry) {
 	registerBackupMixedVersion(r)
 	registerBackupNodeShutdown(r)
 	registerBackupRestoreRoundTrip(r)
+	registerOnlineRestoreRecovery(r)
 	registerBackupFixtures(r)
 	registerBackupS3Clones(r)
 	registerBlobFixtureGC(r)


### PR DESCRIPTION
This commit adds a roachtest for testing the online restore recovery logic by deleting a random SST from the backup during the download phase.

Epic: None

Release note: None