### PR TITLE
pkg/util/log: parse otlp sink from yaml config

### DIFF
--- a/pkg/cli/log_flags_test.go
+++ b/pkg/cli/log_flags_test.go
@@ -57,6 +57,17 @@ func TestSetupLogging(t *testing.T) {
 		`flush-trigger-size: 1.0MiB, ` +
 		`max-buffer-size: 50MiB, ` +
 		`format: newline}}`
+	const defaultOtlpConfig = `otlp-defaults: {` +
+		`insecure: false, ` +
+		`compression: gzip, ` +
+		`filter: INFO, ` +
+		`format: json, ` +
+		`redactable: true, ` +
+		`exit-on-error: false, ` +
+		`buffering: {max-staleness: 5s, ` +
+		`flush-trigger-size: 1.0MiB, ` +
+		`max-buffer-size: 50MiB, ` +
+		`format: newline}}`
 	stdFileDefaultsRe := regexp.MustCompile(
 		`file-defaults: \{` +
 			`dir: (?P<path>[^,]+), ` +
@@ -189,6 +200,7 @@ func TestSetupLogging(t *testing.T) {
 		// Shorten the configuration for legibility during reviews of test changes.
 		actual = strings.ReplaceAll(actual, defaultFluentConfig, "<fluentDefaults>")
 		actual = strings.ReplaceAll(actual, defaultHTTPConfig, "<httpDefaults>")
+		actual = strings.ReplaceAll(actual, defaultOtlpConfig, "<otlpDefaults>")
 		actual = stdFileDefaultsRe.ReplaceAllString(actual, "<stdFileDefaults($path)>")
 		actual = fileDefaultsNoMaxSizeRe.ReplaceAllString(actual, "<fileDefaultsNoMaxSize($path)>")
 		actual = strings.ReplaceAll(actual, fileDefaultsNoDir, "<fileDefaultsNoDir>")

--- a/pkg/cli/testdata/logflags
+++ b/pkg/cli/testdata/logflags
@@ -15,6 +15,7 @@ start
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -51,6 +52,7 @@ start-single-node
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -91,6 +93,7 @@ sql
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledWarningNoRedaction>}}
 
 run
@@ -99,6 +102,7 @@ init
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledWarningNoRedaction>}}
 
 
@@ -112,6 +116,7 @@ bank
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledInfoNoRedaction>}}
 
 
@@ -123,6 +128,7 @@ demo
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrCfg(FATAL,false)>}}
 
 
@@ -139,6 +145,7 @@ start
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledInfoNoRedaction>}}
 
 
@@ -152,6 +159,7 @@ start
 config: {<stdFileDefaults(/pathA/logs)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -190,6 +198,7 @@ start
 config: {<stdFileDefaults(/mypath)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -229,6 +238,7 @@ start
 config: {<stdFileDefaults(/pathA/logs)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -273,6 +283,7 @@ start
 config: {<stdFileDefaults(/mypath)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -310,6 +321,7 @@ start
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -348,6 +360,7 @@ start
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -396,6 +409,7 @@ start
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -455,6 +469,7 @@ start
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledInfoNoRedaction>}}
 
 
@@ -466,6 +481,7 @@ start
 config: {<stdFileDefaults(/mypath)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -505,6 +521,7 @@ start
 config: {<stdFileDefaults(/pathA)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -544,6 +561,7 @@ init
 config: {<fileDefaultsNoMaxSize(/mypath)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: {channels: {INFO: all},
 dir: /mypath,
 file-permissions: "0640",
@@ -563,6 +581,7 @@ start
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -600,6 +619,7 @@ start
 config: {<stdFileDefaults(<defaultLogDir>)>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {file-groups: {default: <fileCfg(INFO: [DEV,
 OPS],
 WARNING: [HEALTH,
@@ -637,6 +657,7 @@ init
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledInfoNoRedaction>}}
 
 # Default when no severity is specified is WARNING.
@@ -647,6 +668,7 @@ init
 config: {<fileDefaultsNoDir>,
 <fluentDefaults>,
 <httpDefaults>,
+<otlpDefaults>,
 sinks: {<stderrEnabledWarningNoRedaction>}}
 
 

--- a/pkg/util/log/flags.go
+++ b/pkg/util/log/flags.go
@@ -366,6 +366,19 @@ func ApplyConfig(
 		attachSinkInfo(httpSinkInfo, &fc.Channels)
 	}
 
+	// Create the OpenTelemetry sinks.
+	for _, fc := range config.Sinks.OtlpServers {
+		if fc.Filter == severity.NONE {
+			continue
+		}
+		optlSinkInfo, err := newOtlpSinkInfo(*fc)
+		if err != nil {
+			return nil, err
+		}
+		attachBufferWrapper(optlSinkInfo, fc.CommonSinkConfig.Buffering, closer)
+		attachSinkInfo(optlSinkInfo, &fc.Channels)
+	}
+
 	// Prepend the interceptor sink to all channels.
 	// We prepend it because we want the interceptors
 	// to see every event before they make their way to disk/network.
@@ -431,6 +444,11 @@ func newHTTPSinkInfo(c logconfig.HTTPSinkConfig) (*sinkInfo, error) {
 	}
 	info.sink = httpSink
 	return info, nil
+}
+
+func newOtlpSinkInfo(_ logconfig.OtlpSinkConfig) (*sinkInfo, error) {
+	// TODO(mudit): Implement newOtlpSink
+	return nil, nil
 }
 
 // applyFilters applies the channel filters to a sinkInfo.

--- a/pkg/util/log/logconfig/testdata/validate
+++ b/pkg/util/log/logconfig/testdata/validate
@@ -880,3 +880,22 @@ file-defaults:
     max-buffer-size: 50MiB
 ----
 ERROR: File-based audit logging cannot coexist with buffering configuration. Disable either the buffering configuration ("buffering") or auditable log ("auditable") configuration.
+
+# Check that missing address in OTLP is reported.
+yaml
+sinks:
+  otlp-servers:
+    custom:
+----
+ERROR: otlp server "custom": address cannot be empty
+
+# Check that invalid proto is rejected.
+yaml
+sinks:
+  otlp-servers:
+    custom:
+      address: localhost:4317
+      compression: ''
+----
+ERROR: otlp server "custom": compression must be 'gzip' or 'none'
+otlp server "custom": no channel selected

--- a/pkg/util/log/logconfig/validate.go
+++ b/pkg/util/log/logconfig/validate.go
@@ -111,14 +111,31 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 		}(),
 		Compression: &GzipCompression,
 	}
+	baseOtlpDefaults := OtlpDefaults{
+		CommonSinkConfig: CommonSinkConfig{
+			Format: func() *string { s := DefaultOtlpFormat; return &s }(),
+			Buffering: CommonBufferSinkConfigWrapper{
+				CommonBufferSinkConfig: CommonBufferSinkConfig{
+					MaxStaleness:     &defaultBufferedStaleness,
+					FlushTriggerSize: &defaultFlushTriggerSize,
+					MaxBufferSize:    &defaultMaxBufferSize,
+					Format:           &bufferFmt,
+				},
+			},
+		},
+		Insecure:    &bf,
+		Compression: &GzipCompression,
+	}
 
 	propagateCommonDefaults(&baseFileDefaults.CommonSinkConfig, baseCommonSinkConfig)
 	propagateCommonDefaults(&baseFluentDefaults.CommonSinkConfig, baseCommonSinkConfig)
 	propagateCommonDefaults(&baseHTTPDefaults.CommonSinkConfig, baseCommonSinkConfig)
+	propagateCommonDefaults(&baseOtlpDefaults.CommonSinkConfig, baseCommonSinkConfig)
 
 	propagateFileDefaults(&c.FileDefaults, baseFileDefaults)
 	propagateFluentDefaults(&c.FluentDefaults, baseFluentDefaults)
 	propagateHTTPDefaults(&c.HTTPDefaults, baseHTTPDefaults)
+	propagateOtlpDefaults(&c.OtlpDefaults, baseOtlpDefaults)
 
 	// Normalize the directory.
 	if err := normalizeDir(&c.FileDefaults.Dir); err != nil {
@@ -157,6 +174,17 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 		fc.sinkName = sinkName
 		if err := c.validateHTTPSinkConfig(fc); err != nil {
 			fmt.Fprintf(&errBuf, "http server %q: %v\n", sinkName, err)
+		}
+	}
+
+	for sinkName, fc := range c.Sinks.OtlpServers {
+		if fc == nil {
+			fc = &OtlpSinkConfig{Channels: SelectChannels()}
+			c.Sinks.OtlpServers[sinkName] = fc
+		}
+		fc.SinkName = sinkName
+		if err := c.validateOtlpSinkConfig(fc); err != nil {
+			fmt.Fprintf(&errBuf, "otlp server %q: %v\n", sinkName, err)
 		}
 	}
 
@@ -241,6 +269,18 @@ func (c *Config) Validate(defaultLogDir *string) (resErr error) {
 		// have a filter yet.
 		if err := fc.Channels.Validate(fc.Filter); err != nil {
 			fmt.Fprintf(&errBuf, "http server %q: %v\n", sinkName, err)
+			continue
+		}
+	}
+
+	for serverName, fc := range c.Sinks.OtlpServers {
+		if len(fc.Channels.Filters) == 0 {
+			fmt.Fprintf(&errBuf, "otlp server %q: no channel selected\n", serverName)
+		}
+		// Propagate the sink-wide default filter to all channels that don't
+		// have a filter yet.
+		if err := fc.Channels.Validate(fc.Filter); err != nil {
+			fmt.Fprintf(&errBuf, "otlp server %q: %v\n", serverName, err)
 			continue
 		}
 	}
@@ -478,6 +518,20 @@ func (c *Config) validateHTTPSinkConfig(hsc *HTTPSinkConfig) error {
 	return c.ValidateCommonSinkConfig(hsc.CommonSinkConfig)
 }
 
+func (c *Config) validateOtlpSinkConfig(otsc *OtlpSinkConfig) error {
+	propagateOtlpDefaults(&otsc.OtlpDefaults, c.OtlpDefaults)
+	otsc.Address = strings.TrimSpace(otsc.Address)
+	if len(otsc.Address) == 0 {
+		return errors.New("address cannot be empty")
+	}
+
+	if *otsc.Compression != GzipCompression && *otsc.Compression != NoneCompression {
+		return errors.New("compression must be 'gzip' or 'none'")
+	}
+
+	return c.ValidateCommonSinkConfig(otsc.CommonSinkConfig)
+}
+
 func normalizeDir(dir **string) error {
 	if *dir == nil {
 		return nil
@@ -509,6 +563,10 @@ func propagateFluentDefaults(target *FluentDefaults, source FluentDefaults) {
 }
 
 func propagateHTTPDefaults(target *HTTPDefaults, source HTTPDefaults) {
+	propagateDefaults(target, source)
+}
+
+func propagateOtlpDefaults(target *OtlpDefaults, source OtlpDefaults) {
 	propagateDefaults(target, source)
 }
 

--- a/pkg/util/log/logconfig/validate_test.go
+++ b/pkg/util/log/logconfig/validate_test.go
@@ -58,6 +58,7 @@ func clearExpectedValues(c *Config) {
 	c.FileDefaults = FileDefaults{}
 	c.FluentDefaults = FluentDefaults{}
 	c.HTTPDefaults = HTTPDefaults{}
+	c.OtlpDefaults = OtlpDefaults{}
 
 	for _, f := range c.Sinks.FileGroups {
 		if *f.Dir == "/default-dir" {


### PR DESCRIPTION
OpenTelemetry is now an industry standard for o11y and is
more efficient than other log sinks currently available.

This commit only defines basic configuration options for
the OTLP sink, like address, insecure, and compression,
and adds logic to parse them from the YAML config. The
actual sink implementation will follow in a future commit.

Informs: https://github.com/cockroachdb/cockroach/issues/143049

Release note: None