### PR TITLE
release-25.2.1-rc: sql: handle math.MinInt64 count in substring_index builtin

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/builtin_function
+++ b/pkg/sql/logictest/testdata/logic_test/builtin_function
@@ -4669,4 +4669,20 @@ SELECT substring_index('a..b..c..d', '..', -2);
 ----
 c..d
 
+# Verify boundary cases of count input. Found in issue #147516.
+query T
+SELECT substring_index('a..b..c..d', '..', -9223372036854775808);
+----
+a..b..c..d
+
+query T
+SELECT substring_index('a..b..c..d', '..', -9223372036854775807);
+----
+a..b..c..d
+
+query T
+SELECT substring_index('a..b..c..d', '..', 9223372036854775807);
+----
+a..b..c..d
+
 subtest end

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -422,11 +422,11 @@ var regularBuiltins = map[string]builtinDefinition{
 				}
 
 				// If count is negative, return the last 'abs(count)' parts joined by delim
-				count = -count
-				if count >= length {
+				if -count >= length || count == math.MinInt {
 					return tree.NewDString(input), nil // If count exceeds occurrences, return the full string
 				}
-				return tree.NewDString(strings.Join(parts[length-count:], delim)), nil
+				start := length + count // count is negative
+				return tree.NewDString(strings.Join(parts[start:], delim)), nil
 			},
 			Info: "Returns a substring of `input` before `count` occurrences of `delim`.\n" +
 				"If `count` is positive, the leftmost part is returned. If `count` is negative, the rightmost part is returned.",


### PR DESCRIPTION
Backport 1/1 commits from #147546 on behalf of @spilchen.

----

The substring_index built-in, introduced in v25.2, did not account for the case where the count argument (3rd parameter) is math.MinInt64. Since -math.MinInt64 overflows in int64, this caused a runtime panic due to a negative slice bound. This change fixes that edge case.

Fixes #147516

Epic: none
Release note (bug fix): Fixed a runtime panic in substring_index when the count argument is the minimum 64-bit integer value.

----

Release justification: bug fix