### PR TITLE
sql: fix OID generation for pg_policy table to ensure uniqueness

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -196,15 +196,15 @@ multi_pol_tab1  CREATE TABLE public.multi_pol_tab1 (
 query ITITBTTT colnames,rowsort
 select oid::INT, polname, polrelid::INT, polcmd, polpermissive, polroles::string, polqual, polwithcheck from pg_catalog.pg_policy
 ----
-oid  polname  polrelid  polcmd  polpermissive  polroles       polqual  polwithcheck
-1    policy1  110       *       true           {0}            NULL     NULL
-2    policy2  110       *       false          {0}            NULL     NULL
-3    policy3  110       *       true           {0}            NULL     NULL
-4    policy4  110       a       true           {0}            NULL     NULL
-5    policy5  110       w       true           {0}            NULL     NULL
-6    policy6  110       d       true           {0}            NULL     NULL
-7    policy7  110       r       true           {0}            NULL     NULL
-8    policy8  110       *       true           {0,835509264}  NULL     NULL
+oid        polname  polrelid  polcmd  polpermissive  polroles       polqual  polwithcheck
+577443713  policy1  110       *       true           {0}            NULL     NULL
+577443714  policy2  110       *       false          {0}            NULL     NULL
+577443715  policy3  110       *       true           {0}            NULL     NULL
+577443716  policy4  110       a       true           {0}            NULL     NULL
+577443717  policy5  110       w       true           {0}            NULL     NULL
+577443718  policy6  110       d       true           {0}            NULL     NULL
+577443719  policy7  110       r       true           {0}            NULL     NULL
+577443720  policy8  110       *       true           {0,835509264}  NULL     NULL
 
 query TTTTTTTT colnames,rowsort
 select schemaname, tablename, policyname, permissive, roles, cmd, qual, with_check from pg_catalog.pg_policies
@@ -283,9 +283,9 @@ vectorized: true
 query ITITBTTT colnames,rowsort
 select oid::INT, polname, polrelid::INT, polcmd, polpermissive, polroles::string, polqual, polwithcheck from pg_catalog.pg_policy WHERE polrelid = 'multi_pol_tab2'::regclass
 ----
-oid  polname   polrelid  polcmd  polpermissive  polroles  polqual  polwithcheck
-1    policy9   113       *       true           {0}       NULL     NULL
-2    policy10  113       *       true           {0}       NULL     NULL
+oid         polname   polrelid  polcmd  polpermissive  polroles  polqual  polwithcheck
+3620125326  policy9   113       *       true           {0}       NULL     NULL
+3620125325  policy10  113       *       true           {0}       NULL     NULL
 
 query TTTTTTTT colnames,rowsort
 select schemaname, tablename, policyname, permissive, roles, cmd, qual, with_check from pg_catalog.pg_policies where tablename = 'multi_pol_tab2'
@@ -297,9 +297,9 @@ public      multi_pol_tab2  policy10    permissive  {public}  ALL  NULL  NULL
 query ITITBTTT colnames,rowsort
 select oid::INT, polname, polrelid::INT, polcmd, polpermissive, polroles::string, polqual, polwithcheck from pg_catalog.pg_policy WHERE polrelid = 'multi_pol_tab3'::regclass
 ----
-oid  polname   polrelid  polcmd  polpermissive  polroles  polqual  polwithcheck
-1    policy11  114       *       true           {0}       NULL     NULL
-2    policy12  114       *       true           {0}       NULL     NULL
+oid         polname   polrelid  polcmd  polpermissive  polroles  polqual  polwithcheck
+3879861597  policy11  114       *       true           {0}       NULL     NULL
+3879861598  policy12  114       *       true           {0}       NULL     NULL
 
 query TTTTTTTT colnames,rowsort
 select schemaname, tablename, policyname, permissive, roles, cmd, qual, with_check from pg_catalog.pg_policies where tablename = 'multi_pol_tab3'

--- a/pkg/sql/pg_catalog.go
+++ b/pkg/sql/pg_catalog.go
@@ -4470,8 +4470,7 @@ https://www.postgresql.org/docs/17/catalog-pg-policy.html`,
 				return errors.AssertionFailedf("unexpected policy command: %s", policy.Command.String())
 			}
 
-			// loop through role names and get all the role oids
-			h := makeOidHasher()
+			// Loop through role names and get all the role OIDs.
 			treeRoleOids := tree.NewDArray(types.Oid)
 			for _, roleName := range policy.RoleNames {
 				if roleName == "public" {
@@ -4516,14 +4515,14 @@ https://www.postgresql.org/docs/17/catalog-pg-policy.html`,
 			}
 
 			if err := addRow(
-				tree.NewDOid(oid.Oid(policy.ID)),                           // oid
+				h.PolicyOid(table.GetID(), policy.ID),                      // oid
 				tree.NewDName(policy.Name),                                 // polname
 				tableOid(table.GetID()),                                    // polrelid
 				tree.NewDString(cmd),                                       // polcmd
 				tree.MakeDBool(policy.Type == catpb.PolicyType_PERMISSIVE), // polpermissive
-				treeRoleOids,                                               // polroles
-				usingExpr,                                                  // polqual
-				checkExpr,                                                  // polwithcheck
+				treeRoleOids, // polroles
+				usingExpr,    // polqual
+				checkExpr,    // polwithcheck
 			); err != nil {
 				return err
 			}
@@ -5338,6 +5337,7 @@ const (
 	dbSchemaRoleTypeTag
 	castTypeTag
 	triggerTypeTag
+	policyTypeTag
 )
 
 func (h oidHasher) writeTypeTag(tag oidTypeTag) {
@@ -5541,6 +5541,13 @@ func (h oidHasher) TriggerOid(tableID descpb.ID, triggerID descpb.TriggerID) *tr
 	h.writeTypeTag(triggerTypeTag)
 	h.writeTable(tableID)
 	h.writeUInt32(uint32(triggerID))
+	return h.getOid()
+}
+
+func (h oidHasher) PolicyOid(tableID descpb.ID, policyID descpb.PolicyID) *tree.DOid {
+	h.writeTypeTag(policyTypeTag)
+	h.writeTable(tableID)
+	h.writeUInt32(uint32(policyID))
 	return h.getOid()
 }
 


### PR DESCRIPTION
Previously, the pg_policy table was using raw policy IDs as OIDs.
Since multiple policies can have the same ID across different tables,
this resulted in duplicate OIDs within pg_policy. This commit fixes
the issue by using the OID hasher pattern to generate unique OIDs
that incorporate both the table ID and policy ID.

Epic: None

Release note (bug fix): Fixed a bug where the pg_catalog.pg_policy
table could contain duplicate OID values when multiple tables had
policies with the same policy ID. All rows in pg_policy now have
unique OIDs as required.