### PR TITLE
roachprod: fix service registration for unregistered services

### DIFF
--- a/pkg/roachprod/install/BUILD.bazel
+++ b/pkg/roachprod/install/BUILD.bazel
@@ -71,6 +71,7 @@ go_test(
     embed = [":install"],
     deps = [
         "//pkg/roachprod/cloud",
+        "//pkg/roachprod/config",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",
         "//pkg/roachprod/vm/gce/testutils",
@@ -79,6 +80,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/randutil",
         "//pkg/util/retry",
+        "//pkg/util/syncutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -464,31 +464,24 @@ func (c *SyncedCluster) Stop(
 	// killProcesses indicates whether processed need to be stopped.
 	killProcesses := true
 
-	// Non system shared process virtual clusters don't get killed but are stopped via SQL.
-	// Figure out if the virtual cluster is one or not.
+	// For shared process secondary tenants, we just stop the service via SQL.
+	// Find out of this is a shared process secondary tenant.
 	if virtualClusterLabel != "" {
 		name, sqlInstance, err := VirtualClusterInfoFromLabel(virtualClusterLabel)
 		if err != nil {
 			return err
 		}
 
-		if name != SystemInterfaceName {
-			services, err := c.DiscoverServices(ctx, name, ServiceTypeSQL)
+		if !IsSystemInterface(name) {
+			isExternal, err := c.IsExternalService(ctx, name)
 			if err != nil {
 				return err
 			}
 
-			if len(services) == 0 {
-				return fmt.Errorf("no service for virtual cluster %q", virtualClusterName)
-			}
-
-			virtualClusterName = name
-			if services[0].ServiceMode == ServiceModeShared {
-				// For shared process virtual clusters, we just stop the service
-				// via SQL.
-				killProcesses = false
-			} else {
+			if isExternal {
 				virtualClusterDisplay = fmt.Sprintf(" virtual cluster %q, instance %d", virtualClusterName, sqlInstance)
+			} else {
+				killProcesses = false
 			}
 		}
 	}
@@ -2268,7 +2261,7 @@ func (c *SyncedCluster) pgurls(
 	}
 	m := make(map[Node]string, len(hosts))
 	for node, host := range hosts {
-		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
+		desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 		if err != nil {
 			return nil, err
 		}
@@ -2303,24 +2296,19 @@ func (c *SyncedCluster) loadBalancerURL(
 	sqlInstance int,
 	auth PGAuthMode,
 ) (string, error) {
-	services, err := c.DiscoverServices(ctx, virtualClusterName, ServiceTypeSQL)
+	// Note that it's possible for our service to not be running on the entire roachprod
+	// cluster, e.g. one of the nodes is a workload node, or we have a separate process
+	// virtual cluster running on a subset of nodes. We must search for our service on
+	// the entire cluster.
+	descs, err := c.ServiceDescriptors(ctx, c.Nodes, virtualClusterName, ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return "", err
 	}
-	port := config.DefaultSQLPort
-	serviceMode := ServiceModeExternal
-	for _, service := range services {
-		if service.VirtualClusterName == virtualClusterName && service.Instance == sqlInstance {
-			serviceMode = service.ServiceMode
-			port = service.Port
-			break
-		}
-	}
-	address, err := c.FindLoadBalancer(l, port)
+	address, err := c.FindLoadBalancer(l, descs[0].Port)
 	if err != nil {
 		return "", err
 	}
-	loadBalancerURL := c.NodeURL(address.IP, address.Port, virtualClusterName, serviceMode, auth, "" /* database */)
+	loadBalancerURL := c.NodeURL(address.IP, address.Port, virtualClusterName, descs[0].ServiceMode, auth, "" /* database */)
 	return loadBalancerURL, nil
 }
 
@@ -2725,7 +2713,7 @@ func (c *SyncedCluster) Reset(l *logger.Logger) error {
 		return nil
 	}
 
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	targetVMs := make(vm.List, len(nodes))
 	for idx, node := range nodes {
 		targetVMs[idx] = c.VMs[node-1]

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -70,6 +70,10 @@ type SyncedCluster struct {
 
 	// Nodes is used by most commands (e.g. Start, Stop, Monitor). It describes
 	// the list of nodes the operation pertains to.
+	//	$ roachprod create local -n 4
+	//	$ roachprod start local          # [1, 2, 3, 4]
+	//	$ roachprod start local:2-4      # [2, 3, 4]
+	//	$ roachprod start local:2,1,4    # [1, 2, 4]
 	Nodes Nodes
 
 	ClusterSettings
@@ -237,17 +241,6 @@ func (c *SyncedCluster) IsLocal() bool {
 
 func (c *SyncedCluster) localVMDir(n Node) string {
 	return local.VMDir(c.Name, int(n))
-}
-
-// TargetNodes is the fully expanded, ordered list of nodes that any given
-// roachprod command is intending to target.
-//
-//	$ roachprod create local -n 4
-//	$ roachprod start local          # [1, 2, 3, 4]
-//	$ roachprod start local:2-4      # [2, 3, 4]
-//	$ roachprod start local:2,1,4    # [1, 2, 4]
-func (c *SyncedCluster) TargetNodes() Nodes {
-	return append(Nodes{}, c.Nodes...)
 }
 
 // GetInternalIP returns the internal IP address of the specified node.

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -270,11 +270,18 @@ func (c *SyncedCluster) allowServiceRegistration() bool {
 	return true
 }
 
-// maybeRegisterServices registers the SQL and Admin UI DNS services
-// for the cluster if no previous services for the virtual or storage
-// cluster are found. Any ports specified in the startOpts are used
-// for the services. If no ports are specified, a search for open
-// ports will be performed and selected for use.
+// maybeRegisterServices registers the SQL and Admin UI DNS services for the cluster if necessary:
+//  1. The system interface is only registered if custom ports are passed in or if it
+//     is running in local mode. By default, the system interface is assumed to be
+//     running on the default ports.
+//  2. Separate process virtual clusters are always registered. They always run on non
+//     default ports as we assume those to be taken by the system interface.
+//  3. Shared-process virtual clusters do not register services, as they share the same
+//     ports as the system interface.
+//
+// If service registration is deemed necessary, ports will be selected in the following order:
+//  1. If the startOpts specify non-zero ports, they will be used.
+//  2. If no port is specified, a search for open ports will be performed and selected for use.
 func (c *SyncedCluster) maybeRegisterServices(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts, portFunc FindOpenPortsFunc,
 ) error {
@@ -286,14 +293,20 @@ func (c *SyncedCluster) maybeRegisterServices(
 	var servicesToRegister ServiceDescriptors
 	switch startOpts.Target {
 	case StartDefault:
-		startOpts.VirtualClusterName = SystemInterfaceName
-		// The system interface on the storage cluster is always regarded as an
-		// external service. Only non-system virtual clusters, running on the
-		// storage cluster, are regarded as shared services.
-		servicesToRegister, err = c.servicesWithOpenPortSelection(
-			ctx, l, startOpts, ServiceModeExternal, serviceMap, portFunc,
-		)
+		// The system interface is registered only when custom ports are specified or
+		// if it is a local cluster. Local clusters utilize non-default ports to prevent
+		// conflicts, which necessitates explicit service registration.
+		if startOpts.customPortsSpecified() || c.IsLocal() {
+			startOpts.VirtualClusterName = SystemInterfaceName
+			// The system interface is always regarded as a shared service, as it contains both a
+			// SQL and KV server.
+			servicesToRegister, err = c.servicesWithOpenPortSelection(
+				ctx, l, startOpts, ServiceModeShared, serviceMap, portFunc,
+			)
+		}
 	case StartServiceForVirtualCluster:
+		// Separate process virtual clusters are always external services,
+		// as they only contain a SQL server.
 		servicesToRegister, err = c.servicesWithOpenPortSelection(
 			ctx, l, startOpts, ServiceModeExternal, serviceMap, portFunc,
 		)
@@ -310,9 +323,9 @@ func (c *SyncedCluster) maybeRegisterServices(
 
 // servicesWithOpenPortSelection returns services to be registered for
 // cases where a new cockroach process is being instantiated and needs
-// to being to available ports. This happens when we start the system
-// interface process, or when we start SQL servers for separate
-// process virtual clusters.
+// to bind to available ports. This happens when we start the system
+// interface process, or when we start SQL servers for separate process
+// virtual clusters. If an existing service is found it is not registered again.
 func (c *SyncedCluster) servicesWithOpenPortSelection(
 	ctx context.Context,
 	l *logger.Logger,
@@ -379,6 +392,136 @@ func (c *SyncedCluster) servicesWithOpenPortSelection(
 	return servicesToRegister, nil
 }
 
+// IsExternalService is a helper that determines if a given virtual cluster
+// is an external service.
+func (c *SyncedCluster) IsExternalService(
+	ctx context.Context, virtualClusterName string,
+) (bool, error) {
+	if IsSystemInterface(virtualClusterName) {
+		return false, nil
+	}
+	services, err := c.discoverServices(ctx, virtualClusterName, ServiceTypeSQL)
+	if err != nil {
+		return false, err
+	}
+
+	// We only register services for external secondary tenants. If we find any
+	// results we know it must be one.
+	return len(services) > 0, nil
+}
+
+// defaultServiceDescriptors returns the default ports for a service type. This is
+// required for scenarios where the services were not registered with a DNS
+// provider (Google DNS). Currently, services will not be registered in the
+// following scenarios:
+//
+// 1. A system interface started with default ports. This is an optimisation
+// to avoid the overhead of registering services when starting a storage
+// cluster with default ports.
+// 2. Shared process virtual clusters. These are always started with the same
+// ports as the system interface, so we do not register them with DNS.
+// 2. Clusters not on GCP
+// 3. Clusters that specify a custom project.
+//
+// Note that because separate process virtual clusters require service registration,
+// there is no default port and only shared process services should call this.
+func defaultServiceDescriptors(
+	virtualClusterName string, nodes Nodes, serviceType ServiceType, sqlInstance int,
+) ServiceDescriptors {
+	var port int
+	switch serviceType {
+	case ServiceTypeSQL:
+		port = config.DefaultSQLPort
+	case ServiceTypeUI:
+		port = config.DefaultAdminUIPort
+	}
+	services := make(ServiceDescriptors, len(nodes))
+	for i, node := range nodes {
+		services[i] = ServiceDesc{
+			VirtualClusterName: virtualClusterName,
+			ServiceType:        serviceType,
+			ServiceMode:        ServiceModeShared,
+			Node:               node,
+			Port:               port,
+			Instance:           sqlInstance,
+		}
+	}
+	return services
+}
+
+// ServiceDescriptors returns the service descriptors for the given nodes and virtual
+// cluster. If no services are found, it returns a service descriptor with the default port
+// for the service type.
+func (c *SyncedCluster) ServiceDescriptors(
+	ctx context.Context,
+	nodes Nodes,
+	virtualClusterName string,
+	serviceType ServiceType,
+	sqlInstance int,
+) (ServiceDescriptors, error) {
+	// Not all virtual clusters are registered with DNS, so we must reconstruct our
+	// service descriptor based on the registration rules stated in maybeRegisterServices.
+	//
+	// We first try to discover a service for the virtual cluster name provided on the
+	// requested node. If we find a result, we are done.
+	services, err := c.discoverServices(
+		ctx, virtualClusterName, serviceType,
+		ServiceNodePredicate(nodes...), ServiceInstancePredicate(sqlInstance),
+	)
+	if err != nil {
+		return ServiceDescriptors{}, err
+	}
+	if len(services) > 0 {
+		return services, nil
+	}
+
+	// If we are looking for the system interface at this point, we know it must be using the default
+	// ports, or we would have found it above. Return the default fallback case.
+	if IsSystemInterface(virtualClusterName) {
+		return defaultServiceDescriptors(
+			virtualClusterName, nodes, serviceType, 0, /* sqlInstance */
+		), nil
+	}
+
+	// If we are looking for a secondary tenant, we know it must be a shared process tenant as all
+	// external process services are registered with DNS. Shared process secondary tenants resolve
+	// to the system interface, so we must attempt to discover that instead.
+	services, err = c.discoverServices(
+		ctx, SystemInterfaceName, serviceType, ServiceNodePredicate(nodes...),
+	)
+	if err != nil {
+		return ServiceDescriptors{}, err
+	}
+
+	// Update the system service to point to the virtual cluster requested.
+	for i := range services {
+		services[i].VirtualClusterName = virtualClusterName
+		services[i].Instance = sqlInstance
+	}
+
+	// If we still have not found a service at this point, it must be a shared process secondary
+	// tenant where the system interface is on the default ports.
+	if len(services) == 0 {
+		return defaultServiceDescriptors(
+			virtualClusterName, nodes, serviceType, sqlInstance,
+		), nil
+	}
+	return services, err
+}
+
+// ServiceDescriptor is a convenience wrapper for ServiceDescriptors that
+// returns only a single service.
+func (c *SyncedCluster) ServiceDescriptor(
+	ctx context.Context,
+	node Node,
+	virtualClusterName string,
+	serviceType ServiceType,
+	sqlInstance int,
+) (ServiceDesc, error) {
+	services, err := c.ServiceDescriptors(ctx, Nodes{node}, virtualClusterName, serviceType, sqlInstance)
+	return services[0], err
+}
+
 // Attempts to fetch the version of the cockroach binary on the first node.
 // N.B. For mixed-version clusters, it's the user's responsibility to start only the nodes of
 // the same version, at a time.
@@ -420,15 +563,9 @@ func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts S
 	}
 
 	if c.allowServiceRegistration() {
-		// Only register services when starting a virtual cluster, or using custom
-		// ports, or for local cluster port management to avoid collisions. The
-		// lookup logic will automatically fall back to the default ports if the
-		// service is not found (or has not been registered).
-		if startOpts.customPortsSpecified() || c.IsLocal() || startOpts.Target != StartDefault {
-			err := c.maybeRegisterServices(ctx, l, startOpts, c.FindOpenPorts)
-			if err != nil {
-				return err
-			}
+		err := c.maybeRegisterServices(ctx, l, startOpts, c.FindOpenPorts)
+		if err != nil {
+			return err
 		}
 	} else {
 		l.Printf(strings.Join([]string{
@@ -692,27 +829,15 @@ func (c *SyncedCluster) NodeURL(
 		v.Add("sslmode", "disable")
 	}
 
-	// The rules for when to include the `cluster` connection parameter
-	// are a little nuanced:
-	//
-	// Firstly, we only want to pass an explicit `cluster` name if the
-	// user provided one.
-	if virtualClusterName != "" &&
-		// If this is a shared service, we should always be passing the
-		// cluster connection parameter.
-		((serviceMode == ServiceModeShared) ||
-			// However, if this is an external process, this means that the
-			// service is either the system tenant, or a virtual cluster
-			// serviced by an external process. We only want to specify the
-			// `cluster` parameter in the former case, as SQL server
-			// processes don't support cluster selection. The main use-case
-			// for specifying the cluster parameter in this case would be in
-			// a shared-process deployment model where the default tenant is
-			// switched, and we want to connect to the system tenant
-			// directly.
-			(serviceMode == ServiceModeExternal && virtualClusterName == SystemInterfaceName)) {
-		v.Add("options", fmt.Sprintf("-ccluster=%s", virtualClusterName))
+	// We only want to pass an explicit `cluster` name if the user provided one.
+	if virtualClusterName != "" {
+		// We can only pass the cluster parameter for shared processes, as SQL server
+		// only processes don't support cluster selection.
+		if serviceMode == ServiceModeShared {
+			v.Add("options", fmt.Sprintf("-ccluster=%s", virtualClusterName))
+		}
 	}
+
 	u.RawQuery = v.Encode()
 	return "'" + u.String() + "'"
 }
@@ -721,7 +846,7 @@ func (c *SyncedCluster) NodeURL(
 func (c *SyncedCluster) NodePort(
 	ctx context.Context, node Node, virtualClusterName string, sqlInstance int,
 ) (int, error) {
-	desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
+	desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return 0, err
 	}
@@ -732,7 +857,7 @@ func (c *SyncedCluster) NodePort(
 func (c *SyncedCluster) NodeUIPort(
 	ctx context.Context, node Node, virtualClusterName string, sqlInstance int,
 ) (int, error) {
-	desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeUI, sqlInstance)
+	desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeUI, sqlInstance)
 	if err != nil {
 		return 0, err
 	}
@@ -757,7 +882,7 @@ func (c *SyncedCluster) ExecOrInteractiveSQL(
 	if len(c.Nodes) != 1 {
 		return fmt.Errorf("invalid number of nodes for interactive sql: %d", len(c.Nodes))
 	}
-	desc, err := c.DiscoverService(ctx, c.Nodes[0], virtualClusterName, ServiceTypeSQL, sqlInstance)
+	desc, err := c.ServiceDescriptor(ctx, c.Nodes[0], virtualClusterName, ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return err
 	}
@@ -784,7 +909,7 @@ func (c *SyncedCluster) ExecSQL(
 	display := fmt.Sprintf("%s: executing sql", c.Name)
 	results, _, err := c.ParallelE(ctx, l, WithNodes(nodes).WithDisplay(display).WithFailSlow(),
 		func(ctx context.Context, node Node) (*RunResultDetails, error) {
-			desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
+			desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeSQL, sqlInstance)
 			if err != nil {
 				return nil, err
 			}
@@ -1053,7 +1178,7 @@ func (c *SyncedCluster) generateStartArgs(
 	instance := startOpts.SQLInstance
 	var sqlPort int
 	if startOpts.Target == StartServiceForVirtualCluster {
-		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, instance)
+		desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeSQL, instance)
 		if err != nil {
 			return nil, err
 		}
@@ -1063,14 +1188,14 @@ func (c *SyncedCluster) generateStartArgs(
 		virtualClusterName = SystemInterfaceName
 		// System interface instance is always 0.
 		instance = 0
-		desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeSQL, instance)
+		desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeSQL, instance)
 		if err != nil {
 			return nil, err
 		}
 		sqlPort = desc.Port
 		args = append(args, fmt.Sprintf("--listen-addr=%s:%d", listenHost, sqlPort))
 	}
-	desc, err := c.DiscoverService(ctx, node, virtualClusterName, ServiceTypeUI, instance)
+	desc, err := c.ServiceDescriptor(ctx, node, virtualClusterName, ServiceTypeUI, instance)
 	if err != nil {
 		return nil, err
 	}
@@ -1093,7 +1218,7 @@ func (c *SyncedCluster) generateStartArgs(
 		joinTargets := startOpts.GetJoinTargets()
 		addresses := make([]string, len(joinTargets))
 		for i, joinNode := range startOpts.GetJoinTargets() {
-			desc, err := c.DiscoverService(ctx, joinNode, SystemInterfaceName, ServiceTypeSQL, 0)
+			desc, err := c.ServiceDescriptor(ctx, joinNode, SystemInterfaceName, ServiceTypeSQL, 0)
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -405,7 +405,7 @@ func (c *SyncedCluster) fetchVersion(
 // Starting the first node is special-cased quite a bit, it's used to distribute
 // certs, set cluster settings, and initialize the cluster. Also, if we're only
 // starting a single node in the cluster and it happens to be the "first" node
-// (node 1, as understood by SyncedCluster.TargetNodes), we use
+// (node 1, as understood by SyncedCluster.Nodes), we use
 // `start-single-node` (this was written to provide a short hand to start a
 // single node cluster with a replication factor of one).
 func (c *SyncedCluster) Start(ctx context.Context, l *logger.Logger, startOpts StartOpts) error {
@@ -1306,7 +1306,7 @@ func (c *SyncedCluster) createAdminUserForSecureCluster(
 	retryOpts := retry.Options{MaxRetries: 20}
 	if err := retryOpts.Do(ctx, func(ctx context.Context) error {
 		// We use the first node in the virtual cluster to create the user.
-		firstNode := c.TargetNodes()[0]
+		firstNode := c.Nodes[0]
 		results, err := c.ExecSQL(
 			ctx, l, Nodes{firstNode}, virtualClusterName, sqlInstance, AuthRootCert, "", /* database */
 			[]string{"-e", stmts})
@@ -1509,7 +1509,7 @@ func (c *SyncedCluster) distributeCerts(ctx context.Context, l *logger.Logger) e
 	if !c.Secure {
 		return nil
 	}
-	for _, node := range c.TargetNodes() {
+	for _, node := range c.Nodes {
 		if node == 1 {
 			return c.DistributeCerts(ctx, l, false)
 		}

--- a/pkg/roachprod/install/monitor.go
+++ b/pkg/roachprod/install/monitor.go
@@ -346,7 +346,7 @@ func (c *SyncedCluster) Monitor(
 ) chan NodeMonitorInfo {
 	ch := make(chan NodeMonitorInfo)
 
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	var wg sync.WaitGroup
 	monitorCtx, cancel := context.WithCancel(ctx)
 

--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -16,11 +16,13 @@ import (
 	"testing/quick"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod/cloud"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/config"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce/testutils"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/local"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/stretchr/testify/require"
 )
 
@@ -97,58 +99,185 @@ func TestServiceNameComponents(t *testing.T) {
 	require.Equal(t, ServiceTypeSQL, serviceType)
 }
 
-func TestMaybeRegisterServices(t *testing.T) {
+type serviceRegistryTest struct {
+	test         *testing.T
+	rng          *rand.Rand
+	provider     vm.DNSProvider
+	providerName string
+	mu           struct {
+		syncutil.Mutex
+		// Port selection is run in parallel on multiple nodes at once.
+		nextOpenPort int
+	}
+}
+
+func newServiceRegistryTest(
+	t *testing.T, rng *rand.Rand, provider vm.DNSProvider, providerName string,
+) serviceRegistryTest {
+	return serviceRegistryTest{
+		test:         t,
+		rng:          rng,
+		provider:     provider,
+		providerName: providerName,
+		mu: struct {
+			syncutil.Mutex
+			nextOpenPort int
+		}{
+			Mutex:        syncutil.Mutex{},
+			nextOpenPort: 500,
+		},
+	}
+}
+
+func (t *serviceRegistryTest) makeVM(clusterName string, i int) vm.VM {
+	return vm.VM{
+		Provider:    t.providerName,
+		DNSProvider: t.providerName,
+		PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), t.provider.Domain()),
+	}
+}
+
+func (t *serviceRegistryTest) newCluster(nodeCount int) *SyncedCluster {
+	clusterName := fmt.Sprintf("cluster-%d", t.rng.Uint32())
+	c := &SyncedCluster{
+		Cluster: cloud.Cluster{
+			Name: clusterName,
+		},
+	}
+	for i := 1; i <= nodeCount; i++ {
+		c.VMs = append(c.VMs, t.makeVM(c.Name, i))
+		c.Nodes = append(c.Nodes, Node(i))
+	}
+	return c
+}
+
+func (t *serviceRegistryTest) randomServiceType() ServiceType {
+	serviceTypes := []ServiceType{ServiceTypeSQL, ServiceTypeUI}
+	return serviceTypes[t.rng.Intn(len(serviceTypes))]
+}
+
+func (t *serviceRegistryTest) randomServiceMode() ServiceMode {
+	serviceModes := []ServiceMode{ServiceModeExternal, ServiceModeShared}
+	return serviceModes[t.rng.Intn(len(serviceModes))]
+}
+
+// randomStartTargets generates a random set of start targets for a cluster.
+// It attempts to mimic potential ways a cockroachdb cluster can be deployed:
+//  1. system-only: Only a single system tenant is started.
+//  2. shared-process: A single system tenant and shared process virtual cluster is started.
+//  3. separate-process: A system tenant is started, and multiple separate process virtual clusters
+//     may be started externally.
+func (t *serviceRegistryTest) randomStartTargets() []StartTarget {
+	// We must always need to start the system tenant.
+	targets := []StartTarget{StartDefault}
+	deploymentModes := []StartTarget{StartDefault, StartServiceForVirtualCluster, StartSharedProcessForVirtualCluster}
+	randomDeploymentMode := deploymentModes[t.rng.Intn(len(deploymentModes))]
+
+	switch randomDeploymentMode {
+	case StartDefault:
+		// System only deployment, we already added StartDefault above.
+	case StartSharedProcessForVirtualCluster:
+		targets = append(targets, randomDeploymentMode)
+	case StartServiceForVirtualCluster:
+		// We can start multiple separate process clusters on a single cluster.
+		numTenants := t.rng.Intn(5) + 1 // Randomly choose between 1 and 5 tenants.
+		for range numTenants {
+			targets = append(targets, StartServiceForVirtualCluster)
+		}
+	}
+
+	return targets
+}
+
+// portFunc returns the next open port. This is a much simplified version of
+// the actual portFunc used in real VMs. Notably it does not allow for the same
+// port to be reused across multiple nodes/clusters. This is done so we don't have
+// to keep track of a cluster to node mapping, which would overcomplicate things.
+func (t *serviceRegistryTest) portFunc(
+	ctx context.Context, l *logger.Logger, node Node, startPort, count int,
+) ([]int, error) {
+	ports := make([]int, count)
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	for i := 0; i < count; i++ {
+		ports[i] = t.mu.nextOpenPort + i
+	}
+	t.mu.nextOpenPort += count
+	return ports, nil
+}
+
+// randomPorts returns a pair of random ports used for service registration.
+func (t *serviceRegistryTest) randomPorts(target StartTarget, startPort int) (sql, adminUI int) {
+	// When starting a virtual cluster, the user can choose to:
+	//	1. Not specify any ports, in which case we use the default port selection method for the virtual cluster type.
+	//	2. Specify custom ports, which should be used. Note that there is a special case for the system tenant when
+	//	the custom ports are the same as the default ports. In this case we want to test that service registration
+	//	handles it as if they were unspecified (i.e. skips service registration).
+	type portSelectionMethod int
+	const (
+		UnspecifiedPorts portSelectionMethod = iota
+		CustomPorts
+		CustomDefaultPorts
+	)
+
+	methods := []portSelectionMethod{UnspecifiedPorts, CustomPorts, CustomDefaultPorts}
+	method := methods[t.rng.Intn(len(methods))]
+	switch method {
+	case UnspecifiedPorts:
+		return 0, 0
+	case CustomPorts:
+		return startPort, startPort + 1
+	case CustomDefaultPorts:
+		// This edge case only applies to the system tenant, so return the unspecified
+		// case for other targets.
+		if target == StartDefault {
+			return config.DefaultSQLPort, config.DefaultAdminUIPort
+		}
+		return 0, 0
+	default:
+		t.test.Fatalf("unexpected port selection method: %d", method)
+	}
+	return 0, 0
+}
+
+func (t *serviceRegistryTest) virtualClusterName(startTarget StartTarget) string {
+	switch startTarget {
+	case StartDefault:
+		return SystemInterfaceName
+	case StartServiceForVirtualCluster:
+		return fmt.Sprintf("separate-process-%s", randutil.RandString(t.rng, 10, randutil.PrintableKeyAlphabet))
+	case StartSharedProcessForVirtualCluster:
+		return fmt.Sprintf("shared-process-%s", randutil.RandString(t.rng, 10, randutil.PrintableKeyAlphabet))
+	}
+	return ""
+}
+
+// TestDuplicateServiceRegistration tests that registering the same services multiple times does not
+// create duplicate DNS records. servicesWithOpenPortSelection should find the service is already
+// registered and return 0 services to register.
+func TestDuplicateServiceRegistration(t *testing.T) {
 	ctx := context.Background()
 	rng, _ := randutil.NewTestRand()
 	dnsServer, dnsProvider, providerName := testutils.ProviderWithTestDNSServer(rng)
 
+	srt := newServiceRegistryTest(t, rng, dnsProvider, providerName)
+
 	// Create a cluster with 3 nodes.
-	makeVM := func(clusterName string, i int) vm.VM {
-		return vm.VM{
-			Provider:    providerName,
-			DNSProvider: providerName,
-			PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), dnsProvider.Domain()),
-		}
-	}
-	makeCluster := func() *SyncedCluster {
-		clusterName := fmt.Sprintf("cluster-%d", rng.Uint32())
-		c := &SyncedCluster{
-			Cluster: cloud.Cluster{
-				Name: clusterName,
-			},
-		}
-		nodeCount := 3
-		for i := 1; i <= nodeCount; i++ {
-			c.VMs = append(c.VMs, makeVM(c.Name, i))
-			c.Nodes = append(c.Nodes, Node(i))
-		}
-		return c
-	}
-
-	// Create a portFunc that returns a list of ports starting from 500.
-	portFunc := func(ctx context.Context, l *logger.Logger, node Node, startPort, count int) ([]int, error) {
-		ports := make([]int, count)
-		for i := 0; i < count; i++ {
-			ports[i] = 500 + i
-		}
-		return ports, nil
-	}
-
-	c := makeCluster()
+	c := srt.newCluster(3)
 	startOpts := StartOpts{
 		Target:      StartDefault,
 		AdminUIPort: 22222,
 	}
 
 	// Register services for the first time.
-	err := c.maybeRegisterServices(ctx, nilLogger(), startOpts, portFunc)
+	err := c.maybeRegisterServices(ctx, nilLogger(), startOpts, srt.portFunc)
 	require.NoError(t, err)
 
 	// Expect only 2 create calls to the DNS server, one for the SQL service and one for the AdminUI service.
 	require.Equal(t, 2, dnsServer.Metrics().CreateCalls)
 
 	// Register services again, this time no new services should be created, the existing services should be used.
-	err = c.maybeRegisterServices(ctx, nilLogger(), startOpts, portFunc)
+	err = c.maybeRegisterServices(ctx, nilLogger(), startOpts, srt.portFunc)
 	require.NoError(t, err)
 
 	// Expect the create call count to remain the same.
@@ -161,32 +290,11 @@ func TestMultipleRegistrations(t *testing.T) {
 	_, testDNS, providerName := testutils.ProviderWithTestDNSServer(rng)
 
 	generator := func(values []reflect.Value, rng *rand.Rand) {
-		makeVM := func(clusterName string, i int) vm.VM {
-			return vm.VM{
-				Provider:    providerName,
-				DNSProvider: providerName,
-				PublicDNS:   fmt.Sprintf("%s.%s", vm.Name(clusterName, i), testDNS.Domain()),
-			}
-		}
-		clusterName := fmt.Sprintf("cluster-%d", rng.Uint32())
-		c := &SyncedCluster{
-			Cluster: cloud.Cluster{
-				Name: clusterName,
-			},
-		}
+		srt := newServiceRegistryTest(t, rng, testDNS, providerName)
+
 		nodeCount := rng.Intn(5) + 3
-		for i := 1; i <= nodeCount; i++ {
-			c.VMs = append(c.VMs, makeVM(c.Name, i))
-			c.Nodes = append(c.Nodes, Node(i))
-		}
-		randomServiceType := func(rng *rand.Rand) ServiceType {
-			serviceTypes := []ServiceType{ServiceTypeSQL, ServiceTypeUI}
-			return serviceTypes[rng.Intn(len(serviceTypes))]
-		}
-		randomServiceMode := func(rng *rand.Rand) ServiceMode {
-			serviceModes := []ServiceMode{ServiceModeExternal, ServiceModeShared}
-			return serviceModes[rng.Intn(len(serviceModes))]
-		}
+		c := srt.newCluster(nodeCount)
+
 		randomServiceName := func(rng *rand.Rand) string {
 			return fmt.Sprintf("service-%d", rng.Intn(5))
 		}
@@ -210,8 +318,8 @@ func TestMultipleRegistrations(t *testing.T) {
 				// Duplicate services are allowed.
 				servicesToRegister[j] = append(servicesToRegister[j], ServiceDesc{
 					VirtualClusterName: serviceName,
-					ServiceType:        randomServiceType(rng),
-					ServiceMode:        randomServiceMode(rng),
+					ServiceType:        srt.randomServiceType(),
+					ServiceMode:        srt.randomServiceMode(),
 					Node:               Node(rng.Intn(len(c.Nodes)) + 1),
 					Port:               500 + rng.Intn(5),
 					Instance:           rng.Intn(2),
@@ -238,6 +346,127 @@ func TestMultipleRegistrations(t *testing.T) {
 
 	require.NoError(t, quick.Check(verify, &quick.Config{
 		MaxCount: 150,
+		Rand:     rng,
+		Values:   generator,
+	}))
+}
+
+// TestServiceDescriptors tests that we are able to find service descriptors for
+// both registered and unregistered services.
+//
+// The test repeatedly creates and registers cockroach clusters. A given cluster
+// can contain just the system interface, or potentially multiple secondary tenants
+// as well. It then attempts to retrieve service descriptors for each of the virtual
+// clusters in a given cluster. We then cross verify based on the start options
+// for each virtual cluster, that our service descriptors are as expected.
+func TestServiceDescriptors(t *testing.T) {
+	ctx := context.Background()
+	rng, _ := randutil.NewTestRand()
+	_, testDNS, providerName := testutils.ProviderWithTestDNSServer(rng)
+
+	srt := newServiceRegistryTest(t, rng, testDNS, providerName)
+	// We make some simplifications to the port selection logic for testing purposes.
+	// We don't bother keeping track of which ports are used by which cluster/node
+	// and instead just sequentially assign ports, e.g. the port 500 can be used once
+	// by every machine in a cluster, but we don't allow that. One side effect of this
+	// is that we will eventually run out of ports if we don't reset nextOpenPort
+	// between clusters.
+	resetPorts := func() {
+		srt.mu.Lock()
+		srt.mu.nextOpenPort = 500
+		srt.mu.Unlock()
+	}
+
+	// One invocation of generator will register a cluster with a random number of
+	// virtual clusters.
+	generator := func(values []reflect.Value, rng *rand.Rand) {
+		defer resetPorts()
+		nodeCount := rng.Intn(5) + 1
+		c := srt.newCluster(nodeCount)
+
+		startTargets := srt.randomStartTargets()
+
+		var opts []StartOpts
+
+		startPort := config.DefaultOpenPortStart
+		for _, target := range startTargets {
+			sqlPort, adminUIPort := srt.randomPorts(target, startPort)
+			startPort += 2
+			startOpts := StartOpts{
+				Target:             target,
+				SQLPort:            sqlPort,
+				AdminUIPort:        adminUIPort,
+				VirtualClusterName: srt.virtualClusterName(target),
+			}
+			require.NoError(t, c.maybeRegisterServices(ctx, nilLogger(), startOpts, srt.portFunc))
+			opts = append(opts, startOpts)
+		}
+
+		values[0] = reflect.ValueOf(c)
+		values[1] = reflect.ValueOf(opts)
+	}
+
+	verify := func(c *SyncedCluster, startOpts []StartOpts) bool {
+		var openPortsUsed int
+		for _, opts := range startOpts {
+			randomNode := Node(rng.Intn(len(c.Nodes)) + 1)
+			desc, err := c.ServiceDescriptor(ctx, randomNode, opts.VirtualClusterName, ServiceTypeSQL, 0)
+			require.NoError(t, err)
+			require.Equal(t, opts.VirtualClusterName, desc.VirtualClusterName)
+			require.Equal(t, ServiceTypeSQL, desc.ServiceType)
+			require.Equal(t, randomNode, desc.Node)
+			expectedServiceMode := ServiceModeShared
+			if opts.Target == StartServiceForVirtualCluster {
+				expectedServiceMode = ServiceModeExternal
+			}
+			require.Equal(t, expectedServiceMode, desc.ServiceMode)
+
+			// Assert that the port is as expected.
+			switch opts.Target {
+			case StartDefault:
+				switch opts.SQLPort {
+				case 0:
+					// System tenant with no custom ports should use the default SQL port.
+					require.Equal(t, config.DefaultSQLPort, desc.Port)
+				default:
+					// If a custom port is specified, we expect it to be used.
+					require.Equal(t, opts.SQLPort, desc.Port)
+				}
+			case StartServiceForVirtualCluster:
+				switch opts.SQLPort {
+				case 0:
+					// Separate process nodes should use the open port selection logic. The port selection
+					// logic is performed in parallel for each node, so we can at best assert that our port
+					// is within a given range.
+					expectedPortMin := 500 + openPortsUsed
+					openPortsUsed += 2 * len(c.Nodes)
+					expectedPortMax := 500 + openPortsUsed
+					require.GreaterOrEqual(t, desc.Port, expectedPortMin)
+					require.LessOrEqual(t, desc.Port, expectedPortMax)
+				default:
+					// If a custom port is specified, we expect it to be used.
+					require.Equal(t, opts.SQLPort, desc.Port)
+				}
+			case StartSharedProcessForVirtualCluster:
+				// A shared process virtual cluster resolves to the system tenant, so we have to cross
+				// validate our expected port with the system tenant's start options.
+				systemStartOpts := startOpts[0]
+				switch systemStartOpts.SQLPort {
+				case 0:
+					require.Equal(t, config.DefaultSQLPort, desc.Port)
+				default:
+					require.Equal(t, systemStartOpts.SQLPort, desc.Port)
+				}
+			}
+		}
+		return true
+	}
+
+	// The TestDNSServer finds records by iterating over all records and checking
+	// for any matches. Listing n records from a size m DNS server will take O(n*m) time,
+	// so we limit the number of iterations to 1000.
+	require.NoError(t, quick.Check(verify, &quick.Config{
+		MaxCount: 1000,
 		Rand:     rng,
 		Values:   generator,
 	}))

--- a/pkg/roachprod/install/services_test.go
+++ b/pkg/roachprod/install/services_test.go
@@ -72,7 +72,7 @@ func TestServicePorts(t *testing.T) {
 		Nodes: allNodes(2),
 	}
 
-	descriptors, err := c.DiscoverServices(context.Background(), "t1", ServiceTypeSQL, ServiceNodePredicate(c.Nodes...))
+	descriptors, err := c.discoverServices(context.Background(), "t1", ServiceTypeSQL, ServiceNodePredicate(c.Nodes...))
 	sort.Slice(descriptors, func(i, j int) bool {
 		return descriptors[i].Port < descriptors[j].Port
 	})

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -831,7 +831,7 @@ func updatePrometheusTargets(
 		wg.Add(1)
 		go func(nodeID int, v vm.VM) {
 			defer wg.Done()
-			desc, err := c.DiscoverService(ctx, install.Node(nodeID), "", install.ServiceTypeUI, 0)
+			desc, err := c.ServiceDescriptor(ctx, install.Node(nodeID), "", install.ServiceTypeUI, 0)
 			if err != nil {
 				l.Errorf("error getting the port for node %d: %v", nodeID, err)
 				return
@@ -1143,7 +1143,7 @@ func PgURL(
 
 	var urls []string
 	for i, ip := range ips {
-		desc, err := c.DiscoverService(ctx, nodes[i], opts.VirtualClusterName, install.ServiceTypeSQL, opts.SQLInstance)
+		desc, err := c.ServiceDescriptor(ctx, nodes[i], opts.VirtualClusterName, install.ServiceTypeSQL, opts.SQLInstance)
 		if err != nil {
 			return nil, err
 		}
@@ -1197,7 +1197,7 @@ func urlGenerator(
 		}
 		port := uConfig.port
 		if port == 0 {
-			desc, err := c.DiscoverService(
+			desc, err := c.ServiceDescriptor(
 				ctx, node, uConfig.virtualClusterName, install.ServiceTypeUI, uConfig.sqlInstance,
 			)
 			if err != nil {
@@ -2778,9 +2778,8 @@ func CreateLoadBalancer(
 	}
 
 	// Find the SQL ports for the service on all nodes.
-	services, err := c.DiscoverServices(
-		ctx, virtualClusterName, install.ServiceTypeSQL,
-		install.ServiceNodePredicate(c.Nodes...), install.ServiceInstancePredicate(sqlInstance),
+	services, err := c.ServiceDescriptors(
+		ctx, c.Nodes, virtualClusterName, install.ServiceTypeSQL, sqlInstance,
 	)
 	if err != nil {
 		return err
@@ -2841,8 +2840,7 @@ func LoadBalancerPgURL(
 		return "", err
 	}
 
-	services, err := c.DiscoverServices(ctx, opts.VirtualClusterName, install.ServiceTypeSQL,
-		install.ServiceInstancePredicate(opts.SQLInstance))
+	services, err := c.ServiceDescriptors(ctx, c.Nodes, opts.VirtualClusterName, install.ServiceTypeSQL, opts.SQLInstance)
 	if err != nil {
 		return "", err
 	}
@@ -2868,8 +2866,7 @@ func LoadBalancerIP(
 	if err != nil {
 		return "", err
 	}
-	services, err := c.DiscoverServices(ctx, virtualClusterName, install.ServiceTypeSQL,
-		install.ServiceInstancePredicate(sqlInstance))
+	services, err := c.ServiceDescriptors(ctx, c.Nodes, virtualClusterName, install.ServiceTypeSQL, sqlInstance)
 	if err != nil {
 		return "", err
 	}

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -433,7 +433,7 @@ func Run(
 	}
 	// If no nodes were specified, run on nodes derived from the clusterName.
 	if len(options.Nodes) == 0 {
-		options.Nodes = c.TargetNodes()
+		options.Nodes = c.Nodes
 	}
 
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
@@ -461,7 +461,7 @@ func RunWithDetails(
 	}
 	// If no nodes were specified, run on nodes derived from the clusterName.
 	if len(options.Nodes) == 0 {
-		options.Nodes = c.TargetNodes()
+		options.Nodes = c.Nodes
 	}
 	cmd := strings.TrimSpace(strings.Join(cmdArray, " "))
 	return c.RunWithDetails(ctx, l, options, TruncateString(cmd, 30), cmd)
@@ -557,7 +557,7 @@ func IP(l *logger.Logger, clusterName string, external bool) ([]string, error) {
 		return nil, err
 	}
 
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	ips := make([]string, len(nodes))
 
 	for i := 0; i < len(nodes); i++ {
@@ -1126,7 +1126,7 @@ func PgURL(
 	if err != nil {
 		return nil, err
 	}
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	ips := make([]string, len(nodes))
 	if opts.External {
 		for i := 0; i < len(nodes); i++ {
@@ -1262,7 +1262,7 @@ func AdminURL(
 		virtualClusterName: virtualClusterName,
 		sqlInstance:        sqlInstance,
 	}
-	return urlGenerator(ctx, c, l, c.TargetNodes(), uConfig)
+	return urlGenerator(ctx, c, l, c.Nodes, uConfig)
 }
 
 // SQLPorts finds the SQL ports for a cluster.
@@ -1350,7 +1350,7 @@ func Pprof(ctx context.Context, l *logger.Logger, clusterName string, opts Pprof
 
 	httpClient := httputil.NewClientWithTimeout(timeout)
 	startTime := timeutil.Now().Unix()
-	err = c.Parallel(ctx, l, install.WithNodes(c.TargetNodes()).WithDisplay(description),
+	err = c.Parallel(ctx, l, install.WithNodes(c.Nodes).WithDisplay(description),
 		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
 			res := &install.RunResultDetails{Node: node}
 			host := c.Host(node)
@@ -2131,7 +2131,7 @@ func CreateSnapshot(
 		return nil, err
 	}
 
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	nodesStatus, err := c.Status(ctx, l)
 
 	if err != nil {
@@ -2263,13 +2263,13 @@ func ApplySnapshots(
 		return err
 	}
 
-	if n := len(c.TargetNodes()); n != len(snapshots) {
+	if n := len(c.Nodes); n != len(snapshots) {
 		return fmt.Errorf("mismatched number of snapshots (%d) to node count (%d)", len(snapshots), n)
 		// TODO(irfansharif): Validate labels (version, instance types).
 	}
 
 	// Detach and delete existing volumes. This is destructive.
-	if err := c.Parallel(ctx, l, install.WithNodes(c.TargetNodes()),
+	if err := c.Parallel(ctx, l, install.WithNodes(c.Nodes),
 		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
 			res := &install.RunResultDetails{Node: node}
 
@@ -2294,7 +2294,7 @@ func ApplySnapshots(
 		return err
 	}
 
-	return c.Parallel(ctx, l, install.WithNodes(c.TargetNodes()),
+	return c.Parallel(ctx, l, install.WithNodes(c.Nodes),
 		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
 			res := &install.RunResultDetails{Node: node}
 
@@ -2406,7 +2406,7 @@ func StartJaeger(
 	// install from source or get linux binaries and start them
 	// with systemd. For now this just matches what we've been
 	// copy and pasting.
-	jaegerNode := c.TargetNodes()[len(c.TargetNodes())-1:]
+	jaegerNode := c.Nodes[len(c.Nodes)-1:]
 	err = install.InstallTool(ctx, l, c, jaegerNode, "docker", l.Stdout, l.Stderr)
 	if err != nil {
 		return err
@@ -2458,7 +2458,7 @@ func StopJaeger(ctx context.Context, l *logger.Logger, clusterName string) error
 	if err != nil {
 		return err
 	}
-	jaegerNode := c.TargetNodes()[len(c.TargetNodes())-1:]
+	jaegerNode := c.Nodes[len(c.Nodes)-1:]
 	stopCmd := fmt.Sprintf("docker stop %s", jaegerContainerName)
 	err = c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(jaegerNode), stopCmd, stopCmd)
 	if err != nil {
@@ -2477,7 +2477,7 @@ func JaegerURL(
 	if err != nil {
 		return "", err
 	}
-	jaegerNode := c.TargetNodes()[len(c.TargetNodes())-1:]
+	jaegerNode := c.Nodes[len(c.Nodes)-1:]
 	urls, err := urlGenerator(ctx, c, l, jaegerNode, urlConfig{
 		usePublicIP:   true,
 		openInBrowser: openInBrowser,
@@ -2619,7 +2619,7 @@ func StorageCollectionPerformAction(
 }
 
 func printNodeToVolumeMapping(c *install.SyncedCluster) {
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	for _, n := range nodes {
 		cVM := c.VMs[n-1]
 		for _, volume := range cVM.NonBootAttachedVolumes {
@@ -2633,7 +2633,7 @@ func printNodeToVolumeMapping(c *install.SyncedCluster) {
 func sendCaptureCommand(
 	ctx context.Context, l *logger.Logger, c *install.SyncedCluster, action string, captureDir string,
 ) error {
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	httpClient := httputil.NewClientWithTimeout(0 /* timeout: None */)
 	_, _, err := c.ParallelE(ctx, l, install.WithNodes(nodes).WithDisplay(fmt.Sprintf("Performing workload capture %s", action)),
 		func(ctx context.Context, node install.Node) (*install.RunResultDetails, error) {
@@ -2713,7 +2713,7 @@ func createAttachMountVolumes(
 	opts vm.VolumeCreateOpts,
 	mountDir string,
 ) error {
-	nodes := c.TargetNodes()
+	nodes := c.Nodes
 	for idx, n := range nodes {
 		curNode := nodes[idx : idx+1]
 
@@ -2780,7 +2780,7 @@ func CreateLoadBalancer(
 	// Find the SQL ports for the service on all nodes.
 	services, err := c.DiscoverServices(
 		ctx, virtualClusterName, install.ServiceTypeSQL,
-		install.ServiceNodePredicate(c.TargetNodes()...), install.ServiceInstancePredicate(sqlInstance),
+		install.ServiceNodePredicate(c.Nodes...), install.ServiceInstancePredicate(sqlInstance),
 	)
 	if err != nil {
 		return err
@@ -2909,7 +2909,7 @@ func Deploy(
 	}
 
 	stageDir := "stage-cockroach"
-	err = c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(c.TargetNodes()), "creating staging dir",
+	err = c.Run(ctx, l, l.Stdout, l.Stderr, install.WithNodes(c.Nodes), "creating staging dir",
 		fmt.Sprintf("rm -rf %[1]s && mkdir -p %[1]s", stageDir))
 	if err != nil {
 		return err
@@ -2919,7 +2919,7 @@ func Deploy(
 		if pathToBinary == "" {
 			return errors.Errorf("%s application requires a path to the binary", applicationName)
 		}
-		err = c.Put(ctx, l, c.TargetNodes(), pathToBinary, filepath.Join(stageDir, "cockroach"))
+		err = c.Put(ctx, l, c.Nodes, pathToBinary, filepath.Join(stageDir, "cockroach"))
 	} else {
 		err = Stage(ctx, l, clusterName, "", "", stageDir, applicationName, version)
 	}
@@ -2929,7 +2929,7 @@ func Deploy(
 	}
 
 	l.Printf("Performing rolling restart of %d nodes on %s", len(c.VMs), clusterName)
-	for _, node := range c.TargetNodes() {
+	for _, node := range c.Nodes {
 		curNode := []install.Node{node}
 
 		err = c.WithNodes(curNode).Stop(ctx, l, sig, wait, gracePeriod, "")


### PR DESCRIPTION
As of #125393, we no longer register all virtual clusters with DNS. This was an optimization made to reduce unnecessary DNS usage when there was only one tenant using the default ports. Specifically, we no longer register shared process tenants and system tenants using the default ports. 

However, some of the existing logic still assumes that registration happens for all virtual clusters. For example, `clusterSynced.Stop` errors out if a shared process virtual cluster is not registered, even though this is now the expected behavior.

This change:

1. Establishes that the `system interface` is a `shared-process service` as it contains both a KV and SQL server. Previously, a system tenant could be registered as either depending on if custom ports were used or not.
2. Renames `DiscoverService` to `ServiceDescriptor` to differentiate it from `DiscoverServices`. `DiscoverService` is a convenience function for `DiscoverServices` that returns just a single service. Importantly, it also implements fall back logic to handle when a service is not found which is necessary now that we no longer register all services. 
3. Renames `DiscoverServices` to `discoverServices`. Since this function does not implement fall back logic needed for correctness, it should not be used directly. All existing usage of `discoverServices` is refactored to use `ServiceDescriptor` instead.
4. Adds a unit test to ensure our new fall back logic behaves as expected.

Release note: none
Epic: none
Fixes: none