### PR TITLE
db-console: change disk throughput graph titles to omit magnitude

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/hardware.tsx
@@ -85,7 +85,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Read MiB/s"
+      title="Disk Read Bytes/s"
       sources={nodeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}
@@ -103,7 +103,7 @@ export default function (props: GraphDashboardProps) {
     </LineGraph>,
 
     <LineGraph
-      title="Disk Write MiB/s"
+      title="Disk Write Bytes/s"
       sources={nodeSources}
       tenantSource={tenantSource}
       showMetricsInTooltip={true}


### PR DESCRIPTION
db-console: change disk throughput graph titles to omit magnitude

In the metrics page, with the hardware graphs selected, you'll notice that the title of the disk throughput graphs include `MiB`. This is confusing, as the magnitude of the y-axis is programmatically determinted (it will be KiB, or GiB depending on how large the deltas are between time segments).

To fix this, we strip the titles of their magnitude, going from MiB/s to simply Bytes/s, so that it's impossible for two prefixes show up in the same view.

Fixes: #141003
Epic: none

Release note (ui change): Changes the titles of the disk throughput graphs in the hardware metrics page to say only Bytes/s instead of MiB/s.