### PR TITLE
kvserver: Implement safe formatter on SnapshotReservationTimeoutError

### DIFF
--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -274,10 +274,8 @@ func (s *Store) throttleSnapshot(
 			if err := ctx.Err(); err != nil {
 				return nil, errors.Wrap(err, "acquiring snapshot reservation")
 			}
-			return nil, errors.Wrapf(
-				queueCtx.Err(),
-				"giving up during snapshot reservation due to cluster setting %q",
-				snapshotReservationQueueTimeoutFraction.Name(),
+			return nil, kvpb.NewSnapshotReservationTimeoutError(
+				queueCtx.Err(), string(snapshotReservationQueueTimeoutFraction.Name()),
 			)
 		case <-s.stopper.ShouldQuiesce():
 			return nil, errors.Errorf("stopped")

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -3471,6 +3471,11 @@ func TestReserveSnapshotQueueTimeoutAvoidsStarvation(t *testing.T) {
 						if errors.Is(err, context.DeadlineExceeded) {
 							return nil
 						}
+						// Also handle the new SnapshotReservationTimeoutError as a timeout condition
+						var snapshotTimeoutErr *kvpb.SnapshotReservationTimeoutError
+						if errors.As(err, &snapshotTimeoutErr) {
+							return nil
+						}
 						return err
 					}
 					defer cleanup()


### PR DESCRIPTION
This patch helps to fix the overly redacted log when there is snapshot reservation timeout. 
To resolve this, created a separate error struct which implements SafeFormatError to 
mark this error as safe when it is logged.

Difference in logging of custom error object and errors.Wrapf error object 

<img width="1534" alt="Screenshot 2025-05-30 at 2 42 15 PM" src="https://github.com/user-attachments/assets/496771f4-a041-435e-8687-1761778e9f2f" />


Epic: CRDB-37533
Part of: CRDB-44885
Release note: None