### PR TITLE
execversion: bump MinAccepted to 25_2

### DIFF
--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -18,7 +18,6 @@ import (
 	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/col/coldata"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvclient/rangecache"
@@ -444,18 +443,9 @@ func (dsp *DistSQLPlanner) setupFlows(
 	if len(statementSQL) > setupFlowRequestStmtMaxLength {
 		statementSQL = statementSQL[:setupFlowRequestStmtMaxLength]
 	}
-	var v execversion.V
-	switch {
-	case dsp.st.Version.IsActive(ctx, clusterversion.V25_2):
-		v = execversion.V25_2
-	case dsp.st.Version.IsActive(ctx, clusterversion.V25_1):
-		v = execversion.V25_1
-	default:
-		v = execversion.V24_3
-	}
 	setupReq := execinfrapb.SetupFlowRequest{
 		LeafTxnInputState: leafInputState,
-		Version:           v,
+		Version:           execversion.V25_2,
 		TraceKV:           recv.tracing.KVTracingEnabled(),
 		CollectStats:      planCtx.collectExecStats,
 		StatementSQL:      statementSQL,

--- a/pkg/sql/execversion/version.go
+++ b/pkg/sql/execversion/version.go
@@ -17,21 +17,13 @@ import (
 // consulting the cluster version.
 type V uint32
 
-// V24_3 is the exec version of all binaries of 24.3 and prior cockroach
-// versions.
-const V24_3 = V(71)
-
-// V25_1 is the exec version of all binaries of 25.1 cockroach versions. It can
-// only be used by the flows once the cluster has upgraded to 25.1.
-const V25_1 = V(72)
-
 // V25_2 is the exec version of all binaries of 25.2 cockroach versions. It can
 // only be used by the flows once the cluster has upgraded to 25.2.
 const V25_2 = V(73)
 
 // MinAccepted is the oldest version that the server is compatible with. A
 // server will not accept flows with older versions.
-const MinAccepted = V24_3
+const MinAccepted = V25_2
 
 // Latest is the latest exec version supported by this binary.
 const Latest = V25_2

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -66,7 +66,6 @@ go_library(
         "//pkg/sql/execinfra/execreleasable",
         "//pkg/sql/execinfrapb",
         "//pkg/sql/execstats",
-        "//pkg/sql/execversion",
         "//pkg/sql/inverted",
         "//pkg/sql/isql",
         "//pkg/sql/memsize",

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -7,7 +7,6 @@ package rowexec
 
 import (
 	"context"
-	"encoding/binary"
 	"math/rand"
 	"time"
 
@@ -16,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catenumpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/execversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/rowenc"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
@@ -35,12 +33,11 @@ import (
 
 // sketchInfo contains the specification and run-time state for each sketch.
 type sketchInfo struct {
-	spec                 execinfrapb.SketchSpec
-	sketch               *hyperloglog.Sketch
-	numNulls             int64
-	numRows              int64
-	size                 int64
-	legacyFingerprinting bool
+	spec     execinfrapb.SketchSpec
+	sketch   *hyperloglog.Sketch
+	numNulls int64
+	numRows  int64
+	size     int64
 }
 
 // A sampler processor returns a random sample of rows, as well as "global"
@@ -100,8 +97,6 @@ func newSamplerProcessor(
 	input execinfra.RowSource,
 	post *execinfrapb.PostProcessSpec,
 ) (*samplerProcessor, error) {
-	legacyFingerprinting := execversion.FromContext(ctx) < execversion.V25_2
-
 	// Limit the memory use by creating a child monitor with a hard limit.
 	// The processor will disable histogram collection if this limit is not
 	// enough.
@@ -128,11 +123,10 @@ func newSamplerProcessor(
 	var sampleCols intsets.Fast
 	for i := range spec.Sketches {
 		s.sketches[i] = sketchInfo{
-			spec:                 spec.Sketches[i],
-			sketch:               hyperloglog.New14(),
-			numNulls:             0,
-			numRows:              0,
-			legacyFingerprinting: legacyFingerprinting,
+			spec:     spec.Sketches[i],
+			sketch:   hyperloglog.New14(),
+			numNulls: 0,
+			numRows:  0,
 		}
 		if spec.Sketches[i].GenerateHistogram {
 			sampleCols.Add(int(spec.Sketches[i].Columns[0]))
@@ -499,10 +493,6 @@ func (s *samplerProcessor) DoesNotUseTxn() bool {
 func (s *sketchInfo) addRow(
 	ctx context.Context, row rowenc.EncDatumRow, typs []*types.T, buf *[]byte,
 ) (err error) {
-	if s.legacyFingerprinting {
-		return s.addRowLegacy(ctx, row, typs, buf)
-	}
-
 	s.numRows++
 	allNulls := true
 	*buf = (*buf)[:0]
@@ -607,89 +597,4 @@ func containsCollatedString(t *types.T) bool {
 		}
 	}
 	return false
-}
-
-// addRowLegacy adds a row to the sketch and updates row counts. This is the
-// legacy implementation from versions prior to 25.2.
-//
-// TODO(mgartner): Remove this once compatibility with 25.1 is no longer needed.
-func (s *sketchInfo) addRowLegacy(
-	ctx context.Context, row rowenc.EncDatumRow, typs []*types.T, buf *[]byte,
-) error {
-	var err error
-	s.numRows++
-
-	var col uint32
-	var useFastPath bool
-	if len(s.spec.Columns) == 1 {
-		col = s.spec.Columns[0]
-		if row[col].IsUnset() {
-			return errors.AssertionFailedf("unset datum: col=%d row=%s", col, row.String(typs))
-		}
-		isNull := row[col].IsNull()
-		useFastPath = typs[col].Family() == types.IntFamily && !isNull
-	}
-
-	if useFastPath {
-		// Fast path for integers.
-		// TODO(radu): make this more general.
-		val, err := row[col].GetInt()
-		if err != nil {
-			return err
-		}
-
-		if cap(*buf) < 8 {
-			*buf = make([]byte, 8)
-		} else {
-			*buf = (*buf)[:8]
-		}
-
-		s.size += int64(row[col].DiskSize())
-
-		// Note: this encoding is not identical with the one in the general path
-		// below, but it achieves the same thing (we want equal integers to
-		// encode to equal []bytes). The only caveat is that all samplers must
-		// use the same encodings, so changes will require a new SketchType to
-		// avoid problems during upgrade.
-		//
-		// We could use a more efficient hash function and use InsertHash, but
-		// it must be a very good hash function (HLL expects the hash values to
-		// be uniformly distributed in the 2^64 range). Experiments (on tpcc
-		// order_line) with simplistic functions yielded bad results.
-		binary.LittleEndian.PutUint64(*buf, uint64(val))
-		s.sketch.Insert(*buf)
-		return nil
-	}
-	isNull := true
-	*buf = (*buf)[:0]
-	for _, col := range s.spec.Columns {
-		// We pass nil DatumAlloc so that each datum allocation was independent
-		// (to prevent bounded memory leaks like we've seen in #136394).
-		// TODO(yuzefovich): the problem in that issue was that the same backing
-		// slice of datums was shared across rows, so if a single row was kept
-		// as a sample, it could keep many garbage alive. To go around that we
-		// simply disabled the batching. We could improve that behavior by using
-		// a DatumAlloc in which we set typeAllocSizes in such a way that all
-		// columns of the same type in a single row would be backed by a single
-		// slice allocation.
-		//
-		// We choose to not perform the memory accounting for possibly decoded
-		// tree.Datum because we will lose the references to row very soon.
-		*buf, err = row[col].Fingerprint(ctx, typs[col], nil /* da */, *buf, nil /* acc */)
-		if err != nil {
-			return err
-		}
-		if isNull {
-			if row[col].IsUnset() {
-				return errors.AssertionFailedf("unset datum: col=%d row=%s", col, row.String(typs))
-			}
-			isNull = row[col].IsNull()
-		}
-		s.size += int64(row[col].DiskSize())
-	}
-	if isNull {
-		s.numNulls++
-	}
-	s.sketch.Insert(*buf)
-	return nil
 }


### PR DESCRIPTION
We no longer need compatibility with 25.1 or prior releases.

Epic: None
Release note: None