### PR TITLE
release-25.2.1-rc: sql: do not rewrite UDF body statement slice while assigning placeholders

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_prepare
+++ b/pkg/sql/logictest/testdata/logic_test/udf_prepare
@@ -6,3 +6,47 @@ PREPARE p AS SELECT $1::INT
 
 statement error pgcode 0A000 cannot evaluate function in this context
 EXECUTE p(f())
+
+statement ok
+DEALLOCATE p;
+
+# Ensure that stable folding does not affect plans stored in the plan cache.
+subtest regression_147186
+
+statement ok
+CREATE FUNCTION f147186() RETURNS INT LANGUAGE SQL AS $$ SELECT CAST(current_setting('foo.bar') AS INT) $$;
+
+statement ok
+CREATE TABLE t147186 (a INT, b INT DEFAULT f147186());
+
+statement ok
+PREPARE p AS INSERT INTO t147186 (a) VALUES ($1);
+
+statement ok
+SET foo.bar = '100';
+
+statement ok
+EXECUTE p(1);
+
+query II rowsort
+SELECT a, b FROM t147186;
+----
+1  100
+
+statement ok
+SET foo.bar = '200';
+
+statement ok
+EXECUTE p(2);
+
+# The second row should reflect the custom var change.
+query II rowsort
+SELECT a, b FROM t147186;
+----
+1  100
+2  200
+
+statement ok
+DEALLOCATE p;
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #147187.

/cc @cockroachdb/release

---

Previously, we accidentally modified the original slice that contains the body statements of a UDF while copying it during the placeholder assignment step. As a result, constant folding that occurred in one session could become visible in the query plan cache, causing incorrect results. This commit fixes the bug by copying the slice as well as the body statements.

This bug only applied to prepared statements, since we don't add plans with stable expressions to the plan cache outside of the prepare path.

Fixes #147186

Release note (bug fix): Fixed a bug that could cause stable expressions to be folded in cached query plans. The bug could cause stable expressions like `current_setting` to return the wrong result if used in a prepared statement. The bug was introduced in point releases v23.2.22, v24.1.14, v24.3.9, and v25.1.2, and the v25.2 alpha.

---

Release justification: critical fix for bug introduced in earlier backport.