### PR TITLE
release-25.2: sql: verify correct query vector length when building a vector search

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -393,6 +393,9 @@ CREATE TABLE exec_test (
   VECTOR INDEX idx2 (b, vec1)
 )
 
+query error pgcode 22000 different vector dimensions 1 and 3
+SELECT a FROM exec_test ORDER BY vec1 <-> '[1]' LIMIT 1;
+
 statement ok
 INSERT INTO exec_test (a, b, vec1) VALUES
   (1, 1, '[1, 2, 3]'),
@@ -402,6 +405,12 @@ INSERT INTO exec_test (a, b, vec1) VALUES
   (5, 2, '[13, 14, 15]'),
   (6, NULL, '[16, 17, 18]'),
   (7, NULL, '[1, 1, 1]');
+
+statement error pgcode 22000 pq: expected 3 dimensions, not 1
+INSERT INTO exec_test (a, b, vec1) VALUES (10, 1, '[1]');
+
+query error pgcode 22000 different vector dimensions 1 and 3
+SELECT a FROM exec_test ORDER BY vec1 <-> '[1]' LIMIT 1;
 
 # TODO(143209): write a full set of tests once we can make them deterministic.
 # For now, we can write tests that return every vector with a given prefix.

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3970,6 +3970,18 @@ func (b *Builder) buildVectorSearch(
 	}
 	targetNeighborCount := uint64(search.TargetNeighborCount)
 
+	// Verify that the query vector and vector column have the same dimensions.
+	resolvedQueryVector, ok := queryVector.(*tree.DPGVector)
+	if !ok {
+		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("expected vector type, got %T", queryVector)
+	}
+	queryVectorLen := int32(len(resolvedQueryVector.T))
+	vectorColumnType := index.VectorColumn().DatumType()
+	if queryVectorLen != vectorColumnType.Width() {
+		return execPlan{}, colOrdMap{}, pgerror.Newf(pgcode.DataException,
+			"different vector dimensions %d and %d", queryVectorLen, vectorColumnType.Width())
+	}
+
 	var res execPlan
 	res.root, err = b.factory.ConstructVectorSearch(
 		table, index, outColOrds, search.PrefixConstraint, queryVector, targetNeighborCount,


### PR DESCRIPTION
Backport 1/1 commits from #146848.

/cc @cockroachdb/release

---

Previously the vector search operator was missing a check to ensure that the query vector had the right number of dimensions to search a given table. This patch adds a verification of query vector size when building a search node.

Fixes: #146693
Release note (bug fix): Fixed an issue where searching a vector with a query vector that doesn't match the dimensions of the vector column in the table would cause a node to crash.

Release justification: bug fix.