### PR TITLE
sql/rls: retain function backrefs when updating policy dependencies

### DIFF
--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -328,9 +328,9 @@ func (desc *immutable) validateInboundFunctionRef(
 	}
 	// Validate all other references are unset.
 	if ref.ColumnIDs != nil || ref.IndexIDs != nil ||
-		ref.ConstraintIDs != nil || ref.TriggerIDs != nil {
-		return errors.AssertionFailedf("function reference has invalid references (%v, %v %v, %v)",
-			ref.ColumnIDs, ref.IndexIDs, ref.ConstraintIDs, ref.TriggerIDs)
+		ref.ConstraintIDs != nil || ref.TriggerIDs != nil || ref.PolicyIDs != nil {
+		return errors.AssertionFailedf("function reference has invalid references (%v, %v %v, %v, %v)",
+			ref.ColumnIDs, ref.IndexIDs, ref.ConstraintIDs, ref.TriggerIDs, ref.PolicyIDs)
 	}
 	// Validate a reference exists to this function.
 	for _, refID := range backrefFunctionDesc.GetDependsOnFunctions() {
@@ -860,7 +860,7 @@ func (desc *Mutable) maybeRemoveTableReference(id descpb.ID) {
 	var ret []descpb.FunctionDescriptor_Reference
 	for _, ref := range desc.DependedOnBy {
 		if ref.ID == id && len(ref.ColumnIDs) == 0 && len(ref.IndexIDs) == 0 &&
-			len(ref.ConstraintIDs) == 0 && len(ref.TriggerIDs) == 0 {
+			len(ref.ConstraintIDs) == 0 && len(ref.TriggerIDs) == 0 && len(ref.PolicyIDs) == 0 {
 			continue
 		}
 		ret = append(ret, ref)

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -705,6 +705,64 @@ ALTER TABLE colref DROP COLUMN c2;
 statement ok
 DROP TABLE colref;
 
+# Added for bug found in issue #147471
+subtest func_ref
+
+statement ok
+CREATE FUNCTION f() RETURNS BOOL LANGUAGE SQL AS $$ SELECT true; $$;
+
+statement ok
+CREATE TABLE t (x INT, y INT, b BOOL DEFAULT f());
+
+statement ok
+CREATE POLICY p ON t USING (f());
+
+query T
+SELECT jsonb_pretty(crdb_internal.pb_to_json('descriptor', descriptor)->'function'->'dependedOnBy') as dependedOnBy
+FROM system.descriptor
+WHERE id = (select 'f'::REGPROC::INT - 100000);
+----
+[
+    {
+        "columnIds": [
+            3
+        ],
+        "id": 127,
+        "policyIds": [
+            1
+        ]
+    }
+]
+
+# Function reference should be updated but still include dependency on policy.
+statement ok
+ALTER TABLE t DROP COLUMN b;
+
+query T
+SELECT jsonb_pretty(crdb_internal.pb_to_json('descriptor', descriptor)->'function'->'dependedOnBy') as dependedOnBy
+FROM system.descriptor
+WHERE id = (select 'f'::REGPROC::INT - 100000);
+----
+[
+    {
+        "id": 127,
+        "policyIds": [
+            1
+        ]
+    }
+]
+
+query B
+SELECT f();
+----
+true
+
+statement ok
+DROP TABLE t;
+
+statement ok
+DROP FUNCTION f;
+
 subtest no_subvar_expr
 
 statement ok


### PR DESCRIPTION
When a row-level security (RLS) policy references a user-defined function, we correctly establish both forward and backward references during creation. However, if a dependency of that function changes (e.g., a column used in the function's default expression is dropped), the schema changer updates the function’s dependencies but inadvertently drops the backreference to the RLS policy.

This leads to a missing backref, causing the schema changes to fail due. This change ensures the policy backref is preserved.

Fixes #147471

Release note (bug fix): Fixed a bug where functions lost their RLS policy backreferences, leading to schema change failures.