### PR TITLE
oidcccl, server: add role synchronisation for DB Console OIDC logins

### DIFF
--- a/pkg/ccl/oidcccl/BUILD.bazel
+++ b/pkg/ccl/oidcccl/BUILD.bazel
@@ -4,6 +4,7 @@ go_library(
     name = "oidcccl",
     srcs = [
         "authentication_oidc.go",
+        "authorization_oidc.go",
         "claim_match.go",
         "settings.go",
         "state.go",
@@ -12,6 +13,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/ccl/jwtauthccl",
+        "//pkg/ccl/securityccl/jwthelper",
         "//pkg/ccl/utilccl",
         "//pkg/roachpb",
         "//pkg/security/username",
@@ -21,6 +23,7 @@ go_library(
         "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
+        "//pkg/sql",
         "//pkg/sql/pgwire",
         "//pkg/sql/pgwire/identmap",
         "//pkg/ui",
@@ -31,6 +34,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_coreos_go_oidc//:go-oidc",
+        "@com_github_lestrrat_go_jwx_v2//jwt",
         "@org_golang_x_oauth2//:oauth2",
     ],
 )
@@ -40,6 +44,7 @@ go_test(
     size = "small",
     srcs = [
         "authentication_oidc_test.go",
+        "authorization_oidc_test.go",
         "main_test.go",
         "settings_test.go",
     ],
@@ -64,7 +69,11 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_coreos_go_oidc//:go-oidc",
+        "@com_github_lestrrat_go_jwx_v2//jwa",
+        "@com_github_lestrrat_go_jwx_v2//jwk",
+        "@com_github_lestrrat_go_jwx_v2//jwt",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_oauth2//:oauth2",
     ],

--- a/pkg/ccl/oidcccl/authentication_oidc.go
+++ b/pkg/ccl/oidcccl/authentication_oidc.go
@@ -19,12 +19,13 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/ccl/jwtauthccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/utilccl"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
+	secuser "github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/identmap"
 	"github.com/cockroachdb/cockroach/pkg/ui"
@@ -34,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	oidc "github.com/coreos/go-oidc"
+	"github.com/lestrrat-go/jwx/v2/jwt"
 	"golang.org/x/oauth2"
 )
 
@@ -131,6 +133,7 @@ type oidcAuthenticationServer struct {
 	// to help us gracefully recover from auth provider downtime without operator intervention.
 	enabled     bool
 	initialized bool
+	execCfg     *sql.ExecutorConfig
 }
 
 type oidcAuthenticationConf struct {
@@ -152,6 +155,9 @@ type oidcAuthenticationConf struct {
 	generateJWTAuthTokenSQLPort  int64
 	providerCustomCA             string
 	httpClient                   *httputil.Client
+	authZEnabled                 bool
+	groupClaim                   string
+	userinfoGroupKey             string
 }
 
 // GetOIDCConf is used to extract certain parts of the OIDC
@@ -187,37 +193,107 @@ type oidcManager struct {
 	oauth2Config *oauth2.Config
 	verifier     *oidc.IDTokenVerifier
 	httpClient   *httputil.Client
+	provider     *oidc.Provider
 }
 
-func (o *oidcManager) ExchangeVerifyGetClaims(
-	ctx context.Context, code string, idTokenKey string,
-) (map[string]json.RawMessage, error) {
+// ExchangeVerifyGetTokenInfo exchanges the auth-code, verifies the ID-token,
+// and extracts claims from both the ID and Access tokens if they are JWTs.
+// Access tokens are only processed if OIDC authorization is enabled for the
+// cluster.
+func (o *oidcManager) ExchangeVerifyGetTokenInfo(
+	ctx context.Context, code, idTokenKey string, authZEnabled bool,
+) (
+	idTokenClaims, accessTokenClaims map[string]json.RawMessage,
+	rawIDToken, rawAccessToken string,
+	err error,
+) {
 	credentials, err := o.Exchange(ctx, code)
 	if err != nil {
-		log.Errorf(ctx, "OIDC: failed to exchange code for token: %v", err)
-		return nil, err
+		return nil, nil, "", "", errors.Wrap(err, "OIDC: failed to exchange code for token")
 	}
 
-	rawIDToken, ok := credentials.Extra(idTokenKey).(string)
-	if !ok {
-		err := errors.New("OIDC: failed to extract ID token from the token credentials")
-		log.Error(ctx, "OIDC: failed to extract ID token from the token credentials")
-		return nil, err
+	// Build the list of tokens we must handle. For the ID token we verify
+	// signature and claims up-front; the access token is copied as-is.
+	// Since we use the OIDC Authorization Code flow (response_type=code),
+	// The token endpoint response must contain both id_token and access_token
+	// (refresh_token is optional). Their presence is therefore guaranteed here.
+	tokensToProcess := []struct {
+		name             string
+		getVerifiedToken func() (string, error)      // fetches the raw token; verifies when needed
+		claims           *map[string]json.RawMessage // destination for parsed claims
+		rawToken         *string                     // destination for the raw token string
+		required         bool
+	}{
+		{
+			name:     idTokenKey,
+			required: true,
+			getVerifiedToken: func() (string, error) {
+				val, _ := credentials.Extra(idTokenKey).(string)
+				if val == "" {
+					log.Ops.Warning(ctx, "OIDC: required id_token missing from credentials")
+					return "", errors.New("OIDC: required id_token missing from credentials")
+				}
+				// The ID token must be verified against the provider.
+				if _, err := o.Verify(ctx, val); err != nil {
+					return "", err
+				}
+				return val, nil
+			},
+			claims:   &idTokenClaims,
+			rawToken: &rawIDToken,
+		},
+		{
+			name:     "access_token",
+			required: authZEnabled,
+			getVerifiedToken: func() (string, error) {
+				val := credentials.AccessToken
+				if val == "" {
+					log.Ops.Warning(ctx, "OIDC: required access_token missing from credentials")
+					return "", errors.New("OIDC: required access_token missing from credentials")
+				}
+				return val, nil
+			},
+			claims:   &accessTokenClaims,
+			rawToken: &rawAccessToken,
+		},
 	}
 
-	idToken, err := o.Verify(ctx, rawIDToken)
-	if err != nil {
-		log.Errorf(ctx, "OIDC: unable to verify ID token: %v", err)
-		return nil, err
+	for _, tokenInfo := range tokensToProcess {
+		if !tokenInfo.required {
+			continue
+		}
+		var err error
+		*tokenInfo.rawToken, err = tokenInfo.getVerifiedToken()
+		if err != nil {
+			return nil, nil, "", "", errors.Wrapf(err, "OIDC: failed to verify %s", tokenInfo.name)
+		}
+		// Attempt to parse the token as a JWT to extract its claims.
+		// We keep this at INFO(1) because opaque tokens are normal for many IdPs;
+		// the message is useful for troubleshooting but not an operator-actionable error.
+		parsedToken, err := jwt.ParseInsecure([]byte(*tokenInfo.rawToken))
+		if err != nil {
+			log.VInfof(ctx, 1, "OIDC: could not parse %s as JWT (this is expected for opaque tokens): %v", tokenInfo.name, err)
+			continue // Not a JWT, so we can't get claims from it.
+		}
+
+		// Convert the jwt.Token into a map to extract all claims.
+		claimsMap, err := parsedToken.AsMap(ctx)
+		if err != nil {
+			return nil, nil, "", "", errors.Wrapf(err, "OIDC: failed to get claims as map from %s", tokenInfo.name)
+		}
+		// The claims map must be marshaled and unmarshaled to convert it to the desired type.
+		jsonBytes, err := json.Marshal(claimsMap)
+		if err != nil {
+			return nil, nil, "", "", errors.Wrapf(err, "OIDC: failed to marshal claims from %s", tokenInfo.name)
+		}
+		var claimsData map[string]json.RawMessage
+		if err := json.Unmarshal(jsonBytes, &claimsData); err != nil {
+			return nil, nil, "", "", errors.Wrapf(err, "OIDC: failed to deserialize claims from %s", tokenInfo.name)
+		}
+		*tokenInfo.claims = claimsData
 	}
 
-	var claims map[string]json.RawMessage
-	if err := idToken.Claims(&claims); err != nil {
-		log.Errorf(ctx, "OIDC: unable to deserialize token claims: %v", err)
-		return nil, err
-	}
-
-	return claims, nil
+	return idTokenClaims, accessTokenClaims, rawIDToken, rawAccessToken, nil
 }
 
 func (o *oidcManager) Verify(ctx context.Context, s string) (*oidc.IDToken, error) {
@@ -247,11 +323,17 @@ func (o oidcManager) AuthCodeURL(s string, option ...oauth2.AuthCodeOption) stri
 	return o.oauth2Config.AuthCodeURL(s, option...)
 }
 
+func (o *oidcManager) UserInfo(ctx context.Context, ts oauth2.TokenSource) (*oidc.UserInfo, error) {
+	octx := oidc.ClientContext(ctx, o.httpClient.Client)
+	return o.provider.UserInfo(octx, ts)
+}
+
 type IOIDCManager interface {
 	Verify(context.Context, string) (*oidc.IDToken, error)
 	Exchange(context.Context, string, ...oauth2.AuthCodeOption) (*oauth2.Token, error)
 	AuthCodeURL(string, ...oauth2.AuthCodeOption) string
-	ExchangeVerifyGetClaims(context.Context, string, string) (map[string]json.RawMessage, error)
+	ExchangeVerifyGetTokenInfo(context.Context, string, string, bool) (idTokenClaims, accessTokenClaims map[string]json.RawMessage, rawIDToken, rawAccessToken string, err error)
+	UserInfo(context.Context, oauth2.TokenSource) (*oidc.UserInfo, error)
 }
 
 var _ IOIDCManager = &oidcManager{}
@@ -291,6 +373,7 @@ var NewOIDCManager func(context.Context, oidcAuthenticationConf, string, []strin
 		verifier:     verifier,
 		oauth2Config: oauth2Config,
 		httpClient:   conf.httpClient,
+		provider:     provider,
 	}, nil
 }
 
@@ -337,6 +420,9 @@ func reloadConfigLocked(
 			httputil.WithDialerTimeout(clientTimeout),
 			httputil.WithCustomCAPEM(OIDCProviderCustomCA.Get(&st.SV)),
 		),
+		authZEnabled:     OIDCAuthZEnabled.Get(&st.SV),
+		groupClaim:       OIDCAuthGroupClaim.Get(&st.SV),
+		userinfoGroupKey: OIDCAuthUserinfoGroupKey.Get(&st.SV),
 	}
 
 	if !oidcAuthServer.conf.enabled && conf.enabled {
@@ -421,8 +507,11 @@ var ConfigureOIDC = func(
 	userLoginFromSSO func(ctx context.Context, username string) (*http.Cookie, error),
 	ambientCtx log.AmbientContext,
 	cluster uuid.UUID,
+	execCfg *sql.ExecutorConfig,
 ) (authserver.OIDC, error) {
-	oidcAuthentication := &oidcAuthenticationServer{}
+	oidcAuthentication := &oidcAuthenticationServer{
+		execCfg: execCfg,
+	}
 
 	// Don't want to use GRPC here since these endpoints require HTTP-Redirect behaviors and the
 	// callback endpoint will be receiving specialized parameters that grpc-gateway will only get
@@ -493,8 +582,11 @@ var ConfigureOIDC = func(
 			return
 		}
 
-		claims, err := oidcAuthentication.manager.ExchangeVerifyGetClaims(ctx, r.URL.Query().Get(codeKey), idTokenKey)
+		idTokenClaims, _, rawIDToken, rawAccessToken, err := oidcAuthentication.manager.
+			ExchangeVerifyGetTokenInfo(ctx, r.URL.Query().Get(codeKey), idTokenKey, oidcAuthentication.conf.authZEnabled)
+
 		if err != nil {
+			log.Errorf(ctx, "OIDC: failed to get and verify token: %v", err)
 			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
 			return
 		}
@@ -509,10 +601,17 @@ var ConfigureOIDC = func(
 		}
 
 		username, err := extractUsernameFromClaims(
-			ctx, claims, oidcAuthentication.conf.claimJSONKey, oidcAuthentication.conf.principalRegex,
+			ctx, idTokenClaims, oidcAuthentication.conf.claimJSONKey, oidcAuthentication.conf.principalRegex,
 		)
 		if err != nil {
 			http.Error(w, genericCallbackHTTPError, http.StatusInternalServerError)
+			return
+		}
+
+		// OIDC authorization
+		if err := oidcAuthentication.authorize(ctx, rawIDToken, rawAccessToken, username); err != nil {
+			log.Errorf(ctx, "OIDC authorization failed with error: %v", err)
+			http.Error(w, genericCallbackHTTPError, http.StatusForbidden)
 			return
 		}
 
@@ -705,7 +804,7 @@ var ConfigureOIDC = func(
 					}
 				} else {
 					log.Infof(ctx, "OIDC: no identity map found for issuer %s; using %s without mapping", token.Issuer, tokenPrincipal)
-					if username, err := username.MakeSQLUsernameFromUserInput(tokenPrincipal, username.PurposeValidation); err != nil {
+					if username, err := secuser.MakeSQLUsernameFromUserInput(tokenPrincipal, secuser.PurposeValidation); err != nil {
 						acceptedUsernames = append(acceptedUsernames, username.Normalized())
 					}
 				}
@@ -827,6 +926,15 @@ var ConfigureOIDC = func(
 		reloadConfig(ambientCtx.AnnotateCtx(ctx), oidcAuthentication, locality, st)
 	})
 	OIDCAuthClientTimeout.SetOnChange(&st.SV, func(ctx context.Context) {
+		reloadConfig(ambientCtx.AnnotateCtx(ctx), oidcAuthentication, locality, st)
+	})
+	OIDCAuthZEnabled.SetOnChange(&st.SV, func(ctx context.Context) {
+		reloadConfig(ambientCtx.AnnotateCtx(ctx), oidcAuthentication, locality, st)
+	})
+	OIDCAuthGroupClaim.SetOnChange(&st.SV, func(ctx context.Context) {
+		reloadConfig(ambientCtx.AnnotateCtx(ctx), oidcAuthentication, locality, st)
+	})
+	OIDCAuthUserinfoGroupKey.SetOnChange(&st.SV, func(ctx context.Context) {
 		reloadConfig(ambientCtx.AnnotateCtx(ctx), oidcAuthentication, locality, st)
 	})
 

--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -87,13 +87,21 @@ func (m mockOidcManager) AuthCodeURL(s string, option ...oauth2.AuthCodeOption) 
 	return m.oauth2Config.AuthCodeURL(s, option...)
 }
 
-func (m mockOidcManager) ExchangeVerifyGetClaims(
-	ctx context.Context, s string, s2 string,
-) (map[string]json.RawMessage, error) {
-	x := map[string]json.RawMessage{}
-	// The email is surrounded by double quotes because it's a serialized JSON string.
-	x["email"] = json.RawMessage([]byte(fmt.Sprintf(`"%s"`, m.claimEmail)))
-	return x, nil
+func (m mockOidcManager) ExchangeVerifyGetTokenInfo(
+	ctx context.Context, code, idTokenKey string, _ bool,
+) (map[string]json.RawMessage, map[string]json.RawMessage, string, string, error) {
+	claims := map[string]json.RawMessage{
+		"email": json.RawMessage(`"test@example.com"`),
+	}
+	// Return nil for access token claims, and the raw token strings.
+	return claims, nil, "dummy-id-token", "dummy-access-token", nil
+}
+
+func (m mockOidcManager) UserInfo(
+	ctx context.Context, ts oauth2.TokenSource,
+) (*oidc.UserInfo, error) {
+	// This mock is not used in this test file, so it can return nil.
+	return nil, nil
 }
 
 var _ IOIDCManager = &mockOidcManager{}

--- a/pkg/ccl/oidcccl/authorization_oidc.go
+++ b/pkg/ccl/oidcccl/authorization_oidc.go
@@ -1,0 +1,175 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package oidcccl
+
+import (
+	"context"
+	"slices"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/securityccl/jwthelper"
+	secuser "github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"golang.org/x/oauth2"
+)
+
+// authorize reconciles SQL role memberships for the given user after a
+// successful OIDC login.
+//
+// Called as a method on *oidcAuthenticationServer, it relies on the server’s
+// configuration (`conf`) and execCfg to:
+//
+//   - Discover which OIDC authorization sources are enabled.
+//   - Collect a "groups" claim from the ID token, the access token, or,
+//     when configured: the provider's /userinfo endpoint.
+//   - Convert the union of all group names into SQL roles and call
+//     sql.EnsureUserOnlyBelongsToRoles so the user’s memberships reflect
+//     the IdP state.
+//
+// Inputs:
+//
+//	ctx            – request context used for logging and database ops
+//	rawIDToken     – verified ID token string
+//	rawAccessToken – access token string (may be opaque)
+//	username       – SQL username extracted from the ID token
+//
+// Return value:
+//
+//	nil   – roles synced and authorization succeeded
+//	error – login must be denied; message explains whether no groups claim
+//	        was found, the list was empty, or a database/error occurred.
+//
+// The function is a no-op (returns nil) when
+// server.oidc_authentication.authorization.enabled is false, preserving the
+// legacy "authentication-only" behavior.
+func (oidcAuthentication *oidcAuthenticationServer) authorize(
+	ctx context.Context, rawIDToken string, rawAccessToken string, username string,
+) error {
+	if !oidcAuthentication.conf.authZEnabled {
+		return nil
+	}
+
+	// When cluster-level authorization is enabled we require an access token.
+	if rawAccessToken == "" {
+		log.Errorf(ctx, "OIDC: access_token missing while authorization is enabled")
+		return errors.New("OIDC: required access_token missing from credentials")
+	}
+
+	var groups []string
+	var err error
+
+	tokenSources := []struct{ raw, name string }{
+		{rawIDToken, "ID token"},
+		{rawAccessToken, "access token"},
+	}
+
+	for _, ts := range tokenSources {
+		if ts.raw == "" {
+			continue // Nothing to parse, this token was not sent
+		}
+
+		if tok, parseErr := jwt.ParseInsecure([]byte(ts.raw)); parseErr == nil {
+			claimGroups, err := jwthelper.ParseGroupsClaim(
+				tok,
+				oidcAuthentication.conf.groupClaim,
+			)
+			if err != nil {
+				// A malformed claim is a warning, but we can still fall back to
+				// the next token or to /userinfo.
+				log.Ops.Warningf(ctx,
+					"OIDC: failed to parse groups claim from %s, will try other sources: %v",
+					ts.name, err)
+				continue
+			}
+			groups = append(groups, claimGroups...)
+		} else {
+			// Parsing failed (for example, opaque access token).  This is a
+			// warning rather than an error because we can continue with other
+			// sources.  Use the OPS channel so operators notice repeated issues.
+			log.Ops.VWarningf(ctx, 1, "OIDC: failed to parse %s: %v", ts.name, parseErr)
+		}
+	}
+
+	// Remove case-insensitive duplicates
+	groups = slices.CompactFunc(groups, func(a, b string) bool {
+		return strings.EqualFold(a, b)
+	})
+
+	// If no groups in ID or access tokens, fall back to the userinfo endpoint
+	if groups == nil && oidcAuthentication.conf.userinfoGroupKey != "" {
+		// Re-create a minimal oauth2.Token for the UserInfo call.
+		oauthTok := &oauth2.Token{AccessToken: rawAccessToken}
+		userinfo, err := oidcAuthentication.manager.UserInfo(ctx, oauth2.StaticTokenSource(oauthTok))
+		if err != nil {
+			log.VErrorf(ctx, 1, "OIDC: failed to get userinfo for authorization: %v", err)
+		} else {
+			var userinfoJSON map[string]any
+			if err := userinfo.Claims(&userinfoJSON); err == nil {
+				if raw, ok := userinfoJSON[oidcAuthentication.conf.userinfoGroupKey]; ok {
+					synthetic := jwt.New()
+					if err := synthetic.Set(oidcAuthentication.conf.userinfoGroupKey, raw); err != nil {
+						log.VErrorf(ctx, 1, "OIDC: failed to set synthetic claim for authorization: %v", err)
+					}
+					groups, err = jwthelper.ParseGroupsClaim(
+						synthetic,
+						oidcAuthentication.conf.userinfoGroupKey,
+					)
+					if err != nil {
+						log.Ops.VWarningf(ctx, 1, "OIDC: failed to parse groups claim from userinfo: %v", err)
+					}
+				} else {
+					log.Ops.VWarningf(ctx, 1, "OIDC: userinfo response did not contain group key: %s", oidcAuthentication.conf.userinfoGroupKey)
+				}
+			} else {
+				log.Ops.VWarningf(ctx, 1, "OIDC: failed to parse userinfo claims: %v", err)
+			}
+		}
+	}
+
+	// Sync roles. An empty slice here means “explicitly no roles”, so we keep going.
+	sqlRoles := make([]secuser.SQLUsername, 0, len(groups))
+	for _, g := range groups {
+		role, err := secuser.MakeSQLUsernameFromUserInput(g, secuser.PurposeValidation)
+		if err != nil {
+			log.Ops.VWarningf(ctx, 1, "OIDC authorization: error finding matching SQL role for group %s: %v", g, err)
+			continue
+		}
+		sqlRoles = append(sqlRoles, role)
+	}
+
+	userSQL, err := secuser.MakeSQLUsernameFromUserInput(
+		username, secuser.PurposeValidation,
+	)
+	if err != nil {
+		return err
+	}
+
+	if err := sql.EnsureUserOnlyBelongsToRoles(
+		ctx, oidcAuthentication.execCfg, userSQL, sqlRoles,
+	); err != nil {
+		return err
+	}
+	// If no groups claim was ever found
+	// this is an authorization failure and the login must be denied
+	// after all roles are revoked
+	if groups == nil {
+		log.Errorf(ctx, "OIDC: unable to locate any groups claim for user %s", username)
+		return errors.Newf("OIDC: unable to complete authentication: no groups claim found for %s", username)
+	}
+
+	// As per policy, an empty list of groups is treated as
+	// an authorization failure and the login must be denied
+	// after all roles are revoked
+	if len(groups) == 0 {
+		log.Errorf(ctx, "OIDC: found empty list of groups for user %s", username)
+		return errors.Newf("OIDC: unable to complete authentication: groups list was empty for %s", username)
+	}
+
+	return nil
+}

--- a/pkg/ccl/oidcccl/authorization_oidc_test.go
+++ b/pkg/ccl/oidcccl/authorization_oidc_test.go
@@ -1,0 +1,700 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package oidcccl
+
+import (
+	"context"
+	"crypto/rand"
+	"crypto/rsa"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
+	"github.com/coreos/go-oidc"
+	"github.com/lestrrat-go/jwx/v2/jwa"
+	"github.com/lestrrat-go/jwx/v2/jwk"
+	"github.com/lestrrat-go/jwx/v2/jwt"
+	"github.com/stretchr/testify/require"
+	"golang.org/x/oauth2"
+)
+
+const (
+	testUser     = "test"
+	roleOwners   = "owners"
+	roleUsers    = "users"
+	roleAuditors = "auditors"
+)
+
+// makeJWT creates an RS256-signed JWT containing the supplied claims.
+func makeJWT(t *testing.T, claims map[string]any, key jwk.Key) string {
+	token := jwt.New()
+	for k, v := range claims {
+		require.NoError(t, token.Set(k, v))
+	}
+	// Sign with the private key
+	raw, err := jwt.Sign(token, jwt.WithKey(jwa.RS256, key))
+	require.NoError(t, err)
+	return string(raw)
+}
+
+// mockManager implements IOIDCManager.  Each instance returns whatever
+// raw ID token and OAuth2 token we injected when it was built.
+type mockManager struct {
+	cfg         *oauth2.Config
+	rawIDToken  string
+	accessToken string
+	email       string
+}
+
+func (m mockManager) Verify(context.Context, string) (*oidc.IDToken, error) { return nil, nil }
+func (m mockManager) Exchange(
+	context.Context, string, ...oauth2.AuthCodeOption,
+) (*oauth2.Token, error) {
+	return nil, nil
+}
+func (m mockManager) AuthCodeURL(state string, _ ...oauth2.AuthCodeOption) string {
+	return m.cfg.AuthCodeURL(state)
+}
+
+func (m mockManager) ExchangeVerifyGetTokenInfo(
+	ctx context.Context, _, _ string, _ bool,
+) (map[string]json.RawMessage, map[string]json.RawMessage, string, string, error) {
+	if m.rawIDToken == "" {
+		// The real implementation would fail to extract the ID token from the
+		// credentials and return an error.
+		return nil, nil, "", "", errors.New("OIDC: required id_token not found in credentials")
+	}
+
+	var idTokenClaims map[string]json.RawMessage
+	// The real implementation calls Verify, which will fail on a non-JWT token.
+	// For this test, we allow unparseable tokens to test the `authorize` function's
+	// handling of them. We still need to extract claims if possible for the
+	// `extractUsernameFromClaims` call that happens before `authorize`.
+	if tok, err := jwt.ParseInsecure([]byte(m.rawIDToken)); err == nil {
+		if claimsMap, err := tok.AsMap(ctx); err == nil {
+			if jsonBytes, err := json.Marshal(claimsMap); err == nil {
+				_ = json.Unmarshal(jsonBytes, &idTokenClaims)
+			}
+		}
+	}
+
+	// The email claim from the ID token is used to find the SQL user.
+	// The mock needs to ensure this claim is present for the login to proceed.
+	if idTokenClaims == nil {
+		idTokenClaims = make(map[string]json.RawMessage)
+	}
+	if _, ok := idTokenClaims["email"]; !ok {
+		idTokenClaims["email"] = json.RawMessage(`"` + m.email + `"`)
+	}
+
+	var accessTokenClaims map[string]json.RawMessage
+	if m.accessToken != "" {
+		if tok, err := jwt.ParseInsecure([]byte(m.accessToken)); err == nil {
+			if claimsMap, err := tok.AsMap(ctx); err == nil {
+				if jsonBytes, err := json.Marshal(claimsMap); err == nil {
+					_ = json.Unmarshal(jsonBytes, &accessTokenClaims)
+				}
+			}
+		}
+	}
+
+	return idTokenClaims, accessTokenClaims, m.rawIDToken, m.accessToken, nil
+}
+
+func (m mockManager) UserInfo(ctx context.Context, ts oauth2.TokenSource) (*oidc.UserInfo, error) {
+	// This mock is not intended to handle UserInfo calls. Returning an error
+	// prevents a nil pointer dereference in the calling code.
+	return nil, errors.New("UserInfo not implemented in this mock")
+}
+
+var _ IOIDCManager = (*mockManager)(nil)
+
+// TestOIDCAuthorization_TokenPaths exercises the public OIDC login and callback
+// handlers.  Each table entry spins up a fresh single-node server, injects a
+// different set of token claims, and verifies the resulting SQL role
+// memberships for the test user.
+func TestOIDCAuthorization_TokenPaths(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Create an RSA key pair for signing tokens.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	jwkKey, err := jwk.FromRaw(privateKey)
+	require.NoError(t, err)
+
+	// A helper to generate JWTs for tests that need them.
+	makeToken := func(groups []string) string {
+		claims := map[string]any{}
+		if groups != nil {
+			claims["groups"] = groups
+		}
+		return makeJWT(t, claims, jwkKey)
+	}
+
+	// Start a brand-new in-process node for this sub-test.
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	app := s.ApplicationLayer()
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// Create the user and any roles that might be granted.
+	sqlDB.Exec(t, `CREATE USER `+testUser)
+	sqlDB.Exec(t, `CREATE ROLE `+roleOwners)
+	sqlDB.Exec(t, `CREATE ROLE `+roleUsers)
+	sqlDB.Exec(t, `CREATE ROLE `+roleAuditors)
+
+	testCases := []struct {
+		name             string
+		idToken          string
+		accessToken      string
+		expectedRoles    []string
+		expectedStatus   int // 0 => default 307
+		wantErrSubstring string
+	}{
+		{
+			name:          "groups in ID token",
+			idToken:       makeToken([]string{roleOwners, roleUsers}),
+			accessToken:   makeToken(nil), // access token has no groups
+			expectedRoles: []string{roleOwners, roleUsers},
+		},
+		{
+			name:          "groups in access token only",
+			idToken:       makeToken(nil), // id token has no groups
+			accessToken:   makeToken([]string{roleOwners}),
+			expectedRoles: []string{roleOwners},
+		},
+		{
+			name:          "groups in both tokens (distinct sets)",
+			idToken:       makeToken([]string{roleOwners, roleAuditors}),
+			accessToken:   makeToken([]string{roleUsers}),
+			expectedRoles: []string{roleOwners, roleUsers, roleAuditors},
+		},
+		{
+			name:          "groups in both tokens (overlap)",
+			idToken:       makeToken([]string{roleOwners, roleUsers}),
+			accessToken:   makeToken([]string{roleUsers, roleAuditors}),
+			expectedRoles: []string{roleOwners, roleUsers, roleAuditors},
+		},
+		{
+			name:             "groups claim absent from both tokens",
+			idToken:          makeToken(nil),
+			accessToken:      makeToken(nil),
+			expectedRoles:    []string{},
+			expectedStatus:   http.StatusForbidden,
+			wantErrSubstring: "OIDC: unable to complete authentication",
+		},
+		{
+			name:             "empty groups list in ID token",
+			idToken:          makeToken([]string{}),
+			accessToken:      makeToken(nil),
+			expectedRoles:    []string{},
+			expectedStatus:   http.StatusForbidden,
+			wantErrSubstring: "OIDC: unable to complete authentication",
+		},
+		{
+			name:             "empty groups list in access token",
+			idToken:          makeToken(nil),
+			accessToken:      makeToken([]string{}),
+			expectedRoles:    []string{},
+			expectedStatus:   http.StatusForbidden,
+			wantErrSubstring: "OIDC: unable to complete authentication",
+		},
+		{
+			name:          "unparseable ID token, groups in access token",
+			idToken:       "this is not a jwt",
+			accessToken:   makeToken([]string{roleUsers}),
+			expectedRoles: []string{roleUsers},
+		},
+		{
+			name:          "groups in ID token, unparseable access token",
+			idToken:       makeToken([]string{roleOwners}),
+			accessToken:   "this is not a jwt either",
+			expectedRoles: []string{roleOwners},
+		},
+		{
+			name:             "unparseable tokens, no groups",
+			idToken:          "foo",
+			accessToken:      "bar",
+			expectedRoles:    []string{},
+			expectedStatus:   http.StatusForbidden,
+			wantErrSubstring: "OIDC: unable to complete authentication",
+		},
+		{
+			name:             "missing ID token",
+			idToken:          "",
+			accessToken:      "does not matter",
+			expectedRoles:    []string{},
+			expectedStatus:   http.StatusInternalServerError,
+			wantErrSubstring: "OIDC: unable to complete authentication",
+		},
+		{
+			name:           "missing access token",
+			idToken:        makeToken([]string{roleOwners}),
+			accessToken:    "",
+			expectedRoles:  []string{},
+			expectedStatus: http.StatusForbidden,
+		},
+	}
+
+	for _, tc := range testCases {
+		tc := tc // capture loop var
+		t.Run(tc.name, func(t *testing.T) {
+			// Replace the factory so that the server uses our mock manager.
+			origFactory := NewOIDCManager
+			t.Cleanup(func() { NewOIDCManager = origFactory })
+			NewOIDCManager = func(_ context.Context, conf oidcAuthenticationConf,
+				redirectURL string, scopes []string) (IOIDCManager, error) {
+
+				cfg := &oauth2.Config{
+					ClientID:     conf.clientID,
+					ClientSecret: conf.clientSecret,
+					RedirectURL:  redirectURL,
+					Endpoint:     oauth2.Endpoint{AuthURL: "https://provider.example.com/auth"},
+					Scopes:       scopes,
+				}
+				return &mockManager{
+					cfg:         cfg,
+					rawIDToken:  tc.idToken,
+					accessToken: tc.accessToken,
+					email:       testUser + "@example.com",
+				}, nil
+			}
+
+			// Enable OIDC plus authorization.
+			st := s.ClusterSettings()
+
+			// Make the issuer unique to prevent race conditions in parallel tests
+			uniq := strings.ReplaceAll(tc.name, " ", "_")
+			OIDCProviderURL.Override(ctx, &st.SV,
+				fmt.Sprintf("https://provider.example.com/%s", uniq))
+			OIDCClientID.Override(ctx, &st.SV, "client")
+			OIDCClientSecret.Override(ctx, &st.SV, "secret")
+			OIDCRedirectURL.Override(ctx, &st.SV, "https://cockroachlabs.com/oidc/v1/callback")
+			OIDCClaimJSONKey.Override(ctx, &st.SV, "email")
+			OIDCPrincipalRegex.Override(ctx, &st.SV, "^([^@]+)@[^@]+$")
+			OIDCEnabled.Override(ctx, &st.SV, true)
+			OIDCAuthZEnabled.Override(ctx, &st.SV, true)
+			OIDCAuthGroupClaim.Override(ctx, &st.SV, "groups")
+
+			// Build an HTTP client that trusts the node certificates.
+			rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
+			client, err := rpcCtx.GetHTTPClient()
+			require.NoError(t, err)
+			// Prevent automatic redirects so we can capture cookies and headers.
+			client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+			// Step 1: hit /oidc/v1/login and capture the state cookie.
+			resp, err := client.Get(app.AdminURL().WithPath("/oidc/v1/login").String())
+			require.NoError(t, err)
+			require.Equal(t, http.StatusFound, resp.StatusCode)
+
+			stateCookie := resp.Cookies()[0]
+			loc, err := url.Parse(resp.Header.Get("Location"))
+			require.NoError(t, err)
+			state := loc.Query().Get("state")
+
+			// Step 2: simulate the IdP redirect to /oidc/v1/callback.
+			cbReq, _ := http.NewRequest("GET",
+				app.AdminURL().WithPath("/oidc/v1/callback").String(), nil)
+			cbReq.AddCookie(stateCookie)
+			q := cbReq.URL.Query()
+			q.Set("state", state)
+			q.Set("code", "dummy")
+			cbReq.URL.RawQuery = q.Encode()
+
+			cbResp, err := client.Do(cbReq)
+			require.NoError(t, err)
+
+			expStatus := tc.expectedStatus
+			if expStatus == 0 {
+				expStatus = http.StatusTemporaryRedirect
+			}
+			require.Equal(t, expStatus, cbResp.StatusCode)
+
+			if tc.wantErrSubstring != "" {
+				body, _ := io.ReadAll(cbResp.Body)
+				require.Contains(t, string(body), tc.wantErrSubstring)
+			}
+
+			// Check which SQL roles were granted to the user.
+			rows := sqlDB.QueryStr(t,
+				`SELECT role FROM system.role_members WHERE member = $1 ORDER BY role`, testUser)
+			actualRoles := make([]string, len(rows))
+			for i, r := range rows {
+				actualRoles[i] = r[0]
+			}
+			require.ElementsMatch(t, tc.expectedRoles, actualRoles)
+		})
+	}
+}
+
+// TestOIDCAuthorization_UserinfoPaths exercises the fallback that fetches the
+// groups list from the provider's /userinfo endpoint when the ID token and
+// access token contain no usable claim.
+func TestOIDCAuthorization_UserinfoPaths(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type tc struct {
+		name           string
+		discoveryDoc   string
+		userinfoStatus int
+		userinfoBody   string
+		wantRoles      []string // nil => expect 403
+		wantErr        bool
+	}
+
+	cases := []tc{
+		{
+			name: "userinfo success",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "userinfo_endpoint": "{{url}}/userinfo",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			userinfoStatus: http.StatusOK,
+			userinfoBody:   fmt.Sprintf(`{"groups":["%s","%s"]}`, roleOwners, roleUsers),
+			wantRoles:      []string{roleOwners, roleUsers},
+		},
+		{
+			name: "userinfo endpoint absent",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			// no userinfo: should end in forbidden
+			wantRoles: nil,
+			wantErr:   true,
+		},
+		{
+			name: "userinfo network error",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "userinfo_endpoint": "http://127.0.0.1:0/userinfo",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			wantRoles: nil,
+			wantErr:   true,
+		},
+		{
+			name: "userinfo empty groups list",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "userinfo_endpoint": "{{url}}/userinfo",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			userinfoStatus: http.StatusOK,
+			userinfoBody:   `{"groups":[]}`,
+			wantRoles:      nil, // Roles should be revoked, login denied.
+			wantErr:        true,
+		},
+		{
+			name: "userinfo non-standard body",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "userinfo_endpoint": "{{url}}/userinfo",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			userinfoStatus: http.StatusOK,
+			userinfoBody:   `this is not json`,
+			wantRoles:      nil,
+			wantErr:        true,
+		},
+		{
+			name: "userinfo missing groups claim",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "userinfo_endpoint": "{{url}}/userinfo",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			userinfoStatus: http.StatusOK,
+			userinfoBody:   `{"email":"test@example.com"}`,
+			wantRoles:      nil,
+			wantErr:        true,
+		},
+		{
+			name: "userinfo invalid groups claim",
+			discoveryDoc: `{
+			  "issuer": "{{url}}",
+			  "token_endpoint": "{{url}}/token",
+			  "userinfo_endpoint": "{{url}}/userinfo",
+			  "jwks_uri": "{{url}}/.well-known/jwks.json"
+			}`,
+			userinfoStatus: http.StatusOK,
+			userinfoBody:   `{"groups":not-a-list}`,
+			wantRoles:      nil,
+			wantErr:        true,
+		},
+	}
+
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.name, func(t *testing.T) {
+			ctx := context.Background()
+
+			// Create an RSA key pair for signing and verifying tokens.
+			privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+			require.NoError(t, err)
+			jwkKey, err := jwk.FromRaw(privateKey)
+			require.NoError(t, err)
+			_ = jwkKey.Set(jwk.KeyIDKey, "test-key-id")
+			_ = jwkKey.Set(jwk.AlgorithmKey, jwa.RS256)
+
+			// The public key is what the verifier will use.
+			publicKey, err := jwk.PublicKeyOf(jwkKey)
+			require.NoError(t, err)
+			jwks := jwk.NewSet()
+			_ = jwks.AddKey(publicKey)
+
+			var ts *httptest.Server
+			handler := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				switch r.URL.Path {
+				case "/.well-known/openid-configuration":
+					doc := strings.ReplaceAll(tc.discoveryDoc, "{{url}}", ts.URL)
+					_, _ = io.WriteString(w, doc)
+				case "/.well-known/jwks.json":
+					w.Header().Set("Content-Type", "application/json")
+					err := json.NewEncoder(w).Encode(jwks)
+					require.NoError(t, err)
+				case "/userinfo":
+					w.WriteHeader(tc.userinfoStatus)
+					_, _ = io.WriteString(w, tc.userinfoBody)
+				case "/token":
+					idTok := makeJWT(t, map[string]any{
+						"iss":   ts.URL, // issuer must match provider URL
+						"email": testUser + "@example.com",
+						"aud":   "client",
+						"exp":   time.Now().Add(time.Hour).Unix(),
+					}, jwkKey)
+					resp := `{
+					  "access_token":"dummy-access",
+					  "id_token":"` + idTok + `",
+					  "token_type":"Bearer",
+					  "expires_in":3600
+					}`
+					w.Header().Set("Content-Type", "application/json")
+					_, _ = io.WriteString(w, resp)
+				default:
+					http.NotFound(w, r)
+				}
+			})
+			ts = httptest.NewServer(handler)
+			defer ts.Close()
+
+			s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+			defer s.Stopper().Stop(ctx)
+			app := s.ApplicationLayer()
+			sqlDB := sqlutils.MakeSQLRunner(db)
+			sqlDB.Exec(t, `CREATE USER `+testUser)
+			sqlDB.Exec(t, `CREATE ROLE `+roleOwners)
+			sqlDB.Exec(t, `CREATE ROLE `+roleUsers)
+			sqlDB.Exec(t, `CREATE ROLE `+roleAuditors)
+
+			st := s.ClusterSettings()
+			OIDCProviderURL.Override(ctx, &st.SV, ts.URL)
+			OIDCClientID.Override(ctx, &st.SV, "client")
+			OIDCClientSecret.Override(ctx, &st.SV, "secret")
+			OIDCRedirectURL.Override(ctx, &st.SV, ts.URL+"/callback")
+			OIDCClaimJSONKey.Override(ctx, &st.SV, "email")
+			OIDCPrincipalRegex.Override(ctx, &st.SV, "^([^@]+)@.*$")
+			OIDCEnabled.Override(ctx, &st.SV, true)
+			OIDCAuthZEnabled.Override(ctx, &st.SV, true)
+			OIDCAuthGroupClaim.Override(ctx, &st.SV, "groups")
+			OIDCAuthUserinfoGroupKey.Override(ctx, &st.SV, "groups")
+
+			rpc := app.NewClientRPCContext(ctx, username.TestUserName())
+			cl, err := rpc.GetHTTPClient()
+			require.NoError(t, err)
+			cl.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+			resp, err := cl.Get(app.AdminURL().WithPath("/oidc/v1/login").String())
+			require.NoError(t, err)
+			cookie := resp.Cookies()[0]
+			loc, _ := url.Parse(resp.Header.Get("Location"))
+			state := loc.Query().Get("state")
+
+			cb, _ := http.NewRequest("GET", app.AdminURL().WithPath("/oidc/v1/callback").String(), nil)
+			cb.AddCookie(cookie)
+			q := cb.URL.Query()
+			q.Set("state", state)
+			q.Set("code", "dummy")
+			cb.URL.RawQuery = q.Encode()
+			cbResp, err := cl.Do(cb)
+			require.NoError(t, err)
+
+			wantStatus := http.StatusTemporaryRedirect
+			if tc.wantErr {
+				// The two error cases should now result in a Forbidden, because the
+				// userinfo fallback will fail gracefully but no groups will be found.
+				wantStatus = http.StatusForbidden
+			}
+			require.Equal(t, wantStatus, cbResp.StatusCode)
+
+			rows := sqlDB.QueryStr(t, fmt.Sprintf(`SELECT role FROM system.role_members WHERE member = '%s' ORDER BY role`, testUser))
+			var got []string
+			for _, r := range rows {
+				got = append(got, r[0])
+			}
+			require.ElementsMatch(t, tc.wantRoles, got)
+		})
+	}
+}
+
+// TestOIDCAuthorization_RoleGrantAndRevoke tests that roles are granted and revoked as expected
+// after a successful OIDC login. This test is modeled after TestLDAPRolesAreGranted.
+func TestOIDCAuthorization_RoleGrantAndRevoke(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	// Create an RSA key pair for signing tokens.
+	privateKey, err := rsa.GenerateKey(rand.Reader, 2048)
+	require.NoError(t, err)
+	jwkKey, err := jwk.FromRaw(privateKey)
+	require.NoError(t, err)
+
+	// Start a brand-new in-process node for this sub-test.
+	s, db, _ := serverutils.StartServer(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+	app := s.ApplicationLayer()
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// Create the user and any roles that might be granted.
+	sqlDB.Exec(t, `CREATE USER `+testUser)
+	sqlDB.Exec(t, `CREATE ROLE `+roleOwners)
+	sqlDB.Exec(t, `CREATE ROLE `+roleUsers)
+	sqlDB.Exec(t, `CREATE ROLE `+roleAuditors)
+
+	// Replace the factory so that the server uses our mock manager.
+	origFactory := NewOIDCManager
+	t.Cleanup(func() { NewOIDCManager = origFactory })
+
+	// Helper to check role membership.
+	checkHasRole := func(t *testing.T, user, role string, shouldHave bool) {
+		var hasRole bool
+		sqlDB.QueryRow(t, fmt.Sprintf("SELECT pg_has_role('%s', '%s', 'MEMBER')", user, role)).Scan(&hasRole)
+		require.Equal(t, shouldHave, hasRole)
+	}
+
+	// A helper function to simulate an OIDC login and callback.
+	performOIDCLogin := func(t *testing.T, client *http.Client, claims map[string]any, expectedStatus int) {
+		NewOIDCManager = func(_ context.Context, conf oidcAuthenticationConf,
+			redirectURL string, scopes []string) (IOIDCManager, error) {
+
+			cfg := &oauth2.Config{
+				ClientID:     conf.clientID,
+				ClientSecret: conf.clientSecret,
+				RedirectURL:  redirectURL,
+				Endpoint:     oauth2.Endpoint{AuthURL: "https://provider.example.com/auth"},
+				Scopes:       scopes,
+			}
+			return &mockManager{
+				cfg:         cfg,
+				rawIDToken:  makeJWT(t, claims, jwkKey),
+				accessToken: makeJWT(t, nil, jwkKey),
+				email:       testUser + "@example.com",
+			}, nil
+		}
+
+		// Enable OIDC plus authorization.
+		st := s.ClusterSettings()
+		OIDCProviderURL.Override(ctx, &st.SV, fmt.Sprintf("https://provider.example.com/%s", t.Name()))
+		OIDCClientID.Override(ctx, &st.SV, "client")
+		OIDCClientSecret.Override(ctx, &st.SV, "secret")
+		OIDCRedirectURL.Override(ctx, &st.SV, "https://cockroachlabs.com/oidc/v1/callback")
+		OIDCClaimJSONKey.Override(ctx, &st.SV, "email")
+		OIDCPrincipalRegex.Override(ctx, &st.SV, "^([^@]+)@[^@]+$")
+		OIDCEnabled.Override(ctx, &st.SV, true)
+		OIDCAuthZEnabled.Override(ctx, &st.SV, true)
+		OIDCAuthGroupClaim.Override(ctx, &st.SV, "groups")
+
+		// Step 1: hit /oidc/v1/login and capture the state cookie.
+		resp, err := client.Get(app.AdminURL().WithPath("/oidc/v1/login").String())
+		require.NoError(t, err)
+		require.Equal(t, http.StatusFound, resp.StatusCode)
+
+		stateCookie := resp.Cookies()[0]
+		loc, err := url.Parse(resp.Header.Get("Location"))
+		require.NoError(t, err)
+		state := loc.Query().Get("state")
+
+		// Step 2: simulate the IdP redirect to /oidc/v1/callback.
+		cbReq, _ := http.NewRequest("GET",
+			app.AdminURL().WithPath("/oidc/v1/callback").String(), nil)
+		cbReq.AddCookie(stateCookie)
+		q := cbReq.URL.Query()
+		q.Set("state", state)
+		q.Set("code", "dummy")
+		cbReq.URL.RawQuery = q.Encode()
+
+		cbResp, err := client.Do(cbReq)
+		require.NoError(t, err)
+		require.Equal(t, expectedStatus, cbResp.StatusCode)
+	}
+
+	// Build an HTTP client that trusts the node certificates.
+	rpcCtx := app.NewClientRPCContext(ctx, username.TestUserName())
+	client, err := rpcCtx.GetHTTPClient()
+	require.NoError(t, err)
+	// Prevent automatic redirects so we can capture cookies and headers.
+	client.CheckRedirect = func(*http.Request, []*http.Request) error { return http.ErrUseLastResponse }
+
+	// Initially, the user should have no roles.
+	checkHasRole(t, testUser, roleOwners, false)
+	checkHasRole(t, testUser, roleUsers, false)
+
+	t.Run("grant one role", func(t *testing.T) {
+		claims := map[string]any{"groups": []string{roleOwners}}
+		performOIDCLogin(t, &client, claims, http.StatusTemporaryRedirect)
+		checkHasRole(t, testUser, roleOwners, true)
+		checkHasRole(t, testUser, roleUsers, false)
+	})
+
+	t.Run("grant another role", func(t *testing.T) {
+		claims := map[string]any{"groups": []string{roleOwners, roleUsers}}
+		performOIDCLogin(t, &client, claims, http.StatusTemporaryRedirect)
+		checkHasRole(t, testUser, roleOwners, true)
+		checkHasRole(t, testUser, roleUsers, true)
+	})
+
+	t.Run("revoke one role", func(t *testing.T) {
+		claims := map[string]any{"groups": []string{roleUsers}}
+		performOIDCLogin(t, &client, claims, http.StatusTemporaryRedirect)
+		checkHasRole(t, testUser, roleOwners, false)
+		checkHasRole(t, testUser, roleUsers, true)
+	})
+
+	t.Run("grant non-existent role", func(t *testing.T) {
+		claims := map[string]any{"groups": []string{roleUsers, "non_existent_role"}}
+		performOIDCLogin(t, &client, claims, http.StatusTemporaryRedirect)
+		// The non-existent role is skipped, should only have roleUsers
+		checkHasRole(t, testUser, roleUsers, true)
+		checkHasRole(t, testUser, roleOwners, false)
+	})
+}

--- a/pkg/ccl/oidcccl/settings.go
+++ b/pkg/ccl/oidcccl/settings.go
@@ -39,6 +39,9 @@ const (
 	OIDCGenerateClusterSSOTokenSQLPortSettingName  = baseOIDCSettingName + "generate_cluster_sso_token.sql_port"
 	oidcAuthClientTimeoutSettingName               = baseOIDCSettingName + "client.timeout"
 	oidcProviderCustomCASettingName                = baseOIDCSettingName + "provider.custom_ca"
+	OIDCAuthZEnabledSettingName                    = baseOIDCSettingName + "authorization.enabled"
+	OIDCAuthGroupClaimSettingName                  = baseOIDCSettingName + "group_claim"
+	OIDCAuthUserinfoGroupKeySettingName            = baseOIDCSettingName + "userinfo_group_key"
 )
 
 // OIDCEnabled enables or disabled OIDC login for the DB Console.
@@ -82,6 +85,33 @@ var OIDCAuthClientTimeout = settings.RegisterDurationSetting(
 		"(e.g. authorization code flow, etc.)",
 	15*time.Second,
 	settings.WithPublic,
+)
+
+// OIDCAuthZEnabled enables authorization for OIDC SSO.
+var OIDCAuthZEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	OIDCAuthZEnabledSettingName, // "server.oidc_authentication.authorization.enabled"
+	"enables role synchronization based on group claims in OIDC tokens",
+	false,
+)
+
+// OIDCAuthGroupClaim is the name of the OIDC claim that contains the groups
+var OIDCAuthGroupClaim = settings.RegisterStringSetting(
+	settings.ApplicationLevel,
+	OIDCAuthGroupClaimSettingName, // "server.oidc_authentication.group_claim"
+	"sets the name of the OIDC claim that contains groups used for authorization",
+	"groups",
+)
+
+// OIDCAuthUserinfoGroupKey is the name of the field in the userinfo response
+// which contains the groups
+// This is an optional fallback for when access_tokens that don't contain a
+// groups claim are used during OIDC auth.
+var OIDCAuthUserinfoGroupKey = settings.RegisterStringSetting(
+	settings.ApplicationLevel,
+	OIDCAuthUserinfoGroupKeySettingName, // "server.oidc_authentication.userinfo_group_key"
+	"sets the field name in userinfo JSON containing the groups claim for authorization",
+	"groups",
 )
 
 type redirectURLConf struct {

--- a/pkg/server/authserver/authentication.go
+++ b/pkg/server/authserver/authentication.go
@@ -102,6 +102,7 @@ var ConfigureOIDC = func(
 	userLoginFromSSO func(ctx context.Context, username string) (*http.Cookie, error),
 	ambientCtx log.AmbientContext,
 	cluster uuid.UUID,
+	execCfg *sql.ExecutorConfig,
 ) (OIDC, error) {
 	return &noOIDCConfigured{}, nil
 }

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2111,13 +2111,14 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 	// the cluster version from storage as the http auth server relies on
 	// the cluster version being initialized.
 	if err := s.http.setupRoutes(ctx,
-		s.authentication,  /* authnServer */
-		s.adminAuthzCheck, /* adminAuthzCheck */
-		s.recorder,        /* metricSource */
-		s.runtime,         /* runtimeStatsSampler */
-		gwMux,             /* handleRequestsUnauthenticated */
-		s.debug,           /* handleDebugUnauthenticated */
-		s.inspectzServer,  /* handleInspectzUnauthenticated */
+		s.sqlServer.ExecutorConfig(), /* execCfg */
+		s.authentication,             /* authnServer */
+		s.adminAuthzCheck,            /* adminAuthzCheck */
+		s.recorder,                   /* metricSource */
+		s.runtime,                    /* runtimeStatsSampler */
+		gwMux,                        /* handleRequestsUnauthenticated */
+		s.debug,                      /* handleDebugUnauthenticated */
+		s.inspectzServer,             /* handleInspectzUnauthenticated */
 		newAPIV2Server(ctx, &apiV2ServerOpts{
 			admin:            s.admin,
 			status:           s.status,

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -27,6 +27,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/srverrors"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/ts"
 	"github.com/cockroachdb/cockroach/pkg/ui"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -144,6 +145,7 @@ var virtualClustersHandler = http.HandlerFunc(func(w http.ResponseWriter, req *h
 
 func (s *httpServer) setupRoutes(
 	ctx context.Context,
+	execCfg *sql.ExecutorConfig,
 	authnServer authserver.Server,
 	adminAuthzCheck privchecker.CheckerForRPCHandlers,
 	metricSource metricMarshaler,
@@ -158,7 +160,7 @@ func (s *httpServer) setupRoutes(
 	// the system settings initialized for it to pick up from the oidcAuthenticationServer.
 	oidc, err := authserver.ConfigureOIDC(
 		ctx, s.cfg.Settings, s.cfg.Locality,
-		s.mux.Handle, authnServer.UserLoginFromSSO, s.cfg.AmbientCtx, s.cfg.ClusterIDContainer.Get(),
+		s.mux.Handle, authnServer.UserLoginFromSSO, s.cfg.AmbientCtx, s.cfg.ClusterIDContainer.Get(), execCfg,
 	)
 	if err != nil {
 		return err

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -825,12 +825,13 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 	// the cluster version from storage as the http auth server relies on
 	// the cluster version being initialized.
 	if err := s.http.setupRoutes(ctx,
-		s.authentication,  /* authnServer */
-		s.adminAuthzCheck, /* adminAuthzCheck */
-		s.recorder,        /* metricSource */
-		s.runtime,         /* runtimeStatsSampler */
-		gwMux,             /* handleRequestsUnauthenticated */
-		s.debug,           /* handleDebugUnauthenticated */
+		s.sqlServer.ExecutorConfig(), /* execCfg */
+		s.authentication,             /* authnServer */
+		s.adminAuthzCheck,            /* adminAuthzCheck */
+		s.recorder,                   /* metricSource */
+		s.runtime,                    /* runtimeStatsSampler */
+		gwMux,                        /* handleRequestsUnauthenticated */
+		s.debug,                      /* handleDebugUnauthenticated */
 		http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			apiutil.WriteJSONResponse(r.Context(), w, http.StatusNotImplemented, nil)
 		}),


### PR DESCRIPTION
Previously, the OIDC callback (`/oidc/v1/callback`) authenticated
Admin-UI users but did not reconcile their IdP groups with SQL roles.
This was inadequate because operators who already rely on automatic
GRANT/REVOKE for JWT and LDAP flows had no equivalent mechanism for
OIDC log-ins, leading to inconsistent privileges and manual role
management.
To address this, this patch introduces group-to-role synchronisation
for OIDC:

* Adds three cluster settings
  `server.oidc_authentication.authorization.enabled`,
  `server.oidc_authentication.group_claim`, and
  `server.oidc_authentication.userinfo_group_key`, mirroring the JWT
  knobs.
* Parses the configured claim from the verified ID-token (array or
  string), normalises, dedupes and sorts it.
* Falls back to the user-info endpoint when the claim is absent and a
  group key is configured.
* Converts groups to validated SQL usernames and invokes
  `EnsureUserOnlyBelongsToRoles`.
* Threads the node’s `*sql.ExecutorConfig` into the OIDC stack.

Epic: CRDB-48763
Fixes: CRDB-51161

Release note (security update): CockroachDB can now synchronise SQL
role membership from the groups claim provided by an OpenID Connect
(OIDC) Identity Provider when
`server.oidc_authentication.authorization.enabled = true`.
.
At login the DB Console gathers the `groups` claim from both the
verified ID token and, when available, the access token (if it is a
JWT).  Any groups found in either token are combined and
de-duplicated.  If no claim is present in either token, the server
will query the provider's `/userinfo` endpoint and extract groups from
there (using `server.oidc_authentication.userinfo_group_key`) as a
final fallback.
.
The resulting list of groups is normalised to SQL role names and
compared to the user’s current role memberships.  Any newly required
roles are GRANTed and any stale ones are REVOKEd, matching the
behaviour already available for JWT and LDAP-based role
synchronisation.