### PR TITLE
kv,rpc,server: consolidate RPC clients creation

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -79,6 +79,7 @@ go_library(
         "replica_tscache.go",
         "replica_write.go",
         "replicate_queue.go",
+        "rpc_clients.go",
         "scanner.go",
         "scheduler.go",
         "snapshot_apply_prepare.go",

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4671,12 +4671,12 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 
 			var targets []target
 			for _, s := range tc.Servers {
-				conn, err := s.NodeDialer().(*nodedialer.Dialer).Dial(ctx, s.NodeID(), rpcbase.DefaultClass)
+				client, err := kvserver.DialPerReplicaClient(s.NodeDialer().(*nodedialer.Dialer), ctx, s.NodeID(), rpcbase.DefaultClass)
 				if err != nil {
 					t.Fatal(err)
 				}
 				targets = append(targets, target{
-					client: kvserver.NewPerReplicaClient(conn),
+					client: client,
 					header: kvserver.StoreRequestHeader{NodeID: s.NodeID(), StoreID: s.GetFirstStoreID()},
 				})
 			}
@@ -4799,11 +4799,10 @@ func TestStoreWaitForReplicaInit(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 	store := tc.GetFirstStoreFromServer(t, 0)
 
-	conn, err := tc.Servers[0].NodeDialer().(*nodedialer.Dialer).Dial(ctx, store.Ident.NodeID, rpcbase.DefaultClass)
+	client, err := kvserver.DialPerReplicaClient(tc.Servers[0].NodeDialer().(*nodedialer.Dialer), ctx, store.Ident.NodeID, rpcbase.DefaultClass)
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := kvserver.NewPerReplicaClient(conn)
 	storeHeader := kvserver.StoreRequestHeader{NodeID: store.Ident.NodeID, StoreID: store.Ident.StoreID}
 
 	// Test that WaitForReplicaInit returns successfully if the replica exists.

--- a/pkg/kv/kvserver/closedts/ctpb/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/ctpb/BUILD.bazel
@@ -4,13 +4,17 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library")
 
 go_library(
     name = "ctpb",
-    srcs = ["service.go"],
+    srcs = [
+        "rpc_clients.go",
+        "service.go",
+    ],
     embed = [":ctpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/closedts/ctpb",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/kv/kvpb",
         "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
         "//pkg/util/timeutil",
     ],
 )

--- a/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
+++ b/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ctpb
+
+import (
+	context "context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialSideTransportClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// SideTransportClient.
+func DialSideTransportClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (SideTransportClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewSideTransportClient(conn), nil
+	}
+	return nil, nil
+}

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -783,18 +783,18 @@ func (r *rpcConn) close() {
 	atomic.StoreInt32(&r.closed, 1)
 }
 
-func (r *rpcConn) maybeConnect(ctx context.Context, stopper *stop.Stopper) error {
+func (r *rpcConn) maybeConnect(ctx context.Context, _ *stop.Stopper) error {
 	if r.stream != nil {
 		// Already connected.
 		return nil
 	}
 
-	conn, err := r.dialer.Dial(ctx, r.nodeID, rpcbase.SystemClass)
+	client, err := ctpb.DialSideTransportClient(r.dialer, ctx, r.nodeID, rpcbase.SystemClass)
 	if err != nil {
 		return err
 	}
 	streamCtx, cancel := context.WithCancel(ctx)
-	stream, err := ctpb.NewSideTransportClient(conn).PushUpdates(streamCtx)
+	stream, err := client.PushUpdates(streamCtx)
 	if err != nil {
 		cancel()
 		return err

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1018,11 +1018,11 @@ func waitForApplication(
 	for _, repl := range replicas {
 		repl := repl // copy for goroutine
 		g.GoCtx(func(ctx context.Context) error {
-			conn, err := dialer.Dial(ctx, repl.NodeID, rpcbase.DefaultClass)
+			client, err := DialPerReplicaClient(dialer, ctx, repl.NodeID, rpcbase.DefaultClass)
 			if err != nil {
 				return errors.Wrapf(err, "could not dial n%d", repl.NodeID)
 			}
-			_, err = NewPerReplicaClient(conn).WaitForApplication(ctx, &WaitForApplicationRequest{
+			_, err = client.WaitForApplication(ctx, &WaitForApplicationRequest{
 				StoreRequestHeader: StoreRequestHeader{NodeID: repl.NodeID, StoreID: repl.StoreID},
 				RangeID:            rangeID,
 				LeaseIndex:         leaseIndex,
@@ -1048,11 +1048,11 @@ func waitForReplicasInit(
 		for _, repl := range replicas {
 			repl := repl // copy for goroutine
 			g.GoCtx(func(ctx context.Context) error {
-				conn, err := dialer.Dial(ctx, repl.NodeID, rpcbase.DefaultClass)
+				client, err := DialPerReplicaClient(dialer, ctx, repl.NodeID, rpcbase.DefaultClass)
 				if err != nil {
 					return errors.Wrapf(err, "could not dial n%d", repl.NodeID)
 				}
-				_, err = NewPerReplicaClient(conn).WaitForReplicaInit(ctx, &WaitForReplicaInitRequest{
+				_, err = client.WaitForReplicaInit(ctx, &WaitForReplicaInitRequest{
 					StoreRequestHeader: StoreRequestHeader{NodeID: repl.NodeID, StoreID: repl.StoreID},
 					RangeID:            rangeID,
 				})

--- a/pkg/kv/kvserver/replica_consistency.go
+++ b/pkg/kv/kvserver/replica_consistency.go
@@ -269,12 +269,11 @@ type ConsistencyCheckResult struct {
 func (r *Replica) collectChecksumFromReplica(
 	ctx context.Context, replica roachpb.ReplicaDescriptor, id uuid.UUID,
 ) (CollectChecksumResponse, error) {
-	conn, err := r.store.cfg.NodeDialer.Dial(ctx, replica.NodeID, rpcbase.DefaultClass)
+	client, err := DialPerReplicaClient(r.store.cfg.NodeDialer, ctx, replica.NodeID, rpcbase.DefaultClass)
 	if err != nil {
 		return CollectChecksumResponse{},
 			errors.Wrapf(err, "could not dial node ID %d", replica.NodeID)
 	}
-	client := NewPerReplicaClient(conn)
 	req := &CollectChecksumRequest{
 		StoreRequestHeader: StoreRequestHeader{NodeID: replica.NodeID, StoreID: replica.StoreID},
 		RangeID:            r.RangeID,

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -1,0 +1,61 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvserver
+
+import (
+	context "context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialMultiRaftClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// MultiRaftClient.
+func DialMultiRaftClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (MultiRaftClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewMultiRaftClient(conn), nil
+	}
+	return nil, nil
+}
+
+// DialPerReplicaClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// PerReplicaClient.
+func DialPerReplicaClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (PerReplicaClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewPerReplicaClient(conn), nil
+	}
+	return nil, nil
+}
+
+// DialPerStoreClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// PerStoreClient.
+func DialPerStoreClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (PerStoreClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewPerStoreClient(conn), nil
+	}
+	return nil, nil
+}

--- a/pkg/kv/kvserver/storage_engine_client.go
+++ b/pkg/kv/kvserver/storage_engine_client.go
@@ -29,11 +29,10 @@ func NewStorageEngineClient(nd *nodedialer.Dialer) *StorageEngineClient {
 func (c *StorageEngineClient) CompactEngineSpan(
 	ctx context.Context, nodeID, storeID int32, startKey, endKey []byte,
 ) error {
-	conn, err := c.nd.Dial(ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
+	client, err := DialPerStoreClient(c.nd, ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
 	if err != nil {
 		return errors.Wrapf(err, "could not dial node ID %d", nodeID)
 	}
-	client := NewPerStoreClient(conn)
 	req := &CompactEngineSpanRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			NodeID:  roachpb.NodeID(nodeID),
@@ -49,12 +48,10 @@ func (c *StorageEngineClient) CompactEngineSpan(
 func (c *StorageEngineClient) GetTableMetrics(
 	ctx context.Context, nodeID, storeID int32, startKey, endKey []byte,
 ) ([]enginepb.SSTableMetricsInfo, error) {
-	conn, err := c.nd.Dial(ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
+	client, err := DialPerStoreClient(c.nd, ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
 	if err != nil {
 		return []enginepb.SSTableMetricsInfo{}, errors.Wrapf(err, "could not dial node ID %d", nodeID)
 	}
-
-	client := NewPerStoreClient(conn)
 	req := &GetTableMetricsRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			NodeID:  roachpb.NodeID(nodeID),
@@ -75,12 +72,10 @@ func (c *StorageEngineClient) GetTableMetrics(
 func (c *StorageEngineClient) ScanStorageInternalKeys(
 	ctx context.Context, nodeID, storeID int32, startKey, endKey []byte, megabytesPerSecond int64,
 ) ([]enginepb.StorageInternalKeysMetrics, error) {
-	conn, err := c.nd.Dial(ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
+	client, err := DialPerStoreClient(c.nd, ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
 	if err != nil {
 		return []enginepb.StorageInternalKeysMetrics{}, errors.Wrapf(err, "could not dial node ID %d", nodeID)
 	}
-
-	client := NewPerStoreClient(conn)
 	req := &ScanStorageInternalKeysRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			NodeID:  roachpb.NodeID(nodeID),
@@ -102,11 +97,10 @@ func (c *StorageEngineClient) ScanStorageInternalKeys(
 func (c *StorageEngineClient) SetCompactionConcurrency(
 	ctx context.Context, nodeID, storeID int32, compactionConcurrency uint64,
 ) error {
-	conn, err := c.nd.Dial(ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
+	client, err := DialPerStoreClient(c.nd, ctx, roachpb.NodeID(nodeID), rpcbase.DefaultClass)
 	if err != nil {
 		return errors.Wrapf(err, "could not dial node ID %d", nodeID)
 	}
-	client := NewPerStoreClient(conn)
 	req := &CompactionConcurrencyRequest{
 		StoreRequestHeader: StoreRequestHeader{
 			NodeID:  roachpb.NodeID(nodeID),

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -34,7 +34,6 @@ import (
 	"github.com/cockroachdb/pebble/objstorage"
 	"go.opentelemetry.io/otel/attribute"
 	"golang.org/x/time/rate"
-	"google.golang.org/grpc"
 )
 
 const (
@@ -667,7 +666,7 @@ func SendEmptySnapshot(
 	clusterID uuid.UUID,
 	st *cluster.Settings,
 	tracer *tracing.Tracer,
-	cc *grpc.ClientConn,
+	mrc MultiRaftClient,
 	now hlc.Timestamp,
 	desc roachpb.RangeDescriptor,
 	to roachpb.ReplicaDescriptor,
@@ -767,7 +766,7 @@ func SendEmptySnapshot(
 		RangeKeysInOrder:   true,
 	}
 
-	stream, err := NewMultiRaftClient(cc).RaftSnapshot(ctx)
+	stream, err := mrc.RaftSnapshot(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/BUILD.bazel
@@ -31,8 +31,15 @@ go_proto_library(
 
 go_library(
     name = "storelivenesspb",
-    srcs = ["service.go"],
+    srcs = [
+        "rpc_clients.go",
+        "service.go",
+    ],
     embed = [":storelivenesspb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/kv/kvserver/storeliveness/storelivenesspb",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
+    ],
 )

--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package storelivenesspb
+
+import (
+	context "context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialStoreLivenessClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// StoreLivenessClient.
+func DialStoreLivenessClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (StoreLivenessClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewStoreLivenessClient(conn), nil
+	}
+	return nil, nil
+}

--- a/pkg/kv/kvserver/storeliveness/transport.go
+++ b/pkg/kv/kvserver/storeliveness/transport.go
@@ -283,13 +283,11 @@ func (t *Transport) startProcessNewQueue(
 			log.Fatalf(ctx, "queue for n%d does not exist", toNodeID)
 		}
 		defer cleanup()
-		conn, err := t.dialer.Dial(ctx, toNodeID, connClass)
+		client, err := slpb.DialStoreLivenessClient(t.dialer, ctx, toNodeID, connClass)
 		if err != nil {
 			// DialNode already logs sufficiently, so just return.
 			return
 		}
-
-		client := slpb.NewStoreLivenessClient(conn)
 		streamCtx, cancel := context.WithCancel(ctx)
 		defer cancel()
 

--- a/pkg/rpc/rpcbase/BUILD.bazel
+++ b/pkg/rpc/rpcbase/BUILD.bazel
@@ -15,7 +15,10 @@ go_library(
 
 go_library(
     name = "rpcbase",
-    srcs = ["connection_class.go"],
+    srcs = [
+        "connection_class.go",
+        "nodedialer.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/rpc/rpcbase",
     visibility = ["//visibility:public"],
     deps = [
@@ -23,5 +26,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc/rpcpb",
         "//pkg/util/envutil",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/rpc/rpcbase/nodedialer.go
+++ b/pkg/rpc/rpcbase/nodedialer.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package rpcbase
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"google.golang.org/grpc"
+)
+
+// TODODRPC is a marker to identify each RPC client creation site that needs to
+// be updated to support DRPC.
+const TODODRPC = false
+
+// NodeDialer interface defines methods for dialing peer nodes using their
+// node IDs.
+type NodeDialer interface {
+	Dial(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
+}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2364,7 +2364,7 @@ func (n *Node) ResetQuorum(
 	log.Infof(ctx, "updated meta2 entry for r%d", desc.RangeID)
 
 	// Set up connection to self. Use rpc.SystemClass to avoid throttling.
-	conn, err := n.storeCfg.NodeDialer.Dial(ctx, n.Descriptor.NodeID, rpcbase.SystemClass)
+	client, err := kvserver.DialMultiRaftClient(n.storeCfg.NodeDialer, ctx, n.Descriptor.NodeID, rpcbase.SystemClass)
 	if err != nil {
 		return nil, err
 	}
@@ -2377,7 +2377,7 @@ func (n *Node) ResetQuorum(
 		n.clusterID.Get(),
 		n.storeCfg.Settings,
 		n.storeCfg.Tracer(),
-		conn,
+		client,
 		n.storeCfg.Clock.Now(),
 		desc,
 		toReplicaDescriptor,


### PR DESCRIPTION
To support DRPC and reuse the connection management logic in [Connection](https://github.com/cockroachdb/cockroach/blob/master/pkg/rpc/connection.go#L54) and [Peer](https://github.com/cockroachdb/cockroach/blob/8fed6e8481da1373020ab2cc95d222df02f61721/pkg/rpc/peer.go#L121), they were refactored to use generics.

Previously, most code established connections to peers using [nodedialer](https://github.com/cockroachdb/cockroach/blob/8fed6e8481da1373020ab2cc95d222df02f61721/pkg/rpc/nodedialer/nodedialer.go#L37-L41) or [rpc.Context](https://github.com/cockroachdb/cockroach/blob/8fed6e8481da1373020ab2cc95d222df02f61721/pkg/rpc/context.go#L2004-L2016), subsequently creating an RPC client. Supporting DRPC would require updating numerous call-sites to conditionally dial `gRPC` or `DRPC` connections, introducing significant boilerplate code.

This commit consolidates RPC client creation logic in the `kvserver` package. Call sites were updated to dial RPC clients than dialing connections. Subsequent work will ensure the appropriate connection type is dialed and the corresponding client is created. RPC clients will be unified to use a consistent interface for both `gRPC` and `DRPC` connections.

Epic: [CRDB-48923](https://cockroachlabs.atlassian.net/browse/CRDB-48923)
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none