### PR TITLE
sql: skip dropped constraints in introspection queries

### DIFF
--- a/pkg/sql/schemachanger/dml_injection_test.go
+++ b/pkg/sql/schemachanger/dml_injection_test.go
@@ -411,6 +411,20 @@ func TestAlterTableDMLInjection(t *testing.T) {
 			query:        "select * from pg_catalog.pg_constraint",
 		},
 		{
+			desc: "drop a column with a check constraint while querying crdb_internal.create_statements",
+			setup: []string{
+				"ALTER TABLE tbl ADD COLUMN i INT CHECK (i is NOT NULL) DEFAULT 10",
+			},
+			schemaChange: "ALTER TABLE tbl DROP COLUMN i",
+			// Run a query against crdb_internal.create_statements. We don't
+			// care about the result — only that it doesn't fail. This is
+			// valuable when dropping constraints because create_statements performs
+			// descriptor introspection, including rendering expressions for
+			// check constraints. If a column in the check constraint is in the
+			// process of being dropped it will have a placeholder name.
+			query: `SELECT * FROM "".crdb_internal.create_statements`,
+		},
+		{
 			desc:         "create index",
 			schemaChange: "CREATE INDEX idx ON tbl (val)",
 		},

--- a/pkg/sql/show_create_clauses.go
+++ b/pkg/sql/show_create_clauses.go
@@ -826,6 +826,12 @@ func showConstraintClause(
 		if e.IsHashShardingConstraint() && !e.IsConstraintUnvalidated() {
 			continue
 		}
+		// Don't include the constraint if it's in the process of being dropped. If
+		// the column is being dropped with the constraint, it might not even have a
+		// valid name.
+		if e.GetConstraintValidity() == descpb.ConstraintValidity_Dropping {
+			continue
+		}
 		f.WriteString(",\n\t")
 		if len(e.GetName()) > 0 {
 			f.WriteString("CONSTRAINT ")
@@ -837,7 +843,7 @@ func showConstraintClause(
 			ctx, desc, e.GetExpr(), evalCtx, semaCtx, sessionData, exprFmtFlags,
 		)
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "failed to format check constraint for table %s", desc.GetName())
 		}
 		f.WriteString(expr)
 		f.WriteString(")")
@@ -846,6 +852,9 @@ func showConstraintClause(
 		}
 	}
 	for _, c := range desc.UniqueConstraintsWithoutIndex() {
+		if c.GetConstraintValidity() == descpb.ConstraintValidity_Dropping {
+			continue
+		}
 		f.WriteString(",\n\t")
 		if len(c.GetName()) > 0 {
 			f.WriteString("CONSTRAINT ")
@@ -865,7 +874,7 @@ func showConstraintClause(
 				ctx, desc, c.GetPredicate(), evalCtx, semaCtx, sessionData, exprFmtFlags,
 			)
 			if err != nil {
-				return err
+				return errors.Wrapf(err, "failed to format unique constraint without index for table %s", desc.GetName())
 			}
 			f.WriteString(pred)
 		}


### PR DESCRIPTION
Dropped constraints remain in table descriptors until the schema change job fully completes. During this time, introspection queries (such as crdb_internal.create_statements) may encounter these constraints, even if they reference columns that are also in the process of being dropped. This can result in errors.

This change updates the introspection logic to ignore constraints that are marked for deletion, preventing such failures.

Informs #147514
Epic: None

Release note (bug fix): Fixed a bug where introspection queries could fail if a dropped constraint referenced a column that was also being dropped.