### PR TITLE
sql: block ALTER TABLE of identity columns not backed by a sequence

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1226,8 +1226,14 @@ func applyColumnMutation(
 				col.GetName(), tableDesc.GetName())
 		}
 
-		// It is assumed that an identify column owns only one sequence.
-		if col.NumUsesSequences() != 1 {
+		numSeqs := col.NumUsesSequences()
+		if numSeqs == 0 {
+			// This can happen when a SERIAL column is created with IDENTITY and
+			// serial_normalization=rowid, meaning it doesn't use a real sequence.
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"identity column %q of relation %q is not backed by a sequence",
+				col.GetName(), tableDesc.GetName())
+		} else if numSeqs > 1 {
 			return errors.AssertionFailedf(
 				"identity column %q of relation %q has %d sequences instead of 1",
 				col.GetName(), tableDesc.GetName(), col.NumUsesSequences())
@@ -1273,8 +1279,14 @@ func applyColumnMutation(
 				col.GetName(), tableDesc.GetName())
 		}
 
-		// It is assumed that an identify column owns only one sequence.
-		if col.NumUsesSequences() != 1 {
+		numSeqs := col.NumUsesSequences()
+		if numSeqs == 0 {
+			// This can happen when a SERIAL column is created with IDENTITY and
+			// serial_normalization=rowid, meaning it doesn't use a real sequence.
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"identity column %q of relation %q is not backed by a sequence",
+				col.GetName(), tableDesc.GetName())
+		} else if numSeqs > 1 {
 			return errors.AssertionFailedf(
 				"identity column %q of relation %q has %d sequences instead of 1",
 				col.GetName(), tableDesc.GetName(), col.NumUsesSequences())

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2313,6 +2313,14 @@ WHERE id = 't'::regclass::oid
 ----
 GENERATED_ALWAYS
 
+skipif config local-schema-locked
+statement error pq: identity column "b" of relation "t" is not backed by a sequence
+ALTER TABLE t ALTER COLUMN b DROP IDENTITY;
+
+skipif config local-schema-locked
+statement error pq: identity column "b" of relation "t" is not backed by a sequence
+ALTER TABLE t ALTER COLUMN b SET CYCLE;
+
 statement ok
 DROP TABLE t;
 


### PR DESCRIPTION
Previously, identity columns not backed by sequences (e.g. SERIAL columns with serial_normalization=rowid) were not protected from ALTER operations that modified identity attributes. This could lead to assertion failures. This change adds checks to block such ALTER TABLE statements.

Fixes #147488
Fixes #146989

Epic: none
Release note (bug fix): Prevented ALTER TABLE from modifying identity attributes on columns not backed by a sequence.