### PR TITLE
log/eventpb: add alter_changefeed structured log event

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -28,6 +28,28 @@ Events in this category pertain to changefeed usage and metrics.
 Events in this category are logged to the `TELEMETRY` channel.
 
 
+### `alter_changefeed`
+
+An event of type `alter_changefeed` is an event for any ALTER CHANGEFEED statements that are run.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `PreviousDescription` | The description of the changefeed job before the ALTER CHANGEFEED. | yes |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Description` | The description of that would show up in the job's description field, redacted | yes |
+| `SinkType` | The type of sink being emitted to (ex: kafka, nodelocal, webhook-https). | no |
+| `NumTables` | The number of tables listed in the query that the changefeed is to run on. | no |
+| `Resolved` | The behavior of emitted resolved spans (ex: yes, no, 10s) | no |
+| `InitialScan` | The desired behavior of initial scans (ex: yes, no, only) | no |
+| `Format` | The data format being emitted (ex: JSON, Avro). | no |
+| `JobId` | The job id for enterprise changefeeds. | no |
+
 ### `changefeed_canceled`
 
 An event of type `changefeed_canceled` is an event for any changefeed cancellations.

--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -266,6 +266,8 @@ func alterChangefeedPlanHook(
 
 		telemetry.Count(telemetryPath)
 
+		logAlterChangefeedTelemetry(ctx, j, jobPayload.Description)
+
 		select {
 		case <-ctx.Done():
 			return ctx.Err()

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -276,7 +276,7 @@ func changefeedPlanHook(
 			p.ExtendedEvalContext().Descs.ReleaseAll(ctx)
 
 			telemetry.Count(`changefeed.create.core`)
-			logChangefeedCreateTelemetry(ctx, jr, changefeedStmt.Select != nil)
+			logCreateChangefeedTelemetry(ctx, jr, changefeedStmt.Select != nil)
 			if err := maybeShowCursorAgeWarning(ctx, p, opts); err != nil {
 				return err
 			}
@@ -369,7 +369,7 @@ func changefeedPlanHook(
 			return err
 		}
 
-		logChangefeedCreateTelemetry(ctx, jr, changefeedStmt.Select != nil)
+		logCreateChangefeedTelemetry(ctx, jr, changefeedStmt.Select != nil)
 
 		select {
 		case <-ctx.Done():
@@ -1768,7 +1768,7 @@ func getChangefeedTargetName(
 	return desc.GetName(), nil
 }
 
-func logChangefeedCreateTelemetry(ctx context.Context, jr *jobs.Record, isTransformation bool) {
+func logCreateChangefeedTelemetry(ctx context.Context, jr *jobs.Record, isTransformation bool) {
 	var changefeedEventDetails eventpb.CommonChangefeedEventDetails
 	if jr != nil {
 		changefeedDetails := jr.Details.(jobspb.ChangefeedDetails)
@@ -1781,6 +1781,22 @@ func logChangefeedCreateTelemetry(ctx context.Context, jr *jobs.Record, isTransf
 	}
 
 	log.StructuredEvent(ctx, severity.INFO, createChangefeedEvent)
+}
+
+func logAlterChangefeedTelemetry(ctx context.Context, job *jobs.Job, prevDescription string) {
+	var changefeedEventDetails eventpb.CommonChangefeedEventDetails
+	if job != nil {
+		changefeedDetails := job.Details().(jobspb.ChangefeedDetails)
+		changefeedEventDetails = makeCommonChangefeedEventDetails(
+			ctx, changefeedDetails, job.Payload().Description, job.ID())
+	}
+
+	alterChangefeedEvent := &eventpb.AlterChangefeed{
+		CommonChangefeedEventDetails: changefeedEventDetails,
+		PreviousDescription:          prevDescription,
+	}
+
+	log.StructuredEvent(ctx, severity.INFO, alterChangefeedEvent)
 }
 
 func logChangefeedFailedTelemetry(

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1458,41 +1458,27 @@ func verifyLogsWithEmittedBytesAndMessages(
 }
 
 func checkCreateChangefeedLogs(t *testing.T, startTime int64) []eventpb.CreateChangefeed {
-	var matchingEntries []eventpb.CreateChangefeed
+	return checkStructuredChangefeedLogs[eventpb.CreateChangefeed](t, `create_changefeed`, startTime)
+}
 
-	for _, m := range checkStructuredLogs(t, "create_changefeed", startTime) {
-		jsonPayload := []byte(m)
-		var event eventpb.CreateChangefeed
-		if err := gojson.Unmarshal(jsonPayload, &event); err != nil {
-			t.Errorf("unmarshalling %q: %v", m, err)
-		}
-		matchingEntries = append(matchingEntries, event)
-	}
-
-	return matchingEntries
+func checkAlterChangefeedLogs(t *testing.T, startTime int64) []eventpb.AlterChangefeed {
+	return checkStructuredChangefeedLogs[eventpb.AlterChangefeed](t, `alter_changefeed`, startTime)
 }
 
 func checkChangefeedFailedLogs(t *testing.T, startTime int64) []eventpb.ChangefeedFailed {
-	var matchingEntries []eventpb.ChangefeedFailed
-
-	for _, m := range checkStructuredLogs(t, "changefeed_failed", startTime) {
-		jsonPayload := []byte(m)
-		var event eventpb.ChangefeedFailed
-		if err := gojson.Unmarshal(jsonPayload, &event); err != nil {
-			t.Errorf("unmarshalling %q: %v", m, err)
-		}
-		matchingEntries = append(matchingEntries, event)
-	}
-
-	return matchingEntries
+	return checkStructuredChangefeedLogs[eventpb.ChangefeedFailed](t, `changefeed_failed`, startTime)
 }
 
 func checkChangefeedCanceledLogs(t *testing.T, startTime int64) []eventpb.ChangefeedCanceled {
-	var matchingEntries []eventpb.ChangefeedCanceled
+	return checkStructuredChangefeedLogs[eventpb.ChangefeedCanceled](t, `changefeed_canceled`, startTime)
+}
 
-	for _, m := range checkStructuredLogs(t, "changefeed_canceled", startTime) {
+func checkStructuredChangefeedLogs[E any](t *testing.T, name string, startTime int64) []E {
+	var matchingEntries []E
+
+	for _, m := range checkStructuredLogs(t, name, startTime) {
 		jsonPayload := []byte(m)
-		var event eventpb.ChangefeedCanceled
+		var event E
 		if err := gojson.Unmarshal(jsonPayload, &event); err != nil {
 			t.Errorf("unmarshalling %q: %v", m, err)
 		}

--- a/pkg/util/log/eventpb/changefeed_events.proto
+++ b/pkg/util/log/eventpb/changefeed_events.proto
@@ -25,6 +25,17 @@ message CreateChangefeed {
   bool transformation = 2 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// AlterChangefeed is an event for any ALTER CHANGEFEED statements that are run.
+message AlterChangefeed {
+  CommonChangefeedEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+
+  // The description of the changefeed job before the ALTER CHANGEFEED.
+  string previous_description = 2 [(gogoproto.jsontag) = ",omitempty"];
+
+  // TODO(yang): Consider expanding this log to include removed/added/changed options
+  // and added/dropped targets.
+}
+
 // ChangefeedFailed is an event for any changefeed failure since the plan hook
 // was triggered.
 message ChangefeedFailed {

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -5,6 +5,9 @@ package eventpb
 import "github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 
 // LoggingChannel implements the EventPayload interface.
+func (m *AlterChangefeed) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *ChangefeedCanceled) LoggingChannel() logpb.Channel { return logpb.Channel_TELEMETRY }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -28,6 +28,26 @@ func (m *AdminQuery) AppendJSONFields(printComma bool, b redact.RedactableBytes)
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *AlterChangefeed) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonChangefeedEventDetails.AppendJSONFields(printComma, b)
+
+	if m.PreviousDescription != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"PreviousDescription\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.PreviousDescription)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *AlterDatabaseAddRegion) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)


### PR DESCRIPTION
Fixes #79770

Release note (ops change): This patch adds an `alter_changefeed`
structured log event to provide more visibility into when an
ALTER CHANGEFEED happened and what changed.