### PR TITLE
sql: Index routine virtual tables by routine IDs.

### DIFF
--- a/docs/generated/sql/bnf/show_create_stmt.bnf
+++ b/docs/generated/sql/bnf/show_create_stmt.bnf
@@ -3,3 +3,4 @@ show_create_stmt ::=
 	| 'SHOW' 'CREATE' 'ALL' 'SCHEMAS'
 	| 'SHOW' 'CREATE' 'ALL' 'TABLES'
 	| 'SHOW' 'CREATE' 'ALL' 'TYPES'
+	| 'SHOW' 'CREATE' 'ALL' 'ROUTINES'

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -855,6 +855,7 @@ show_create_stmt ::=
 	| 'SHOW' 'CREATE' 'ALL' 'SCHEMAS'
 	| 'SHOW' 'CREATE' 'ALL' 'TABLES'
 	| 'SHOW' 'CREATE' 'ALL' 'TYPES'
+	| 'SHOW' 'CREATE' 'ALL' 'ROUTINES'
 
 show_create_schedules_stmt ::=
 	'SHOW' 'CREATE' 'ALL' 'SCHEDULES'

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -1926,6 +1926,13 @@ func TestTenantLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestTenantLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestTenantLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -1938,6 +1938,13 @@ func TestReadCommittedLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestReadCommittedLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestReadCommittedLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -1924,6 +1924,13 @@ func TestRepeatableReadLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestRepeatableReadLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestRepeatableReadLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -74,6 +74,9 @@ func TryDelegate(
 	case *tree.ShowCreateAllTypes:
 		return d.delegateShowCreateAllTypes()
 
+	case *tree.ShowCreateAllRoutines:
+		return d.delegateShowCreateAllRoutines()
+
 	case *tree.ShowDatabaseIndexes:
 		return d.delegateShowDatabaseIndexes(t)
 

--- a/pkg/sql/delegate/show_function.go
+++ b/pkg/sql/delegate/show_function.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 	"github.com/cockroachdb/errors"
 )
 
@@ -84,4 +85,17 @@ AND %[1]s = %[4]s
 	fullQuery := fmt.Sprintf(query,
 		nameCol, tab, lexbase.EscapeSQLString(udfSchema), lexbase.EscapeSQLString(un.Parts[0]))
 	return d.parse(fullQuery)
+}
+
+func (d *delegator) delegateShowCreateAllRoutines() (tree.Statement, error) {
+	sqltelemetry.IncrementShowCounter(sqltelemetry.Create)
+
+	const showCreateAllRoutinesQuery = `SELECT crdb_internal.show_create_all_routines(%[1]s) AS create_statement;`
+	databaseLiteral := d.evalCtx.SessionData().Database
+
+	query := fmt.Sprintf(showCreateAllRoutinesQuery,
+		lexbase.EscapeSQLString(databaseLiteral),
+	)
+
+	return d.parse(query)
 }

--- a/pkg/sql/logictest/testdata/logic_test/show_create_all_routines
+++ b/pkg/sql/logictest/testdata/logic_test/show_create_all_routines
@@ -1,0 +1,164 @@
+statement ok
+CREATE DATABASE d
+
+statement ok
+USE d
+
+query T colnames
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+
+statement ok
+CREATE FUNCTION add_one(x INT) RETURNS INT AS 'SELECT x + 1' LANGUAGE SQL;
+
+query T colnames
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+CREATE FUNCTION public.add_one(x INT8)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF 
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+  SELECT x + 1;
+$$;
+
+statement ok
+CREATE OR REPLACE PROCEDURE double_triple(INOUT double INT, OUT triple INT)
+AS $$
+BEGIN
+  double := double * 2;
+  triple := double * 3;
+END;
+$$ LANGUAGE PLpgSQL;
+
+
+query T colnames,nosort
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+CREATE FUNCTION public.add_one(x INT8)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+  SELECT x + 1;
+$$;
+CREATE PROCEDURE public.double_triple(INOUT double INT8, OUT triple INT8)
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  BEGIN
+  double := double * 2;
+  triple := double * 3;
+  END;
+$$;
+
+statement ok
+CREATE FUNCTION add_one(x FLOAT) RETURNS FLOAT AS 'SELECT x + 1' LANGUAGE SQL;
+
+query T colnames,nosort
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+CREATE FUNCTION public.add_one(x INT8)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+  SELECT x + 1;
+$$;
+CREATE FUNCTION public.add_one(x FLOAT8)
+  RETURNS FLOAT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+  SELECT x + 1;
+$$;
+CREATE PROCEDURE public.double_triple(INOUT double INT8, OUT triple INT8)
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  BEGIN
+  double := double * 2;
+  triple := double * 3;
+  END;
+$$;
+
+
+#test dropping routines
+statement ok
+DROP FUNCTION add_one(x INT8);
+
+statement ok
+DROP FUNCTION add_one(x FLOAT8);
+
+query T colnames
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+CREATE PROCEDURE public.double_triple(INOUT double INT8, OUT triple INT8)
+  LANGUAGE plpgsql
+  SECURITY INVOKER
+  AS $$
+  BEGIN
+  double := double * 2;
+  triple := double * 3;
+  END;
+$$;
+
+statement ok
+DROP PROCEDURE double_triple;
+
+query T colnames
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+
+# test user defined schema
+statement ok
+CREATE SCHEMA s;
+
+statement ok
+CREATE FUNCTION add_one(x INT) RETURNS INT AS 'SELECT x + 1' LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION s.add_one(x INT) RETURNS INT AS 'SELECT x + 1' LANGUAGE SQL;
+
+query T colnames,nosort
+SHOW CREATE ALL ROUTINES;
+----
+create_statement
+CREATE FUNCTION public.add_one(x INT8)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+  SELECT x + 1;
+$$;
+CREATE FUNCTION s.add_one(x INT8)
+  RETURNS INT8
+  VOLATILE
+  NOT LEAKPROOF
+  CALLED ON NULL INPUT
+  LANGUAGE SQL
+  SECURITY INVOKER
+  AS $$
+  SELECT x + 1;
+$$;

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1900,6 +1900,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1900,6 +1900,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1914,6 +1914,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/sql/logictest/tests/local-legacy-schema-changer/generated_test.go
@@ -1872,6 +1872,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-24.3/generated_test.go
@@ -1816,6 +1816,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.1/generated_test.go
@@ -1830,6 +1830,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
@@ -1893,6 +1893,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-schema-locked/generated_test.go
+++ b/pkg/sql/logictest/tests/local-schema-locked/generated_test.go
@@ -1732,6 +1732,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -1914,6 +1914,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -2089,6 +2089,13 @@ func TestLogic_show_create(
 	runLogicTest(t, "show_create")
 }
 
+func TestLogic_show_create_all_routines(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "show_create_all_routines")
+}
+
 func TestLogic_show_create_all_schemas(
 	t *testing.T,
 ) {

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -9683,6 +9683,7 @@ show_transfer_stmt:
 // SHOW CREATE ALL SCHEMAS
 // SHOW CREATE ALL TABLES
 // SHOW CREATE ALL TYPES
+// SHOW CREATE ALL ROUTINES
 // %SeeAlso: WEBDOCS/show-create.html
 show_create_stmt:
   SHOW CREATE table_name opt_show_create_format_options
@@ -9767,6 +9768,10 @@ show_create_stmt:
 | SHOW CREATE ALL TYPES
   {
     $$.val = &tree.ShowCreateAllTypes{}
+  }
+| SHOW CREATE ALL ROUTINES
+  {
+    $$.val = &tree.ShowCreateAllRoutines{}
   }
 | SHOW CREATE error // SHOW HELP: SHOW CREATE
 

--- a/pkg/sql/parser/testdata/show_routines
+++ b/pkg/sql/parser/testdata/show_routines
@@ -45,3 +45,11 @@ SHOW PROCEDURES
 SHOW PROCEDURES -- fully parenthesized
 SHOW PROCEDURES -- literals removed
 SHOW PROCEDURES -- identifiers removed
+
+parse
+SHOW CREATE ALL ROUTINES
+----
+SHOW CREATE ALL ROUTINES
+SHOW CREATE ALL ROUTINES -- fully parenthesized
+SHOW CREATE ALL ROUTINES -- literals removed
+SHOW CREATE ALL ROUTINES -- identifiers removed

--- a/pkg/sql/sem/builtins/BUILD.bazel
+++ b/pkg/sql/sem/builtins/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "pgcrypto_builtins.go",
         "pgvector_builtins.go",
         "replication_builtins.go",
+        "show_create_all_routines_builtin.go",
         "show_create_all_schemas_builtin.go",
         "show_create_all_tables_builtin.go",
         "show_create_all_types_builtin.go",

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2662,6 +2662,7 @@ var builtinOidsArray = []string{
 	2699: `jsonb_path_match(target: jsonb, path: jsonpath) -> bool`,
 	2700: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb) -> bool`,
 	2701: `jsonb_path_match(target: jsonb, path: jsonpath, vars: jsonb, silent: bool) -> bool`,
+	2702: `crdb_internal.show_create_all_routines(database_name: string) -> string`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -589,6 +589,18 @@ The output can be used to recreate a database.'
 			volatility.Volatile,
 		),
 	),
+	"crdb_internal.show_create_all_routines": makeBuiltin(
+		tree.FunctionProperties{},
+		makeGeneratorOverload(
+			tree.ParamTypes{
+				{Name: "database_name", Typ: types.String},
+			},
+			showCreateAllRoutinesGeneratorType,
+			makeShowCreateAllRoutinesGenerator,
+			"Returns rows of CREATE FUNCTION statements for all functions in the specified database.",
+			volatility.Volatile,
+		),
+	),
 	"crdb_internal.decode_plan_gist": makeBuiltin(
 		tree.FunctionProperties{},
 		makeGeneratorOverload(
@@ -2817,6 +2829,7 @@ func (p *payloadsForTraceGenerator) Close(_ context.Context) {
 var showCreateAllSchemasGeneratorType = types.String
 var showCreateAllTypesGeneratorType = types.String
 var showCreateAllTablesGeneratorType = types.String
+var showCreateAllRoutinesGeneratorType = types.String
 
 // Phase is used to determine if CREATE statements or ALTER statements
 // are being generated for showCreateAllTables.
@@ -3139,6 +3152,98 @@ func makeShowCreateAllTypesGenerator(
 ) (eval.ValueGenerator, error) {
 	dbName := string(tree.MustBeDString(args[0]))
 	return &showCreateAllTypesGenerator{
+		evalPlanner: evalCtx.Planner,
+		dbName:      dbName,
+		acc:         evalCtx.Planner.Mon().MakeBoundAccount(),
+	}, nil
+}
+
+// ShowCreateAllRoutinesGenerator supports the execution of
+// crdb_internal.show_create_all_routines(dbName).
+type showCreateAllRoutinesGenerator struct {
+	evalPlanner  eval.Planner
+	txn          *kv.Txn
+	dbName       string
+	acc          mon.BoundAccount
+	functionIds  []int64
+	procedureIds []int64
+
+	// The following could be updated during the generator's lifecycle
+	// by calls to Next()
+	curr     tree.Datum
+	idxFuncs int
+	idxProcs int
+}
+
+// ResolvedType implements the eval.ValueGenerator interface.
+func (s *showCreateAllRoutinesGenerator) ResolvedType() *types.T {
+	return showCreateAllRoutinesGeneratorType
+}
+
+// Start implements the eval.ValueGenerator interface.
+func (s *showCreateAllRoutinesGenerator) Start(ctx context.Context, txn *kv.Txn) error {
+	functionIds, procedureIds, err := getRoutineCreateStatementIds(ctx, s.evalPlanner, txn, s.dbName, &s.acc)
+	if err != nil {
+		return err
+	}
+	s.functionIds = functionIds
+	s.procedureIds = procedureIds
+	s.txn = txn
+	s.idxFuncs = -1
+	s.idxProcs = -1
+
+	return nil
+}
+
+func (s *showCreateAllRoutinesGenerator) Next(ctx context.Context) (bool, error) {
+	s.idxFuncs++
+	if s.idxFuncs < len(s.functionIds) {
+		createStmt, err := getFunctionCreateStatement(
+			ctx, s.evalPlanner, s.txn, s.functionIds[s.idxFuncs], s.dbName,
+		)
+		if err != nil {
+			return false, err
+		}
+		createStmtStr := string(tree.MustBeDString(createStmt))
+		s.curr = tree.NewDString(createStmtStr + ";")
+		return true, nil
+	}
+
+	s.idxProcs++
+	if s.idxProcs < len(s.procedureIds) {
+		createStmt, err := getProcedureCreateStatement(
+			ctx, s.evalPlanner, s.txn, s.procedureIds[s.idxProcs], s.dbName,
+		)
+		if err != nil {
+			return false, err
+		}
+		createStmtStr := string(tree.MustBeDString(createStmt))
+		s.curr = tree.NewDString(createStmtStr + ";")
+		return true, nil
+	}
+
+	return false, nil
+}
+
+// Values implements the eval.ValueGenerator interface.
+func (s *showCreateAllRoutinesGenerator) Values() (tree.Datums, error) {
+	return tree.Datums{s.curr}, nil
+}
+
+// Close implements the eval.ValueGenerator interface.
+func (s *showCreateAllRoutinesGenerator) Close(ctx context.Context) {
+	s.acc.Close(ctx)
+}
+
+// makeShowCreateAllRoutinesGenerator creates a generator to support the
+// crdb_internal.show_create_all_routines(dbName) builtin.
+// We use the timestamp of when the generator is created as the
+// timestamp to pass to AS OF SYSTEM TIME for looking up the create routine
+func makeShowCreateAllRoutinesGenerator(
+	ctx context.Context, evalCtx *eval.Context, args tree.Datums,
+) (eval.ValueGenerator, error) {
+	dbName := string(tree.MustBeDString(args[0]))
+	return &showCreateAllRoutinesGenerator{
 		evalPlanner: evalCtx.Planner,
 		dbName:      dbName,
 		acc:         evalCtx.Planner.Mon().MakeBoundAccount(),

--- a/pkg/sql/sem/builtins/show_create_all_routines_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_routines_builtin.go
@@ -1,0 +1,136 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the LICENSE file.
+
+package builtins
+
+import (
+	"context"
+	"fmt"
+	"unsafe"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/sql/lexbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/util/mon"
+	"github.com/cockroachdb/errors"
+)
+
+// We must make two separate queries and get IDs separately for functions and procedures, as they exist on
+// separate internal virtual tables and this is a convenient way to get CREATE statements for all routines
+// from the same generator and command.
+func getRoutineCreateStatementIds(
+	ctx context.Context, evalPlanner eval.Planner, txn *kv.Txn, dbName string, acc *mon.BoundAccount,
+) (funcIDs []int64, procIDs []int64, retErr error) {
+	escapedDB := lexbase.EscapeSQLIdent(dbName)
+
+	funcsQuery := fmt.Sprintf(`
+		SELECT function_id
+		FROM %s.crdb_internal.create_function_statements
+		WHERE database_name = $1`, escapedDB)
+
+	procsQuery := fmt.Sprintf(`
+		SELECT procedure_id
+		FROM %s.crdb_internal.create_procedure_statements
+		WHERE database_name = $1`, escapedDB)
+
+	itFuncs, err := evalPlanner.QueryIteratorEx(
+		ctx,
+		"crdb_internal.show_create_all_routines",
+		sessiondata.NoSessionDataOverride,
+		funcsQuery,
+		dbName,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		retErr = errors.CombineErrors(retErr, itFuncs.Close())
+	}()
+
+	var ok bool
+	for ok, err = itFuncs.Next(ctx); ok; ok, err = itFuncs.Next(ctx) {
+		id := tree.MustBeDInt(itFuncs.Cur()[0])
+		funcIDs = append(funcIDs, int64(id))
+		if growErr := acc.Grow(ctx, int64(unsafe.Sizeof(id))); growErr != nil {
+			return nil, nil, growErr
+		}
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	itProcs, err := evalPlanner.QueryIteratorEx(
+		ctx,
+		"crdb_internal.show_create_all_routines",
+		sessiondata.NoSessionDataOverride,
+		procsQuery,
+		dbName,
+	)
+	if err != nil {
+		return nil, nil, err
+	}
+	defer func() {
+		retErr = errors.CombineErrors(retErr, itProcs.Close())
+	}()
+
+	for ok, err = itProcs.Next(ctx); ok; ok, err = itProcs.Next(ctx) {
+		id := tree.MustBeDInt(itProcs.Cur()[0])
+		procIDs = append(procIDs, int64(id))
+		if growErr := acc.Grow(ctx, int64(unsafe.Sizeof(id))); growErr != nil {
+			return nil, nil, growErr
+		}
+	}
+	if err != nil {
+		return nil, nil, err
+	}
+
+	return funcIDs, procIDs, nil
+}
+
+func getFunctionCreateStatement(
+	ctx context.Context, evalPlanner eval.Planner, txn *kv.Txn, id int64, dbName string,
+) (tree.Datum, error) {
+	query := fmt.Sprintf(`
+		SELECT create_statement
+		FROM %s.crdb_internal.create_function_statements
+		WHERE function_id = $1
+	`, lexbase.EscapeSQLIdent(dbName))
+	row, err := evalPlanner.QueryRowEx(
+		ctx,
+		"crdb_internal.show_create_all_routines",
+		sessiondata.NoSessionDataOverride,
+		query,
+		id,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return row[0], nil
+}
+
+func getProcedureCreateStatement(
+	ctx context.Context, evalPlanner eval.Planner, txn *kv.Txn, id int64, dbName string,
+) (tree.Datum, error) {
+	query := fmt.Sprintf(`
+		SELECT create_statement
+		FROM %s.crdb_internal.create_procedure_statements
+		WHERE procedure_id = $1
+	`, lexbase.EscapeSQLIdent(dbName))
+	row, err := evalPlanner.QueryRowEx(
+		ctx,
+		"crdb_internal.show_create_all_routines",
+		sessiondata.NoSessionDataOverride,
+		query,
+		id,
+	)
+
+	if err != nil {
+		return nil, err
+	}
+	return row[0], nil
+}

--- a/pkg/sql/sem/tree/show.go
+++ b/pkg/sql/sem/tree/show.go
@@ -867,6 +867,14 @@ func (node *ShowCreateAllTypes) Format(ctx *FmtCtx) {
 	ctx.WriteString("SHOW CREATE ALL TYPES")
 }
 
+// ShowCreateAllRoutines represents a SHOW CREATE ALL ROUTINES statement.
+type ShowCreateAllRoutines struct{}
+
+// Format implements the NodeFormatter interface.
+func (node *ShowCreateAllRoutines) Format(ctx *FmtCtx) {
+	ctx.WriteString("SHOW CREATE ALL ROUTINES")
+}
+
 // ShowCreateSchedules represents a SHOW CREATE SCHEDULE statement.
 type ShowCreateSchedules struct {
 	ScheduleID Expr

--- a/pkg/sql/sem/tree/stmt.go
+++ b/pkg/sql/sem/tree/stmt.go
@@ -1773,6 +1773,15 @@ func (*ShowCreateAllTypes) StatementType() StatementType { return TypeDML }
 func (*ShowCreateAllTypes) StatementTag() string { return "SHOW CREATE ALL TYPES" }
 
 // StatementReturnType implements the Statement interface.
+func (*ShowCreateAllRoutines) StatementReturnType() StatementReturnType { return Rows }
+
+// StatementType implements the Statement interface.
+func (*ShowCreateAllRoutines) StatementType() StatementType { return TypeDML }
+
+// StatementTag returns a short string identifying the type of statement.
+func (*ShowCreateAllRoutines) StatementTag() string { return "SHOW CREATE ALL ROUTINES" }
+
+// StatementReturnType implements the Statement interface.
 func (*ShowCreateSchedules) StatementReturnType() StatementReturnType { return Rows }
 
 // StatementType implements the Statement interface.
@@ -2616,6 +2625,7 @@ func (n *ShowCreate) String() string                          { return AsString(
 func (n *ShowCreateAllSchemas) String() string                { return AsString(n) }
 func (n *ShowCreateAllTables) String() string                 { return AsString(n) }
 func (n *ShowCreateAllTypes) String() string                  { return AsString(n) }
+func (n *ShowCreateAllRoutines) String() string               { return AsString(n) }
 func (n *ShowCreateSchedules) String() string                 { return AsString(n) }
 func (n *ShowDatabases) String() string                       { return AsString(n) }
 func (n *ShowDatabaseIndexes) String() string                 { return AsString(n) }


### PR DESCRIPTION
resolves #147659 

adds indexing by routine IDs to the `crdb_internal.create_function_statements` and `crdb_internal.create_function_statements` tables. This is important for efficiency of querying these tables by routine IDs, which is necessary for `SHOW CREATE` statements involving these tables.