### PR TITLE
ui: Change the description message for slow executions

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/insights/types.ts
@@ -173,16 +173,11 @@ export const highContentionInsight = (
   };
 };
 
-export const slowExecutionInsight = (
-  execType: InsightExecEnum,
-  latencyThreshold?: number,
-): Insight => {
-  let threshold = latencyThreshold + "ms";
-  if (!latencyThreshold) {
-    threshold =
-      "the value of the 'sql.insights.latency_threshold' cluster setting";
-  }
-  const description = `This ${execType} took longer than ${threshold} to execute.`;
+export const slowExecutionInsight = (execType: InsightExecEnum): Insight => {
+  const description =
+    `An execution of this ${execType} was marked as slow. Slow executions ` +
+    `are determined by the 'sql.insights.latency_threshold' and 'sql.insights.anomaly_detection.threshold' ` +
+    `cluster settings.`;
   return {
     name: InsightNameEnum.SLOW_EXECUTION,
     label: InsightEnumToLabel.get(InsightNameEnum.SLOW_EXECUTION),
@@ -278,7 +273,7 @@ export const getInsightFromCause = (
     case InsightNameEnum.HIGH_RETRY_COUNT:
       return highRetryCountInsight(execOption);
     default:
-      return slowExecutionInsight(execOption, latencyThreshold);
+      return slowExecutionInsight(execOption);
   }
 };
 


### PR DESCRIPTION
Previously the wording caused confusion as sometimes executions are marked as slow even though they finish before the latency threshold.

Fixes: #140097
Release note (ui change): Change the wording for the slow execution insight