### PR TITLE
sql/row: order primary index deletes before secondary index deletes

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -527,9 +527,9 @@ query T kvtrace
 EXECUTE p(1)
 ----
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/114/1/1/0
 Del /Table/114/2/10/1/0
 Del /Table/114/3/100/1/0
-Del /Table/114/1/1/0
 
 statement ok
 DEALLOCATE p
@@ -605,9 +605,9 @@ EXECUTE p(10)
 ----
 Scan /Table/114/2/1{0-1} lock Exclusive (Block, Unreplicated)
 Scan /Table/114/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/114/1/1/0
 Del /Table/114/2/10/1/0
 Del /Table/114/3/100/1/0
-Del /Table/114/1/1/0
 
 subtest locking_behavior
 
@@ -646,9 +646,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE k = 1
 ----
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/1/1/0
 Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
-Del /Table/115/1/1/0
 
 # Only non-unique secondary index is scanned and locked.
 statement ok
@@ -674,9 +674,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE i = 2
 ----
 Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
+Del (locking) /Table/115/1/1/0
 Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
-Del (locking) /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);
@@ -707,9 +707,9 @@ DELETE FROM t139160 WHERE i = 2 RETURNING v
 ----
 Scan /Table/115/2/{2-3} lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/1/1/0
 Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
-Del /Table/115/1/1/0
 
 # Only unique secondary index is scanned and locked.
 statement ok
@@ -735,9 +735,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE u = 3
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
+Del (locking) /Table/115/1/1/0
 Del /Table/115/2/2/1/0
 Del /Table/115/3/3/0
-Del (locking) /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);
@@ -768,9 +768,9 @@ DELETE FROM t139160 WHERE u = 3 RETURNING v
 ----
 Scan /Table/115/3/3/0 lock Exclusive (Block, Unreplicated)
 Scan /Table/115/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/115/1/1/0
 Del /Table/115/2/2/1/0
 Del /Table/115/3/3/0
-Del /Table/115/1/1/0
 
 statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4);
@@ -798,9 +798,9 @@ query T kvtrace
 DELETE FROM t139160 WHERE v = 4
 ----
 Scan /Table/115/{1-2}
+Del (locking) /Table/115/1/1/0
 Del /Table/115/2/2/1/0
 Del (locking) /Table/115/3/3/0
-Del (locking) /Table/115/1/1/0
 
 statement ok
 CREATE TABLE t139105 (k INT PRIMARY KEY, v INT, FAMILY (k, v));
@@ -850,14 +850,14 @@ query T kvtrace
 DELETE FROM t139160_families WHERE k = 1
 ----
 Scan /Table/117/1/1/{0-2/2} lock Exclusive (Block, Unreplicated)
-Del /Table/117/2/2/1/0
-Del /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del (locking) /Table/117/1/1/0
 Del (locking) /Table/117/1/1/1/1
 Del (locking) /Table/117/1/1/2/1
 Del (locking) /Table/117/1/1/3/1
+Del /Table/117/2/2/1/0
+Del /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4);
@@ -866,14 +866,14 @@ query T kvtrace
 DELETE FROM t139160_families WHERE i = 2
 ----
 Scan /Table/117/2/{2-3} lock Exclusive (Block, Unreplicated)
-Del /Table/117/2/2/1/0
-Del /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del (locking) /Table/117/1/1/0
 Del (locking) /Table/117/1/1/1/1
 Del (locking) /Table/117/1/1/2/1
 Del (locking) /Table/117/1/1/3/1
+Del /Table/117/2/2/1/0
+Del /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4);
@@ -883,14 +883,14 @@ DELETE FROM t139160_families WHERE i = 2 RETURNING v
 ----
 Scan /Table/117/2/{2-3} lock Exclusive (Block, Unreplicated)
 Scan /Table/117/1/{1-2} lock Exclusive (Block, Unreplicated)
-Del /Table/117/2/2/1/0
-Del /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del (locking) /Table/117/1/1/0
 Del (locking) /Table/117/1/1/1/1
 Del (locking) /Table/117/1/1/2/1
 Del (locking) /Table/117/1/1/3/1
+Del /Table/117/2/2/1/0
+Del /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4);
@@ -899,14 +899,14 @@ query T kvtrace
 DELETE FROM t139160_families WHERE u = 3
 ----
 Scan /Table/117/3/3/{0-1/2} lock Exclusive (Block, Unreplicated)
-Del /Table/117/2/2/1/0
-Del /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del (locking) /Table/117/1/1/0
 Del (locking) /Table/117/1/1/1/1
 Del (locking) /Table/117/1/1/2/1
 Del (locking) /Table/117/1/1/3/1
+Del /Table/117/2/2/1/0
+Del /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4);
@@ -916,14 +916,14 @@ DELETE FROM t139160_families WHERE u = 3 RETURNING v
 ----
 Scan /Table/117/3/3/{0-1/2} lock Exclusive (Block, Unreplicated)
 Scan /Table/117/1/{1-2} lock Exclusive (Block, Unreplicated)
-Del /Table/117/2/2/1/0
-Del /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del (locking) /Table/117/1/1/0
 Del (locking) /Table/117/1/1/1/1
 Del (locking) /Table/117/1/1/2/1
 Del (locking) /Table/117/1/1/3/1
+Del /Table/117/2/2/1/0
+Del /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 # Sanity check a couple of session variables.
 statement ok
@@ -937,14 +937,14 @@ query T kvtrace
 DELETE FROM t139160_families WHERE k = 1
 ----
 Scan /Table/117/1/1/{0-2/2} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/117/2/2/1/0
-Del (locking) /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del /Table/117/1/1/0
 Del /Table/117/1/1/1/1
 Del /Table/117/1/1/2/1
 Del /Table/117/1/1/3/1
+Del (locking) /Table/117/2/2/1/0
+Del (locking) /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 statement ok
 SET optimizer_enable_lock_elision = false;
@@ -956,14 +956,14 @@ query T kvtrace
 DELETE FROM t139160_families WHERE k = 1
 ----
 Scan /Table/117/1/1/{0-2/2} lock Exclusive (Block, Unreplicated)
-Del (locking) /Table/117/2/2/1/0
-Del (locking) /Table/117/2/2/1/2/1
-Del (locking) /Table/117/3/3/0
-Del (locking) /Table/117/3/3/1/1
 Del (locking) /Table/117/1/1/0
 Del (locking) /Table/117/1/1/1/1
 Del (locking) /Table/117/1/1/2/1
 Del (locking) /Table/117/1/1/3/1
+Del (locking) /Table/117/2/2/1/0
+Del (locking) /Table/117/2/2/1/2/1
+Del (locking) /Table/117/3/3/0
+Del (locking) /Table/117/3/3/1/1
 
 statement ok
 RESET optimizer_enable_lock_elision;

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -50,9 +50,9 @@ query T kvtrace
 DELETE FROM d WHERE a=1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/106/1/1/0
 Del /Table/106/2/Arr/0/1/0
 Del /Table/106/2/Arr/7/1/0
-Del /Table/106/1/1/0
 
 query T kvtrace
 INSERT INTO d VALUES(2, '[{"a": "b"}, 3, {"a": "b"}]')

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index_multi_column
@@ -66,21 +66,21 @@ query T kvtrace
 DELETE FROM t WHERE k = 2
 ----
 Scan /Table/106/1/2/0 lock Exclusive (Block, Unreplicated)
+Del /Table/106/1/2/0
 Del /Table/106/2/333/Arr/0/2/0
 Del /Table/106/2/333/Arr/7/2/0
 Del /Table/106/3/333/"foo"/Arr/0/2/0
 Del /Table/106/3/333/"foo"/Arr/7/2/0
-Del /Table/106/1/2/0
 
 query T kvtrace
 DELETE FROM t WHERE k = 3
 ----
 Scan /Table/106/1/3/0 lock Exclusive (Block, Unreplicated)
+Del /Table/106/1/3/0
 Del /Table/106/2/333/Arr/3/3/0
 Del /Table/106/2/333/Arr/"a"/"b"/3/0
 Del /Table/106/3/333/"foo"/Arr/3/3/0
 Del /Table/106/3/333/"foo"/Arr/"a"/"b"/3/0
-Del /Table/106/1/3/0
 
 # Don't insert NULL values in the inverted column.
 query T kvtrace
@@ -148,6 +148,6 @@ query T kvtrace
 DELETE FROM t WHERE k = 5
 ----
 Scan /Table/106/1/5/0 lock Exclusive (Block, Unreplicated)
+Del /Table/106/1/5/0
 Del /Table/106/2/NULL/"a"/"b"/5/0
 Del /Table/106/3/NULL/"foo"/"a"/"b"/5/0
-Del /Table/106/1/5/0

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -275,27 +275,27 @@ query T kvtrace
 DELETE FROM t WHERE a = 5
 ----
 Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/2/4/5/0
 Del /Table/113/1/5/0
+Del /Table/113/2/4/5/0
 
 # Deleted row matches the first partial index.
 query T kvtrace
 DELETE FROM t WHERE a = 6
 ----
 Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/1/6/0
 Del /Table/113/2/11/6/0
 Del /Table/113/3/11/6/0
-Del /Table/113/1/6/0
 
 # Deleted row matches both partial indexes.
 query T kvtrace
 DELETE FROM t WHERE a = 12
 ----
 Scan /Table/113/1/12/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/1/12/0
 Del /Table/113/2/11/12/0
 Del /Table/113/3/11/12/0
 Del /Table/113/4/"foo"/12/0
-Del /Table/113/1/12/0
 
 # Deleted row does not match partial index with predicate column that is not
 # indexed.
@@ -311,8 +311,8 @@ query T kvtrace
 DELETE FROM u WHERE k = 2
 ----
 Scan /Table/114/1/2/0 lock Exclusive (Block, Unreplicated)
-Del /Table/114/2/3/2/0
 Del /Table/114/1/2/0
+Del /Table/114/2/3/2/0
 
 # ---------------------------------------------------------
 # UPDATE
@@ -446,9 +446,9 @@ query T kvtrace
 UPDATE t SET a = 21 WHERE a = 20
 ----
 Scan /Table/113/1/20/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/1/20/0
 Del /Table/113/2/11/20/0
 Del /Table/113/3/11/20/0
-Del /Table/113/1/20/0
 CPut /Table/113/1/21/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/bar
 Put /Table/113/2/11/21/0 -> /BYTES/
 Put /Table/113/3/11/21/0 -> /BYTES/
@@ -460,9 +460,9 @@ query T kvtrace
 UPDATE t SET a = 22, b = 9, c = 'foo' WHERE a = 21
 ----
 Scan /Table/113/1/21/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/1/21/0
 Del /Table/113/2/11/21/0
 Del /Table/113/3/11/21/0
-Del /Table/113/1/21/0
 CPut /Table/113/1/22/0 -> /TUPLE/2:2:Int/9/1:3:Bytes/foo
 Put /Table/113/2/9/22/0 -> /BYTES/
 Put /Table/113/4/"foo"/22/0 -> /BYTES/
@@ -696,8 +696,8 @@ query T kvtrace
 INSERT INTO t VALUES (5, 3, 'baz') ON CONFLICT (a) DO UPDATE SET a = 6
 ----
 Scan /Table/113/1/5/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/2/4/5/0
 Del /Table/113/1/5/0
+Del /Table/113/2/4/5/0
 CPut /Table/113/1/6/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/bar
 Put /Table/113/2/4/6/0 -> /BYTES/
 
@@ -707,8 +707,8 @@ query T kvtrace
 INSERT INTO t VALUES (6, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 7, c = 'foo'
 ----
 Scan /Table/113/1/6/0 lock Exclusive (Block, Unreplicated)
-Del /Table/113/2/4/6/0
 Del /Table/113/1/6/0
+Del /Table/113/2/4/6/0
 CPut /Table/113/1/7/0 -> /TUPLE/2:2:Int/4/1:3:Bytes/foo
 Put /Table/113/2/4/7/0 -> /BYTES/
 Put /Table/113/4/"foo"/7/0 -> /BYTES/
@@ -720,9 +720,9 @@ query T kvtrace
 INSERT INTO t VALUES (7, 3, 'bar') ON CONFLICT (a) DO UPDATE SET a = 8, b = 11
 ----
 Scan /Table/113/1/7/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/1/7/0
 Del /Table/113/2/4/7/0
 Del /Table/113/4/"foo"/7/0
-Del /Table/113/1/7/0
 CPut /Table/113/1/8/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foo
 Put /Table/113/2/11/8/0 -> /BYTES/
 Put /Table/113/3/11/8/0 -> /BYTES/
@@ -733,9 +733,9 @@ query T kvtrace
 INSERT INTO t VALUES (8, 4, 'bar') ON CONFLICT (a) DO UPDATE SET a = 9, c = 'foobar'
 ----
 Scan /Table/113/1/8/0 lock Exclusive (Block, Unreplicated)
+Del /Table/113/1/8/0
 Del /Table/113/2/11/8/0
 Del /Table/113/3/11/8/0
-Del /Table/113/1/8/0
 CPut /Table/113/1/9/0 -> /TUPLE/2:2:Int/11/1:3:Bytes/foobar
 Put /Table/113/2/11/9/0 -> /BYTES/
 Put /Table/113/3/11/9/0 -> /BYTES/
@@ -900,9 +900,9 @@ query T kvtrace
 DELETE FROM inv WHERE a = 1
 ----
 Scan /Table/107/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/107/1/1/0
 Del /Table/107/2/"num"/1/1/0
 Del /Table/107/2/"x"/"y"/1/0
-Del /Table/107/1/1/0
 
 query T kvtrace
 DELETE FROM inv WHERE a = 2
@@ -971,9 +971,9 @@ query T kvtrace
 UPDATE inv SET a = 4 WHERE a = 2
 ----
 Scan /Table/107/1/2/0 lock Exclusive (Block, Unreplicated)
+Del /Table/107/1/2/0
 Del /Table/107/2/"num"/4/2/0
 Del /Table/107/2/"x"/"y"/2/0
-Del /Table/107/1/2/0
 CPut /Table/107/1/4/0 -> /TUPLE/2:2:SentinelType/{"num": 4, "x": "y"}/1:3:Bytes/bar
 Put /Table/107/2/"num"/4/4/0 -> /BYTES/
 Put /Table/107/2/"x"/"y"/4/0 -> /BYTES/
@@ -1083,8 +1083,8 @@ DELETE FROM t57085_p WHERE p = 1;
 ----
 Del (locking) /Table/115/1/1/0
 Scan /Table/116/{1-2}
-Del /Table/116/2/1/10/0
 Del (locking) /Table/116/1/10/0
+Del /Table/116/2/1/10/0
 Del (locking) /Table/116/1/20/0
 
 # Tests for partial vector indexes.
@@ -1157,8 +1157,8 @@ DELETE FROM vec WHERE a = 10
 ----
 Scan /Table/108/1/10/0
 Scan /Table/108/2/"foo"/{1/1-2}
-Del /Table/108/2/"foo"/1/1/10/0
 Del (locking) /Table/108/1/10/0
+Del /Table/108/2/"foo"/1/1/10/0
 
 query T kvtrace
 DELETE FROM vec WHERE a = 20
@@ -1242,8 +1242,8 @@ UPDATE vec SET a = 40 WHERE a = 20
 Scan /Table/108/1/20/0
 Scan /Table/108/2/"bar"/{1/1-2}
 Scan /Table/108/2/"bar"/{1/2-2}
-Del /Table/108/2/"bar"/1/1/20/0
 Del (locking) /Table/108/1/20/0
+Del /Table/108/2/"bar"/1/1/20/0
 CPut /Table/108/1/40/0 -> /TUPLE/
 Put /Table/108/2/"bar"/1/1/40/0 -> /BYTES/:redacted:
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
+++ b/pkg/sql/opt/exec/execbuilder/testdata/secondary_index_column_families
@@ -40,6 +40,10 @@ query T kvtrace(prefix=/Table/106)
 DELETE FROM t1 WHERE x = 1
 ----
 Scan /Table/106/1/1/{0-1/2} lock Exclusive (Block, Unreplicated)
+Del (locking) /Table/106/1/1/0
+Del (locking) /Table/106/1/1/1/1
+Del (locking) /Table/106/1/1/2/1
+Del (locking) /Table/106/1/1/3/1
 Del /Table/106/2/1/1/0
 Del (locking) /Table/106/3/1/0
 Del /Table/106/4/1/1/0
@@ -48,10 +52,6 @@ Del /Table/106/4/1/1/3/1
 Del (locking) /Table/106/5/1/0
 Del (locking) /Table/106/5/1/2/1
 Del (locking) /Table/106/5/1/3/1
-Del (locking) /Table/106/1/1/0
-Del (locking) /Table/106/1/1/1/1
-Del (locking) /Table/106/1/1/2/1
-Del (locking) /Table/106/1/1/3/1
 
 # Put some data back into the table.
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -198,8 +198,8 @@ $trace_query
 ----
 colbatchscan  Scan /Table/108/{1-2} lock Exclusive (Block, Unreplicated)
 colbatchscan  fetched: /kv/kv_pkey/1/v -> /2
-count         Del (locking) /Table/108/2/2/0
 count         Del /Table/108/1/1/0
+count         Del (locking) /Table/108/2/2/0
 count         fast path completed
 sql query     rows affected: 1
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1434,9 +1434,9 @@ INSERT INTO t139160 VALUES (11, 12, 3, 14) ON CONFLICT (u) DO UPDATE SET k = 11,
 ----
 Scan /Table/126/3/3/0
 Scan /Table/126/1/1/0
+Del (locking) /Table/126/1/1/0
 Del /Table/126/2/2/1/0
 Del (locking) /Table/126/3/3/0
-Del (locking) /Table/126/1/1/0
 CPut /Table/126/1/11/0 -> /TUPLE/2:2:Int/12/1:3:Int/3/1:4:Int/14
 Put /Table/126/2/12/11/0 -> /BYTES/0x3306
 CPut /Table/126/3/3/0 -> /BYTES/0x932318

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_mutation
@@ -105,8 +105,8 @@ Scan /Table/106/1/2/0
 Scan /Table/106/2/{1/1-2}
 Scan /Table/106/3/10/{1/1-2}
 Scan /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/{1/1-2}
+Del (locking) /Table/106/1/2/0
 Del /Table/106/2/1/1/2/0
 Del /Table/106/3/10/1/1/2/0
 Del /Table/106/4/"\x16\x05\x15\xef\x17\xbd\x00\x00\x00 \x00 \x00 "/1/1/2/0
 Del /Table/106/5/10/2/0
-Del (locking) /Table/106/1/2/0

--- a/pkg/sql/testdata/index_mutations/delete_preserving_delete
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_delete
@@ -22,8 +22,8 @@ kvtrace
 DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/106/2/2/100/1/0
 Del /Table/106/1/1/0
+Put (delete) /Table/106/2/2/100/1/0
 
 # ---------------------------------------------------------
 # Partial Index With Delete Preserving Encoding
@@ -57,8 +57,8 @@ kvtrace
 DELETE FROM tpi WHERE a = 3
 ----
 Scan /Table/107/1/3/0 lock Exclusive (Block, Unreplicated)
-Put (delete) /Table/107/2/"foo"/3/0
 Del /Table/107/1/3/0
+Put (delete) /Table/107/2/"foo"/3/0
 
 # ---------------------------------------------------------
 # Expression Index With Delete Preserving Encoding
@@ -84,8 +84,8 @@ kvtrace
 DELETE FROM tei WHERE a + b = 102
 ----
 Scan /Table/108/{1-2}
-Put (delete) /Table/108/2/102/1/0
 Del (locking) /Table/108/1/1/0
+Put (delete) /Table/108/2/102/1/0
 
 # ---------------------------------------------------------
 # Inverted Index With Delete Preserving Encoding
@@ -111,11 +111,11 @@ kvtrace
 DELETE FROM tii WHERE a = 1
 ----
 Scan /Table/109/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/109/1/1/0
 Put (delete) /Table/109/2/NULL/1/0
 Put (delete) /Table/109/2/1/1/0
 Put (delete) /Table/109/2/2/1/0
 Put (delete) /Table/109/2/3/1/0
-Del /Table/109/1/1/0
 
 # ---------------------------------------------------------
 # Multicolumn Inverted Index With Delete Preserving Encoding
@@ -142,6 +142,6 @@ kvtrace
 DELETE FROM tmi WHERE a = 1
 ----
 Scan /Table/110/1/1/0 lock Exclusive (Block, Unreplicated)
+Del /Table/110/1/1/0
 Put (delete) /Table/110/2/2/"a"/"foo"/1/0
 Put (delete) /Table/110/2/2/"b"/"bar"/1/0
-Del /Table/110/1/1/0

--- a/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
+++ b/pkg/sql/testdata/index_mutations/delete_preserving_unique_index
@@ -24,8 +24,8 @@ kvtrace
 DELETE FROM ti WHERE a = 1
 ----
 Scan /Table/106/1/1/0 lock Exclusive (Block, Unreplicated)
-Put (delete) (locking) /Table/106/2/1/100/0
 Del /Table/106/1/1/0
+Put (delete) (locking) /Table/106/2/1/100/0
 
 kvtrace
 INSERT INTO ti VALUES (1, 1, 100)


### PR DESCRIPTION
Change row.Deleter to order writes to the primary index first, before writes to the secondary index. This matches row.Inserter and row.Updater.

This is needed to assist #147117 in achieving deterministic error ordering for LDR and DeleteSwap.

Informs: #144503, #146117

Release note: None