### PR TITLE
release-25.1: schemachangerccl: increase polling duration for TestSubzonesRemovedByGCAfterIndexSwap

### DIFF
--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	gosql "database/sql"
 	"testing"
-	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/ccl/multiregionccl/multiregionccltestutils"
@@ -233,7 +232,6 @@ CREATE TABLE person (
 	})
 
 	// Keep retrying until the old index and temporary index are removed by the GC job.
-	runner.SucceedsSoonDuration = 30 * time.Second
 	runner.CheckQueryResultsRetry(t, subzonesQuery, [][]string{
 		{"3", "north_america", "4", `/3/"CA"`, "NULL"},
 		{"3", "north_america", "4", `/3/"US"`, "NULL"},

--- a/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
+++ b/pkg/ccl/schemachangerccl/schemachanger_ccl_test.go
@@ -233,7 +233,7 @@ CREATE TABLE person (
 	})
 
 	// Keep retrying until the old index and temporary index are removed by the GC job.
-	runner.SucceedsSoonDuration = 12 * time.Second
+	runner.SucceedsSoonDuration = 30 * time.Second
 	runner.CheckQueryResultsRetry(t, subzonesQuery, [][]string{
 		{"3", "north_america", "4", `/3/"CA"`, "NULL"},
 		{"3", "north_america", "4", `/3/"US"`, "NULL"},


### PR DESCRIPTION
Backport:
  * 1/1 commits from "schemachangerccl: increase polling duration for TestSubzonesRemovedByGCAfterIndexSwap" (#144698)
  * 1/1 commits from "schemachangerccl: increase polling duration for TestSubzonesRemovedByGCAfterIndexSwap" (#146891)

Please see individual PRs for details.

/cc @cockroachdb/release

fixes: https://github.com/cockroachdb/cockroach/issues/147347

Release justification: test only change
