### PR TITLE
release-25.1: randgen: increase pool size for "heavy" configs

### DIFF
--- a/pkg/sql/randgen/BUILD.bazel
+++ b/pkg/sql/randgen/BUILD.bazel
@@ -68,6 +68,10 @@ go_test(
         "types_test.go",
     ],
     embed = [":randgen"],
+    exec_properties = select({
+        "//build/toolchains:is_heavy": {"test.Pool": "large"},
+        "//conditions:default": {"test.Pool": "default"},
+    }),
     deps = [
         "//pkg/base",
         "//pkg/ccl",


### PR DESCRIPTION
Backport 1/1 commits from #147556 on behalf of @yuzefovich.

----

We just saw an engflow failure that looks like an OOM under race config, so let's bump the size.

Fixes: #147255.

Release note: None

----

Release justification: test-only change.