### PR TITLE
collector: consolidate RPC clients creation

### DIFF
--- a/pkg/util/tracing/collector/collector.go
+++ b/pkg/util/tracing/collector/collector.go
@@ -147,12 +147,11 @@ func (t *TraceCollector) getTraceSpanRecordingsForInstance(
 	ctx context.Context, traceID tracingpb.TraceID, instanceID base.SQLInstanceID,
 ) []tracingpb.Recording {
 	log.Infof(ctx, "getting span recordings from instance %s", instanceID)
-	conn, err := t.dialer.Dial(ctx, roachpb.NodeID(instanceID), rpcbase.DefaultClass)
+	traceClient, err := tracingservicepb.DialTracingClient(t.dialer, ctx, roachpb.NodeID(instanceID), rpcbase.DefaultClass)
 	if err != nil {
 		log.Warningf(ctx, "failed to dial instance %s: %v", instanceID, err)
 		return nil
 	}
-	traceClient := tracingservicepb.NewTracingClient(conn)
 	var resp *tracingservicepb.GetSpanRecordingsResponse
 	resp, err = traceClient.GetSpanRecordings(ctx,
 		&tracingservicepb.GetSpanRecordingsRequest{TraceID: traceID})

--- a/pkg/util/tracing/tracingservicepb/BUILD.bazel
+++ b/pkg/util/tracing/tracingservicepb/BUILD.bazel
@@ -30,7 +30,12 @@ go_proto_library(
 
 go_library(
     name = "tracingservicepb",
+    srcs = ["rpc_clients.go"],
     embed = [":tracingservicepb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/tracing/tracingservicepb",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/roachpb",
+        "//pkg/rpc/rpcbase",
+    ],
 )

--- a/pkg/util/tracing/tracingservicepb/rpc_clients.go
+++ b/pkg/util/tracing/tracingservicepb/rpc_clients.go
@@ -1,0 +1,29 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package tracingservicepb
+
+import (
+	context "context"
+
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+)
+
+// DialTracingClient establishes a DRPC connection if enabled; otherwise,
+// it falls back to gRPC. The established connection is used to create a
+// TracingClient.
+func DialTracingClient(
+	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (TracingClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.Dial(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewTracingClient(conn), nil
+	}
+	return nil, nil
+}


### PR DESCRIPTION
This commit consolidates tracing RPC client creation logic in the collector package. It is a continuation of the work done in https://github.com/cockroachdb/cockroach/pull/147606.

Epic: [CRDB-48923](https://cockroachlabs.atlassian.net/browse/CRDB-48923)
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none