### PR TITLE
sql: add function and procedure to \h show create

### DIFF
--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -9675,10 +9675,11 @@ show_transfer_stmt:
   }
 | SHOW TRANSFER error // SHOW HELP: SHOW TRANSFER
 
-// %Help: SHOW CREATE - display the CREATE statement for a table, sequence, view, or database
+// %Help: SHOW CREATE - display the CREATE statement for one or more database objects
 // %Category: DDL
 // %Text:
-// SHOW CREATE [ TABLE | SEQUENCE | VIEW | DATABASE ] <object_name>
+// SHOW CREATE [ TABLE | SEQUENCE | VIEW | DATABASE | FUNCTION | PROCEDURE ] <object_name>
+// SHOW CREATE TRIGGER <trigger_name> ON <table_name>
 // SHOW CREATE [ SECONDARY ] INDEXES FROM <table_name>
 // SHOW CREATE ALL SCHEMAS
 // SHOW CREATE ALL TABLES


### PR DESCRIPTION
Previously `\h show create;` did not show FUNCTION or PROCEDURE in the CLI doc. With these changes we can now see them.

Fixes: #146679
Epic: CRDB-49398

Release note (bug fix): `FUNCTION` and `PROCEDURE` are now shown via `\h show create` in the CLI doc.