### PR TITLE
sql: enable exponential backoff in read committed stmt retry loop

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4036,7 +4036,7 @@ max_connections                                            -1
 max_identifier_length                                      128
 max_index_keys                                             32
 max_prepared_transactions                                  2147483647
-max_retries_for_read_committed                             10
+max_retries_for_read_committed                             100
 node_id                                                    1
 null_ordered_last                                          off
 on_update_rehome_row_enabled                               on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4011,7 +4011,7 @@ idle_in_transaction_session_timeout                        0
 idle_session_timeout                                       0
 index_join_streamer_batch_size                             8.0 MiB
 index_recommendations_enabled                              off
-initial_retry_backoff_for_read_committed                   0
+initial_retry_backoff_for_read_committed                   2
 inject_retry_errors_enabled                                off
 inject_retry_errors_on_commit_enabled                      off
 integer_datetimes                                          on

--- a/pkg/sql/logictest/testdata/logic_test/manual_retry
+++ b/pkg/sql/logictest/testdata/logic_test/manual_retry
@@ -38,7 +38,7 @@ query error restart transaction: TransactionRetryWithProtoRefreshError: forced b
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 onlyif config local-read-committed
-query error restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=10: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
+query error restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=100: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3005,7 +3005,7 @@ idle_in_transaction_session_timeout                        0                   N
 idle_session_timeout                                       0                   NULL      NULL        NULL        string
 index_join_streamer_batch_size                             8.0 MiB             NULL      NULL        NULL        string
 index_recommendations_enabled                              off                 NULL      NULL        NULL        string
-initial_retry_backoff_for_read_committed                   0                   NULL      NULL        NULL        string
+initial_retry_backoff_for_read_committed                   2                   NULL      NULL        NULL        string
 inject_retry_errors_enabled                                off                 NULL      NULL        NULL        string
 inject_retry_errors_on_commit_enabled                      off                 NULL      NULL        NULL        string
 integer_datetimes                                          on                  NULL      NULL        NULL        string
@@ -3236,7 +3236,7 @@ idle_in_transaction_session_timeout                        0                   N
 idle_session_timeout                                       0                   NULL  user     NULL      0s                  0s
 index_join_streamer_batch_size                             8.0 MiB             NULL  user     NULL      8.0 MiB             8.0 MiB
 index_recommendations_enabled                              off                 NULL  user     NULL      on                  false
-initial_retry_backoff_for_read_committed                   0                   NULL  user     NULL      0s                  0s
+initial_retry_backoff_for_read_committed                   2                   NULL  user     NULL      2ms                 2ms
 inject_retry_errors_enabled                                off                 NULL  user     NULL      off                 off
 inject_retry_errors_on_commit_enabled                      off                 NULL  user     NULL      off                 off
 integer_datetimes                                          on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3030,7 +3030,7 @@ max_connections                                            -1                  N
 max_identifier_length                                      128                 NULL      NULL        NULL        string
 max_index_keys                                             32                  NULL      NULL        NULL        string
 max_prepared_transactions                                  2147483647          NULL      NULL        NULL        string
-max_retries_for_read_committed                             10                  NULL      NULL        NULL        string
+max_retries_for_read_committed                             100                 NULL      NULL        NULL        string
 node_id                                                    1                   NULL      NULL        NULL        string
 null_ordered_last                                          off                 NULL      NULL        NULL        string
 on_update_rehome_row_enabled                               on                  NULL      NULL        NULL        string
@@ -3261,7 +3261,7 @@ max_connections                                            -1                  N
 max_identifier_length                                      128                 NULL  user     NULL      128                 128
 max_index_keys                                             32                  NULL  user     NULL      32                  32
 max_prepared_transactions                                  2147483647          NULL  user     NULL      2147483647          2147483647
-max_retries_for_read_committed                             10                  NULL  user     NULL      10                  10
+max_retries_for_read_committed                             100                 NULL  user     NULL      100                 100
 node_id                                                    1                   NULL  user     NULL      1                   1
 null_ordered_last                                          off                 NULL  user     NULL      off                 off
 on_update_rehome_row_enabled                               on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -144,7 +144,7 @@ max_connections                                            -1
 max_identifier_length                                      128
 max_index_keys                                             32
 max_prepared_transactions                                  2147483647
-max_retries_for_read_committed                             10
+max_retries_for_read_committed                             100
 node_id                                                    1
 null_ordered_last                                          off
 on_update_rehome_row_enabled                               on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -119,7 +119,7 @@ idle_in_transaction_session_timeout                        0
 idle_session_timeout                                       0
 index_join_streamer_batch_size                             8.0 MiB
 index_recommendations_enabled                              off
-initial_retry_backoff_for_read_committed                   0
+initial_retry_backoff_for_read_committed                   2
 inject_retry_errors_enabled                                off
 inject_retry_errors_on_commit_enabled                      off
 integer_datetimes                                          on

--- a/pkg/sql/logictest/testdata/logic_test/txn
+++ b/pkg/sql/logictest/testdata/logic_test/txn
@@ -1188,7 +1188,7 @@ query error pgcode 40001 restart transaction: TransactionRetryWithProtoRefreshEr
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 onlyif config local-read-committed
-query error pgcode 40001 pq: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=10: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
+query error pgcode 40001 pq: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=100: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 query T
@@ -1330,7 +1330,7 @@ query error pgcode 40001 restart transaction: TransactionRetryWithProtoRefreshEr
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 onlyif config local-read-committed
-query error pgcode 40001 pq: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=10: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
+query error pgcode 40001 pq: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=100: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 statement ok
@@ -1602,7 +1602,7 @@ query error pgcode 40001 restart transaction: TransactionRetryWithProtoRefreshEr
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 onlyif config local-read-committed
-query error pgcode 40001 pq: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=10: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
+query error pgcode 40001 pq: restart transaction: read committed retry limit exceeded; set by max_retries_for_read_committed=100: TransactionRetryWithProtoRefreshError: forced by crdb_internal.force_retry\(\)
 SELECT crdb_internal.force_retry('1h':::INTERVAL)
 
 statement ok

--- a/pkg/sql/opt/exec/explain/output_test.go
+++ b/pkg/sql/opt/exec/explain/output_test.go
@@ -362,6 +362,8 @@ func TestRetryFields(t *testing.T) {
 	sqlDB := sqlutils.MakeSQLRunner(conn)
 	sqlDB.Exec(t, "CREATE SEQUENCE s")
 	sqlDB.Exec(t, "CREATE TABLE a (a INT)")
+	// Speed up retries.
+	sqlDB.Exec(t, "SET initial_retry_backoff_for_read_committed = '1us'")
 
 	retryCountRE := regexp.MustCompile(`number of transaction retries: (\d+)`)
 	retryTimeRE := regexp.MustCompile(`time spent retrying the transaction: ([\d\.]+)[µsm]+`)

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4060,7 +4060,7 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(ms, 10), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return "0s"
+			return "2ms"
 		},
 	},
 }

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2275,7 +2275,7 @@ var varGen = map[string]sessionVar{
 			return strconv.FormatInt(int64(evalCtx.SessionData().MaxRetriesForReadCommitted), 10), nil
 		},
 		GlobalDefault: func(sv *settings.Values) string {
-			return "10"
+			return "100"
 		},
 	},
 


### PR DESCRIPTION
Increase the defaults of `max_retries_for_read_committed` and `initial_backoff_of_retries_for_read_committed`.

See individual commits for details and release notes.

Informs: #145377

Release note: None