### PR TITLE
gceworker: use who instead of w

### DIFF
--- a/build/bootstrap/autoshutdown.cron.sh
+++ b/build/bootstrap/autoshutdown.cron.sh
@@ -49,7 +49,7 @@ active_exists() {
   [[ $age -lt $AUTO_SHUTDOWN_DURATION ]]
 }
 
-if active_exists || w -hs | grep pts | grep -vq "pts/[0-9]* *tmux" || pgrep unison || pgrep -f remote-dev-server.sh; then
+if active_exists || who | grep pts | grep -vq "pts/[0-9]* *tmux" || pgrep unison || pgrep -f remote-dev-server.sh; then
   # Auto-shutdown is disabled (via /.active) or there is a remote session.
   echo 0 > $FILE
   exit 0


### PR DESCRIPTION
Previously, we used the `w` command to check for active sessions, but it stopped reporting TTYs in the output in Ubuntu 24.04. The `who` command still reports the TTYs correctly. 

Upstream report: https://bugs.launchpad.net/ubuntu/+source/procps/+bug/2092307

Release note: none
Epic: none