### PR TITLE
crosscluster/physical: deflake TestTenantStreamingFailback

### DIFF
--- a/pkg/crosscluster/physical/stream_ingestion_job_test.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job_test.go
@@ -199,21 +199,19 @@ func TestTenantStreamingFailback(t *testing.T) {
 	var ts1 string
 	sqlA.QueryRow(t, "SELECT cluster_logical_timestamp()").Scan(&ts1)
 
+	t.Logf("waiting for g@%s", ts1)
+	replicationtestutils.WaitUntilReplicatedTime(t,
+		replicationtestutils.DecimalTimeToHLC(t, ts1),
+		sqlB,
+		jobspb.JobID(consumerGJobID))
+
 	// Randomize query execution to verify fast failback works for both
 	// `COMPLETE REPLICATION TO LATEST` and `COMPLETE REPLICATION TO SYSTEM TIME`
 	rng, _ := randutil.NewPseudoRand()
 	if rng.Intn(2) == 0 {
-		t.Logf("waiting for g@%s", ts1)
-		replicationtestutils.WaitUntilReplicatedTime(t,
-			replicationtestutils.DecimalTimeToHLC(t, ts1),
-			sqlB,
-			jobspb.JobID(consumerGJobID))
-
 		t.Logf("completing replication on g@%s", ts1)
 		sqlB.Exec(t, fmt.Sprintf("ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO SYSTEM TIME '%s'", ts1))
 	} else {
-		t.Log("waiting for initial scan on g")
-		replicationtestutils.WaitUntilStartTimeReached(t, sqlB, jobspb.JobID(consumerGJobID))
 		t.Log("completing replication on g to latest")
 		sqlB.Exec(t, "ALTER VIRTUAL CLUSTER g COMPLETE REPLICATION TO LATEST")
 	}


### PR DESCRIPTION
Previously, this test would fail with a scary fingerprint mismatch violation error, but it was because one test path did not wait for the fingerprint time to get replicated.

Fixes #146444

Release note: none