### PR TITLE
crosscluster: add batch handler test support for sql writers

### DIFF
--- a/pkg/crosscluster/logical/sql_crud_writer.go
+++ b/pkg/crosscluster/logical/sql_crud_writer.go
@@ -45,7 +45,7 @@ func newCrudSqlWriter(
 	discard jobspb.LogicalReplicationDetails_Discard,
 	procConfigByDestID map[descpb.ID]sqlProcessorTableConfig,
 	jobID jobspb.JobID,
-) (*sqlCrudWriter, error) {
+) (BatchHandler, error) {
 	decoder, err := newEventDecoder(ctx, cfg.DB, evalCtx.Settings, procConfigByDestID)
 	if err != nil {
 		return nil, err

--- a/pkg/crosscluster/logical/table_batch_handler_test.go
+++ b/pkg/crosscluster/logical/table_batch_handler_test.go
@@ -30,7 +30,7 @@ import (
 
 func newCrudBatchHandler(
 	t *testing.T, s serverutils.ApplicationLayerInterface, tableName string,
-) (*sqlCrudWriter, catalog.TableDescriptor) {
+) (BatchHandler, catalog.TableDescriptor) {
 	ctx := context.Background()
 	desc := cdctest.GetHydratedTableDescriptor(t, s.ExecutorConfig(), tree.Name(tableName))
 	sd := sql.NewInternalSessionData(ctx, s.ClusterSettings(), "" /* opName */)


### PR DESCRIPTION
This extends the batch handler tests so that they can be used to validate the SQL writers. The new tests are skipped because the SQL writers do not correctly handle tombstones that should win LWW.

Release note: none
Informs: #146117