### PR TITLE
roachtest: give more disk space to schemachange/bulkingest

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -339,7 +339,7 @@ func makeSchemaChangeBulkIngestTest(
 	return registry.TestSpec{
 		Name:             "schemachange/bulkingest",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode()),
+		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.VolumeSize(200)),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,


### PR DESCRIPTION
The test was failing due to insufficient space. The test size was recently increased in f63c38811ce8edee5b1fb765f5dd0d1e1c91f4d1, which is the likely reason for the issue.

fixes https://github.com/cockroachdb/cockroach/issues/147207
Release note: None