### PR TITLE
server: consolidate RPC clients creation

### DIFF
--- a/pkg/keyvisualizer/keyvispb/BUILD.bazel
+++ b/pkg/keyvisualizer/keyvispb/BUILD.bazel
@@ -31,7 +31,12 @@ go_proto_library(
 
 go_library(
     name = "keyvispb",
+    srcs = ["rpc_clients.go"],
     embed = [":keyvispb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/keyvisualizer/keyvispb",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
+    ],
 )

--- a/pkg/keyvisualizer/keyvispb/rpc_clients.go
+++ b/pkg/keyvisualizer/keyvispb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package keyvispb
+
+import (
+	context "context"
+
+	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialKeyVisualizerClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// KeyVisualizerClient.
+func DialKeyVisualizerClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (KeyVisualizerClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewKeyVisualizerClient(conn), nil
+	}
+	return nil, nil
+}

--- a/pkg/server/key_visualizer_server.go
+++ b/pkg/server/key_visualizer_server.go
@@ -69,8 +69,8 @@ func (s *KeyVisualizerServer) getSamplesFromFanOut(
 	samplePeriod := keyvissettings.SampleInterval.Get(&s.settings.SV)
 
 	dialFn := func(ctx context.Context, nodeID roachpb.NodeID) (interface{}, error) {
-		conn, err := s.kvNodeDialer.Dial(ctx, nodeID, rpcbase.DefaultClass)
-		return keyvispb.NewKeyVisualizerClient(conn), err
+		client, err := keyvispb.DialKeyVisualizerClient(s.kvNodeDialer, ctx, nodeID, rpcbase.DefaultClass)
+		return client, err
 	}
 
 	nodeFn := func(ctx context.Context, client interface{}, nodeID roachpb.NodeID) (interface{}, error) {


### PR DESCRIPTION
This commit consolidates keyvisualizer RPC client creation logic in the server package. It is a continuation of the work done in https://github.com/cockroachdb/cockroach/pull/147606.

Epic: CRDB-48923
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none