### PR TITLE
regionliveness: avoid region_liveness can when disabled

### DIFF
--- a/pkg/sql/regionliveness/prober.go
+++ b/pkg/sql/regionliveness/prober.go
@@ -274,6 +274,11 @@ func (l *livenessProber) QueryLiveness(ctx context.Context, txn *kv.Txn) (LiveRe
 func (l *livenessProber) QueryUnavailablePhysicalRegions(
 	ctx context.Context, txn *kv.Txn, filterAvailable bool,
 ) (UnavailableAtPhysicalRegions, error) {
+	regionLivenessEnabled, _ := l.GetProbeTimeout()
+	if !regionLivenessEnabled {
+		return UnavailableAtPhysicalRegions{}, nil
+	}
+
 	// Scan the entire region liveness table.
 	regionLivenessIndex := l.codec.IndexPrefix(uint32(systemschema.RegionLivenessTable.GetID()), uint32(systemschema.RegionLivenessTable.GetPrimaryIndexID()))
 	keyValues, err := txn.Scan(ctx, regionLivenessIndex, regionLivenessIndex.PrefixEnd(), 0)


### PR DESCRIPTION
Previously QueryUnavailablePhysicalRegions would scan the region liveness table even when region liveness was disabled.

Fixes: https://github.com/cockroachdb/cockroach/issues/147651
Epic: none
Release note: None