### PR TITLE
logictest: enable schema locked in remaining tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 # We've seen this test hit a timeout in fakedist configs under race.
 skip under race
 
@@ -223,6 +221,7 @@ CREATE TABLE t (rowid INT PRIMARY KEY, y INT NOT NULL, FAMILY (rowid, y));
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y)
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t
 ----
@@ -233,6 +232,18 @@ t  CREATE TABLE public.t (
      UNIQUE INDEX t_rowid_key (rowid ASC),
      FAMILY fam_0_rowid_y (rowid, y)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     rowid INT8 NOT NULL,
+     y INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC),
+     UNIQUE INDEX t_rowid_key (rowid ASC),
+     FAMILY fam_0_rowid_y (rowid, y)
+   ) WITH (schema_locked = true);
 
 subtest index_rewrites
 # Test that indexes that need to get rewritten indeed get rewritten.
@@ -255,6 +266,12 @@ CREATE TABLE t (
   INDEX i7 (z) USING HASH WITH (bucket_count=4), -- will be rewritten.
   FAMILY (x, y, z, w, v)
 );
+
+# Because of #146725 we can't have schema_locked set, since this
+# fallback to the legacy schema changer.
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = false);
 
 statement ok
 INSERT INTO t VALUES (1, 2, 3, 4, '{}');
@@ -435,6 +452,12 @@ CREATE TABLE t (
 statement ok
 INSERT INTO t VALUES (1, 2, 3);
 
+# Because of #146725 we can't have schema_locked set, since this
+# fallback to the legacy schema changer.
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = false);
+
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y) USING HASH WITH (bucket_count=10)
 
@@ -501,6 +524,12 @@ CREATE TABLE t (
 statement ok
 INSERT INTO t VALUES (1, 2, 3);
 
+# Because of #146725 we can't have schema_locked set, since this
+# fallback to the legacy schema changer.
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = false);
+
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y)
 
@@ -535,6 +564,7 @@ DROP TABLE IF EXISTS t;
 statement ok
 CREATE TABLE t (rowid INT NOT NULL);
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t
 ----
@@ -544,10 +574,21 @@ t  CREATE TABLE public.t (
      CONSTRAINT t_pkey PRIMARY KEY (rowid_1 ASC)
    );
 
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     rowid INT8 NOT NULL,
+     rowid_1 INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (rowid_1 ASC)
+   ) WITH (schema_locked = true);
+
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (rowid)
 
 # Legacy schema changer will keep the rowid column.
+skipif config local-schema-locked
 skipif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
@@ -556,6 +597,15 @@ t  CREATE TABLE public.t (
      rowid INT8 NOT NULL,
      CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     rowid INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (rowid ASC)
+   ) WITH (schema_locked = true);
 
 # Regression for old primary key not using PrimaryIndexEncoding as its encoding type.
 subtest encoding_bug
@@ -583,7 +633,7 @@ statement ok
 DROP TABLE IF EXISTS t;
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL)
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false);
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -602,7 +652,7 @@ statement ok
 DROP TABLE IF EXISTS t;
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL)
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -638,6 +688,7 @@ statement ok
 ALTER TABLE t ADD PRIMARY KEY (x)
 
 # Row ID isn't removed by legacy schema changer.
+skipif config local-schema-locked
 skipif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
@@ -646,6 +697,15 @@ t  CREATE TABLE public.t (
      x INT8 NOT NULL,
      CONSTRAINT t_pkey PRIMARY KEY (x ASC)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC)
+   ) WITH (schema_locked = true);
 
 statement ok
 DROP TABLE IF EXISTS t;
@@ -656,6 +716,7 @@ CREATE TABLE t (x INT NOT NULL);
 statement ok
 ALTER TABLE t ADD PRIMARY KEY (x) USING HASH WITH (bucket_count=4)
 
+skipif config local-schema-locked
 skipif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
@@ -665,6 +726,16 @@ t  CREATE TABLE public.t (
      crdb_internal_x_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(x))), 4:::INT8)) VIRTUAL,
      CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=4)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     crdb_internal_x_shard_4 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(x))), 4:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=4)
+   ) WITH (schema_locked = true);
 
 statement ok
 DROP TABLE IF EXISTS t;
@@ -676,6 +747,7 @@ statement ok
 ALTER TABLE t ADD CONSTRAINT "my_pk" PRIMARY KEY (x)
 
 # Row ID isn't removed by legacy schema changer.
+skipif config local-schema-locked
 skipif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
@@ -685,18 +757,35 @@ t  CREATE TABLE public.t (
      CONSTRAINT my_pk PRIMARY KEY (x ASC)
    );
 
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     CONSTRAINT my_pk PRIMARY KEY (x ASC)
+   ) WITH (schema_locked = true);
+
 statement ok
-CREATE INDEX i ON t (x);
+CREATE INDEX i ON t (x)
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = false);
 
 statement error pgcode 42P07 constraint with name \"i\" already exists
 ALTER TABLE t DROP CONSTRAINT "my_pk", ADD CONSTRAINT "i" PRIMARY KEY (x);
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = true);
 
 # Regression for #45362.
 statement ok
 DROP TABLE IF EXISTS t;
 
 statement ok
-CREATE TABLE t (x INT NOT NULL)
+CREATE TABLE t (x INT NOT NULL) WITH (schema_locked = false)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -734,8 +823,9 @@ subtest add_drop_pk
 statement ok
 DROP TABLE IF EXISTS t;
 
+# Legacy schema changer statements
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y))
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y)) WITH (schema_locked = false)
 
 statement error pq: relation "t" \([0-9]+\): unimplemented: primary key dropped without subsequent addition of new primary key in same transaction
 ALTER TABLE t DROP CONSTRAINT "t_pkey"
@@ -772,7 +862,7 @@ statement ok
 DROP TABLE t;
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y))
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y)) WITH (schema_locked = false)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -791,7 +881,7 @@ statement ok
 DROP TABLE t;
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y))
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL, FAMILY (x), FAMILY (y))  WITH (schema_locked = false)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -823,7 +913,7 @@ statement ok
 DROP TABLE t;
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL)
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -925,10 +1015,10 @@ statement ok
 DROP TABLE IF EXISTS t1, t2 CASCADE;
 
 statement ok
-CREATE TABLE t1 (x INT PRIMARY KEY, y INT NOT NULL);
+CREATE TABLE t1 (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false);
 
 statement ok
-CREATE TABLE t2 (x INT)
+CREATE TABLE t2 (x INT) WITH (schema_locked = false)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -951,7 +1041,7 @@ statement ok
 DROP TABLE IF EXISTS t;
 
 statement ok
-CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL)
+CREATE TABLE t (x INT PRIMARY KEY, y INT NOT NULL) WITH (schema_locked = false)
 
 statement error pq: table "t" does not have a primary key, cannot perform ADD COLUMN z INT8 AS \(x \+ 1\) STORED
 ALTER TABLE t DROP CONSTRAINT t_pkey, ADD COLUMN z INT AS (x + 1) STORED, ADD PRIMARY KEY (y)
@@ -975,6 +1065,7 @@ ALTER TABLE t ADD PRIMARY KEY (x)
 statement ok
 COMMIT
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t
 ----
@@ -986,6 +1077,19 @@ t  CREATE TABLE public.t (
      INDEX t_y_idx (y ASC),
      FAMILY fam_0_x_y_rowid (x, y, rowid)
    );
+
+onlyif config local-schmema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     y INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC),
+     INDEX t_y_idx (y ASC),
+     FAMILY fam_0_x_y_rowid (x, y, rowid)
+   ) WITH (schema_locked = true);
 
 # Ensure that index y got rewritten. If it was not rewritten,
 # it would have an id less than 3.
@@ -1013,6 +1117,7 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (x)
 statement ok
 COMMIT
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t
 ----
@@ -1024,6 +1129,20 @@ t  CREATE TABLE public.t (
      INDEX t_y_idx (y ASC),
      FAMILY fam_0_x_y_rowid (x, y, rowid)
    );
+
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     y INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC),
+     INDEX t_y_idx (y ASC),
+     FAMILY fam_0_x_y_rowid (x, y, rowid)
+   ) WITH (schema_locked = true);
 
 # Ensure that index y got rewritten. If it was not rewritten,
 # it would have an id less than 3.
@@ -1057,6 +1176,7 @@ ALTER TABLE t ADD PRIMARY KEY (x)
 statement ok
 COMMIT
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t
 ----
@@ -1072,6 +1192,23 @@ t  CREATE TABLE public.t (
      INDEX i3 (w ASC) STORING (y, z),
      FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     y INT8 NULL,
+     z INT8 NULL,
+     w INT8 NULL,
+     rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC),
+     INDEX i1 (y ASC),
+     UNIQUE INDEX i2 (z ASC),
+     INDEX i3 (w ASC) STORING (y, z),
+     FAMILY fam_0_x_y_z_w_rowid (x, y, z, w, rowid)
+   ) WITH (schema_locked = true);
 
 # All index id's should be larger than 4.
 query IT
@@ -1095,6 +1232,7 @@ statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (x) USING HASH WITH (bucket_count=3)
 
 # old shard column isn't removed by legacy schema changer.
+skipif config local-schema-locked
 skipif config local-legacy-schema-changer
 query TT
 SHOW CREATE t
@@ -1104,6 +1242,16 @@ t  CREATE TABLE public.t (
      crdb_internal_x_shard_3 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(x))), 3:::INT8)) VIRTUAL,
      CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=3)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     x INT8 NOT NULL,
+     crdb_internal_x_shard_3 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(x))), 3:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (x ASC) USING HASH WITH (bucket_count=3)
+   ) WITH (schema_locked = true);
 
 # Changes on a hash sharded index that change the columns will cause the old
 # primary key to be copied.
@@ -1116,6 +1264,7 @@ CREATE TABLE t (x INT PRIMARY KEY USING HASH WITH (bucket_count=2), y INT NOT NU
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (y) USING HASH WITH (bucket_count=2)
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t
 ----
@@ -1128,6 +1277,20 @@ t  CREATE TABLE public.t (
      UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=2),
      FAMILY fam_0_x_y (x, y)
    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t
+----
+t  CREATE TABLE public.t (
+     crdb_internal_x_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(x))), 2:::INT8)) VIRTUAL,
+     x INT8 NOT NULL,
+     y INT8 NOT NULL,
+     crdb_internal_y_shard_2 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(y))), 2:::INT8)) VIRTUAL,
+     CONSTRAINT t_pkey PRIMARY KEY (y ASC) USING HASH WITH (bucket_count=2),
+     UNIQUE INDEX t_x_key (x ASC) USING HASH WITH (bucket_count=2),
+     FAMILY fam_0_x_y (x, y)
+   ) WITH (schema_locked = true);
 
 # Regression for #49079.
 statement ok
@@ -1214,9 +1377,17 @@ t1_pkey  id    ASC
 t1_pkey  id2   ASC
 t1_pkey  name  N/A
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t1 SET (schema_locked = false)
+
 # Validate drop and recreate
 statement ok
 alter table t1 drop constraint t1_pkey, alter primary key using columns(id, id2);
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t1 SET (schema_locked = true)
 
 # Row ID isn't removed by legacy schema changer.
 skipif config local-legacy-schema-changer
@@ -1316,6 +1487,7 @@ CREATE TABLE table_with_virtual_cols (
 );
 ALTER TABLE table_with_virtual_cols ALTER PRIMARY KEY USING COLUMNS (new_pk)
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE TABLE table_with_virtual_cols
 ----
@@ -1327,6 +1499,19 @@ table_with_virtual_cols  CREATE TABLE public.table_with_virtual_cols (
                            UNIQUE INDEX table_with_virtual_cols_id_key (id ASC),
                            FAMILY fam_0_id_new_pk (id, new_pk)
                          );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE TABLE table_with_virtual_cols
+----
+table_with_virtual_cols  CREATE TABLE public.table_with_virtual_cols (
+                           id INT8 NOT NULL,
+                           new_pk INT8 NOT NULL,
+                           virtual_col INT8 NULL AS (1:::INT8) VIRTUAL,
+                           CONSTRAINT table_with_virtual_cols_pkey PRIMARY KEY (new_pk ASC),
+                           UNIQUE INDEX table_with_virtual_cols_id_key (id ASC),
+                           FAMILY fam_0_id_new_pk (id, new_pk)
+                         ) WITH (schema_locked = true);
 
 # Test that we do not create new indexes for the old primary key when going
 # from sharded to non-sharded and back.
@@ -1431,6 +1616,7 @@ a  b  k
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t];
 ----
@@ -1442,6 +1628,19 @@ CREATE TABLE public.t (
   INDEX t_idx_b_k (b ASC, k ASC),
   UNIQUE INDEX t_a_key (a ASC)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  k INT8 NOT NULL AS (a + b) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  INDEX t_idx_b_k (b ASC, k ASC),
+  UNIQUE INDEX t_a_key (a ASC)
+) WITH (schema_locked = true);
 
 query III colnames,rowsort
 SELECT * FROM t@t_pkey
@@ -1467,6 +1666,7 @@ a  b  k
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (b, k);
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t];
 ----
@@ -1479,6 +1679,21 @@ CREATE TABLE public.t (
   UNIQUE INDEX t_a_key (a ASC),
   UNIQUE INDEX t_k_key (k ASC)
 );
+
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  k INT8 NOT NULL AS (a + b) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (b ASC, k ASC),
+  INDEX t_idx_b_k (b ASC, k ASC),
+  UNIQUE INDEX t_a_key (a ASC),
+  UNIQUE INDEX t_k_key (k ASC)
+) WITH (schema_locked = true);
 
 query III colnames,rowsort
 SELECT * FROM t@t_pkey
@@ -1511,6 +1726,7 @@ a  b  k
 statement ok
 ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (a);
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t];
 ----
@@ -1524,6 +1740,22 @@ CREATE TABLE public.t (
   UNIQUE INDEX t_k_key (k ASC),
   UNIQUE INDEX t_b_k_key (b ASC, k ASC)
 );
+
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t];
+----
+CREATE TABLE public.t (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  k INT8 NOT NULL AS (a + b) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (a ASC),
+  INDEX t_idx_b_k (b ASC, k ASC),
+  UNIQUE INDEX t_a_key (a ASC),
+  UNIQUE INDEX t_k_key (k ASC),
+  UNIQUE INDEX t_b_k_key (b ASC, k ASC)
+) WITH (schema_locked = true);
 
 query III colnames,rowsort
 SELECT * FROM t@t_pkey
@@ -1585,6 +1817,7 @@ ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH BUC
 statement ok
 ALTER TABLE t_test_param ALTER PRIMARY KEY USING COLUMNS (b) USING HASH WITH BUCKET_COUNT = 5;
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t_test_param]
 ----
@@ -1596,6 +1829,19 @@ CREATE TABLE public.t_test_param (
   UNIQUE INDEX t_test_param_a_key (a ASC),
   FAMILY fam_0_a_b (a, b)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_test_param]
+----
+CREATE TABLE public.t_test_param (
+  a INT8 NOT NULL,
+  b INT8 NOT NULL,
+  crdb_internal_b_shard_5 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(b))), 5:::INT8)) VIRTUAL,
+  CONSTRAINT t_test_param_pkey PRIMARY KEY (b ASC) USING HASH WITH (bucket_count=5),
+  UNIQUE INDEX t_test_param_a_key (a ASC),
+  FAMILY fam_0_a_b (a, b)
+) WITH (schema_locked = true);
 
 subtest pkey-comment-carry-over
 
@@ -1735,6 +1981,12 @@ CREATE TABLE t (
 	i INT PRIMARY KEY USING HASH WITH (bucket_count=7) DEFAULT unique_rowid(),
 	j INT NOT NULL UNIQUE
 )
+
+# Because of #146725 we can't have schema_locked set, since this
+# fallback to the legacy schema changer.
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = false);
 
 # Assert that the primary key is hash-sharded and the unique index is created.
 query TTT
@@ -1884,7 +2136,7 @@ ALTER TABLE t_90306 ALTER PRIMARY KEY USING COLUMNS (k);
 subtest regression_90836
 
 statement ok
-CREATE TABLE t_90836(a INT NOT NULL, b INT NOT NULL, CONSTRAINT "constraint" PRIMARY KEY (a));
+CREATE TABLE t_90836(a INT NOT NULL, b INT NOT NULL, CONSTRAINT "constraint" PRIMARY KEY (a)) WITH (schema_locked = false);
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -1917,6 +2169,7 @@ CREATE TABLE t_96730 (i INT PRIMARY KEY, j INT NOT NULL, k STRING NOT NULL, FAMI
 statement ok
 ALTER TABLE t_96730 ALTER PRIMARY KEY USING COLUMNS (j, k) USING HASH
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE TABLE t_96730
 ----
@@ -1928,6 +2181,19 @@ t_96730  CREATE TABLE public.t_96730 (
            CONSTRAINT t_96730_pkey PRIMARY KEY (j ASC, k ASC) USING HASH WITH (bucket_count=16),
            UNIQUE INDEX t_96730_i_key (i ASC)
          );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE TABLE t_96730
+----
+t_96730  CREATE TABLE public.t_96730 (
+           i INT8 NOT NULL,
+           j INT8 NOT NULL,
+           k STRING NOT NULL,
+           crdb_internal_j_k_shard_16 INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes(j, k))), 16:::INT8)) VIRTUAL,
+           CONSTRAINT t_96730_pkey PRIMARY KEY (j ASC, k ASC) USING HASH WITH (bucket_count=16),
+           UNIQUE INDEX t_96730_i_key (i ASC)
+         ) WITH (schema_locked = true);
 
 # If we had a partial unique index on the old primary key columns, and after a
 # ALTER PRIMARY KEY, we will create a unique secondary index on the old primary
@@ -1941,6 +2207,7 @@ CREATE TABLE t_99303 (i INT NOT NULL PRIMARY KEY, j INT NOT NULL, UNIQUE INDEX (
 statement ok
 ALTER TABLE t_99303 ALTER PRIMARY KEY USING COLUMNS (j);
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE t_99303
 ----
@@ -1951,6 +2218,18 @@ t_99303  CREATE TABLE public.t_99303 (
            UNIQUE INDEX t_99303_i_key (i ASC) WHERE i > 0:::INT8,
            UNIQUE INDEX t_99303_i_key1 (i ASC)
          );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE t_99303
+----
+t_99303  CREATE TABLE public.t_99303 (
+           i INT8 NOT NULL,
+           j INT8 NOT NULL,
+           CONSTRAINT t_99303_pkey PRIMARY KEY (j ASC),
+           UNIQUE INDEX t_99303_i_key (i ASC) WHERE i > 0:::INT8,
+           UNIQUE INDEX t_99303_i_key1 (i ASC)
+         ) WITH (schema_locked = true);
 
 subtest end
 
@@ -2055,6 +2334,7 @@ CREATE TABLE table_w0_66 ( "Abc" INT4 PRIMARY KEY, "ab\f" INT2 NOT NULL, FAMILY 
 statement ok
 ALTER TABLE public.table_w0_66 ALTER PRIMARY KEY USING COLUMNS ("Abc", "ab\f") USING HASH;
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE public.table_w0_66]
 ----
@@ -2066,5 +2346,18 @@ CREATE TABLE public.table_w0_66 (
   UNIQUE INDEX "table_w0_66_Abc_key" ("Abc" ASC),
   FAMILY "fam_0_Abc_ab\f" ("Abc", "ab\f")
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE public.table_w0_66]
+----
+CREATE TABLE public.table_w0_66 (
+  "Abc" INT4 NOT NULL,
+  "ab\f" INT2 NOT NULL,
+  "crdb_internal_Abc_ab\f_shard_16" INT8 NOT VISIBLE NOT NULL AS (mod(fnv32(md5(crdb_internal.datums_to_bytes("Abc", "ab\f"))), 16:::INT8)) VIRTUAL,
+  CONSTRAINT table_w0_66_pkey PRIMARY KEY ("Abc" ASC, "ab\f" ASC) USING HASH WITH (bucket_count=16),
+  UNIQUE INDEX "table_w0_66_Abc_key" ("Abc" ASC),
+  FAMILY "fam_0_Abc_ab\f" ("Abc", "ab\f")
+) WITH (schema_locked = true);
 
 subtest end

--- a/pkg/sql/logictest/testdata/logic_test/create_table
+++ b/pkg/sql/logictest/testdata/logic_test/create_table
@@ -1,4 +1,6 @@
-# LogicTest: !local-schema-locked
+# Keep schema locked disabled by default for this test.
+statement ok
+SET create_table_with_schema_locked=false
 
 subtest regression_42858
 

--- a/pkg/sql/logictest/testdata/logic_test/cursor
+++ b/pkg/sql/logictest/testdata/logic_test/cursor
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 statement ok
 SET autocommit_before_ddl = false
 
@@ -555,6 +553,10 @@ bar  SELECT 1, 2, 3  false  false  false
 statement ok
 COMMIT
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE a SET (schema_locked=false);
+
 query TTBBB
 SELECT name, statement, is_scrollable, is_holdable, is_binary FROM pg_catalog.pg_cursors
 ----
@@ -642,6 +644,10 @@ FETCH 1 a b;
 
 statement ok
 COMMIT;
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE a SET (schema_locked=true);
 
 # Test holdable cursors.
 subtest holdable

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -1,6 +1,6 @@
 # Legacy schema changer is skipped because mutation IDs throughout log
 # entries will differ. "event_log_legacy" file is for the legacy schema changer.
-# LogicTest: !local-legacy-schema-changer !local-schema-locked
+# LogicTest: !local-legacy-schema-changer
 # knob-opt: sync-event-log
 
 # For some reason, some of the queries produce non-deterministic results if

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 statement ok
 CREATE TABLE t (
   k INT PRIMARY KEY,
@@ -16,6 +14,7 @@ CREATE TABLE t (
   FAMILY (k, a, b, c, j, v)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
@@ -35,6 +34,27 @@ CREATE TABLE public.t (
   FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 );
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  INDEX t_a_plus_b_idx ((a + b) ASC),
+  INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
+  INVERTED INDEX t_b_j_a_asc (b DESC, (j->'a':::STRING)),
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3)) vector_l2_ops),
+  FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
+) WITH (schema_locked = true);
+
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t WITH REDACT]
 ----
@@ -53,6 +73,26 @@ CREATE TABLE public.t (
   VECTOR INDEX t_vec (a DESC, (v::VECTOR(3)) vector_l2_ops),
   FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t WITH REDACT]
+----
+CREATE TABLE public.t (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL AS (a + ‹×›:::INT8) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  INDEX t_a_plus_b_idx ((a + b) ASC),
+  INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
+  INVERTED INDEX t_b_j_a_asc (b DESC, (j->‹×›:::STRING)),
+  VECTOR INDEX t_vec (a DESC, (v::VECTOR(3)) vector_l2_ops),
+  FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
+) WITH (schema_locked = true);
 
 query TTBTTTB colnames
 SELECT * FROM [SHOW COLUMNS FROM t] ORDER BY column_name
@@ -198,6 +238,7 @@ CREATE INDEX t_a_plus_ten_idx ON t ((a + 10))
 statement error index \"err\" contains duplicate expression
 CREATE INDEX err ON t ((a + 10), (a + 10))
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
@@ -216,6 +257,30 @@ CREATE TABLE public.t (
   INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
   FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL AS (a + 10:::INT8) VIRTUAL,
+  CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+  INDEX t_a_plus_b_idx ((a + b) ASC),
+  INDEX t_lower_c_idx (lower(c) ASC),
+  INDEX t_lower_c_a_plus_b_idx (lower(c) ASC, (a + b) ASC),
+  INDEX t_a_plus_ten_idx ((a + 10:::INT8) ASC),
+  FAMILY fam_0_k_a_b_c_j_v (k, a, b, c, j, v)
+) WITH (schema_locked = true);
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked=false);
 
 # Referencing an inaccessible column in a CHECK constraint is not allowed.
 statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
@@ -242,6 +307,10 @@ CREATE INDEX err ON t (crdb_internal_idx_expr_2)
 # not allowed.
 statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced
 CREATE INDEX err ON t (a) WHERE crdb_internal_idx_expr_2 > 0
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked=true);
 
 # Referencing an inaccessible column in a FK is not allowed.
 statement error column \"crdb_internal_idx_expr_2\" is inaccessible and cannot be referenced by a foreign key
@@ -345,6 +414,10 @@ ALTER TABLE t ADD COLUMN crdb_internal_idx_expr INT
 statement ok
 ALTER TABLE t DROP COLUMN crdb_internal_idx_expr
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked=false);
+
 statement error random\(\): volatile functions are not allowed in EXPRESSION INDEX ELEMENT
 CREATE INDEX err ON t ((a + random()::INT))
 
@@ -359,6 +432,10 @@ CREATE INDEX err ON t (a, (NULL), b)
 
 statement ok
 CREATE INDEX t_cast_idx ON t (a, (NULL::TEXT), b)
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked=true);
 
 statement ok
 CREATE INDEX err ON t (a, (j->'a'));
@@ -465,6 +542,7 @@ CREATE TABLE copy_generated (LIKE src INCLUDING GENERATED);
 CREATE TABLE copy_indexes (LIKE src INCLUDING INDEXES);
 CREATE TABLE copy_all (LIKE src INCLUDING ALL)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy]
 ----
@@ -479,6 +557,21 @@ CREATE TABLE public.copy (
   CONSTRAINT copy_pkey PRIMARY KEY (rowid ASC)
 );
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE copy]
+----
+CREATE TABLE public.copy (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT copy_pkey PRIMARY KEY (rowid ASC)
+) WITH (schema_locked = true);
+
 # Inaccessible expression index columns should not be copied if the indexes are
 # not copied. copy should not have any crdb_internal_idx_expr columns.
 query I
@@ -490,6 +583,7 @@ SELECT count(*) FROM (
 ----
 0
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_generated]
 ----
@@ -504,6 +598,21 @@ CREATE TABLE public.copy_generated (
   CONSTRAINT copy_generated_pkey PRIMARY KEY (rowid ASC)
 );
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE copy_generated]
+----
+CREATE TABLE public.copy_generated (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT copy_generated_pkey PRIMARY KEY (rowid ASC)
+) WITH (schema_locked = true);
+
 # Inaccessible expression index columns should not be copied if the indexes are
 # not copied. copy_generated should not have any crdb_internal_idx_expr columns.
 query I
@@ -515,6 +624,7 @@ SELECT count(*) FROM (
 ----
 0
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_indexes]
 ----
@@ -533,6 +643,25 @@ CREATE TABLE public.copy_indexes (
   VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)) vector_l2_ops)
 );
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE copy_indexes]
+----
+CREATE TABLE public.copy_indexes (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL,
+  CONSTRAINT src_pkey PRIMARY KEY (k ASC),
+  INDEX src_expr_idx ((a + b) ASC),
+  INDEX named_idx ((a + 1:::INT8) ASC),
+  UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
+  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
+  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)) vector_l2_ops)
+) WITH (schema_locked = true);
+
 # Inaccessible expression index columns should be copied if the indexes are
 # copied. copy_indexes should have crdb_internal_idx_expr columns.
 query I
@@ -544,6 +673,7 @@ SELECT count(*) FROM (
 ----
 5
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE copy_all]
 ----
@@ -561,6 +691,25 @@ CREATE TABLE public.copy_all (
   INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
   VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)) vector_l2_ops)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE copy_all]
+----
+CREATE TABLE public.copy_all (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  comp INT8 NULL AS (1:::INT8 + 10:::INT8) VIRTUAL,
+  CONSTRAINT src_pkey PRIMARY KEY (k ASC),
+  INDEX src_expr_idx ((a + b) ASC),
+  INDEX named_idx ((a + 1:::INT8) ASC),
+  UNIQUE INDEX src_expr_key ((a + 10:::INT8) ASC),
+  INVERTED INDEX src_expr_expr1_idx ((a + b) ASC, (j->'a':::STRING)),
+  VECTOR INDEX src_b_expr_idx (b ASC, (v::VECTOR(3)) vector_l2_ops)
+) WITH (schema_locked = true);
 
 # Inaccessible expression index columns should be copied if the indexes are
 # copied. copy_all should have crdb_internal_idx_expr columns.
@@ -589,6 +738,7 @@ CREATE UNIQUE INDEX ON anon (lower(c), b);
 CREATE INDEX ON anon ((a + 10), b, lower(c));
 CREATE INDEX ON anon ((a + 10), (b + 100), lower(c));
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE anon]
 ----
@@ -605,6 +755,24 @@ CREATE TABLE public.anon (
   INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
   FAMILY fam_0_k_a_b_c (k, a, b, c)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE anon]
+----
+CREATE TABLE public.anon (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
+  INDEX anon_expr_idx ((a + b) ASC),
+  INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
+  UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+  INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
+  INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
+  FAMILY fam_0_k_a_b_c (k, a, b, c)
+) WITH (schema_locked = true);
 
 statement ok
 DROP TABLE anon;
@@ -623,6 +791,7 @@ CREATE TABLE anon (
   FAMILY (k, a, b, c)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE anon]
 ----
@@ -639,6 +808,25 @@ CREATE TABLE public.anon (
   INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
   FAMILY fam_0_k_a_b_c (k, a, b, c)
 );
+
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE anon]
+----
+CREATE TABLE public.anon (
+  k INT8 NOT NULL,
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  CONSTRAINT anon_pkey PRIMARY KEY (k ASC),
+  INDEX anon_expr_idx ((a + b) ASC),
+  INDEX anon_expr_b_idx ((a + 10:::INT8) ASC, b ASC),
+  UNIQUE INDEX anon_expr_b_key (lower(c) ASC, b ASC),
+  INDEX anon_expr_b_expr1_idx ((a + 10:::INT8) ASC, b ASC, lower(c) ASC),
+  INDEX anon_expr_expr1_expr2_idx ((a + 10:::INT8) ASC, (b + 100:::INT8) ASC, lower(c) ASC),
+  FAMILY fam_0_k_a_b_c (k, a, b, c)
+) WITH (schema_locked = true);
 
 # Querying expression indexes.
 
@@ -808,7 +996,7 @@ DROP TABLE bf
 # transaction. This is a limitation of virtual computed columns.
 
 statement ok
-CREATE TABLE bf (a INT)
+CREATE TABLE bf (a INT) WITH (schema_locked = false)
 
 statement ok
 SET autocommit_before_ddl = false
@@ -1191,6 +1379,7 @@ CREATE INDEX t72012_idx ON t72012 ((abs(col)));
 statement ok
 ALTER TABLE t72012 ALTER COLUMN col SET NOT NULL
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE TABLE t72012
 ----
@@ -1200,6 +1389,18 @@ t72012  CREATE TABLE public.t72012 (
           CONSTRAINT t72012_pkey PRIMARY KEY (rowid ASC),
           INDEX t72012_idx (abs(col) ASC)
         );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE TABLE t72012
+----
+t72012  CREATE TABLE public.t72012 (
+          col INT8 NOT NULL,
+          rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+          CONSTRAINT t72012_pkey PRIMARY KEY (rowid ASC),
+          INDEX t72012_idx (abs(col) ASC)
+        ) WITH (schema_locked = true);
+
 
 statement ok
 ALTER TABLE t72012 ALTER COLUMN col DROP NOT NULL;
@@ -1220,6 +1421,10 @@ CREATE TABLE t74216 (
     UNIQUE ((a::STRING))
 )
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = false)
+
 # create index using an expression works even when retried
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -1227,6 +1432,10 @@ SET LOCAL autocommit_before_ddl=off;
 CREATE INDEX t_a_times_three_idx ON t ((a * 3));
 SELECT crdb_internal.force_retry('10ms');
 COMMIT
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE t SET (schema_locked = true)
 
 # JSON Expression Unique Indexes
 
@@ -1256,6 +1465,7 @@ CREATE TABLE expr_tab (
   FAMILY fam (a, b, c)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE expr_tab]
 ----
@@ -1267,6 +1477,19 @@ CREATE TABLE public.expr_tab (
   INDEX expr_tab_expr_b_idx ((a * 2:::INT8) ASC, b ASC),
   FAMILY fam (a, b, c)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE expr_tab]
+----
+CREATE TABLE public.expr_tab (
+  a INT8 NOT NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  CONSTRAINT expr_tab_pkey PRIMARY KEY (a ASC, (b + 100:::INT8) ASC, lower(c) ASC),
+  INDEX expr_tab_expr_b_idx ((a * 2:::INT8) ASC, b ASC),
+  FAMILY fam (a, b, c)
+) WITH (schema_locked = true);
 
 query TT
 SELECT c.conname, c.condef
@@ -1288,6 +1511,7 @@ CREATE TABLE expr_tab2 (
   FAMILY fam (a, b, c)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE expr_tab2]
 ----
@@ -1299,6 +1523,19 @@ CREATE TABLE public.expr_tab2 (
   INDEX expr_tab2_expr_expr1_idx ((c || 'suffix':::STRING) ASC, (a - b) ASC),
   FAMILY fam (a, b, c)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE expr_tab2]
+----
+CREATE TABLE public.expr_tab2 (
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NOT NULL,
+  CONSTRAINT expr_tab2_pkey PRIMARY KEY ((a + b) ASC, c ASC),
+  INDEX expr_tab2_expr_expr1_idx ((c || 'suffix':::STRING) ASC, (a - b) ASC),
+  FAMILY fam (a, b, c)
+) WITH (schema_locked = true);
 
 query TT
 SELECT c.conname, c.condef
@@ -1320,6 +1557,7 @@ CREATE TABLE expr_tab3 (
   FAMILY fam (a, b, c)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE expr_tab3]
 ----
@@ -1331,6 +1569,19 @@ CREATE TABLE public.expr_tab3 (
   UNIQUE INDEX expr_tab3_expr_expr1_key ((b / 2:::INT8) ASC, upper(c) ASC),
   FAMILY fam (a, b, c)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE expr_tab3]
+----
+CREATE TABLE public.expr_tab3 (
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  CONSTRAINT expr_tab3_pkey PRIMARY KEY ((a + b) ASC, (b * 2:::INT8) ASC, lower(c) ASC),
+  UNIQUE INDEX expr_tab3_expr_expr1_key ((b / 2:::INT8) ASC, upper(c) ASC),
+  FAMILY fam (a, b, c)
+) WITH (schema_locked = true);
 
 query TT
 SELECT c.conname, c.condef
@@ -1352,6 +1603,7 @@ CREATE TABLE expr_tab4 (
   FAMILY fam (a, b)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE expr_tab4]
 ----
@@ -1362,6 +1614,18 @@ CREATE TABLE public.expr_tab4 (
   INDEX expr_tab4_expr_idx ((a + 1:::INT8) ASC),
   FAMILY fam (a, b)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE expr_tab4]
+----
+CREATE TABLE public.expr_tab4 (
+  a INT8 NULL,
+  b INT8 NULL,
+  CONSTRAINT expr_tab4_pkey PRIMARY KEY ((a + b) ASC),
+  INDEX expr_tab4_expr_idx ((a + 1:::INT8) ASC),
+  FAMILY fam (a, b)
+) WITH (schema_locked = true);
 
 query TT
 SELECT c.conname, c.condef
@@ -1387,6 +1651,7 @@ CREATE TABLE expr_tab5 (
   FAMILY fam (a, b, c, j, v)
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE expr_tab5]
 ----
@@ -1402,6 +1667,23 @@ CREATE TABLE public.expr_tab5 (
   VECTOR INDEX expr_tab5_expr_idx1 ((v::VECTOR(3)) vector_l2_ops),
   FAMILY fam (a, b, c, j, v)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE expr_tab5]
+----
+CREATE TABLE public.expr_tab5 (
+  a INT8 NULL,
+  b INT8 NULL,
+  c STRING NULL,
+  j JSONB NULL,
+  v VECTOR NULL,
+  CONSTRAINT expr_tab5_pkey PRIMARY KEY ((a + b) ASC),
+  INDEX expr_tab5_expr_expr1_idx ((a * b) ASC, (b - a) ASC),
+  INVERTED INDEX expr_tab5_expr_idx ((j->'data':::STRING)),
+  VECTOR INDEX expr_tab5_expr_idx1 ((v::VECTOR(3)) vector_l2_ops),
+  FAMILY fam (a, b, c, j, v)
+) WITH (schema_locked = true);
 
 query TT
 SELECT c.conname, c.condef

--- a/pkg/sql/logictest/testdata/logic_test/jobs
+++ b/pkg/sql/logictest/testdata/logic_test/jobs
@@ -1,11 +1,14 @@
-# LogicTest: !local-schema-locked
-
-# Disable declarative schema changer for this test.
+# Disable declarative schema changer for this test and schema locked by
+# default for this test.
 statement ok
 SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer = 'off';
 
 statement ok
+SET CLUSTER SETTING sql.defaults.create_table_with_schema_locked = 'off'
+
+statement ok
 SET use_declarative_schema_changer = 'off';
+SET create_table_with_schema_locked = 'off';
 
 # These test verify that a user's job are visible via
 # crdb_internal.jobs and SHOW JOBS.

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1,4 +1,3 @@
-# LogicTest: !local-schema-locked
 # knob-opt: disable-corpus-generation sync-event-log
 
 skip_on_retry
@@ -829,6 +828,7 @@ SET experimental_computed_column_rewrites = "(ts :: STRING) -> (to_char(ts AT TI
 statement ok
 ALTER TABLE trewrite ADD COLUMN c STRING AS (ts::STRING) STORED
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
 ----
@@ -839,6 +839,18 @@ CREATE TABLE public.trewrite (
   CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
   FAMILY fam_0_k_ts (k, ts, c)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE trewrite]
+----
+CREATE TABLE public.trewrite (
+  k INT8 NOT NULL,
+  ts TIMESTAMPTZ NULL,
+  c STRING NULL AS (to_char(timezone('utc':::STRING, ts))) STORED,
+  CONSTRAINT trewrite_pkey PRIMARY KEY (k ASC),
+  FAMILY fam_0_k_ts (k, ts, c)
+) WITH (schema_locked = true);
 
 subtest create-index
 
@@ -1457,6 +1469,7 @@ ALTER TABLE t ADD COLUMN j INT DEFAULT 42;
 statement ok
 COMMIT
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t]
 ----
@@ -1467,6 +1480,18 @@ CREATE TABLE public.t (
   CONSTRAINT t_pkey PRIMARY KEY (i ASC),
   UNIQUE INDEX t_k_key (k ASC)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t]
+----
+CREATE TABLE public.t (
+  i INT8 NOT NULL,
+  k INT8 NOT NULL AS (i + 3:::INT8) STORED,
+  j INT8 NULL DEFAULT 42:::INT8,
+  CONSTRAINT t_pkey PRIMARY KEY (i ASC),
+  UNIQUE INDEX t_k_key (k ASC)
+) WITH (schema_locked = true);
 
 query III rowsort
 SELECT * FROM t
@@ -1519,7 +1544,7 @@ statement ok
 SET CLUSTER SETTING sql.schema.force_declarative_statements='!ALTER TABLE'
 
 statement ok
-CREATE TABLE stmt_ctrl(n int primary key)
+CREATE TABLE stmt_ctrl(n int primary key) WITH (schema_locked = false)
 
 statement error pgcode 0A000 cannot explain a statement which is not supported by the declarative schema changer
 EXPLAIN (DDL) ALTER TABLE stmt_ctrl ADD COLUMN j BOOL

--- a/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
+++ b/pkg/sql/logictest/testdata/logic_test/partial_txn_commit
@@ -1,7 +1,11 @@
-# LogicTest: !local-schema-locked
-
 # This test exercises the presence of an explanatory hint when a transaction
 # ends up partially committed and partially aborted.
+
+# Tables can't be created with schema_locked if we need
+# to manipulate them with the legacy schema changer, since
+# only non-backfilling changes in that mode will work correctly.
+statement ok
+SET create_table_with_schema_locked=false
 
 statement ok
 SET autocommit_before_ddl = false

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 subtest ttl_expire_after_must_be_interval
 
 statement error value of "ttl_expire_after" must be an interval
@@ -119,6 +117,7 @@ CREATE TABLE crdb_internal_functions_tbl (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE crdb_internal_functions_tbl]
 ----
@@ -127,6 +126,16 @@ CREATE TABLE public.crdb_internal_functions_tbl (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT crdb_internal_functions_tbl_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE crdb_internal_functions_tbl]
+----
+CREATE TABLE public.crdb_internal_functions_tbl (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT crdb_internal_functions_tbl_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, schema_locked = true);
 
 statement ok
 SELECT crdb_internal.validate_ttl_scheduled_jobs()
@@ -240,7 +249,7 @@ CREATE TABLE tbl_reloptions (
 )
 
 query T rowsort
-SELECT unnest(reloptions) FROM pg_class WHERE relname = 'tbl_reloptions'
+SELECT * FROM (SELECT unnest(reloptions) as opt FROM pg_class WHERE relname = 'tbl_reloptions') WHERE opt NOT LIKE 'schema_locked%'
 ----
 ttl='on'
 ttl_expire_after='00:10:00':::INTERVAL
@@ -287,7 +296,7 @@ SET autocommit_before_ddl = false
 statement ok
 CREATE TABLE tbl_existing_ttl_concurrent_schema_change (
   id INT PRIMARY KEY
-) WITH (ttl_expire_after = '10 minutes')
+) WITH (ttl_expire_after = '10 minutes', schema_locked=false)
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
 ALTER TABLE tbl_existing_ttl_concurrent_schema_change RESET (ttl), RESET (ttl_expire_after)
@@ -321,7 +330,7 @@ SET autocommit_before_ddl = false
 statement ok
 CREATE TABLE tbl_add_ttl_concurrent_schema_change (
    id INT PRIMARY KEY
-)
+) WITH (schema_locked = false)
 
 statement error cannot modify TTL settings while another schema change on the table is being processed
 ALTER TABLE tbl_add_ttl_concurrent_schema_change SET (ttl_expire_after = '10 minutes'), SET (ttl_select_batch_size = 200)
@@ -379,6 +388,7 @@ ALTER TABLE tbl_reset_ttl SET (ttl = 'off')
 statement ok
 ALTER TABLE tbl_reset_ttl RESET (ttl)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_reset_ttl]
 ----
@@ -386,6 +396,15 @@ CREATE TABLE public.tbl_reset_ttl (
   id INT8 NOT NULL,
   CONSTRAINT tbl_reset_ttl_pkey PRIMARY KEY (id ASC)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_reset_ttl]
+----
+CREATE TABLE public.tbl_reset_ttl (
+  id INT8 NOT NULL,
+  CONSTRAINT tbl_reset_ttl_pkey PRIMARY KEY (id ASC)
+) WITH (schema_locked = true);
 
 statement ok
 SELECT crdb_internal.validate_ttl_scheduled_jobs()
@@ -596,6 +615,7 @@ CREATE TABLE tbl_ttl_on_noop (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_on_noop]
 ----
@@ -604,11 +624,22 @@ CREATE TABLE public.tbl_ttl_on_noop (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_on_noop]
+----
+CREATE TABLE public.tbl_ttl_on_noop (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, schema_locked = true);
 
 # Test no-ops.
 statement ok
 ALTER TABLE tbl_ttl_on_noop SET (ttl = 'on')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_on_noop]
 ----
@@ -617,6 +648,16 @@ CREATE TABLE public.tbl_ttl_on_noop (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_on_noop]
+----
+CREATE TABLE public.tbl_ttl_on_noop (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_ttl_on_noop_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, schema_locked = true);
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_ttl_on_noop'
@@ -652,6 +693,7 @@ CREATE TABLE tbl_create_ttl_job_cron (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes', ttl_job_cron = '@daily')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_ttl_job_cron]
 ----
@@ -660,6 +702,18 @@ CREATE TABLE public.tbl_create_ttl_job_cron (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_create_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily');
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_ttl_job_cron]
+----
+CREATE TABLE public.tbl_create_ttl_job_cron (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_create_ttl_job_cron_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@daily', schema_locked = true);
+
+
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_create_ttl_job_cron'
@@ -682,6 +736,7 @@ CREATE TABLE tbl_set_ttl_job_cron (
 statement ok
 ALTER TABLE tbl_set_ttl_job_cron SET (ttl_job_cron = '@weekly')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_job_cron]
 ----
@@ -690,6 +745,18 @@ CREATE TABLE public.tbl_set_ttl_job_cron (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_set_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@weekly');
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_job_cron]
+----
+CREATE TABLE public.tbl_set_ttl_job_cron (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_ttl_job_cron_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_job_cron = '@weekly', schema_locked = true);
+
+
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_ttl_job_cron'
@@ -712,6 +779,7 @@ CREATE TABLE tbl_reset_ttl_job_cron (
 statement ok
 ALTER TABLE tbl_reset_ttl_job_cron RESET (ttl_job_cron)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_reset_ttl_job_cron]
 ----
@@ -720,6 +788,16 @@ CREATE TABLE public.tbl_reset_ttl_job_cron (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_reset_ttl_job_cron_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_reset_ttl_job_cron]
+----
+CREATE TABLE public.tbl_reset_ttl_job_cron (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_reset_ttl_job_cron_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, schema_locked = true);
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_reset_ttl_job_cron'
@@ -815,6 +893,7 @@ CREATE TABLE tbl_set_ttl_params (
 NOTICE: The TTL rate limit is per leaseholder per table.
 DETAIL: See the documentation for additional details: https://www.cockroachlabs.com/docs/dev/row-level-ttl#ttl-storage-parameters
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
 ----
@@ -823,6 +902,16 @@ CREATE TABLE public.tbl_set_ttl_params (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_select_batch_size = 10, ttl_delete_batch_size = 20, ttl_select_rate_limit = 30, ttl_delete_rate_limit = 40, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true, ttl_disable_changefeed_replication = true);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
+----
+CREATE TABLE public.tbl_set_ttl_params (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_select_batch_size = 10, ttl_delete_batch_size = 20, ttl_select_rate_limit = 30, ttl_delete_rate_limit = 40, ttl_pause = true, ttl_row_stats_poll_interval = '1m0s', ttl_label_metrics = true, ttl_disable_changefeed_replication = true, schema_locked = true);
 
 skipif config local-read-committed local-repeatable-read
 query T noticetrace
@@ -835,6 +924,7 @@ onlyif config local-read-committed local-repeatable-read
 statement ok
 ALTER TABLE tbl_set_ttl_params SET (ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_row_stats_poll_interval = '2m0s')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
 ----
@@ -843,6 +933,17 @@ CREATE TABLE public.tbl_set_ttl_params (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_pause = true, ttl_row_stats_poll_interval = '2m0s', ttl_label_metrics = true, ttl_disable_changefeed_replication = true);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
+----
+CREATE TABLE public.tbl_set_ttl_params (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_select_batch_size = 110, ttl_delete_batch_size = 120, ttl_select_rate_limit = 130, ttl_delete_rate_limit = 140, ttl_pause = true, ttl_row_stats_poll_interval = '2m0s', ttl_label_metrics = true, ttl_disable_changefeed_replication = true, schema_locked = true);
+
 
 statement ok
 ALTER TABLE tbl_set_ttl_params RESET (
@@ -856,6 +957,7 @@ ALTER TABLE tbl_set_ttl_params RESET (
   ttl_disable_changefeed_replication
 )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
 ----
@@ -864,6 +966,18 @@ CREATE TABLE public.tbl_set_ttl_params (
   crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
   CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_ttl_params]
+----
+CREATE TABLE public.tbl_set_ttl_params (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_ttl_params_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, schema_locked = true);
+
+
 
 subtest end
 
@@ -876,6 +990,7 @@ CREATE TABLE tbl_create_table_ttl_expiration_expression (
   FAMILY (id, expire_at)
 ) WITH (ttl_expiration_expression = 'expire_at')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
 ----
@@ -886,9 +1001,21 @@ CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at');
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', schema_locked = true);
+
 statement ok
 ALTER TABLE tbl_create_table_ttl_expiration_expression RESET (ttl)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
 ----
@@ -898,6 +1025,17 @@ CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
   CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at (id, expire_at)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_create_table_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_create_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (schema_locked = true);
 
 subtest end
 
@@ -910,6 +1048,7 @@ CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql (
   FAMILY (id, expire_at)
 ) WITH (ttl_expiration_expression = 'IF(expire_at > parse_timestamp(''2020-01-01 00:00:00'') AT TIME ZONE ''UTC'', expire_at, NULL)')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql]
 ----
@@ -919,6 +1058,17 @@ CREATE TABLE public.tbl_create_table_ttl_expiration_expression_escape_sql (
   CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > parse_timestamp(\'2020-01-01 00:00:00\') AT TIME ZONE \'UTC\', expire_at, NULL)');
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_create_table_ttl_expiration_expression_escape_sql]
+----
+CREATE TABLE public.tbl_create_table_ttl_expiration_expression_escape_sql (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_create_table_ttl_expiration_expression_escape_sql_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = e'IF(expire_at > parse_timestamp(\'2020-01-01 00:00:00\') AT TIME ZONE \'UTC\', expire_at, NULL)', schema_locked = true);
 
 subtest end
 
@@ -945,8 +1095,16 @@ ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
 statement ok
 SET use_declarative_schema_changer = 'off'
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (schema_locked = false)
+
 statement error cannot drop column "expire_at" referenced by row-level TTL expiration expression "expire_at"\nHINT: use ALTER TABLE .*
 ALTER TABLE tbl_alter_table_ttl_expiration_expression DROP COLUMN expire_at
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (schema_locked = true)
 
 statement ok
 SET use_declarative_schema_changer = 'on'
@@ -954,6 +1112,7 @@ SET use_declarative_schema_changer = 'on'
 statement error cannot alter type of column "expire_at" referenced by row-level TTL expiration expression "expire_at"\nHINT: use ALTER TABLE .*
 ALTER TABLE tbl_alter_table_ttl_expiration_expression ALTER expire_at TYPE TIMESTAMP USING (expire_at AT TIME ZONE 'UTC')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
@@ -964,10 +1123,22 @@ CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at');
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', schema_locked = true);
+
 # try setting it again
 statement ok
 ALTER TABLE tbl_alter_table_ttl_expiration_expression SET (ttl_expiration_expression = '((expire_at AT TIME ZONE ''UTC'') + ''5 minutes'':::INTERVAL) AT TIME ZONE ''UTC''')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
@@ -978,9 +1149,21 @@ CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = e'((expire_at AT TIME ZONE \'UTC\') + \'5 minutes\':::INTERVAL) AT TIME ZONE \'UTC\'');
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = e'((expire_at AT TIME ZONE \'UTC\') + \'5 minutes\':::INTERVAL) AT TIME ZONE \'UTC\'', schema_locked = true);
+
 statement ok
 ALTER TABLE tbl_alter_table_ttl_expiration_expression RESET (ttl)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
 ----
@@ -990,6 +1173,17 @@ CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
   CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at (id, expire_at)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_alter_table_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_alter_table_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_alter_table_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (schema_locked = true);
 
 subtest end
 
@@ -1005,6 +1199,7 @@ CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after (
 statement ok
 ALTER TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after SET (ttl_expiration_expression = 'crdb_internal_expiration')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
 ----
@@ -1015,6 +1210,18 @@ CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
   CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration');
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_add_ttl_expiration_expression_to_ttl_expire_after]
+----
+CREATE TABLE public.tbl_add_ttl_expiration_expression_to_ttl_expire_after (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_add_ttl_expiration_expression_to_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', schema_locked = true);
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_add_ttl_expiration_expression_to_ttl_expire_after'
@@ -1034,7 +1241,7 @@ CREATE TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression (
   id INT PRIMARY KEY,
   expire_at TIMESTAMPTZ,
   FAMILY (id, expire_at)
-) WITH (ttl_expiration_expression = 'expire_at')
+) WITH (ttl_expiration_expression = 'expire_at', schema_locked = false)
 
 statement ok
 ALTER TABLE tbl_add_ttl_expire_after_to_ttl_expiration_expression SET (ttl_expire_after = '10 minutes')
@@ -1068,6 +1275,7 @@ CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes', ttl_expiration_expression = 'crdb_internal_expiration')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
 ----
@@ -1077,9 +1285,20 @@ CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression 
   CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration');
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
+----
+CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, ttl_expiration_expression = 'crdb_internal_expiration', schema_locked = true);
+
 statement ok
 ALTER TABLE create_table_ttl_expire_after_and_ttl_expiration_expression RESET (ttl)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
 ----
@@ -1088,6 +1307,15 @@ CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression 
   CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
 );
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_ttl_expire_after_and_ttl_expiration_expression]
+----
+CREATE TABLE public.create_table_ttl_expire_after_and_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  CONSTRAINT create_table_ttl_expire_after_and_ttl_expiration_expression_pkey PRIMARY KEY (id ASC)
+) WITH (schema_locked = true);
+
 subtest end
 
 subtest alter_table_ttl_expire_after_and_ttl_expiration_expression
@@ -1095,7 +1323,7 @@ subtest alter_table_ttl_expire_after_and_ttl_expiration_expression
 statement ok
 CREATE TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression (
   id INT PRIMARY KEY
-)
+) WITH (schema_locked = false)
 
 statement ok
 ALTER TABLE tbl_alter_table_ttl_expire_after_and_ttl_expiration_expression SET (ttl_expire_after = '10 minutes', ttl_expiration_expression = 'crdb_internal_expiration')
@@ -1134,6 +1362,7 @@ CREATE TABLE tbl_ttl_expiration_expression_renamed (
 statement ok
 ALTER TABLE tbl_ttl_expiration_expression_renamed RENAME expires_at TO expires_at_renamed
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_expiration_expression_renamed]
 ----
@@ -1144,6 +1373,17 @@ CREATE TABLE public.tbl_ttl_expiration_expression_renamed (
   FAMILY fam (id, expires_at_renamed)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expires_at_renamed');
 
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_ttl_expiration_expression_renamed]
+----
+CREATE TABLE public.tbl_ttl_expiration_expression_renamed (
+  id INT8 NOT NULL,
+  expires_at_renamed TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_ttl_expiration_expression_renamed_pkey PRIMARY KEY (id ASC),
+  FAMILY fam (id, expires_at_renamed)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expires_at_renamed', schema_locked = true);
+
 subtest end
 
 subtest crdb_internal_expiration_already_defined
@@ -1152,7 +1392,7 @@ statement ok
 CREATE TABLE tbl_crdb_internal_expiration_already_defined (
   id INT PRIMARY KEY,
   crdb_internal_expiration TIMESTAMPTZ
-)
+) WITH (schema_locked = false)
 
 statement error cannot add TTL to table with the crdb_internal_expiration column already defined
 ALTER TABLE tbl_crdb_internal_expiration_already_defined SET (ttl_expire_after = '10 minutes')
@@ -1169,7 +1409,7 @@ subtest end
 subtest desc_pk_without_ttl_add_ttl
 
 statement ok
-CREATE TABLE tbl_desc_pk_without_ttl_add_ttl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC))
+CREATE TABLE tbl_desc_pk_without_ttl_add_ttl (id INT, id2 INT, PRIMARY KEY (id, id2 DESC)) WITH (schema_locked = false)
 
 statement ok
 ALTER TABLE tbl_desc_pk_without_ttl_add_ttl SET (ttl_expire_after = '10 minutes')
@@ -1191,7 +1431,7 @@ subtest create_table_no_ttl_set_ttl_expire_after
 statement ok
 CREATE TABLE create_table_no_ttl_set_ttl_expire_after (
    id INT PRIMARY KEY
-)
+) WITH (schema_locked = false)
 
 statement ok
 ALTER TABLE create_table_no_ttl_set_ttl_expire_after SET (ttl_expire_after = '10 minutes')
@@ -1236,6 +1476,7 @@ CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression (
 statement ok
 ALTER TABLE create_table_no_ttl_set_ttl_expiration_expression SET (ttl_expiration_expression = 'expire_at')
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression]
 ----
@@ -1245,6 +1486,17 @@ CREATE TABLE public.create_table_no_ttl_set_ttl_expiration_expression (
   CONSTRAINT create_table_no_ttl_set_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at');
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE create_table_no_ttl_set_ttl_expiration_expression]
+----
+CREATE TABLE public.create_table_no_ttl_set_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT create_table_no_ttl_set_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', schema_locked = true);
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'create_table_no_ttl_set_ttl_expiration_expression'
@@ -1303,6 +1555,7 @@ CREATE TABLE tbl_set_both_reset_ttl_expire_after (
 statement ok
 ALTER TABLE tbl_set_both_reset_ttl_expire_after RESET (ttl_expire_after)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_both_reset_ttl_expire_after]
 ----
@@ -1312,6 +1565,17 @@ CREATE TABLE public.tbl_set_both_reset_ttl_expire_after (
   CONSTRAINT tbl_set_both_reset_ttl_expire_after_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at)
 ) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at');
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_both_reset_ttl_expire_after]
+----
+CREATE TABLE public.tbl_set_both_reset_ttl_expire_after (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  CONSTRAINT tbl_set_both_reset_ttl_expire_after_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at)
+) WITH (ttl = 'on', ttl_expiration_expression = 'expire_at', schema_locked = true);
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_both_reset_ttl_expire_after'
@@ -1340,6 +1604,7 @@ CREATE TABLE tbl_set_both_reset_ttl_expiration_expression (
 statement ok
 ALTER TABLE tbl_set_both_reset_ttl_expiration_expression RESET (ttl_expiration_expression)
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_both_reset_ttl_expiration_expression]
 ----
@@ -1350,6 +1615,18 @@ CREATE TABLE public.tbl_set_both_reset_ttl_expiration_expression (
   CONSTRAINT tbl_set_both_reset_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
   FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
 ) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL);
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE tbl_set_both_reset_ttl_expiration_expression]
+----
+CREATE TABLE public.tbl_set_both_reset_ttl_expiration_expression (
+  id INT8 NOT NULL,
+  expire_at TIMESTAMPTZ NULL,
+  crdb_internal_expiration TIMESTAMPTZ NOT VISIBLE NOT NULL DEFAULT current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL ON UPDATE current_timestamp():::TIMESTAMPTZ + '00:10:00':::INTERVAL,
+  CONSTRAINT tbl_set_both_reset_ttl_expiration_expression_pkey PRIMARY KEY (id ASC),
+  FAMILY fam_0_id_expire_at_crdb_internal_expiration (id, expire_at, crdb_internal_expiration)
+) WITH (ttl = 'on', ttl_expire_after = '00:10:00':::INTERVAL, schema_locked = true);
 
 let $label_suffix
 SELECT relname || ' [' || oid || ']' FROM pg_class WHERE relname = 'tbl_set_both_reset_ttl_expiration_expression'

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 # Skip the rest of the test if a retry occurs. They can happen and are fine
 # but there's no way to encapsulate that in logictests.
 skip_on_retry
@@ -8,6 +6,11 @@ skip_on_retry
 # transactions, so we disable autocommit behavior.
 statement ok
 SET autocommit_before_ddl = false
+
+# Also disable schema locked by default for these tests, since only
+# declarative can auto unset it.
+statement ok
+SET create_table_with_schema_locked = 'off';
 
 subtest create_and_add_fk_in_same_txn
 

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 statement ok
 CREATE TABLE t (x INT PRIMARY KEY, y INT, z INT, INDEX i (z));
 INSERT INTO t VALUES (1, 2, 3)
@@ -233,6 +231,10 @@ CREATE INDEX idx ON tab3(x) STORING (tableoid)
 statement error pgcode 0A000 index cannot store system column crdb_internal_mvcc_timestamp
 CREATE INDEX idx ON tab3(x) STORING (crdb_internal_mvcc_timestamp)
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE tab3 SET (schema_locked=false)
+
 statement error pgcode 42703 column "crdb_internal_mvcc_timestamp" does not exist
 CREATE INDEX idx ON tab3(x, (crdb_internal_mvcc_timestamp + 10))
 
@@ -244,6 +246,10 @@ CREATE INDEX idx ON tab3(x) STORING (crdb_internal_origin_id)
 
 statement error pgcode 42703 column "crdb_internal_origin_id" does not exist
 CREATE INDEX idx ON tab3(x, (crdb_internal_origin_id + 10))
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE tab3 SET (schema_locked=true)
 
 subtest alter_commands
 

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 statement ok
 SET DATABASE = ""
 
@@ -225,6 +223,7 @@ CREATE TABLE test.precision (x DECIMAL(0, 2))
 statement error at or near "\)": syntax error: scale \(4\) must be between 0 and precision \(2\)
 CREATE TABLE test.precision (x DECIMAL(2, 4))
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE TABLE test.users
 ----
@@ -245,6 +244,28 @@ test.public.users  CREATE TABLE public.users (
                      CONSTRAINT check_nickname_name CHECK (length(nickname) < length(name)),
                      CONSTRAINT check_nickname CHECK (length(nickname) < 10:::INT8)
                    );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE TABLE test.users
+----
+test.public.users  CREATE TABLE public.users (
+                     id INT8 NOT NULL,
+                     name VARCHAR NOT NULL,
+                     title VARCHAR NULL,
+                     nickname STRING NULL,
+                     username STRING(10) NULL,
+                     email VARCHAR(100) NULL,
+                     CONSTRAINT users_pkey PRIMARY KEY (id ASC),
+                     INDEX foo (name ASC),
+                     UNIQUE INDEX bar (id ASC, name ASC),
+                     FAMILY "primary" (id, name),
+                     FAMILY fam_1_title (title),
+                     FAMILY fam_2_nickname (nickname),
+                     FAMILY fam_3_username_email (username, email),
+                     CONSTRAINT check_nickname_name CHECK (length(nickname) < length(name)),
+                     CONSTRAINT check_nickname CHECK (length(nickname) < 10:::INT8)
+                   ) WITH (schema_locked = true);
 
 statement ok
 CREATE TABLE test.dupe_generated (
@@ -282,6 +303,7 @@ CREATE TABLE test.named_constraints (
   FAMILY fam_3_username_email (username, email)
 )
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE TABLE test.named_constraints
 ----
@@ -304,6 +326,30 @@ test.public.named_constraints  CREATE TABLE public.named_constraints (
                                  CONSTRAINT ck2 CHECK (length(nickname) < length(name)),
                                  CONSTRAINT ck1 CHECK (length(nickname) < 10:::INT8)
                                );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE TABLE test.named_constraints
+----
+test.public.named_constraints  CREATE TABLE public.named_constraints (
+                                 id INT8 NOT NULL,
+                                 name VARCHAR NOT NULL,
+                                 title VARCHAR NULL DEFAULT 'VP of Something':::STRING,
+                                 nickname STRING NULL,
+                                 username STRING(10) NULL,
+                                 email VARCHAR(100) NULL,
+                                 CONSTRAINT pk PRIMARY KEY (id ASC),
+                                 UNIQUE INDEX uq (email ASC),
+                                 INDEX foo (name ASC),
+                                 UNIQUE INDEX uq2 (username ASC),
+                                 UNIQUE INDEX bar (id ASC, name ASC),
+                                 FAMILY "primary" (id, name),
+                                 FAMILY fam_1_title (title),
+                                 FAMILY fam_2_nickname (nickname),
+                                 FAMILY fam_3_username_email (username, email),
+                                 CONSTRAINT ck2 CHECK (length(nickname) < length(name)),
+                                 CONSTRAINT ck1 CHECK (length(nickname) < 10:::INT8)
+                               ) WITH (schema_locked = true);
 
 query TTTTB colnames
 SELECT * FROM [SHOW CONSTRAINTS FROM test.named_constraints] ORDER BY constraint_name
@@ -496,6 +542,7 @@ CREATE TABLE test.null_default (
   ts timestamp NULL DEFAULT NULL
 )
 
+skipif config local-schema-locked
 query TT
 SHOW CREATE TABLE test.null_default
 ----
@@ -503,7 +550,17 @@ test.public.null_default  CREATE TABLE public.null_default (
                             ts TIMESTAMP NULL,
                             rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
                             CONSTRAINT null_default_pkey PRIMARY KEY (rowid ASC)
-                          );
+                         );
+
+onlyif config local-schema-locked
+query TT
+SHOW CREATE TABLE test.null_default
+----
+test.public.null_default  CREATE TABLE public.null_default (
+                            ts TIMESTAMP NULL,
+                            rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+                            CONSTRAINT null_default_pkey PRIMARY KEY (rowid ASC)
+                          ) WITH (schema_locked = true);
 
 # Issue #13873: don't permit invalid default columns
 statement error could not parse "blah" as type decimal

--- a/pkg/sql/logictest/testdata/logic_test/update
+++ b/pkg/sql/logictest/testdata/logic_test/update
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 statement ok
 CREATE TABLE kv (
   k INT PRIMARY KEY,
@@ -481,7 +479,7 @@ UPDATE derived SET y = 'abcd'
 subtest regression_29494
 
 statement ok
-CREATE TABLE t29494(x INT PRIMARY KEY); INSERT INTO t29494 VALUES (12)
+CREATE TABLE t29494(x INT PRIMARY KEY) WITH (schema_locked = false); INSERT INTO t29494 VALUES (12)
 
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -534,7 +532,7 @@ COMMIT
 
 # Use delete-only mutation columns with default and computed expressions.
 statement ok
-CREATE TABLE mutation (m INT PRIMARY KEY, n INT)
+CREATE TABLE mutation (m INT PRIMARY KEY, n INT) WITH (schema_locked = false)
 
 statement ok
 INSERT INTO mutation VALUES (1, 1)

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -1,5 +1,3 @@
-# LogicTest: !local-schema-locked
-
 # Test that we don't allow FAMILY constraints with virtual columns.
 statement error virtual computed column "v" cannot be part of a family
 CREATE TABLE t (
@@ -823,6 +821,10 @@ a  b   v
 2  20  22
 3  30  33
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE sc SET (schema_locked = false);
+
 # Add virtual columns inside an explicit transactions.
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -836,6 +838,10 @@ ALTER TABLE sc ADD COLUMN w2 INT AS (b*2) VIRTUAL
 
 statement ok
 COMMIT
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE sc SET (schema_locked = true);
 
 query IIIII rowsort,colnames
 SELECT * FROM sc
@@ -879,6 +885,10 @@ DROP INDEX v_idx
 statement ok
 ALTER TABLE sc DROP COLUMN v
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE sc SET (schema_locked = false);
+
 # Add a column and an index on that column in the same transaction.
 statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
@@ -893,6 +903,10 @@ CREATE INDEX v_idx ON sc(v)
 statement ok
 END
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE sc SET (schema_locked = true);
+
 query I rowsort
 SELECT a FROM sc@v_idx
 ----
@@ -905,6 +919,10 @@ DROP INDEX v_idx
 
 statement ok
 ALTER TABLE sc DROP COLUMN v
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE sc SET (schema_locked = false);
 
 # Adding a column and a partial index using that column in the predicate in the
 # same transaction is not allowed.
@@ -920,6 +938,10 @@ CREATE INDEX partial_idx ON sc(b) WHERE v > 20
 
 statement ok
 END
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE sc SET (schema_locked = true);
 
 statement ok
 ALTER TABLE sc ADD COLUMN v INT AS (a+b) VIRTUAL
@@ -1081,7 +1103,7 @@ SELECT k, iv, jv FROM inv@iv_jv_idx WHERE iv = 20 AND jv @> '{"b": "c"}' ORDER B
 subtest referencing_mutations
 
 statement ok
-CREATE TABLE t_ref (i INT PRIMARY KEY);
+CREATE TABLE t_ref (i INT PRIMARY KEY) WITH (schema_locked = false);
 
 statement error pgcode 0A000 virtual computed column "k" referencing columns \("j"\) added in the current transaction
 ALTER TABLE t_ref ADD COLUMN j INT NOT NULL DEFAULT 42,
@@ -1187,6 +1209,7 @@ statement ok
 CREATE TABLE t63167_a (a INT, v INT AS (a + 1) VIRTUAL);
 CREATE TABLE t63167_b (LIKE t63167_a INCLUDING ALL);
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t63167_b]
 ----
@@ -1196,6 +1219,17 @@ CREATE TABLE public.t63167_b (
   rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
   CONSTRAINT t63167_b_pkey PRIMARY KEY (rowid ASC)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t63167_b]
+----
+CREATE TABLE public.t63167_b (
+  a INT8 NULL,
+  v INT8 NULL AS (a + 1:::INT8) VIRTUAL,
+  rowid INT8 NOT VISIBLE NOT NULL DEFAULT unique_rowid(),
+  CONSTRAINT t63167_b_pkey PRIMARY KEY (rowid ASC)
+) WITH (schema_locked = true);
 
 # Test that columns backfills to tables with virtual columns work.
 subtest column_backfill
@@ -1300,6 +1334,10 @@ ALTER TABLE virtual_pk ADD COLUMN d INT NOT NULL DEFAULT 42;
 statement ok
 ALTER TABLE virtual_pk DROP COLUMN d;
 
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE virtual_pk SET (schema_locked = false)
+
 # Run the operations in an explicit transaction, explicitly using
 # the legacy schema changer.
 statement ok
@@ -1315,6 +1353,10 @@ SET LOCAL autocommit_before_ddl = false;
 SET LOCAL use_declarative_schema_changer = off;
 ALTER TABLE virtual_pk DROP COLUMN d;
 COMMIT;
+
+onlyif config local-schema-locked
+statement ok
+ALTER TABLE virtual_pk SET (schema_locked = true)
 
 # This tests that the type of a computed expression properly reflects the
 # user's intention. Before this test was added, the declarative schema changer
@@ -1353,6 +1395,7 @@ ALTER TABLE t_added ADD COLUMN i2 INT2 GENERATED ALWAYS AS (2) VIRTUAL;
 #    CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
 # )
 
+skipif config local-schema-locked
 query T
 SELECT create_statement FROM [SHOW CREATE TABLE t_added]
 ----
@@ -1365,6 +1408,20 @@ CREATE TABLE public.t_added (
   i2 INT2 NULL AS (2:::INT8) VIRTUAL,
   CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
 );
+
+onlyif config local-schema-locked
+query T
+SELECT create_statement FROM [SHOW CREATE TABLE t_added]
+----
+CREATE TABLE public.t_added (
+  i INT8 NOT NULL,
+  i4n INT4 NULL AS (NULL) VIRTUAL,
+  dn DECIMAL(5,2) NULL AS (NULL) VIRTUAL,
+  d DECIMAL(5,2) NULL AS (123.1:::DECIMAL) VIRTUAL,
+  i4 INT4 NULL AS (4:::INT8) VIRTUAL,
+  i2 INT2 NULL AS (2:::INT8) VIRTUAL,
+  CONSTRAINT t_added_pkey PRIMARY KEY (i ASC)
+) WITH (schema_locked = true);
 
 statement ok
 DROP TABLE t_added

--- a/pkg/sql/logictest/tests/local-schema-locked/generated_test.go
+++ b/pkg/sql/logictest/tests/local-schema-locked/generated_test.go
@@ -157,6 +157,13 @@ func TestLogic_alter_default_privileges_with_grant_option(
 	runLogicTest(t, "alter_default_privileges_with_grant_option")
 }
 
+func TestLogic_alter_primary_key(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "alter_primary_key")
+}
+
 func TestLogic_alter_role(
 	t *testing.T,
 ) {
@@ -486,11 +493,25 @@ func TestLogic_create_statements(
 	runLogicTest(t, "create_statements")
 }
 
+func TestLogic_create_table(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_table")
+}
+
 func TestLogic_cross_join(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "cross_join")
+}
+
+func TestLogic_cursor(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "cursor")
 }
 
 func TestLogic_custom_escape_character(
@@ -759,6 +780,13 @@ func TestLogic_errors(
 	runLogicTest(t, "errors")
 }
 
+func TestLogic_event_log(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "event_log")
+}
+
 func TestLogic_exclude_data_from_backup(
 	t *testing.T,
 ) {
@@ -785,6 +813,13 @@ func TestLogic_export(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "export")
+}
+
+func TestLogic_expression_index(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "expression_index")
 }
 
 func TestLogic_external_connection_privileges(
@@ -1067,6 +1102,13 @@ func TestLogic_inverted_join_multi_column(
 	runLogicTest(t, "inverted_join_multi_column")
 }
 
+func TestLogic_jobs(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "jobs")
+}
+
 func TestLogic_join(
 	t *testing.T,
 ) {
@@ -1221,6 +1263,13 @@ func TestLogic_namespace(
 	runLogicTest(t, "namespace")
 }
 
+func TestLogic_new_schema_changer(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "new_schema_changer")
+}
+
 func TestLogic_no_primary_key(
 	t *testing.T,
 ) {
@@ -1317,6 +1366,13 @@ func TestLogic_partial_index(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "partial_index")
+}
+
+func TestLogic_partial_txn_commit(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "partial_txn_commit")
 }
 
 func TestLogic_partitioning(
@@ -1599,6 +1655,13 @@ func TestLogic_row_level_security(
 	runLogicTest(t, "row_level_security")
 }
 
+func TestLogic_row_level_ttl(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "row_level_ttl")
+}
+
 func TestLogic_rows_from(
 	t *testing.T,
 ) {
@@ -1653,6 +1716,13 @@ func TestLogic_schema_change_feature_flags(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "schema_change_feature_flags")
+}
+
+func TestLogic_schema_change_in_txn(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "schema_change_in_txn")
 }
 
 func TestLogic_schema_change_logical_replication(
@@ -2054,11 +2124,25 @@ func TestLogic_system(
 	runLogicTest(t, "system")
 }
 
+func TestLogic_system_columns(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "system_columns")
+}
+
 func TestLogic_system_namespace(
 	t *testing.T,
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "system_namespace")
+}
+
+func TestLogic_table(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "table")
 }
 
 func TestLogic_target_names(
@@ -2432,6 +2516,13 @@ func TestLogic_unique(
 	runLogicTest(t, "unique")
 }
 
+func TestLogic_update(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "update")
+}
+
 func TestLogic_update_from(
 	t *testing.T,
 ) {
@@ -2514,6 +2605,13 @@ func TestLogic_views(
 ) {
 	defer leaktest.AfterTest(t)()
 	runLogicTest(t, "views")
+}
+
+func TestLogic_virtual_columns(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "virtual_columns")
 }
 
 func TestLogic_virtual_table_privileges(


### PR DESCRIPTION
Previously, a number of tests were skipped for the local-schema-locked config, since we needed to update a number of expected results. To address this, this patch enables local-schema-locked for all remaining tests. The alter_primary_key has cases related to hash shaded indexes bypassed due to: #146725 (which are labeled).

Informs: #129694

Release note: None