### PR TITLE
roachprod: correct error statement for cluster config creation fail

### DIFF
--- a/pkg/roachprod/promhelperclient/client.go
+++ b/pkg/roachprod/promhelperclient/client.go
@@ -130,7 +130,7 @@ func (c *PromClient) setUrl(url string) {
 
 // instanceConfigRequest is the HTTP request received for generating instance config
 type instanceConfigRequest struct {
-	//Config is the content of the yaml file
+	// Config is the content of the yaml file
 	Config   string `json:"config"`
 	Insecure bool   `json:"insecure"`
 }
@@ -140,7 +140,7 @@ func (c *PromClient) UpdatePrometheusTargets(
 	ctx context.Context,
 	clusterName string,
 	forceFetchCreds bool,
-	nodes map[int][]*NodeInfo,
+	nodeTargets NodeTargets,
 	insecure bool,
 	l *logger.Logger,
 ) error {
@@ -148,7 +148,7 @@ func (c *PromClient) UpdatePrometheusTargets(
 		l.Printf("Prometheus registration is disabled")
 		return nil
 	}
-	req, err := buildCreateRequest(nodes, insecure)
+	req, err := buildCreateRequest(nodeTargets, insecure)
 	if err != nil {
 		return err
 	}
@@ -171,7 +171,7 @@ func (c *PromClient) UpdatePrometheusTargets(
 		defer func() { _ = response.Body.Close() }()
 		if response.StatusCode == http.StatusUnauthorized && !forceFetchCreds {
 			l.Printf("request failed - this may be due to a stale token. retrying with forceFetchCreds true ...")
-			return c.UpdatePrometheusTargets(ctx, clusterName, true, nodes, insecure, l)
+			return c.UpdatePrometheusTargets(ctx, clusterName, true, nodeTargets, insecure, l)
 		}
 		body, err := io.ReadAll(response.Body)
 		if err != nil {
@@ -253,8 +253,23 @@ type NodeInfo struct {
 	CustomLabels map[string]string // Custom labels to be added to the cluster config
 }
 
+// NodeTargets contains prometheus scrape targets for each node.
+type NodeTargets map[int][]*NodeInfo
+
+func (nt NodeTargets) String() string {
+	var parts []string
+	for port, infos := range nt {
+		var targets []string
+		for _, info := range infos {
+			targets = append(targets, info.Target)
+		}
+		parts = append(parts, fmt.Sprintf("%d:[%s]", port, strings.Join(targets, ",")))
+	}
+	return strings.Join(parts, " ")
+}
+
 // createClusterConfigFile creates the cluster config file per node
-func buildCreateRequest(nodes map[int][]*NodeInfo, insecure bool) (io.Reader, error) {
+func buildCreateRequest(nodes NodeTargets, insecure bool) (io.Reader, error) {
 	configs := make([]*CCParams, 0)
 	for _, n := range nodes {
 		for _, node := range n {

--- a/pkg/roachprod/promhelperclient/client_test.go
+++ b/pkg/roachprod/promhelperclient/client_test.go
@@ -46,12 +46,12 @@ func TestUpdatePrometheusTargets(t *testing.T) {
 			}, nil
 		}
 		err := c.UpdatePrometheusTargets(ctx, "c1", false,
-			map[int][]*NodeInfo{1: {{Target: "n1"}}}, true, l)
+			NodeTargets{1: {{Target: "n1"}}}, true, l)
 		require.NotNil(t, err)
 		require.Equal(t, fmt.Sprintf(ErrorMessage, 400, getUrl(promUrl, "c1"), "failed"), err.Error())
 	})
 	t.Run("UpdatePrometheusTargets succeeds", func(t *testing.T) {
-		nodeInfos := map[int][]*NodeInfo{
+		nodeInfos := NodeTargets{
 			1: {{
 				Target: "n1",
 			}},

--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -818,7 +818,7 @@ func updatePrometheusTargets(
 	}
 
 	cl := promhelperclient.NewPromClient()
-	nodeIPPorts := make(map[int][]*promhelperclient.NodeInfo)
+	nodeIPPorts := promhelperclient.NodeTargets{}
 	nodeIPPortsMutex := syncutil.RWMutex{}
 	var wg sync.WaitGroup
 	for _, node := range c.Nodes {


### PR DESCRIPTION
Previously the NodeInfo to Node was stored in an ambiguous map structure, leading to an improper printing of the ip ports stored in it, this patch creates a type alias with a String() method to replace all instances of this map structure.

Release note: none
Fixes: none
Epic: none
Informs: none