### PR TITLE
sql/schemachange: draft to investigate descriptor not found (SQLSTATE XXUUU)

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -1644,10 +1644,13 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		return nil, err
 	}
 
-	// Check if the table has any policies
-	tableHasPolicies := false
+	// Check if the table has any policies or triggers
+	tableHasPolicies, tableHasTriggers := false, false
 	if tableExists {
 		if tableHasPolicies, err = og.tableHasPolicies(ctx, tx, tableName); err != nil {
+			return nil, err
+		}
+		if tableHasTriggers, err = og.tableHasTriggers(ctx, tx, tableName); err != nil {
 			return nil, err
 		}
 	}
@@ -1703,9 +1706,36 @@ func (og *operationGenerator) dropColumn(ctx context.Context, tx pgx.Tx) (*opStm
 		// It is possible that we cannot drop column because
 		// it is referenced in a policy expression.
 		{code: pgcode.InvalidTableDefinition, condition: tableHasPolicies},
+		// It is possible that we cannot drop column because
+		// it is depended on by a trigger.
+		{code: pgcode.DependentObjectsStillExist, condition: tableHasTriggers},
 	})
 	stmt.sql = fmt.Sprintf(`ALTER TABLE %s DROP COLUMN %s`, tableName.String(), columnName.String())
 	return stmt, nil
+}
+
+// tableHasTriggers checks if a table has any triggers defined
+func (og *operationGenerator) tableHasTriggers(
+	ctx context.Context, tx pgx.Tx, tableName *tree.TableName,
+) (bool, error) {
+	// Query to check if a table has any triggers
+	query := `
+	SELECT EXISTS (
+		SELECT 1
+		FROM information_schema.triggers
+		WHERE event_object_schema = $1
+		AND event_object_table = $2
+		LIMIT 1
+	)
+	`
+
+	var hasTriggers bool
+	err := tx.QueryRow(ctx, query, tableName.Schema(), tableName.Object()).Scan(&hasTriggers)
+	if err != nil {
+		return false, err
+	}
+
+	return hasTriggers, nil
 }
 
 // tableHasPolicies checks if a table has any row-level security policies defined
@@ -4390,6 +4420,9 @@ FROM
 	})
 	opStmt.potentialExecErrors.addAll(codesWithConditions{
 		{pgcode.InvalidFunctionDefinition, hasFuncRefs},
+		// When create function calls a trigger function we get this error,
+		// because trigger functions can only be called by triggers.
+		{pgcode.FeatureNotSupported, true},
 	})
 
 	return opStmt, nil
@@ -4469,9 +4502,14 @@ func (og *operationGenerator) dropFunction(ctx context.Context, tx pgx.Tx) (*opS
 	if err != nil {
 		return nil, err
 	}
-	return newOpStmt(stmt, codesWithConditions{
+
+	opStmt := newOpStmt(stmt, codesWithConditions{
 		{expectedCode, true},
-	}), nil
+	})
+
+	// Needed for a trigger being created with a dependency on log_change_timestamp().
+	opStmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
+	return opStmt, nil
 }
 
 func (og *operationGenerator) alterFunctionRename(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
@@ -5268,4 +5306,218 @@ func (og *operationGenerator) randUser(ctx context.Context, tx pgx.Tx) (string, 
 	}
 	og.LogMessage(fmt.Sprintf("Found real user: '%s'", realUser))
 	return realUser, nil
+}
+
+// createTrigger generates a CREATE TRIGGER statement.
+func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
+	tableName, err := og.randTable(ctx, tx, og.pctExisting(true), "")
+	if err != nil {
+		return nil, err
+	}
+
+	tableExists, err := og.tableExists(ctx, tx, tableName)
+	if err != nil {
+		return nil, err
+	}
+
+	// First, ensure the trigger_log table exists
+	//	_, err = tx.Exec(ctx, `
+	//CREATE TABLE IF NOT EXISTS trigger_log (
+	//    changed_at TIMESTAMP DEFAULT current_timestamp
+	//)`)
+	//	if err != nil {
+	//		return nil, err
+	//	}
+
+	// Query to show the descriptor ID of the trigger_log table
+	var descriptorID int
+	err = tx.QueryRow(ctx, `
+		SELECT table_id FROM crdb_internal.tables 
+		WHERE name = 'trigger_log' AND database_name = current_database()
+	`).Scan(&descriptorID)
+	if err != nil {
+		og.LogMessage(fmt.Sprintf("Could not get descriptor ID for trigger_log table: %v", err))
+	} else {
+		og.LogMessage(fmt.Sprintf("trigger_log table descriptor ID: %d", descriptorID))
+	}
+	if err != nil {
+		return nil, err
+	}
+
+	triggerFunctionName := fmt.Sprintf("trigger_function_%s", og.newUniqueSeqNumSuffix())
+
+	// Generate random SQL statements for the trigger function
+	var triggerBody strings.Builder
+	triggerBody.WriteString("BEGIN ")
+
+	// Add the basic trigger log insert
+	// triggerBody.WriteString("INSERT INTO trigger_log VALUES (current_timestamp);")
+
+	// Try to generate a random SELECT statement for more complex dependencies
+	selectStmt, err := og.selectStmt(ctx, tx)
+	if err == nil && selectStmt != nil {
+		// Add the SELECT statement
+		triggerBody.WriteString(fmt.Sprintf("%s;", selectStmt.sql))
+	}
+
+	//// Try to generate a random INSERT statement for more dependencies
+	//insertStmt, err := og.insertRow(ctx, tx)
+	//if err == nil && insertStmt != nil {
+	//	// Add the INSERT statement
+	//	triggerBody.WriteString(fmt.Sprintf("\t\t%s;\n", insertStmt.sql))
+	//}
+
+	triggerBody.WriteString("RETURN NULL;END;")
+
+	triggerFunction := fmt.Sprintf(`CREATE FUNCTION %s() RETURNS TRIGGER AS $$ %s $$ LANGUAGE PLpgSQL`, triggerFunctionName, triggerBody.String())
+
+	// Create the trigger function
+	// _, err = tx.Exec(ctx, triggerFunction)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	og.LogMessage(fmt.Sprintf("Created trigger function %s", triggerFunction))
+
+	// Check if the trigger function exists.
+	// In some cases drop function will drop this function.
+	// triggerFunctionExists := false
+	// err = tx.QueryRow(ctx, `
+	// 	SELECT EXISTS(
+	// 		SELECT 1 FROM information_schema.routines
+	// 		WHERE routine_name = 'log_change_timestamp'
+	// 	)`).Scan(&triggerFunctionExists)
+	// if err != nil {
+	// 	return nil, err
+	// }
+
+	// Create TRIGGER statement components
+	triggerActionTime := "BEFORE"
+	if og.randIntn(2) == 1 {
+		triggerActionTime = "AFTER"
+	}
+
+	eventTypes := []string{"INSERT", "UPDATE", "DELETE"}
+	numEvents := og.randIntn(3) + 1 // 1-3 events
+	events := make([]string, 0, numEvents)
+	eventsSet := make(map[string]bool)
+
+	for i := 0; i < numEvents; i++ {
+		eventIndex := og.randIntn(len(eventTypes))
+		event := eventTypes[eventIndex]
+		if !eventsSet[event] {
+			events = append(events, event)
+			eventsSet[event] = true
+		}
+	}
+
+	// Join events with OR
+	eventClause := strings.Join(events, " OR ")
+
+	triggerName := fmt.Sprintf("trigger_%s", og.newUniqueSeqNumSuffix())
+
+	// Build the SQL statement
+	sqlStatement := fmt.Sprintf("%s;CREATE TRIGGER %s %s %s ON %s FOR EACH ROW EXECUTE FUNCTION %s()",
+		triggerFunction, triggerName, triggerActionTime, eventClause, tableName, triggerFunctionName)
+
+	og.LogMessage(fmt.Sprintf("createTrigger: %s", sqlStatement))
+
+	opStmt := makeOpStmt(OpStmtDDL)
+	opStmt.sql = sqlStatement
+
+	opStmt.expectedExecErrors.addAll(codesWithConditions{
+		{code: pgcode.FeatureNotSupported, condition: !og.useDeclarativeSchemaChanger},
+		{code: pgcode.UndefinedTable, condition: !tableExists},
+		//{code: pgcode.UndefinedFunction, condition: !triggerFunctionExists},
+	})
+
+	// In some cases drop function will drop the trigger function.
+	opStmt.potentialExecErrors.addAll(codesWithConditions{
+		{code: pgcode.UndefinedFunction, condition: true},
+		// Can be hit if the trigger function has a
+		// query on a table that doesn't exist.
+		{code: pgcode.UndefinedTable, condition: true},
+	})
+
+	return opStmt, nil
+}
+
+// dropTrigger generates a DROP TRIGGER statement.
+func (og *operationGenerator) dropTrigger(ctx context.Context, tx pgx.Tx) (*opStmt, error) {
+	// Find an existing trigger
+	triggerWithInfo, err := og.findExistingTrigger(ctx, tx)
+	if err != nil {
+		return nil, err
+	}
+	if triggerWithInfo == nil {
+		// Set up expected errors since we know this trigger doesn't exist
+		opStmt := makeOpStmt(OpStmtDDL)
+		opStmt.sql = `DROP TRIGGER dummy_trigger ON dummy_table`
+
+		opStmt.expectedExecErrors.add(pgcode.UndefinedTable)
+
+		og.LogMessage("dropTrigger (non-existent): DROP TRIGGER dummy_trigger ON dummy_table")
+
+		return opStmt, nil
+	}
+
+	// Build the SQL statement
+	sqlStatement := fmt.Sprintf("DROP TRIGGER %s ON %s", triggerWithInfo.triggerName, &triggerWithInfo.table)
+
+	// Construct DROP TRIGGER statement
+	og.LogMessage(fmt.Sprintf("dropTrigger: %s", sqlStatement))
+
+	opStmt := makeOpStmt(OpStmtDDL)
+	opStmt.sql = sqlStatement
+
+	return opStmt, nil
+}
+
+// triggerInfo contains information about a trigger.
+type triggerInfo struct {
+	table       tree.TableName
+	triggerName string
+}
+
+// findExistingTrigger returns a triggerInfo struct with the qualified table name and trigger name.
+// It also returns a boolean indicating whether a trigger was found.
+func (og *operationGenerator) findExistingTrigger(
+	ctx context.Context, tx pgx.Tx,
+) (*triggerInfo, error) {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
+		return nil, err
+	}
+
+	var triggerWithInfo triggerInfo
+
+	// Query to find all triggers in the database using information_schema
+	triggerQuery := `
+		SELECT
+			event_object_schema,
+			event_object_table,
+			trigger_name
+		FROM
+			information_schema.triggers
+		ORDER BY random()
+		LIMIT 1
+	`
+
+	var schemaName, tableName, triggerName string
+	err := tx.QueryRow(ctx, triggerQuery).Scan(&schemaName, &tableName, &triggerName)
+	if err != nil {
+		if errors.Is(err, pgx.ErrNoRows) {
+			return nil, nil
+		}
+		return nil, err
+	}
+
+	triggerWithInfo = triggerInfo{
+		table: tree.MakeTableNameFromPrefix(tree.ObjectNamePrefix{
+			SchemaName:     tree.Name(schemaName),
+			ExplicitSchema: true,
+		}, tree.Name(tableName)),
+		triggerName: triggerName,
+	}
+
+	return &triggerWithInfo, nil
 }

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5321,13 +5321,13 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 	}
 
 	// First, ensure the trigger_log table exists
-	//	_, err = tx.Exec(ctx, `
-	//CREATE TABLE IF NOT EXISTS trigger_log (
-	//    changed_at TIMESTAMP DEFAULT current_timestamp
-	//)`)
-	//	if err != nil {
-	//		return nil, err
-	//	}
+	_, err = tx.Exec(ctx, `
+	CREATE TABLE IF NOT EXISTS trigger_log (
+	   changed_at TIMESTAMP DEFAULT current_timestamp
+	)`)
+	if err != nil {
+		return nil, err
+	}
 
 	// Query to show the descriptor ID of the trigger_log table
 	var descriptorID int
@@ -5351,7 +5351,7 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 	triggerBody.WriteString("BEGIN ")
 
 	// Add the basic trigger log insert
-	// triggerBody.WriteString("INSERT INTO trigger_log VALUES (current_timestamp);")
+	triggerBody.WriteString("INSERT INTO trigger_log VALUES (current_timestamp);")
 
 	// Try to generate a random SELECT statement for more complex dependencies
 	selectStmt, err := og.selectStmt(ctx, tx)

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -127,6 +127,7 @@ const (
 	createTableAs       // CREATE TABLE <table> AS <def>
 	createView          // CREATE VIEW <view> AS <def>
 	createFunction      // CREATE FUNCTION <function> ...
+	createTrigger       // CREATE TRIGGER <trigger> {...} ON <table> EXECUTE FUNCTION <function>()
 
 	// COMMENT ON ...
 
@@ -140,6 +141,7 @@ const (
 	dropSchema   // DROP SCHEMA <schema>
 	dropSequence // DROP SEQUENCE <sequence>
 	dropTable    // DROP TABLE <table>
+	dropTrigger  // DROP TRIGGER <trigger> ON <table>
 	dropView     // DROP VIEW <view>
 
 	// Unimplemented operations. TODO(sql-foundations): Audit and/or implement these operations.
@@ -246,6 +248,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	createSequence:                    (*operationGenerator).createSequence,
 	createTable:                       (*operationGenerator).createTable,
 	createTableAs:                     (*operationGenerator).createTableAs,
+	createTrigger:                     (*operationGenerator).createTrigger,
 	createTypeEnum:                    (*operationGenerator).createEnum,
 	createTypeComposite:               (*operationGenerator).createCompositeType,
 	createView:                        (*operationGenerator).createView,
@@ -255,6 +258,7 @@ var opFuncs = []func(*operationGenerator, context.Context, pgx.Tx) (*opStmt, err
 	dropSchema:                        (*operationGenerator).dropSchema,
 	dropSequence:                      (*operationGenerator).dropSequence,
 	dropTable:                         (*operationGenerator).dropTable,
+	dropTrigger:                       (*operationGenerator).dropTrigger,
 	dropView:                          (*operationGenerator).dropView,
 	renameIndex:                       (*operationGenerator).renameIndex,
 	renameSequence:                    (*operationGenerator).renameSequence,
@@ -301,6 +305,7 @@ var opWeights = []int{
 	createSequence:                    1,
 	createTable:                       10,
 	createTableAs:                     1,
+	createTrigger:                     1,
 	createTypeEnum:                    1,
 	createTypeComposite:               1,
 	createView:                        1,
@@ -310,6 +315,7 @@ var opWeights = []int{
 	dropSchema:                        1,
 	dropSequence:                      1,
 	dropTable:                         1,
+	dropTrigger:                       1,
 	dropView:                          1,
 	renameIndex:                       1,
 	renameSequence:                    1,
@@ -342,11 +348,13 @@ var opDeclarativeVersion = map[opType]clusterversion.Key{
 	createPolicy:                      clusterversion.V25_2,
 	createSchema:                      clusterversion.MinSupported,
 	createSequence:                    clusterversion.MinSupported,
+	createTrigger:                     clusterversion.MinSupported,
 	dropFunction:                      clusterversion.MinSupported,
 	dropIndex:                         clusterversion.MinSupported,
 	dropPolicy:                        clusterversion.V25_2,
 	dropSchema:                        clusterversion.MinSupported,
 	dropSequence:                      clusterversion.MinSupported,
 	dropTable:                         clusterversion.MinSupported,
+	dropTrigger:                       clusterversion.MinSupported,
 	dropView:                          clusterversion.MinSupported,
 }

--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -305,7 +305,7 @@ var opWeights = []int{
 	createSequence:                    1,
 	createTable:                       10,
 	createTableAs:                     1,
-	createTrigger:                     1,
+	createTrigger:                     5,
 	createTypeEnum:                    1,
 	createTypeComposite:               1,
 	createView:                        1,

--- a/pkg/workload/schemachange/optype_string.go
+++ b/pkg/workload/schemachange/optype_string.go
@@ -55,14 +55,16 @@ func _() {
 	_ = x[createTableAs-39]
 	_ = x[createView-40]
 	_ = x[createFunction-41]
-	_ = x[commentOn-42]
-	_ = x[dropFunction-43]
-	_ = x[dropIndex-44]
-	_ = x[dropPolicy-45]
-	_ = x[dropSchema-46]
-	_ = x[dropSequence-47]
-	_ = x[dropTable-48]
-	_ = x[dropView-49]
+	_ = x[createTrigger-42]
+	_ = x[commentOn-43]
+	_ = x[dropFunction-44]
+	_ = x[dropIndex-45]
+	_ = x[dropPolicy-46]
+	_ = x[dropSchema-47]
+	_ = x[dropSequence-48]
+	_ = x[dropTable-49]
+	_ = x[dropTrigger-50]
+	_ = x[dropView-51]
 }
 
 func (i opType) String() string {
@@ -151,6 +153,8 @@ func (i opType) String() string {
 		return "createView"
 	case createFunction:
 		return "createFunction"
+	case createTrigger:
+		return "createTrigger"
 	case commentOn:
 		return "commentOn"
 	case dropFunction:
@@ -165,6 +169,8 @@ func (i opType) String() string {
 		return "dropSequence"
 	case dropTable:
 		return "dropTable"
+	case dropTrigger:
+		return "dropTrigger"
 	case dropView:
 		return "dropView"
 	default:

--- a/pkg/workload/schemachange/schemachange.go
+++ b/pkg/workload/schemachange/schemachange.go
@@ -359,6 +359,30 @@ func (s *schemaChange) setClusterSettings(ctx context.Context, url string) (err 
 			return errors.WithStack(err)
 		}
 	}
+
+// 	// First, ensure the trigger_log table exists
+// 	_, err = conn.Exec(ctx, `
+// CREATE TABLE IF NOT EXISTS trigger_log (
+//     changed_at TIMESTAMP DEFAULT current_timestamp
+// )`)
+// 	if err != nil {
+// 		return errors.WithStack(err)
+// 	}
+
+// 	// Create the function with legacy schema changer
+// 	_, err = conn.Exec(ctx, `
+// CREATE OR REPLACE FUNCTION log_change_timestamp()
+// RETURNS TRIGGER AS $$
+// BEGIN
+//     INSERT INTO trigger_log
+//     VALUES (current_timestamp);
+//     RETURN NULL;
+// END;
+// $$ LANGUAGE PLpgSQL`)
+// 	if err != nil {
+// 		return errors.WithStack(err)
+// 	}
+
 	return nil
 }
 


### PR DESCRIPTION
```
   {
    "message": "trigger_log table descriptor ID: 124"
   },
   {
    "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
    "queryArgs": [
     "public",
     "table_w0_6"
    ],
    "result": true
   },
   {
    "query": "SELECT EXISTS (SELECT table_name FROM information_schema.tables WHERE (table_schema = $1) AND (table_name = $2))",
    "queryArgs": [
     "public",
     "table_w1_1"
    ],
    "result": true
   },
   {
    "message": "Created trigger function CREATE FUNCTION trigger_function_w0_50() RETURNS TRIGGER AS $$ BEGIN INSERT INTO trigger_log VALUES (current_timestamp);SELECT t1.col1_w1_9 AS col0, t0.col6_w0_11 AS col1, t0.col6_w0_10 AS col2, t1.col1_w1_18 AS col3, t1.col1_w1_3 AS col4, t0.col6_w0_7 AS col5, t1.col1_w1_11 AS col6, t0.col6_w0_9 AS col7, t1.col1_w1_9 AS col8, t0.col6_w0_12 AS col9, t1.col1_w1_11 AS col10, t1.col1_w1_3 AS col11, t1.col1_w1_17 AS col12, t0.col6_w0_12 AS col13 FROM public.table_w0_6 AS t0 ,public.table_w1_1 AS t1 FETCH FIRST 1 ROWS ONLY;RETURN NULL;END; $$ LANGUAGE PLpgSQL"
   },
   {
    "message": "createTrigger: CREATE FUNCTION trigger_function_w0_50() RETURNS TRIGGER AS $$ BEGIN INSERT INTO trigger_log VALUES (current_timestamp);SELECT t1.col1_w1_9 AS col0, t0.col6_w0_11 AS col1, t0.col6_w0_10 AS col2, t1.col1_w1_18 AS col3, t1.col1_w1_3 AS col4, t0.col6_w0_7 AS col5, t1.col1_w1_11 AS col6, t0.col6_w0_9 AS col7, t1.col1_w1_9 AS col8, t0.col6_w0_12 AS col9, t1.col1_w1_11 AS col10, t1.col1_w1_3 AS col11, t1.col1_w1_17 AS col12, t0.col6_w0_12 AS col13 FROM public.table_w0_6 AS t0 ,public.table_w1_1 AS t1 FETCH FIRST 1 ROWS ONLY;RETURN NULL;END; $$ LANGUAGE PLpgSQL;CREATE TRIGGER trigger_w0_51 AFTER INSERT OR DELETE ON public.table_w0_6 FOR EACH ROW EXECUTE FUNCTION trigger_function_w0_50()"
   }
  ],
  "previousStatements": [
   "CREATE FUNCTION trigger_function_w0_50() RETURNS TRIGGER AS $$ BEGIN INSERT INTO trigger_log VALUES (current_timestamp);SELECT t1.col1_w1_9 AS col0, t0.col6_w0_11 AS col1, t0.col6_w0_10 AS col2, t1.col1_w1_18 AS col3, t1.col1_w1_3 AS col4, t0.col6_w0_7 AS col5, t1.col1_w1_11 AS col6, t0.col6_w0_9 AS col7, t1.col1_w1_9 AS col8, t0.col6_w0_12 AS col9, t1.col1_w1_11 AS col10, t1.col1_w1_3 AS col11, t1.col1_w1_17 AS col12, t0.col6_w0_12 AS col13 FROM public.table_w0_6 AS t0 ,public.table_w1_1 AS t1 FETCH FIRST 1 ROWS ONLY;RETURN NULL;END; $$ LANGUAGE PLpgSQL;CREATE TRIGGER trigger_w0_51 AFTER INSERT OR DELETE ON public.table_w0_6 FOR EACH ROW EXECUTE FUNCTION trigger_function_w0_50()"
  ]
 }
}
Schema Workload Stats
Total Schema Statements Executed = 33
Total Schema Statements Succeeded = 33
Total Schema Statement Expected Failures = 0
Total Transactions Committed = 19
Total Transactions Rolled Back = 24
Total Transactions Executed = 43
test logs left over in: /Users/bdedej/go/src/github.com/cockroachdb/cockroach/y/_tmp/7d1af777aae5fb8cc05bf2aaa6382e4b/logTestWorkload1765799075
--- FAIL: TestWorkload (38.89s)
    test_log_scope.go:165: test logs captured to: /Users/bdedej/go/src/github.com/cockroachdb/cockroach/y/_tmp/7d1af777aae5fb8cc05bf2aaa6382e4b/logTestWorkload1765799075
    test_log_scope.go:76: use -show-logs to present logs inline
    schema_change_external_test.go:132:
        	Error Trace:	pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go:132
        	Error:      	Received unexpected error:
        	            	***UNEXPECTED COMMIT ERROR; Received an unexpected commit error: ERROR: error executing PreCommitPhase stage 2 of 2 with 20 MutationType ops: *scop.UpdateTableBackReferencesInRelations: &{{{}} 113 [{106 [2 8 10 16 17] 0} {124 [1] 0}]}: referenced descriptor ID 124: looking up ID 124: descriptor not found (SQLSTATE XXUUU)
        	            	(1) forced error mark
        	            	  | "fatal error when running txn"
        	            	  | github.com/cockroachdb/errors/withstack/*withstack.withStack::
        	            	Wraps: (2)
        	            	Wraps: (3) attached stack trace
        	            	  -- stack trace:
        	            	  | github.com/cockroachdb/cockroach/pkg/workload/schemachange.(*schemaChangeWorker).run
        	            	  | 	pkg/workload/schemachange/schemachange.go:705
        	            	  | pkg/ccl/testccl/workload/schemachange/schemachange_test_test.TestWorkload.TestWorkload.func4.func6
        	            	  | 	pkg/ccl/testccl/workload/schemachange/schema_change_external_test.go:121
        	            	  | golang.org/x/sync/errgroup.(*Group).Go.func1
        	            	  | 	external/org_golang_x_sync/errgroup/errgroup.go:78
        	            	  | runtime.goexit
        	            	  | 	src/runtime/asm_arm64.s:1223
        	            	Wraps: (4) ***UNEXPECTED COMMIT ERROR; Received an unexpected commit error
        	            	Wraps: (5) ERROR: error executing PreCommitPhase stage 2 of 2 with 20 MutationType ops: *scop.UpdateTableBackReferencesInRelations: &{{{}} 113 [{106 [2 8 10 16 17] 0} {124 [1] 0}]}: referenced descriptor ID 124: looking up ID 124: descriptor not found (SQLSTATE XXUUU)
        	            	Error types: (1) *markers.withMark (2) *schemachange.ErrorState (3) *withstack.withStack (4) *errutil.withPrefix (5) *pgconn.PgError
        	Test:       	TestWorkload
    schema_change_external_test.go:97: backup, tracing data, and system table dumps in /Users/bdedej/go/src/github.com/cockroachdb/cockroach/y/_tmp/7d1af777aae5fb8cc05bf2aaa6382e4b/logTestWorkload1765799075
    panic.go:635: -- test log scope end --
FAIL
```