### PR TITLE
sql: consolidate RPC clients creation

### DIFF
--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "flow_diagram.go",
         "processors.go",
         "processors_changefeed.go",
+        "rpc_clients.go",
     ],
     embed = [":execinfrapb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb",
@@ -21,6 +22,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
         "//pkg/security/username",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/catalogkeys",

--- a/pkg/sql/execinfrapb/rpc_clients.go
+++ b/pkg/sql/execinfrapb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package execinfrapb
+
+import (
+	context "context"
+
+	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialDistSQLClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// DistSQLClient.
+func DialDistSQLClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (DistSQLClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewDistSQLClient(conn), nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
This commit consolidates distsql RPC client creation logic in the sql package. It is a continuation of the work done in https://github.com/cockroachdb/cockroach/pull/147606.

Epic: [CRDB-48923](https://cockroachlabs.atlassian.net/browse/CRDB-48923)
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none