### PR TITLE
kvserver: fix data race in (*Replica).State

### DIFF
--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1931,13 +1931,14 @@ func (r *Replica) State(ctx context.Context) kvserverpb.RangeInfo {
 		slices.Sort(sl)
 		ri.PausedReplicas = sl
 	}
+	nodeID := r.shMu.state.Lease.Replica.NodeID
 	r.mu.RUnlock()
 	r.sideTransportClosedTimestamp.mu.Lock()
 	ri.ClosedTimestampSideTransportInfo.ReplicaClosed = r.sideTransportClosedTimestamp.mu.cur.ts
 	ri.ClosedTimestampSideTransportInfo.ReplicaLAI = r.sideTransportClosedTimestamp.mu.cur.lai
 	r.sideTransportClosedTimestamp.mu.Unlock()
 	centralClosed, centralLAI := r.store.cfg.ClosedTimestampReceiver.GetClosedTimestamp(
-		ctx, r.RangeID, r.shMu.state.Lease.Replica.NodeID)
+		ctx, r.RangeID, nodeID)
 	ri.ClosedTimestampSideTransportInfo.CentralClosed = centralClosed
 	ri.ClosedTimestampSideTransportInfo.CentralLAI = centralLAI
 	if err := r.breaker.Signal().Err(); err != nil {


### PR DESCRIPTION
We were mistakenly reading r.shMu.state.Lease.Replica.NodeID without holding neither the replica mutex nor raftMu.

Fixes: #147618

Release note: None