### PR TITLE
sql: fix rolbypassrls column in pg_roles and pg_authid tables

### DIFF
--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -2930,6 +2930,11 @@ func (r roleOptions) createRole() (tree.DBool, error) {
 	return tree.DBool(createRole), err
 }
 
+func (r roleOptions) bypassRLS() (tree.DBool, error) {
+	bypassRLS, err := r.Exists("BYPASSRLS")
+	return tree.DBool(bypassRLS), err
+}
+
 // forEachRoleAtCacheReadTS reads from system.users and related tables using a
 // timestamp based on when the role membership cache was refreshed.
 func forEachRoleAtCacheReadTS(

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -5323,4 +5323,40 @@ DROP TABLE trigger_rls_table;
 DROP USER alice;
 DROP USER bob;
 
+subtest bypassrls_pg_roles_pg_authid
+
+statement ok
+CREATE ROLE can_bypassrls WITH BYPASSRLS;
+
+statement ok
+CREATE ROLE cannot_bypassrls;
+
+query B
+SELECT rolbypassrls FROM pg_authid WHERE rolname = 'can_bypassrls';
+----
+true
+
+query B
+SELECT rolbypassrls FROM pg_authid WHERE rolname = 'cannot_bypassrls';
+----
+false
+
+query B
+SELECT rolbypassrls FROM pg_roles WHERE rolname = 'can_bypassrls';
+----
+true
+
+
+query B
+SELECT rolbypassrls FROM pg_roles WHERE rolname = 'cannot_bypassrls';
+----
+false
+
+
+statement ok
+DROP ROLE can_bypassrls;
+
+statement ok
+DROP ROLE cannot_bypassrls;
+
 subtest end

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -637,6 +637,10 @@ https://www.postgresql.org/docs/9.5/catalog-pg-authid.html`,
 			if err != nil {
 				return err
 			}
+			bypassRLS, err := options.bypassRLS()
+			if err != nil {
+				return err
+			}
 
 			isSuper, err := userIsSuper(ctx, p, userName)
 			if err != nil {
@@ -652,7 +656,7 @@ https://www.postgresql.org/docs/9.5/catalog-pg-authid.html`,
 				tree.MakeDBool(isRoot || createDB),   // rolcreatedb
 				tree.MakeDBool(roleCanLogin),         // rolcanlogin.
 				tree.DBoolFalse,                      // rolreplication
-				tree.DBoolFalse,                      // rolbypassrls
+				tree.MakeDBool(bypassRLS),            // rolbypassrls
 				negOneVal,                            // rolconnlimit
 				passwdStarString,                     // rolpassword
 				rolValidUntil,                        // rolvaliduntil
@@ -2986,6 +2990,10 @@ https://www.postgresql.org/docs/9.5/view-pg-roles.html`,
 				if err != nil {
 					return err
 				}
+				bypassRLS, err := options.bypassRLS()
+				if err != nil {
+					return err
+				}
 				isSuper, err := userIsSuper(ctx, p, userName)
 				if err != nil {
 					return err
@@ -3004,7 +3012,7 @@ https://www.postgresql.org/docs/9.5/view-pg-roles.html`,
 					negOneVal,                             // rolconnlimit
 					passwdStarString,                      // rolpassword
 					rolValidUntil,                         // rolvaliduntil
-					tree.DBoolFalse,                       // rolbypassrls
+					tree.MakeDBool(bypassRLS),             // rolbypassrls
 					settings,                              // rolconfig
 				)
 			})


### PR DESCRIPTION
Previously, the rolbypassrls column in `pg_roles` and `pg_authid` tables
was hardcoded to return false, regardless of whether a role had the BYPASSRLS
option set. The fix adds a bypassRLS() method to check for the BYPASSRLS
option and updates the tables to use this method instead of hardcoded values.

Fixes: #146228
Epic: CRDB-48807

Release note (bug fix): Fixed a bug where the rolbypassrls column in
pg_roles and pg_authid tables always returned false, even for roles with the
BYPASSRLS option.