### PR TITLE
sql: normalize collated strings for LIKE comparisons

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/collatedstring
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring
@@ -193,6 +193,16 @@ SELECT 'ü' COLLATE de < 'x' COLLATE de
 ----
 true
 
+query B
+SELECT e'\u00E9' COLLATE "en_US" = e'\u0065\u0301' COLLATE "en_US";
+----
+true
+
+query B
+SELECT e'\u00E9' COLLATE "en_US" LIKE e'\u0065\u0301' COLLATE "en_US";
+----
+true
+
 
 statement error syntax error: invalid locale e: language: tag is not well-formed
 CREATE TABLE e1 (

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -104,6 +104,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_lib_pq//oid",
+        "@org_golang_x_text//unicode/norm",
     ],
 )
 


### PR DESCRIPTION
#### sql: normalize collated strings for LIKE comparisons

Fixes: #147623
Epic: CRDB-51169
Release note: None
