### PR TITLE
aggmetric: acquire lock in label config evaluation in SQLMetric

### DIFF
--- a/pkg/util/metric/aggmetric/counter_test.go
+++ b/pkg/util/metric/aggmetric/counter_test.go
@@ -46,7 +46,7 @@ func TestAggCounter(t *testing.T) {
 	c := NewSQLCounter(metric.Metadata{
 		Name: "foo_counter",
 	})
-	c.labelConfig.Store(uint64(metric.LabelConfigAppAndDB))
+	c.mu.labelConfig = metric.LabelConfigAppAndDB
 	r.AddMetric(c)
 	cacheStorage := cache.NewUnorderedCache(cache.Config{
 		Policy: cache.CacheLRU,

--- a/pkg/util/metric/aggmetric/gauge_test.go
+++ b/pkg/util/metric/aggmetric/gauge_test.go
@@ -35,7 +35,7 @@ func TestSQLGaugeEviction(t *testing.T) {
 	g.mu.children = &UnorderedCacheWrapper{
 		cache: cacheStorage,
 	}
-	g.labelConfig.Store(uint64(metric.LabelConfigAppAndDB))
+	g.mu.labelConfig = metric.LabelConfigAppAndDB
 
 	for i := 0; i < cacheSize; i++ {
 		g.Update(1, "1", strconv.Itoa(i))
@@ -69,7 +69,7 @@ func TestSQLGaugeMethods(t *testing.T) {
 		cache: cacheStorage,
 	}
 	r.AddMetric(g)
-	g.labelConfig.Store(uint64(metric.LabelConfigAppAndDB))
+	g.mu.labelConfig = metric.LabelConfigAppAndDB
 
 	g.Update(10, "1", "1")
 	g.Update(10, "2", "2")

--- a/pkg/util/metric/aggmetric/histogram_test.go
+++ b/pkg/util/metric/aggmetric/histogram_test.go
@@ -63,7 +63,7 @@ func TestSQLHistogram(t *testing.T) {
 	h.mu.children = &UnorderedCacheWrapper{
 		cache: cacheStorage,
 	}
-	h.labelConfig.Store(uint64(metric.LabelConfigAppAndDB))
+	h.mu.labelConfig = metric.LabelConfigAppAndDB
 
 	for i := 0; i < cacheSize; i++ {
 		h.RecordValue(1, "1", strconv.Itoa(i))


### PR DESCRIPTION
Previously, We are evaluating label config and then accordingly passing label
values to `getOrAddChild` method in SQLMetric. `getOrAddChild` method acquires
lock and then get/add child. This is inadequate because we are evaluating
label config before invoking `getOrAddChild`. This resulted in below issue
get/add child is happening inside the lock:

 P0,T0: initialise metrics with labelConfig as `LabelConfigApp`.
 P0,T1: increment SQL counter with 1 is invoked.
 P0,T2: `getChildByLabelConfig` method evaluates labelConfig as
	`LabelConfigApp`.
 P0,T3: invokes `getOrAddChild` method with just app as parameter.
 P1,T4: `ReinitialiseChildMetrics` acquires the lock, clears existing child
	 metrics, updates labelConfig as `LabelConfigAppAndDB` and release
	 lock.
 P0,T5: `getOrAddChild` acquires the lock, inserts the new child (c1) with app
	 and release lock.
 P2,T6: scrape metrics invokes `Each` method inside the lock. It expects 2
	label values for the child as latest labelConfig is LabelConfigAppAndDB
	and tries to fetch 2 label values app and db. However, child c1 has
	single value (app) which will throw an error.

It is happening because methods on SQLMetric expects length of
`labelValuesSlice` of `ChildMetric` should match according to `labelConfig`
value. This contract is broken in `getOrAddChild` as we don't lock the metric
object with its children map during modification of `labelConfig`. This is
reflected in `Each`'s implementation, where the code assumes that every child's
`labelValuesSlice` has a length consistent with the parent's `labelConfig`.

To address this, this patch makes sure that we are evaluating LabelConfig and
get/add child metric inside the same lock.

Epic: None
Fixes: https://github.com/cockroachdb/cockroach/issues/147475
Release note (bug fix): Concurrent invocation of child metric updates and
metric reinitialisation will not result in error during scrape.