### PR TITLE
eval: refactor builtins that access Context.Txn explicitly

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -507,7 +507,7 @@ func createChangefeedJobRecord(
 
 	if opts.HasEndTime() {
 		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(opts.GetEndTime())}
-		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context, asof.OptionAllowFutureTimestamp)
+		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context, p.Txn(), asof.OptionAllowFutureTimestamp)
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/ccl/changefeedccl/scheduled_changefeed.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed.go
@@ -410,7 +410,7 @@ func dryRunCreateChangefeed(
 	scheduleID jobspb.ScheduleID,
 	createChangefeedNode *tree.CreateChangefeed,
 ) error {
-	sp, err := p.ExtendedEvalContext().Txn.CreateSavepoint(ctx)
+	sp, err := p.Txn().CreateSavepoint(ctx)
 	if err != nil {
 		return err
 	}
@@ -430,7 +430,7 @@ func dryRunCreateChangefeed(
 		return invokeCreateChangefeed(ctx, changefeedFn)
 	}()
 
-	if rollbackErr := p.ExtendedEvalContext().Txn.RollbackToSavepoint(ctx, sp); rollbackErr != nil {
+	if rollbackErr := p.Txn().RollbackToSavepoint(ctx, sp); rollbackErr != nil {
 		if err != nil {
 			return errors.CombineErrors(rollbackErr, err)
 		}

--- a/pkg/crosscluster/logical/create_logical_replication_stmt.go
+++ b/pkg/crosscluster/logical/create_logical_replication_stmt.go
@@ -580,7 +580,7 @@ func evalLogicalReplicationOptions(
 			return nil, err
 		}
 		asOfClause := tree.AsOfClause{Expr: tree.NewStrVal(cursor)}
-		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context)
+		asOf, err := asof.Eval(ctx, asOfClause, p.SemaCtx(), &p.ExtendedEvalContext().Context, p.Txn())
 		if err != nil {
 			return nil, err
 		}

--- a/pkg/crosscluster/physical/alter_replication_job.go
+++ b/pkg/crosscluster/physical/alter_replication_job.go
@@ -171,8 +171,10 @@ func alterReplicationJobHook(
 				return nil, nil, false, errors.AssertionFailedf("unexpected nil cutover expression")
 			}
 
-			ct, err := asof.EvalSystemTimeExpr(ctx, evalCtx, p.SemaCtx(), alterTenantStmt.Cutover.Timestamp,
-				alterReplicationJobOp, asof.ReplicationCutover)
+			ct, err := asof.EvalSystemTimeExpr(
+				ctx, evalCtx, p.Txn(), p.SemaCtx(), alterTenantStmt.Cutover.Timestamp,
+				alterReplicationJobOp, asof.ReplicationCutover,
+			)
 			if err != nil {
 				return nil, nil, false, err
 			}

--- a/pkg/revert/alter_reset_tenant.go
+++ b/pkg/revert/alter_reset_tenant.go
@@ -32,8 +32,10 @@ func alterTenantResetHook(
 		return nil, nil, false, pgerror.Newf(pgcode.InsufficientPrivilege, "only the system tenant can alter tenant")
 	}
 
-	timestamp, err := asof.EvalSystemTimeExpr(ctx, &p.ExtendedEvalContext().Context, p.SemaCtx(), alterTenantStmt.Timestamp,
-		alterTenantResetOp, asof.ReplicationCutover)
+	timestamp, err := asof.EvalSystemTimeExpr(
+		ctx, &p.ExtendedEvalContext().Context, p.Txn(), p.SemaCtx(),
+		alterTenantStmt.Timestamp, alterTenantResetOp, asof.ReplicationCutover,
+	)
 	if err != nil {
 		return nil, nil, false, err
 	}

--- a/pkg/sql/apply_join.go
+++ b/pkg/sql/apply_join.go
@@ -133,7 +133,7 @@ func (a *applyJoinNode) Next(params runParams) (bool, error) {
 					break
 				}
 				// Compute join.
-				predMatched, err := a.pred.eval(params.ctx, params.EvalContext(), a.run.leftRow, rrow)
+				predMatched, err := a.pred.eval(params.ctx, params.EvalContext(), params.p.Txn(), a.run.leftRow, rrow)
 				if err != nil {
 					return false, err
 				}

--- a/pkg/sql/backfill.go
+++ b/pkg/sql/backfill.go
@@ -781,10 +781,6 @@ func (sc *SchemaChanger) validateConstraints(
 			desc := descI.(*tabledesc.Mutable)
 			// Each check operates at the historical timestamp.
 			return runHistoricalTxn(ctx, func(ctx context.Context, txn descs.Txn, evalCtx *extendedEvalContext) error {
-				// If the constraint is a check constraint that fails validation, we
-				// need a semaContext set up that can resolve types in order to pretty
-				// print the check expression back to the user.
-				evalCtx.Txn = txn.KV()
 				// Use the DistSQLTypeResolver because we need to resolve types by ID.
 				collection := evalCtx.Descs
 				resolver := descs.NewDistSQLTypeResolver(collection, txn.KV())

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -377,9 +377,9 @@ func (cb *ColumnBackfiller) RunColumnBackfillChunk(
 		// Evaluate the new values. This must be done separately for
 		// each row so as to handle impure functions correctly.
 		for j, e := range cb.updateExprs {
-			val, err := eval.Expr(ctx, cb.evalCtx, e)
+			val, err := eval.Expr(ctx, cb.evalCtx, e, nil /* optionalTxn */)
 			if err != nil {
-				if errors.Is(err, eval.ErrNilTxnInClusterContext) {
+				if errors.Is(err, eval.ErrNilTxnForBuiltin) {
 					// Cannot use expressions that depend on the transaction of the
 					// evaluation context as the default value for backfill.
 					return roachpb.Key{}, pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
@@ -1044,9 +1044,9 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 			if !ok {
 				continue
 			}
-			val, err := eval.Expr(ctx, ib.evalCtx, texpr)
+			val, err := eval.Expr(ctx, ib.evalCtx, texpr, nil /* optionalTxn */)
 			if err != nil {
-				if errors.Is(err, eval.ErrNilTxnInClusterContext) {
+				if errors.Is(err, eval.ErrNilTxnForBuiltin) {
 					// Cannot use expressions that depend on the transaction of the
 					// evaluation context as the default value for backfill.
 					err = pgerror.WithCandidateCode(err, pgcode.FeatureNotSupported)
@@ -1116,7 +1116,7 @@ func (ib *IndexBackfiller) BuildIndexEntriesChunk(
 				// predicate expression evaluates to true.
 				texpr := ib.predicates[idx.GetID()]
 
-				val, err := eval.Expr(ctx, ib.evalCtx, texpr)
+				val, err := eval.Expr(ctx, ib.evalCtx, texpr, nil /* optionalTxn */)
 				if err != nil {
 					return nil, nil, memUsedPerChunk, err
 				}

--- a/pkg/sql/colexec/builtin_funcs_test.go
+++ b/pkg/sql/colexec/builtin_funcs_test.go
@@ -228,7 +228,7 @@ func BenchmarkCompareSpecializedOperators(b *testing.B) {
 		OneInputHelper:      colexecop.MakeOneInputHelper(source),
 		allocator:           testAllocator,
 		evalCtx:             evalCtx,
-		funcExpr:            typedExpr.(*tree.FuncExpr),
+		overload:            typedExpr.(*tree.FuncExpr).ResolvedOverload(),
 		outputIdx:           outputIdx,
 		columnTypes:         typs,
 		outputType:          types.String,

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -353,7 +353,7 @@ func NewColBatchScan(
 		return nil, nil, err
 	}
 	if shouldCollectStats {
-		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+		if flowTxn := flowCtx.Txn; flowTxn != nil {
 			base.ContentionEventsListener.Init(flowTxn.ID())
 		}
 	}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -645,7 +645,7 @@ func NewColIndexJoin(
 		op.mem.inputBatchSizeLimit = cFetcherMemoryLimit
 	}
 	if shouldCollectStats {
-		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+		if flowTxn := flowCtx.Txn; flowTxn != nil {
 			op.ContentionEventsListener.Init(flowTxn.ID())
 		}
 	}

--- a/pkg/sql/colflow/explain_vec.go
+++ b/pkg/sql/colflow/explain_vec.go
@@ -41,7 +41,7 @@ func convertToVecTree(
 		return nil, func() {}, errors.AssertionFailedf("unexpectedly non-empty LocalProcessors when plan is not local")
 	}
 	flowBase := flowinfra.NewFlowBase(
-		*flowCtx,
+		flowCtx,
 		nil,                     /* sp */
 		nil,                     /* flowReg */
 		&execinfra.RowChannel{}, /* rowSyncFlowConsumer */

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -1130,7 +1130,7 @@ func (s *vectorizedFlowCreator) setupOutput(
 func (s *vectorizedFlowCreator) setupFlow(
 	ctx context.Context, processorSpecs []execinfrapb.ProcessorSpec, opt flowinfra.FuseOpt,
 ) (opChains execopnode.OpChains, batchFlowCoordinator *BatchFlowCoordinator, err error) {
-	flowCtx := &s.f.FlowCtx
+	flowCtx := s.f.FlowCtx
 	if vecErr := colexecerror.CatchVectorizedRuntimeError(func() {
 		// The column factory will not change the eval context, so we can use
 		// the one we have in the flow context, without making a copy.

--- a/pkg/sql/colflow/vectorized_flow_test.go
+++ b/pkg/sql/colflow/vectorized_flow_test.go
@@ -229,7 +229,7 @@ func TestDrainOnlyInputDAG(t *testing.T) {
 	ctx := context.Background()
 	defer evalCtx.Stop(ctx)
 	flowBase := flowinfra.NewFlowBase(
-		execinfra.FlowCtx{
+		&execinfra.FlowCtx{
 			Cfg:     &execinfra.ServerConfig{},
 			EvalCtx: &evalCtx,
 			Mon:     evalCtx.TestingMon,
@@ -279,7 +279,7 @@ func TestVectorizedFlowTempDirectory(t *testing.T) {
 	newVectorizedFlow := func(queriesSpilled *metric.Counter) *vectorizedFlow {
 		return NewVectorizedFlow(
 			&flowinfra.FlowBase{
-				FlowCtx: execinfra.FlowCtx{
+				FlowCtx: &execinfra.FlowCtx{
 					Cfg: &execinfra.ServerConfig{
 						Settings:        st,
 						TempFS:          env,

--- a/pkg/sql/distsql/inbound_test.go
+++ b/pkg/sql/distsql/inbound_test.go
@@ -98,7 +98,7 @@ func TestOutboxInboundStreamIntegration(t *testing.T) {
 
 	// WaitGroup for the outbox and inbound stream. If the WaitGroup is done, no
 	// goroutines were leaked. Grab the flow's waitGroup to avoid a copy warning.
-	f := &flowinfra.FlowBase{}
+	f := &flowinfra.FlowBase{FlowCtx: &flowCtx}
 	wg := f.GetWaitGroup()
 
 	// Use RegisterFlow to register our consumer, which we will control.

--- a/pkg/sql/distsql/server.go
+++ b/pkg/sql/distsql/server.go
@@ -183,7 +183,6 @@ func (ds *ServerImpl) setupFlow(
 ) (retCtx context.Context, _ flowinfra.Flow, _ execopnode.OpChains, retErr error) {
 	var sp *tracing.Span                       // will be Finish()ed by Flow.Cleanup()
 	var monitor, diskMonitor *mon.BytesMonitor // will be closed in Flow.Cleanup()
-	var onFlowCleanupEnd func(context.Context) // will be called at the very end of Flow.Cleanup()
 	// Make sure that we clean up all resources (which in the happy case are
 	// cleaned up in Flow.Cleanup()) if an error is encountered.
 	defer func() {
@@ -194,11 +193,7 @@ func (ds *ServerImpl) setupFlow(
 			if diskMonitor != nil {
 				diskMonitor.Stop(ctx)
 			}
-			if onFlowCleanupEnd != nil {
-				onFlowCleanupEnd(ctx)
-			} else {
-				reserved.Close(ctx)
-			}
+			reserved.Close(ctx)
 			// We finish the span after performing other cleanup in case that
 			// cleanup accesses the context with the span.
 			if sp != nil {
@@ -278,35 +273,8 @@ func (ds *ServerImpl) setupFlow(
 			if err != nil {
 				return nil, nil, nil, err
 			}
-			// We create an eval context variable scoped to this block and
-			// reference it in the onFlowCleanupEnd closure. If the closure
-			// referenced evalCtx, then the pointer would be heap allocated
-			// because it is modified in the other branch of the conditional,
-			// and Go's escape analysis cannot determine that the capture and
-			// modification are mutually exclusive.
-			localEvalCtx := evalCtx
-			// We're about to mutate the evalCtx and we want to restore its
-			// original state once the flow cleans up. Note that we could have
-			// made a copy of the whole evalContext, but that isn't free, so we
-			// choose to restore the original state in order to avoid
-			// performance regressions.
-			origTxn := localEvalCtx.Txn
-			onFlowCleanupEnd = func(ctx context.Context) {
-				localEvalCtx.Txn = origTxn
-				reserved.Close(ctx)
-			}
-			// Update the Txn field early (before f.SetTxn() below) since some
-			// processors capture the field in their constructor (see #41992).
-			localEvalCtx.Txn = leafTxn
-		} else {
-			onFlowCleanupEnd = func(ctx context.Context) {
-				reserved.Close(ctx)
-			}
 		}
 	} else {
-		onFlowCleanupEnd = func(ctx context.Context) {
-			reserved.Close(ctx)
-		}
 		if localState.IsLocal {
 			return nil, nil, nil, errors.AssertionFailedf(
 				"EvalContext expected to be populated when IsLocal is set")
@@ -344,7 +312,6 @@ func (ds *ServerImpl) setupFlow(
 			Sequence:                  &faketreeeval.DummySequenceOperators{},
 			Tenant:                    &faketreeeval.DummyTenantOperator{},
 			Regions:                   &faketreeeval.DummyRegionOperator{},
-			Txn:                       leafTxn,
 			SQLLivenessReader:         ds.ServerConfig.SQLLivenessReader,
 			BlockingSQLLivenessReader: ds.ServerConfig.BlockingSQLLivenessReader,
 			SQLStatsController:        ds.ServerConfig.SQLStatsController,
@@ -357,9 +324,16 @@ func (ds *ServerImpl) setupFlow(
 		evalCtx.TestingKnobs.ForceProductionValues = req.EvalContext.TestingKnobsForceProductionValues
 	}
 
+	// If we already created the LeafTxn, then we'll use it for the flow;
+	// otherwise, we must be running on the gateway, so we take the RootTxn if
+	// provided.
+	flowTxn := leafTxn
+	if flowTxn == nil {
+		flowTxn = localState.Txn
+	}
 	// Create the FlowCtx for the flow.
 	flowCtx := ds.newFlowContext(
-		ctx, req.Flow.FlowID, evalCtx, monitor, diskMonitor, makeLeaf, req.TraceKV,
+		ctx, req.Flow.FlowID, evalCtx, monitor, diskMonitor, flowTxn, makeLeaf, req.TraceKV,
 		req.CollectStats, localState, req.Flow.Gateway == ds.NodeID.SQLInstanceID(),
 	)
 
@@ -371,7 +345,7 @@ func (ds *ServerImpl) setupFlow(
 	f := newFlow(
 		flowCtx, sp, ds.flowRegistry, rowSyncFlowConsumer, batchSyncFlowConsumer,
 		localState.LocalProcs, localState.LocalVectorSources, isVectorized,
-		onFlowCleanupEnd, req.StatementSQL,
+		reserved.Close, req.StatementSQL,
 	)
 	opt := flowinfra.FuseNormally
 	if !localState.MustUseLeafTxn() {
@@ -452,6 +426,7 @@ func (ds *ServerImpl) newFlowContext(
 	id execinfrapb.FlowID,
 	evalCtx *eval.Context,
 	monitor, diskMonitor *mon.BytesMonitor,
+	txn *kv.Txn,
 	makeLeafTxn func(context.Context) (*kv.Txn, error),
 	traceKV bool,
 	collectStats bool,
@@ -465,7 +440,7 @@ func (ds *ServerImpl) newFlowContext(
 		ID:             id,
 		EvalCtx:        evalCtx,
 		Mon:            monitor,
-		Txn:            evalCtx.Txn,
+		Txn:            txn,
 		MakeLeafTxn:    makeLeafTxn,
 		NodeID:         ds.ServerConfig.NodeID,
 		TraceKV:        traceKV,
@@ -489,7 +464,7 @@ func (ds *ServerImpl) newFlowContext(
 			ctx, descs.WithDescriptorSessionDataProvider(dsdp),
 		)
 		flowCtx.IsDescriptorsCleanupRequired = true
-		flowCtx.EvalCatalogBuiltins.Init(evalCtx.Codec, evalCtx.Txn, flowCtx.Descriptors)
+		flowCtx.EvalCatalogBuiltins.Init(evalCtx.Codec, flowCtx.Txn, flowCtx.Descriptors)
 		evalCtx.CatalogBuiltins = &flowCtx.EvalCatalogBuiltins
 	}
 	return flowCtx

--- a/pkg/sql/distsql/vectorized_panic_propagation_test.go
+++ b/pkg/sql/distsql/vectorized_panic_propagation_test.go
@@ -33,7 +33,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(st)
 	defer evalCtx.Stop(ctx)
 
-	flowCtx := execinfra.FlowCtx{
+	flowCtx := &execinfra.FlowCtx{
 		EvalCtx: &evalCtx,
 		Mon:     evalCtx.TestingMon,
 		Cfg:     &execinfra.ServerConfig{Settings: cluster.MakeTestingClusterSettings()},
@@ -53,7 +53,7 @@ func TestNonVectorizedPanicDoesntHangServer(t *testing.T) {
 
 	mat := colexec.NewMaterializer(
 		nil, /* streamingMemAcc */
-		&flowCtx,
+		flowCtx,
 		0, /* processorID */
 		colexecargs.OpWithMetaInfo{Root: &colexecop.CallbackOperator{
 			NextCb: func() coldata.Batch {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4450,7 +4450,7 @@ func (dsp *DistSQLPlanner) createValuesSpecFromTuples(
 	for rowIdx, tuple := range tuples {
 		var buf []byte
 		for colIdx, typedExpr := range tuple {
-			datum, err := eval.Expr(ctx, evalCtx, typedExpr)
+			datum, err := eval.Expr(ctx, evalCtx, typedExpr, planCtx.planner.Txn())
 			if err != nil {
 				return nil, err
 			}

--- a/pkg/sql/distsql_plan_changefeed.go
+++ b/pkg/sql/distsql_plan_changefeed.go
@@ -106,7 +106,7 @@ func PlanCDCExpression(
 
 	// Reset catalog to cdc specific implementation.
 	opc.catalog = cdcCat
-	opc.optimizer.Init(ctx, p.EvalContext(), opc.catalog)
+	opc.optimizer.Init(ctx, p.EvalContext(), p.Txn(), opc.catalog)
 
 	memo, err := opc.buildExecMemo(ctx)
 	if err != nil {
@@ -120,7 +120,7 @@ func PlanCDCExpression(
 	const disableTelemetryAndPlanGists = false
 	if err := opc.runExecBuilder(
 		ctx, &p.curPlan, &p.stmt, newExecFactory(ctx, p), memo, p.SemaCtx(),
-		p.EvalContext(), allowAutoCommit, disableTelemetryAndPlanGists,
+		p.EvalContext(), p.Txn(), allowAutoCommit, disableTelemetryAndPlanGists,
 	); err != nil {
 		return CDCExpressionPlan{}, err
 	}

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2154,7 +2154,7 @@ func (dsp *DistSQLPlanner) PlanAndRun(
 		// is no point in providing the locality filter since it will be ignored
 		// anyway, so we don't use NewPlanningCtxWithOracle constructor.
 		localPlanCtx := dsp.NewPlanningCtx(
-			ctx, extEvalCtx, planCtx.planner, extEvalCtx.Txn, LocalDistribution,
+			ctx, extEvalCtx, planCtx.planner, txn, LocalDistribution,
 		)
 		localPlanCtx.setUpForMainQuery(ctx, planCtx.planner, recv)
 		localPhysPlan, localPhysPlanCleanup, err := dsp.createPhysPlan(ctx, localPlanCtx, plan)

--- a/pkg/sql/distsql_running.go
+++ b/pkg/sql/distsql_running.go
@@ -2392,7 +2392,7 @@ func (dsp *DistSQLPlanner) planAndRunCascadeOrTrigger(
 ) (ok, checksContainLocking bool) {
 	execFactory := newExecFactory(ctx, planner)
 	cascadePlan, err := pq.PlanFn(
-		ctx, &planner.semaCtx, &evalCtx.Context, execFactory,
+		ctx, &planner.semaCtx, &evalCtx.Context, planner.Txn(), execFactory,
 		pq.Buffer, numBufferedRows, allowAutoCommit,
 	)
 	if err != nil {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2251,7 +2251,7 @@ func checkResultType(typ *types.T, fmtCode pgwirebase.FormatCode) error {
 func (p *planner) EvalAsOfTimestamp(
 	ctx context.Context, asOfClause tree.AsOfClause, opts ...asof.EvalOption,
 ) (eval.AsOfSystemTime, error) {
-	asOf, err := asof.Eval(ctx, asOfClause, &p.semaCtx, p.EvalContext(), opts...)
+	asOf, err := asof.Eval(ctx, asOfClause, &p.semaCtx, p.EvalContext(), p.Txn(), opts...)
 	if err != nil {
 		return eval.AsOfSystemTime{}, err
 	}

--- a/pkg/sql/execinfra/execagg/base.go
+++ b/pkg/sql/execinfra/execagg/base.go
@@ -97,7 +97,9 @@ func GetAggregateConstructor(
 	for j, argument := range aggInfo.Arguments {
 		h := execexpr.Helper{}
 		// Pass nil types and row - there are no variables in these expressions.
-		if err = h.Init(ctx, argument, nil /* types */, semaCtx, evalCtx); err != nil {
+		// Also pass nil txn since we shouldn't see any builtins that need the
+		// txn either.
+		if err = h.Init(ctx, argument, nil /* types */, semaCtx, evalCtx, nil /* txn */); err != nil {
 			err = errors.Wrapf(err, "%s", argument)
 			return
 		}

--- a/pkg/sql/execinfra/execexpr/BUILD.bazel
+++ b/pkg/sql/execinfra/execexpr/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/execinfra/execexpr",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/sql/catalog",
         "//pkg/sql/catalog/typedesc",
         "//pkg/sql/execinfrapb",

--- a/pkg/sql/execinfra/processorsbase.go
+++ b/pkg/sql/execinfra/processorsbase.go
@@ -175,7 +175,7 @@ func (h *ProcOutputHelper) Init(
 		} else {
 			h.OutputTypes = make([]*types.T, nRenders)
 		}
-		if err := h.eh.Init(ctx, nRenders, coreOutputTypes, semaCtx, evalCtx); err != nil {
+		if err := h.eh.Init(ctx, nRenders, coreOutputTypes, semaCtx, evalCtx, flowCtx.Txn); err != nil {
 			return err
 		}
 		for i, expr := range post.RenderExprs {

--- a/pkg/sql/fingerprint_span.go
+++ b/pkg/sql/fingerprint_span.go
@@ -101,7 +101,7 @@ func (p *planner) fingerprintSpanFanout(
 	defer sp.Finish()
 
 	var (
-		txn        = p.EvalContext().Txn
+		txn        = p.Txn()
 		execCfg    = p.ExecutorConfig().(*ExecutorConfig)
 		dsp        = p.DistSQLPlanner()
 		extEvalCtx = p.ExtendedEvalContext()

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -18,7 +18,6 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/base",
-        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/rpc",
         "//pkg/rpc/rpcbase",

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -621,7 +621,7 @@ func TestEvalCtxTxnOnRemoteNodes(t *testing.T) {
 		db := tc.ServerConn(0)
 		var opt string
 		if vectorize {
-			opt = "experimental_always"
+			opt = "on"
 		} else {
 			opt = "off"
 		}

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -578,8 +578,7 @@ ALTER TABLE t EXPERIMENTAL_RELOCATE VALUES (ARRAY[2], 1), (ARRAY[1], 2), (ARRAY[
 }
 
 // Test that we can evaluate built-in functions that use the txn on remote
-// nodes. We have a bug where the EvalCtx.Txn field was only correctly populated
-// on the gateway.
+// nodes.
 func TestEvalCtxTxnOnRemoteNodes(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -10,7 +10,6 @@ import (
 	"sync"
 	"unsafe"
 
-	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfra/execopnode"
@@ -79,10 +78,6 @@ type Flow interface {
 	// gateway node if the flow is vectorized and the physical plan is fully
 	// local (in all other cases the second return argument is nil).
 	Setup(ctx context.Context, spec *execinfrapb.FlowSpec, opt FuseOpt) (context.Context, execopnode.OpChains, error)
-
-	// SetTxn is used to provide the transaction in which the flow will run.
-	// It needs to be called after Setup() and before Start/Run.
-	SetTxn(*kv.Txn)
 
 	// Start starts the flow. Processors run asynchronously in their own
 	// goroutines. Wait() needs to be called to wait for the flow to finish.
@@ -177,7 +172,7 @@ type Flow interface {
 // implements Flow interface for convenience and for usage in tests, but if
 // FlowBase.Setup is called, it'll panic.
 type FlowBase struct {
-	execinfra.FlowCtx
+	*execinfra.FlowCtx
 
 	// resumeCtx is only captured for using inside of Flow.Resume() implementations.
 	resumeCtx context.Context
@@ -277,11 +272,6 @@ func (f *FlowBase) Setup(
 	return ctx, nil, nil
 }
 
-// SetTxn is part of the Flow interface.
-func (f *FlowBase) SetTxn(txn *kv.Txn) {
-	f.FlowCtx.Txn = txn
-}
-
 // ConcurrentTxnUse is part of the Flow interface.
 func (f *FlowBase) ConcurrentTxnUse() bool {
 	numProcessorsThatMightUseTxn := 0
@@ -315,7 +305,7 @@ var _ Flow = &FlowBase{}
 // sp, if not nil, is the Span corresponding to the flow. The flow takes
 // ownership; Cleanup() will finish it.
 func NewFlowBase(
-	flowCtx execinfra.FlowCtx,
+	flowCtx *execinfra.FlowCtx,
 	sp *tracing.Span,
 	flowReg *FlowRegistry,
 	rowSyncFlowConsumer execinfra.RowReceiver,
@@ -359,7 +349,7 @@ func (f *FlowBase) StatementSQL() string {
 
 // GetFlowCtx is part of the Flow interface.
 func (f *FlowBase) GetFlowCtx() *execinfra.FlowCtx {
-	return &f.FlowCtx
+	return f.FlowCtx
 }
 
 // AddStartable is part of the Flow interface.

--- a/pkg/sql/flowinfra/flow.go
+++ b/pkg/sql/flowinfra/flow.go
@@ -280,7 +280,6 @@ func (f *FlowBase) Setup(
 // SetTxn is part of the Flow interface.
 func (f *FlowBase) SetTxn(txn *kv.Txn) {
 	f.FlowCtx.Txn = txn
-	f.EvalCtx.Txn = txn
 }
 
 // ConcurrentTxnUse is part of the Flow interface.

--- a/pkg/sql/flowinfra/flow_registry_test.go
+++ b/pkg/sql/flowinfra/flow_registry_test.go
@@ -66,16 +66,16 @@ func TestFlowRegistry(t *testing.T) {
 	reg := NewFlowRegistry()
 
 	id1 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
-	f1 := &FlowBase{}
+	f1 := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 
 	id2 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
-	f2 := &FlowBase{}
+	f2 := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 
 	id3 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
-	f3 := &FlowBase{}
+	f3 := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 
 	id4 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
-	f4 := &FlowBase{}
+	f4 := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 
 	// A basic duration; needs to be significantly larger than possible delays
 	// in scheduling goroutines.
@@ -209,7 +209,7 @@ func TestStreamConnectionTimeout(t *testing.T) {
 	// Register a flow with a very low timeout. After it times out, we'll attempt
 	// to connect a stream, but it'll be too late.
 	id1 := execinfrapb.FlowID{UUID: uuid.MakeV4()}
-	f1 := &FlowBase{}
+	f1 := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 	f1.mu.ctxCancel = func() {}
 	streamID1 := execinfrapb.StreamID(1)
 	consumer := &distsqlutils.RowBuffer{}
@@ -304,7 +304,7 @@ func TestHandshake(t *testing.T) {
 				}
 			}
 			connectConsumer := func() {
-				f1 := &FlowBase{}
+				f1 := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 				consumer := &distsqlutils.RowBuffer{}
 				wg := &sync.WaitGroup{}
 				wg.Add(1)
@@ -369,7 +369,7 @@ func TestFlowRegistryDrain(t *testing.T) {
 	ctx := context.Background()
 	reg := NewFlowRegistry()
 
-	flow := &FlowBase{}
+	flow := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 	flow.mu.ctxCancel = func() {}
 	id := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 	registerFlow := func(t *testing.T, id execinfrapb.FlowID) {
@@ -570,7 +570,7 @@ func TestInboundStreamTimeoutIsRetryable(t *testing.T) {
 	}
 	wg.Add(1)
 	if err := fr.RegisterFlow(
-		context.Background(), execinfrapb.FlowID{}, &FlowBase{}, inboundStreams, 0, /* timeout */
+		context.Background(), execinfrapb.FlowID{}, &FlowBase{FlowCtx: &execinfra.FlowCtx{}}, inboundStreams, 0, /* timeout */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -614,7 +614,7 @@ func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 
 	// RegisterFlow with an immediate timeout.
 	if err := fr.RegisterFlow(
-		ctx, execinfrapb.FlowID{}, &FlowBase{}, inboundStreams, 0, /* timeout */
+		ctx, execinfrapb.FlowID{}, &FlowBase{FlowCtx: &execinfra.FlowCtx{}}, inboundStreams, 0, /* timeout */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -628,7 +628,7 @@ func TestTimeoutPushDoesntBlockRegister(t *testing.T) {
 	// Attempt to register a flow. Note that this flow has no inbound streams, so
 	// Pushing to the RowBuffer is unexpected.
 	if err := fr.RegisterFlow(
-		ctx, execinfrapb.FlowID{UUID: uuid.MakeV4()}, &FlowBase{}, nil /* inboundStreams */, time.Hour, /* timeout */
+		ctx, execinfrapb.FlowID{UUID: uuid.MakeV4()}, &FlowBase{FlowCtx: &execinfra.FlowCtx{}}, nil /* inboundStreams */, time.Hour, /* timeout */
 	); err != nil {
 		t.Fatal(err)
 	}
@@ -669,7 +669,7 @@ func TestFlowCancelPartiallyBlocked(t *testing.T) {
 
 	// RegisterFlow with an immediate timeout.
 	flow := &FlowBase{
-		FlowCtx: execinfra.FlowCtx{
+		FlowCtx: &execinfra.FlowCtx{
 			ID: execinfrapb.FlowID{UUID: uuid.MakeV4()},
 		},
 		inboundStreams: inboundStreams,
@@ -751,7 +751,7 @@ func TestErrorOnSlowHandshake(t *testing.T) {
 	flowID := execinfrapb.FlowID{UUID: uuid.MakeV4()}
 	streamID := execinfrapb.StreamID(1)
 	cancelCh := make(chan struct{})
-	f := &FlowBase{}
+	f := &FlowBase{FlowCtx: &execinfra.FlowCtx{}}
 	f.mu.ctxCancel = func() {
 		cancelCh <- struct{}{}
 	}

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -466,7 +466,7 @@ func (n *insertFastPathNode) BatchedNext(params runParams) (bool, error) {
 		inputRow := n.run.inputRow(rowIdx)
 		for col, typedExpr := range tupleRow {
 			var err error
-			inputRow[col], err = eval.Expr(params.ctx, params.EvalContext(), typedExpr)
+			inputRow[col], err = eval.Expr(params.ctx, params.EvalContext(), typedExpr, params.p.Txn())
 			if err != nil {
 				err = interceptAlterColumnTypeParseError(n.run.insertCols, col, err)
 				return false, err

--- a/pkg/sql/instrumentation.go
+++ b/pkg/sql/instrumentation.go
@@ -1163,9 +1163,9 @@ func (ih *instrumentationHelper) SetIndexRecommendations(
 				// memo is empty.
 				opc.reset(ctx)
 				evalCtx := opc.p.EvalContext()
-				f.Init(ctx, evalCtx, opc.catalog)
+				f.Init(ctx, evalCtx, opc.p.Txn(), opc.catalog)
 				f.FoldingControl().AllowStableFolds()
-				bld := optbuilder.New(ctx, &opc.p.semaCtx, evalCtx, opc.catalog, f, opc.p.stmt.AST)
+				bld := optbuilder.New(ctx, &opc.p.semaCtx, evalCtx, opc.p.Txn(), opc.catalog, f, opc.p.stmt.AST)
 				err := bld.Build()
 				if err != nil {
 					log.Warningf(ctx, "unable to build memo: %s", err)

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -3152,7 +3152,7 @@ CREATE TABLE t_89025 (i int primary key);
 statement ok
 INSERT INTO t_89025 VALUES (1)
 
-statement error pgcode 0A000 cannot use crdb_internal\.lease_holder in this context
+statement error pgcode 0A000 .* cannot use builtin in this context
 ALTER TABLE t_89025 ADD COLUMN j INT DEFAULT (crdb_internal.lease_holder('a'));
 
 statement ok
@@ -3922,7 +3922,7 @@ statement ok
 CREATE TABLE t_98269 (i INT PRIMARY KEY);
 INSERT INTO t_98269 VALUES (0);
 
-statement error pgcode 0A000 .* nil txn in cluster context
+statement error pgcode 0A000 .* cannot use builtin in this context
 ALTER TABLE t_98269 ADD COLUMN j DECIMAL NOT NULL DEFAULT cluster_logical_timestamp();
 
 # In #99185, we saw test failures that result from adding a foreign key

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/clusterversion",
+        "//pkg/kv",
         "//pkg/security/username",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog",

--- a/pkg/sql/opt/BUILD.bazel
+++ b/pkg/sql/opt/BUILD.bazel
@@ -75,6 +75,7 @@ go_test(
     embed = [":opt"],
     deps = [
         "//pkg/base",
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/opt/bench/BUILD.bazel
+++ b/pkg/sql/opt/bench/BUILD.bazel
@@ -20,6 +20,7 @@ go_test(
     embed = [":bench"],
     deps = [
         "//pkg/base",
+        "//pkg/kv",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",
         "//pkg/server",

--- a/pkg/sql/opt/distribution/BUILD.bazel
+++ b/pkg/sql/opt/distribution/BUILD.bazel
@@ -21,6 +21,7 @@ go_test(
     srcs = ["distribution_test.go"],
     embed = [":distribution"],
     deps = [
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/opt/memo",
         "//pkg/sql/opt/norm",

--- a/pkg/sql/opt/distribution/distribution_test.go
+++ b/pkg/sql/opt/distribution/distribution_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -24,8 +25,9 @@ func TestBuildProvided(t *testing.T) {
 	tc := testcat.New()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, tc)
+	f.Init(context.Background(), evalCtx, txn, tc)
 
 	testCases := []struct {
 		leftDist  []string
@@ -109,8 +111,9 @@ func TestGetDistributions(t *testing.T) {
 	tc := testcat.New()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, tc)
+	f.Init(context.Background(), evalCtx, txn, tc)
 
 	testCases := []struct {
 		leftDist  []string

--- a/pkg/sql/opt/exec/BUILD.bazel
+++ b/pkg/sql/opt/exec/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     visibility = ["//visibility:public"],
     # Pin the dependencies required in the auto-generated code.
     deps = [
+        "//pkg/kv",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",  # keep
         "//pkg/sql/inverted",

--- a/pkg/sql/opt/exec/execbuilder/BUILD.bazel
+++ b/pkg/sql/opt/exec/execbuilder/BUILD.bazel
@@ -15,6 +15,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/exec/execbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/server/telemetry",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/sql/opt/exec/execbuilder/builder.go
+++ b/pkg/sql/opt/exec/execbuilder/builder.go
@@ -11,6 +11,7 @@ import (
 	"strconv"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
@@ -64,6 +65,7 @@ type Builder struct {
 	disableTelemetry bool
 	semaCtx          *tree.SemaContext
 	evalCtx          *eval.Context
+	txn              *kv.Txn
 	colOrdsAlloc     colOrdMapAllocator
 
 	// subqueries accumulates information about subqueries that are part of scalar
@@ -247,6 +249,7 @@ func New(
 	e opt.Expr,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	allowAutoCommit bool,
 	isANSIDML bool,
 ) *Builder {
@@ -259,6 +262,7 @@ func New(
 		ctx:                    ctx,
 		semaCtx:                semaCtx,
 		evalCtx:                evalCtx,
+		txn:                    txn,
 		allowAutoCommit:        allowAutoCommit,
 		initialAllowAutoCommit: allowAutoCommit,
 		IsANSIDML:              isANSIDML,

--- a/pkg/sql/opt/exec/execbuilder/format.go
+++ b/pkg/sql/opt/exec/execbuilder/format.go
@@ -44,6 +44,7 @@ func fmtInterceptor(f *memo.ExprFmtCtx, scalar opt.ScalarExpr) string {
 		scalar,
 		nil,   /* semaCtx */
 		nil,   /* evalCtx */
+		nil,   /* txn */
 		false, /* allowAutoCommit */
 		false, /* isANSIDML */
 	)

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -1284,7 +1284,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (_ execPlan, outputCols colO
 			}
 		}()
 
-		o.Init(ctx, b.evalCtx, b.catalog)
+		o.Init(ctx, b.evalCtx, b.txn, b.catalog)
 		f := o.Factory()
 
 		// Copy the right expression into a new memo, replacing each bound column
@@ -1332,7 +1332,7 @@ func (b *Builder) buildApplyJoin(join memo.RelExpr) (_ execPlan, outputCols colO
 			return nil, err
 		}
 
-		eb := New(ctx, ef, &o, f.Memo(), b.catalog, newRightSide, b.semaCtx, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
+		eb := New(ctx, ef, &o, f.Memo(), b.catalog, newRightSide, b.semaCtx, b.evalCtx, b.txn, false /* allowAutoCommit */, b.IsANSIDML)
 		eb.disableTelemetry = true
 		eb.withExprs = withExprs
 		eb.routineResultBuffers = b.routineResultBuffers
@@ -3400,6 +3400,7 @@ func (b *Builder) buildRecursiveCTE(
 		catalog: b.catalog,
 		semaCtx: b.semaCtx,
 		evalCtx: b.evalCtx,
+		txn:     b.txn,
 		// If the recursive query itself contains CTEs, building it in the function
 		// below will add to withExprs. Cap the slice to force reallocation on any
 		// appends, so that they don't overwrite overwrite later appends by our

--- a/pkg/sql/opt/exec/execbuilder/scalar.go
+++ b/pkg/sql/opt/exec/execbuilder/scalar.go
@@ -866,7 +866,7 @@ func (b *Builder) buildSubquery(
 			memo.ExtractTailCalls(input, tailCalls)
 
 			ef := ref.(exec.Factory)
-			eb := New(ctx, ef, b.optimizer, b.mem, b.catalog, input, b.semaCtx, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
+			eb := New(ctx, ef, b.optimizer, b.mem, b.catalog, input, b.semaCtx, b.evalCtx, b.txn, false /* allowAutoCommit */, b.IsANSIDML)
 			eb.withExprs = withExprs
 			eb.routineResultBuffers = b.routineResultBuffers
 			eb.disableTelemetry = true
@@ -1200,7 +1200,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 		for i := range stmts {
 			stmt := stmts[i]
 			props := stmtProps[i]
-			o.Init(ctx, b.evalCtx, b.catalog)
+			o.Init(ctx, b.evalCtx, b.txn, b.catalog)
 			f := o.Factory()
 
 			// Copy the expression into a new memo. Replace parameter references
@@ -1274,7 +1274,7 @@ func (b *Builder) buildRoutinePlanGenerator(
 
 			// Build the memo into a plan.
 			ef := ref.(exec.Factory)
-			eb := New(ctx, ef, &o, f.Memo(), b.catalog, optimizedExpr, b.semaCtx, b.evalCtx, false /* allowAutoCommit */, b.IsANSIDML)
+			eb := New(ctx, ef, &o, f.Memo(), b.catalog, optimizedExpr, b.semaCtx, b.evalCtx, b.txn, false /* allowAutoCommit */, b.IsANSIDML)
 			eb.withExprs = withExprs
 			eb.disableTelemetry = true
 			eb.planLazySubqueries = true
@@ -1376,7 +1376,7 @@ func (b *Builder) buildTxnControl(
 		// Build the plan for the "continuation" procedure that will resume
 		// execution of the parent stored procedure in a new transaction.
 		var f norm.Factory
-		f.Init(ctx, b.evalCtx, b.catalog)
+		f.Init(ctx, b.evalCtx, b.txn, b.catalog)
 		f.CopyMetadataFrom(b.mem)
 
 		// Use the evaluated arguments to construct the continuation procedure.

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -178,11 +178,11 @@ func (b *Builder) buildExplain(
 			// factory must be the inner factory.
 			var gf explain.PlanGistFactory
 			gf.Init(f)
-			ef := explain.NewFactory(&gf, b.semaCtx, b.evalCtx)
+			ef := explain.NewFactory(&gf, b.semaCtx, b.evalCtx, b.txn)
 
 			explainBld := New(
 				b.ctx, ef, b.optimizer, b.mem, b.catalog, explainExpr.Input,
-				b.semaCtx, b.evalCtx, b.initialAllowAutoCommit, b.IsANSIDML,
+				b.semaCtx, b.evalCtx, b.txn, b.initialAllowAutoCommit, b.IsANSIDML,
 			)
 			explainBld.disableTelemetry = true
 			plan, err := explainBld.Build()

--- a/pkg/sql/opt/exec/explain/BUILD.bazel
+++ b/pkg/sql/opt/exec/explain/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
     # Pin the dependencies used in auto-generated code.
     deps = [
         "//pkg/geo/geopb",
+        "//pkg/kv",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/roachpb",
         "//pkg/sql/appstatspb",
@@ -67,6 +68,7 @@ go_test(
     deps = [
         "//pkg/base",
         "//pkg/ccl",
+        "//pkg/kv",
         "//pkg/multitenant/tenantcapabilitiespb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/opt/exec/explain/explain_factory_test.go
+++ b/pkg/sql/opt/exec/explain/explain_factory_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -22,7 +23,7 @@ import (
 // TestFactory is a general API test for Factory. It is not intended as an
 // exhaustive test of all factory Construct methods.
 func TestFactory(t *testing.T) {
-	f := NewFactory(exec.StubFactory{}, &tree.SemaContext{}, &eval.Context{})
+	f := NewFactory(exec.StubFactory{}, &tree.SemaContext{}, &eval.Context{}, &kv.Txn{})
 
 	n, err := f.ConstructValues(
 		[][]tree.TypedExpr{

--- a/pkg/sql/opt/exec/explain/plan_gist_test.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/exec/explain"
@@ -50,7 +51,7 @@ func explainGist(gist string, catalog cat.Catalog) string {
 }
 
 func plan(ot *opttester.OptTester, t *testing.T) string {
-	f := explain.NewFactory(exec.StubFactory{}, &tree.SemaContext{}, &eval.Context{})
+	f := explain.NewFactory(exec.StubFactory{}, &tree.SemaContext{}, &eval.Context{}, &kv.Txn{})
 	expr, err := ot.Optimize()
 	if err != nil {
 		t.Error(err)

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -10,6 +10,7 @@ import (
 	"context"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -328,6 +329,7 @@ type PostQuery struct {
 		ctx context.Context,
 		semaCtx *tree.SemaContext,
 		evalCtx *eval.Context,
+		txn *kv.Txn,
 		execFactory Factory,
 		bufferRef Node,
 		numBufferedRows int,

--- a/pkg/sql/opt/idxconstraint/BUILD.bazel
+++ b/pkg/sql/opt/idxconstraint/BUILD.bazel
@@ -27,6 +27,7 @@ go_test(
     data = glob(["testdata/**"]),
     deps = [
         ":idxconstraint",
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
         "//pkg/sql/opt/constraint",

--- a/pkg/sql/opt/invertedidx/BUILD.bazel
+++ b/pkg/sql/opt/invertedidx/BUILD.bazel
@@ -59,6 +59,7 @@ go_test(
         "//pkg/geo",
         "//pkg/geo/geoindex",
         "//pkg/geo/geopb",
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/inverted",
         "//pkg/sql/opt",

--- a/pkg/sql/opt/invertedidx/tsearch_test.go
+++ b/pkg/sql/opt/invertedidx/tsearch_test.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/invertedidx"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -23,6 +24,7 @@ func TestTryFilterTSVector(t *testing.T) {
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 
 	tc := testcat.New()
 	if _, err := tc.ExecuteDDL(
@@ -31,7 +33,7 @@ func TestTryFilterTSVector(t *testing.T) {
 		t.Fatal(err)
 	}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, tc)
+	f.Init(context.Background(), evalCtx, txn, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)
@@ -87,7 +89,7 @@ func TestTryFilterTSVector(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Logf("test case: %v", tc)
-		filters := testutils.BuildFilters(t, &f, &semaCtx, evalCtx, tc.filters)
+		filters := testutils.BuildFilters(t, &f, &semaCtx, evalCtx, txn, tc.filters)
 
 		// We're not testing that the correct SpanExpression is returned here;
 		// that is tested elsewhere. This is just testing that we are constraining

--- a/pkg/sql/opt/lookupjoin/BUILD.bazel
+++ b/pkg/sql/opt/lookupjoin/BUILD.bazel
@@ -31,6 +31,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":lookupjoin"],
     deps = [
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
         "//pkg/sql/opt/exec/execbuilder",

--- a/pkg/sql/opt/memo/BUILD.bazel
+++ b/pkg/sql/opt/memo/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/geo/geoindex",
+        "//pkg/kv",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/tabledesc",
@@ -82,6 +83,7 @@ go_test(
     ],
     embed = [":memo"],
     deps = [
+        "//pkg/kv",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/security/username",
         "//pkg/settings/cluster",

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -12,6 +12,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/constraint"
@@ -1425,6 +1426,7 @@ type PostQueryBuilder interface {
 		ctx context.Context,
 		semaCtx *tree.SemaContext,
 		evalCtx *eval.Context,
+		txn *kv.Txn,
 		catalog cat.Catalog,
 		factory interface{},
 		binding opt.WithID,

--- a/pkg/sql/opt/memo/expr_test.go
+++ b/pkg/sql/opt/memo/expr_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -59,9 +60,10 @@ func TestExprIsNeverNull(t *testing.T) {
 				ctx := context.Background()
 				semaCtx := tree.MakeSemaContext(nil /* resolver */)
 				evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+				txn := &kv.Txn{}
 
 				var o xform.Optimizer
-				o.Init(ctx, &evalCtx, catalog)
+				o.Init(ctx, &evalCtx, txn, catalog)
 
 				var sv testutils.ScalarVars
 
@@ -86,7 +88,7 @@ func TestExprIsNeverNull(t *testing.T) {
 					d.Fatalf(t, "%v", err)
 				}
 
-				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
+				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, txn, o.Factory())
 				scalar, err := b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))

--- a/pkg/sql/opt/memo/interner_test.go
+++ b/pkg/sql/opt/memo/interner_test.go
@@ -14,6 +14,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/inverted"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -1096,6 +1097,7 @@ func (*testingPostQueryBuilder) Build(
 	_ context.Context,
 	_ *tree.SemaContext,
 	_ *eval.Context,
+	_ *kv.Txn,
 	_ cat.Catalog,
 	_ interface{},
 	_ opt.WithID,

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -10,6 +10,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -420,7 +421,7 @@ func (m *Memo) HasPlaceholders() bool {
 // perform KV operations on behalf of the transaction associated with the
 // provided catalog, and those errors are required to be propagated.
 func (m *Memo) IsStale(
-	ctx context.Context, evalCtx *eval.Context, catalog cat.Catalog,
+	ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, catalog cat.Catalog,
 ) (bool, error) {
 	// Memo is stale if fields from SessionData that can affect planning have
 	// changed.
@@ -495,7 +496,7 @@ func (m *Memo) IsStale(
 	// Memo is stale if the fingerprint of any object in the memo's metadata has
 	// changed, or if the current user no longer has sufficient privilege to
 	// access the object.
-	if depsUpToDate, err := m.Metadata().CheckDependencies(ctx, evalCtx, catalog); err != nil || !depsUpToDate {
+	if depsUpToDate, err := m.Metadata().CheckDependencies(ctx, evalCtx, txn, catalog); err != nil || !depsUpToDate {
 		return true, err
 	}
 	return false, nil

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -185,7 +185,7 @@ func TestMemoIsStale(t *testing.T) {
 	ctx := context.Background()
 	stale := func() {
 		t.Helper()
-		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, txn, catalog); err != nil {
 			t.Fatal(err)
 		} else if !isStale {
 			t.Errorf("memo should be stale")
@@ -197,7 +197,7 @@ func TestMemoIsStale(t *testing.T) {
 		var o2 xform.Optimizer
 		opttestutils.BuildQuery(t, &o2, catalog, &evalCtx, txn, query)
 
-		if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, txn, catalog); err != nil {
 			t.Fatal(err)
 		} else if isStale {
 			t.Errorf("memo should not be stale")
@@ -206,7 +206,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	notStale := func() {
 		t.Helper()
-		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
+		if isStale, err := o.Memo().IsStale(ctx, &evalCtx, txn, catalog); err != nil {
 			t.Fatal(err)
 		} else if isStale {
 			t.Errorf("memo should not be stale")
@@ -585,7 +585,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
-	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)
+	_, err = o.Memo().IsStale(ctx, &evalCtx, txn, catalog)
 	if exp := "user does not have privilege"; !testutils.IsError(err, exp) {
 		t.Fatalf("expected %q error, but got %+v", exp, err)
 	}
@@ -594,7 +594,7 @@ func TestMemoIsStale(t *testing.T) {
 
 	// User no longer has execution privilege on a UDF.
 	catalog.RevokeExecution(catalog.Function("one").Oid)
-	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)
+	_, err = o.Memo().IsStale(ctx, &evalCtx, txn, catalog)
 	if exp := "user does not have privilege to execute function"; !testutils.IsError(err, exp) {
 		t.Fatalf("expected %q error, but got %+v", exp, err)
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/isolation"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
@@ -65,9 +66,10 @@ func TestCompositeSensitive(t *testing.T) {
 	datadriven.RunTest(t, datapathutils.TestDataPath(t, "composite_sensitive"), func(t *testing.T, d *datadriven.TestData) string {
 		semaCtx := tree.MakeSemaContext(nil /* resolver */)
 		evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+		txn := &kv.Txn{}
 
 		var f norm.Factory
-		f.Init(context.Background(), &evalCtx, nil /* catalog */)
+		f.Init(context.Background(), &evalCtx, txn, nil /* catalog */)
 		md := f.Metadata()
 
 		if d.Cmd != "composite-sensitive" {
@@ -94,7 +96,7 @@ func TestCompositeSensitive(t *testing.T) {
 			d.Fatalf(t, "error parsing: %v", err)
 		}
 
-		b := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, &f)
+		b := optbuilder.NewScalar(context.Background(), &semaCtx, &evalCtx, txn, &f)
 		scalar, err := b.Build(expr)
 		if err != nil {
 			d.Fatalf(t, "error building: %v", err)
@@ -111,11 +113,12 @@ func TestMemoInit(t *testing.T) {
 	}
 
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	txn := &kv.Txn{}
 
 	var o xform.Optimizer
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT * FROM abc WHERE $1=10")
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn, "SELECT * FROM abc WHERE $1=10")
 
-	o.Init(context.Background(), &evalCtx, catalog)
+	o.Init(context.Background(), &evalCtx, txn, catalog)
 	if !o.Memo().IsEmpty() {
 		t.Fatal("memo should be empty")
 	}
@@ -168,6 +171,7 @@ func TestMemoIsStale(t *testing.T) {
 	// planner's GetMultiregionConfig is nil, so we nil out the planner.
 	evalCtx.Planner = nil
 	evalCtx.StreamManagerFactory = nil
+	txn := &kv.Txn{}
 
 	// Use a test query that references each schema object (apart table with
 	// restricted access) to help verify that the memo is not invalidated
@@ -175,7 +179,7 @@ func TestMemoIsStale(t *testing.T) {
 	const query = "SELECT a, b+one(), 'hiya'::typ FROM abcview v, xy WHERE a = x AND c='foo'"
 
 	var o xform.Optimizer
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, query)
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn, query)
 	o.Memo().Metadata().AddSchema(catalog.Schema())
 
 	ctx := context.Background()
@@ -191,7 +195,7 @@ func TestMemoIsStale(t *testing.T) {
 		// tests as written still pass if the default value is 0. To detect this, we
 		// create a new memo with the changed setting and verify it's not stale.
 		var o2 xform.Optimizer
-		opttestutils.BuildQuery(t, &o2, catalog, &evalCtx, query)
+		opttestutils.BuildQuery(t, &o2, catalog, &evalCtx, txn, query)
 
 		if isStale, err := o2.Memo().IsStale(ctx, &evalCtx, catalog); err != nil {
 			t.Fatal(err)
@@ -666,6 +670,7 @@ func TestMemoIsStale(t *testing.T) {
 // cycles.
 func TestStatsAvailable(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	txn := &kv.Txn{}
 
 	catalog := testcat.New()
 	if _, err := catalog.ExecuteDDL(
@@ -685,13 +690,13 @@ func TestStatsAvailable(t *testing.T) {
 	}
 
 	// Stats should not be available for any expression.
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT * FROM t WHERE a=1")
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn, "SELECT * FROM t WHERE a=1")
 	testNotAvailable(o.Memo().RootExpr().(memo.RelExpr))
 
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT sum(a), b FROM t GROUP BY b")
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn, "SELECT sum(a), b FROM t GROUP BY b")
 	testNotAvailable(o.Memo().RootExpr().(memo.RelExpr))
 
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx,
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn,
 		"SELECT * FROM t AS t1, t AS t2 WHERE t1.a = t2.a AND t1.b = 5",
 	)
 	testNotAvailable(o.Memo().RootExpr().(memo.RelExpr))
@@ -723,13 +728,13 @@ func TestStatsAvailable(t *testing.T) {
 	}
 
 	// Stats should be available for all expressions.
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT * FROM t WHERE a=1")
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn, "SELECT * FROM t WHERE a=1")
 	testAvailable(o.Memo().RootExpr().(memo.RelExpr))
 
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, "SELECT sum(a), b FROM t GROUP BY b")
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn, "SELECT sum(a), b FROM t GROUP BY b")
 	testAvailable(o.Memo().RootExpr().(memo.RelExpr))
 
-	opttestutils.BuildQuery(t, &o, catalog, &evalCtx,
+	opttestutils.BuildQuery(t, &o, catalog, &evalCtx, txn,
 		"SELECT * FROM t AS t1, t AS t2 WHERE t1.a = t2.a AND t1.b = 5",
 	)
 	testAvailable(o.Memo().RootExpr().(memo.RelExpr))

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -11,6 +11,7 @@ import (
 	"reflect"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -30,8 +31,9 @@ import (
 
 func TestMetadata(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), &evalCtx, nil /* catalog */)
+	f.Init(context.Background(), &evalCtx, txn, nil /* catalog */)
 	md := f.Metadata()
 
 	schID := md.AddSchema(&testcat.Schema{})
@@ -383,8 +385,9 @@ func TestIndexColumns(t *testing.T) {
 // TestDuplicateTable tests that we can extract a set of columns from an index ordinal.
 func TestDuplicateTable(t *testing.T) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), &evalCtx, nil /* catalog */)
+	f.Init(context.Background(), &evalCtx, txn, nil /* catalog */)
 	md := f.Metadata()
 	cat := testcat.New()
 	_, err := cat.ExecuteDDL("CREATE TABLE a (b BOOL, b2 BOOL, INDEX (b2) WHERE b)")

--- a/pkg/sql/opt/metadata_test.go
+++ b/pkg/sql/opt/metadata_test.go
@@ -100,7 +100,7 @@ func TestMetadata(t *testing.T) {
 	}
 
 	md.AddDependency(opt.DepByName(&tab.TabName), tab, privilege.CREATE)
-	depsUpToDate, err := md.CheckDependencies(context.Background(), &evalCtx, testCat)
+	depsUpToDate, err := md.CheckDependencies(context.Background(), &evalCtx, txn, testCat)
 	if err == nil || depsUpToDate {
 		t.Fatalf("expected table privilege to be revoked")
 	}
@@ -198,7 +198,7 @@ func TestMetadata(t *testing.T) {
 		}
 	}
 
-	depsUpToDate, err = md.CheckDependencies(context.Background(), &evalCtx, testCat)
+	depsUpToDate, err = md.CheckDependencies(context.Background(), &evalCtx, txn, testCat)
 	if err == nil || depsUpToDate {
 		t.Fatalf("expected table privilege to be revoked in metadata copy")
 	}

--- a/pkg/sql/opt/norm/BUILD.bazel
+++ b/pkg/sql/opt/norm/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/norm",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/opt",
@@ -82,6 +83,7 @@ go_test(
     ],
     embed = [":norm"],
     deps = [
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
         "//pkg/sql/opt/memo",

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -690,7 +690,7 @@ func (c *CustomFuncs) FoldFunction(
 		private.Overload,
 	)
 
-	result, err := eval.Expr(c.f.ctx, c.f.evalCtx, fn, c.f.evalCtx.Txn)
+	result, err := eval.Expr(c.f.ctx, c.f.evalCtx, fn, c.f.txn)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -690,7 +690,7 @@ func (c *CustomFuncs) FoldFunction(
 		private.Overload,
 	)
 
-	result, err := eval.Expr(c.f.ctx, c.f.evalCtx, fn)
+	result, err := eval.Expr(c.f.ctx, c.f.evalCtx, fn, c.f.evalCtx.Txn)
 	if err != nil {
 		return nil, false
 	}

--- a/pkg/sql/opt/norm/project_set_funcs.go
+++ b/pkg/sql/opt/norm/project_set_funcs.go
@@ -121,7 +121,7 @@ func (c *CustomFuncs) ConstructValuesFromZips(zip memo.ZipExpr) memo.RelExpr {
 			if err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generator retrieval failed"))
 			}
-			if err = generator.Start(c.f.ctx, c.f.evalCtx.Txn); err != nil {
+			if err = generator.Start(c.f.ctx, c.f.txn); err != nil {
 				panic(errors.NewAssertionErrorWithWrappedErrf(err, "generator.Start failed"))
 			}
 

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
     deps = [
         "//pkg/build",
         "//pkg/clusterversion",
+        "//pkg/kv",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/security/username",
         "//pkg/server/telemetry",
@@ -124,6 +125,7 @@ go_test(
     data = glob(["testdata/**"]),
     embed = [":optbuilder"],
     deps = [
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/colinfo/colinfotestutils",

--- a/pkg/sql/opt/optbuilder/builder.go
+++ b/pkg/sql/opt/optbuilder/builder.go
@@ -10,6 +10,7 @@ import (
 	"strconv"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -96,6 +97,7 @@ type Builder struct {
 	verboseTracing bool
 	semaCtx        *tree.SemaContext
 	evalCtx        *eval.Context
+	txn            *kv.Txn
 	catalog        cat.Catalog
 	scopeAlloc     []scope
 
@@ -209,6 +211,7 @@ func New(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factory *norm.Factory,
 	stmt tree.Statement,
@@ -224,6 +227,7 @@ func New(
 		verboseTracing:     log.ExpensiveLogEnabled(ctx, 2),
 		semaCtx:            semaCtx,
 		evalCtx:            evalCtx,
+		txn:                txn,
 		catalog:            catalog,
 		checkPrivilegeUser: catalog.GetCurrentUser(),
 	}

--- a/pkg/sql/opt/optbuilder/builder_test.go
+++ b/pkg/sql/opt/optbuilder/builder_test.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder"
@@ -80,9 +81,10 @@ func TestBuilder(t *testing.T) {
 				evalCtx.SessionData().OptimizerUseVirtualComputedColumnStats = true
 				evalCtx.SessionData().OptimizerUseImprovedZigzagJoinCosting = true
 				evalCtx.SessionData().OptimizerUseImprovedMultiColumnSelectivityEstimate = true
+				txn := &kv.Txn{}
 
 				var o xform.Optimizer
-				o.Init(ctx, &evalCtx, catalog)
+				o.Init(ctx, &evalCtx, txn, catalog)
 				var sv testutils.ScalarVars
 
 				for _, arg := range d.CmdArgs {
@@ -109,7 +111,7 @@ func TestBuilder(t *testing.T) {
 				// Disable normalization rules: we want the tests to check the result
 				// of the build process.
 				o.DisableOptimizations()
-				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, o.Factory())
+				b := optbuilder.NewScalar(ctx, &semaCtx, &evalCtx, txn, o.Factory())
 				scalar, err := b.Build(expr)
 				if err != nil {
 					return fmt.Sprintf("error: %s\n", strings.TrimSpace(err.Error()))

--- a/pkg/sql/opt/optbuilder/fk_cascade.go
+++ b/pkg/sql/opt/optbuilder/fk_cascade.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -86,13 +87,14 @@ func (cb *onDeleteCascadeBuilder) Build(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factoryI interface{},
 	binding opt.WithID,
 	bindingProps *props.Relational,
 	colMap opt.ColMap,
 ) (_ memo.RelExpr, err error) {
-	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, catalog, factoryI, cb.stmtTreeInitFn,
+	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, txn, catalog, factoryI, cb.stmtTreeInitFn,
 		func(b *Builder) memo.RelExpr {
 			opt.MaybeInjectOptimizerTestingPanic(ctx, evalCtx)
 
@@ -289,13 +291,14 @@ func (cb *onDeleteFastCascadeBuilder) Build(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factoryI interface{},
 	_ opt.WithID,
 	_ *props.Relational,
 	_ opt.ColMap,
 ) (_ memo.RelExpr, err error) {
-	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, catalog, factoryI, cb.stmtTreeInitFn,
+	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, txn, catalog, factoryI, cb.stmtTreeInitFn,
 		func(b *Builder) memo.RelExpr {
 			opt.MaybeInjectOptimizerTestingPanic(ctx, evalCtx)
 
@@ -466,13 +469,14 @@ func (cb *onDeleteSetBuilder) Build(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factoryI interface{},
 	binding opt.WithID,
 	bindingProps *props.Relational,
 	colMap opt.ColMap,
 ) (_ memo.RelExpr, err error) {
-	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, catalog, factoryI, cb.stmtTreeInitFn,
+	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, txn, catalog, factoryI, cb.stmtTreeInitFn,
 		func(b *Builder) memo.RelExpr {
 			opt.MaybeInjectOptimizerTestingPanic(ctx, evalCtx)
 
@@ -719,13 +723,14 @@ func (cb *onUpdateCascadeBuilder) Build(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factoryI interface{},
 	binding opt.WithID,
 	bindingProps *props.Relational,
 	colMap opt.ColMap,
 ) (_ memo.RelExpr, err error) {
-	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, catalog, factoryI, cb.stmtTreeInitFn,
+	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, txn, catalog, factoryI, cb.stmtTreeInitFn,
 		func(b *Builder) memo.RelExpr {
 			opt.MaybeInjectOptimizerTestingPanic(ctx, evalCtx)
 
@@ -997,13 +1002,14 @@ func buildTriggerCascadeHelper(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factoryI interface{},
 	stmtTreeInitFn func() statementTree,
 	fn func(b *Builder) memo.RelExpr,
 ) (_ memo.RelExpr, err error) {
 	factory := factoryI.(*norm.Factory)
-	b := New(ctx, semaCtx, evalCtx, catalog, factory, nil /* stmt */)
+	b := New(ctx, semaCtx, evalCtx, txn, catalog, factory, nil /* stmt */)
 	if stmtTreeInitFn != nil {
 		b.stmtTree = stmtTreeInitFn()
 	}

--- a/pkg/sql/opt/optbuilder/scalar.go
+++ b/pkg/sql/opt/optbuilder/scalar.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/seqexpr"
 	"github.com/cockroachdb/cockroach/pkg/sql/lex"
@@ -880,7 +881,7 @@ func (b *Builder) constructUnary(
 
 // ScalarBuilder is a specialized variant of Builder that can be used to create
 // a scalar from a TypedExpr. This is used to build scalar expressions for
-// testing. It is also used temporarily to interface with the old planning code.
+// testing.
 //
 // TypedExprs can refer to columns in the current scope using IndexedVars (@1,
 // @2, etc). When we build a scalar, we have to provide information about these
@@ -894,7 +895,11 @@ type ScalarBuilder struct {
 // NewScalar creates a new ScalarBuilder. The columns in the metadata are accessible
 // from scalar expressions via IndexedVars.
 func NewScalar(
-	ctx context.Context, semaCtx *tree.SemaContext, evalCtx *eval.Context, factory *norm.Factory,
+	ctx context.Context,
+	semaCtx *tree.SemaContext,
+	evalCtx *eval.Context,
+	txn *kv.Txn,
+	factory *norm.Factory,
 ) *ScalarBuilder {
 	md := factory.Metadata()
 	sb := &ScalarBuilder{
@@ -903,6 +908,7 @@ func NewScalar(
 			ctx:     ctx,
 			semaCtx: semaCtx,
 			evalCtx: evalCtx,
+			txn:     txn,
 		},
 	}
 	sb.scope.builder = &sb.Builder

--- a/pkg/sql/opt/optbuilder/select.go
+++ b/pkg/sql/opt/optbuilder/select.go
@@ -1486,6 +1486,7 @@ func (b *Builder) validateAsOf(asOfClause tree.AsOfClause) {
 		asOfClause,
 		b.semaCtx,
 		b.evalCtx,
+		b.txn,
 		asof.OptionAllowBoundedStaleness,
 	)
 	if err != nil {

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"fmt"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
@@ -537,13 +538,14 @@ func (tb *rowLevelAfterTriggerBuilder) Build(
 	ctx context.Context,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	catalog cat.Catalog,
 	factoryI interface{},
 	binding opt.WithID,
 	bindingProps *props.Relational,
 	colMap opt.ColMap,
 ) (_ memo.RelExpr, err error) {
-	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, catalog, factoryI, tb.stmtTreeInitFn,
+	return buildTriggerCascadeHelper(ctx, semaCtx, evalCtx, txn, catalog, factoryI, tb.stmtTreeInitFn,
 		func(b *Builder) memo.RelExpr {
 			f := b.factory
 			md := f.Metadata()

--- a/pkg/sql/opt/ordering/BUILD.bazel
+++ b/pkg/sql/opt/ordering/BUILD.bazel
@@ -54,6 +54,7 @@ go_test(
     ],
     embed = [":ordering"],
     deps = [
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",

--- a/pkg/sql/opt/ordering/group_by_test.go
+++ b/pkg/sql/opt/ordering/group_by_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -25,8 +26,9 @@ import (
 func TestDistinctOnProvided(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, testcat.New())
+	f.Init(context.Background(), evalCtx, txn, testcat.New())
 	md := f.Metadata()
 	for i := 1; i <= 5; i++ {
 		md.AddColumn(fmt.Sprintf("c%d", i), types.Int)

--- a/pkg/sql/opt/ordering/inverted_join_test.go
+++ b/pkg/sql/opt/ordering/inverted_join_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -28,8 +29,9 @@ func TestInvertedJoinProvided(t *testing.T) {
 	tc := testcat.New()
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, tc)
+	f.Init(context.Background(), evalCtx, txn, tc)
 	md := f.Metadata()
 
 	// Add the table with the inverted index.

--- a/pkg/sql/opt/ordering/lookup_join_test.go
+++ b/pkg/sql/opt/ordering/lookup_join_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -38,8 +39,9 @@ func TestLookupJoinProvided(t *testing.T) {
 	}
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, tc)
+	f.Init(context.Background(), evalCtx, txn, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)
@@ -236,8 +238,9 @@ func TestLookupJoinCanProvide(t *testing.T) {
 	ctx := context.Background()
 	evalCtx := eval.NewTestingEvalContext(st)
 	evalCtx.SessionData().OptimizerPlanLookupJoinsWithReverseScans = true
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, tc)
+	f.Init(context.Background(), evalCtx, txn, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)

--- a/pkg/sql/opt/ordering/project_test.go
+++ b/pkg/sql/opt/ordering/project_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/norm"
@@ -23,8 +24,9 @@ import (
 func TestProject(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(context.Background(), evalCtx, testcat.New())
+	f.Init(context.Background(), evalCtx, txn, testcat.New())
 	md := f.Metadata()
 	for i := 1; i <= 4; i++ {
 		md.AddColumn(fmt.Sprintf("col%d", i), types.Int)

--- a/pkg/sql/opt/ordering/row_number_test.go
+++ b/pkg/sql/opt/ordering/row_number_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
@@ -71,8 +72,9 @@ func TestOrdinalityProvided(t *testing.T) {
 		t.Run(fmt.Sprintf("case%d", tcIdx+1), func(t *testing.T) {
 			st := cluster.MakeTestingClusterSettings()
 			evalCtx := eval.NewTestingEvalContext(st)
+			txn := &kv.Txn{}
 			var f norm.Factory
-			f.Init(context.Background(), evalCtx, nil /* catalog */)
+			f.Init(context.Background(), evalCtx, txn, nil /* catalog */)
 			input := &testexpr.Instance{
 				Rel: &props.Relational{OutputCols: opt.MakeColSet(1, 2, 3, 4, 5)},
 				Provided: &physical.Provided{

--- a/pkg/sql/opt/ordering/scan_test.go
+++ b/pkg/sql/opt/ordering/scan_test.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -32,8 +33,9 @@ func TestScan(t *testing.T) {
 	st := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()
 	evalCtx := eval.NewTestingEvalContext(st)
+	txn := &kv.Txn{}
 	var f norm.Factory
-	f.Init(ctx, evalCtx, tc)
+	f.Init(ctx, evalCtx, txn, tc)
 	md := f.Metadata()
 	tn := tree.NewUnqualifiedTableName("t")
 	tab := md.AddTable(tc.Table(tn), tn)

--- a/pkg/sql/opt/partialidx/BUILD.bazel
+++ b/pkg/sql/opt/partialidx/BUILD.bazel
@@ -23,6 +23,7 @@ go_test(
     data = glob(["testdata/**"]),
     deps = [
         ":partialidx",
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/opt",
         "//pkg/sql/opt/exec/execbuilder",

--- a/pkg/sql/opt/testutils/BUILD.bazel
+++ b/pkg/sql/opt/testutils/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/testutils",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/sql/opt",
         "//pkg/sql/opt/cat",
         "//pkg/sql/opt/memo",

--- a/pkg/sql/opt/testutils/opttester/forcing_opt.go
+++ b/pkg/sql/opt/testutils/opttester/forcing_opt.go
@@ -60,7 +60,7 @@ func newForcingOptimizer(
 		remaining:   steps,
 		lastMatched: opt.InvalidRuleName,
 	}
-	fo.o.Init(context.Background(), &tester.evalCtx, tester.catalog)
+	fo.o.Init(context.Background(), &tester.evalCtx, tester.txn, tester.catalog)
 	fo.o.Factory().FoldingControl().AllowStableFolds()
 	fo.coster.Init(&fo.o, &fo.groups)
 	fo.o.SetCoster(&fo.coster)

--- a/pkg/sql/opt/xform/BUILD.bazel
+++ b/pkg/sql/opt/xform/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/xform",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/inverted",
@@ -87,6 +88,7 @@ go_test(
     }),
     deps = [
         "//pkg/config/zonepb",
+        "//pkg/kv",
         "//pkg/roachpb",
         "//pkg/security/securityassets",
         "//pkg/security/securitytest",

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -2134,7 +2134,7 @@ func (ef *execFactory) ConstructAlterTableSplit(
 		return nil, err
 	}
 
-	expirationTime, err := parseExpirationTime(ef.ctx, ef.planner.EvalContext(), expiration)
+	expirationTime, err := parseExpirationTime(ef.ctx, ef.planner.EvalContext(), ef.planner.Txn(), expiration)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"strings"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
@@ -126,7 +127,7 @@ func (p *planner) prepareUsingOptimizer(
 		// would be a better way to accomplish this goal. See CREATE TABLE for an
 		// example.
 		f := opc.optimizer.Factory()
-		bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), opc.catalog, f, t.Select)
+		bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), p.Txn(), opc.catalog, f, t.Select)
 		if err := bld.Build(); err != nil {
 			return opc.flags, err
 		}
@@ -290,6 +291,7 @@ func (p *planner) runExecBuild(
 			execMemo,
 			p.SemaCtx(),
 			p.EvalContext(),
+			p.Txn(),
 			p.autoCommit,
 			disableTelemetryAndPlanGists,
 		)
@@ -327,6 +329,7 @@ func (p *planner) runExecBuild(
 					execMemo,
 					p.SemaCtx(),
 					p.EvalContext(),
+					p.Txn(),
 					p.autoCommit,
 					disableTelemetryAndPlanGists,
 				)
@@ -350,6 +353,7 @@ func (p *planner) runExecBuild(
 		execMemo,
 		p.SemaCtx(),
 		p.EvalContext(),
+		p.Txn(),
 		p.autoCommit,
 		disableTelemetryAndPlanGists,
 	)
@@ -390,7 +394,7 @@ func (opc *optPlanningCtx) init(p *planner) {
 func (opc *optPlanningCtx) reset(ctx context.Context) {
 	p := opc.p
 	opc.catalog.reset()
-	opc.optimizer.Init(ctx, p.EvalContext(), opc.catalog)
+	opc.optimizer.Init(ctx, p.EvalContext(), p.Txn(), opc.catalog)
 	opc.flags = 0
 
 	// We only allow memo caching for SELECT/INSERT/UPDATE/DELETE. We could
@@ -494,7 +498,7 @@ func (opc *optPlanningCtx) buildReusableMemo(
 	// that there's even less to do during the EXECUTE phase.
 	//
 	f := opc.optimizer.Factory()
-	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), opc.catalog, f, opc.p.stmt.AST)
+	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), p.Txn(), opc.catalog, f, opc.p.stmt.AST)
 	bld.KeepPlaceholders = true
 	if opc.flags.IsSet(planFlagSessionMigration) {
 		bld.SkipAOST = true
@@ -850,7 +854,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 	// available.
 	f := opc.optimizer.Factory()
 	f.FoldingControl().AllowStableFolds()
-	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), opc.catalog, f, opc.p.stmt.AST)
+	bld := optbuilder.New(ctx, &p.semaCtx, p.EvalContext(), p.Txn(), opc.catalog, f, opc.p.stmt.AST)
 	if err := bld.Build(); err != nil {
 		return nil, err
 	}
@@ -907,6 +911,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	mem *memo.Memo,
 	semaCtx *tree.SemaContext,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	allowAutoCommit bool,
 	disableTelemetryAndPlanGists bool,
 ) error {
@@ -920,7 +925,7 @@ func (opc *optPlanningCtx) runExecBuilder(
 	if !planTop.instrumentation.ShouldBuildExplainPlan() {
 		bld = execbuilder.New(
 			ctx, f, &opc.optimizer, mem, opc.catalog, mem.RootExpr(),
-			semaCtx, evalCtx, allowAutoCommit, statements.IsANSIDML(stmt.AST),
+			semaCtx, evalCtx, txn, allowAutoCommit, statements.IsANSIDML(stmt.AST),
 		)
 		if disableTelemetryAndPlanGists {
 			bld.DisableTelemetry()
@@ -932,10 +937,10 @@ func (opc *optPlanningCtx) runExecBuilder(
 		result = plan.(*planComponents)
 	} else {
 		// Create an explain factory and record the explain.Plan.
-		explainFactory := explain.NewFactory(f, semaCtx, evalCtx)
+		explainFactory := explain.NewFactory(f, semaCtx, evalCtx, txn)
 		bld = execbuilder.New(
 			ctx, explainFactory, &opc.optimizer, mem, opc.catalog, mem.RootExpr(),
-			semaCtx, evalCtx, allowAutoCommit, statements.IsANSIDML(stmt.AST),
+			semaCtx, evalCtx, txn, allowAutoCommit, statements.IsANSIDML(stmt.AST),
 		)
 		if disableTelemetryAndPlanGists {
 			bld.DisableTelemetry()
@@ -1063,7 +1068,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 
 	// Optimize with the saved memo and hypothetical tables. Walk through the
 	// optimal plan to determine index recommendations.
-	opc.optimizer.Init(ctx, f.EvalContext(), opc.catalog)
+	opc.optimizer.Init(ctx, f.EvalContext(), opc.p.Txn(), opc.catalog)
 	f.CopyAndReplace(
 		savedMemo,
 		savedMemo.RootExpr().(memo.RelExpr),
@@ -1087,7 +1092,7 @@ func (opc *optPlanningCtx) makeQueryIndexRecommendation(
 	// Use the origCtx instead of ctx since the optimizer will hold onto this
 	// context after this function ends, and we don't want "use of Span after
 	// Finish" errors.
-	opc.optimizer.Init(origCtx, f.EvalContext(), opc.catalog)
+	opc.optimizer.Init(origCtx, f.EvalContext(), opc.p.Txn(), opc.catalog)
 	savedMemo.Metadata().UpdateTableMeta(origCtx, f.EvalContext(), optTables)
 	f.CopyAndReplace(
 		savedMemo,

--- a/pkg/sql/plan_opt.go
+++ b/pkg/sql/plan_opt.go
@@ -141,7 +141,7 @@ func (p *planner) prepareUsingOptimizer(
 			if !pm.TypeHints.Identical(p.semaCtx.Placeholders.TypeHints) {
 				opc.log(ctx, "query cache hit but type hints don't match")
 			} else {
-				isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.catalog)
+				isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), p.Txn(), opc.catalog)
 				if err != nil {
 					return 0, err
 				}
@@ -679,7 +679,7 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(ctx context.Context) (*memo.M
 	prep := opc.p.stmt.Prepared
 
 	if prep.GenericMemo != nil {
-		isStale, err := prep.GenericMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		isStale, err := prep.GenericMemo.IsStale(ctx, opc.p.EvalContext(), opc.p.Txn(), opc.catalog)
 		if err != nil {
 			return nil, err
 		} else if isStale {
@@ -694,7 +694,7 @@ func (opc *optPlanningCtx) chooseValidPreparedMemo(ctx context.Context) (*memo.M
 	}
 
 	if prep.BaseMemo != nil {
-		isStale, err := prep.BaseMemo.IsStale(ctx, opc.p.EvalContext(), opc.catalog)
+		isStale, err := prep.BaseMemo.IsStale(ctx, opc.p.EvalContext(), opc.p.Txn(), opc.catalog)
 		if err != nil {
 			return nil, err
 		} else if isStale {
@@ -825,7 +825,7 @@ func (opc *optPlanningCtx) buildExecMemo(ctx context.Context) (_ *memo.Memo, _ e
 		// Consult the query cache.
 		cachedData, ok := p.execCfg.QueryCache.Find(&p.queryCacheSession, opc.p.stmt.SQL)
 		if ok {
-			if isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.catalog); err != nil {
+			if isStale, err := cachedData.Memo.IsStale(ctx, p.EvalContext(), opc.p.Txn(), opc.catalog); err != nil {
 				return nil, err
 			} else if isStale {
 				opc.log(ctx, "query cache hit but needed update")

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -441,7 +441,7 @@ func newInternalPlanner(
 		sessionDataMutatorCallbacks: sessionDataMutatorCallbacks{},
 	}
 
-	p.extendedEvalCtx = internalExtendedEvalCtx(ctx, sds, params.collection, txn, ts, ts, execCfg)
+	p.extendedEvalCtx = internalExtendedEvalCtx(sds, params.collection, ts, ts, execCfg)
 	p.extendedEvalCtx.Planner = p
 	p.extendedEvalCtx.StreamManagerFactory = p
 	p.extendedEvalCtx.PrivilegedAccessor = p
@@ -503,10 +503,8 @@ func newInternalPlanner(
 // there's no session to speak of here, different fields are filled in here to
 // keep the tests using the internal planner passing.
 func internalExtendedEvalCtx(
-	ctx context.Context,
 	sds *sessiondata.Stack,
 	tables *descs.Collection,
-	txn *kv.Txn,
 	txnTimestamp time.Time,
 	stmtTimestamp time.Time,
 	execCfg *ExecutorConfig,
@@ -539,7 +537,6 @@ func internalExtendedEvalCtx(
 	}
 	ret := extendedEvalContext{
 		Context: eval.Context{
-			Txn:                            txn,
 			SessionDataStack:               sds,
 			TxnReadOnly:                    false,
 			TxnImplicit:                    true,

--- a/pkg/sql/reference_provider.go
+++ b/pkg/sql/reference_provider.go
@@ -115,8 +115,8 @@ func (f *referenceProviderFactory) NewReferenceProvider(
 	ctlg := &optCatalog{}
 	ctlg.init(f.p)
 	var optFactory norm.Factory
-	optFactory.Init(ctx, f.p.EvalContext(), ctlg)
-	optBld := optbuilder.New(ctx, f.p.SemaCtx(), f.p.EvalContext(), ctlg, &optFactory, stmt)
+	optFactory.Init(ctx, f.p.EvalContext(), f.p.Txn(), ctlg)
+	optBld := optbuilder.New(ctx, f.p.SemaCtx(), f.p.EvalContext(), f.p.Txn(), ctlg, &optFactory, stmt)
 	if err := optBld.Build(); err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/filterer.go
+++ b/pkg/sql/rowexec/filterer.go
@@ -62,7 +62,7 @@ func newFiltererProcessor(
 		return nil, err
 	}
 
-	if err := f.filter.Init(ctx, spec.Filter, types, &f.SemaCtx, f.evalCtx); err != nil {
+	if err := f.filter.Init(ctx, spec.Filter, types, &f.SemaCtx, f.evalCtx, f.FlowCtx.Txn); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/rowexec/inverted_filterer.go
+++ b/pkg/sql/rowexec/inverted_filterer.go
@@ -135,7 +135,7 @@ func newInvertedFilterer(
 		semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
 		var exprHelper execexpr.Helper
 		colTypes := []*types.T{spec.PreFiltererSpec.Type}
-		if err := exprHelper.Init(ctx, spec.PreFiltererSpec.Expression, colTypes, semaCtx, evalCtx); err != nil {
+		if err := exprHelper.Init(ctx, spec.PreFiltererSpec.Expression, colTypes, semaCtx, evalCtx, ifr.FlowCtx.Txn); err != nil {
 			return nil, err
 		}
 		preFilterer, preFiltererState, err := invertedidx.NewBoundPreFilterer(

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -262,7 +262,7 @@ func newInvertedJoiner(
 	// execbuilder.Builder.buildInvertedJoin.
 	onExprColTypes[len(ij.inputTypes)+ij.invertedFetchedColOrdinal] = spec.InvertedColumnOriginalType
 
-	if err := ij.onExprHelper.Init(ctx, spec.OnExpr, onExprColTypes, semaCtx, evalCtx); err != nil {
+	if err := ij.onExprHelper.Init(ctx, spec.OnExpr, onExprColTypes, semaCtx, evalCtx, ij.FlowCtx.Txn); err != nil {
 		return nil, err
 	}
 	combinedRowLen := len(onExprColTypes)
@@ -273,7 +273,7 @@ func newInvertedJoiner(
 
 	if ij.datumsToInvertedExpr == nil {
 		var invertedExprHelper execexpr.Helper
-		if err := invertedExprHelper.Init(ctx, spec.InvertedExpr, onExprColTypes, semaCtx, evalCtx); err != nil {
+		if err := invertedExprHelper.Init(ctx, spec.InvertedExpr, onExprColTypes, semaCtx, evalCtx, ij.FlowCtx.Txn); err != nil {
 			return nil, err
 		}
 		ij.datumsToInvertedExpr, err = invertedidx.NewDatumsToInvertedExpr(

--- a/pkg/sql/rowexec/inverted_joiner.go
+++ b/pkg/sql/rowexec/inverted_joiner.go
@@ -309,7 +309,7 @@ func newInvertedJoiner(
 	}
 
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
-		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+		if flowTxn := flowCtx.Txn; flowTxn != nil {
 			ij.contentionEventsListener.Init(flowTxn.ID())
 		}
 		ij.input = newInputStatCollector(ij.input)

--- a/pkg/sql/rowexec/joinerbase.go
+++ b/pkg/sql/rowexec/joinerbase.go
@@ -95,7 +95,7 @@ func (jb *joinerBase) init(
 		return nil, err
 	}
 	semaCtx := flowCtx.NewSemaContext(flowCtx.Txn)
-	return evalCtx, jb.onCond.Init(ctx, onExpr, onCondTypes, semaCtx, evalCtx)
+	return evalCtx, jb.onCond.Init(ctx, onExpr, onCondTypes, semaCtx, evalCtx, flowCtx.Txn)
 }
 
 // joinSide is the utility type to distinguish between two sides of the join.

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -611,7 +611,7 @@ func newJoinReader(
 	}
 
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
-		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+		if flowTxn := flowCtx.Txn; flowTxn != nil {
 			jr.contentionEventsListener.Init(flowTxn.ID())
 		}
 		jr.input = newInputStatCollector(jr.input)

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -438,12 +438,12 @@ func newJoinReader(
 		lookupExprTypes = append(lookupExprTypes, rightTypes...)
 
 		semaCtx := flowCtx.NewSemaContext(jr.txn)
-		if err := jr.lookupExpr.Init(ctx, spec.LookupExpr, lookupExprTypes, semaCtx, evalCtx); err != nil {
+		if err := jr.lookupExpr.Init(ctx, spec.LookupExpr, lookupExprTypes, semaCtx, evalCtx, flowCtx.Txn); err != nil {
 			return nil, err
 		}
 		if !spec.RemoteLookupExpr.Empty() {
 			if err := jr.remoteLookupExpr.Init(
-				ctx, spec.RemoteLookupExpr, lookupExprTypes, semaCtx, evalCtx,
+				ctx, spec.RemoteLookupExpr, lookupExprTypes, semaCtx, evalCtx, flowCtx.Txn,
 			); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/rowexec/project_set.go
+++ b/pkg/sql/rowexec/project_set.go
@@ -110,7 +110,7 @@ func newProjectSetProcessor(
 
 	// Initialize exprHelper.
 	semaCtx := ps.FlowCtx.NewSemaContext(ps.FlowCtx.Txn)
-	err := ps.eh.Init(ctx, len(ps.spec.Exprs), ps.input.OutputTypes(), semaCtx, ps.evalCtx)
+	err := ps.eh.Init(ctx, len(ps.spec.Exprs), ps.input.OutputTypes(), semaCtx, ps.evalCtx, flowCtx.Txn)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -160,7 +160,7 @@ func newTableReader(
 	}
 
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
-		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+		if flowTxn := flowCtx.Txn; flowTxn != nil {
 			tr.contentionEventsListener.Init(flowTxn.ID())
 		}
 		tr.fetcher = newRowFetcherStatCollector(&fetcher)

--- a/pkg/sql/rowexec/zigzagjoiner.go
+++ b/pkg/sql/rowexec/zigzagjoiner.go
@@ -331,7 +331,7 @@ func newZigzagJoiner(
 
 	collectingStats := false
 	if execstats.ShouldCollectStats(ctx, flowCtx.CollectStats) {
-		if flowTxn := flowCtx.EvalCtx.Txn; flowTxn != nil {
+		if flowTxn := flowCtx.Txn; flowTxn != nil {
 			z.contentionEventsListener.Init(flowTxn.ID())
 		}
 		collectingStats = true

--- a/pkg/sql/rowflow/row_based_flow.go
+++ b/pkg/sql/rowflow/row_based_flow.go
@@ -253,7 +253,7 @@ func (f *rowBasedFlow) makeProcessorAndOutput(
 
 	proc, err := rowexec.NewProcessor(
 		ctx,
-		&f.FlowCtx,
+		f.FlowCtx,
 		ps.ProcessorID,
 		&ps.Core,
 		&ps.Post,
@@ -269,7 +269,7 @@ func (f *rowBasedFlow) makeProcessorAndOutput(
 	rowRecv := output.(*copyingRowReceiver).RowReceiver
 	switch o := rowRecv.(type) {
 	case router:
-		o.init(ctx, &f.FlowCtx, ps.ProcessorID, types)
+		o.init(ctx, f.FlowCtx, ps.ProcessorID, types)
 	case *flowinfra.Outbox:
 		o.Init(types)
 	}
@@ -421,7 +421,7 @@ func (f *rowBasedFlow) setupOutboundStream(
 
 	case execinfrapb.StreamEndpointSpec_REMOTE:
 		atomic.AddInt32(&f.numOutboxes, 1)
-		outbox := flowinfra.NewOutbox(&f.FlowCtx, processorID, spec.TargetNodeID, sid, &f.numOutboxes, f.FlowCtx.Gateway)
+		outbox := flowinfra.NewOutbox(f.FlowCtx, processorID, spec.TargetNodeID, sid, &f.numOutboxes, f.FlowCtx.Gateway)
 		f.AddStartable(outbox)
 		return outbox, nil
 
@@ -463,7 +463,7 @@ func (f *rowBasedFlow) setupRouter(
 		// NB: Stream IDs are indexes into slices, so we'd expect to OOM long
 		// before a stream ID exceeds 2^31.
 		mn := mon.MakeName("router").WithID(int32(spec.Streams[i].StreamID))
-		memoryMonitors[i] = execinfra.NewLimitedMonitor(ctx, f.Mon, &f.FlowCtx, mn.Limited())
+		memoryMonitors[i] = execinfra.NewLimitedMonitor(ctx, f.Mon, f.FlowCtx, mn.Limited())
 		unlimitedMemMonitors[i] = execinfra.NewMonitor(ctx, f.Mon, mn.Unlimited())
 		diskMonitors[i] = execinfra.NewMonitor(ctx, f.DiskMonitor, mn.Disk())
 	}

--- a/pkg/sql/sem/asof/BUILD.bazel
+++ b/pkg/sql/sem/asof/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/sem/asof",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/kv",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/sem/eval",
@@ -28,6 +29,7 @@ go_test(
     srcs = ["as_of_test.go"],
     deps = [
         ":asof",
+        "//pkg/kv",
         "//pkg/settings/cluster",
         "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",

--- a/pkg/sql/sem/asof/as_of_test.go
+++ b/pkg/sql/sem/asof/as_of_test.go
@@ -8,6 +8,7 @@ package asof_test
 import (
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/asof"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
@@ -18,6 +19,7 @@ import (
 
 func BenchmarkDatumToHLC(b *testing.B) {
 	evalCtx := eval.MakeTestingEvalContext(cluster.MakeTestingClusterSettings())
+	txn := &kv.Txn{}
 	stmtTimestamp := timeutil.Now()
 	usage := asof.AsOf
 
@@ -32,7 +34,7 @@ func BenchmarkDatumToHLC(b *testing.B) {
 		b.Run(tc.name, func(b *testing.B) {
 			var err error
 			for i := 0; i < b.N; i++ {
-				_, err = asof.DatumToHLC(&evalCtx, stmtTimestamp, tc.d, usage)
+				_, err = asof.DatumToHLC(&evalCtx, txn, stmtTimestamp, tc.d, usage)
 			}
 			require.NoError(b, err)
 		})

--- a/pkg/sql/sem/asof/type_check.go
+++ b/pkg/sql/sem/asof/type_check.go
@@ -8,6 +8,7 @@ package asof
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -47,6 +48,7 @@ func TypeCheckSystemTimeExpr(
 func EvalSystemTimeExpr(
 	ctx context.Context,
 	evalCtx *eval.Context,
+	txn *kv.Txn,
 	semaCtx *tree.SemaContext,
 	systemTimeExpr tree.Expr,
 	op string,
@@ -64,5 +66,5 @@ func EvalSystemTimeExpr(
 		return hlc.MaxTimestamp, nil
 	}
 	stmtTimestamp := evalCtx.GetStmtTimestamp()
-	return DatumToHLC(evalCtx, stmtTimestamp, d, usage)
+	return DatumToHLC(evalCtx, txn, stmtTimestamp, d, usage)
 }

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -2922,9 +2923,9 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 		tree.Overload{
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Decimal),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				return evalCtx.GetClusterTimestamp()
-			},
+			FnWithTxn: eval.FnWithTxnOverload(func(ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, args tree.Datums) (tree.Datum, error) {
+				return evalCtx.GetClusterTimestamp(txn)
+			}),
 			Info: `Returns the logical time of the current transaction as
 a CockroachDB HLC in decimal form.
 
@@ -6080,15 +6081,15 @@ SELECT
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "val", Typ: types.Interval}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			FnWithTxn: eval.FnWithTxnOverload(func(ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, args tree.Datums) (tree.Datum, error) {
 				minDuration := args[0].(*tree.DInterval).Duration
 				elapsed := duration.MakeDuration(int64(evalCtx.StmtTimestamp.Sub(evalCtx.TxnTimestamp)), 0, 0)
 				if elapsed.Compare(minDuration) < 0 {
-					return nil, evalCtx.Txn.GenerateForcedRetryableErr(
+					return nil, txn.GenerateForcedRetryableErr(
 						ctx, "forced by crdb_internal.force_retry()")
 				}
 				return tree.DZero, nil
-			},
+			}),
 			Info:       "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility: volatility.Volatile,
 		},
@@ -6101,16 +6102,16 @@ SELECT
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "val", Typ: types.Int}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			FnWithTxn: eval.FnWithTxnOverload(func(ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, args tree.Datums) (tree.Datum, error) {
 				retries := int64(evalCtx.Planner.RetryCounter())
 				maxRetries := int64(tree.MustBeDInt(args[0]))
 				if retries < maxRetries {
-					return nil, evalCtx.Txn.GenerateForcedRetryableErr(
+					return nil, txn.GenerateForcedRetryableErr(
 						ctx, "forced by crdb_internal.force_retry()",
 					)
 				}
 				return tree.DZero, nil
-			},
+			}),
 			Info:             "This function is used only by CockroachDB's developers for testing purposes.",
 			Volatility:       volatility.Volatile,
 			DistsqlBlocklist: true, // applicable only on the gateway
@@ -6125,25 +6126,21 @@ SELECT
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "key", Typ: types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Int),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if evalCtx.Txn == nil { // can occur during backfills
-					return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-						"cannot use crdb_internal.lease_holder in this context")
-				}
+			FnWithTxn: eval.FnWithTxnOverload(func(ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, args tree.Datums) (tree.Datum, error) {
 				key := []byte(tree.MustBeDBytes(args[0]))
-				b := evalCtx.Txn.NewBatch()
+				b := txn.NewBatch()
 				b.AddRawRequest(&kvpb.LeaseInfoRequest{
 					RequestHeader: kvpb.RequestHeader{
 						Key: key,
 					},
 				})
-				if err := evalCtx.Txn.Run(ctx, b); err != nil {
+				if err := txn.Run(ctx, b); err != nil {
 					return nil, pgerror.Wrap(err, pgcode.InvalidParameterValue, "error fetching leaseholder")
 				}
 				resp := b.RawResponse().Responses[0].GetInner().(*kvpb.LeaseInfoResponse)
 
 				return tree.NewDInt(tree.DInt(resp.Lease.Replica.StoreID)), nil
-			},
+			}),
 			Info:       "This function is used to fetch the leaseholder corresponding to a request key",
 			Volatility: volatility.Volatile,
 		},
@@ -6158,13 +6155,9 @@ SELECT
 		tree.Overload{
 			Types:      tree.ParamTypes{{Name: "key", Typ: types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Jsonb),
-			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				if evalCtx.Txn == nil { // can occur during backfills
-					return nil, pgerror.Newf(pgcode.FeatureNotSupported,
-						"cannot use crdb_internal.lease_holder_with_errors in this context")
-				}
+			FnWithTxn: eval.FnWithTxnOverload(func(ctx context.Context, evalCtx *eval.Context, txn *kv.Txn, args tree.Datums) (tree.Datum, error) {
 				key := []byte(tree.MustBeDBytes(args[0]))
-				b := evalCtx.Txn.DB().NewBatch()
+				b := txn.DB().NewBatch()
 				b.AddRawRequest(&kvpb.LeaseInfoRequest{
 					RequestHeader: kvpb.RequestHeader{
 						Key: key,
@@ -6175,7 +6168,7 @@ SELECT
 					Error       string
 				}
 				lhae := &leaseholderAndError{}
-				if err := evalCtx.Txn.DB().Run(ctx, b); err != nil {
+				if err := txn.DB().Run(ctx, b); err != nil {
 					lhae.Error = err.Error()
 				} else {
 					resp := b.RawResponse().Responses[0].GetInner().(*kvpb.LeaseInfoResponse)
@@ -6191,7 +6184,7 @@ SELECT
 					return nil, err
 				}
 				return jsonDatum, nil
-			},
+			}),
 			Info:       "This function is used to fetch the leaseholder corresponding to a request key",
 			Volatility: volatility.Volatile,
 		},
@@ -10275,7 +10268,9 @@ var arrayToJSONImpls = makeBuiltin(jsonProps(),
 	tree.Overload{
 		Types:      tree.ParamTypes{{Name: "array", Typ: types.AnyArray}},
 		ReturnType: tree.FixedReturnType(types.Jsonb),
-		Fn:         toJSONImpl.Fn,
+		Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+			return toJSONObject(evalCtx, args[0])
+		},
 		Info:       "Returns the array as JSON or JSONB.",
 		Volatility: volatility.Stable,
 	},

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -2314,7 +2314,6 @@ func (j *jsonRecordSetGenerator) Next(ctx context.Context) (bool, error) {
 }
 
 type checkConsistencyGenerator struct {
-	txn                *kv.Txn // to load range descriptors
 	consistencyChecker eval.ConsistencyCheckRunner
 	rangeDescIterator  rangedesc.Iterator
 	mode               kvpb.ChecksumMode
@@ -2398,7 +2397,6 @@ func makeCheckConsistencyGenerator(
 		return nil, err
 	}
 	return &checkConsistencyGenerator{
-		txn:                evalCtx.Txn,
 		consistencyChecker: evalCtx.ConsistencyChecker,
 		rangeDescIterator:  rangeDescIterator,
 		mode:               mode,

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -81,6 +81,7 @@ go_library(
         "//pkg/util",
         "//pkg/util/arith",
         "//pkg/util/bitarray",
+        "//pkg/util/buildutil",
         "//pkg/util/cidr",
         "//pkg/util/duration",
         "//pkg/util/encoding",

--- a/pkg/sql/sem/eval/BUILD.bazel
+++ b/pkg/sql/sem/eval/BUILD.bazel
@@ -81,7 +81,6 @@ go_library(
         "//pkg/util",
         "//pkg/util/arith",
         "//pkg/util/bitarray",
-        "//pkg/util/buildutil",
         "//pkg/util/cidr",
         "//pkg/util/duration",
         "//pkg/util/encoding",

--- a/pkg/sql/sem/eval/binary_op.go
+++ b/pkg/sql/sem/eval/binary_op.go
@@ -35,7 +35,8 @@ import (
 func BinaryOp(
 	ctx context.Context, evalCtx *Context, op tree.BinaryEvalOp, left, right tree.Datum,
 ) (tree.Datum, error) {
-	return op.Eval(ctx, (*evaluator)(evalCtx), left, right)
+	e := &evaluator{Context: evalCtx}
+	return op.Eval(ctx, e, left, right)
 }
 
 func (e *evaluator) EvalAppendToMaybeNullArrayOp(

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -169,9 +169,6 @@ type Context struct {
 
 	PreparedStatementState PreparedStatementState
 
-	// The transaction in which the statement is executing.
-	Txn *kv.Txn
-
 	ReCache           *tree.RegexpCache
 	ToCharFormatCache *tochar.FormatCache
 
@@ -443,7 +440,6 @@ func MakeTestingEvalContext(st *cluster.Settings) Context {
 func MakeTestingEvalContextWithMon(st *cluster.Settings, monitor *mon.BytesMonitor) Context {
 	ctx := Context{
 		Codec:            keys.SystemSQLCodec,
-		Txn:              &kv.Txn{},
 		SessionDataStack: sessiondata.NewStack(&sessiondata.SessionData{}),
 		Settings:         st,
 		NodeID:           base.TestingIDContainer,

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
-	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/errors"
 )
@@ -28,9 +27,6 @@ import (
 func Expr(
 	ctx context.Context, evalCtx *Context, n tree.TypedExpr, optionalTxn ...*kv.Txn,
 ) (tree.Datum, error) {
-	if len(optionalTxn) == 0 {
-		return n.Eval(ctx, (*evaluator)(evalCtx))
-	}
 	var txn *kv.Txn
 	var explicitNilTxn bool
 	if len(optionalTxn) > 1 {
@@ -39,18 +35,16 @@ func Expr(
 		txn = optionalTxn[0]
 		explicitNilTxn = txn == nil
 	}
-	return n.Eval(ctx, &evaluatorWithTxn{evaluator: (*evaluator)(evalCtx), txn: txn, explicitNilTxn: explicitNilTxn})
+	return n.Eval(ctx, &evaluator{Context: evalCtx, txn: txn, explicitNilTxn: explicitNilTxn})
 }
 
-type evaluator Context
-
-type evaluatorWithTxn struct {
-	*evaluator
+type evaluator struct {
+	*Context
 	txn            *kv.Txn
 	explicitNilTxn bool
 }
 
-func (e *evaluator) ctx() *Context { return (*Context)(e) }
+func (e *evaluator) ctx() *Context { return e.Context }
 
 func (e *evaluator) EvalAllColumnsSelector(
 	ctx context.Context, selector *tree.AllColumnsSelector,
@@ -518,10 +512,13 @@ func (e *evaluator) EvalFuncExpr(ctx context.Context, expr *tree.FuncExpr) (tree
 	}
 
 	if fn.FnWithTxn != nil {
-		if buildutil.CrdbTestBuild {
-			return nil, errors.AssertionFailedf("attempting to evaluate a builtin that uses txn in context without passing txn argument to eval.Expr")
+		if e.txn == nil {
+			if e.explicitNilTxn {
+				return nil, ErrNilTxnForBuiltin
+			}
+			return nil, errors.AssertionFailedf("txn wasn't provided in this context")
 		}
-		return nil, pgerror.Newf(pgcode.FeatureNotSupported, "cannot evaluate function that uses txn in this context")
+		return fn.FnWithTxn.(FnWithTxnOverload)(ctx, e.ctx(), e.txn, args)
 	}
 	if fn.Body != "" {
 		// This expression evaluator cannot run functions defined with a SQL body.
@@ -543,31 +540,6 @@ func (e *evaluator) EvalFuncExpr(ctx context.Context, expr *tree.FuncExpr) (tree
 		}
 	}
 	return res, nil
-}
-
-func (e *evaluatorWithTxn) EvalFuncExpr(
-	ctx context.Context, expr *tree.FuncExpr,
-) (tree.Datum, error) {
-	fn := expr.ResolvedOverload()
-	if fn.FnWithTxn == nil {
-		return e.evaluator.EvalFuncExpr(ctx, expr)
-	}
-
-	nullResult, args, err := e.evalFuncArgs(ctx, expr)
-	if err != nil {
-		return nil, err
-	}
-	if nullResult {
-		return tree.DNull, err
-	}
-
-	if e.txn == nil {
-		if e.explicitNilTxn {
-			return nil, ErrNilTxnForBuiltin
-		}
-		return nil, errors.AssertionFailedf("txn wasn't provided in this context")
-	}
-	return fn.FnWithTxn.(FnWithTxnOverload)(ctx, e.ctx(), e.txn, args)
 }
 
 func (e *evaluator) evalFuncArgs(

--- a/pkg/sql/sem/eval/generators.go
+++ b/pkg/sql/sem/eval/generators.go
@@ -28,7 +28,8 @@ func GetFuncGenerator(
 	if ol.GeneratorWithExprs != nil {
 		return ol.GeneratorWithExprs.(GeneratorWithExprsOverload)(ctx, evalCtx, expr.Exprs)
 	}
-	nullArg, args, err := (*evaluator)(evalCtx).evalFuncArgs(ctx, expr)
+	e := &evaluator{Context: evalCtx}
+	nullArg, args, err := e.evalFuncArgs(ctx, expr)
 	if err != nil || nullArg {
 		return nil, err
 	}
@@ -39,7 +40,8 @@ func GetFuncGenerator(
 func GetRoutineGenerator(
 	ctx context.Context, evalCtx *Context, expr *tree.RoutineExpr,
 ) (ValueGenerator, error) {
-	args, err := (*evaluator)(evalCtx).evalRoutineArgs(ctx, expr.Args)
+	e := &evaluator{Context: evalCtx}
+	args, err := e.evalRoutineArgs(ctx, expr.Args)
 	if err != nil {
 		return nil, err
 	}
@@ -53,7 +55,7 @@ func GetRoutineGenerator(
 			}
 		}
 	}
-	return (*evaluator)(evalCtx).Planner.RoutineExprGenerator(ctx, expr, args), nil
+	return e.Planner.RoutineExprGenerator(ctx, expr, args), nil
 }
 
 // Table generators, also called "set-generating functions", are

--- a/pkg/sql/sem/eval/timeconv_test.go
+++ b/pkg/sql/sem/eval/timeconv_test.go
@@ -65,18 +65,17 @@ func TestClusterTimestampConversion(t *testing.T) {
 			false, // omitInRangefeeds
 		)
 
-		ctx := eval.Context{
-			Txn: kv.NewTxnFromProto(
-				context.Background(),
-				db,
-				1, /* gatewayNodeID */
-				ts,
-				kv.RootTxn,
-				&txnProto,
-			),
-		}
+		txn := kv.NewTxnFromProto(
+			context.Background(),
+			db,
+			1, /* gatewayNodeID */
+			ts,
+			kv.RootTxn,
+			&txnProto,
+		)
+		var evalCtx eval.Context
 
-		dec, err := ctx.GetClusterTimestamp()
+		dec, err := evalCtx.GetClusterTimestamp(txn)
 		require.NoError(t, err)
 		final := dec.Text('f')
 		if final != d.expected {

--- a/pkg/sql/sem/eval/unary_op.go
+++ b/pkg/sql/sem/eval/unary_op.go
@@ -17,7 +17,8 @@ import (
 func UnaryOp(
 	ctx context.Context, evalCtx *Context, op tree.UnaryEvalOp, in tree.Datum,
 ) (tree.Datum, error) {
-	return op.Eval(ctx, (*evaluator)(evalCtx), in)
+	e := &evaluator{Context: evalCtx}
+	return op.Eval(ctx, e, in)
 }
 
 func (e *evaluator) EvalCbrtDecimalOp(

--- a/pkg/sql/sem/eval/window_funcs.go
+++ b/pkg/sql/sem/eval/window_funcs.go
@@ -120,7 +120,8 @@ func (wfr *WindowFrameRun) getValueByOffset(
 	if value == tree.DNull {
 		return tree.DNull, nil
 	}
-	return binOp.EvalOp.Eval(ctx, (*evaluator)(evalCtx), value, offset)
+	e := &evaluator{Context: evalCtx}
+	return binOp.EvalOp.Eval(ctx, e, value, offset)
 }
 
 // FrameStartIdx returns the index of starting row in the frame (which is the first to be included).

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -55,6 +55,11 @@ type WindowOverload interface {
 	Window()
 }
 
+// FnWithTxnOverload is an opaque type used to box an eval.FnWithTxnOverload.
+type FnWithTxnOverload interface {
+	FnWithTxnOverload()
+}
+
 // FnWithExprsOverload is an opaque type used to box an
 // eval.FnWithExprsOverload.
 type FnWithExprsOverload interface {
@@ -198,6 +203,10 @@ type Overload struct {
 	//
 	// The opaque wrapper needs to be type asserted into eval.FnOverload.
 	Fn FnOverload
+
+	// FnWithTxnOverload is for builtins that need access to a kv.Txn object,
+	// but is otherwise identical to Fn.
+	FnWithTxn FnWithTxnOverload
 
 	// FnWithExprs is for builtins that need access to their arguments as Exprs
 	// and not pre-evaluated Datums, but is otherwise identical to Fn.

--- a/pkg/sql/sql_cursor.go
+++ b/pkg/sql/sql_cursor.go
@@ -88,6 +88,7 @@ func (p *planner) DeclareCursor(ctx context.Context, s *tree.DeclareCursor) (pla
 				memo,
 				p.SemaCtx(),
 				p.EvalContext(),
+				p.Txn(),
 				p.autoCommit,
 				false, /* disableTelemetryAndPlanGists */
 			); err != nil {

--- a/pkg/sql/values.go
+++ b/pkg/sql/values.go
@@ -83,7 +83,7 @@ func (n *valuesNode) startExec(params runParams) error {
 	for _, tupleRow := range n.tuples {
 		for i, typedExpr := range tupleRow {
 			var err error
-			row[i], err = eval.Expr(params.ctx, params.EvalContext(), typedExpr)
+			row[i], err = eval.Expr(params.ctx, params.EvalContext(), typedExpr, params.p.Txn())
 			if err != nil {
 				return err
 			}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -1731,8 +1731,8 @@ var varGen = map[string]sessionVar{
 	// been executed yet.
 	// See https://github.com/postgres/postgres/blob/REL_10_STABLE/src/backend/utils/misc/guc.c#L3401-L3409
 	`transaction_isolation`: {
-		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
-			level := tree.FromKVIsoLevel(evalCtx.Txn.IsoLevel())
+		Get: func(_ *extendedEvalContext, txn *kv.Txn) (string, error) {
+			level := tree.FromKVIsoLevel(txn.IsoLevel())
 			return strings.ToLower(level.String()), nil
 		},
 		RuntimeSet: func(ctx context.Context, evalCtx *extendedEvalContext, local bool, s string) error {

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -374,6 +374,7 @@ func (v *vTableLookupJoinNode) pushRow(lookedUpRow ...tree.Datum) error {
 	if ok, err := v.pred.eval(
 		v.run.params.ctx,
 		v.run.params.EvalContext(),
+		v.run.params.p.Txn(),
 		v.run.row[:len(v.inputCols)],
 		v.run.row[len(v.inputCols):],
 	); !ok || err != nil {


### PR DESCRIPTION
This commit extracts all builtins that access `eval.Context.Txn` field
explicitly into a newly-added `FnWithTxn` field of the overload. This is
a step towards removing `eval.Context.Txn` field to clarify which txn is
being used during the execution.

`Context` is type-aliased to `evaluator` which implements a few
evaluator interfaces. This commit introduces an extension that overrides
`EvalFuncExpr` method implementation to handle `FnWithTxn` overloads,
everything else is delegated to `evaluator` (the "vanilla" evaluator
returns an error when trying to evaluate `FnWithTxn`, which is an
assertion failure in test builds).

`eval.Expr` signature has been adjusted to take in an optional txn
argument. If expression evaluation is performed in the context where we
_might_ be evaluating builtins that use txns, then the txn needs to be
given or explicit `nil` txn needs to be passed to use the extended
`evaluatorWithTxn`.

Informs: #41992.
Epic: None
Release note: None