### PR TITLE
release-25.2: builtins: mark to_reg* builtins as DistSQL-blocklisted

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/pg_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/pg_builtins
@@ -1065,3 +1065,19 @@ ubar     interval  NULL
 ufoo     interval  NULL
 
 subtest end
+
+# Regression test for not marking to_reg* builtins as DistSQL-blocklisted
+# (#144384).
+statement ok
+CREATE TABLE t144384 (c TEXT);
+
+statement ok
+CREATE INDEX i144384 ON t144384(c);
+
+statement ok
+INSERT INTO t144384 VALUES ('i144384');
+
+query T
+SELECT to_regclass(c) FROM t144384;
+----
+i144384

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -8008,7 +8008,8 @@ in the current database. Returns an error if validation fails.`,
 
 	"crdb_internal.revalidate_unique_constraints_in_table": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true,
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "table_name", Typ: types.String}},
@@ -8032,7 +8033,8 @@ table. Returns an error if validation fails.`,
 
 	"crdb_internal.revalidate_unique_constraint": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true,
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "table_name", Typ: types.String}, {Name: "constraint_name", Typ: types.String}},
@@ -8058,7 +8060,8 @@ table. Returns an error if validation fails.`,
 	),
 	"crdb_internal.is_constraint_active": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true,
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "table_name", Typ: types.String}, {Name: "constraint_name", Typ: types.String}},

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -571,7 +571,11 @@ func makeCreateRegDef(typ *types.T) builtinDefinition {
 }
 
 func makeToRegOverload(typ *types.T, helpText string) builtinDefinition {
-	return makeBuiltin(tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+	return makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true,
+		},
 		tree.Overload{
 			Types: tree.ParamTypes{
 				{Name: "text", Typ: types.String},


### PR DESCRIPTION
Backport 1/1 commits from #147362 on behalf of @yuzefovich.

----

We currently require blocklisting operations on Oids, and we previously forgot to do that for some builtins (a few `to_reg*` ones as well as a few more I found when auditing call sites of `eval.ParseDOid`).

Fixes: #144384.

Release note (bug fix): CockroachDB could previously incorrectly evaluate `to_regclass`, `to_regnamespace`, `to_regproc`, `to_regprocedure`, `to_regrole`, and `to_regtype` builtin functions when the query using them happened to be evaluated in distributed fashion. The bug has been present since the introduction of these builtins in 23.1 and is now fixed.

----

Release justification: bug fix.