### PR TITLE
release-25.2: CODEOWNERS: mark vecindex and a couple util pkgs as owned by Queries

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -73,6 +73,7 @@
 /pkg/sql/control_job*        @cockroachdb/sql-queries-prs @cockroachdb/jobs-prs
 /pkg/sql/job_exec_context*   @cockroachdb/sql-queries-prs @cockroachdb/jobs-prs
 /pkg/sql/delegate/*job*.go   @cockroachdb/jobs-prs @cockroachdb/disaster-recovery
+/pkg/sql/vecindex/           @cockroachdb/sql-queries-prs
 
 /pkg/sql/importer/           @cockroachdb/sql-queries-prs
 /pkg/sql/importer/export*    @cockroachdb/cdc-prs
@@ -600,12 +601,17 @@
 #!/pkg/util/                 @cockroachdb/unowned
 /pkg/util/addr/              @cockroachdb/obs-prs
 /pkg/util/admission/         @cockroachdb/admission-control
+/pkg/util/cancelchecker/     @cockroachdb/sql-queries-prs
+/pkg/util/encoding/          @cockroachdb/sql-queries-prs
 /pkg/util/goschedstats       @cockroachdb/admission-control
 /pkg/util/grunning/          @cockroachdb/admission-control
+/pkg/util/intsets/           @cockroachdb/sql-queries-prs
+/pkg/util/json/              @cockroachdb/sql-queries-prs
 /pkg/util/jsonpath/          @cockroachdb/sql-queries-prs
 /pkg/util/log/               @cockroachdb/obs-prs @cockroachdb/obs-india-prs
 /pkg/util/metric/            @cockroachdb/obs-prs @cockroachdb/obs-india-prs
 /pkg/util/mon                @cockroachdb/sql-queries-prs
+/pkg/util/num32              @cockroachdb/sql-queries-prs
 /pkg/util/schedulerlatency/  @cockroachdb/admission-control
 /pkg/util/stop/              @cockroachdb/kv-prs
 /pkg/util/tracing            @cockroachdb/obs-prs @cockroachdb/obs-india-prs

--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -175,8 +175,7 @@ func TestListFailuresFromJSON(t *testing.T) {
 				message: `=== RUN   TestPretty/["hello",_["world"]]
     --- FAIL: TestPretty/["hello",_["world"]] (0.00s)
     	json_test.go:1656: injected failure`,
-				mention: []string{"@cockroachdb/unowned"},
-				labels:  []string{"C-test-failure", "release-blocker"},
+				labels: []string{"C-test-failure", "release-blocker", "T-sql-queries"},
 			}},
 			formatter: DefaultFormatter,
 		},


### PR DESCRIPTION
Backport 1/1 commits from #146776.

/cc @cockroachdb/release

---

Informs: #146692.

Epic: None
Release note: None

Release justification: infra-only change.