### PR TITLE
roachtest: add mutator to panic and restart a node

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -295,6 +295,11 @@ type (
 		// Run implements the actual functionality of the step. This
 		// signature should remain in sync with `stepFunc`.
 		Run(context.Context, *logger.Logger, *rand.Rand, *Helper) error
+		// ConcurrencyDisabled returns true if the step should not be run
+		// concurrently with other steps. This is the case for any steps
+		// that involve restarting a node, as they may attempt to connect
+		// to an unavailable node.
+		ConcurrencyDisabled() bool
 	}
 
 	// singleStep represents steps that implement the pieces on top of

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators_test.go
@@ -29,7 +29,7 @@ func TestPreserveDowngradeOptionRandomizerMutator(t *testing.T) {
 	require.NoError(t, err)
 
 	var mut preserveDowngradeOptionRandomizerMutator
-	mutations := mut.Generate(newRand(), plan)
+	mutations := mut.Generate(newRand(), plan, nil)
 	require.NotEmpty(t, mutations)
 	require.True(t, len(mutations)%2 == 0, "should produce even number of mutations") // one removal and one insertion per upgrade
 
@@ -97,7 +97,7 @@ func TestClusterSettingMutator(t *testing.T) {
 
 		const settingName = "test_cluster_setting"
 		mut := newClusterSettingMutator(settingName, possibleValues, options...)
-		mutations := mut.Generate(newRand(), plan)
+		mutations := mut.Generate(newRand(), plan, nil)
 
 		// Number of mutations should be 1 <= n <= maxChanges
 		require.GreaterOrEqual(t, len(mutations), 1, "plan:\n%s", plan.PrettyPrint())

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -127,9 +127,11 @@ type (
 		// this probability for specific mutator implementations as
 		// needed.
 		Probability() float64
-		// Generate takes a test plan and a RNG and returns the list of
-		// mutations that should be applied to the plan.
-		Generate(*rand.Rand, *TestPlan) []mutation
+		// Generate takes a test plan, the testPlanner, and an RNG and returns the list of
+		// mutations that should be applied to the plan. The test plan is the intended output
+		// after applying the mutations. The testPlanner is used to access specific attributes
+		// of the test plan, such as the current context or the services.
+		Generate(*rand.Rand, *TestPlan, *testPlanner) []mutation
 	}
 
 	// mutationOp encodes the type of mutation and controls how the
@@ -211,6 +213,10 @@ const (
 	spanConfigTenantLimit = 50000
 )
 
+var failureInjectionMutators = []mutator{
+	panicNodeMutator{},
+}
+
 // clusterSettingMutators includes a list of all
 // cluster setting mutator implementations.
 var clusterSettingMutators = []mutator{
@@ -250,9 +256,12 @@ var clusterSettingMutators = []mutator{
 // planMutators includes a list of all known `mutator`
 // implementations. A subset of these mutations might be enabled in
 // any mixedversion test plan.
-var planMutators = append([]mutator{
-	preserveDowngradeOptionRandomizerMutator{},
-},
+var planMutators = append(
+	append([]mutator{
+		preserveDowngradeOptionRandomizerMutator{},
+	},
+		failureInjectionMutators...,
+	),
 	clusterSettingMutators...,
 )
 
@@ -418,11 +427,22 @@ func (p *testPlanner) Plan() *TestPlan {
 		isLocal:        p.isLocal,
 	}
 
-	// Probabilistically enable some of of the mutators on the base test
-	// plan generated above.
+	failureInjections := make(map[string]struct{})
+	for _, m := range failureInjectionMutators {
+		failureInjections[m.Name()] = struct{}{}
+	}
+
+	// Probabilistically enable some of the mutators on the base test
+	// plan generated above. We disable any failure injections that
+	// would occur on clusters with less than three nodes as this
+	// can lead to uninteresting failures (e.g. a single node
+	// panic failure).
 	for _, mut := range planMutators {
 		if p.mutatorEnabled(mut) {
-			mutations := mut.Generate(p.prng, testPlan)
+			if _, found := failureInjections[mut.Name()]; found && len(p.currentContext.System.Descriptor.Nodes) < 3 {
+				continue
+			}
+			mutations := mut.Generate(p.prng, testPlan, p)
 			testPlan.applyMutations(p.prng, mutations)
 			testPlan.enabledMutators = append(testPlan.enabledMutators, mut)
 		}
@@ -1396,12 +1416,16 @@ func (ss stepSelector) InsertSequential(rng *rand.Rand, impl singleStepProtocol)
 	})
 }
 
+// InsertBefore inserts the step before the selected step. This is not guaranteed to be a non-concurrent insert, if the
+// selected step is part of a `concurrentRunStep`, the new step will be concurrent with the selected step.
 func (ss stepSelector) InsertBefore(impl singleStepProtocol) []mutation {
 	return ss.insert(impl, func() mutationOp {
 		return mutationInsertBefore
 	})
 }
 
+// InsertAfter inserts the step after the selected step. This is not guaranteed to be a non-concurrent insert, if the
+// selected step is part of a `concurrentRunStep`, the new step will be concurrent with the selected step.
 func (ss stepSelector) InsertAfter(impl singleStepProtocol) []mutation {
 	return ss.insert(impl, func() mutationOp {
 		return mutationInsertAfter

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -553,7 +553,7 @@ func Test_stepSelectorFilter(t *testing.T) {
 			name:                   "no filter",
 			predicate:              func(*singleStep) bool { return true },
 			expectedAllSteps:       true,
-			expectedRandomStepType: runHookStep{},
+			expectedRandomStepType: restartWithNewBinaryStep{},
 		},
 		{
 			name: "filter eliminates all steps",
@@ -861,7 +861,9 @@ type concurrentUserHooksMutator struct{}
 func (concurrentUserHooksMutator) Name() string         { return "concurrent_user_hooks_mutator" }
 func (concurrentUserHooksMutator) Probability() float64 { return 0.5 }
 
-func (concurrentUserHooksMutator) Generate(rng *rand.Rand, plan *TestPlan) []mutation {
+func (concurrentUserHooksMutator) Generate(
+	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
+) []mutation {
 	// Insert our `testSingleStep` implementation concurrently with every
 	// user-provided function.
 	return plan.
@@ -880,7 +882,9 @@ type removeUserHooksMutator struct{}
 func (removeUserHooksMutator) Name() string         { return "remove_user_hooks_mutator" }
 func (removeUserHooksMutator) Probability() float64 { return 0.5 }
 
-func (removeUserHooksMutator) Generate(rng *rand.Rand, plan *TestPlan) []mutation {
+func (removeUserHooksMutator) Generate(
+	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
+) []mutation {
 	return plan.
 		newStepSelector().
 		Filter(func(s *singleStep) bool {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -178,6 +178,9 @@ func (*testSingleStep) Background() shouldStop { return nil }
 func (tss *testSingleStep) Run(_ context.Context, _ *logger.Logger, _ *rand.Rand, _ *Helper) error {
 	return tss.runFunc()
 }
+func (s testSingleStep) ConcurrencyDisabled() bool {
+	return false
+}
 
 func newTestStep(f func() error) *singleStep {
 	initialVersion := clusterupgrade.MustParseVersion(predecessorVersion)

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math"
 	"math/rand"
+	"regexp"
 	"strings"
 	"time"
 
@@ -37,6 +38,17 @@ const systemTag = "mixedversion-system"
 // situations where the cluster is not recovering.
 var startTimeout = 30 * time.Minute
 
+// restartSystemSettings provides the custom start options
+// necessary for restarting the system interface on a node.
+func restartSystemSettings(waitForReplication bool, initTarget int) []option.StartStopOption {
+	customStartOpts := []option.StartStopOption{option.WithInitTarget(initTarget)}
+	if waitForReplication {
+		customStartOpts = append(customStartOpts, option.WaitForReplication())
+	}
+	customStartOpts = append(customStartOpts, option.SkipInit)
+	return customStartOpts
+}
+
 // installFixturesStep is the step that copies the fixtures from
 // `pkg/cmd/roachtest/fixtures` for a specific version into the nodes'
 // store dir.
@@ -56,6 +68,10 @@ func (s installFixturesStep) Run(
 	return clusterupgrade.InstallFixtures(
 		ctx, l, h.runner.cluster, h.System.Descriptor.Nodes, s.version,
 	)
+}
+
+func (s installFixturesStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // startStep is the step that starts the cluster from a specific
@@ -103,6 +119,9 @@ func (s startStep) Run(ctx context.Context, l *logger.Logger, _ *rand.Rand, h *H
 		startCtx, l, h.runner.cluster, systemNodes, startOpts(customStartOpts...), clusterSettings...,
 	)
 }
+func (s startStep) ConcurrencyDisabled() bool {
+	return true
+}
 
 // startSharedProcessVirtualCluster step creates a new shared-process
 // virtual cluster with the given name, and starts it. At the end of
@@ -135,6 +154,10 @@ func (s startSharedProcessVirtualClusterStep) Run(
 	// until we are able to connect to the tenant on every node before
 	// moving on. The test runner infrastructure relies on that ability.
 	return waitForTenantProcess(ctx, l, h, h.Tenant.Descriptor.Nodes, h.DeploymentMode())
+}
+
+func (s startSharedProcessVirtualClusterStep) ConcurrencyDisabled() bool {
+	return true
 }
 
 // startSeparateProcessVirtualCluster step creates a new separate-process
@@ -174,6 +197,10 @@ func (s startSeparateProcessVirtualClusterStep) Run(
 	h.runner.cluster.SetDefaultVirtualCluster(s.name)
 
 	return waitForTenantProcess(ctx, l, h, h.Tenant.Descriptor.Nodes, h.DeploymentMode())
+}
+
+func (s startSeparateProcessVirtualClusterStep) ConcurrencyDisabled() bool {
+	return true
 }
 
 type restartVirtualClusterStep struct {
@@ -220,6 +247,10 @@ func (s restartVirtualClusterStep) Run(
 	return h.runner.cluster.StartServiceForVirtualClusterE(ctx, l, startOpts, settings)
 }
 
+func (s restartVirtualClusterStep) ConcurrencyDisabled() bool {
+	return true
+}
+
 // waitForStableClusterVersionStep implements the process of waiting
 // for the `version` cluster setting being the same on all nodes of
 // the cluster and equal to the binary version of the first node in
@@ -246,6 +277,10 @@ func (s waitForStableClusterVersionStep) Run(
 	return clusterupgrade.WaitForClusterUpgrade(
 		ctx, l, s.nodes, serviceByName(h, s.virtualClusterName).Connect, s.timeout,
 	)
+}
+
+func (s waitForStableClusterVersionStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // preserveDowngradeOptionStep sets the `preserve_downgrade_option`
@@ -276,6 +311,10 @@ func (s preserveDowngradeOptionStep) Run(
 	}
 
 	return service.Exec(rng, "SET CLUSTER SETTING cluster.preserve_downgrade_option = $1", bv.String())
+}
+
+func (s preserveDowngradeOptionStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // restartWithNewBinaryStep restarts a certain `node` with a new
@@ -312,10 +351,7 @@ func (s restartWithNewBinaryStep) Description() string {
 func (s restartWithNewBinaryStep) Run(
 	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
 ) error {
-	customStartOpts := []option.StartStopOption{option.WithInitTarget(s.initTarget)}
-	if s.waitForReplication {
-		customStartOpts = append(customStartOpts, option.WaitForReplication())
-	}
+	customStartOpts := restartSystemSettings(s.waitForReplication, s.initTarget)
 
 	startCtx, cancel := context.WithTimeout(ctx, startTimeout)
 	defer cancel()
@@ -348,6 +384,10 @@ func (s restartWithNewBinaryStep) Run(
 	return nil
 }
 
+func (s restartWithNewBinaryStep) ConcurrencyDisabled() bool {
+	return true
+}
+
 // allowUpgradeStep resets the `preserve_downgrade_option` cluster
 // setting, allowing the upgrade migrations to run and the cluster
 // version to eventually reach the binary version on the nodes.
@@ -370,6 +410,10 @@ func (s allowUpgradeStep) Run(
 	return serviceByName(h, s.virtualClusterName).Exec(
 		rng, "RESET CLUSTER SETTING cluster.preserve_downgrade_option",
 	)
+}
+
+func (s allowUpgradeStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // waitStep does nothing but sleep for the provided duration. Most
@@ -395,6 +439,10 @@ func (s waitStep) Run(ctx context.Context, l *logger.Logger, _ *rand.Rand, h *He
 	return nil
 }
 
+func (s waitStep) ConcurrencyDisabled() bool {
+	return false
+}
+
 // runHookStep is a step used to run a user-provided hook (i.e.,
 // callbacks passed to `OnStartup`, `InMixedVersion`, or `AfterTest`).
 type runHookStep struct {
@@ -410,6 +458,10 @@ func (s runHookStep) Description() string {
 
 func (s runHookStep) Run(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper) error {
 	return s.hook.fn(ctx, l, rng, h)
+}
+
+func (s runHookStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // setClusterSettingStep sets the cluster setting `name` to `value`.
@@ -467,6 +519,10 @@ func (s setClusterSettingStep) Run(
 	)
 }
 
+func (s setClusterSettingStep) ConcurrencyDisabled() bool {
+	return false
+}
+
 // setClusterVersionStep sets the special `version` cluster setting to
 // the provided version.
 type setClusterVersionStep struct {
@@ -509,6 +565,10 @@ func (s setClusterVersionStep) Run(
 	return service.Exec(rng, "SET CLUSTER SETTING version = $1", binaryVersion)
 }
 
+func (s setClusterVersionStep) ConcurrencyDisabled() bool {
+	return false
+}
+
 // resetClusterSetting resets cluster setting `name`.
 type resetClusterSettingStep struct {
 	minVersion         *clusterupgrade.Version
@@ -531,6 +591,10 @@ func (s resetClusterSettingStep) Run(
 	)
 }
 
+func (s resetClusterSettingStep) ConcurrencyDisabled() bool {
+	return false
+}
+
 // deleteAllTenantsVersionOverrideStep is a hack that deletes bad data
 // from the `system.tenant_settings` table; specifically an
 // all-tenants (tenant_id = 0) override for the 'version' key. See
@@ -551,6 +615,10 @@ func (s deleteAllTenantsVersionOverrideStep) Run(
 ) error {
 	const stmt = "DELETE FROM system.tenant_settings WHERE tenant_id = $1 and name = $2"
 	return h.System.Exec(rng, stmt, 0, "version")
+}
+
+func (s deleteAllTenantsVersionOverrideStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // disableRateLimitersStep disables both the KV and the tenant(SQL) rate limiter
@@ -607,6 +675,10 @@ func (s disableRateLimitersStep) Run(
 	}
 
 	return h.System.Exec(rng, stmt)
+}
+
+func (s disableRateLimitersStep) ConcurrencyDisabled() bool {
+	return false
 }
 
 // nodesRunningAtLeast returns a list of nodes running a system or
@@ -714,4 +786,71 @@ func startStopOpts(opts ...option.StartStopOption) []option.StartStopOption {
 	return append([]option.StartStopOption{
 		option.NoBackupSchedule,
 	}, opts...)
+}
+
+// TODO(kyleli): This step currently only affects the system tenant, should support panicking secondary tenants as well.
+// TODO(kyleli): Current mixedversion cannot support separating this into two steps (panic and restart) because during
+// each step the framework checks each node to ensure they are all alive and healthy. Ideally there should be a state
+// that allows the framework to skip this check, so that we can panic a node and then restart it in a separate step.
+type panicNodeStep struct {
+	initTarget int
+	targetNode option.NodeListOption
+	rt         test.Test
+}
+
+func (s panicNodeStep) Background() shouldStop { return nil }
+
+func (s panicNodeStep) Description() string {
+	return fmt.Sprintf("panicking system interface on node %d", s.targetNode[0])
+}
+
+var connectionRefusedRegex = regexp.MustCompile(`dial tcp .*: connect: connection refused`)
+
+func (s panicNodeStep) Run(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper) error {
+	nodeVersion, err := h.System.NodeVersion(s.targetNode[0])
+	if err != nil {
+		return errors.Wrapf(err, "failed to get node version for %s", s.targetNode)
+	}
+	binary := clusterupgrade.CockroachPathForVersion(s.rt, nodeVersion)
+	settings := install.MakeClusterSettings(
+		install.BinaryOption(binary),
+		install.TagOption(systemTag),
+	)
+	customStartOpts := restartSystemSettings(true, s.initTarget)
+
+	h.ExpectDeath()
+
+	const stmt = "SELECT crdb_internal.force_panic('expected panic from panicNodeMutator')"
+	err = h.System.ExecWithGateway(
+		rng,
+		s.targetNode,
+		stmt,
+	)
+
+	if err == nil {
+		return errors.Errorf("expected panic statement to fail, but it succeeded on %s", s.targetNode)
+	}
+
+	isTCPError := connectionRefusedRegex.MatchString(err.Error())
+
+	// The expected behavior is that the panic statement will fail with a TCP connection error,
+	// so any other error is unexpected and should cause the test to fail.
+	if !isTCPError {
+		return errors.Wrapf(err, "unexpected error when executing panic statement on %s", s.targetNode)
+	}
+
+	startCtx, cancel := context.WithTimeout(ctx, startTimeout)
+	defer cancel()
+
+	return h.runner.cluster.StartE(
+		startCtx,
+		l,
+		startOpts(customStartOpts...),
+		settings,
+		s.targetNode,
+	)
+}
+
+func (s panicNodeStep) ConcurrencyDisabled() bool {
+	return true
 }


### PR DESCRIPTION
This change adds a new mutator that will enable the ability to randomly panic a node. Currently the node is immediately restarted upon crashing, with the end goal of being able to panic a node and waiting some number of steps before restarting it.

Fixes: None
Epic: None
Release note: None
Team City: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel?branch=147641&buildTypeTab=overview&mode=builds&hideProblemsFromDependencies=false&hideTestsFromDependencies=false