### PR TITLE
workload/schemachanger: detect trigger-based self-dependencies in tableHasDependencies

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -117,7 +117,7 @@ func (og *operationGenerator) tableHasDependencies(
                             ns.oid = c.relnamespace
                      WHERE c.relname = $1 AND ns.nspname = $2
                 )
-           AND fd.descriptor_id != fd.dependedonby_id
+           AND NOT (fd.descriptor_id = fd.dependedonby_id AND fd.dependedonby_type = 'fk')
            AND fd.dependedonby_type != 'sequence'
            %s
        )


### PR DESCRIPTION
Previously, tableHasDependencies excluded all self-dependencies under the assumption that they originated from foreign keys. However, triggers can also create self-references now (see #147018), and that should be counted as true dependencies since it will block things like a table rename.

This change updates the query to exclude only self-dependencies where the dependedonby_type is 'fk', allowing ones from triggers to be detected correctly.

Informs #147514

Epic: none
Release note: none