### PR TITLE
builtins: add more builtins to DistsqlBlocklist

### DIFF
--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -4439,7 +4439,8 @@ value if you rely on the HLC for accuracy.`,
 
 	"oidvectortypes": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategoryCompatibility,
+			Category:         builtinconstants.CategoryCompatibility,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types: tree.ParamTypes{
@@ -4631,7 +4632,10 @@ value if you rely on the HLC for accuracy.`,
 		}),
 
 	"crdb_internal.read_file": makeBuiltin(
-		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types: tree.ParamTypes{
 				{Name: "uri", Typ: types.String},
@@ -4647,7 +4651,10 @@ value if you rely on the HLC for accuracy.`,
 		}),
 
 	"crdb_internal.write_file": makeBuiltin(
-		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types: tree.ParamTypes{
 				{Name: "data", Typ: types.Bytes},
@@ -7805,7 +7812,8 @@ table's zone configuration this will return NULL.`,
 	// for table %d"
 	"crdb_internal.force_delete_table_data": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemRepair,
+			Category:         builtinconstants.CategorySystemRepair,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "id", Typ: types.Int}},
@@ -7826,7 +7834,8 @@ table's zone configuration this will return NULL.`,
 
 	"crdb_internal.serialize_session": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
@@ -7841,7 +7850,8 @@ table's zone configuration this will return NULL.`,
 
 	"crdb_internal.deserialize_session": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "session", Typ: types.Bytes}},
@@ -7857,7 +7867,8 @@ table's zone configuration this will return NULL.`,
 
 	"crdb_internal.create_session_revival_token": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
@@ -7871,7 +7882,8 @@ table's zone configuration this will return NULL.`,
 	),
 	"crdb_internal.validate_session_revival_token": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "token", Typ: types.Bytes}},
@@ -7887,7 +7899,8 @@ table's zone configuration this will return NULL.`,
 
 	"crdb_internal.validate_ttl_scheduled_jobs": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
@@ -7907,7 +7920,8 @@ table's zone configuration this will return NULL.`,
 
 	"crdb_internal.repair_ttl_table_scheduled_job": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
@@ -8007,7 +8021,8 @@ table's zone configuration this will return NULL.`,
 
 	"crdb_internal.revalidate_unique_constraints_in_all_tables": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
@@ -8429,7 +8444,8 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 	),
 	"crdb_internal.fingerprint": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			// If the second arg is set to true, this overload allows the caller to
@@ -9015,8 +9031,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 		},
 	),
 	"crdb_internal.plpgsql_gen_cursor_name": makeBuiltin(tree.FunctionProperties{
-		Category:     builtinconstants.CategoryIDGeneration,
-		Undocumented: true,
+		Category:         builtinconstants.CategoryIDGeneration,
+		Undocumented:     true,
+		DistsqlBlocklist: true, // applicable only on the gateway
 	},
 		tree.Overload{
 			Types: tree.ParamTypes{
@@ -9036,8 +9053,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 		},
 	),
 	"crdb_internal.plpgsql_close": makeBuiltin(tree.FunctionProperties{
-		Category:     builtinconstants.CategoryString,
-		Undocumented: true,
+		Category:         builtinconstants.CategoryString,
+		Undocumented:     true,
+		DistsqlBlocklist: true, // applicable only on the gateway
 	},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "name", Typ: types.RefCursor}},
@@ -9056,8 +9074,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 		},
 	),
 	"crdb_internal.plpgsql_fetch": makeBuiltin(tree.FunctionProperties{
-		Category:     builtinconstants.CategoryString,
-		Undocumented: true,
+		Category:         builtinconstants.CategoryString,
+		Undocumented:     true,
+		DistsqlBlocklist: true, // applicable only on the gateway
 	},
 		tree.Overload{
 			Types: tree.ParamTypes{
@@ -9112,8 +9131,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 	),
 	"crdb_internal.protect_mvcc_history": makeBuiltin(
 		tree.FunctionProperties{
-			Category:     builtinconstants.CategoryClusterReplication,
-			Undocumented: true,
+			Category:         builtinconstants.CategoryClusterReplication,
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types: tree.ParamTypes{
@@ -9150,8 +9170,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 	),
 	"crdb_internal.extend_mvcc_history_protection": makeBuiltin(
 		tree.FunctionProperties{
-			Category:     builtinconstants.CategoryClusterReplication,
-			Undocumented: true,
+			Category:         builtinconstants.CategoryClusterReplication,
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types: tree.ParamTypes{
@@ -9174,8 +9195,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 	),
 	"crdb_internal.clear_query_plan_cache": makeBuiltin(
 		tree.FunctionProperties{
-			Category:     builtinconstants.CategorySystemRepair,
-			Undocumented: true,
+			Category:         builtinconstants.CategorySystemRepair,
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
@@ -9190,8 +9212,9 @@ specified store on the node it's run from. One of 'mvccGC', 'merge', 'split',
 	),
 	"crdb_internal.clear_table_stats_cache": makeBuiltin(
 		tree.FunctionProperties{
-			Category:     builtinconstants.CategorySystemRepair,
-			Undocumented: true,
+			Category:         builtinconstants.CategorySystemRepair,
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
@@ -9221,7 +9244,11 @@ WHERE object_id = table_descriptor_id
 			Language:   tree.RoutineLangSQL,
 		},
 	),
-	"crdb_internal.type_is_indexable": makeBuiltin(defProps(),
+	"crdb_internal.type_is_indexable": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),
@@ -9244,8 +9271,9 @@ WHERE object_id = table_descriptor_id
 	),
 	"crdb_internal.backup_compaction": makeBuiltin(
 		tree.FunctionProperties{
-			Undocumented: true,
-			ReturnLabels: []string{"job_id"},
+			Undocumented:     true,
+			DistsqlBlocklist: true, // applicable only on the gateway
+			ReturnLabels:     []string{"job_id"},
 		},
 		tree.Overload{
 			Types: tree.ParamTypes{

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -140,7 +140,11 @@ var generators = map[string]builtinDefinition{
 			volatility.Stable,
 		),
 	),
-	"crdb_internal.scan": makeBuiltin(genProps(),
+	"crdb_internal.scan": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategoryGenerator,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "start_key", Typ: types.Bytes},
@@ -296,7 +300,11 @@ var generators = map[string]builtinDefinition{
 		),
 	),
 
-	"workload_index_recs": makeBuiltin(genProps(),
+	"workload_index_recs": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategoryGenerator,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{},
 			WorkloadIndexRecsGeneratorType,
@@ -501,7 +509,8 @@ var generators = map[string]builtinDefinition{
 
 	"crdb_internal.list_sql_keys_in_range": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
@@ -516,7 +525,8 @@ var generators = map[string]builtinDefinition{
 
 	"crdb_internal.payloads_for_span": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
@@ -530,7 +540,8 @@ var generators = map[string]builtinDefinition{
 	),
 	"crdb_internal.payloads_for_trace": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
@@ -543,7 +554,10 @@ var generators = map[string]builtinDefinition{
 		),
 	),
 	"crdb_internal.show_create_all_schemas": makeBuiltin(
-		tree.FunctionProperties{},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_name", Typ: types.String},
@@ -557,7 +571,10 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.show_create_all_tables": makeBuiltin(
-		tree.FunctionProperties{},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_name", Typ: types.String},
@@ -588,7 +605,10 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.show_create_all_types": makeBuiltin(
-		tree.FunctionProperties{},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "database_name", Typ: types.String},
@@ -614,7 +634,10 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.decode_plan_gist": makeBuiltin(
-		tree.FunctionProperties{},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "gist", Typ: types.String},
@@ -627,7 +650,9 @@ The output can be used to recreate a database.'
 		),
 	),
 	"crdb_internal.decode_external_plan_gist": makeBuiltin(
-		tree.FunctionProperties{},
+		tree.FunctionProperties{
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
 				{Name: "gist", Typ: types.String},
@@ -677,7 +702,11 @@ The last argument is a JSONB object containing the following optional fields:
 			volatility.Volatile,
 		),
 	),
-	"crdb_internal.tenant_span_stats": makeBuiltin(genProps(),
+	"crdb_internal.tenant_span_stats": makeBuiltin(
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategoryGenerator,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		// This overload defines a built-in that returns the range count,
 		// approximate disk size, live range bytes, total range bytes,
 		// and live range byte percentage for all tables that belong to the
@@ -735,7 +764,8 @@ The last argument is a JSONB object containing the following optional fields:
 	),
 	"crdb_internal.sstable_metrics": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
@@ -752,7 +782,8 @@ The last argument is a JSONB object containing the following optional fields:
 	),
 	"crdb_internal.scan_storage_internal_keys": makeBuiltin(
 		tree.FunctionProperties{
-			Category: builtinconstants.CategorySystemInfo,
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		makeGeneratorOverload(
 			tree.ParamTypes{
@@ -782,8 +813,9 @@ The last argument is a JSONB object containing the following optional fields:
 	),
 	"crdb_internal.execute_internally": makeBuiltin(
 		tree.FunctionProperties{
-			Undocumented: true,
-			Category:     builtinconstants.CategoryGenerator,
+			Undocumented:     true,
+			Category:         builtinconstants.CategoryGenerator,
+			DistsqlBlocklist: true, // applicable only on the gateway
 		},
 		makeInternallyExecutedQueryGeneratorOverload(false /* withSessionBound */, false /* withOverrides */, false /* withTxn */),
 		makeInternallyExecutedQueryGeneratorOverload(true /* withSessionBound */, false /* withOverrides */, false /* withTxn */),

--- a/pkg/sql/sem/builtins/pg_builtins.go
+++ b/pkg/sql/sem/builtins/pg_builtins.go
@@ -922,7 +922,10 @@ var pgBuiltins = map[string]builtinDefinition{
 	// none.
 	// https://www.postgresql.org/docs/11/functions-info.html
 	"pg_my_temp_schema": makeBuiltin(
-		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Oid),
@@ -955,7 +958,10 @@ var pgBuiltins = map[string]builtinDefinition{
 	// session's temporary schema.
 	// https://www.postgresql.org/docs/11/functions-info.html
 	"pg_is_other_temp_schema": makeBuiltin(
-		tree.FunctionProperties{Category: builtinconstants.CategorySystemInfo},
+		tree.FunctionProperties{
+			Category:         builtinconstants.CategorySystemInfo,
+			DistsqlBlocklist: true, // applicable only on the gateway
+		},
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "oid", Typ: types.Oid}},
 			ReturnType: tree.FixedReturnType(types.Bool),

--- a/pkg/sql/sem/tree/function_definition.go
+++ b/pkg/sql/sem/tree/function_definition.go
@@ -105,14 +105,11 @@ type FunctionProperties struct {
 	// considered undocumented.
 	Private bool
 
-	// DistsqlBlocklist is set to true when a function depends on
-	// members of the EvalContext that are not marshaled by DistSQL
-	// (e.g. planner). Currently used for DistSQL to determine if
-	// expressions can be evaluated on a different node without sending
-	// over the EvalContext.
-	//
-	// TODO(andrei): Get rid of the planner from the EvalContext and then we can
-	// get rid of this blocklist.
+	// DistsqlBlocklist is set to true when a function depends on members of the
+	// EvalContext that are not marshaled by DistSQL (e.g. anything inside Planner
+	// other than Mon() which is implemented by DummyEvalPlanner). Currently used
+	// for DistSQL to determine if expressions can be evaluated on a different
+	// node without sending over the EvalContext.
 	DistsqlBlocklist bool
 
 	// Category is used to generate documentation strings.


### PR DESCRIPTION
While adding a builtin for a test, I noticed that a neighboring builtin that accessed `evalctx.Planner` was not marked with `DistsqlBlocklist`. Then I noticed that many more functions accessing Planner were not marked with `DistsqlBlocklist`. I tried to ignore it, but I could not. Hence this yak-shave.

Epic: None

Release note: None