### PR TITLE
roachtest: enable create_table_with_schema_locked for ORM tests

### DIFF
--- a/pkg/cmd/roachtest/tests/django_blocklist.go
+++ b/pkg/cmd/roachtest/tests/django_blocklist.go
@@ -158,6 +158,9 @@ var enabledDjangoTests = []string{
 
 // Maintain that this list is alphabetized.
 var djangoBlocklist = blocklist{
+	// Schema change used by this test:
+	// ALTER TABLE schema_author ALTER COLUMN name SET DATA TYPE STRING, ALTER COLUMN name DROP NOT NULL
+	`schema.tests.SchemaTests.test_alter`:                              "ALTER COLUMN ... DROP NOT NULL is not supported in declarative schema changer (prevents from working with schema_locked)",
 	`schema.tests.SchemaTests.test_alter_text_field_to_date_field`:     "alter type requires USING",
 	`schema.tests.SchemaTests.test_alter_text_field_to_datetime_field`: "alter type requires USING",
 	`schema.tests.SchemaTests.test_alter_text_field_to_time_field`:     "alter type requires USING",

--- a/pkg/cmd/roachtest/tests/orm_helpers.go
+++ b/pkg/cmd/roachtest/tests/orm_helpers.go
@@ -77,6 +77,7 @@ func alterZoneConfigAndClusterSettings(
 		`ALTER ROLE ALL SET statement_timeout = '60s'`,
 		`ALTER ROLE ALL SET default_transaction_isolation = 'read committed'`,
 		`ALTER ROLE ALL SET autocommit_before_ddl = 'true'`,
+		`ALTER ROLE ALL SET create_table_with_schema_locked='true'`,
 	} {
 		if _, err := db.ExecContext(ctx, cmd); err != nil {
 			return err


### PR DESCRIPTION
Previously, schema_locked had to be manually set after creating objects,
to make sure objects were schema_locked. We recently added the ability
to create tables by default with schema_locked, which we will enable by
default in our ORM tests.


Informs: #129694
Release note: None