### PR TITLE
sql/rls: refactor rls filter injection

### DIFF
--- a/pkg/sql/opt/exec/explain/testdata/row_level_security
+++ b/pkg/sql/opt/exec/explain/testdata/row_level_security
@@ -293,7 +293,7 @@ UPDATE writer SET key = key * 10;
 └── • render
     │
     └── • norows
-          policies: row-level security enabled, no policies applied.
+          policies: applied (filtered all rows)
 
 exec-ddl
 CREATE POLICY p_update1 ON writer FOR UPDATE USING (key = 5)  WITH CHECK (value like 'updater: %')
@@ -396,6 +396,11 @@ UPDATE writer SET key = 10 WHERE true;
 # Show policy information for delete
 # ----------------------------------------------------------------------
 
+# First ensure no policies apply.
+exec-ddl
+DROP POLICY p_select ON writer;
+----
+
 plan
 DELETE FROM writer WHERE key = 1;
 ----
@@ -405,6 +410,22 @@ DELETE FROM writer WHERE key = 1;
 │
 └── • norows
       policies: row-level security enabled, no policies applied.
+
+# Create a SELECT policy again. But still no delete policy, so everything is
+# filtered.
+exec-ddl
+CREATE POLICY p_select ON writer FOR SELECT USING (true);
+----
+
+plan
+DELETE FROM writer WHERE key = 1;
+----
+• delete
+│ from: writer
+│ auto commit
+│
+└── • norows
+      policies: applied (filtered all rows)
 
 exec-ddl
 CREATE POLICY p_delete ON writer FOR DELETE USING (key = 1);

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -115,7 +115,7 @@ update t1
       │    │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    │    └── flags: avoid-full-scan
       │    │    │    └── filters
-      │    │    │         └── false
+      │    │    │         └── ((c1:7 % 2) = 0) AND false
       │    │    └── filters
       │    │         └── c1:7 > 0
       │    └── projections
@@ -516,7 +516,7 @@ delete t1
       │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    └── flags: avoid-full-scan
       │    └── filters
-      │         └── false
+      │         └── ((c1:7 % 2) = 0) AND false
       └── filters
            └── (c1:7 >= 0) AND (c1:7 <= 20)
 
@@ -781,7 +781,7 @@ update t1
       │    │    │    ├── columns: c1:7 c2:8 c3:9 rowid:10!null crdb_internal_mvcc_timestamp:11 tableoid:12
       │    │    │    └── flags: avoid-full-scan
       │    │    └── filters
-      │    │         └── false
+      │    │         └── true AND false
       │    └── projections
       │         └── 'new val' [as=c2_new:13]
       └── projections

--- a/pkg/sql/opt/row_level_security.go
+++ b/pkg/sql/opt/row_level_security.go
@@ -99,8 +99,10 @@ func (r *RowLevelSecurityMeta) GetPoliciesUsed(
 // is complete for a given table. If no policies were recorded for the table,
 // it updates the 'NoPoliciesApplied' flag to indicate this.
 func (r *RowLevelSecurityMeta) RefreshNoPoliciesAppliedForTable(tableID TableID) {
-	if _, ok := r.PoliciesApplied[tableID]; !ok {
+	if a, ok := r.PoliciesApplied[tableID]; !ok {
 		r.NoPoliciesApplied = true
+	} else {
+		r.NoPoliciesApplied = a.Filter.Len() == 0 && a.Check.Len() == 0
 	}
 }
 


### PR DESCRIPTION
This does a refactor of the logic that adds the filter for row-level security (RLS) policies. The intent is to match what we did for the check constraint. Namely a single function (addRowLevelSecurityFilter) that you can quickly see at a glance what policies are applied to the various policy command scope.

There is a slight update to the optbuilder tests as we include redundant clauses that didn't exist before. These will get optimized out.

During the refactor, I fixed a bug where the RLS state mishandled applied policies: if a SELECT policy existed but no DELETE or UPDATE policy was present, we incorrectly treated it as if no policy applied.

Epic: none
Release note: none