### PR TITLE
sql: increase observability of automatic statement retries

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -8823,6 +8823,22 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.auto_retry.count
+      exported_name: sql_statements_auto_retry_count
+      description: Number of SQL statement automatic retries
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.statements.auto_retry.count.internal
+      exported_name: sql_statements_auto_retry_count_internal
+      description: Number of SQL statement automatic retries (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.stats.activity.update.latency
       exported_name: sql_stats_activity_update_latency
       description: The latency of updates made by the SQL activity updater job. Includes failed update attempts
@@ -8986,6 +9002,22 @@ layers:
     - name: sql.transaction_timeout.count.internal
       exported_name: sql_transaction_timeout_count_internal
       description: Count of statements that failed because they exceeded the transaction timeout (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.txn.auto_retry.count
+      exported_name: sql_txn_auto_retry_count
+      description: Number of SQL transaction automatic retries
+      y_axis_label: SQL Transactions
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.txn.auto_retry.count.internal
+      exported_name: sql_txn_auto_retry_count_internal
+      description: Number of SQL transaction automatic retries (internal queries)
       y_axis_label: SQL Internal Statements
       type: COUNTER
       unit: COUNT

--- a/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
+++ b/pkg/ccl/kvccl/kvfollowerreadsccl/testdata/boundedstaleness/single_row
@@ -245,7 +245,7 @@ query idx=2
 SELECT * FROM t2 AS OF SYSTEM TIME with_min_timestamp(now() - '10s', true) WHERE pk = 2
 ----
 pq: referenced descriptor ID 105: looking up ID 105: descriptor not found
-events (7 found):
+events (8 found):
  * event 1: colbatchscan trace on node_idx 2: local read
  * event 2: transaction retry on node_idx: 2
  * event 3: colbatchscan trace on node_idx 2: local read
@@ -253,12 +253,13 @@ events (7 found):
  * event 5: colbatchscan trace on node_idx 2: local read
  * event 6: transaction retry on node_idx: 2
  * event 7: colbatchscan trace on node_idx 2: local read
+ * event 8: transaction retry on node_idx: 2
 
 query idx=2
 SELECT * FROM t2 AS OF SYSTEM TIME with_min_timestamp(now() - '10s', true) WHERE pk = 2
 ----
 pq: referenced descriptor ID 105: looking up ID 105: descriptor not found
-events (7 found):
+events (8 found):
  * event 1: colbatchscan trace on node_idx 2: local read
  * event 2: transaction retry on node_idx: 2
  * event 3: colbatchscan trace on node_idx 2: local read
@@ -266,3 +267,4 @@ events (7 found):
  * event 5: colbatchscan trace on node_idx 2: local read
  * event 6: transaction retry on node_idx: 2
  * event 7: colbatchscan trace on node_idx 2: local read
+ * event 8: transaction retry on node_idx: 2

--- a/pkg/ccl/logictestccl/testdata/logic_test/txn_retry
+++ b/pkg/ccl/logictestccl/testdata/logic_test/txn_retry
@@ -1,0 +1,92 @@
+# Test that automatic transaction retries and automatic statement retries are
+# counted separately.
+
+statement ok
+SET max_retries_for_read_committed = 5
+
+statement ok
+SET tracing = on
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+# There's currently some quirky behavior for the first statement of a read-
+# committed transaction: it is subject to both transaction retries and statement
+# retries. We can see this if we force more than max_retries_for_read_committed
+# number of retries for the first statement.
+
+query I
+SELECT crdb_internal.force_retry(7)
+----
+0
+
+statement ok
+SET tracing = off
+
+# We use transaction retry count + statement retry count to decide if we have
+# retried enough. We don't currently remember statement retry counts across
+# transaction retries, so we end up retrying 17 times here instead of 7.
+
+query T nosort
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
+----
+executing after 1 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 2 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 3 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 4 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 5 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 1 transaction retries, last retry reason: read committed retry limit exceeded; set by max_retries_for_read_committed=5: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 1 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 2 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 3 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 4 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 5 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 2 transaction retries, last retry reason: read committed retry limit exceeded; set by max_retries_for_read_committed=5: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 1 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 2 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 3 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 4 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 5 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+
+statement ok
+SET tracing = on
+
+query I
+SELECT crdb_internal.force_retry(3)
+----
+0
+
+statement ok
+SET tracing = off
+
+# We use transaction retry count + statement retry count to decide if we have
+# retried enough. We don't currently remember which statements participated in
+# previous transaction retries, so we end up retrying 1 time here instead of 3.
+
+query T nosort
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
+----
+executing after 2 transaction retries, last retry reason: read committed retry limit exceeded; set by max_retries_for_read_committed=5: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 1 statement retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+
+statement ok
+SET tracing = on
+
+query I
+SELECT 0
+----
+0
+
+statement ok
+SET tracing = off
+
+# By the time we get to the last statement, the transaction retry count hasn't
+# been affected by any of the statement retries, showing that it is separate.
+
+query T nosort
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
+----
+executing after 2 transaction retries, last retry reason: read committed retry limit exceeded; set by max_retries_for_read_committed=5: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+
+statement ok
+COMMIT

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2948,6 +2948,13 @@ func TestTenantLogicCCL_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestTenantLogicCCL_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestTenantLogicCCL_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -264,6 +264,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -264,6 +264,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -271,6 +271,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -257,6 +257,13 @@ func TestCCLLogic_subject(
 	runCCLLogicTest(t, "subject")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
@@ -264,6 +264,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2883,6 +2883,13 @@ func TestReadCommittedLogicCCL_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestReadCommittedLogicCCL_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestReadCommittedLogicCCL_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2869,6 +2869,13 @@ func TestRepeatableReadLogicCCL_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestRepeatableReadLogicCCL_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestRepeatableReadLogicCCL_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-schema-locked/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-schema-locked/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 31,
+    shard_count = 32,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-schema-locked/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-schema-locked/generated_test.go
@@ -250,6 +250,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -264,6 +264,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -376,6 +376,13 @@ func TestCCLLogic_triggers(
 	runCCLLogicTest(t, "triggers")
 }
 
+func TestCCLLogic_txn_retry(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "txn_retry")
+}
+
 func TestCCLLogic_udf_params(
 	t *testing.T,
 ) {

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -616,6 +616,8 @@ func makeMetrics(internal bool, sv *settings.Values) Metrics {
 			TransactionTimeoutCount:           metric.NewCounter(getMetricMeta(MetaTransactionTimeout, internal)),
 			FullTableOrIndexScanCount:         aggmetric.NewSQLCounter(getMetricMeta(MetaFullTableOrIndexScan, internal)),
 			FullTableOrIndexScanRejectedCount: metric.NewCounter(getMetricMeta(MetaFullTableOrIndexScanRejected, internal)),
+			TxnRetryCount:                     metric.NewCounter(getMetricMeta(MetaTxnRetry, internal)),
+			StatementRetryCount:               metric.NewCounter(getMetricMeta(MetaStatementRetry, internal)),
 		},
 		StartedStatementCounters:  makeStartedStatementCounters(internal),
 		ExecutedStatementCounters: makeExecutedStatementCounters(internal),

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2729,7 +2729,12 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 
 	maxRetries := int(ex.sessionData().MaxRetriesForReadCommitted)
 	for attemptNum := 0; ; attemptNum++ {
-		if attemptNum > 0 {
+		// TODO(99410): Fix the phase time for pausable portals.
+		startExecTS := crtime.NowMono()
+		ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.PlannerMostRecentStartExecStmt, startExecTS)
+		if attemptNum == 0 {
+			ex.statsCollector.PhaseTimes().SetSessionPhaseTime(sessionphase.PlannerFirstStartExecStmt, startExecTS)
+		} else {
 			ex.sessionTracing.TraceRetryInformation(
 				ctx, "statement", p.autoRetryStmtCounter, p.autoRetryStmtReason,
 			)

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -2811,6 +2811,7 @@ func (ex *connExecutor) dispatchReadCommittedStmtToExecutionEngine(
 			ppInfo.dispatchReadCommittedStmtToExecutionEngine.autoRetryStmtReason = p.autoRetryStmtReason
 			ppInfo.dispatchReadCommittedStmtToExecutionEngine.autoRetryStmtCounter = p.autoRetryStmtCounter
 		}
+		ex.metrics.EngineMetrics.StatementRetryCount.Inc(1)
 	}
 	return nil
 }
@@ -4398,6 +4399,7 @@ func (ex *connExecutor) recordTransactionFinish(
 		ex.sessionData().Database, ex.sessionData().ApplicationName)
 	ex.metrics.EngineMetrics.SQLTxnLatency.RecordValue(elapsedTime.Nanoseconds(),
 		ex.sessionData().Database, ex.sessionData().ApplicationName)
+	ex.metrics.EngineMetrics.TxnRetryCount.Inc(int64(ex.state.mu.autoRetryCounter))
 
 	ex.txnIDCacheWriter.Record(contentionpb.ResolvedTxnID{
 		TxnID:            ev.txnID,

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -1079,6 +1079,10 @@ func (ex *connExecutor) execStmtInOpenState(
 		}()
 	}
 
+	if ex.state.mu.autoRetryReason != nil {
+		p.autoRetryCounter = int(ex.state.mu.autoRetryCounter)
+	}
+
 	if ex.executorType != executorTypeInternal &&
 		ex.state.mu.txn.IsoLevel() == isolation.ReadCommitted &&
 		!ex.implicitTxn() {
@@ -2125,6 +2129,10 @@ func (ex *connExecutor) execStmtInOpenStateWithPausablePortal(
 			// region" error occurs.
 			ex.execRelease(ctx, releaseHomeRegionSavepoint, res)
 		}()
+	}
+
+	if ex.state.mu.autoRetryReason != nil {
+		p.autoRetryCounter = int(ex.state.mu.autoRetryCounter)
 	}
 
 	if ex.executorType != executorTypeInternal &&

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1348,6 +1348,18 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaTxnRetry = metric.Metadata{
+		Name:        "sql.txn.auto_retry.count",
+		Help:        "Number of SQL transaction automatic retries",
+		Measurement: "SQL Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
+	MetaStatementRetry = metric.Metadata{
+		Name:        "sql.statements.auto_retry.count",
+		Help:        "Number of SQL statement automatic retries",
+		Measurement: "SQL Statements",
+		Unit:        metric.Unit_COUNT,
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2861,8 +2861,12 @@ func (st *SessionTracing) TracePlanCheckEnd(ctx context.Context, err error, dist
 }
 
 // TraceRetryInformation conditionally emits a trace message for retry information.
-func (st *SessionTracing) TraceRetryInformation(ctx context.Context, retries int, err error) {
-	log.VEventfDepth(ctx, 2, 1, "executing after %d retries, last retry reason: %v", retries, err)
+func (st *SessionTracing) TraceRetryInformation(
+	ctx context.Context, retryScope string, retries int, err error,
+) {
+	log.VEventfDepth(
+		ctx, 2, 1, "executing after %d %s retries, last retry reason: %v", retries, retryScope, err,
+	)
 }
 
 // TraceExecStart conditionally emits a trace message at the moment

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -75,6 +75,14 @@ type EngineMetrics struct {
 	// FullTableOrIndexScanRejectedCount counts the number of queries that were
 	// rejected because of the `disallow_full_table_scans` guardrail.
 	FullTableOrIndexScanRejectedCount *metric.Counter
+
+	// TxnRetryCount counts the number of automatic transaction retries that
+	// have occurred.
+	TxnRetryCount *metric.Counter
+
+	// StatementRetryCount counts the number of automatic statement retries that
+	// have occurred under READ COMMITTED isolation.
+	StatementRetryCount *metric.Counter
 }
 
 // EngineMetrics implements the metric.Struct interface.

--- a/pkg/sql/executor_statement_metrics.go
+++ b/pkg/sql/executor_statement_metrics.go
@@ -127,14 +127,17 @@ func (GuardrailMetrics) MetricStruct() {}
 // last executed statement/query and performs the associated
 // accounting in the passed-in EngineMetrics.
 //   - distSQLUsed reports whether the query was distributed.
-//   - automaticRetryCount is the count of implicit txn retries
+//   - automaticRetryTxnCount is the count of implicit txn retries
+//     so far.
+//   - automaticRetryStmtCount is the count of implicit stmt retries
 //     so far.
 //   - result is the result set computed by the query/statement.
 //   - err is the error encountered, if any.
 func (ex *connExecutor) recordStatementSummary(
 	ctx context.Context,
 	planner *planner,
-	automaticRetryCount int,
+	automaticRetryTxnCount int,
+	automaticRetryStmtCount int,
 	rowsAffected int,
 	stmtErr error,
 	stats topLevelQueryStats,
@@ -160,7 +163,9 @@ func (ex *connExecutor) recordStatementSummary(
 
 	stmt := &planner.stmt
 	flags := planner.curPlan.flags
-	ex.recordStatementLatencyMetrics(stmt, flags, automaticRetryCount, runLatRaw, svcLatRaw)
+	ex.recordStatementLatencyMetrics(
+		stmt, flags, automaticRetryTxnCount+automaticRetryStmtCount, runLatRaw, svcLatRaw,
+	)
 
 	fullScan := flags.IsSet(planFlagContainsFullIndexScan) || flags.IsSet(planFlagContainsFullTableScan)
 
@@ -180,6 +185,10 @@ func (ex *connExecutor) recordStatementSummary(
 	implicitTxn := flags.IsSet(planFlagImplicitTxn)
 	stmtFingerprintID := appstatspb.ConstructStatementFingerprintID(
 		stmt.StmtNoConstants, implicitTxn, planner.SessionData().Database)
+	autoRetryReason := ex.state.mu.autoRetryReason
+	if automaticRetryStmtCount > 0 {
+		autoRetryReason = planner.autoRetryStmtReason
+	}
 	recordedStmtStats := &sqlstats.RecordedStmtStats{
 		FingerprintID:        stmtFingerprintID,
 		QuerySummary:         stmt.StmtSummary,
@@ -190,9 +199,9 @@ func (ex *connExecutor) recordStatementSummary(
 		PlanHash:             planner.instrumentation.planGist.Hash(),
 		SessionID:            ex.planner.extendedEvalCtx.SessionID,
 		StatementID:          stmt.QueryID,
-		AutoRetryCount:       automaticRetryCount,
+		AutoRetryCount:       automaticRetryTxnCount + automaticRetryStmtCount,
 		Failed:               stmtErr != nil,
-		AutoRetryReason:      ex.state.mu.autoRetryReason,
+		AutoRetryReason:      autoRetryReason,
 		RowsAffected:         rowsAffected,
 		IdleLatencySec:       idleLatSec,
 		ParseLatencySec:      parseLatSec,
@@ -289,7 +298,7 @@ func (ex *connExecutor) recordStatementSummary(
 				"run %.2fµs (%.1f%%), "+
 				"overhead %.2fµs (%.1f%%), "+
 				"session age %.4fs",
-			rowsAffected, automaticRetryCount,
+			rowsAffected, automaticRetryTxnCount+automaticRetryStmtCount,
 			parseLatSec*1e6, 100*parseLatSec/svcLatSec,
 			planLatSec*1e6, 100*planLatSec/svcLatSec,
 			runLatSec*1e6, 100*runLatSec/svcLatSec,

--- a/pkg/sql/faketreeeval/evalctx.go
+++ b/pkg/sql/faketreeeval/evalctx.go
@@ -572,6 +572,11 @@ func (ep *DummyEvalPlanner) ClearQueryPlanCache() {}
 // ClearTableStatsCache is part of the eval.Planner interface.
 func (ep *DummyEvalPlanner) ClearTableStatsCache() {}
 
+// RetryCounter is part of the eval.Planner interface.
+func (ep *DummyEvalPlanner) RetryCounter() int {
+	return 0
+}
+
 // DummyPrivilegedAccessor implements the tree.PrivilegedAccessor interface by returning errors.
 type DummyPrivilegedAccessor struct{}
 

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -45,3 +45,44 @@ SELECT cluster_logical_timestamp(); INSERT INTO test_retry VALUES (1);
 
 statement ok
 COMMIT
+
+statement ok
+RESET kv_transaction_buffered_writes_enabled
+
+# Test the overload of crdb_internal.force_retry that counts retries.
+subtest force_retry
+
+statement ok
+SET tracing = on
+
+query I
+SELECT crdb_internal.force_retry(0)
+----
+0
+
+statement ok
+SET tracing = off
+
+query T nosort
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
+----
+executing after 0 retries, last retry reason: <nil>
+
+statement ok
+SET tracing = on
+
+query I
+SELECT crdb_internal.force_retry(3)
+----
+0
+
+statement ok
+SET tracing = off
+
+query T nosort
+SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
+----
+executing after 0 retries, last retry reason: <nil>
+executing after 1 retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 2 retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 3 retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()

--- a/pkg/sql/logictest/testdata/logic_test/txn_retry
+++ b/pkg/sql/logictest/testdata/logic_test/txn_retry
@@ -66,7 +66,6 @@ SET tracing = off
 query T nosort
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
 ----
-executing after 0 retries, last retry reason: <nil>
 
 statement ok
 SET tracing = on
@@ -82,7 +81,6 @@ SET tracing = off
 query T nosort
 SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE '%executing after % retries%'
 ----
-executing after 0 retries, last retry reason: <nil>
-executing after 1 retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
-executing after 2 retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
-executing after 3 retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 1 transaction retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 2 transaction retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()
+executing after 3 transaction retries, last retry reason: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry()

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -66,6 +66,7 @@ go_test(
     embed = [":explain"],
     deps = [
         "//pkg/base",
+        "//pkg/ccl",
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/opt/exec/explain/main_test.go
+++ b/pkg/sql/opt/exec/explain/main_test.go
@@ -9,6 +9,7 @@ import (
 	"os"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/ccl"
 	"github.com/cockroachdb/cockroach/pkg/security/securityassets"
 	"github.com/cockroachdb/cockroach/pkg/security/securitytest"
 	"github.com/cockroachdb/cockroach/pkg/server"
@@ -16,6 +17,7 @@ import (
 )
 
 func TestMain(m *testing.M) {
+	defer ccl.TestingEnableEnterprise()()
 	securityassets.SetLoader(securitytest.EmbeddedAssets)
 	serverutils.InitTestServerFactory(server.TestServerFactory)
 	os.Exit(m.Run())

--- a/pkg/sql/opt/exec/explain/output.go
+++ b/pkg/sql/opt/exec/explain/output.go
@@ -375,17 +375,17 @@ func (ob *OutputBuilder) AddContentionTime(contentionTime time.Duration) {
 
 // AddRetryCount adds a top-level retry-count field. Cannot be called while
 // inside a node.
-func (ob *OutputBuilder) AddRetryCount(count uint64) {
+func (ob *OutputBuilder) AddRetryCount(retryScope string, count uint64) {
 	if !ob.flags.Deflake.HasAny(DeflakeVolatile) && count > 0 {
-		ob.AddTopLevelField("number of transaction retries", string(humanizeutil.Count(count)))
+		ob.AddTopLevelField("number of "+retryScope+" retries", string(humanizeutil.Count(count)))
 	}
 }
 
 // AddRetryTime adds a top-level statement retry time field. Cannot be called
 // while inside a node.
-func (ob *OutputBuilder) AddRetryTime(delta time.Duration) {
+func (ob *OutputBuilder) AddRetryTime(retryScope string, delta time.Duration) {
 	if !ob.flags.Deflake.HasAny(DeflakeVolatile) && delta > 0 {
-		ob.AddTopLevelField("time spent retrying the transaction", string(humanizeutil.Duration(delta)))
+		ob.AddTopLevelField("time spent retrying the "+retryScope, string(humanizeutil.Duration(delta)))
 	}
 }
 

--- a/pkg/sql/prepared_stmt.go
+++ b/pkg/sql/prepared_stmt.go
@@ -259,6 +259,15 @@ type portalPauseInfo struct {
 		cleanup cleanupFuncStack
 	}
 
+	dispatchReadCommittedStmtToExecutionEngine struct {
+		// autoRetryStmtReason is the planner.autoRetryStmtReason to restore when
+		// resuming a portal.
+		autoRetryStmtReason error
+		// autoRetryStmtCounter is the planner.autoRetryStmtCounter to restore when
+		// resuming a portal.
+		autoRetryStmtCounter int
+	}
+
 	// TODO(sql-session): replace certain fields here with planner.
 	// https://github.com/cockroachdb/cockroach/issues/99625
 	dispatchToExecutionEngine struct {

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2662,6 +2662,7 @@ var builtinOidsArray = []string{
 	2699: `jsonb_path_match(target: jsonb, path: jsonpath) -> bool`,
 	2700: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb) -> bool`,
 	2701: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> bool`,
+	2702: `crdb_internal.force_retry(val: int) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -448,6 +448,9 @@ type Planner interface {
 
 	// ClearTableStatsCache removes all entries from the node's table stats cache.
 	ClearTableStatsCache()
+
+	// RetryCounter is the number of times this statement has been retried.
+	RetryCounter() int
 }
 
 // InternalRows is an iterator interface that's exposed by the internal

--- a/pkg/sql/sessionphase/session_phase.go
+++ b/pkg/sql/sessionphase/session_phase.go
@@ -44,6 +44,15 @@ const (
 	// PlannerEndLogicalPlan is the SessionPhase when planning ends.
 	PlannerEndLogicalPlan
 
+	// PlannerFirstStartExecStmt is the SessionPhase when execution starts for the
+	// first time. Will only be set if using read committed isolation.
+	PlannerFirstStartExecStmt
+
+	// PlannerMostRecentStartExecStmt is the SessionPhase when execution starts
+	// for the most recent time. Will only be set if using read committed
+	// isolation.
+	PlannerMostRecentStartExecStmt
+
 	// PlannerStartExecStmt is the SessionPhase when execution starts.
 	PlannerStartExecStmt
 
@@ -167,6 +176,13 @@ func (t *Times) GetServiceLatencyNoOverhead() time.Duration {
 // NOTE: SessionQueryServiced phase must have been set.
 func (t *Times) GetServiceLatencyTotal() time.Duration {
 	return t.times[SessionQueryServiced].Sub(t.times[SessionQueryReceived])
+}
+
+// GetStatementRetryLatency returns the time that was spent retrying the
+// statement. (This is only applicable to Read Committed isolation, and will
+// always be zero under stronger isolation levels.)
+func (t *Times) GetStatementRetryLatency() time.Duration {
+	return t.times[PlannerMostRecentStartExecStmt].Sub(t.times[PlannerFirstStartExecStmt])
 }
 
 // GetRunLatency returns the time between a query execution starting and

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -69,11 +69,9 @@ type txnState struct {
 		// bundles, and also is surfaced in the DB Console.
 		autoRetryReason error
 
-		// autoRetryCounter keeps track of the number of automatic retries that have
-		// occurred. It includes per-statement retries performed under READ
-		// COMMITTED as well as transaction retries for serialization failures under
-		// REPEATABLE READ and SERIALIZABLE. It's 0 whenever the transaction state
-		// is not stateOpen.
+		// autoRetryCounter keeps track of the number of automatic transaction
+		// retries that have occurred. It's 0 whenever the transaction state is not
+		// stateOpen.
 		autoRetryCounter int32
 
 		hasSavepoints bool


### PR DESCRIPTION
In #107044 we added statement-level automatic retries to the conn executor. These retries are used under Read Committed isolation to try to prevent retryable errors from escaping to the application.

This PR adds more observability to statement-level retries, in some cases bringing it up to par with transaction-level retries. See individual commits for details.

Informs: #145377

Release note: None