### PR TITLE
release-25.1: sql: fix maybeAdjustVirtualIndexScanForExplain for good

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_gist
@@ -279,3 +279,12 @@ SELECT crdb_internal.decode_plan_gist('AgH8/f//nxkAAN6DgICAgDQAAAADAZz9//+fGQAAz
                     │
                     └── • virtual table
                           table: @primary
+
+# Regression test for trying to decode a plan gist that contains a virtual table
+# with a virtual index that didn't exist on older versions (#142989, #147838).
+query T nosort
+SELECT crdb_internal.decode_plan_gist('AgHk+v//3xoEAKAFAgAABQQGBA==');
+----
+• virtual table
+  table: @?
+  spans: 1+ spans

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -326,7 +326,7 @@ func maybeAdjustVirtualIndexScanForExplain(
 ) (_ cat.Index, _ exec.ScanParams, extraAttribute string) {
 	idx, ok := index.(*optVirtualIndex)
 	if !ok {
-		return idx, params, extraAttribute
+		return index, params, extraAttribute
 	}
 	if idx.idx != nil && idx.idx.GetID() != 1 && params.IndexConstraint != nil {
 		// If we picked the virtual index, check that we can actually use it.


### PR DESCRIPTION
Backport 1/1 commits from #147841 on behalf of @yuzefovich.

----

This commit fixes a silly bug that was added in c99d4f77a2806ff6cbb86cc13e7edb1a2badd332 which was a fix itself - if we don't have `optVirtualIndex`, we need to return the original index and we mistakenly were returning a nil value.

This commit also adds a regression test for this - the edge case occurs when we try to decode a plan gist that includes a new virtual table or a new virtual index that don't exist on the binary where we're decoding the gist.

Fixes: #147838.

Release note: None

----

Release justification: bug fix.