### PR TITLE
ui: Fix collapsing behaviour on tables

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/table/table.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/table/table.tsx
@@ -70,12 +70,18 @@ export function Table<T extends object & { children?: T[] }>(
             }
             return expanded ? (
               <CaretDownOutlined
-                onClick={e => onExpand(record, e)}
+                onClick={e => {
+                  e.stopPropagation();
+                  onExpand(record, e);
+                }}
                 className={cx("expand-toggle")}
               />
             ) : (
               <CaretRightOutlined
-                onClick={e => onExpand(record, e)}
+                onClick={e => {
+                  e.stopPropagation();
+                  onExpand(record, e);
+                }}
                 className={cx("expand-toggle")}
               />
             );


### PR DESCRIPTION
Previously, clicking the arrow icon to expand a region in the nodes table worked, but clicking the arrow to collapse did not. Instead, you had to click elsewhere on the row to collapse the region.

This behaviour occurs since expandRowByClick is enabled on the table, and so once the row is expanded, clicking the arrow to collapse triggers the collapse and a subsequent expansion.

Fixes: #146676
Release note: None