### PR TITLE
kv: increase adoption of Stopper Handle API

### DIFF
--- a/pkg/internal/client/requestbatcher/batcher.go
+++ b/pkg/internal/client/requestbatcher/batcher.go
@@ -241,9 +241,16 @@ func New(cfg Config) *RequestBatcher {
 	}
 	b.sendBatchOpName = redact.Sprintf("%s.sendBatch", b.cfg.Name)
 	bgCtx := cfg.AmbientCtx.AnnotateCtx(context.Background())
-	if err := cfg.Stopper.RunAsyncTask(bgCtx, b.cfg.Name.StripMarkers(), b.run); err != nil {
+	bgCtx, hdl, err := cfg.Stopper.GetHandle(bgCtx, stop.TaskOpts{
+		TaskName: b.cfg.Name.StripMarkers(),
+	})
+	if err != nil {
 		panic(err)
 	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		b.run(ctx)
+	}(bgCtx)
 	return b
 }
 
@@ -341,7 +348,7 @@ func (b *RequestBatcher) sendDone(ba *batch) {
 }
 
 func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
-	if err := b.cfg.Stopper.RunAsyncTask(ctx, "send-batch", func(ctx context.Context) {
+	work := func(ctx context.Context) {
 		defer b.sendDone(ba)
 		var batchRequest *kvpb.BatchRequest
 		var br *kvpb.BatchResponse
@@ -425,9 +432,19 @@ func (b *RequestBatcher) sendBatch(ctx context.Context, ba *batch) {
 			}
 			ba.reqs, prevResps = nextReqs, nextPrevResps
 		}
-	}); err != nil {
-		b.sendDone(ba)
 	}
+
+	ctx, hdl, err := b.cfg.Stopper.GetHandle(ctx, stop.TaskOpts{
+		TaskName: "send-batch",
+	})
+	if err != nil {
+		b.sendDone(ba)
+		return
+	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		work(ctx)
+	}(ctx)
 }
 
 func (b *RequestBatcher) sendResponse(req *request, resp Response) {

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_heartbeater.go
@@ -566,67 +566,76 @@ func (h *txnHeartbeater) abortTxnAsyncLocked(ctx context.Context) {
 
 	const taskName = "txnHeartbeater: aborting txn"
 	log.VEventf(ctx, 2, "async abort for txn: %s", txn)
-	if err := h.stopper.RunAsyncTask(h.AnnotateCtx(context.Background()), taskName,
-		func(ctx context.Context) {
-			if err := timeutil.RunWithTimeout(ctx, taskName, abortTxnAsyncTimeout,
-				func(ctx context.Context) error {
-					h.mu.Lock()
-					defer h.mu.Unlock()
 
-					// If we find an abortTxnAsyncResultC, that means an async
-					// rollback request is already in flight, so there's no
-					// point in us running another. This can happen because the
-					// TxnCoordSender also calls abortTxnAsyncLocked()
-					// independently of the heartbeat loop.
-					if h.mu.abortTxnAsyncResultC != nil {
-						log.VEventf(ctx, 2,
-							"skipping async abort due to concurrent async abort for %s", txn)
-						return nil
-					}
+	work := func(ctx context.Context) {
+		if err := timeutil.RunWithTimeout(ctx, taskName, abortTxnAsyncTimeout,
+			func(ctx context.Context) error {
+				h.mu.Lock()
+				defer h.mu.Unlock()
 
-					// TxnCoordSender allows EndTxn(commit=false) through even
-					// after we set finalObservedStatus, and that request can
-					// race with us for the mutex. Thus, if we find an in-flight
-					// request here, after checking ifReqs=0 before being spawned,
-					// we deduce that it must have been a rollback and there's no
-					// point in sending another rollback.
-					if h.mu.ifReqs > 0 {
-						log.VEventf(ctx, 2,
-							"skipping async abort due to client rollback for %s", txn)
-						return nil
-					}
-
-					// Set up a result channel to signal to an incoming client
-					// rollback that an async rollback is already in progress,
-					// and pass it the result. The buffer allows storing the
-					// result even when no client rollback arrives. Recall that
-					// the SendLocked() call below releases the mutex while
-					// running, allowing concurrent incoming requests.
-					h.mu.abortTxnAsyncResultC = make(chan abortTxnAsyncResult, 1)
-
-					// Send the abort request through the interceptor stack. This is
-					// important because we need the txnPipeliner to append lock spans
-					// to the EndTxn request.
-					br, pErr := h.wrapped.SendLocked(ctx, ba)
-					if pErr != nil {
-						log.VErrEventf(ctx, 1, "async abort failed for %s: %s ", txn, pErr)
-						h.metrics.AsyncRollbacksFailed.Inc(1)
-					}
-
-					// Pass the result to a waiting client rollback, if any, and
-					// remove the channel since we're no longer in flight.
-					h.mu.abortTxnAsyncResultC <- abortTxnAsyncResult{br: br, pErr: pErr}
-					h.mu.abortTxnAsyncResultC = nil
+				// If we find an abortTxnAsyncResultC, that means an async
+				// rollback request is already in flight, so there's no
+				// point in us running another. This can happen because the
+				// TxnCoordSender also calls abortTxnAsyncLocked()
+				// independently of the heartbeat loop.
+				if h.mu.abortTxnAsyncResultC != nil {
+					log.VEventf(ctx, 2,
+						"skipping async abort due to concurrent async abort for %s", txn)
 					return nil
-				},
-			); err != nil {
-				log.VEventf(ctx, 1, "async abort failed for %s: %s", txn, err)
-			}
-		},
-	); err != nil {
+				}
+
+				// TxnCoordSender allows EndTxn(commit=false) through even
+				// after we set finalObservedStatus, and that request can
+				// race with us for the mutex. Thus, if we find an in-flight
+				// request here, after checking ifReqs=0 before being spawned,
+				// we deduce that it must have been a rollback and there's no
+				// point in sending another rollback.
+				if h.mu.ifReqs > 0 {
+					log.VEventf(ctx, 2,
+						"skipping async abort due to client rollback for %s", txn)
+					return nil
+				}
+
+				// Set up a result channel to signal to an incoming client
+				// rollback that an async rollback is already in progress,
+				// and pass it the result. The buffer allows storing the
+				// result even when no client rollback arrives. Recall that
+				// the SendLocked() call below releases the mutex while
+				// running, allowing concurrent incoming requests.
+				h.mu.abortTxnAsyncResultC = make(chan abortTxnAsyncResult, 1)
+
+				// Send the abort request through the interceptor stack. This is
+				// important because we need the txnPipeliner to append lock spans
+				// to the EndTxn request.
+				br, pErr := h.wrapped.SendLocked(ctx, ba)
+				if pErr != nil {
+					log.VErrEventf(ctx, 1, "async abort failed for %s: %s ", txn, pErr)
+					h.metrics.AsyncRollbacksFailed.Inc(1)
+				}
+
+				// Pass the result to a waiting client rollback, if any, and
+				// remove the channel since we're no longer in flight.
+				h.mu.abortTxnAsyncResultC <- abortTxnAsyncResult{br: br, pErr: pErr}
+				h.mu.abortTxnAsyncResultC = nil
+				return nil
+			},
+		); err != nil {
+			log.VEventf(ctx, 1, "async abort failed for %s: %s", txn, err)
+		}
+	}
+
+	asyncCtx, hdl, err := h.stopper.GetHandle(h.AnnotateCtx(context.Background()), stop.TaskOpts{
+		TaskName: taskName,
+	})
+	if err != nil {
 		log.Warningf(ctx, "%v", err)
 		h.metrics.AsyncRollbacksFailed.Inc(1)
+		return
 	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		work(ctx)
+	}(asyncCtx)
 }
 
 // randLockingIndex returns the index of the first request that acquires locks

--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -1384,186 +1384,186 @@ func (w *workerCoordinator) performRequestAsync(
 	responsesOverhead int64,
 	headOfLine bool,
 ) {
+	work := func(ctx context.Context) {
+		defer w.asyncRequestCleanup(false /* budgetMuAlreadyLocked */)
+		w.s.metrics.BatchesSent.Inc(1)
+		w.s.metrics.BatchesInProgress.Inc(1)
+		defer w.s.metrics.BatchesInProgress.Dec(1)
+
+		ba := &kvpb.BatchRequest{}
+		ba.Header.WaitPolicy = w.lockWaitPolicy
+		ba.Header.TargetBytes = targetBytes
+		ba.Header.AllowEmpty = !headOfLine
+		ba.Header.WholeRowsOfSize = w.s.maxKeysPerRow
+		// TODO(yuzefovich): consider setting MaxSpanRequestKeys whenever
+		// applicable (#67885).
+		ba.AdmissionHeader = w.requestAdmissionHeader
+		// We always have some memory reserved against the memory account,
+		// regardless of the value of headOfLine.
+		ba.AdmissionHeader.NoMemoryReservedAtSource = false
+		ba.Requests = req.reqs
+
+		if buildutil.CrdbTestBuild {
+			if w.s.mode == InOrder {
+				for i := range req.positions[:len(req.positions)-1] {
+					if req.positions[i] >= req.positions[i+1] {
+						w.s.results.setError(errors.AssertionFailedf(
+							"positions aren't ascending: %d before %d at index %d",
+							req.positions[i], req.positions[i+1], i,
+						))
+						return
+					}
+				}
+			}
+		}
+
+		// TODO(yuzefovich): in Enqueue we split all requests into
+		// single-range batches, so ideally ba touches a single range in
+		// which case we hit the fast path in the DistSender. However, if
+		// the range boundaries have changed after we performed the split
+		// (or we had stale range cache at the time of the split), the
+		// DistSender will transparently re-split ba into several
+		// sub-batches that will be executed sequentially because of the
+		// presence of limits. We could, instead, ask the DistSender to not
+		// perform that re-splitting and return an error, then we'll rely on
+		// the updated range cache to perform re-splitting ourselves. This
+		// should offer some performance improvements since we'd eliminate
+		// unnecessary blocking (due to sequential evaluation of sub-batches
+		// by the DistSender). For the initial implementation it doesn't
+		// seem important though.
+
+		// Note that we don't add a separate log.VEventf here before calling
+		// Send since we create a separate tracing span for each async
+		// request which is sufficient to highlight where the handoff from
+		// SQL occurred.
+		br, err := w.sendFn(ctx, ba)
+		if err != nil {
+			// TODO(yuzefovich): if err is
+			// ReadWithinUncertaintyIntervalError and there is only a single
+			// Streamer in a single local flow, attempt to transparently
+			// refresh.
+			log.VEventf(ctx, 2, "dropping response: error from kv: %v", err)
+			w.s.results.setError(err)
+			return
+		}
+		atomic.AddInt64(&w.s.atomics.batchRequestsIssued, 1)
+
+		// First, we have to reconcile the memory budget. We do it
+		// separately from processing the results because we want to know
+		// how many Gets and Scans need to be allocated for the ResumeSpans,
+		// if any are present. At the moment, due to limitations of the KV
+		// layer (#75452) we cannot reuse original requests because the KV
+		// doesn't allow mutability.
+		fp, err := calculateFootprint(req, br)
+		if err != nil {
+			log.VEventf(ctx, 2, "dropping response: error calculating footprint: %v", err)
+			w.s.results.setError(err)
+			return
+		}
+		atomic.AddInt64(w.s.atomics.kvPairsRead, fp.kvPairsRead)
+
+		// Now adjust the budget based on the actual memory footprint of
+		// non-empty responses as well as resume spans, if any.
+		respOverestimate := targetBytes + responsesOverhead - fp.memoryFootprintBytes - fp.responsesOverhead
+		reqOveraccounted := req.reqsReservedBytes - fp.resumeReqsMemUsage
+		if fp.resumeReqsMemUsage == 0 {
+			// There will be no resume request, so we will lose the
+			// reference to the slices in req and can release its memory
+			// reservation.
+			reqOveraccounted += req.overheadAccountedFor
+		}
+		overaccountedTotal := respOverestimate + reqOveraccounted
+		if overaccountedTotal >= 0 {
+			w.s.budget.release(ctx, overaccountedTotal)
+		} else {
+			// There is an under-accounting at the moment, so we have to
+			// increase the memory reservation.
+			//
+			// This under-accounting can occur in a couple of edge cases:
+			// 1) the estimate of the response sizes is pretty good (i.e.
+			// respOverestimate is around 0), but we received many partial
+			// responses with ResumeSpans that take up much more space than
+			// the original requests;
+			// 2) we have a single large row in the response. In this case
+			// headOfLine must be true (targetBytes might be 1 or higher,
+			// but not enough for that large row).
+			toConsume := -overaccountedTotal
+			if err = w.s.budget.consume(ctx, toConsume, headOfLine /* allowDebt */); err != nil {
+				log.VEventf(ctx, 2,
+					"dropping response: root memory pool exhausted (head:%v): %v", headOfLine, err,
+				)
+				// TODO(yuzefovich): rather than dropping the response
+				// altogether, consider blocking to wait for the budget to
+				// open up, up to some limit.
+				atomic.AddInt64(&w.s.atomics.droppedBatchResponses, 1)
+				w.s.budget.release(ctx, targetBytes)
+				if !headOfLine {
+					// Since this is not the head of the line, we'll just
+					// discard the result and add the request back to be
+					// served.
+					//
+					// This is opportunistic behavior where we're hoping
+					// that once other requests are fully processed (i.e.
+					// the corresponding results are Release()'d), we'll be
+					// able to make progress on this request too.
+					// TODO(yuzefovich): consider updating the
+					// avgResponseSize and/or storing the information about
+					// the returned bytes size in req.
+
+					// The KV layer doesn't allow evaluation of the same
+					// Gets and Scans multiple times, so we need to make
+					// fresh copies of them.
+					req.deepCopyRequests(w.s)
+					w.s.requestsToServe.add(req)
+					return
+				}
+				// The error indicates that the root memory pool has been
+				// exhausted, so we'll exit to be safe (in order not to OOM
+				// the node).
+				// TODO(yuzefovich): if the response contains multiple rows,
+				// consider adding the request back to be served with a note
+				// to issue it with smaller targetBytes.
+				w.s.results.setError(err)
+				return
+			}
+		}
+
+		// Do admission control after we've finalized the memory accounting.
+		if br != nil && w.responseAdmissionQ != nil {
+			responseAdmission := admission.WorkInfo{
+				TenantID:   roachpb.SystemTenantID,
+				Priority:   admissionpb.WorkPriority(w.requestAdmissionHeader.Priority),
+				CreateTime: w.requestAdmissionHeader.CreateTime,
+			}
+			if _, err = w.responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
+				log.VEventf(ctx, 2, "dropping response: admission control: %v", err)
+				w.s.results.setError(err)
+				return
+			}
+		}
+
+		// Finally, process the results and add the ResumeSpans to be
+		// processed as well.
+		log.VEventf(ctx, 2,
+			"responses:%d targetBytes:%d {footprint:%v overhead:%v resumeMem:%v gets:%v scans:%v incpGets:%v "+
+				"incpScans:%v startedScans:%v kvs:%v}",
+			len(br.Responses), targetBytes, fp.memoryFootprintBytes, fp.responsesOverhead,
+			fp.resumeReqsMemUsage, fp.numGetResults, fp.numScanResults, fp.numIncompleteGets,
+			fp.numIncompleteScans, fp.numStartedScans, fp.kvPairsRead,
+		)
+		processSingleRangeResponse(ctx, w.s, req, br, fp)
+	}
+
 	w.s.waitGroup.Add(1)
 	w.s.adjustNumRequestsInFlight(1 /* delta */)
 	if err := w.s.stopper.RunAsyncTaskEx(
-		ctx,
-		stop.TaskOpts{
+		ctx, stop.TaskOpts{
 			TaskName: AsyncRequestOp,
 			SpanOpt:  stop.ChildSpan,
 			// Note that we don't wait for the semaphore since it's the caller's
 			// responsibility to ensure that a new goroutine can be spun up.
 			Sem: w.asyncSem,
-		},
-		func(ctx context.Context) {
-			defer w.asyncRequestCleanup(false /* budgetMuAlreadyLocked */)
-			w.s.metrics.BatchesSent.Inc(1)
-			w.s.metrics.BatchesInProgress.Inc(1)
-			defer w.s.metrics.BatchesInProgress.Dec(1)
-
-			ba := &kvpb.BatchRequest{}
-			ba.Header.WaitPolicy = w.lockWaitPolicy
-			ba.Header.TargetBytes = targetBytes
-			ba.Header.AllowEmpty = !headOfLine
-			ba.Header.WholeRowsOfSize = w.s.maxKeysPerRow
-			// TODO(yuzefovich): consider setting MaxSpanRequestKeys whenever
-			// applicable (#67885).
-			ba.AdmissionHeader = w.requestAdmissionHeader
-			// We always have some memory reserved against the memory account,
-			// regardless of the value of headOfLine.
-			ba.AdmissionHeader.NoMemoryReservedAtSource = false
-			ba.Requests = req.reqs
-
-			if buildutil.CrdbTestBuild {
-				if w.s.mode == InOrder {
-					for i := range req.positions[:len(req.positions)-1] {
-						if req.positions[i] >= req.positions[i+1] {
-							w.s.results.setError(errors.AssertionFailedf(
-								"positions aren't ascending: %d before %d at index %d",
-								req.positions[i], req.positions[i+1], i,
-							))
-							return
-						}
-					}
-				}
-			}
-
-			// TODO(yuzefovich): in Enqueue we split all requests into
-			// single-range batches, so ideally ba touches a single range in
-			// which case we hit the fast path in the DistSender. However, if
-			// the range boundaries have changed after we performed the split
-			// (or we had stale range cache at the time of the split), the
-			// DistSender will transparently re-split ba into several
-			// sub-batches that will be executed sequentially because of the
-			// presence of limits. We could, instead, ask the DistSender to not
-			// perform that re-splitting and return an error, then we'll rely on
-			// the updated range cache to perform re-splitting ourselves. This
-			// should offer some performance improvements since we'd eliminate
-			// unnecessary blocking (due to sequential evaluation of sub-batches
-			// by the DistSender). For the initial implementation it doesn't
-			// seem important though.
-
-			// Note that we don't add a separate log.VEventf here before calling
-			// Send since we create a separate tracing span for each async
-			// request which is sufficient to highlight where the handoff from
-			// SQL occurred.
-			br, err := w.sendFn(ctx, ba)
-			if err != nil {
-				// TODO(yuzefovich): if err is
-				// ReadWithinUncertaintyIntervalError and there is only a single
-				// Streamer in a single local flow, attempt to transparently
-				// refresh.
-				log.VEventf(ctx, 2, "dropping response: error from kv: %v", err)
-				w.s.results.setError(err)
-				return
-			}
-			atomic.AddInt64(&w.s.atomics.batchRequestsIssued, 1)
-
-			// First, we have to reconcile the memory budget. We do it
-			// separately from processing the results because we want to know
-			// how many Gets and Scans need to be allocated for the ResumeSpans,
-			// if any are present. At the moment, due to limitations of the KV
-			// layer (#75452) we cannot reuse original requests because the KV
-			// doesn't allow mutability.
-			fp, err := calculateFootprint(req, br)
-			if err != nil {
-				log.VEventf(ctx, 2, "dropping response: error calculating footprint: %v", err)
-				w.s.results.setError(err)
-				return
-			}
-			atomic.AddInt64(w.s.atomics.kvPairsRead, fp.kvPairsRead)
-
-			// Now adjust the budget based on the actual memory footprint of
-			// non-empty responses as well as resume spans, if any.
-			respOverestimate := targetBytes + responsesOverhead - fp.memoryFootprintBytes - fp.responsesOverhead
-			reqOveraccounted := req.reqsReservedBytes - fp.resumeReqsMemUsage
-			if fp.resumeReqsMemUsage == 0 {
-				// There will be no resume request, so we will lose the
-				// reference to the slices in req and can release its memory
-				// reservation.
-				reqOveraccounted += req.overheadAccountedFor
-			}
-			overaccountedTotal := respOverestimate + reqOveraccounted
-			if overaccountedTotal >= 0 {
-				w.s.budget.release(ctx, overaccountedTotal)
-			} else {
-				// There is an under-accounting at the moment, so we have to
-				// increase the memory reservation.
-				//
-				// This under-accounting can occur in a couple of edge cases:
-				// 1) the estimate of the response sizes is pretty good (i.e.
-				// respOverestimate is around 0), but we received many partial
-				// responses with ResumeSpans that take up much more space than
-				// the original requests;
-				// 2) we have a single large row in the response. In this case
-				// headOfLine must be true (targetBytes might be 1 or higher,
-				// but not enough for that large row).
-				toConsume := -overaccountedTotal
-				if err = w.s.budget.consume(ctx, toConsume, headOfLine /* allowDebt */); err != nil {
-					log.VEventf(ctx, 2,
-						"dropping response: root memory pool exhausted (head:%v): %v", headOfLine, err,
-					)
-					// TODO(yuzefovich): rather than dropping the response
-					// altogether, consider blocking to wait for the budget to
-					// open up, up to some limit.
-					atomic.AddInt64(&w.s.atomics.droppedBatchResponses, 1)
-					w.s.budget.release(ctx, targetBytes)
-					if !headOfLine {
-						// Since this is not the head of the line, we'll just
-						// discard the result and add the request back to be
-						// served.
-						//
-						// This is opportunistic behavior where we're hoping
-						// that once other requests are fully processed (i.e.
-						// the corresponding results are Release()'d), we'll be
-						// able to make progress on this request too.
-						// TODO(yuzefovich): consider updating the
-						// avgResponseSize and/or storing the information about
-						// the returned bytes size in req.
-
-						// The KV layer doesn't allow evaluation of the same
-						// Gets and Scans multiple times, so we need to make
-						// fresh copies of them.
-						req.deepCopyRequests(w.s)
-						w.s.requestsToServe.add(req)
-						return
-					}
-					// The error indicates that the root memory pool has been
-					// exhausted, so we'll exit to be safe (in order not to OOM
-					// the node).
-					// TODO(yuzefovich): if the response contains multiple rows,
-					// consider adding the request back to be served with a note
-					// to issue it with smaller targetBytes.
-					w.s.results.setError(err)
-					return
-				}
-			}
-
-			// Do admission control after we've finalized the memory accounting.
-			if br != nil && w.responseAdmissionQ != nil {
-				responseAdmission := admission.WorkInfo{
-					TenantID:   roachpb.SystemTenantID,
-					Priority:   admissionpb.WorkPriority(w.requestAdmissionHeader.Priority),
-					CreateTime: w.requestAdmissionHeader.CreateTime,
-				}
-				if _, err = w.responseAdmissionQ.Admit(ctx, responseAdmission); err != nil {
-					log.VEventf(ctx, 2, "dropping response: admission control: %v", err)
-					w.s.results.setError(err)
-					return
-				}
-			}
-
-			// Finally, process the results and add the ResumeSpans to be
-			// processed as well.
-			log.VEventf(ctx, 2,
-				"responses:%d targetBytes:%d {footprint:%v overhead:%v resumeMem:%v gets:%v scans:%v incpGets:%v "+
-					"incpScans:%v startedScans:%v kvs:%v}",
-				len(br.Responses), targetBytes, fp.memoryFootprintBytes, fp.responsesOverhead,
-				fp.resumeReqsMemUsage, fp.numGetResults, fp.numScanResults, fp.numIncompleteGets,
-				fp.numIncompleteScans, fp.numStartedScans, fp.kvPairsRead,
-			)
-			processSingleRangeResponse(ctx, w.s, req, br, fp)
-		}); err != nil {
+		}, work); err != nil {
 		// The new goroutine for the request wasn't spun up, so we have to
 		// perform the cleanup of this request ourselves.
 		w.asyncRequestCleanup(true /* budgetMuAlreadyLocked */)

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -704,7 +704,6 @@ func (ir *IntentResolver) lockInFlightTxnCleanup(
 // of async task with the intention that it be used as a hook to update metrics.
 // It will not be called if an error is returned.
 func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
-	_ context.Context, // TODO(tbg): remove
 	admissionHeader kvpb.AdmissionHeader,
 	rangeID roachpb.RangeID,
 	txn *roachpb.Transaction,

--- a/pkg/kv/kvserver/intentresolver/intent_resolver.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver.go
@@ -489,12 +489,12 @@ func (ir *IntentResolver) MaybePushTransactions(
 // run asynchronously; otherwise, it's run synchronously if
 // allowSyncProcessing is true; if false, an error is returned.
 func (ir *IntentResolver) runAsyncTask(
-	ctx context.Context, allowSyncProcessing bool, taskFn func(context.Context),
+	origCtx context.Context, allowSyncProcessing bool, taskFn func(context.Context),
 ) error {
 	if ir.testingKnobs.DisableAsyncIntentResolution {
 		return errors.New("intents not processed as async resolution is disabled")
 	}
-	err := ir.stopper.RunAsyncTaskEx(
+	ctx, hdl, err := ir.stopper.GetHandle(
 		// If we've successfully launched a background task, dissociate
 		// this work from our caller's context and timeout.
 		ir.ambientCtx.AnnotateCtx(context.Background()),
@@ -502,21 +502,23 @@ func (ir *IntentResolver) runAsyncTask(
 			TaskName:   "storage.IntentResolver: processing intents",
 			Sem:        ir.sem,
 			WaitForSem: false,
-		},
-		taskFn,
-	)
+		})
 	if err != nil {
 		if errors.Is(err, stop.ErrThrottled) {
 			ir.Metrics.IntentResolverAsyncThrottled.Inc(1)
 			if allowSyncProcessing {
 				// A limited task was not available. Rather than waiting for
 				// one, we reuse the current goroutine.
-				taskFn(ctx)
+				taskFn(origCtx)
 				return nil
 			}
 		}
 		return errors.Wrapf(err, "during async intent resolution")
 	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		taskFn(ctx)
+	}(ctx)
 	return nil
 }
 
@@ -702,14 +704,14 @@ func (ir *IntentResolver) lockInFlightTxnCleanup(
 // of async task with the intention that it be used as a hook to update metrics.
 // It will not be called if an error is returned.
 func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
-	ctx context.Context,
+	_ context.Context, // TODO(tbg): remove
 	admissionHeader kvpb.AdmissionHeader,
 	rangeID roachpb.RangeID,
 	txn *roachpb.Transaction,
 	now hlc.Timestamp,
 	onComplete func(pushed, succeeded bool),
 ) error {
-	return ir.stopper.RunAsyncTaskEx(
+	ctx, hdl, err := ir.stopper.GetHandle(
 		// If we've successfully launched a background task,
 		// dissociate this work from our caller's context and
 		// timeout.
@@ -724,66 +726,70 @@ func (ir *IntentResolver) CleanupTxnIntentsOnGCAsync(
 			// them. Not much harm in having old txn records lying around in
 			// the meantime.
 			WaitForSem: false,
-		},
-		func(ctx context.Context) {
-			var pushed, succeeded bool
-			defer func() {
-				if onComplete != nil {
-					onComplete(pushed, succeeded)
-				}
-			}()
-			locked, release := ir.lockInFlightTxnCleanup(ctx, txn.ID)
-			if !locked {
+		})
+	if err != nil {
+		return err
+	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		var pushed, succeeded bool
+		defer func() {
+			if onComplete != nil {
+				onComplete(pushed, succeeded)
+			}
+		}()
+		locked, release := ir.lockInFlightTxnCleanup(ctx, txn.ID)
+		if !locked {
+			return
+		}
+		defer release()
+		// If the transaction is not yet finalized, but expired, push it
+		// before resolving the intents.
+		if !txn.Status.IsFinalized() {
+			if !txnwait.IsExpired(now, txn) {
+				log.VErrEventf(ctx, 3, "cannot push a %s transaction which is not expired: %s", txn.Status, txn)
 				return
 			}
-			defer release()
-			// If the transaction is not yet finalized, but expired, push it
-			// before resolving the intents.
-			if !txn.Status.IsFinalized() {
-				if !txnwait.IsExpired(now, txn) {
-					log.VErrEventf(ctx, 3, "cannot push a %s transaction which is not expired: %s", txn.Status, txn)
-					return
-				}
-				b := &kv.Batch{}
-				b.Header.Timestamp = now
-				b.AddRawRequest(&kvpb.PushTxnRequest{
-					RequestHeader: kvpb.RequestHeader{Key: txn.Key},
-					PusherTxn: roachpb.Transaction{
-						TxnMeta: enginepb.TxnMeta{Priority: enginepb.MaxTxnPriority},
-					},
-					PusheeTxn: txn.TxnMeta,
-					PushType:  kvpb.PUSH_ABORT,
-				})
-				pushed = true
-				if err := ir.db.Run(ctx, b); err != nil {
-					log.VErrEventf(ctx, 2, "failed to push %s, expired txn (%s): %s", txn.Status, txn, err)
-					return
-				}
-				// Update the txn with the result of the push, such that the intents we're about
-				// to resolve get a final status.
-				finalizedTxn := &b.RawResponse().Responses[0].GetInner().(*kvpb.PushTxnResponse).PusheeTxn
-				txn = txn.Clone()
-				txn.Update(finalizedTxn)
+			b := &kv.Batch{}
+			b.Header.Timestamp = now
+			b.AddRawRequest(&kvpb.PushTxnRequest{
+				RequestHeader: kvpb.RequestHeader{Key: txn.Key},
+				PusherTxn: roachpb.Transaction{
+					TxnMeta: enginepb.TxnMeta{Priority: enginepb.MaxTxnPriority},
+				},
+				PusheeTxn: txn.TxnMeta,
+				PushType:  kvpb.PUSH_ABORT,
+			})
+			pushed = true
+			if err := ir.db.Run(ctx, b); err != nil {
+				log.VErrEventf(ctx, 2, "failed to push %s, expired txn (%s): %s", txn.Status, txn, err)
+				return
 			}
-			var onCleanupComplete func(error)
-			if onComplete != nil {
-				onCompleteCopy := onComplete // copy onComplete for use in onCleanupComplete
-				onCleanupComplete = func(err error) {
-					onCompleteCopy(pushed, err == nil)
-				}
+			// Update the txn with the result of the push, such that the intents we're about
+			// to resolve get a final status.
+			finalizedTxn := &b.RawResponse().Responses[0].GetInner().(*kvpb.PushTxnResponse).PusheeTxn
+			txn = txn.Clone()
+			txn.Update(finalizedTxn)
+		}
+		var onCleanupComplete func(error)
+		if onComplete != nil {
+			onCompleteCopy := onComplete // copy onComplete for use in onCleanupComplete
+			onCleanupComplete = func(err error) {
+				onCompleteCopy(pushed, err == nil)
 			}
-			// Set onComplete to nil to disable the deferred call as the call has now
-			// been delegated to the callback passed to cleanupFinishedTxnIntents.
-			onComplete = nil
-			err := ir.cleanupFinishedTxnIntents(
-				ctx, admissionHeader, rangeID, txn, false /* poison */, onCleanupComplete)
-			if err != nil {
-				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
-				}
+		}
+		// Set onComplete to nil to disable the deferred call as the call has now
+		// been delegated to the callback passed to cleanupFinishedTxnIntents.
+		onComplete = nil
+		err := ir.cleanupFinishedTxnIntents(
+			ctx, admissionHeader, rangeID, txn, false /* poison */, onCleanupComplete)
+		if err != nil {
+			if ir.every.ShouldLog() {
+				log.Warningf(ctx, "failed to cleanup transaction intents: %+v", err)
 			}
-		},
-	)
+		}
+	}(ctx)
+	return nil
 }
 
 func (ir *IntentResolver) gcTxnRecord(
@@ -865,23 +871,28 @@ func (ir *IntentResolver) cleanupFinishedTxnIntents(
 	// gcTxnRecord completes, which may cancel the context and abort the cleanup
 	// either due to a defer cancel() or client disconnection. We give it a timeout
 	// as well, to avoid goroutine leakage.
-	return ir.stopper.RunAsyncTask(
-		ir.ambientCtx.AnnotateCtx(context.Background()),
-		"storage.IntentResolver: cleanup txn records",
-		func(ctx context.Context) {
-			err := timeutil.RunWithTimeout(ctx, "cleanup txn record",
-				gcTxnRecordTimeout, func(ctx context.Context) error {
-					return ir.gcTxnRecord(ctx, rangeID, txn)
-				})
-			if onComplete != nil {
-				onComplete(err)
+	ctx, hdl, err := ir.stopper.GetHandle(ir.ambientCtx.AnnotateCtx(context.Background()), stop.TaskOpts{
+		TaskName: "storage.IntentResolver: cleanup txn records",
+	})
+	if err != nil {
+		return err
+	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		err := timeutil.RunWithTimeout(ctx, "cleanup txn record",
+			gcTxnRecordTimeout, func(ctx context.Context) error {
+				return ir.gcTxnRecord(ctx, rangeID, txn)
+			})
+		if onComplete != nil {
+			onComplete(err)
+		}
+		if err != nil {
+			if ir.every.ShouldLog() {
+				log.Warningf(ctx, "failed to gc transaction record: %v", err)
 			}
-			if err != nil {
-				if ir.every.ShouldLog() {
-					log.Warningf(ctx, "failed to gc transaction record: %v", err)
-				}
-			}
-		})
+		}
+	}(ctx)
+	return nil
 }
 
 // ResolveOptions is used during intent resolution.

--- a/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
+++ b/pkg/kv/kvserver/intentresolver/intent_resolver_test.go
@@ -226,8 +226,7 @@ func TestCleanupTxnIntentsOnGCAsync(t *testing.T) {
 			}
 			txn := c.txn.Clone()
 			txn.LockSpans = append([]roachpb.Span{}, c.intentSpans...)
-			err := ir.CleanupTxnIntentsOnGCAsync(
-				ctx, kvpb.AdmissionHeader{}, 1, txn, clock.Now(), onComplete)
+			err := ir.CleanupTxnIntentsOnGCAsync(kvpb.AdmissionHeader{}, 1, txn, clock.Now(), onComplete)
 			if err != nil {
 				t.Fatalf("unexpected error sending async transaction")
 			}

--- a/pkg/kv/kvserver/mvcc_gc_queue.go
+++ b/pkg/kv/kvserver/mvcc_gc_queue.go
@@ -744,18 +744,16 @@ func (mgcq *mvccGCQueue) process(
 		},
 		func(ctx context.Context, txn *roachpb.Transaction) error {
 			err := repl.store.intentResolver.
-				CleanupTxnIntentsOnGCAsync(
-					ctx, gcAdmissionHeader(repl.store.ClusterSettings()), repl.RangeID, txn, gcTimestamp,
-					func(pushed, succeeded bool) {
-						if pushed {
-							mgcq.store.metrics.GCPushTxn.Inc(1)
-						}
-						if succeeded {
-							mgcq.store.metrics.GCResolveSuccess.Inc(int64(len(txn.LockSpans)))
-						} else {
-							mgcq.store.metrics.GCTxnIntentsResolveFailed.Inc(int64(len(txn.LockSpans)))
-						}
-					})
+				CleanupTxnIntentsOnGCAsync(gcAdmissionHeader(repl.store.ClusterSettings()), repl.RangeID, txn, gcTimestamp, func(pushed, succeeded bool) {
+					if pushed {
+						mgcq.store.metrics.GCPushTxn.Inc(1)
+					}
+					if succeeded {
+						mgcq.store.metrics.GCResolveSuccess.Inc(int64(len(txn.LockSpans)))
+					} else {
+						mgcq.store.metrics.GCTxnIntentsResolveFailed.Inc(int64(len(txn.LockSpans)))
+					}
+				})
 			if errors.Is(err, stop.ErrThrottled) {
 				log.Eventf(ctx, "processing txn %s: %s; skipping for future GC", txn.ID.Short(), err)
 				return nil

--- a/pkg/kv/kvserver/raft_transport.go
+++ b/pkg/kv/kvserver/raft_transport.go
@@ -384,57 +384,58 @@ func (t *RaftTransport) RaftMessageBatch(stream MultiRaft_RaftMessageBatchServer
 	taskCtx = t.AnnotateCtx(taskCtx)
 	defer cancel()
 
-	if err := t.stopper.RunAsyncTaskEx(
-		taskCtx,
-		stop.TaskOpts{
-			TaskName: "storage.RaftTransport: processing batch",
-			SpanOpt:  stop.ChildSpan,
-		}, func(ctx context.Context) {
-			errCh <- func() error {
-				defer func() {
-					if fn := t.knobs.OnServerStreamDisconnected; fn != nil {
-						fn()
-					}
-				}()
-
-				stream := &lockedRaftMessageResponseStream{wrapped: stream}
-				for {
-					batch, err := stream.Recv()
-					if err != nil {
-						return err
-					}
-					if !batch.Now.IsEmpty() {
-						t.clock.Update(batch.Now)
-					}
-					if len(batch.AdmittedStates) != 0 {
-						// Dispatch the admitted vectors to RACv2.
-						// NB: we do this via this special path instead of using the
-						// handleRaftRequest path since we don't have a full-fledged
-						// RaftMessageRequest for each range (each of these responses could
-						// be for a different range), and because what we need to do w.r.t.
-						// queueing is much simpler (we don't need to worry about queue size
-						// since we only keep the highest admitted marks from each replica).
-						t.kvflowcontrol2.piggybackedResponseScheduler.
-							ScheduleAdmittedResponseForRangeRACv2(ctx, batch.AdmittedStates)
-					}
-					if len(batch.Requests) == 0 {
-						continue
-					}
-					for i := range batch.Requests {
-						req := &batch.Requests[i]
-						t.metrics.MessagesRcvd.Inc(1)
-						if pErr := t.handleRaftRequest(ctx, req, stream); pErr != nil {
-							if err := stream.Send(newRaftMessageResponse(req, pErr)); err != nil {
-								return err
-							}
-							t.metrics.ReverseSent.Inc(1)
-						}
-					}
-				}
-			}()
-		}); err != nil {
+	taskCtx, hdl, err := t.stopper.GetHandle(taskCtx, stop.TaskOpts{
+		TaskName: "storage.RaftTransport: processing batch",
+		SpanOpt:  stop.ChildSpan,
+	})
+	if err != nil {
 		return err
 	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		errCh <- func() error {
+			defer func() {
+				if fn := t.knobs.OnServerStreamDisconnected; fn != nil {
+					fn()
+				}
+			}()
+
+			stream := &lockedRaftMessageResponseStream{wrapped: stream}
+			for {
+				batch, err := stream.Recv()
+				if err != nil {
+					return err
+				}
+				if !batch.Now.IsEmpty() {
+					t.clock.Update(batch.Now)
+				}
+				if len(batch.AdmittedStates) != 0 {
+					// Dispatch the admitted vectors to RACv2.
+					// NB: we do this via this special path instead of using the
+					// handleRaftRequest path since we don't have a full-fledged
+					// RaftMessageRequest for each range (each of these responses could
+					// be for a different range), and because what we need to do w.r.t.
+					// queueing is much simpler (we don't need to worry about queue size
+					// since we only keep the highest admitted marks from each replica).
+					t.kvflowcontrol2.piggybackedResponseScheduler.
+						ScheduleAdmittedResponseForRangeRACv2(ctx, batch.AdmittedStates)
+				}
+				if len(batch.Requests) == 0 {
+					continue
+				}
+				for i := range batch.Requests {
+					req := &batch.Requests[i]
+					t.metrics.MessagesRcvd.Inc(1)
+					if pErr := t.handleRaftRequest(ctx, req, stream); pErr != nil {
+						if err := stream.Send(newRaftMessageResponse(req, pErr)); err != nil {
+							return err
+						}
+						t.metrics.ReverseSent.Inc(1)
+					}
+				}
+			}
+		}()
+	}(taskCtx)
 
 	select {
 	case err := <-errCh:
@@ -553,30 +554,33 @@ func (t *RaftTransport) processQueue(
 
 	ctx := stream.Context()
 
-	if err := t.stopper.RunAsyncTask(
-		ctx, "storage.RaftTransport: processing queue",
-		func(ctx context.Context) {
-			errCh <- func() error {
-				for {
-					resp, err := stream.Recv()
-					if err != nil {
-						return err
-					}
-					t.metrics.ReverseRcvd.Inc(1)
-					incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(resp.ToReplica.StoreID)
-					if !ok {
-						log.Warningf(ctx, "no handler found for store %s in response %s",
-							resp.ToReplica.StoreID, resp)
-						continue
-					}
-					if err := incomingMessageHandler.HandleRaftResponse(ctx, resp); err != nil {
-						return err
-					}
-				}
-			}()
-		}); err != nil {
+	goCtx, hdl, err := t.stopper.GetHandle(ctx, stop.TaskOpts{
+		TaskName: "storage.RaftTransport: processing queue",
+	})
+	if err != nil {
 		return err
 	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		errCh <- func() error {
+			for {
+				resp, err := stream.Recv()
+				if err != nil {
+					return err
+				}
+				t.metrics.ReverseRcvd.Inc(1)
+				incomingMessageHandler, ok := t.getIncomingRaftMessageHandler(resp.ToReplica.StoreID)
+				if !ok {
+					log.Warningf(ctx, "no handler found for store %s in response %s",
+						resp.ToReplica.StoreID, resp)
+					continue
+				}
+				if err := incomingMessageHandler.HandleRaftResponse(ctx, resp); err != nil {
+					return err
+				}
+			}
+		}()
+	}(goCtx)
 
 	// For replication admission control v2.
 	maybeAnnotateWithAdmittedStates := func(
@@ -864,10 +868,9 @@ func (t *RaftTransport) startProcessNewQueue(
 			log.Warningf(ctx, "while processing outgoing Raft queue to node %d: %s:", toNodeID, err)
 		}
 	}
-	err := t.stopper.RunAsyncTask(ctx, "storage.RaftTransport: sending/receiving messages",
-		func(ctx context.Context) {
-			pprof.Do(ctx, pprof.Labels("remote_node_id", toNodeID.String()), worker)
-		})
+	ctx, hdl, err := t.stopper.GetHandle(ctx, stop.TaskOpts{
+		TaskName: "storage.RaftTransport: sending/receiving messages",
+	})
 	if err != nil {
 		t.connectionMu.Lock()
 		t.queues[class].Delete(toNodeID)
@@ -875,6 +878,10 @@ func (t *RaftTransport) startProcessNewQueue(
 		t.connectionMu.Unlock()
 		return false
 	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		pprof.Do(ctx, pprof.Labels("remote_node_id", toNodeID.String()), worker)
+	}(ctx)
 	return true
 }
 
@@ -884,48 +891,52 @@ func (t *RaftTransport) startProcessNewQueue(
 // them, to prevent an unbounded accumulation of memory. This "connected
 // nodes" is a client-side view of the world.
 func (t *RaftTransport) startDroppingFlowTokensForDisconnectedNodes(ctx context.Context) error {
-	return t.stopper.RunAsyncTask(
-		ctx,
-		"kvserver.RaftTransport: drop flow tokens for disconnected nodes",
-		func(ctx context.Context) {
-			settingChangeCh := make(chan struct{}, 1)
-			kvadmission.FlowTokenDropInterval.SetOnChange(
-				&t.st.SV, func(ctx context.Context) {
-					select {
-					case settingChangeCh <- struct{}{}:
-					default:
-					}
-				})
-
-			var timer timeutil.Timer
-			defer timer.Stop()
-
-			for {
-				interval := kvadmission.FlowTokenDropInterval.Get(&t.st.SV)
-				if interval > 0 {
-					timer.Reset(interval)
-				} else {
-					// Disable the mechanism.
-					timer.Stop()
-				}
+	ctx, hdl, err := t.stopper.GetHandle(ctx, stop.TaskOpts{
+		TaskName: "kvserver.RaftTransport: drop flow tokens for disconnected nodes",
+	})
+	if err != nil {
+		return err
+	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		settingChangeCh := make(chan struct{}, 1)
+		kvadmission.FlowTokenDropInterval.SetOnChange(
+			&t.st.SV, func(ctx context.Context) {
 				select {
-				case <-timer.C:
-					t.dropFlowTokensForDisconnectedNodes()
-					continue
-
-				case <-settingChangeCh:
-					// Loop around to use the updated timer.
-					continue
-
-				case <-ctx.Done():
-					return
-
-				case <-t.stopper.ShouldQuiesce():
-					return
+				case settingChangeCh <- struct{}{}:
+				default:
 				}
+			})
+
+		var timer timeutil.Timer
+		defer timer.Stop()
+
+		for {
+			interval := kvadmission.FlowTokenDropInterval.Get(&t.st.SV)
+			if interval > 0 {
+				timer.Reset(interval)
+			} else {
+				// Disable the mechanism.
+				timer.Stop()
 			}
-		},
-	)
+			select {
+			case <-timer.C:
+				t.dropFlowTokensForDisconnectedNodes()
+				continue
+
+			case <-settingChangeCh:
+				// Loop around to use the updated timer.
+				continue
+
+			case <-ctx.Done():
+				return
+
+			case <-t.stopper.ShouldQuiesce():
+				return
+			}
+		}
+	}(ctx)
+	return nil
 }
 
 // TestingDropFlowTokensForDisconnectedNodes exports

--- a/pkg/kv/kvserver/storeliveness/support_manager.go
+++ b/pkg/kv/kvserver/storeliveness/support_manager.go
@@ -178,9 +178,17 @@ func (sm *SupportManager) Start(ctx context.Context) error {
 		return err
 	}
 
-	return sm.stopper.RunAsyncTask(
-		ctx, "storeliveness.SupportManager: loop", sm.startLoop,
-	)
+	ctx, hdl, err := sm.stopper.GetHandle(ctx, stop.TaskOpts{
+		TaskName: "storeliveness.SupportManager: loop",
+	})
+	if err != nil {
+		return err
+	}
+	go func(ctx context.Context) {
+		defer hdl.Activate(ctx).Release(ctx)
+		sm.startLoop(ctx)
+	}(ctx)
+	return nil
 }
 
 // onRestart initializes the SupportManager with state persisted on disk.


### PR DESCRIPTION
Continues https://github.com/cockroachdb/cockroach/pull/142059.

I opened a recent TPCC execution trace in https://github.com/felixge/sqlprof and worked through the output of the below query, which roughly shows which stopper tasks were active in the execution. I then added more based on looking at more execution traces from the 300 node scale test.

```
select * from (select count(*) as hits,  list_slice(s.funcs, -3, -2) as root
  from stack_samples ss
  join stacks s on ss.src_stack_id = s.stack_id
  where root[2] LIKE '%Stopper%' group by root) order by hits desc;
```

I recommend reviewing with whitespace changes suppressed, and to watch out for ctx assignments, as the new API is more brittle with regards to them.

Epic: CRDB-42584