### PR TITLE
sql: fix rolbypassrls global in pg_roles and pg_authid tables

### DIFF
--- a/pkg/cli/clisqlshell/testdata/describe
+++ b/pkg/cli/clisqlshell/testdata/describe
@@ -1966,10 +1966,10 @@ SELECT rolname AS "Role name",
        memberof AS "Member of"
   FROM roles
 Role name,Attributes,Member of
-myuser,"Superuser, Create role, Create DB",{admin}
-root,"Superuser, Create role, Create DB",{admin}
-admin,"Superuser, Create role, Create DB",{}
-node,"Superuser, Create role, Create DB, Cannot login",{}
+myuser,"Superuser, Create role, Create DB, Bypass RLS",{admin}
+root,"Superuser, Create role, Create DB, Bypass RLS",{admin}
+admin,"Superuser, Create role, Create DB, Bypass RLS",{}
+node,"Superuser, Create role, Create DB, Cannot login, Bypass RLS",{}
 
 cli
 \du myuser
@@ -2008,7 +2008,7 @@ SELECT rolname AS "Role name",
        memberof AS "Member of"
   FROM roles
 Role name,Attributes,Member of
-myuser,"Superuser, Create role, Create DB",{admin}
+myuser,"Superuser, Create role, Create DB, Bypass RLS",{admin}
 
 subtest end
 

--- a/pkg/sql/information_schema.go
+++ b/pkg/sql/information_schema.go
@@ -2925,16 +2925,6 @@ func (r roleOptions) createDB() (tree.DBool, error) {
 	return tree.DBool(createDB), err
 }
 
-func (r roleOptions) createRole() (tree.DBool, error) {
-	createRole, err := r.Exists("CREATEROLE")
-	return tree.DBool(createRole), err
-}
-
-func (r roleOptions) bypassRLS() (tree.DBool, error) {
-	bypassRLS, err := r.Exists("BYPASSRLS")
-	return tree.DBool(bypassRLS), err
-}
-
 // forEachRoleAtCacheReadTS reads from system.users and related tables using a
 // timestamp based on when the role membership cache was refreshed.
 func forEachRoleAtCacheReadTS(

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2761,9 +2761,9 @@ FROM pg_catalog.pg_roles
 ORDER BY rolname
 ----
 oid         rolname   rolconnlimit  rolpassword  rolvaliduntil  rolbypassrls  rolconfig
-2310524507  admin     -1            ********     NULL           false         NULL
-3233629770  node      -1            ********     NULL           false         NULL
-1546506610  root      -1            ********     NULL           false         NULL
+2310524507  admin     -1            ********     NULL           true          NULL
+3233629770  node      -1            ********     NULL           true          NULL
+1546506610  root      -1            ********     NULL           true          NULL
 2264919399  testuser  -1            ********     NULL           false         NULL
 
 # Regression test for https://github.com/cockroachdb/cockroach/issues/136230.
@@ -4800,7 +4800,7 @@ ORDER BY rolname
 ----
 rolname    rolcreatedb  rolconfig  rolinherit  rolcanlogin  rolvaliduntil
 testrole1  false        NULL       true        false        NULL
-testuser1  false        NULL       true        true         NULL
+testuser1  true         NULL       true        true         NULL
 testuser2  false        NULL       true        true         NULL
 
 query TBBBBT colnames
@@ -4812,8 +4812,8 @@ ORDER BY rolname
 rolname    rolcreatedb  rolcreaterole  rolinherit  rolcanlogin  rolvaliduntil
 root       true         true           true        true         NULL
 testrole1  false        false          true        false        NULL
-testuser1  false        false          true        true         NULL
-testuser2  false        false          true        true         NULL
+testuser1  true         false          true        true         NULL
+testuser2  false        true           true        true         NULL
 
 # Testing users that have admin role
 

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -5331,9 +5331,16 @@ CREATE ROLE can_bypassrls WITH BYPASSRLS;
 statement ok
 CREATE ROLE cannot_bypassrls;
 
+statement ok
+CREATE ROLE can_bypassrls_global;
+
+statement ok
+GRANT SYSTEM BYPASSRLS TO can_bypassrls_global; 
+
 query B
-SELECT rolbypassrls FROM pg_authid WHERE rolname = 'can_bypassrls';
+SELECT rolbypassrls FROM pg_authid WHERE rolname = 'can_bypassrls' OR rolname = 'can_bypassrls_global';
 ----
+true
 true
 
 query B
@@ -5342,8 +5349,9 @@ SELECT rolbypassrls FROM pg_authid WHERE rolname = 'cannot_bypassrls';
 false
 
 query B
-SELECT rolbypassrls FROM pg_roles WHERE rolname = 'can_bypassrls';
+SELECT rolbypassrls FROM pg_roles WHERE rolname = 'can_bypassrls' OR rolname = 'can_bypassrls_global';
 ----
+true
 true
 
 
@@ -5358,5 +5366,101 @@ DROP ROLE can_bypassrls;
 
 statement ok
 DROP ROLE cannot_bypassrls;
+
+subtest createrole_pg_roles_pg_authid
+
+statement ok
+CREATE ROLE can_createrole WITH CREATEROLE;
+
+statement ok
+CREATE ROLE cannot_createrole;
+
+statement ok
+CREATE ROLE can_createrole_global;
+
+statement ok
+GRANT SYSTEM CREATEROLE TO can_createrole_global; 
+
+query B
+SELECT rolcreaterole FROM pg_authid WHERE rolname = 'can_createrole' OR rolname = 'can_createrole_global';
+----
+true
+true
+
+query B
+SELECT rolcreaterole FROM pg_authid WHERE rolname = 'cannot_createrole';
+----
+false
+
+query B
+SELECT rolcreaterole FROM pg_roles WHERE rolname = 'can_createrole' OR rolname = 'can_createrole_global';
+----
+true
+true
+
+query B
+SELECT rolcreaterole FROM pg_roles WHERE rolname = 'cannot_createrole';
+----
+false
+
+statement ok
+DROP ROLE can_createrole;
+
+statement ok
+DROP ROLE cannot_createrole;
+
+statement ok
+REVOKE SYSTEM CREATEROLE FROM can_createrole_global; 
+
+statement ok
+DROP ROLE can_createrole_global;
+
+subtest createdb_pg_roles_pg_authid
+
+statement ok
+CREATE ROLE can_createdb WITH CREATEDB;
+
+statement ok
+CREATE ROLE cannot_createdb;
+
+statement ok
+CREATE ROLE can_createdb_global;
+
+statement ok
+GRANT SYSTEM CREATEDB TO can_createdb_global; 
+
+query B
+SELECT rolcreatedb FROM pg_authid WHERE rolname = 'can_createdb' OR rolname = 'can_createdb_global';
+----
+true
+true
+
+query B
+SELECT rolcreatedb FROM pg_authid WHERE rolname = 'cannot_createdb';
+----
+false
+
+query B
+SELECT rolcreatedb FROM pg_roles WHERE rolname = 'can_createdb' OR rolname = 'can_createdb_global';
+----
+true
+true
+
+query B
+SELECT rolcreatedb FROM pg_roles WHERE rolname = 'cannot_createdb';
+----
+false
+
+statement ok
+DROP ROLE can_createdb;
+
+statement ok
+DROP ROLE cannot_createdb;
+
+statement ok
+REVOKE SYSTEM CREATEDB FROM can_createdb_global; 
+
+statement ok
+DROP ROLE can_createdb_global;
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/synthetic_privileges
@@ -320,11 +320,19 @@ SELECT has_table_privilege('testuser4', 'crdb_internal.feature_usage', 'SELECT')
 ----
 false
 
+# Cleanup the privilege that was added.
+statement ok
+REVOKE SYSTEM MODIFYCLUSTERSETTING FROM testuser
+
 # This subtest makes sure that an unknown privilege in the system.privileges
 # table does not break code that is trying to look up other privileges.
 # This situation can happen if a new synthetic privilege is backported to an
 # older branch.
 subtest unknown_privilege
+
+# Add an arbitrary privilege so that we can test manually overriding it.
+statement ok
+GRANT SYSTEM CREATEDB TO testuser
 
 statement ok
 INSERT INTO system.users VALUES ('node', NULL, true, 0);


### PR DESCRIPTION
 This change adds coverage for global bypassrl via
`GRANT SYSTEM BYPASSRLS TO user_name;`.

Fixes: #146228
Epic: CRDB-48807

Release note: None