### PR TITLE
sql/schemachanger: fix nil pointer preparing a schema changer statement

### DIFF
--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -95,7 +95,9 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 	// If we successfully planned a schema change here, then update telemetry
 	// to indicate that we used the new schema changer.
 	telemetry.Inc(sqltelemetry.DeclarativeSchemaChangerCounter)
-	p.curPlan.instrumentation.schemaChangerMode = schemaChangerModeDeclarative
+	// The curPlan may not be initialized yet, but will pick up the instrumentation
+	// from the planner.
+	p.instrumentation.schemaChangerMode = schemaChangerModeDeclarative
 
 	return &schemaChangePlanNode{
 		stmt:               stmt,

--- a/pkg/sql/sql_prepare_test.go
+++ b/pkg/sql/sql_prepare_test.go
@@ -55,3 +55,20 @@ func TestPreparePrepareExecute(t *testing.T) {
 	_, err = s.Exec(3)
 	require.Contains(t, err.Error(), "expected 0 arguments, got 1")
 }
+
+// Makes sure that schema changes can be prepared as the first operation in
+// on a connection.
+func TestPrepareSchemaChange(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{Insecure: true})
+	defer srv.Stopper().Stop(context.Background())
+
+	newConn := srv.SQLConn(t)
+	s, err := newConn.Prepare("PREPARE x AS CREATE SCHEMA sc1;")
+	require.NoError(t, err)
+
+	_, err = s.Exec()
+	require.NoError(t, err)
+}


### PR DESCRIPTION
Previously, the code to track if a plan was using the declarative or legacy schema changer updated the instrumentation based on curPlan. This worked correctly if a previous statement was executed and the instrumentation was set up on that plan. However, if a PREPARE is the first statement on a connection, this breaks. To address this, this patch updates the planner's instrumentation to track if a statement is a declarative schema change.

Fixes: #146907
Informs: #147271
Fixes: #147256
Informs: #147251
Fixes: #145305

Release note (bug fix): Prepare statements on schema changes could fail with runtime errors.