### PR TITLE
kvserver,kvflowcontrol: remove some RACv1 => v2 protocol transition code

### DIFF
--- a/pkg/kv/kvserver/flow_control_stores.go
+++ b/pkg/kv/kvserver/flow_control_stores.go
@@ -11,7 +11,6 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowhandle"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
@@ -168,23 +167,8 @@ func (sh *storeForFlowControl) LookupReplicationAdmissionHandle(
 		return nil, false
 	}
 	// NB: Admit is called soon after this lookup.
-	level := repl.flowControlV2.GetEnabledWhenLeader()
-	useV1 := level == kvflowcontrol.V2NotEnabledWhenLeader
-	var v1Handle kvflowcontrol.ReplicationAdmissionHandle
-	if useV1 {
-		repl.mu.Lock()
-		var found bool
-		v1Handle, found = repl.mu.replicaFlowControlIntegration.handle()
-		repl.mu.Unlock()
-		if !found {
-			return nil, found
-		}
-	}
-	// INVARIANT: useV1 => v1Handle was found.
-	return admissionDemuxHandle{
-		v1Handle: v1Handle,
-		r:        repl,
-		useV1:    useV1,
+	return admissionHandle{
+		r: repl,
 	}, true
 }
 
@@ -239,37 +223,6 @@ func (sh *storeForFlowControl) OnRaftTransportDisconnected(
 		replica.mu.replicaFlowControlIntegration.onRaftTransportDisconnected(ctx, storeIDs...)
 		return true
 	})
-}
-
-// storeFlowControlHandleFactory is a concrete implementation of
-// kvflowcontrol.HandleFactory.
-type storeFlowControlHandleFactory Store
-
-var _ kvflowcontrol.HandleFactory = &storeFlowControlHandleFactory{}
-
-// makeStoreFlowControlHandleFactory returns a new storeFlowControlHandleFactory
-// instance.
-func makeStoreFlowControlHandleFactory(store *Store) *storeFlowControlHandleFactory {
-	return (*storeFlowControlHandleFactory)(store)
-}
-
-// NewHandle is part of the kvflowcontrol.HandleFactory interface.
-func (shf *storeFlowControlHandleFactory) NewHandle(
-	rangeID roachpb.RangeID, tenantID roachpb.TenantID,
-) kvflowcontrol.Handle {
-	s := (*Store)(shf)
-	var knobs *kvflowcontrol.TestingKnobs
-	if s.TestingKnobs() != nil {
-		knobs = s.TestingKnobs().FlowControlTestingKnobs
-	}
-	return kvflowhandle.New(
-		s.cfg.KVFlowController,
-		s.cfg.KVFlowHandleMetrics,
-		s.cfg.Clock,
-		rangeID,
-		tenantID,
-		knobs,
-	)
 }
 
 // NoopStoresFlowControlIntegration is a no-op implementation of the
@@ -429,34 +382,13 @@ func (ss *storesForRACv2) Inspect() []roachpb.RangeID {
 	return rangeIDs
 }
 
-type admissionDemuxHandle struct {
-	v1Handle kvflowcontrol.ReplicationAdmissionHandle
-	r        *Replica
-	useV1    bool
+type admissionHandle struct {
+	r *Replica
 }
 
 // Admit implements kvflowcontrol.ReplicationAdmissionHandle.
-func (h admissionDemuxHandle) Admit(
+func (h admissionHandle) Admit(
 	ctx context.Context, pri admissionpb.WorkPriority, ct time.Time,
 ) (admitted bool, err error) {
-	if h.useV1 {
-		admitted, err = h.v1Handle.Admit(ctx, pri, ct)
-		if err != nil {
-			return admitted, err
-		}
-		// It is possible a transition from v1 => v2 happened while waiting, which
-		// can cause either value of admitted. See the comment in
-		// ReplicationAdmissionHandle.
-		level := h.r.flowControlV2.GetEnabledWhenLeader()
-		if level == kvflowcontrol.V2NotEnabledWhenLeader {
-			return admitted, err
-		}
-		// Transition from v1 => v2 happened while waiting. Fall through to wait
-		// on v2, since it is possible that nothing was waited on, or the
-		// overloaded stream was not waited on. This double wait is acceptable
-		// since during the transition from v1 => v2 only elastic work should be
-		// subject to replication AC, and we would like to err towards not
-		// overloading.
-	}
 	return h.r.flowControlV2.AdmitForEval(ctx, pri, ct)
 }

--- a/pkg/kv/kvserver/kvflowcontrol/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/BUILD.bazel
@@ -15,7 +15,6 @@ go_library(
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
         "//pkg/roachpb",
         "//pkg/settings",
-        "//pkg/settings/cluster",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/ctxutil",
         "//pkg/util/humanizeutil",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/BUILD.bazel
@@ -45,7 +45,6 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":replica_rac2"],
     deps = [
-        "//pkg/kv/kvserver/kvflowcontrol",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb",
         "//pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb",
         "//pkg/kv/kvserver/kvflowcontrol/rac2",

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission.go
@@ -93,6 +93,8 @@ type interval struct {
 //
 // Returns true iff the leaderTerm was not stale.
 //
+// TODO(rac1): remove the return value since unused.
+//
 // INVARIANT: first <= last.
 func (p *lowPriOverrideState) sideChannelForLowPriOverride(
 	leaderTerm uint64, first, last uint64, lowPriOverride bool,
@@ -148,16 +150,6 @@ func (p *lowPriOverrideState) sideChannelForLowPriOverride(
 		}
 	}
 	p.intervals.Push(interval{first: first, last: last, lowPriOverride: lowPriOverride})
-	return true
-}
-
-// sideChannelForV1Leader returns true iff the leaderTerm advanced.
-func (p *lowPriOverrideState) sideChannelForV1Leader(leaderTerm uint64) bool {
-	if leaderTerm <= p.leaderTerm {
-		return false
-	}
-	p.leaderTerm = leaderTerm
-	p.intervals.ShrinkToPrefix(0)
 	return true
 }
 

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/admission_test.go
@@ -59,12 +59,6 @@ func TestLowPriOverrideState(t *testing.T) {
 				notStaleTerm := lpos.sideChannelForLowPriOverride(leaderTerm, first, last, lowPriOverride)
 				return fmt.Sprintf("not-stale-term: %t\n%s", notStaleTerm, lposString())
 
-			case "side-channel-v1":
-				var leaderTerm uint64
-				d.ScanArgs(t, "leader-term", &leaderTerm)
-				termAdvanced := lpos.sideChannelForV1Leader(leaderTerm)
-				return fmt.Sprintf("term-advanced: %t\n%s", termAdvanced, lposString())
-
 			case "get-effective-priority":
 				// Example:
 				//  get-effective-priority index=4 pri=HighPri

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/processor_test.go
@@ -13,7 +13,6 @@ import (
 	"testing"
 	"time"
 
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowcontrolpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/kvflowinspectpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
@@ -289,7 +288,7 @@ func TestProcessorBasic(t *testing.T) {
 	var p *processorImpl
 	tenantID := roachpb.MustMakeTenantID(4)
 	muAsserter := makeTestMutexAsserter()
-	reset := func(enabled kvflowcontrol.V2EnabledWhenLeaderLevel) {
+	reset := func() {
 		b.Reset()
 		r = newTestReplica(&b)
 		sched = testRaftScheduler{b: &b}
@@ -308,12 +307,10 @@ func TestProcessorBasic(t *testing.T) {
 			ACWorkQueue:            &q,
 			MsgAppSender:           testMsgAppSender{},
 			RangeControllerFactory: &rcFactory,
-			EnabledWhenLeaderLevel: enabled,
 			EvalWaitMetrics:        rac2.NewEvalWaitMetrics(),
 		}).(*processorImpl)
-		fmt.Fprintf(&b, "n%s,s%s,r%s: replica=%s, tenant=%s, enabled-level=%s\n",
-			p.opts.NodeID, p.opts.StoreID, p.opts.RangeID, p.opts.ReplicaID, tenantID,
-			enabledLevelString(p.GetEnabledWhenLeader()))
+		fmt.Fprintf(&b, "n%s,s%s,r%s: replica=%s, tenant=%s\n",
+			p.opts.NodeID, p.opts.StoreID, p.opts.RangeID, p.opts.ReplicaID, tenantID)
 	}
 	builderStr := func() string {
 		str := b.String()
@@ -329,8 +326,7 @@ func TestProcessorBasic(t *testing.T) {
 
 			switch d.Cmd {
 			case "reset":
-				enabledLevel := parseEnabledLevel(t, d)
-				reset(enabledLevel)
+				reset()
 				return builderStr()
 
 			case "init-raft":
@@ -388,28 +384,6 @@ func TestProcessorBasic(t *testing.T) {
 				unlockFunc()
 				return builderStr()
 
-			case "set-enabled-level":
-				enabledLevel := parseEnabledLevel(t, d)
-				var state RaftNodeBasicState
-				if r.raftNode != nil {
-					state = RaftNodeBasicState{
-						Term:              r.raftNode.term,
-						IsLeader:          r.raftNode.isLeader,
-						Leader:            r.raftNode.leader,
-						NextUnstableIndex: r.raftNode.nextUnstableIndex,
-						Leaseholder:       r.leaseholder,
-					}
-				}
-				unlockFunc := LockRaftMu(&muAsserter)
-				p.SetEnabledWhenLeaderRaftMuLocked(ctx, enabledLevel, state)
-				unlockFunc()
-				return builderStr()
-
-			case "get-enabled-level":
-				enabledLevel := p.GetEnabledWhenLeader()
-				fmt.Fprintf(&b, "enabled-level: %s\n", enabledLevelString(enabledLevel))
-				return builderStr()
-
 			case "on-desc-changed":
 				desc := parseRangeDescriptor(t, d)
 				unlockFunc := LockRaftMuAndReplicaMu(&muAsserter)
@@ -446,8 +420,7 @@ func TestProcessorBasic(t *testing.T) {
 				fmt.Fprintf(&b, ".....\n")
 				if len(event.Entries) > 0 {
 					fmt.Fprintf(&b, "AdmitRaftEntries:\n")
-					destroyedOrV2 := p.AdmitRaftEntriesRaftMuLocked(ctx, event)
-					fmt.Fprintf(&b, "destroyed-or-leader-using-v2: %t\n", destroyedOrV2)
+					p.AdmitRaftEntriesRaftMuLocked(ctx, event)
 					printLogTracker()
 				}
 				unlockFunc()
@@ -480,10 +453,6 @@ func TestProcessorBasic(t *testing.T) {
 				return builderStr()
 
 			case "side-channel":
-				var usingV2 bool
-				if d.HasArg("v2") {
-					usingV2 = true
-				}
 				var leaderTerm uint64
 				d.ScanArgs(t, "leader-term", &leaderTerm)
 				var first, last uint64
@@ -494,11 +463,10 @@ func TestProcessorBasic(t *testing.T) {
 					lowPriOverride = true
 				}
 				info := SideChannelInfoUsingRaftMessageRequest{
-					UsingV2Protocol: usingV2,
-					LeaderTerm:      leaderTerm,
-					First:           first,
-					Last:            last,
-					LowPriOverride:  lowPriOverride,
+					LeaderTerm:     leaderTerm,
+					First:          first,
+					Last:           last,
+					LowPriOverride: lowPriOverride,
 				}
 				unlockFunc := LockRaftMu(&muAsserter)
 				p.SideChannelForPriorityOverrideAtFollowerRaftMuLocked(info)
@@ -566,38 +534,6 @@ func parseAdmissionPriority(t *testing.T, td *datadriven.TestData) admissionpb.W
 	}
 	t.Fatalf("unknown priority %s", priStr)
 	return admissionpb.NormalPri
-}
-
-func parseEnabledLevel(
-	t *testing.T, td *datadriven.TestData,
-) kvflowcontrol.V2EnabledWhenLeaderLevel {
-	if td.HasArg("enabled-level") {
-		var str string
-		td.ScanArgs(t, "enabled-level", &str)
-		switch str {
-		case "not-enabled":
-			return kvflowcontrol.V2NotEnabledWhenLeader
-		case "v1-encoding":
-			return kvflowcontrol.V2EnabledWhenLeaderV1Encoding
-		case "v2-encoding":
-			return kvflowcontrol.V2EnabledWhenLeaderV2Encoding
-		default:
-			t.Fatalf("unrecoginized level %s", str)
-		}
-	}
-	return kvflowcontrol.V2NotEnabledWhenLeader
-}
-
-func enabledLevelString(enabledLevel kvflowcontrol.V2EnabledWhenLeaderLevel) string {
-	switch enabledLevel {
-	case kvflowcontrol.V2NotEnabledWhenLeader:
-		return "not-enabled"
-	case kvflowcontrol.V2EnabledWhenLeaderV1Encoding:
-		return "v1-encoding"
-	case kvflowcontrol.V2EnabledWhenLeaderV2Encoding:
-		return "v2-encoding"
-	}
-	return "unknown-level"
 }
 
 func parseRangeDescriptor(t *testing.T, td *datadriven.TestData) roachpb.RangeDescriptor {

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/low_pri_override_state
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/low_pri_override_state
@@ -146,26 +146,3 @@ not-stale-term: true
 leader-term: 6
 intervals:
  [ 35,  40] => true
-
-# Existing term. Old message claiming v1 is ignored.
-side-channel-v1 leader-term=6
-----
-term-advanced: false
-leader-term: 6
-intervals:
- [ 35,  40] => true
-
-
-# Old term. Message is ignored.
-side-channel-v1 leader-term=5
-----
-term-advanced: false
-leader-term: 6
-intervals:
- [ 35,  40] => true
-
-# New term. Message claiming v1 is relevant.
-side-channel-v1 leader-term=7
-----
-term-advanced: true
-leader-term: 7

--- a/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
+++ b/pkg/kv/kvserver/kvflowcontrol/replica_rac2/testdata/processor
@@ -3,12 +3,7 @@
 
 reset
 ----
-n1,s2,r3: replica=5, tenant=4, enabled-level=not-enabled
-
-# Not enabled to use v2 if become leader.
-get-enabled-level
-----
-enabled-level: not-enabled
+n1,s2,r3: replica=5, tenant=4
 
 on-destroy
 ----
@@ -31,19 +26,7 @@ HandleRaftReady:
 
 reset
 ----
-n1,s2,r3: replica=5, tenant=4, enabled-level=not-enabled
-
-get-enabled-level
-----
-enabled-level: not-enabled
-
-# Can use v1 encoding and v2 protocol, if become leader.
-set-enabled-level enabled-level=v1-encoding
-----
-
-get-enabled-level
-----
-enabled-level: v1-encoding
+n1,s2,r3: replica=5, tenant=4
 
 # When replica is initialized, stable index and admitted indices are at the tip
 # of the log. The leader and leaseholder are both on replica-id 10.
@@ -70,23 +53,24 @@ set-raft-state log-term=50 log-index=24 next-unstable-index=25
 ----
 Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:24} next-unstable: 25
 
-# handleRaftReady. It thinks the leader is using v1, so there is no
-# advancement of admitted, or submission of this entry for admission.
+# handleRaftReady. We didn't provide information via the side-channel for the
+# entry, which is tolerated.
 handle-raft-ready-and-admit entries=v1/i24/t45/pri0/time2/len100 leader-term=50
 ----
 HandleRaftReady:
 .....
 AdmitRaftEntries:
-destroyed-or-leader-using-v2: false
-LogTracker [+dirty]: mark:{Term:50 Index:24}, stable:23, admitted:[23 23 23 23]
+ ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:24} Priority:LowPri}}) = true
+LogTracker: mark:{Term:50 Index:24}, stable:23, admitted:[23 23 23 23]
+LowPri: {Term:50 Index:24}
 
 # A new entry 25 appended to raft by the leader at term 50.
 set-raft-state log-term=50 log-index=25 next-unstable-index=26
 ----
 Raft: term: 50 leader: 10 leaseholder: 10 mark: {Term:50 Index:25} next-unstable: 26
 
-# Told that the leader is using v2. And that [25,25] has no low-pri override.
-side-channel v2 leader-term=50 first=25 last=25
+# Told that [25,25] has no low-pri override.
+side-channel leader-term=50 first=25 last=25
 ----
 
 # The index 25 entry is v1 encoded, so by default it is low-pri. Admitted vector
@@ -97,9 +81,8 @@ HandleRaftReady:
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:25} Priority:LowPri}}) = true
-destroyed-or-leader-using-v2: true
 LogTracker: mark:{Term:50 Index:25}, stable:23, admitted:[23 23 23 23]
-LowPri: {Term:50 Index:25}
+LowPri: {Term:50 Index:24} {Term:50 Index:25}
 
 # The leader has changed.
 # TODO(pav-kv): the leader can't have changed without bumping the term.
@@ -108,19 +91,19 @@ set-raft-state leader=11
 Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:25} next-unstable: 26
 
 # Stable index is advanced to 25, and the admitted vector is updated. The
-# low-pri admitted index is 24 since there is an entry at 25 that is not
+# low-pri admitted index is 23 since there is an entry at 24 that is not
 # admitted.
 synced-log term=50 index=25
 ----
-LogTracker [+dirty]: mark:{Term:50 Index:25}, stable:25, admitted:[24 25 25 25]
-LowPri: {Term:50 Index:25}
+LogTracker [+dirty]: mark:{Term:50 Index:25}, stable:25, admitted:[23 25 25 25]
+LowPri: {Term:50 Index:24} {Term:50 Index:25}
 
-# handleRaftReady with no entries. Since the leader is using v2, and the
-# admitted vector was updated, the new vector is handed to the piggybacker.
+# handleRaftReady with no entries. Since the admitted vector was updated, the
+# new vector is handed to the piggybacker.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
- Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 25 25 25])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[23 25 25 25])
 .....
 
 # A new entry 26 appended to raft by the same leader at term 50.
@@ -129,19 +112,18 @@ set-raft-state log-term=50 log-index=26 next-unstable-index=27
 Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:26} next-unstable: 27
 
 # Side channel for entries [26, 26] with no low-pri override.
-side-channel v2 leader-term=50 first=26 last=26
+side-channel leader-term=50 first=26 last=26
 ----
 
-# The index 26 entry uses v2 and is using pri=2, which is AboveNormalPri.
+# The index 26 entry uses v2 encoding and is using pri=2, which is AboveNormalPri.
 handle-raft-ready-and-admit entries=v2/i26/t45/pri2/time2/len100 leader-term=50
 ----
 HandleRaftReady:
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:user-high-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:26} Priority:AboveNormalPri}}) = true
-destroyed-or-leader-using-v2: true
-LogTracker: mark:{Term:50 Index:26}, stable:25, admitted:[24 25 25 25]
-LowPri: {Term:50 Index:25}
+LogTracker: mark:{Term:50 Index:26}, stable:25, admitted:[23 25 25 25]
+LowPri: {Term:50 Index:24} {Term:50 Index:25}
 AboveNormalPri: {Term:50 Index:26}
 
 # handleRaftReady is a noop.
@@ -154,21 +136,21 @@ HandleRaftReady:
 # admitted, which will be piggybacked in the next handleRaftReady.
 synced-log term=50 index=26
 ----
-LogTracker [+dirty]: mark:{Term:50 Index:26}, stable:26, admitted:[24 26 25 26]
-LowPri: {Term:50 Index:25}
+LogTracker [+dirty]: mark:{Term:50 Index:26}, stable:26, admitted:[23 26 25 26]
+LowPri: {Term:50 Index:24} {Term:50 Index:25}
 AboveNormalPri: {Term:50 Index:26}
 
 # Some admitted indices are advanced, but LowPri and AboveNormalPri cannot
-# advance past the index 25 and index 26 entries respectively, that are
+# advance past the index 24 and index 26 entries respectively, that are
 # waiting for admission. The new admitted vector is piggybacked.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
- Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[24 26 25 26])
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t50/[23 26 25 26])
 .....
 
-# Callback is accurate and index 25 is admitted. The admitted index advances for
-# AboveNormalPri.
+# Callback is accurate and index 25 (and 24) at LowPri is admitted. The
+# admitted index advances for LowPri.
 admitted-log-entry leader-term=50 index=25 pri=0
 ----
  RaftScheduler.EnqueueRaftReady(rangeID=3)
@@ -188,7 +170,7 @@ set-raft-state log-term=50 log-index=27 next-unstable-index=28
 Raft: term: 50 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} next-unstable: 28
 
 # Side channel for entries [27,27] indicate a low-pri override.
-side-channel v2 leader-term=50 first=27 last=27 low-pri
+side-channel leader-term=50 first=27 last=27 low-pri
 ----
 
 # The index 27 entry is marked AboveNormalPri, but will be treated as LowPri.
@@ -198,23 +180,25 @@ HandleRaftReady:
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:27} Priority:LowPri}}) = true
-destroyed-or-leader-using-v2: true
 LogTracker: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 25 26]
 LowPri: {Term:50 Index:27}
 AboveNormalPri: {Term:50 Index:26}
 
+# Noop, since there is waiting to be admitted entry at HighPri.
 admitted-log-entry leader-term=50 index=27 pri=3
 ----
 LogTracker: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 25 26]
 LowPri: {Term:50 Index:27}
 AboveNormalPri: {Term:50 Index:26}
 
+# Admit the entry at index 26 at AboveNormalPri.
 admitted-log-entry leader-term=50 index=26 pri=2
 ----
  RaftScheduler.EnqueueRaftReady(rangeID=3)
 LogTracker [+dirty+sched]: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 26 26]
 LowPri: {Term:50 Index:27}
 
+# The new admitted vector is piggybacked.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
@@ -226,14 +210,8 @@ set-raft-state term=51
 ----
 Raft: term: 51 leader: 11 leaseholder: 10 mark: {Term:50 Index:27} next-unstable: 28
 
-# index 27 is still waiting for admission, but we switch to a new leader that
-# is using the v1 protocol. NB: in practice, we will never have the v1
-# protocol be used after v2 encoding has happened, but processor does not
-# mind.
-side-channel v1 leader-term=51 first=27 last=27
-----
-
 # Stable index advanced to 27, as well as all admitted indices except LowPri.
+# Index 27 at LowPri is still waiting for admission.
 synced-log term=50 index=27
 ----
 LogTracker [+dirty]: mark:{Term:50 Index:27}, stable:27, admitted:[26 27 27 27]
@@ -245,31 +223,26 @@ handle-raft-ready-and-admit
 HandleRaftReady:
 .....
 
+side-channel leader-term=51 first=27 last=27
+----
+
 # A new entry at index 27 overwrites the previous one, and regresses the stable
 # and admitted indices.
 handle-raft-ready-and-admit entries=v1/i27/t46/pri0/time2/len100 leader-term=51
 ----
 HandleRaftReady:
+ Piggybacker.Add(n11, [r3,s11,5->11] admitted=t51/[26 26 26 26])
 .....
 AdmitRaftEntries:
-destroyed-or-leader-using-v2: false
-LogTracker [+dirty]: mark:{Term:51 Index:27}, stable:26, admitted:[26 26 26 26]
+ ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:51 Index:27} Priority:LowPri}}) = true
+LogTracker: mark:{Term:51 Index:27}, stable:26, admitted:[26 26 26 26]
+LowPri: {Term:51 Index:27}
 
 # Noop. Stale entry admission.
 admitted-log-entry leader-term=50 index=27 pri=0
 ----
-LogTracker [+dirty]: mark:{Term:51 Index:27}, stable:26, admitted:[26 26 26 26]
-
-# Same leader switches to v2.
-side-channel v2 leader-term=51 first=27 last=27
-----
-
-# Admitted vector is now sent to the leader.
-handle-raft-ready-and-admit
-----
-HandleRaftReady:
- Piggybacker.Add(n11, [r3,s11,5->11] admitted=t51/[26 26 26 26])
-.....
+LogTracker: mark:{Term:51 Index:27}, stable:26, admitted:[26 26 26 26]
+LowPri: {Term:51 Index:27}
 
 # Noop, since not the leader.
 enqueue-piggybacked-admitted from=25 to=5 term=50 index=24 pri=0
@@ -302,9 +275,8 @@ HandleRaftReady:
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:52 Index:28} Priority:LowPri}}) = true
-destroyed-or-leader-using-v2: true
 LogTracker: mark:{Term:52 Index:28}, stable:26, admitted:[26 26 26 26]
-LowPri: {Term:52 Index:28}
+LowPri: {Term:51 Index:27} {Term:52 Index:28}
 
 # AdmitForEval returns true since there is a RangeController which admitted.
 admit-for-eval pri=low-pri
@@ -418,15 +390,6 @@ handle-raft-ready-and-admit
 HandleRaftReady:
 .....
 
-# Noop, since destroyed.
-set-enabled-level enabled-level=v2-encoding
-----
-
-# Noop.
-get-enabled-level
-----
-enabled-level: v1-encoding
-
 # Noop.
 enqueue-piggybacked-admitted from=25 to=5 term=52 index=24 pri=0
 ----
@@ -436,7 +399,7 @@ process-piggybacked-admitted
 ----
 
 # Noop.
-side-channel v2 leader-term=53 first=29 last=29
+side-channel leader-term=53 first=29 last=29
 ----
 
 # Noop.
@@ -445,7 +408,6 @@ handle-raft-ready-and-admit entries=v1/i29/t45/pri0/time2/len100 leader-term=53
 HandleRaftReady:
 .....
 AdmitRaftEntries:
-destroyed-or-leader-using-v2: true
 LogTracker [+dirty]: mark:{Term:53 Index:29}, stable:28, admitted:[28 28 28 28]
 
 # Noop.
@@ -453,21 +415,16 @@ admitted-log-entry leader-term=52 index=28 pri=0
 ----
 LogTracker [+dirty]: mark:{Term:53 Index:29}, stable:28, admitted:[28 28 28 28]
 
-# Test transitioning to v2 protocol after becoming leader.
 reset
 ----
-n1,s2,r3: replica=5, tenant=4, enabled-level=not-enabled
+n1,s2,r3: replica=5, tenant=4
 
-get-enabled-level
-----
-enabled-level: not-enabled
-
-init-raft log-term=50 log-index=24
+init-raft log-term=50 log-index=25
 ----
 
 set-raft-state term=50 leader=5 leaseholder=5
 ----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:24} next-unstable: 25
+Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:25} next-unstable: 26
 
 # Noop, since don't know the descriptor.
 handle-raft-ready-and-admit
@@ -479,29 +436,15 @@ HandleRaftReady:
 on-desc-changed  replicas=n11/s11/11,n13/s13/13
 ----
 
+# RangeController is created.
 handle-raft-ready-and-admit
 ----
 HandleRaftReady:
-.....
-
-set-raft-state log-term=50 log-index=25 next-unstable-index=26
-----
-Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:25} next-unstable: 26
-
-# v1 protocol, so does not do anything.
-handle-raft-ready-and-admit entries=v1/i25/t45/pri0/time2/len100 leader-term=50
-----
-HandleRaftReady:
-.....
-AdmitRaftEntries:
-destroyed-or-leader-using-v2: false
-LogTracker: mark:{Term:50 Index:25}, stable:24, admitted:[24 24 24 24]
-
-# RangeController is created.
-set-enabled-level enabled-level=v1-encoding
-----
  RangeControllerFactory.New(replicaSet=[(n11,s11):11,(n13,s13):13], leaseholder=5, nextRaftIndex=26, forceFlushIndex=0)
+ RangeController.HandleRaftEventRaftMuLocked([])
+.....
 
+# Raft is about to send us a newly appended entry 26.
 set-raft-state log-term=50 log-index=26 next-unstable-index=27
 ----
 Raft: term: 50 leader: 5 leaseholder: 5 mark: {Term:50 Index:26} next-unstable: 27
@@ -514,14 +457,13 @@ HandleRaftReady:
 .....
 AdmitRaftEntries:
  ACWorkQueue.Admit({StoreID:2 TenantID:4 Priority:low-pri CreateTime:2 RequestedCount:100 Ingested:false RangeID:3 ReplicaID:5 CallbackState:{Mark:{Term:50 Index:26} Priority:LowPri}}) = true
-destroyed-or-leader-using-v2: true
-LogTracker: mark:{Term:50 Index:26}, stable:24, admitted:[24 24 24 24]
+LogTracker: mark:{Term:50 Index:26}, stable:25, admitted:[25 25 25 25]
 LowPri: {Term:50 Index:26}
 
 # Entry is admitted.
 admitted-log-entry leader-term=50 index=26 pri=0
 ----
-LogTracker: mark:{Term:50 Index:26}, stable:24, admitted:[24 24 24 24]
+LogTracker: mark:{Term:50 Index:26}, stable:25, admitted:[25 25 25 25]
 
 # Noop, since stable index is still 24.
 handle-raft-ready-and-admit
@@ -553,7 +495,6 @@ HandleRaftReady:
  RangeController.HandleRaftEventRaftMuLocked([27])
 .....
 AdmitRaftEntries:
-destroyed-or-leader-using-v2: true
 LogTracker: mark:{Term:50 Index:27}, stable:26, admitted:[26 26 26 26]
 
 # Everything up to 27 is admitted.

--- a/pkg/kv/kvserver/kvflowcontrol/testing_knobs.go
+++ b/pkg/kv/kvserver/kvflowcontrol/testing_knobs.go
@@ -20,9 +20,6 @@ type TestingKnobs struct {
 	// OverrideTokenDeduction is used to override how many tokens are deducted
 	// post-evaluation.
 	OverrideTokenDeduction func(tokens Tokens) Tokens
-	// OverrideV2EnabledWhenLeaderLevel is used to override the level at which
-	// RACv2 is enabled when a replica is the leader.
-	OverrideV2EnabledWhenLeaderLevel func() V2EnabledWhenLeaderLevel
 	// OverridePullPushMode is used to override whether the pull mode, or push
 	// mode is enabled.
 	//

--- a/pkg/kv/kvserver/raftlog/payload.go
+++ b/pkg/kv/kvserver/raftlog/payload.go
@@ -24,6 +24,8 @@ type EncodeOptions struct {
 	// RaftAdmissionMeta is non-nil iff this entry should be encoded using an AC
 	// encoding.
 	RaftAdmissionMeta *kvflowcontrolpb.RaftAdmissionMeta
+	// TODO(rac1): remove, since this is always true.
+	//
 	// When this entry should be encoded using an AC encoding, this specifies
 	// whether a WithACAndPriority encoding should be used.
 	EncodePriority bool

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -27,7 +27,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/gc"
-	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvflowcontrol/replica_rac2"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
@@ -455,11 +454,9 @@ type Replica struct {
 		// decoder is used to decode committed raft entries.
 		decoder replicaDecoder
 
-		flowControlLevel kvflowcontrol.V2EnabledWhenLeaderLevel
-
 		// Scratch for populating rac2.RaftEvent.MsgApps for flowControlV2.
 		msgAppScratchForFlowControl map[roachpb.ReplicaID][]raftpb.Message
-		// Scratch for populating rac2.RaftEvent.ReplicaSateInfo for flowContrlV2.
+		// Scratch for populating rac2.RaftEvent.ReplicaSateInfo for flowControlV2.
 		replicaStateScratchForFlowControl map[roachpb.ReplicaID]rac2.ReplicaStateInfo
 
 		// rangefeedCTLagObserver is used to observe the closed timestamp lag of


### PR DESCRIPTION
The transition code is not needed since the transition happened in v24.3.

Informs #136529

Release note: None