### PR TITLE
kvserver: simplify clearSubsumedReplicaDiskData

### DIFF
--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -157,29 +157,28 @@ func clearSubsumedReplicaDiskData(
 	desc *roachpb.RangeDescriptor,
 	subsumedDescs []*roachpb.RangeDescriptor,
 ) (clearedSpans []roachpb.Span, _ error) {
-	// NB: we don't clear RangeID local key spans here. That happens
-	// via the call to DestroyReplica.
-	getKeySpans := func(d *roachpb.RangeDescriptor) []roachpb.Span {
-		return rditer.Select(d.RangeID, rditer.SelectOpts{
-			Ranged: rditer.SelectRangedOptions{
-				RSpan:      d.RSpan(),
-				SystemKeys: true,
-				UserKeys:   true,
-				LockTable:  true,
-			},
-		})
-	}
-	keySpans := getKeySpans(desc)
-	totalKeySpans := append([]roachpb.Span(nil), keySpans...)
+	// RangeID-local key spans for the subsumed replicas are cleared via the
+	// DestroyReplica calls below.
+	//
+	// In addition, we need to clear all RKey-based keys covered by this replica
+	// and the subsumed replicas RSpans. The desc.RSpan() is already cleared by
+	// the MultiSSTWriter which prepared the snapshot, though the total span can
+	// be wider than desc.RSpan(), so we need to additionally clear the delta
+	// here. This is handled and explained further down.
+	keySpan := desc.RSpan()
+	totalSpan := keySpan
+
 	for _, subDesc := range subsumedDescs {
-		// We have to create an SST for the subsumed replica's range-id local keys.
+		// We have to create an SST for the subsumed replica's RangeID-local keys.
 		subsumedReplSSTFile := &storage.MemObject{}
 		subsumedReplSST := storage.MakeIngestionSSTWriter(
 			ctx, st, subsumedReplSSTFile,
 		)
-		// NOTE: We set mustClearRange to true because we are setting
-		// RangeTombstoneKey. Since Clears and Puts need to be done in increasing
-		// order of keys, it is not safe to use ClearRangeIter.
+		// NB: MustUseClearRange makes DestroyReplica write all Clears and Puts in
+		// increasing order of keys, as required by the SST writer. Without this
+		// flag, DestroyReplica can clear the RangeID-local keyspace using
+		// individual key deletes, and then write a RangeTombstone (which is also
+		// part of RangeID-local) out of order.
 		opts := kvstorage.ClearRangeDataOptions{
 			ClearReplicatedByRangeID:   true,
 			ClearUnreplicatedByRangeID: true,
@@ -205,23 +204,20 @@ func clearSubsumedReplicaDiskData(
 			}
 		}
 
-		srKeySpans := getKeySpans(subDesc)
-		// Compute the total key space covered by the current replica and all
-		// subsumed replicas.
-		for i := range srKeySpans {
-			if srKeySpans[i].Key.Compare(totalKeySpans[i].Key) < 0 {
-				totalKeySpans[i].Key = srKeySpans[i].Key
-			}
-			if srKeySpans[i].EndKey.Compare(totalKeySpans[i].EndKey) > 0 {
-				totalKeySpans[i].EndKey = srKeySpans[i].EndKey
-			}
+		// Maintain the RSpan covering our replica and all subsumed replicas.
+		subSpan := subDesc.RSpan()
+		if subSpan.Key.Compare(totalSpan.Key) < 0 {
+			totalSpan.Key = subSpan.Key
+		}
+		if subSpan.EndKey.Compare(totalSpan.EndKey) > 0 {
+			totalSpan.EndKey = subSpan.EndKey
 		}
 	}
 
-	// We might have to create SSTs for the range local keys, lock table keys,
-	// and user keys depending on if the subsumed replicas are not fully
-	// contained by the replica in our snapshot. The following is an example to
-	// this case happening.
+	// We might have to create SSTs for the range local keys, lock table keys, and
+	// user keys depending on if the subsumed replicas are not fully contained by
+	// the replica in our snapshot. The following is an example to this case
+	// happening.
 	//
 	// a       b       c       d
 	// |---1---|-------2-------|  S1
@@ -231,58 +227,56 @@ func clearSubsumedReplicaDiskData(
 	// Since the merge is the first operation to happen, a follower could be down
 	// before it completes. It is reasonable for a snapshot for r1 from S3 to
 	// subsume both r1 and r2 in S1.
-	for i := range keySpans {
-		// The snapshot must never subsume a replica that extends the range of the
-		// replica to the left. This is because splits and merges (the only
-		// operation that change the key bounds) always leave the start key intact.
-		// Extending to the left implies that either we merged "to the left" (we
-		// don't), or that we're applying a snapshot for another range (we don't do
-		// that either). Something is severely wrong for this to happen.
-		if totalKeySpans[i].Key.Compare(keySpans[i].Key) < 0 {
-			log.Fatalf(ctx, "subsuming replica to our left; key span: %v; total key span %v",
-				keySpans[i], totalKeySpans[i])
-		}
-
-		// In the comments below, s1, ..., sn are the end keys for the subsumed
-		// replicas (for the current keySpan).
-		// Note that if there aren't any subsumed replicas (the common case), the
-		// next comparison is always zero and this loop is a no-op.
-
-		if totalKeySpans[i].EndKey.Compare(keySpans[i].EndKey) <= 0 {
-			// The subsumed replicas are fully contained in the snapshot:
-			//
-			// [a---s1---...---sn)
-			// [a---------------------b)
-			//
-			// We don't need to clear additional keyspace here, since clearing `[a,b)`
-			// will also clear all subsumed replicas.
-			continue
-		}
-
-		// The subsumed replicas extend past the snapshot:
+	//
+	// The snapshot must never subsume a replica that extends the range of the
+	// replica to the left. This is because splits and merges (the only operation
+	// that change the key bounds) always leave the start key intact. Extending to
+	// the left implies that either we merged "to the left" (we don't), or that
+	// we're applying a snapshot for another range (we don't do that either).
+	// Something is severely wrong for this to happen.
+	if totalSpan.Key.Compare(keySpan.Key) < 0 {
+		log.Fatalf(ctx, "subsuming replica to our left; key span: %v; total key span %v",
+			keySpan, totalSpan)
+	}
+	// In the comments below, s1, ..., sn are the end keys for the subsumed
+	// replicas (for the current keySpan).
+	// Note that if there aren't any subsumed replicas (the common case), the next
+	// comparison is always zero, and we return early.
+	if totalSpan.EndKey.Compare(keySpan.EndKey) <= 0 {
+		// The subsumed replicas are fully contained in the snapshot:
 		//
-		// [a----------------s1---...---sn)
+		// [a---s1---...---sn)
 		// [a---------------------b)
 		//
-		// We need to additionally clear [b,sn).
-
+		// We don't need to clear additional keyspace here, since clearing `[a,b)`
+		// will also clear all subsumed replicas.
+		return clearedSpans, nil
+	}
+	// The subsumed replicas extend past the snapshot:
+	//
+	// [a----------------s1---...---sn)
+	// [a---------------------b)
+	//
+	// We need to additionally clear [b,sn), for each key-based replicated span.
+	// TODO(pav-kv): factor our the RSpan select, without the dummy RangeID.
+	for _, span := range rditer.Select(0, rditer.SelectOpts{
+		Ranged: rditer.SelectRangedOptions{RSpan: roachpb.RSpan{
+			Key: keySpan.EndKey, EndKey: totalSpan.EndKey,
+		}},
+	}) {
 		subsumedReplSSTFile := &storage.MemObject{}
 		subsumedReplSST := storage.MakeIngestionSSTWriter(
 			ctx, st, subsumedReplSSTFile,
 		)
 		if err := storage.ClearRangeWithHeuristic(
-			ctx,
-			reader,
-			&subsumedReplSST,
-			keySpans[i].EndKey,
-			totalKeySpans[i].EndKey,
+			ctx, reader, &subsumedReplSST,
+			span.Key, span.EndKey,
 			kvstorage.ClearRangeThresholdPointKeys,
 		); err != nil {
 			subsumedReplSST.Close()
 			return nil, err
 		}
-		clearedSpans = append(clearedSpans,
-			roachpb.Span{Key: keySpans[i].EndKey, EndKey: totalKeySpans[i].EndKey})
+		clearedSpans = append(clearedSpans, span)
 		if err := subsumedReplSST.Finish(); err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The change deduplicates the logic that computes the `RSpan` delta in `clearSubsumedReplicaDiskData`. Instead of computing the delta in each plane, compute the delta first and then project it onto the planes.

Epic: CRDB-46488