### PR TITLE
gossip: register `Gossip` service with DRPC server

### DIFF
--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -357,6 +357,20 @@ func NewTestWithLocality(
 	return gossip
 }
 
+type drpcGossip Gossip
+
+// AsDRPCServer returns the DRPC server implementation for the Gossip service.
+func (n *Gossip) AsDRPCServer() DRPCGossipServer {
+	return (*drpcGossip)(n)
+}
+
+// Gossip implements the DRPC service. It receives gossiped information from a
+// peer node. The received delta is combined with the infostore, and this node's
+// own gossip is returned to requesting client.
+func (g *drpcGossip) Gossip(stream DRPCGossip_GossipStream) error {
+	return (*Gossip)(g).gossip(stream)
+}
+
 // AssertNotStarted fatals if the Gossip instance was already started.
 func (g *Gossip) AssertNotStarted(ctx context.Context) {
 	if g.started {

--- a/pkg/gossip/server.go
+++ b/pkg/gossip/server.go
@@ -103,6 +103,11 @@ func (s *server) GetNodeMetrics() *Metrics {
 // The received delta is combined with the infostore, and this
 // node's own gossip is returned to requesting client.
 func (s *server) Gossip(stream Gossip_GossipServer) error {
+	return s.gossip(stream)
+}
+
+// gossip is the shared implementation for Gossip for both gRPC and DRPC.
+func (s *server) gossip(stream RPCGossip_GossipStream) error {
 	args, err := stream.Recv()
 	if err != nil {
 		return err

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -408,6 +408,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	}
 
 	gossip.RegisterGossipServer(grpcServer.Server, g)
+	if err := gossip.DRPCRegisterGossip(drpcServer, g.AsDRPCServer()); err != nil {
+		return nil, err
+	}
 
 	var dialerKnobs nodedialer.DialerTestingKnobs
 	if dk := cfg.TestingKnobs.DialerKnobs; dk != nil {


### PR DESCRIPTION
Enable the `Gossip` service on the DRPC server in addition to gRPC. This is controlled by `rpc.experimental_drpc.enabled` (off by default).

This change is part of a series and is similar to:
https://github.com/cockroachdb/cockroach/pull/146926

Note: This only registers the service; the client is not updated to use the DRPC client, so this service will not have any functional effect.

Fixes: #146472
Epic: CRDB-48925
Release note: None