### PR TITLE
opt: track project equivalencies when inlining projections into filters

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -681,7 +681,7 @@ func (b *Builder) buildExistsSubquery(
 					props.OrderingChoice{},
 				),
 				memo.ProjectionsExpr{f.ConstructProjectionsItem(memo.TrueSingleton, existsCol)},
-				opt.ColSet{}, /* passthrough */
+				&memo.ProjectPrivate{},
 			)
 		}
 

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -1125,6 +1125,7 @@ func (prj *ProjectExpr) initUnexportedFields(mem *Memo) {
 	// Determine the "internal" functional dependencies (for the union of input
 	// columns and synthesized columns).
 	prj.internalFuncDeps.CopyFrom(&inputProps.FuncDeps)
+	prj.internalFuncDeps.AddEquiv(prj.Equiv)
 	for i := range prj.Projections {
 		item := &prj.Projections[i]
 		if v, ok := item.Element.(*VariableExpr); ok && inputProps.OutputCols.Contains(v.Col) {

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -1897,6 +1897,9 @@ func FormatPrivate(f *ExprFmtCtx, private interface{}, physProps *physical.Requi
 	case *ScanPrivate:
 		f.formatIndex(t.Table, t.Index, ScanIsReverseFn(f.Memo.Metadata(), t, &physProps.Ordering))
 
+	case *ProjectPrivate:
+		// Nothing to show.
+
 	case *SequenceSelectPrivate:
 		seq := f.Memo.metadata.Sequence(t.Sequence)
 		fmt.Fprintf(f.Buffer, " %s", seq.Name())

--- a/pkg/sql/opt/memo/interner.go
+++ b/pkg/sql/opt/memo/interner.go
@@ -465,6 +465,12 @@ func (h *hasher) HashOptionalColList(val opt.OptionalColList) {
 	h.hash = hash
 }
 
+func (h *hasher) HashEquivGroups(equiv props.EquivGroups) {
+	for i, n := 0, equiv.GroupCount(); i < n; i++ {
+		h.HashColSet(equiv.Group(i))
+	}
+}
+
 func (h *hasher) HashOrdering(val opt.Ordering) {
 	hash := h.hash
 	for _, id := range val {
@@ -968,6 +974,18 @@ func (h *hasher) IsColListEqual(l, r opt.ColList) bool {
 
 func (h *hasher) IsOptionalColListEqual(l, r opt.OptionalColList) bool {
 	return l.Equals(r)
+}
+
+func (h *hasher) IsEquivGroupsEqual(l, r props.EquivGroups) bool {
+	if l.GroupCount() != r.GroupCount() {
+		return false
+	}
+	for i, n := 0, l.GroupCount(); i < n; i++ {
+		if l.Group(i) != r.Group(i) {
+			return false
+		}
+	}
+	return true
 }
 
 func (h *hasher) IsOrderingEqual(l, r opt.Ordering) bool {

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1266,6 +1266,17 @@ func (c *CustomFuncs) MakePassthrough(passthrough opt.ColSet) *memo.ProjectPriva
 	return &memo.ProjectPrivate{Passthrough: passthrough}
 }
 
+// MakePassthroughWithEquivGroups constructs a new ProjectPrivate with the given
+// passthrough columns and equivalence groups.
+func (c *CustomFuncs) MakePassthroughWithEquivGroups(
+	passthrough opt.ColSet, equiv props.EquivGroups,
+) *memo.ProjectPrivate {
+	return &memo.ProjectPrivate{
+		Passthrough: passthrough,
+		Equiv:       equiv,
+	}
+}
+
 // ----------------------------------------------------------------------
 //
 // Values functions

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1248,7 +1248,22 @@ func (c *CustomFuncs) ProjectExtraCol(
 	in memo.RelExpr, extra opt.ScalarExpr, extraID opt.ColumnID,
 ) memo.RelExpr {
 	projections := memo.ProjectionsExpr{c.f.ConstructProjectionsItem(extra, extraID)}
-	return c.f.ConstructProject(in, projections, in.Relational().OutputCols)
+	return c.f.ConstructProject(in, projections,
+		&memo.ProjectPrivate{
+			Passthrough: in.Relational().OutputCols,
+		},
+	)
+}
+
+// Passthrough returns the passthrough column set of the ProjectPrivate.
+func (c *CustomFuncs) Passthrough(private *memo.ProjectPrivate) opt.ColSet {
+	return private.Passthrough
+}
+
+// MakePassthrough returns a new ProjectPrivate with the given passthrough
+// columns.
+func (c *CustomFuncs) MakePassthrough(passthrough opt.ColSet) *memo.ProjectPrivate {
+	return &memo.ProjectPrivate{Passthrough: passthrough}
 }
 
 // ----------------------------------------------------------------------

--- a/pkg/sql/opt/norm/groupby_funcs.go
+++ b/pkg/sql/opt/norm/groupby_funcs.go
@@ -130,7 +130,11 @@ func (c *CustomFuncs) ConstructProjectionFromDistinctOn(
 			projections = append(projections, c.f.ConstructProjectionsItem(varExpr, aggs[i].Col))
 		}
 	}
-	return c.f.ConstructProject(input, projections, passthrough)
+	return c.f.ConstructProject(input, projections,
+		&memo.ProjectPrivate{
+			Passthrough: passthrough,
+		},
+	)
 }
 
 // AreValuesDistinct returns true if a constant Values operator input contains

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -9,6 +9,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/errors"
@@ -223,6 +224,17 @@ func (c *CustomFuncs) InlineSelectProject(
 		)
 	}
 	return newFilters
+}
+
+// EquivGroupsFromFilters returns equivalence groups derived from the given
+// filters.
+func (c *CustomFuncs) EquivGroupsFromFilters(filters memo.FiltersExpr) props.EquivGroups {
+	var eq props.EquivGroups
+	for i := range filters {
+		item := &filters[i]
+		eq.AddFromFDs(&item.ScalarProps().FuncDeps)
+	}
+	return eq
 }
 
 // InlineProjectProject searches the projection expressions for any variable

--- a/pkg/sql/opt/norm/inline_funcs.go
+++ b/pkg/sql/opt/norm/inline_funcs.go
@@ -256,7 +256,11 @@ func (c *CustomFuncs) InlineProjectProject(
 		}
 	}
 
-	return c.f.ConstructProject(innerProject.Input, newProjections, newPassthrough)
+	return c.f.ConstructProject(innerProject.Input, newProjections,
+		&memo.ProjectPrivate{
+			Passthrough: newPassthrough,
+		},
+	)
 }
 
 // Recursively walk the tree looking for references to projection expressions
@@ -498,7 +502,9 @@ func (c *CustomFuncs) ConvertUDFToSubquery(
 		c.f.ConstructProject(
 			replace(stmt).(memo.RelExpr),
 			nil, /* projections */
-			opt.MakeColSet(returnColID),
+			&memo.ProjectPrivate{
+				Passthrough: opt.MakeColSet(returnColID),
+			},
 		),
 		&memo.SubqueryPrivate{},
 	)

--- a/pkg/sql/opt/norm/join_funcs.go
+++ b/pkg/sql/opt/norm/join_funcs.go
@@ -605,7 +605,11 @@ func (c *CustomFuncs) ExtractJoinComparison(
 		// produce columns from both sides.
 		outputCols = leftCols.Union(rightCols)
 	}
-	return c.f.ConstructProject(join, memo.EmptyProjectionsExpr, outputCols)
+	return c.f.ConstructProject(join, memo.EmptyProjectionsExpr,
+		&memo.ProjectPrivate{
+			Passthrough: outputCols,
+		},
+	)
 }
 
 // CommuteJoinFlags returns a join private for the commuted join (where the left

--- a/pkg/sql/opt/norm/project_builder.go
+++ b/pkg/sql/opt/norm/project_builder.go
@@ -95,5 +95,9 @@ func (pb *projectBuilder) buildProject(input memo.RelExpr) memo.RelExpr {
 		// Avoid creating a Project that does nothing and just gets elided.
 		return input
 	}
-	return pb.c.f.ConstructProject(input, pb.projections, pb.passthrough)
+	return pb.c.f.ConstructProject(input, pb.projections,
+		&memo.ProjectPrivate{
+			Passthrough: pb.passthrough,
+		},
+	)
 }

--- a/pkg/sql/opt/norm/project_funcs.go
+++ b/pkg/sql/opt/norm/project_funcs.go
@@ -662,7 +662,11 @@ func (c *CustomFuncs) PushColumnRemappingIntoValues(
 		&memo.ValuesPrivate{Cols: newValuesColList, ID: c.f.Metadata().NextUniqueID()})
 
 	// Construct and return a new ProjectExpr with the new ValuesExpr as input.
-	return c.f.ConstructProject(newValues, newProjections, newPassthrough)
+	return c.f.ConstructProject(newValues, newProjections,
+		&memo.ProjectPrivate{
+			Passthrough: newPassthrough,
+		},
+	)
 }
 
 // AssignmentCastCols returns the set of column IDs that undergo an assignment
@@ -800,7 +804,9 @@ func (c *CustomFuncs) PushAssignmentCastsIntoValues(
 			&memo.ValuesPrivate{Cols: newValuesCols, ID: c.f.Metadata().NextUniqueID()},
 		),
 		newProjections,
-		newPassthrough,
+		&memo.ProjectPrivate{
+			Passthrough: newPassthrough,
+		},
 	)
 }
 

--- a/pkg/sql/opt/norm/prune_cols_funcs.go
+++ b/pkg/sql/opt/norm/prune_cols_funcs.go
@@ -301,7 +301,11 @@ func (c *CustomFuncs) PruneCols(target memo.RelExpr, neededCols opt.ColSet) memo
 				projections = append(projections, *item)
 			}
 		}
-		return c.f.ConstructProject(t.Input, projections, passthrough)
+		return c.f.ConstructProject(t.Input, projections,
+			&memo.ProjectPrivate{
+				Passthrough: passthrough,
+			},
+		)
 
 	default:
 		// In other cases, we wrap the input in a Project operator.
@@ -311,7 +315,11 @@ func (c *CustomFuncs) PruneCols(target memo.RelExpr, neededCols opt.ColSet) memo
 		// higher-level expression, or if it's not part of the PruneCols set.
 		pruneCols := c.DerivePruneCols(target, c.f.disabledRules).Difference(neededCols)
 		colSet := c.OutputCols(target).Difference(pruneCols)
-		return c.f.ConstructProject(target, memo.EmptyProjectionsExpr, colSet)
+		return c.f.ConstructProject(target, memo.EmptyProjectionsExpr,
+			&memo.ProjectPrivate{
+				Passthrough: colSet,
+			},
+		)
 	}
 }
 

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -165,7 +165,7 @@
     $left:*
     $right:* &
         (HasOuterCols $right) &
-        (Project $input:* $projections:* $passthrough:*)
+        (Project $input:* $projections:* $projPrivate:*)
     $on:*
     $private:*
 )
@@ -174,7 +174,12 @@
     (Project
         ((OpName) $left $input [] $private)
         $projections
-        (UnionCols (OutputCols $left) $passthrough)
+        (MakePassthrough
+            (UnionCols
+                (OutputCols $left)
+                (Passthrough $projPrivate)
+            )
+        )
     )
     $on
 )
@@ -197,7 +202,7 @@
                 )
         )
         $projections:*
-        $passthrough:*
+        $projPrivate:*
     )
     $on:*
     $private:*
@@ -209,13 +214,18 @@
         (Project
             $selectInput
             $projections
-            (UnionCols $passthrough (OutputCols $selectInput))
+            (MakePassthrough
+                (UnionCols
+                    (Passthrough $projPrivate)
+                    (OutputCols $selectInput)
+                )
+            )
         )
         (ConcatFilters $on $filters)
         $private
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # TryDecorrelateProjectInnerJoin tries to decorrelate by hoisting the filter of
@@ -239,7 +249,7 @@
             $innerPrivate:*
         )
         $projections:*
-        $passthrough:*
+        $projPrivate:*
     )
     $on:*
     $private:*
@@ -256,13 +266,18 @@
                 $innerPrivate
             )
             $projections
-            (UnionCols $passthrough (OutputCols $join))
+            (MakePassthrough
+                (UnionCols
+                    (Passthrough $projPrivate)
+                    (OutputCols $join)
+                )
+            )
         )
         (ConcatFilters $on $innerOn)
         $private
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # TryDecorrelateInnerJoin tries to decorrelate an InnerJoin operator nested
@@ -403,7 +418,7 @@
         $on
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # TryDecorrelateUnion replaces a Union/UnionAll beneath a ScalarGroupBy with a
@@ -461,12 +476,14 @@
             (EmptyJoinPrivate)
         )
         (MakeCoalesceProjectionsForUnion $unionPrivate)
-        (MakeEmptyColSet)
+        (MakePassthrough (MakeEmptyColSet))
     )
     (ConvertAnyNotNullAggsToProjections $aggs)
-    (IntersectionCols
-        (GroupingOutputCols $private $aggs)
-        (OutputCols $input)
+    (MakePassthrough
+        (IntersectionCols
+            (GroupingOutputCols $private $aggs)
+            (OutputCols $input)
+        )
     )
 )
 
@@ -614,7 +631,7 @@
             $canaryCol
         )
         []
-        (OutputCols2 $left $right)
+        (MakePassthrough (OutputCols2 $left $right))
     )
     $on
 )
@@ -651,7 +668,7 @@
         (MakeGrouping (KeyCols $newLeft) (EmptyOrdering))
     )
     []
-    (OutputCols $left)
+    (MakePassthrough (OutputCols $left))
 )
 
 # TryDecorrelateLimitOne "pushes down" a Join into a Limit 1 operator, in an
@@ -691,7 +708,7 @@
         (MakeGrouping (KeyCols $newLeft) $ordering)
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # TryDecorrelateLimit "pushes down" a Join into a Limit operator with a limit
@@ -732,7 +749,7 @@
         (LimitToRowNumberFilter $limit $rowNumCol)
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # TryDecorrelateProjectSet "pushes down" an InnerJoinApply operator into a
@@ -861,7 +878,7 @@
         $on
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # TryDecorrelateMax1Row "pushes down" a Join into a Max1Row operator, in an
@@ -908,7 +925,7 @@
         )
     )
     []
-    (OutputCols2 $left $right)
+    (MakePassthrough (OutputCols2 $left $right))
 )
 
 # HoistUnboundFilterFromExistsSubquery pulls a filter condition out of an
@@ -1091,10 +1108,10 @@
         $item:* & (HasHoistableSubquery $item)
         ...
     ]
-    $passthrough:*
+    $private:*
 )
 =>
-(HoistProjectSubquery $input $projections $passthrough)
+(HoistProjectSubquery $input $projections (Passthrough $private))
 
 # HoistJoinSubquery extracts subqueries from a join filter and joins them with
 # the join's right input. This and other subquery hoisting patterns create a

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -87,7 +87,7 @@
     (Project
         $left
         (ProjectRemappedCols $toRemap $leftCols $fds)
-        $leftCols
+        (MakePassthrough $leftCols)
     )
     $aggs
     (MakeGrouping
@@ -123,7 +123,7 @@
     (Project
         $right
         (ProjectRemappedCols $toRemap $rightCols $fds)
-        $rightCols
+        (MakePassthrough $rightCols)
     )
     $aggs
     (MakeGrouping
@@ -148,7 +148,11 @@
         (ColsAreStrictKey (GroupingCols $groupingPrivate) $input)
 )
 =>
-(Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
+(Project
+    $input
+    []
+    (MakePassthrough (GroupingOutputCols $groupingPrivate $aggs))
+)
 
 # EliminateUpsertDistinct is similar to EliminateDistinct, but it only checks if
 # the grouping columns are a lax key because UpsertDistinctOn considers NULL
@@ -161,7 +165,11 @@
         (ColsAreLaxKey (GroupingCols $groupingPrivate) $input)
 )
 =>
-(Project $input [] (GroupingOutputCols $groupingPrivate $aggs))
+(Project
+    $input
+    []
+    (MakePassthrough (GroupingOutputCols $groupingPrivate $aggs))
+)
 
 # EliminateGroupBy is similar to EliminateDistinct, but it operates on GroupBy
 # expressions where the grouping columns are statically known to form a strict
@@ -183,9 +191,11 @@
 (Project
     $input
     (ConvertAnyNotNullAggsToProjections $aggs)
-    (IntersectionCols
-        (GroupingOutputCols $groupingPrivate $aggs)
-        (OutputCols $input)
+    (MakePassthrough
+        (IntersectionCols
+            (GroupingOutputCols $groupingPrivate $aggs)
+            (OutputCols $input)
+        )
     )
 )
 
@@ -610,7 +620,7 @@
 #      a. The aggregate only references cols from the Window operator's input.
 #      b. The aggregate is a ConstAgg (or ConstNotNull, AnyNotNull, or FirstAgg)
 #         that passes through the result of a window function.
-# 
+#
 # Assuming all of the above are satisfied, each GroupBy aggregate that only
 # references the Window's input can be left alone (5a). Then, each ConstAgg
 # referencing a window function can be replaced by that function (5b).

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -44,13 +44,13 @@
         $item:* & (ColsIntersect (OuterCols $item) $constCols)
         ...
     ]
-    $passthrough:*
+    $private:*
 )
 =>
 (Project
     $input
     (InlineProjectionConstants $projections $input $constCols)
-    $passthrough
+    $private
 )
 
 # InlineSelectConstants finds variable references in Filters expressions that
@@ -147,7 +147,7 @@
     (Project
         $input:*
         $projections:* & (CanInlineProjections $projections)
-        $passthrough:*
+        $private:*
     )
     $filters:* & ^(FilterHasCorrelatedSubquery $filters)
 )
@@ -155,7 +155,7 @@
 (Project
     (Select $input (InlineSelectProject $filters $projections))
     $projections
-    $passthrough
+    $private
 )
 
 # InlineSelectVirtualColumns pushes Select filters referencing virtual columns
@@ -241,7 +241,7 @@
     (Project
         $scan:(Scan $scanPrivate:*)
         $projections:*
-        $passthrough:*
+        $private:*
     )
     $filters:* &
         ^(ColsAreEmpty
@@ -262,7 +262,7 @@
             (InlineSelectProject $inlinableFilters $projections)
         )
         $projections
-        $passthrough
+        $private
     )
     (DiffFilters $filters $inlinableFilters)
 )
@@ -285,15 +285,15 @@
 (Project
     $input:(Project * $innerProjections:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         ^(HasDuplicateRefs
             $projections
-            $passthrough
+            (Passthrough $private)
             (ProjectionCols $innerProjections)
         )
 )
 =>
-(InlineProjectProject $input $projections $passthrough)
+(InlineProjectProject $input $projections (Passthrough $private))
 
 # InlineUDF converts a UDF to a subquery. A UDF can only be inlined if it is
 # non-volatile and has a single statement in the function body. See

--- a/pkg/sql/opt/norm/rules/inline.opt
+++ b/pkg/sql/opt/norm/rules/inline.opt
@@ -155,7 +155,10 @@
 (Project
     (Select $input (InlineSelectProject $filters $projections))
     $projections
-    $private
+    (MakePassthroughWithEquivGroups
+        (Passthrough $private)
+        (EquivGroupsFromFilters $filters)
+    )
 )
 
 # InlineSelectVirtualColumns pushes Select filters referencing virtual columns
@@ -262,7 +265,10 @@
             (InlineSelectProject $inlinableFilters $projections)
         )
         $projections
-        $private
+        (MakePassthroughWithEquivGroups
+            (Passthrough $private)
+            (EquivGroupsFromFilters $inlinableFilters)
+        )
     )
     (DiffFilters $filters $inlinableFilters)
 )

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -331,7 +331,11 @@
 [SimplifyLeftJoinWithZeroRowsRight, Normalize]
 (LeftJoin $left:* $right:* & (HasZeroRows $right))
 =>
-(Project $left (MakeNullProjections $right) (OutputCols $left))
+(Project
+    $left
+    (MakeNullProjections $right)
+    (MakePassthrough (OutputCols $left))
+)
 
 # SimplifyRightJoin reduces a FullJoin operator to a LeftJoin operator when it's
 # known that every row in the join's right input will match at least one row in
@@ -446,7 +450,7 @@ $left
                 (ProjectionOuterCols $projections)
                 (OutputCols $input)
             )
-        $passThrough:*
+        $projPrivate:*
     )
     $on:*
     $private:*
@@ -460,7 +464,9 @@ $left
         $private
     )
     $projections
-    (UnionCols (OutputCols $left) $passThrough)
+    (MakePassthrough
+        (UnionCols (OutputCols $left) (Passthrough $projPrivate))
+    )
 )
 
 # HoistJoinProjectLeft is the same as HoistJoinProjectRight, but for the left
@@ -471,7 +477,7 @@ $left
         $input:*
         $projections:* &
             (AllAreRemappingProjections $projections)
-        $passThrough:*
+        $projPrivate:*
     )
     $right:* &
 
@@ -493,7 +499,12 @@ $left
         $private
     )
     $projections
-    (UnionCols $passThrough (OutputCols $right))
+    (MakePassthrough
+        (UnionCols
+            (Passthrough $projPrivate)
+            (OutputCols $right)
+        )
+    )
 )
 
 # SimplifyJoinNotNullEquality simplifies an Is/IsNot equality filter condition
@@ -841,7 +852,7 @@ $left
     (Project
         $left
         (MakeProjectionsFromValues $right)
-        (OutputCols $left)
+        (MakePassthrough (OutputCols $left))
     )
     $on
 )

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -24,7 +24,7 @@ $input
 # to minimize the number of rows that other operators need to process.
 [PushLimitIntoProject, Normalize]
 (Limit
-    (Project $input:* $projections:* $passthrough:*)
+    (Project $input:* $projections:* $private:*)
     $limit:*
     $ordering:* &
         (OrderingCanProjectCols
@@ -36,7 +36,7 @@ $input
 (Project
     (Limit $input $limit (PruneOrdering $ordering $cols))
     $projections
-    $passthrough
+    $private
 )
 
 # PushOffsetIntoProject pushes the Offset operator into its Project input. It is
@@ -44,7 +44,7 @@ $input
 # order to minimize the number of rows that other operators need to process.
 [PushOffsetIntoProject, Normalize]
 (Offset
-    (Project $input:* $projections:* $passthrough:*)
+    (Project $input:* $projections:* $private:*)
     $offset:*
     $ordering:* &
         (OrderingCanProjectCols
@@ -56,7 +56,7 @@ $input
 (Project
     (Offset $input $offset (PruneOrdering $ordering $cols))
     $projections
-    $passthrough
+    $private
 )
 
 # PushLimitIntoOffset pushes the Limit operator into the offset. This should

--- a/pkg/sql/opt/norm/rules/mutation.opt
+++ b/pkg/sql/opt/norm/rules/mutation.opt
@@ -9,7 +9,7 @@
 # columns nor the columns referenced in the partial index predicate.
 [SimplifyPartialIndexProjections, Normalize]
 (Update
-    $project:(Project $input:* $projections:* $passthrough:*)
+    $project:(Project $input:* $projections:* $private:*)
     $uniqueChecks:*
     $fkChecks:*
     $mutationPrivate:* &
@@ -32,13 +32,13 @@
                 $simplifiedPrivate
             ):(SimplifyPartialIndexProjections
                 $projections
-                $passthrough
+                (Passthrough $private)
                 $simplifiableCols
                 $mutationPrivate
             )
             $simplifiedProjections
         )
-        $passthrough
+        $private
     )
     $uniqueChecks
     $fkChecks

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -25,10 +25,10 @@
         (JoinDoesNotDuplicateLeftRows $join) &
         (JoinPreservesLeftRows $join)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanRemapCols
             $fromCols:(UnionCols
-                $passthrough
+                (Passthrough $private)
                 (ProjectionOuterCols $projections)
             )
             $leftCols:(OutputCols $left)
@@ -41,10 +41,19 @@
     $left
     (MergeProjections
         (RemapProjectionCols $projections $leftCols $fds)
-        (ProjectRemappedCols $passthrough $leftCols $fds)
-        $passthrough
+        (ProjectRemappedCols
+            (Passthrough $private)
+            $leftCols
+            $fds
+        )
+        (Passthrough $private)
     )
-    (DifferenceCols $passthrough (OutputCols $right))
+    (MakePassthrough
+        (DifferenceCols
+            (Passthrough $private)
+            (OutputCols $right)
+        )
+    )
 )
 
 # EliminateJoinUnderProjectRight mirrors EliminateJoinUnderProjectLeft, except
@@ -55,10 +64,10 @@
         (JoinDoesNotDuplicateRightRows $join) &
         (JoinPreservesRightRows $join)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanRemapCols
             $fromCols:(UnionCols
-                $passthrough
+                (Passthrough $private)
                 (ProjectionOuterCols $projections)
             )
             $rightCols:(OutputCols $right)
@@ -71,10 +80,19 @@
     $right
     (MergeProjections
         (RemapProjectionCols $projections $rightCols $fds)
-        (ProjectRemappedCols $passthrough $rightCols $fds)
-        $passthrough
+        (ProjectRemappedCols
+            (Passthrough $private)
+            $rightCols
+            $fds
+        )
+        (Passthrough $private)
     )
-    (DifferenceCols $passthrough (OutputCols $left))
+    (MakePassthrough
+        (DifferenceCols
+            (Passthrough $private)
+            (OutputCols $left)
+        )
+    )
 )
 
 # EliminateProject discards a Project operator which is not adding or removing
@@ -83,8 +101,8 @@
 (Project
     $input:*
     $projections:[]
-    $passthrough:* &
-        (ColsAreEqual $passthrough (OutputCols $input))
+    $private:* &
+        (ColsAreEqual (Passthrough $private) (OutputCols $input))
 )
 =>
 $input
@@ -97,7 +115,7 @@ $input
     $input:(Project $innerInput:* $innerProjections:*)
     $projections:* &
         (CanMergeProjections $projections $innerProjections)
-    $passthrough:*
+    $private:*
 )
 =>
 (Project
@@ -105,11 +123,13 @@ $input
     (MergeProjections
         $projections
         $innerProjections
-        $passthrough
+        (Passthrough $private)
     )
-    (DifferenceCols
-        $passthrough
-        (ProjectionCols $innerProjections)
+    (MakePassthrough
+        (DifferenceCols
+            (Passthrough $private)
+            (ProjectionCols $innerProjections)
+        )
     )
 )
 
@@ -132,10 +152,14 @@ $input
             $projections
             (OutputCols $input)
         )
-    $passthrough:*
+    $private:*
 )
 =>
-(MergeProjectWithValues $projections $passthrough $input)
+(MergeProjectWithValues
+    $projections
+    (Passthrough $private)
+    $input
+)
 
 # PushColumnRemappingIntoValues folds ProjectionsItems into the passthrough set
 # if they simply remap Values output columns that are not already in
@@ -168,15 +192,19 @@ $input
 (Project
     $input:(Values)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPushColumnRemappingIntoValues
             $projections
-            $passthrough
+            (Passthrough $private)
             $input
         )
 )
 =>
-(PushColumnRemappingIntoValues $input $projections $passthrough)
+(PushColumnRemappingIntoValues
+    $input
+    $projections
+    (Passthrough $private)
+)
 
 # PushAssignmentCastsIntoValues pushes assignment cast projections into Values
 # rows.
@@ -221,12 +249,12 @@ $input
 (Project
     $input:(Values)
     $projections:*
-    $passthrough:* &
+    $private:* &
         ^(ColsAreEmpty
             $castCols:(IntersectionCols
                 (DifferenceCols
                     (AssignmentCastCols $projections)
-                    $passthrough
+                    (Passthrough $private)
                 )
                 (OutputCols $input)
             )
@@ -236,7 +264,7 @@ $input
 (PushAssignmentCastsIntoValues
     $input
     $projections
-    $passthrough
+    (Passthrough $private)
     $castCols
 )
 
@@ -266,7 +294,7 @@ $input
             $projections
             $col:(SingleColFromSet (OutputCols $input))
         )
-    $passthrough:* & (ColsAreEmpty $passthrough)
+    $private:* & (ColsAreEmpty (Passthrough $private))
 )
 =>
 (Project
@@ -275,7 +303,7 @@ $input
         $tupleCols:(MakeColsForUnnestTuples $col)
     )
     (FoldTupleColumnAccess $projections $tupleCols $col)
-    $passthrough
+    $private
 )
 
 # FoldJSONAccessIntoValues replaces a Values operator that has a single JSON
@@ -319,7 +347,7 @@ $input
             $projections
             $col:(SingleColFromSet (OutputCols $input))
         )
-    $passthrough:* & (ColsAreEmpty $passthrough)
+    $private:* & (ColsAreEmpty (Passthrough $private))
 )
 =>
 (Project
@@ -328,7 +356,7 @@ $input
         $jsonCols:(MakeColsForUnnestJSON $input $col)
     )
     (FoldJSONFieldAccess $projections $jsonCols $col $input)
-    $passthrough
+    $private
 )
 
 # FoldIsNullProject folds "x IS NULL" projections to false if "x" is not null in
@@ -343,11 +371,11 @@ $input
             ...
         ] &
         (IsColNotNull $col $input)
-    $passthrough:*
+    $private:*
 )
 =>
 (Project
     $input
     (FoldIsNullProjectionsItems $projections $input)
-    $passthrough
+    $private
 )

--- a/pkg/sql/opt/norm/rules/prune_cols.opt
+++ b/pkg/sql/opt/norm/rules/prune_cols.opt
@@ -36,17 +36,17 @@
 (Project
     $project:(Project)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $project
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
 =>
-(Project (PruneCols $project $needed) $projections $passthrough)
+(Project (PruneCols $project $needed) $projections $private)
 
 # PruneScanCols discards Scan operator columns that are never used. The needed
 # columns are pushed down into the Scan's opt.ScanOpDef private.
@@ -54,17 +54,17 @@
 (Project
     $input:(Scan)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
 =>
-(Project (PruneCols $input $needed) $projections $passthrough)
+(Project (PruneCols $input $needed) $projections $private)
 
 # PruneSelectCols discards Select input columns that are never used.
 #
@@ -75,13 +75,13 @@
 (Project
     (Select $input:* $filters:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols3
                 (FilterOuterCols $filters)
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -89,7 +89,7 @@
 (Project
     (Select (PruneCols $input $needed) $filters)
     $projections
-    $passthrough
+    $private
 )
 
 # PruneLimitCols discards Limit input columns that are never used.
@@ -101,13 +101,13 @@
 (Project
     (Limit $input:* $limit:* $ordering:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols3
                 (OrderingCols $ordering)
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -119,7 +119,7 @@
         (PruneOrdering $ordering $needed)
     )
     $projections
-    $passthrough
+    $private
 )
 
 # PruneOffsetCols discards Offset input columns that are never used.
@@ -131,13 +131,13 @@
 (Project
     (Offset $input:* $offset:* $ordering:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols3
                 (OrderingCols $ordering)
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -149,7 +149,7 @@
         (PruneOrdering $ordering $needed)
     )
     $projections
-    $passthrough
+    $private
 )
 
 # PruneJoinLeftCols discards columns on the left side of a join that are never
@@ -160,7 +160,7 @@
 (Project
     $input:(Join $left:* $right:* $on:* $private:*)
     $projections:*
-    $passthrough:* &
+    $projPrivate:* &
         (CanPruneCols
             $left
             $needed:(UnionCols4
@@ -173,7 +173,7 @@
                     )
                 )
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $projPrivate)
             )
         )
 )
@@ -186,7 +186,7 @@
         $private
     )
     $projections
-    $passthrough
+    $projPrivate
 )
 
 # PruneJoinRightCols discards columns on the right side of a join that are never
@@ -201,7 +201,7 @@
 (Project
     $input:(Join $left:* $right:* $on:* $private:*)
     $projections:*
-    $passthrough:* &
+    $projPrivate:* &
         (CanPruneCols
             $right
             $needed:(UnionCols3
@@ -213,7 +213,7 @@
                     )
                 )
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $projPrivate)
             )
         )
 )
@@ -226,7 +226,7 @@
         $private
     )
     $projections
-    $passthrough
+    $projPrivate
 )
 
 # PruneSemiAntiJoinRightCols discards columns on the right side of a
@@ -258,12 +258,12 @@
         $groupingPrivate:*
     )
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneAggCols
             $aggregations
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -275,7 +275,7 @@
         $groupingPrivate
     )
     $projections
-    $passthrough
+    $private
 )
 
 # PruneGroupByCols discards GroupBy input columns that are never used. Note that
@@ -305,30 +305,30 @@
 (Project
     $input:(Values)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
 =>
-(Project (PruneCols $input $needed) $projections $passthrough)
+(Project (PruneCols $input $needed) $projections $private)
 
 # PruneOrdinalityCols discards Ordinality input columns that are never used.
 [PruneOrdinalityCols, Normalize]
 (Project
     (Ordinality $input:* $ordinalityPrivate:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols3
                 (NeededOrdinalityCols $ordinalityPrivate)
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -339,7 +339,7 @@
         (PruneOrderingOrdinality $ordinalityPrivate $needed)
     )
     $projections
-    $passthrough
+    $private
 )
 
 # PruneExplainCols discards Explain input columns that are never used by its
@@ -361,13 +361,13 @@
 (Project
     $input:(ProjectSet $innerInput:* $zip:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols3
                 (ZipOuterCols $zip)
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -375,7 +375,7 @@
 (Project
     (ProjectSet (PruneCols $innerInput $needed) $zip)
     $projections
-    $passthrough
+    $private
 )
 
 # PruneWindowOutputCols eliminates unused window functions from a Window
@@ -384,11 +384,11 @@
 (Project
     (Window $input:* $windows:* $private:*)
     $projections:*
-    $passthrough:* &
+    $projPrivate:* &
         (CanPruneWindows
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $projPrivate)
             )
             $windows
         )
@@ -397,7 +397,7 @@
 (Project
     (Window $input (PruneWindows $needed $windows) $private)
     $projections
-    $passthrough
+    $projPrivate
 )
 
 # PruneWindowInputCols discards window passthrough columns which are never used.
@@ -407,13 +407,13 @@
 (Project
     $input:(Window $innerInput:* $fn:* $private:*)
     $projections:*
-    $passthrough:* &
+    $projPrivate:* &
         (CanPruneCols
             $input
             $needed:(UnionCols3
                 (NeededWindowCols $fn $private)
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $projPrivate)
             )
         )
 )
@@ -421,7 +421,7 @@
 (Project
     (Window (PruneCols $innerInput $needed) $fn $private)
     $projections
-    $passthrough
+    $projPrivate
 )
 
 # PruneMutationFetchCols removes columns from the mutation operator's FetchCols
@@ -491,13 +491,13 @@
         $mutationPrivate:*
     )
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneMutationReturnCols
             $mutationPrivate
             $needed:(UnionCols3
                 (PrimaryKeyCols (MutationTable $mutationPrivate))
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -510,7 +510,7 @@
         (PruneMutationReturnCols $mutationPrivate $needed)
     )
     $projections
-    $passthrough
+    $private
 )
 
 # PruneInsertReturnCols removes columns from the Insert operator's ReturnCols
@@ -530,13 +530,13 @@
         $mutationPrivate:*
     )
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneMutationReturnCols
             $mutationPrivate
             $needed:(UnionCols3
                 (PrimaryKeyCols (MutationTable $mutationPrivate))
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
@@ -550,7 +550,7 @@
         (PruneMutationReturnCols $mutationPrivate $needed)
     )
     $projections
-    $passthrough
+    $private
 )
 
 # PruneWithScanCols discards columns scanned from the WithScan that are never
@@ -559,17 +559,17 @@
 (Project
     $input:(WithScan)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $input
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
 =>
-(Project (PruneCols $input $needed) $projections $passthrough)
+(Project (PruneCols $input $needed) $projections $private)
 
 # PruneWithCols pushes a Project operator beneath a With. It's ok to
 # unconditionally push this Project down, since in the pruning case, we're
@@ -580,12 +580,12 @@
 (Project
     (With $binding:* $input:* $private:*)
     $projections:*
-    $passthrough:*
+    $projPrivate:*
 )
 =>
 (With
     $binding
-    (Project $input $projections $passthrough)
+    (Project $input $projections $projPrivate)
     $private
 )
 
@@ -606,22 +606,30 @@
 (Project
     $union:(UnionAll $left:* $right:* $colmap:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (CanPruneCols
             $union
             $needed:(UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
         )
 )
 =>
 (Project
     (UnionAll
-        (Project $left [] (NeededColMapLeft $needed $colmap))
-        (Project $right [] (NeededColMapRight $needed $colmap))
+        (Project
+            $left
+            []
+            (MakePassthrough (NeededColMapLeft $needed $colmap))
+        )
+        (Project
+            $right
+            []
+            (MakePassthrough (NeededColMapRight $needed $colmap))
+        )
         (PruneSetPrivate $needed $colmap)
     )
     $projections
-    $passthrough
+    $private
 )

--- a/pkg/sql/opt/norm/rules/reject_nulls.opt
+++ b/pkg/sql/opt/norm/rules/reject_nulls.opt
@@ -217,7 +217,7 @@
                 ^(ColsAreEmpty
                     $projectionCols:(ProjectionCols $projections)
                 )
-            $passthrough:*
+            $private:*
         ) &
         ^(ColsAreEmpty $rejectNullCols:(RejectNullCols $input))
     $filters:* &
@@ -250,7 +250,7 @@
             ]
         )
         $projections
-        $passthrough
+        $private
     )
     $filters
 )

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -242,7 +242,7 @@ $input
             (Project
                 (Limit $input (IntConst 1) (EmptyOrdering))
                 [ (ProjectionsItem (True) (MakeBoolCol)) ]
-                (MakeEmptyColSet)
+                (MakePassthrough (MakeEmptyColSet))
             )
             (EmbeddedSubqueryPrivate $existsPrivate)
         )
@@ -325,7 +325,8 @@ $udf
         $values:(Values * $valuesPrivate:*)
         [ (ProjectionsItem $tuple:(Tuple)) ] &
             (IsTupleOfVars $tuple (ValuesCols $valuesPrivate))
-        $passthrough:* & (ColsAreEmpty $passthrough)
+        $projPrivate:* &
+            (ColsAreEmpty (Passthrough $projPrivate))
     )
     $scalar:*
     $private:*

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -84,7 +84,7 @@ $input
 # computed columns.
 [PushSelectIntoProject, Normalize]
 (Select
-    (Project $input:* $projections:* $passthrough:*)
+    (Project $input:* $projections:* $private:*)
     $filters:[
         ...
         $item:* &
@@ -100,7 +100,7 @@ $input
             (ExtractBoundConditions $filters $inputCols)
         )
         $projections
-        $passthrough
+        $private
     )
     (ExtractUnboundConditions $filters $inputCols)
 )

--- a/pkg/sql/opt/norm/set_funcs.go
+++ b/pkg/sql/opt/norm/set_funcs.go
@@ -46,20 +46,20 @@ func (c *CustomFuncs) projectColMapSide(toList, fromList opt.ColList) memo.Proje
 // be passed-through from the left side in a SetPrivate when eliminating a set
 // operation, like in EliminateUnionAllLeft. Columns in both the output
 // ColList and the left ColList should be passed-through.
-func (c *CustomFuncs) ProjectPassthroughLeft(set *memo.SetPrivate) opt.ColSet {
+func (c *CustomFuncs) ProjectPassthroughLeft(set *memo.SetPrivate) *memo.ProjectPrivate {
 	out := set.OutCols.ToSet()
 	out.IntersectionWith(set.LeftCols.ToSet())
-	return out
+	return &memo.ProjectPrivate{Passthrough: out}
 }
 
 // ProjectPassthroughRight returns a ColSet that contains the columns that can
 // be passed-through from the right side in a SetPrivate when eliminating a set
 // operation, like in EliminateUnionAllRight. Columns in both the output
 // ColList and the right ColList should be passed-through.
-func (c *CustomFuncs) ProjectPassthroughRight(set *memo.SetPrivate) opt.ColSet {
+func (c *CustomFuncs) ProjectPassthroughRight(set *memo.SetPrivate) *memo.ProjectPrivate {
 	out := set.OutCols.ToSet()
 	out.IntersectionWith(set.RightCols.ToSet())
-	return out
+	return &memo.ProjectPrivate{Passthrough: out}
 }
 
 // PruneSetPrivate returns a SetPrivate based on the given SetPrivate, but with

--- a/pkg/sql/opt/norm/testdata/rules/inline
+++ b/pkg/sql/opt/norm/testdata/rules/inline
@@ -729,6 +729,93 @@ project
       │              └── 1.0
       └── 107
 
+exec-ddl
+CREATE TABLE t134816 (
+  a  BOOL,
+  b  INT2,
+  c  INT4,
+  d  STRING AS (lower(CAST(a AS STRING))) VIRTUAL,
+  e  INT8,
+  f INT8 AS (c + b) VIRTUAL,
+  PRIMARY KEY (c)
+)
+----
+
+# Regression test for #134816. The equivalence of columns 14 and 19 should
+# remain at the root after equality filters involving virtual columns are
+# inlined.
+opt
+  SELECT NULL
+    FROM t134816 AS t1
+    JOIN t134816 AS t2 ON t1.c = t2.f AND t1.c <= t2.c
+    JOIN t134816 AS t3 ON t2.f = t3.c AND t2.b = t3.c
+ORDER BY t2.a, t3.c, t2.f, t2.d
+   LIMIT 2
+----
+project
+ ├── columns: "?column?":25  [hidden: a:9 f:14!null c:19!null]
+ ├── cardinality: [0 - 2]
+ ├── immutable
+ ├── fd: ()-->(25), (14)==(19), (19)==(14)
+ ├── ordering: +9,+(14|19) opt(25) [actual: +9,+14]
+ ├── limit
+ │    ├── columns: c:3!null a:9 b:10!null f:14!null c:19!null
+ │    ├── internal-ordering: +9,+(3|10|14|19)
+ │    ├── cardinality: [0 - 2]
+ │    ├── immutable
+ │    ├── fd: (3)==(10,14,19), (10)==(3,14,19), (14)==(3,10,19), (19)==(3,10,14)
+ │    ├── ordering: +9,+(3|10|14|19) [actual: +9,+10]
+ │    ├── inner-join (lookup t134816)
+ │    │    ├── columns: c:3!null a:9 b:10!null f:14!null c:19!null
+ │    │    ├── key columns: [10] = [19]
+ │    │    ├── lookup columns are key
+ │    │    ├── immutable
+ │    │    ├── fd: (3)==(10,14,19), (10)==(3,14,19), (14)==(3,10,19), (19)==(3,10,14)
+ │    │    ├── ordering: +9,+(3|10|14|19) [actual: +9,+10]
+ │    │    ├── limit hint: 2.00
+ │    │    ├── inner-join (lookup t134816)
+ │    │    │    ├── columns: c:3!null a:9 b:10!null f:14!null
+ │    │    │    ├── key columns: [14] = [3]
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── immutable
+ │    │    │    ├── fd: (3)==(10,14), (10)==(3,14), (14)==(3,10)
+ │    │    │    ├── ordering: +9,+(3|10|14) [actual: +9,+10]
+ │    │    │    ├── limit hint: 100.00
+ │    │    │    ├── sort
+ │    │    │    │    ├── columns: a:9 b:10!null f:14!null
+ │    │    │    │    ├── immutable
+ │    │    │    │    ├── fd: (10)==(14), (14)==(10)
+ │    │    │    │    ├── ordering: +9,+(10|14) [actual: +9,+10]
+ │    │    │    │    ├── limit hint: 100.00
+ │    │    │    │    └── project
+ │    │    │    │         ├── columns: f:14!null a:9 b:10!null
+ │    │    │    │         ├── immutable
+ │    │    │    │         ├── fd: (10)==(14), (14)==(10)
+ │    │    │    │         ├── select
+ │    │    │    │         │    ├── columns: a:9 b:10!null c:11!null
+ │    │    │    │         │    ├── immutable
+ │    │    │    │         │    ├── key: (11)
+ │    │    │    │         │    ├── fd: (11)-->(9,10)
+ │    │    │    │         │    ├── scan t134816
+ │    │    │    │         │    │    ├── columns: a:9 b:10 c:11!null
+ │    │    │    │         │    │    ├── computed column expressions
+ │    │    │    │         │    │    │    ├── d:12
+ │    │    │    │         │    │    │    │    └── lower(a:9::STRING)
+ │    │    │    │         │    │    │    └── f:14
+ │    │    │    │         │    │    │         └── c:11 + b:10
+ │    │    │    │         │    │    ├── key: (11)
+ │    │    │    │         │    │    └── fd: (11)-->(9,10)
+ │    │    │    │         │    └── filters
+ │    │    │    │         │         ├── c:11 >= (c:11 + b:10) [outer=(10,11), immutable, constraints=(/11: (/NULL - ])]
+ │    │    │    │         │         └── b:10 = (c:11 + b:10) [outer=(10,11), immutable, constraints=(/10: (/NULL - ])]
+ │    │    │    │         └── projections
+ │    │    │    │              └── c:11 + b:10 [as=f:14, outer=(10,11), immutable]
+ │    │    │    └── filters (true)
+ │    │    └── filters (true)
+ │    └── 2
+ └── projections
+      └── NULL [as="?column?":25]
+
 # --------------------------------------------------
 # InlineSelectVirtualColumns
 # --------------------------------------------------

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -2783,7 +2783,7 @@ exprnorm expect=HoistJoinProjectRight
         (ProjectionsItem (Var "x") (NewColumn "foo" "int"))
         (ProjectionsItem (Var "x") (NewColumn "bar" "int"))
       ]
-      ""
+      []
     )
     [
       (Eq (Var "foo") (Const 20 "int"))
@@ -2833,7 +2833,7 @@ exprnorm expect-not=HoistJoinProjectRight format=show-types
         (ProjectionsItem (Var "x") (NewColumn "foo" "int2"))
         (ProjectionsItem (Var "x") (NewColumn "bar" "int4"))
       ]
-      ""
+      []
     )
     [
       (Eq (Var "foo") (Const 20 "int"))
@@ -3059,7 +3059,7 @@ exprnorm expect=HoistJoinProjectLeft
         (ProjectionsItem (Var "x") (NewColumn "foo" "int"))
         (ProjectionsItem (Var "x") (NewColumn "bar" "int"))
       ]
-      ""
+      []
     )
     (Scan [ (Table "a") (Cols "k") ])
     [
@@ -3149,7 +3149,7 @@ exprnorm expect-not=HoistJoinProjectLeft disable=TryDecorrelateSelect
         (ProjectionsItem (Var "x") (NewColumn "bar" "int"))
         (ProjectionsItem (Var "z") (NewColumn "baz" "int"))
       ]
-      ""
+      []
     )
     (Select (Scan [ (Table "a") (Cols "k") ]) [ (Eq (Var "k") (Var "baz")) ])
     [

--- a/pkg/sql/opt/norm/testdata/rules/scalar
+++ b/pkg/sql/opt/norm/testdata/rules/scalar
@@ -190,7 +190,7 @@ exprnorm expect=EliminateCast
       (ProjectionsItem (Cast (Null "char(2)") "bit")                           (NewColumn "c4" "bit"))
       (ProjectionsItem (Cast (Cast (Var "s") "string") "text")                 (NewColumn "c5" "text"))
     ]
-    ""
+    []
   )
   (Presentation "c1,c2,c3,c4,c5")
   (NoOrdering)

--- a/pkg/sql/opt/norm/with_funcs.go
+++ b/pkg/sql/opt/norm/with_funcs.go
@@ -55,7 +55,7 @@ func (c *CustomFuncs) InlineWith(binding, input memo.RelExpr, priv *memo.WithPri
 						t.OutCols[i],
 					)
 				}
-				return c.f.ConstructProject(binding, projections, opt.ColSet{})
+				return c.f.ConstructProject(binding, projections, &memo.ProjectPrivate{})
 			}
 			// TODO(justin): should apply joins block inlining because they can lead
 			// to expressions being executed multiple times?
@@ -136,7 +136,7 @@ func (c *CustomFuncs) InlineWithScanOfValues(
 		Cols: newCols,
 		ID:   c.f.Metadata().NextUniqueID(),
 	})
-	return c.f.ConstructProject(newValuesExpr, projections, opt.ColSet{})
+	return c.f.ConstructProject(newValuesExpr, projections, &memo.ProjectPrivate{})
 }
 
 // ApplyLimitToRecursiveCTEScan re-optimizes the recursive branch of a recursive

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -188,14 +188,12 @@ define Select {
 # can be removed, reordered, or renamed. In addition, new columns can be
 # synthesized.
 #
-# Projections describes the synthesized columns constructed by Project, and
-# Passthrough describes the input columns that are passed through as Project
-# output columns.
+# Projections describes the synthesized columns constructed by Project.
 [Relational]
 define Project {
     Input RelExpr
     Projections ProjectionsExpr
-    Passthrough ColSet
+    _ ProjectPrivate
 
     # notNullCols is the set of columns (input or synthesized) that are known to
     # be not-null.
@@ -204,6 +202,13 @@ define Project {
     # internalFuncDeps are the functional dependencies between all columns
     # (input or synthesized).
     internalFuncDeps FuncDepSet
+}
+
+[Private]
+define ProjectPrivate {
+    # Passthrough describes the input columns that are passed through as Project
+    # output columns.
+    Passthrough ColSet
 }
 
 # InvertedFilter filters rows from its input result set, based on the

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -209,6 +209,10 @@ define ProjectPrivate {
     # Passthrough describes the input columns that are passed through as Project
     # output columns.
     Passthrough ColSet
+
+    # EquivGroups contains equivalencies of projected columns. It is populated
+    # by rules that inline filters below the projection.
+    Equiv EquivGroups
 }
 
 # InvertedFilter filters rows from its input result set, based on the

--- a/pkg/sql/opt/optbuilder/mutation_builder_unique.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder_unique.go
@@ -584,8 +584,11 @@ func (h *uniqueCheckHelper) buildInsertionCheck(
 	// normalization rules to prune any unnecessary columns from the expression.
 	// The key columns are always needed in order to display the constraint
 	// violation error.
-	project := f.ConstructProject(semiJoin, nil /* projections */, keyCols.ToSet())
-
+	project := f.ConstructProject(semiJoin, nil, /* projections */
+		&memo.ProjectPrivate{
+			Passthrough: keyCols.ToSet(),
+		},
+	)
 	uniqueChecks := f.ConstructUniqueChecksItem(project, &memo.UniqueChecksItemPrivate{
 		Table:        h.mb.tabID,
 		CheckOrdinal: h.uniqueOrdinal,

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -2097,13 +2097,21 @@ func (b *plpgsqlBuilder) addRuntimeCheck(
 	runtimeCheckColName := b.makeIdentifier("_plpgsql_runtime_check")
 	runtimeCheckCol := b.ob.factory.Metadata().AddColumn(runtimeCheckColName, types.Int)
 	proj := memo.ProjectionsExpr{b.ob.factory.ConstructProjectionsItem(caseExpr, runtimeCheckCol)}
-	s.expr = b.ob.factory.ConstructProject(s.expr, proj, originalCols)
+	s.expr = b.ob.factory.ConstructProject(s.expr, proj,
+		&memo.ProjectPrivate{
+			Passthrough: originalCols,
+		},
+	)
 
 	// Add an optimization barrier to ensure that the runtime checks are not
 	// eliminated by column-pruning. Then, remove the temporary columns from the
 	// output.
 	b.ob.addBarrier(s)
-	s.expr = b.ob.factory.ConstructProject(s.expr, memo.ProjectionsExpr{}, originalCols)
+	s.expr = b.ob.factory.ConstructProject(s.expr, memo.ProjectionsExpr{},
+		&memo.ProjectPrivate{
+			Passthrough: originalCols,
+		},
+	)
 }
 
 // buildFetch projects a call to the crdb_internal.plpgsql_fetch builtin

--- a/pkg/sql/opt/optbuilder/project.go
+++ b/pkg/sql/opt/optbuilder/project.go
@@ -54,7 +54,11 @@ func (b *Builder) constructProject(input memo.RelExpr, cols []scopeColumn) memo.
 		}
 	}
 
-	return b.factory.ConstructProject(input, projections, passthrough)
+	return b.factory.ConstructProject(input, projections,
+		&memo.ProjectPrivate{
+			Passthrough: passthrough,
+		},
+	)
 }
 
 // dropOrderingAndExtraCols removes the ordering in the scope and projects away
@@ -66,7 +70,11 @@ func (b *Builder) dropOrderingAndExtraCols(s *scope) {
 		for i := range s.cols {
 			passthrough.Add(s.cols[i].id)
 		}
-		s.expr = b.factory.ConstructProject(s.expr, nil /* projections */, passthrough)
+		s.expr = b.factory.ConstructProject(s.expr, nil, /* projections */
+			&memo.ProjectPrivate{
+				Passthrough: passthrough,
+			},
+		)
 		s.extraCols = nil
 	}
 }

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -767,7 +767,11 @@ func (b *Builder) buildScan(
 			}
 			proj = append(proj, item)
 		})
-		outScope.expr = b.factory.ConstructProject(outScope.expr, proj, scanColIDs)
+		outScope.expr = b.factory.ConstructProject(outScope.expr, proj,
+			&memo.ProjectPrivate{
+				Passthrough: scanColIDs,
+			},
+		)
 	}
 
 	// Apply any filters required to enforce RLS policies. This must be done

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -280,7 +280,7 @@ func (mb *mutationBuilder) applyChangesFromTriggers(
 		panic(errors.AssertionFailedf("missing NEW column for trigger"))
 	}
 	f := mb.b.factory
-	passThroughCols := triggerScope.colSet()
+	passthrough := triggerScope.colSet()
 	projections := make(memo.ProjectionsExpr, 0, len(tableTyp.TupleContents()))
 	for i, colTyp := range tableTyp.TupleContents() {
 		c := mb.tab.Column(visibleColOrds[i])
@@ -305,7 +305,11 @@ func (mb *mutationBuilder) applyChangesFromTriggers(
 		}
 		projections = append(projections, f.ConstructProjectionsItem(elem, elemCol.id))
 	}
-	triggerScope.expr = f.ConstructProject(triggerScope.expr, projections, passThroughCols)
+	triggerScope.expr = f.ConstructProject(triggerScope.expr, projections,
+		&memo.ProjectPrivate{
+			Passthrough: passthrough,
+		},
+	)
 }
 
 // ensureNoRowsModifiedByTrigger adds a runtime check to the scope that ensures

--- a/pkg/sql/opt/optbuilder/util.go
+++ b/pkg/sql/opt/optbuilder/util.go
@@ -808,11 +808,15 @@ func (b *Builder) addBarrier(s *scope) {
 func (b *Builder) projectColWithMetadataName(
 	s *scope, name string, typ *types.T, scalar opt.ScalarExpr,
 ) opt.ColumnID {
-	passThroughCols := s.colSet()
+	passthrough := s.colSet()
 	colName := scopeColName("").WithMetadataName(name)
 	col := b.synthesizeColumn(s, colName, typ, nil /* expr */, scalar /* scalar */)
 	proj := memo.ProjectionsExpr{b.factory.ConstructProjectionsItem(scalar, col.id)}
-	s.expr = b.factory.ConstructProject(s.expr, proj, passThroughCols)
+	s.expr = b.factory.ConstructProject(s.expr, proj,
+		&memo.ProjectPrivate{
+			Passthrough: passthrough,
+		},
+	)
 	return col.id
 }
 

--- a/pkg/sql/opt/optbuilder/window.go
+++ b/pkg/sql/opt/optbuilder/window.go
@@ -649,7 +649,11 @@ func (b *Builder) constructScalarWindowGroup(
 
 	scalarAggExpr := b.factory.ConstructScalarGroupBy(input, aggs, &memo.GroupingPrivate{})
 	if len(projections) != 0 {
-		return b.factory.ConstructProject(scalarAggExpr, projections, passthrough)
+		return b.factory.ConstructProject(scalarAggExpr, projections,
+			&memo.ProjectPrivate{
+				Passthrough: passthrough,
+			},
+		)
 	}
 	return scalarAggExpr
 }

--- a/pkg/sql/opt/optgen/cmd/optgen/metadata.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/metadata.go
@@ -231,6 +231,7 @@ func newMetadata(compiled *lang.CompiledExpr, pkg string) *metadata {
 		"RelPropsPtr":          {fullName: "props.Relational", isPointer: true, usePointerIntern: true},
 		"ScalarProps":          {fullName: "props.Scalar"},
 		"FuncDepSet":           {fullName: "props.FuncDepSet"},
+		"EquivGroups":          {fullName: "props.EquivGroups"},
 		"JoinMultiplicity":     {fullName: "props.JoinMultiplicity"},
 		"OpaqueMetadata":       {fullName: "opt.OpaqueMetadata", isInterface: true},
 		"JobCommand":           {fullName: "tree.JobCommand", passByVal: true},

--- a/pkg/sql/opt/props/func_dep.go
+++ b/pkg/sql/opt/props/func_dep.go
@@ -1136,9 +1136,14 @@ func (f *FuncDepSet) AddFrom(fdset *FuncDepSet) {
 // AddEquivFrom is similar to AddFrom, except that it only adds equivalence
 // dependencies from the given set to this set.
 func (f *FuncDepSet) AddEquivFrom(fdset *FuncDepSet) {
-	for i := 0; i < fdset.equiv.GroupCount(); i++ {
+	f.AddEquiv(fdset.equiv)
+}
+
+// AddEquiv adds a set of equivalence groups to the FD set.
+func (f *FuncDepSet) AddEquiv(equiv EquivGroups) {
+	for i := 0; i < equiv.GroupCount(); i++ {
 		// NOTE: the ColSet of an equiv group is immutable.
-		f.addEquivalency(fdset.equiv.Group(i))
+		f.addEquivalency(equiv.Group(i))
 	}
 	f.tryToReduceKey(opt.ColSet{} /* notNullCols */)
 }

--- a/pkg/sql/opt/xform/groupby_funcs.go
+++ b/pkg/sql/opt/xform/groupby_funcs.go
@@ -173,7 +173,9 @@ func (c *CustomFuncs) MakeProjectFromPassthroughAggs(
 	c.e.mem.AddProjectToGroup(&memo.ProjectExpr{
 		Input:       input,
 		Projections: projections,
-		Passthrough: passthrough,
+		ProjectPrivate: memo.ProjectPrivate{
+			Passthrough: passthrough,
+		},
 	}, grp)
 }
 

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -461,7 +461,7 @@ func (c *CustomFuncs) generateLookupJoinsImpl(
 			lookupJoin.Input = c.e.f.ConstructProject(
 				lookupJoin.Input,
 				lookupConstraint.InputProjections,
-				lookupJoin.Input.Relational().OutputCols,
+				c.MakePassthrough(lookupJoin.Input.Relational().OutputCols),
 			)
 		}
 
@@ -2081,10 +2081,12 @@ func (c *CustomFuncs) GenerateLocalityOptimizedSearchOfLookupJoins(
 
 	// Project away columns which weren't in the original output columns.
 	if !localJoinOutputCols.Equals(localBranch.Relational().OutputCols) {
-		localBranch = c.e.f.ConstructProject(localBranch, memo.ProjectionsExpr{}, localJoinOutputCols)
+		localBranch = c.e.f.ConstructProject(localBranch, memo.ProjectionsExpr{},
+			c.MakePassthrough(localJoinOutputCols))
 	}
 	if !remoteJoinOutputCols.Equals(remoteBranch.Relational().OutputCols) {
-		remoteBranch = c.e.f.ConstructProject(remoteBranch, memo.ProjectionsExpr{}, remoteJoinOutputCols)
+		remoteBranch = c.e.f.ConstructProject(remoteBranch, memo.ProjectionsExpr{},
+			c.MakePassthrough(remoteJoinOutputCols))
 	}
 
 	sp :=

--- a/pkg/sql/opt/xform/limit_funcs.go
+++ b/pkg/sql/opt/xform/limit_funcs.go
@@ -568,7 +568,8 @@ func (c *CustomFuncs) TryGenerateVectorSearch(
 		vectorSearch = c.e.f.ConstructLookupJoin(vectorSearch, nil /* on */, lookupPrivate)
 
 		// Add back the projections, including the distance column.
-		vectorSearch = c.e.f.ConstructProject(vectorSearch, projections, passthrough)
+		vectorSearch = c.e.f.ConstructProject(vectorSearch, projections,
+			c.MakePassthrough(passthrough))
 
 		// Build a top-k operator ordering by the distance column and limited by the
 		// NN count to obtain the final result. We verified when the rule matched

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -54,5 +54,5 @@
         (ParameterizedJoinPrivate)
     )
     []
-    (OutputCols (Root))
+    (MakePassthrough (OutputCols (Root)))
 )

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -88,7 +88,7 @@
         $private
     )
     []
-    (OutputCols $left)
+    (MakePassthrough (OutputCols $left))
 )
 
 # ConvertSemiToInnerJoin applies in the cases where CommuteSemiJoin does not:
@@ -121,7 +121,7 @@
         (MakeGrouping (KeyCols $newLeft) (EmptyOrdering))
     )
     []
-    (OutputCols $left)
+    (MakePassthrough (OutputCols $left))
 )
 
 # SplitDisjunctionOfJoinTerms splits disjunctions (OR expressions) of ON clause
@@ -192,7 +192,7 @@
         (MakeGrouping $groupingCols (EmptyOrdering))
     )
     []
-    (OutputCols (Root))
+    (MakePassthrough (OutputCols (Root)))
 )
 
 # SplitDisjunctionOfAntiJoinTerms splits disjunctions (OR expressions) of ON
@@ -247,7 +247,7 @@
         (MakeGrouping $groupingCols (EmptyOrdering))
     )
     []
-    (OutputCols (Root))
+    (MakePassthrough (OutputCols (Root)))
 )
 
 # GenerateMergeJoins creates MergeJoin operators for the join, using the
@@ -469,7 +469,7 @@
     $proj:(Project
         $right:* & (CanHoistProjectInput $right)
         $projections:* & ^(HasVolatileProjection $projections)
-        $passthrough:*
+        $projPrivate:*
     )
     $on:* &
         ^(ColsIntersect
@@ -482,7 +482,9 @@
 (Project
     (InnerJoin $left $right $on $private)
     $projections
-    (UnionCols $passthrough (OutputCols $left))
+    (MakePassthrough
+        (UnionCols (Passthrough $projPrivate) (OutputCols $left))
+    )
 )
 
 # HoistProjectFromLeftJoin pulls a project of a canonical scan or of a select
@@ -511,7 +513,7 @@
     (Project
         $right:* & (CanHoistProjectInput $right)
         $projections:* & ^(HasVolatileProjection $projections)
-        $passthrough:*
+        $projPrivate:*
     )
     $on:* &
         ^(ColsIntersect
@@ -527,7 +529,9 @@
 (Project
     (LeftJoin $left $right $on $private)
     (MakeProjectionsForOuterJoin $canaryCol $projections)
-    (UnionCols $passthrough (OutputCols $left))
+    (MakePassthrough
+        (UnionCols (Passthrough $projPrivate) (OutputCols $left))
+    )
 )
 
 # GenerateLocalityOptimizedAntiJoin converts an anti join into a locality

--- a/pkg/sql/opt/xform/rules/limit.opt
+++ b/pkg/sql/opt/xform/rules/limit.opt
@@ -72,11 +72,7 @@
 # with similar behavior is necessary.
 [PushLimitIntoProjectFilteredScan, Explore]
 (Limit
-    (Project
-            (Scan $scanPrivate:*)
-            $projections:*
-            $passthrough:*
-        ) &
+    (Project (Scan $scanPrivate:*) $projections:* $private:*) &
         (PushLimitIntoProjectFilteredScanEnabled)
     (Const $limit:* & (IsPositiveInt $limit))
     $ordering:* & (CanLimitFilteredScan $scanPrivate $ordering)
@@ -85,7 +81,7 @@
 (Project
     (Scan (LimitScanPrivate $scanPrivate $limit $ordering))
     $projections
-    $passthrough
+    $private
 )
 
 # PushLimitIntoIndexJoin pushes a limit through an index join. Since index
@@ -319,7 +315,7 @@
                 )
                 ...
             ]
-            $passthrough:*
+            $private:*
         ) &
         ^(HasOuterCols $project)
     (Const $limit:* & (IsPositiveInt $limit))
@@ -329,7 +325,7 @@
 (TryGenerateVectorSearch
     $scan
     $filters
-    $passthrough
+    (Passthrough $private)
     $vectorCol
     $queryVector
     $projections

--- a/pkg/sql/opt/xform/rules/project.opt
+++ b/pkg/sql/opt/xform/rules/project.opt
@@ -53,14 +53,14 @@
 (Project
     (IndexJoin $input:*)
     $projections:*
-    $passthrough:* &
+    $private:* &
         (ColsAreSubset
             (UnionCols
                 (ProjectionOuterCols $projections)
-                $passthrough
+                (Passthrough $private)
             )
             (OutputCols $input)
         )
 )
 =>
-(Project $input $projections $passthrough)
+(Project $input $projections $private)

--- a/pkg/sql/opt/xform/rules/select.opt
+++ b/pkg/sql/opt/xform/rules/select.opt
@@ -293,5 +293,5 @@
         )
     )
     []
-    (OutputCols $input)
+    (MakePassthrough (OutputCols $input))
 )


### PR DESCRIPTION
#### opt: add ProjectPrivate

ProjecExprs now have a ProjectPrivate field. For now it only contains
the passthrough columns. Future commits will add additional fields.

Release note: None

#### opt: add EquivGroups to ProjectPrivate

EquivGroups have been added to ProjectPrivate. Rules that inline
projections into filters populate this field with equivalencies that
would otherwise be lost in the filter push down. For example,
consider...

TODO: Add example.

Fixes #134816

Release note: None
