### PR TITLE
release-25.2: sql: fix memory leak in index backfill progress tracking

### DIFF
--- a/pkg/sql/execinfra/server_config.go
+++ b/pkg/sql/execinfra/server_config.go
@@ -245,7 +245,7 @@ type TestingKnobs struct {
 
 	// RunBeforeIndexBackfillProgressUpdate is called before updating the
 	// progress for a single index backfill.
-	RunBeforeIndexBackfillProgressUpdate func(completed []roachpb.Span)
+	RunBeforeIndexBackfillProgressUpdate func(ctx context.Context, completed []roachpb.Span)
 
 	// SerializeIndexBackfillCreationAndIngestion ensures that every index batch
 	// created during an index backfill is also ingested before moving on to the


### PR DESCRIPTION
Backport 1/1 commits from #147511 on behalf of @rafiss.

----

Previously, when resuming an index backfill job, the completed spans
from the job's checkpoint would be repeatedly added to the progress
tracker on each update, causing unbounded memory growth. For large
tables with many ranges, this could exhaust available memory and
cause the backfill to fail.

This change fixes the memory leak by initializing the completed spans
group once with the checkpointed progress at job startup, then only
adding new spans from subsequent batches. A test-only assertion is
added to detect overlapping spans in progress updates.

The test is also updated to verify that checkpointed spans properly
enclose all completed work and to remove flaky timing dependencies.
These test changes also address the test issues that were present since
the test was first added in 058a7f5.
The testing changes include:
- Use a context in the testing hook so that when the job is paused, the
  testing hook does not keep blocking.
- Fixed a race condition by getting the progress from the persisted
  progress, rather than a different hook.
- Avoid using `require` / `t.Fatal` from inside a goroutine, which
  violates the expectations of testing.T.

fixes https://github.com/cockroachdb/cockroach/issues/140358
fixes https://github.com/cockroachdb/cockroach/issues/147209

Release note (bug fix): Fixed a memory leak in index backfill jobs
where completed spans were duplicated in memory on each progress
update after resuming from a checkpoint. This could cause out-of-memory
errors when backfilling indexes on large tables with many ranges. This
bug affected release version v25.2.0 and pre-release versions
v25.2.0-alpha.3 through v25.2.0-rc.1.


----

Release justification: critical bug fix