### PR TITLE
changefeedccl: include key, size, and mvcc timestamp in Kafka v2 message too large errors

### DIFF
--- a/pkg/ccl/changefeedccl/sink_pubsub_v2.go
+++ b/pkg/ccl/changefeedccl/sink_pubsub_v2.go
@@ -238,7 +238,9 @@ type pubsubBuffer struct {
 var _ BatchBuffer = (*pubsubBuffer)(nil)
 
 // Append implements the BatchBuffer interface
-func (psb *pubsubBuffer) Append(key []byte, value []byte, attributes attributes) {
+func (psb *pubsubBuffer) Append(
+	ctx context.Context, key []byte, value []byte, attributes attributes,
+) {
 	var content []byte
 	switch psb.sc.format {
 	case changefeedbase.OptFormatJSON:

--- a/pkg/ccl/changefeedccl/sink_webhook_v2.go
+++ b/pkg/ccl/changefeedccl/sink_webhook_v2.go
@@ -356,7 +356,7 @@ type webhookCSVBuffer struct {
 var _ BatchBuffer = (*webhookCSVBuffer)(nil)
 
 // Append implements the BatchBuffer interface.
-func (cb *webhookCSVBuffer) Append(key []byte, value []byte, _ attributes) {
+func (cb *webhookCSVBuffer) Append(ctx context.Context, key []byte, value []byte, _ attributes) {
 	cb.bytes = append(cb.bytes, value...)
 	cb.messageCount += 1
 }
@@ -380,7 +380,7 @@ type webhookJSONBuffer struct {
 var _ BatchBuffer = (*webhookJSONBuffer)(nil)
 
 // Append implements the BatchBuffer interface.
-func (jb *webhookJSONBuffer) Append(key []byte, value []byte, _ attributes) {
+func (jb *webhookJSONBuffer) Append(ctx context.Context, key []byte, value []byte, _ attributes) {
 	jb.messages = append(jb.messages, value)
 	jb.numBytes += len(value)
 }


### PR DESCRIPTION
Kafka v1 error messages for oversized messages included the message key and size, which made it easier to identify problematic data. Kafka v2 was missing this information.

This change restores that missing context. It modifies the Append and Flush method signatures to pass context, allowing the MVCC timestamp to be attached to each Kafka message. The error message for MESSAGE_TOO_LARGE errors is updated to include:
- The message key
- The combined size of the key and value
- The MVCC timestamp
This helps identify what data could not be
delivered.

Fixes #144994
Epic: CRDB-49646

Release note (general change): Kafka v2 changefeed sinks now include the message key, size, and MVCC timestamp in message too large error logs.