### PR TITLE
release-24.1: sql: block ALTER TABLE of identity columns not backed by a sequence

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -1218,8 +1218,14 @@ func applyColumnMutation(
 				col.GetName(), tableDesc.GetName())
 		}
 
-		// It is assumed that an identify column owns only one sequence.
-		if col.NumUsesSequences() != 1 {
+		numSeqs := col.NumUsesSequences()
+		if numSeqs == 0 {
+			// This can happen when a SERIAL column is created with IDENTITY and
+			// serial_normalization=rowid, meaning it doesn't use a real sequence.
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"identity column %q of relation %q is not backed by a sequence",
+				col.GetName(), tableDesc.GetName())
+		} else if numSeqs > 1 {
 			return errors.AssertionFailedf(
 				"identity column %q of relation %q has %d sequences instead of 1",
 				col.GetName(), tableDesc.GetName(), col.NumUsesSequences())
@@ -1265,8 +1271,14 @@ func applyColumnMutation(
 				col.GetName(), tableDesc.GetName())
 		}
 
-		// It is assumed that an identify column owns only one sequence.
-		if col.NumUsesSequences() != 1 {
+		numSeqs := col.NumUsesSequences()
+		if numSeqs == 0 {
+			// This can happen when a SERIAL column is created with IDENTITY and
+			// serial_normalization=rowid, meaning it doesn't use a real sequence.
+			return pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+				"identity column %q of relation %q is not backed by a sequence",
+				col.GetName(), tableDesc.GetName())
+		} else if numSeqs > 1 {
 			return errors.AssertionFailedf(
 				"identity column %q of relation %q has %d sequences instead of 1",
 				col.GetName(), tableDesc.GetName(), col.NumUsesSequences())

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -2050,6 +2050,42 @@ INSERT INTO t (c) VALUES (2)
 statement ok
 DROP TABLE t
 
+subtest generated_with_serial_unique_row_id
+
+statement ok
+SET serial_normalization = rowid
+
+statement ok
+CREATE TABLE t(a INT PRIMARY KEY)
+
+statement ok
+ALTER TABLE t ADD COLUMN b SERIAL GENERATED ALWAYS AS IDENTITY
+
+query T
+SELECT crdb_internal.pb_to_json('desc', descriptor)->'table'->'columns'->1->>'defaultExpr'
+FROM system.descriptor
+WHERE id = 't'::regclass::oid
+----
+unique_rowid()
+
+query T
+SELECT crdb_internal.pb_to_json('desc', descriptor)->'table'->'columns'->1->>'generatedAsIdentityType'
+FROM system.descriptor
+WHERE id = 't'::regclass::oid
+----
+GENERATED_ALWAYS
+
+statement error pq: identity column "b" of relation "t" is not backed by a sequence
+ALTER TABLE t ALTER COLUMN b DROP IDENTITY;
+
+statement error pq: identity column "b" of relation "t" is not backed by a sequence
+ALTER TABLE t ALTER COLUMN b SET CYCLE;
+
+statement ok
+DROP TABLE t;
+
+subtest end
+
 subtest generated_as_identity_with_seq_option
 statement ok
 DROP TABLE IF EXISTS t;
@@ -2453,8 +2489,8 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name               state   refobjid
-201       test_serial_b_seq  PUBLIC  200
-200       test_serial        PUBLIC  NULL
+202       test_serial_b_seq  PUBLIC  201
+201       test_serial        PUBLIC  NULL
 
 statement ok
 DROP TABLE test_serial;
@@ -2488,8 +2524,8 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name               state   refobjid
-203       test_serial_b_seq  PUBLIC  202
-202       test_serial        PUBLIC  NULL
+204       test_serial_b_seq  PUBLIC  203
+203       test_serial        PUBLIC  NULL
 
 statement ok
 ALTER TABLE test_serial DROP COLUMN b;
@@ -2504,7 +2540,7 @@ FROM (
 LEFT JOIN pg_catalog.pg_depend r ON l.table_id = r.objid;
 ----
 table_id  name         state   refobjid
-202       test_serial  PUBLIC  NULL
+203       test_serial  PUBLIC  NULL
 
 statement ok
 DROP TABLE test_serial;


### PR DESCRIPTION
Backport 1/1 commits from #147698.

/cc @cockroachdb/release

---

Previously, identity columns not backed by sequences (e.g. SERIAL columns with serial_normalization=rowid) were not protected from ALTER operations that modified identity attributes. This could lead to assertion failures. This change adds checks to block such ALTER TABLE statements.

Fixes #147488
Fixes #146989

Epic: none
Release note (bug fix): Prevented ALTER TABLE from modifying identity attributes on columns not backed by a sequence.

Release justification: fixes an issue found in a sentry report