### PR TITLE
blobs: consolidate RPC clients creation

### DIFF
--- a/pkg/blobs/blobspb/BUILD.bazel
+++ b/pkg/blobs/blobspb/BUILD.bazel
@@ -22,7 +22,12 @@ go_proto_library(
 
 go_library(
     name = "blobspb",
+    srcs = ["rpc_clients.go"],
     embed = [":blobspb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/blobs/blobspb",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
+    ],
 )

--- a/pkg/blobs/blobspb/rpc_clients.go
+++ b/pkg/blobs/blobspb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package blobspb
+
+import (
+	context "context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialBlobClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// BlobClient.
+func DialBlobClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (BlobClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewBlobClient(conn), nil
+	}
+	return nil, nil
+}

--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -200,11 +200,11 @@ func NewBlobClientFactory(
 		if localNodeID == dialTarget && allowLocalFastpath {
 			return NewLocalClient(externalIODir)
 		}
-		conn, err := dialer.Dial(ctx, dialTarget, rpcbase.DefaultClass)
+		client, err := blobspb.DialBlobClient(dialer, ctx, dialTarget, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, errors.Wrapf(err, "connecting to node %d", dialTarget)
 		}
-		return newRemoteClient(blobspb.NewBlobClient(conn)), nil
+		return newRemoteClient(client), nil
 	}
 }
 


### PR DESCRIPTION
This commit consolidates blob RPC client creation logic in the blobs package. It is a continuation of the work done in https://github.com/cockroachdb/cockroach/pull/147606.

Epic: CRDB-48923
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none