### PR TITLE
randgen: increase pool size for "heavy" configs

### DIFF
--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -71,6 +71,10 @@ go_test(
         "types_test.go",
     ],
     embed = [":randgen"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
We just saw an engflow failure that looks like an OOM under race config, so let's bump the size.

Fixes: #147255.

Release note: None