### PR TITLE
opt: do not produce unneeded PK cols in inverted index scans

### DIFF
--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -8567,7 +8567,7 @@ CREATE TABLE t136078 (
 )
 ----
 
-opt set=(optimizer_use_trigram_similarity_optimization=false)
+opt expect=GenerateInvertedIndexScans set=(optimizer_use_trigram_similarity_optimization=false)
 SELECT b FROM t136078 WHERE 'abc' % col3_8
 ----
 project
@@ -8597,6 +8597,36 @@ project
            │              └── ["bc ", "bc "]
            └── filters
                 └── 'abc' % lower(b:2) [outer=(2), stable]
+
+exec-ddl
+CREATE TABLE t143070 (
+  a STRING,
+  b STRING,
+  c STRING AS (b) VIRTUAL,
+  PRIMARY KEY (a, b),
+  INVERTED INDEX (c gin_trgm_ops)
+)
+----
+
+# Regression test for #143070. The inverted index scan should not produce
+# unneeded PK cols.
+opt expect=GenerateInvertedIndexScans
+SELECT 1 FROM t143070 WHERE c LIKE 'aaa'
+----
+project
+ ├── columns: "?column?":7!null
+ ├── fd: ()-->(7)
+ ├── select
+ │    ├── columns: b:2!null
+ │    ├── fd: ()-->(2)
+ │    ├── scan t143070@t143070_c_idx,inverted
+ │    │    ├── columns: b:2!null
+ │    │    └── inverted constraint: /6/1/2
+ │    │         └── spans: ["aaa", "aaa"]
+ │    └── filters
+ │         └── b:2 LIKE 'aaa' [outer=(2), constraints=(/2: [/'aaa' - /'aaa']; tight), fd=()-->(2)]
+ └── projections
+      └── 1 [as="?column?":7]
 
 
 # --------------------------------------------------


### PR DESCRIPTION
A minor bug has been fixed where an inverted index scan could produce
more PK columns than necessary. This caused test-only assertion failures
but does not cause any known, user-visible bugs. The bug was caused by
the incorrect assumption that all inverted index scans need to produces
all PK columns. In actuality, an inverted index scan can produce a
subset of PK columns if the original scan produces a subset of PK
columns and neither an inverted filter nor an index join are needed.

Fixes #143070

Release note: None
