### PR TITLE
roachtest: end sysbench's bench.txt with newline

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -820,6 +820,6 @@ func sysbenchToGoBench(name string, result string) (string, error) {
 	}
 
 	// Return formatted benchmark string with all metrics.
-	return fmt.Sprintf("%s\t1\t%s queries/sec\t%s txns/sec\t%s ms/min\t%s ms/avg\t%s ms/p95\t%s ms/max",
+	return fmt.Sprintf("%s\t1\t%s queries/sec\t%s txns/sec\t%s ms/min\t%s ms/avg\t%s ms/p95\t%s ms/max\n",
 		benchName, qps, tps, minLat, avgLat, p95Lat, maxLat), nil
 }

--- a/pkg/cmd/roachtest/tests/sysbench_test.go
+++ b/pkg/cmd/roachtest/tests/sysbench_test.go
@@ -47,7 +47,7 @@ Threads fairness:
     events (avg/stddev):           11954.3281/1290.50
     execution time (avg/stddev):   599.9974/0.01`,
 			benchmarkName:  "sysbench-settings/oltp_read_write/nodes=3/cpu=8/conc=64",
-			expectedOutput: "BenchmarkSysbenchSettings/a=oltp_read_write/nodes=3/cpu=8/conc=64\t1\t25501.03 queries/sec\t1275.05 txns/sec\t11.86 ms/min\t50.19 ms/avg\t81.48 ms/p95\t276.58 ms/max",
+			expectedOutput: "BenchmarkSysbenchSettings/a=oltp_read_write/nodes=3/cpu=8/conc=64\t1\t25501.03 queries/sec\t1275.05 txns/sec\t11.86 ms/min\t50.19 ms/avg\t81.48 ms/p95\t276.58 ms/max\n",
 			expectError:    false,
 		},
 		{


### PR DESCRIPTION
Otherwise, they can't be concatenated as easily for use with benchstat.

Epic: CRDB-42584
Release note: none