### PR TITLE
roachtest: modify probe ranges operation to not run in parallel

### DIFF
--- a/pkg/cmd/roachtest/operations/probe_ranges.go
+++ b/pkg/cmd/roachtest/operations/probe_ranges.go
@@ -88,7 +88,7 @@ func registerProbeRanges(r registry.Registry) {
 		Owner:              registry.OwnerKV, // Contact SRE first, as they own the prober.
 		Timeout:            30 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		CanRunConcurrently: registry.OperationCannotRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase, registry.OperationRequiresZeroUnavailableRanges},
 		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 			return runProbeRanges(ctx, o, c, false)
@@ -99,7 +99,7 @@ func registerProbeRanges(r registry.Registry) {
 		Owner:              registry.OwnerKV, // Contact SRE first, as they own the prober.
 		Timeout:            30 * time.Minute,
 		CompatibleClouds:   registry.AllClouds,
-		CanRunConcurrently: registry.OperationCanRunConcurrently,
+		CanRunConcurrently: registry.OperationCannotRunConcurrently,
 		Dependencies:       []registry.OperationDependency{registry.OperationRequiresPopulatedDatabase, registry.OperationRequiresZeroUnavailableRanges},
 		Run: func(ctx context.Context, o operation.Operation, c cluster.Cluster) registry.OperationCleanup {
 			return runProbeRanges(ctx, o, c, true)


### PR DESCRIPTION
We initially set up this operation to run concurrently, but are seeing range errors that seem to be from other operations running at the same time. In order to more usefully rely on this operation, we would like to try running this operation sequentially instead.

https://cockroachlabs.atlassian.net/browse/CC-30594

Fixes: #102034
Release note: None
Epic: None