### PR TITLE
roachtest: number of incrementals now matches fixture spec

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -294,7 +294,7 @@ func (bd *backupDriver) monitorBackups(ctx context.Context) error {
 				}
 			}
 
-			if backupCount >= bd.sp.fixture.IncrementalChainLength {
+			if backupCount >= bd.sp.fixture.IncrementalChainLength+1 {
 				pauseSchedulesQuery := fmt.Sprintf(
 					`PAUSE SCHEDULES WITH x AS (SHOW SCHEDULES) SELECT id FROM x WHERE label = '%s'`, scheduleLabel,
 				)


### PR DESCRIPTION
Roachtest fixtures had one less incremental than specified in `IncrementalChainLength` because we were counting the full backup as part of the number of incrementals. This updates the fixture roachtests to ensure that the right number of incrementals are created.

Epic: None

Release note: None