### PR TITLE
codelabs: edit testing to correct command

### DIFF
--- a/docs/codelabs/01-sql-statement.md
+++ b/docs/codelabs/01-sql-statement.md
@@ -493,8 +493,8 @@ FROBNICATE ALL
 ```
 
 Back to the terminal, make sure you are at `~/go/src/github.com/cockroachdb/cockroach`,
-and run `./dev test pkg/sql/parser -f TestParseDatadriven --rewrite`.
-The flag `--rewrite` is meant to automatically rewrite the datadriven test with the output it received.
+and run `./dev test pkg/sql/parser -f TestParseDataDriven --rewrite`.
+The flag `--rewrite` is meant to automatically rewrite the DataDriven test with the output it received.
 
 Wait until the test command finishes, and open `pkg/sql/parser/testdata/frobnicate`, and you would expect:
 


### PR DESCRIPTION
Previously, it said to run Datadriven tests.
However, the correct form is DataDriven.
The Datadriven command is incorrect.
Now, it is corrected.

Epic: None
Release note: None