### PR TITLE
e2e-tests: add cypress tests for scale cluster

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/cypress.scale.config.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress.scale.config.ts
@@ -1,4 +1,4 @@
-// Copyright 2022 The Cockroach Authors.
+// Copyright 2025 The Cockroach Authors.
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
@@ -8,19 +8,30 @@ import { defineConfig } from "cypress";
 const DOCKER_OVERRIDES: Partial<Cypress.UserConfigOptions["e2e"]> = {
   baseUrl: "https://crdbhost:8080",
   reporter: "teamcity",
-  downloadsFolder: "/artifacts/cypress/downloads",
-  screenshotsFolder: "/artifacts/cypress/screenshots",
-  videosFolder: "/artifacts/cypress/videos",
+  downloadsFolder: "/artifacts/cypress/scale/downloads",
+  screenshotsFolder: "/artifacts/cypress/scale/screenshots",
+  videosFolder: "/artifacts/cypress/scale/videos",
 };
 
 export default defineConfig({
   e2e: {
     baseUrl: "http://localhost:8080",
     video: true,
+    specPattern: "cypress/scale/**/*.{js,jsx,ts,tsx}",
     numTestsKeptInMemory: 0,
+    viewportWidth: 1920,
+    viewportHeight: 1080,
     setupNodeEvents(on, config) {
-      config.env.username = "cypress";
-      config.env.password = "tests";
+      on("task", {
+        logTiming: (data) => {
+          console.log(
+            `📊 Measured Timing: ${data.renderName} - ${data.duration.toFixed(
+              2,
+            )}ms`,
+          );
+          return null;
+        },
+      });
       return config;
     },
     // Override some settings when running in Docker

--- a/pkg/ui/workspaces/e2e-tests/cypress/scale/db-console.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/scale/db-console.cy.ts
@@ -1,0 +1,153 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+describe("Scale Testing - DB Console", () => {
+  beforeEach(() => {
+    cy.login("roachprod", "cockroachdb");
+  });
+
+  it("loads the overview page within acceptable time", () => {
+    cy.measureRender(
+      "Overview Page",
+      () => cy.visit("#/"),
+      () =>
+        cy
+          .get(".node-liveness.cluster-summary__metric.live-nodes", {
+            timeout: 30000,
+          })
+          .invoke("text")
+          .then((text) => {
+            const value = parseInt(text.trim(), 10);
+            expect(value).to.be.greaterThan(0);
+          }),
+    );
+
+    cy.get(".cluster-overview").should("be.visible");
+  });
+  it("loads the Metrics page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Metrics Page Graph",
+      () => cy.visit("#/metrics/hardware/cluster"),
+      () =>
+        cy.get("canvas", { timeout: 30000 }).then(($canvas) => {
+          const canvas = $canvas[0];
+          const ctx = canvas.getContext("2d");
+          const { width, height } = canvas;
+          const imageData = ctx.getImageData(0, 0, width, height).data;
+
+          // Check if any pixel is not fully transparent (alpha > 0)
+          const hasPixels = Array.from({ length: width * height }).some(
+            (_, i) => {
+              return imageData[i * 4 + 3] !== 0; // alpha channel
+            },
+          );
+
+          expect(hasPixels).to.be.true;
+        }),
+    );
+
+    cy.get("h3").contains("Metrics").should("be.visible");
+    cy.contains("Dashboard:").should("be.visible");
+    cy.get("button")
+      .contains(/Past Hour|1h/)
+      .should("be.visible");
+  });
+
+  it("loads the Databases page, refreshes, and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Databases Page",
+      () => cy.visit("#/databases"),
+      () =>
+        cy
+          .get("[data-row-key='1']", { timeout: 30000 })
+          .contains("system")
+          .should("exist"),
+    );
+
+    cy.get("h3").contains("Databases").should("be.visible");
+  });
+
+  it("loads the SQL Activity page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "SQL Activity Page Table",
+      () => cy.visit("#/sql-activity"),
+      () => cy.get("table tr td", { timeout: 30000 }).should("exist"),
+    );
+
+    cy.get("h3").contains("SQL Activity").should("be.visible");
+    cy.get('[role="tablist"]').should("be.visible");
+    cy.get('[role="tab"]').contains("Statements").should("be.visible");
+    cy.get('[role="tab"]').contains("Transactions").should("be.visible");
+    cy.get('[role="tab"]').contains("Sessions").should("be.visible");
+    cy.get("button")
+      .contains(/Past Hour|1h/)
+      .should("be.visible");
+  });
+
+  it("loads the Jobs page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Jobs Page Table",
+      () => cy.visit("#/jobs"),
+      () => cy.get("table tr td", { timeout: 30000 }).should("exist"),
+    );
+
+    cy.get("h3").contains("Jobs").should("be.visible");
+
+    cy.get("button")
+      .contains(/Status:/)
+      .should("be.visible");
+    cy.get("button").contains(/Type:/).should("be.visible");
+    cy.get("button").contains(/Show:/).should("be.visible");
+  });
+
+  it("loads the Network page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Network Page Table",
+      () => cy.visit("#/reports/network/region"),
+      () => cy.get("table", { timeout: 30000 }).should("exist"),
+    );
+
+    cy.get("h3").contains("Network").should("be.visible");
+    cy.contains("Sort By:").should("be.visible");
+  });
+
+  it("loads the Insights page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Insights Page Table",
+      () => cy.visit("#/insights"),
+      () => cy.get("table tr td", { timeout: 30000 }).should("exist"),
+    );
+
+    cy.get("h3").contains("Insights").should("be.visible");
+    cy.get('[role="tablist"]').should("be.visible");
+    cy.get('[role="tab"]').contains("Workload Insights").should("be.visible");
+    cy.get('[role="tab"]').contains("Schema Insights").should("be.visible");
+    cy.get("button")
+      .contains(/Past Hour|1h/)
+      .should("be.visible");
+  });
+
+  it("loads the Hot Ranges page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Hot Ranges Table",
+      () => cy.visit("#/hotranges"),
+      () => cy.get("table tr td", { timeout: 30000 }).should("exist"),
+    );
+  });
+
+  it("loads the Schedules page and displays the correct heading and key elements", () => {
+    cy.measureRender(
+      "Schedules Page",
+      () => cy.visit("#/schedules"),
+      () => cy.get("table tr td", { timeout: 30000 }).should("exist"),
+    );
+
+    cy.get("h3").contains("Schedules").should("be.visible");
+    cy.get("button")
+      .contains(/Status:/)
+      .should("be.visible");
+    cy.get("button").contains(/Show:/).should("be.visible");
+  });
+});

--- a/pkg/ui/workspaces/e2e-tests/cypress/support/commands.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/support/commands.ts
@@ -23,3 +23,49 @@ Cypress.Commands.add("getUserWithExactPrivileges", (privs: SQLPrivilege[]) => {
     );
   });
 });
+
+// measureRender can capture render time for a given action. Currently this will
+// only work in scale tests because the `logTiming` task is only available in
+// scale tests.
+Cypress.Commands.add(
+  "measureRender",
+  { prevSubject: "optional" },
+  (subject, renderName, actionFn, assertionChain) => {
+    // If subject is provided, it means the command is chained (e.g., cy.get('selector').measureRender(...))
+    const chainable = subject ? cy.wrap(subject) : cy;
+
+    let startTime;
+
+    chainable
+      .then(() => {
+        startTime = performance.now();
+      })
+      .then(() => {
+        // Execute the action function provided by the user
+        // The actionFn should return a chainable Cypress command
+        return actionFn();
+      })
+      .then((actionResult) => {
+        // Assert on the element/state that indicates render completion
+        // The assertionChain should be a function that takes the result
+        // of the action and returns a chainable assertion
+        const assertionChainable = assertionChain(actionResult);
+
+        // Ensure the assertion chain is properly waited on
+        return assertionChainable.then(() => {
+          const endTime = performance.now();
+          const duration = endTime - startTime;
+          const testTitle = Cypress.currentTest.title;
+
+          cy.task("logTiming", {
+            testTitle,
+            renderName,
+            duration,
+          });
+          cy.screenshot(`timing-${renderName}-${Date.now()}`);
+
+          return assertionChainable;
+        });
+      });
+  },
+);

--- a/pkg/ui/workspaces/e2e-tests/cypress/support/index.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/support/index.ts
@@ -34,6 +34,11 @@ declare global {
        */
       login(username: string, password: string): Chainable<void>;
       getUserWithExactPrivileges(privs: SQLPrivilege[]): Chainable<User>;
+      measureRender(
+        renderName: string,
+        actionFn: () => Chainable<any>,
+        assertionChain: (result: any) => Chainable<any>,
+      ): Chainable<any>;
     }
   }
 }

--- a/pkg/ui/workspaces/e2e-tests/package.json
+++ b/pkg/ui/workspaces/e2e-tests/package.json
@@ -9,6 +9,8 @@
     "test:debug": "./build/start-crdb-then.sh pnpm cy:debug",
     "cy:run": "cypress run --e2e",
     "cy:debug": "cypress open --e2e --browser=chrome",
+    "cy:scale:debug": "cypress open --config-file cypress.scale.config.ts --browser=chrome",
+    "cy:scale": "cypress run --config-file cypress.scale.config.ts --browser=chrome",
     "lint": "eslint './**/*.ts'",
     "lint:fix": "eslint --fix './**/*.ts'"
   },


### PR DESCRIPTION
This commit adds files to enable the use of Cypress to smoke test DB Console on a cluster to see if it meets basic performance requirements. This can be used on a scale cluster to make sure we can render all the standard pages in a reasonable amount of time.

The test will print out timing information for key elements in the logs. Additionally, screenshots are taken immediately after the timing snapshot to enable easy analysis of what's on the page at time of timer capture. You can then confirm that the page is "useful".

Resolves: #51018

Release note: None