### PR TITLE
opt: fix hints for placeholder fast path

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index_flags
@@ -357,3 +357,41 @@ vectorized: true
       missing stats
       table: abcd@abcd_pkey
       spans: FULL SCAN
+
+# Regression tests for #147363. Statements should not error because the fast path
+# picks a plan that does not adhere to hints.
+statement ok
+CREATE TABLE t147363 (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a, b),
+  INDEX i (a, b)
+)
+
+statement ok
+PREPARE p147363 AS
+SELECT * FROM t147363@i WHERE a = $1 AND b = $2
+
+statement ok
+EXECUTE p147363(1, 2)
+
+statement ok
+DEALLOCATE p147363
+
+statement ok
+PREPARE p147363 AS
+SELECT * FROM t147363@{FORCE_INVERTED_INDEX} WHERE a = $1 AND b = $2
+
+statement error pgcode XXUUU could not produce a query plan conforming to the FORCE_INVERTED_INDEX hint
+EXECUTE p147363(1, 2)
+
+statement ok
+DEALLOCATE p147363
+
+statement ok
+PREPARE p147363 AS
+SELECT * FROM t147363@{FORCE_ZIGZAG} WHERE a = $1 AND b = $2
+
+statement error pgcode XXUUU could not produce a query plan conforming to the FORCE_ZIGZAG hint
+EXECUTE p147363(1, 2)

--- a/pkg/sql/opt/xform/placeholder_fast_path.go
+++ b/pkg/sql/opt/xform/placeholder_fast_path.go
@@ -88,6 +88,11 @@ func (o *Optimizer) TryPlaceholderFastPath() (ok bool, err error) {
 		return false, nil
 	}
 
+	if scan.Flags.ForceInvertedIndex || scan.Flags.ForceZigzag {
+		// We don't support inverted or zigzag indexes in the fast path.
+		return false, nil
+	}
+
 	var constrainedCols opt.ColSet
 	for i := range sel.Filters {
 		// Each condition must be an equality between a variable and a constant
@@ -124,6 +129,10 @@ func (o *Optimizer) TryPlaceholderFastPath() (ok bool, err error) {
 		index := tabMeta.Table.Index(ord)
 		if index.Type() != idxtype.FORWARD {
 			// Skip inverted and vector indexes.
+			continue
+		}
+		if scan.Flags.ForceIndex && scan.ScanPrivate.Flags.Index != ord {
+			// If an index is forced, skip all other indexes.
 			continue
 		}
 

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/scan
@@ -345,3 +345,33 @@ placeholder-scan t_dec
  ├── fd: ()-->(1,2)
  └── span
       └── $1
+
+# Regression tests for #147363. The placeholder fast path should respect index
+# flags.
+exec-ddl
+CREATE TABLE t147363 (
+  a INT,
+  b INT,
+  c INT,
+  PRIMARY KEY (a, b),
+  INDEX i (a, b)
+)
+----
+
+# No fast path is selected because i is not covering.
+placeholder-fast-path
+SELECT * FROM t147363@i WHERE a = $1 AND b = $2
+----
+no fast path
+
+# The fast path does not support inverted indexes.
+placeholder-fast-path
+SELECT * FROM t147363@{FORCE_INVERTED_INDEX} WHERE a = $1 AND b = $2
+----
+no fast path
+
+# The fast path does not support zig-zag joins.
+placeholder-fast-path
+SELECT * FROM t147363@{FORCE_ZIGZAG} WHERE a = $1 AND b = $2
+----
+no fast path


### PR DESCRIPTION
Fixes #147363

Release note (bug fix): A bug has been fixed that cause the optimizer to
ignore index hints when optimizing some forms of prepared statements.
This could result in one of two unexepcted behaviors: a query errors
with the message "index cannot be used for this query" when the index
can actually be used, or query using an index that does not adhere to
the hint. The hints relevant to this bug are regular index hints, e.g.,
`SELECT * FROM tab@index`, `FORCE_INVERTED_INDEX` and `FORCE_ZIGZAG`.
