### PR TITLE
release-25.1: pkg/keys: make PrettyPrintRange redactable

### DIFF
--- a/pkg/keys/BUILD.bazel
+++ b/pkg/keys/BUILD.bazel
@@ -21,6 +21,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
     ],
 )
 
@@ -47,6 +48,7 @@ go_test(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/cockroachdb/redact/interfaces"
 )
 
 // PrettyPrintTimeseriesKey is a hook for pretty printing a timeseries key. The
@@ -869,83 +870,161 @@ func init() {
 //
 //	start
 //
-// It prints at most maxChars, truncating components as needed. See
-// TestPrettyPrintRange for some examples.
-func PrettyPrintRange(start, end roachpb.Key, maxChars int) string {
-	var b bytes.Buffer
+// It prints at most maxChars, truncating components as needed. The output is
+// redactable and honors redaction markers that may already be present in the
+// start and end keys. See TestPrettyPrintRange for some examples.
+func PrettyPrintRange(start, end roachpb.Key, maxChars int) redact.RedactableString {
+	var b redact.StringBuilder
 	if maxChars < 8 {
 		maxChars = 8
 	}
-	prettyStart := safeFormatInternal(nil /* valDirs */, start, DontQuoteRaw).StripMarkers()
+
+	prettyStart := safeFormatInternal(nil /* valDirs */, start, DontQuoteRaw)
 	if len(end) == 0 {
-		if len(prettyStart) <= maxChars {
+		if utf8.RuneCountInString(string(prettyStart)) <= maxChars {
 			return prettyStart
 		}
-		copyEscape(&b, prettyStart[:maxChars-1])
-		b.WriteRune('…')
-		return b.String()
+		CopyEscapeTrunc(&b, string(prettyStart), maxChars)
+		return b.RedactableString()
 	}
-	prettyEnd := safeFormatInternal(nil /* valDirs */, end, DontQuoteRaw).StripMarkers()
+
+	prettyEnd := safeFormatInternal(nil /* valDirs */, end, DontQuoteRaw)
 	i := 0
 	// Find the common prefix.
 	for ; i < len(prettyStart) && i < len(prettyEnd) && prettyStart[i] == prettyEnd[i]; i++ {
 	}
+
 	// If we don't have space for at least '{a…-b…}' after the prefix, only print
 	// the prefix (or part of it).
-	if i > maxChars-7 {
-		if i > maxChars-1 {
-			i = maxChars - 1
+	prefixCharCount := utf8.RuneCountInString(string(prettyStart[:i]))
+	if prefixCharCount > maxChars-7 {
+		CopyEscapeTrunc(&b, string(prettyStart[:i]), maxChars)
+		if prefixCharCount <= maxChars {
+			b.SafeRune('…')
 		}
-		copyEscape(&b, prettyStart[:i])
-		b.WriteRune('…')
-		return b.String()
-	}
-	b.WriteString(prettyStart[:i])
-	remaining := (maxChars - i - 3) / 2
-
-	printTrunc := func(b *bytes.Buffer, what string, maxChars int) {
-		if len(what) <= maxChars {
-			copyEscape(b, what)
-		} else {
-			copyEscape(b, what[:maxChars-1])
-			b.WriteRune('…')
-		}
+		return b.RedactableString()
 	}
 
-	b.WriteByte('{')
-	printTrunc(&b, prettyStart[i:], remaining)
-	b.WriteByte('-')
-	printTrunc(&b, prettyEnd[i:], remaining)
-	b.WriteByte('}')
+	// copy the common prefix
+	CopyEscapeTrunc(&b, string(prettyStart[:i]), prefixCharCount)
+	remaining := (maxChars - prefixCharCount - 3) / 2
 
-	return b.String()
+	b.SafeRune('{')
+	CopyEscapeTrunc(&b, string(prettyStart[i:]), remaining)
+	b.SafeRune('-')
+	CopyEscapeTrunc(&b, string(prettyEnd[i:]), remaining)
+	b.SafeRune('}')
+	return b.RedactableString()
 }
 
-// copyEscape copies the string to the buffer, and avoids writing
-// invalid UTF-8 sequences and control characters.
-func copyEscape(buf *bytes.Buffer, s string) {
-	buf.Grow(len(s))
-	// k is the index in s before which characters have already
-	// been copied into buf.
-	k := 0
-	for i := 0; i < len(s); i++ {
-		c := s[i]
+// CopyEscapeTrunc copies the string to the buffer, and avoids writing invalid UTF-8
+// sequences and control characters. If redaction markers are found the chars
+// within it will be marked as unsafe and the rest will be marked as safe. This
+// will work even if the redaction markers are partially present in the string.
+func CopyEscapeTrunc(buf *redact.StringBuilder, s string, maxChars int) {
+	strCharCount := utf8.RuneCountInString(s)
+	if maxChars > strCharCount {
+		maxChars = strCharCount
+	}
+
+	isTruncated := false
+	if maxChars < strCharCount {
+		// if we are truncating the string, we need to account for the ellipsis
+		maxChars -= 1
+		isTruncated = true
+	}
+
+	buf.Grow(maxChars)
+
+	// Set initial safety state based on the presence of redaction markers:
+	//   * If we encounter an open `›` later in the string, sets `safe` to
+	//   `false` because all chars until `›` are unsafe.
+	//   * If we encounter a close `‹` later in the string, sets `safe` to
+	//   `true` because all chars until `‹` are safe.
+	//   * If there are no redaction markers, everything is safe.
+	safe := true
+	for _, r := range s {
+		if r == '‹' {
+			break
+		}
+		if r == '›' {
+			safe = false
+			break
+		}
+	}
+
+	printStr := func(str string) {
+		if safe {
+			buf.Print(redact.SafeString(str))
+			return
+		}
+
+		buf.Print(str)
+	}
+
+	printByte := func(c byte) {
+		if safe {
+			buf.SafeByte(interfaces.SafeByte(c))
+			return
+		}
+
+		buf.UnsafeByte(c)
+	}
+
+	var writtenTill, currIdx, charsWritten int
+	for currIdx = 0; currIdx < len(s) && charsWritten < maxChars; currIdx++ {
+		c := s[currIdx]
 		if c < utf8.RuneSelf && strconv.IsPrint(rune(c)) {
+			charsWritten++
 			continue
 		}
-		buf.WriteString(s[k:i])
-		l, width := utf8.DecodeRuneInString(s[i:])
-		if l == utf8.RuneError || l < 0x20 {
+
+		l, width := utf8.DecodeRuneInString(s[currIdx:])
+		switch {
+		case l == utf8.RuneError || l < 0x20:
+			// write everything from writtenTill to current index before processing the invalid
+			// character
+			if writtenTill < currIdx {
+				printStr(s[writtenTill:currIdx])
+			}
+
 			const hex = "0123456789abcdef"
-			buf.WriteByte('\\')
-			buf.WriteByte('x')
-			buf.WriteByte(hex[c>>4])
-			buf.WriteByte(hex[c&0xf])
-		} else {
-			buf.WriteRune(l)
+			printByte('\\')
+			printByte('x')
+			printByte(hex[c>>4])
+			printByte(hex[c&0xf])
+
+			writtenTill = currIdx + width
+			currIdx += width - 1
+			charsWritten += 1 // count this as a single char
+
+		case l == '‹':
+			// write everything from writtenTill to current index as safe and flip the safe
+			// flag to false
+			printStr(s[writtenTill:currIdx])
+			writtenTill = currIdx + width
+			currIdx += width - 1
+			safe = false
+
+		case l == '›':
+			// write everything from writtenTill to current index as unsafe and flip the safe
+			// flag to true
+			printStr(s[writtenTill:currIdx])
+			writtenTill = currIdx + width
+			currIdx += width - 1
+			safe = true
+
+		default:
+			charsWritten++
+			currIdx += width - 1
 		}
-		k = i + width
-		i += width - 1
 	}
-	buf.WriteString(s[k:])
+
+	if writtenTill < currIdx {
+		printStr(s[writtenTill:currIdx])
+	}
+
+	if isTruncated {
+		buf.SafeRune('…')
+	}
 }

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -126,7 +126,7 @@ func (d *atomicDescString) store(replicaID roachpb.ReplicaID, desc *roachpb.Rang
 		} else {
 			const maxRangeChars = 30
 			rngStr := keys.PrettyPrintRange(roachpb.Key(desc.StartKey), roachpb.Key(desc.EndKey), maxRangeChars)
-			w.UnsafeString(rngStr)
+			w.Print(rngStr)
 		}
 	})
 

--- a/pkg/kv/kvserver/replica_test.go
+++ b/pkg/kv/kvserver/replica_test.go
@@ -492,9 +492,9 @@ func TestReplicaStringAndSafeFormat(t *testing.T) {
 	// String.
 	assert.Equal(t, "[n1,s2,r3/4:{a-b}]", r.String())
 	// Redactable string.
-	assert.EqualValues(t, "[n1,s2,r3/4:‹{a-b}›]", redact.Sprint(r))
+	assert.EqualValues(t, "[n1,s2,r3/4:{‹a›-‹b›}]", redact.Sprint(r))
 	// Redacted string.
-	assert.EqualValues(t, "[n1,s2,r3/4:‹×›]", redact.Sprint(r).Redact())
+	assert.EqualValues(t, "[n1,s2,r3/4:{‹×›-‹×›}]", redact.Sprint(r).Redact())
 }
 
 // TestReplicaContains verifies that the range uses Key.Address() in

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -95,7 +95,7 @@ var (
 	// PrettyPrintRange prints a key range in human readable format. It's
 	// implemented in package git.com/cockroachdb/cockroach/keys to avoid
 	// package circle import.
-	PrettyPrintRange func(start, end Key, maxChars int) string
+	PrettyPrintRange func(start, end Key, maxChars int) redact.RedactableString
 )
 
 // RKey denotes a Key whose local addressing has been accounted for.
@@ -2581,7 +2581,7 @@ func (s Span) AsRange() interval.Range {
 
 func (s Span) String() string {
 	const maxChars = math.MaxInt32
-	return PrettyPrintRange(s.Key, s.EndKey, maxChars)
+	return PrettyPrintRange(s.Key, s.EndKey, maxChars).StripMarkers()
 }
 
 // SplitOnKey returns two spans where the left span has EndKey and right span
@@ -2778,7 +2778,7 @@ func (rs RSpan) ContainsKeyRange(start, end RKey) bool {
 
 func (rs RSpan) String() string {
 	const maxChars = math.MaxInt32
-	return PrettyPrintRange(Key(rs.Key), Key(rs.EndKey), maxChars)
+	return PrettyPrintRange(Key(rs.Key), Key(rs.EndKey), maxChars).StripMarkers()
 }
 
 // Intersect returns the intersection of the current span and the


### PR DESCRIPTION
Backport 1/1 commits from #141409.

/cc @cockroachdb/release

---

The diff in #138632 was to big for a single PR. So, it's being broken into individual stable changes. This is the first PR from that.

---

Currently, the start and end keys supplied to `PrettyPrintRange` are already redactable. But the current implementation of `PrettyPrintRange` ignores the redactable nature of the keys. The markers are stripped off and raw strings are used to form the string representation of the `Span`/`RSpan`/`RangeDescriptor`. This led to the entire string getting redacted.

This commit fixes that by incorporating the redaction markers into the algorithm that constructs the string representation in PrettyPrintRange and returns a `redact.RedactableString`. This will make sure that only the sensitive parts of the keys are redacted instead of the whole range.

Summary of changes:

  * `PrettyPrintRange` returns RedactableString instead of standard string
  * The `CopyEscape` function (now renamed to `CopyEscapeTrunc`) is now responsible for maintaining the redactability while copying contents.
  * `CopyEscapeTrunc` also handles truncating the string if it exceeds the `maxChars`
  * Export `CopyEscapeTrunc` so that unit tests can be written for it (since tests are in `keys_test` package)

Epic: CRDB-37533
Part of: CRDB-44885
Release note: None

Release justification: This commit significantly reduces over redaction of logs that contain Spans and RSpans.
