### PR TITLE
upgrade: consolidate RPC clients creation

### DIFF
--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -102,6 +102,7 @@ go_library(
     name = "serverpb",
     srcs = [
         "admin.go",
+        "rpc_clients.go",
         "status.go",
     ],
     embed = [":serverpb_go_proto"],
@@ -110,6 +111,7 @@ go_library(
     deps = [
         "//pkg/gossip",
         "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
         "//pkg/util/errorutil",
         "//pkg/util/metric",
         "@com_github_prometheus_client_model//go",

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package serverpb
+
+import (
+	context "context"
+
+	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialMigrationClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// MigrationClient.
+func DialMigrationClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (MigrationClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewMigrationClient(conn), nil
+	}
+	return nil, nil
+}

--- a/pkg/upgrade/upgradecluster/cluster.go
+++ b/pkg/upgrade/upgradecluster/cluster.go
@@ -139,11 +139,10 @@ func (c *Cluster) ForEveryNodeOrServer(
 		grp.GoCtx(func(ctx context.Context) error {
 			defer alloc.Release()
 
-			conn, err := c.c.Dialer.Dial(ctx, node.ID, rpcbase.DefaultClass)
+			client, err := serverpb.DialMigrationClient(c.c.Dialer, ctx, node.ID, rpcbase.DefaultClass)
 			if err != nil {
 				return err
 			}
-			client := serverpb.NewMigrationClient(conn)
 			return fn(ctx, client)
 		})
 	}


### PR DESCRIPTION
This commit consolidates migration RPC client creation logic in the upgrade package. It is a continuation of the work done in https://github.com/cockroachdb/cockroach/pull/147606.

Epic: CRDB-48923
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none