### PR TITLE
release-24.3: ui: fix activate diagnostics modal infinite render bug

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/statementsDiagnostics/activateStatementDiagnosticsModal.tsx
@@ -126,7 +126,7 @@ export const ActivateStatementDiagnosticsModal = React.forwardRef<
     };
   });
 
-  if (planGists && selectedPlanGist === "") {
+  if (planGists && selectedPlanGist === "" && !!planGists[0]) {
     setSelectedPlanGist(planGists[0]);
   }
 


### PR DESCRIPTION
Backport 1/1 commits from #147437 on behalf of @kyle-a-wong.

----

The activate diagnostics modal runs into an infinite render bug when a statement fingerprint contains an empty string gist.

This commit fixes the infinite render by checking if the gist is an empty string

Fixes: #140639
Epic: None
Release note: None

----

Release justification: