### PR TITLE
ui: fix live data percentage on table overview

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/pages/databases/views/tableDetailsV2/tableOverview.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/pages/databases/views/tableDetailsV2/tableOverview.tsx
@@ -93,7 +93,7 @@ export const TableOverview: React.FC<TableOverviewProps> = ({
                 value={
                   <LiveDataPercent
                     liveBytes={metadata.totalLiveDataBytes}
-                    totalBytes={metadata.totalLiveDataBytes}
+                    totalBytes={metadata.totalDataBytes}
                   />
                 }
               />


### PR DESCRIPTION
Fixes a bug where the live data percentage on the table details overview page was using the wrong values, resulting in it always showing 100%.

fixes: #136476
Epic: None
Release note: None