### PR TITLE
buildutil.bzl: fix disallowed_imports_test logic and refactor BUILD.bazel

### DIFF
--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -163,4 +163,5 @@ stringer(
 disallowed_imports_test(
     "roachpb",
     disallow_cdeps = True,
+    disallowed_list = [],
 )

--- a/pkg/server/diagnostics/BUILD.bazel
+++ b/pkg/server/diagnostics/BUILD.bazel
@@ -87,4 +87,5 @@ disallowed_imports_test(
     "diagnostics",
     # TODO(#81378): This should be flipped to "true".
     disallow_cdeps = False,
+    disallowed_list = [],
 )

--- a/pkg/testutils/buildutil/buildutil.bzl
+++ b/pkg/testutils/buildutil/buildutil.bzl
@@ -49,6 +49,8 @@ _deps_aspect = aspect(
 )
 
 def _find_deps_with_disallowed_prefixes(current_pkg, dep_pkgs, prefixes):
+    if prefixes == None:
+        return []
     return [dp for dp_list in [
         [(d, p) for p in prefixes if d.startswith(p) and d != current_pkg]
         for d in dep_pkgs
@@ -61,11 +63,13 @@ def _deps_rule_impl(ctx):
         prefixes = ctx.attr.disallowed_prefixes,
     )
     deps = {k: None for k in ctx.attr.src[_DepsInfo].deps.to_list()}
-    if ctx.attr.allowlist:
+    if ctx.attr.has_allowlist:
         failed = [p for p in deps if p not in ctx.attr.allowlist and
                                      p.label != ctx.attr.src.label]
-    else:
+    elif ctx.attr.has_disallowed_list:
         failed = [p for p in ctx.attr.disallowed_list if p in deps]
+    else:
+        failed = []
     failures = []
     if failed_prefixes:
         failures.extend([
@@ -108,10 +112,14 @@ _deps_rule = rule(
         "disallow_cdeps": attr.bool(mandatory = False, default = False),
         "disallowed_list": attr.label_list(providers = [GoInfo]),
         "disallowed_prefixes": attr.string_list(mandatory = False, allow_empty = True),
+        "has_allowlist": attr.bool(default = False),
+        "has_disallowed_list": attr.bool(default = False),
     },
 )
 
 def _validate_disallowed_prefixes(prefixes):
+    if prefixes == None:
+        return []
     validated = []
     repo_prefix = "github.com/cockroachdb/cockroach/"
     short_prefix = "pkg/"
@@ -130,11 +138,15 @@ def _validate_disallowed_prefixes(prefixes):
 
 def disallowed_imports_test(
         src,
-        disallowed_list = [],
-        disallowed_prefixes = [],
+        disallowed_list = None,
+        disallowed_prefixes = None,
         disallow_cdeps = False,
-        allowlist = []):
-    if (disallowed_list and allowlist) or (disallowed_prefixes and allowlist):
+        allowlist = None):
+
+    if allowlist == None and disallowed_list == None and disallowed_prefixes == None:
+        fail("Either allowlist, disallowed_list or disallowed_prefixes should be passed, to block " +
+           "all imports you must explicitly pass allowlist = []")
+    if (allowlist != None and disallowed_list != None) or (allowlist != None and disallowed_prefixes != None):
         fail("allowlist or (disallowed_list or disallowed_prefixes) can be " +
              "provided, but not both")
     disallowed_prefixes = _validate_disallowed_prefixes(disallowed_prefixes)
@@ -147,6 +159,8 @@ def disallowed_imports_test(
         disallowed_list = disallowed_list,
         disallowed_prefixes = disallowed_prefixes,
         disallow_cdeps = disallow_cdeps,
+        has_allowlist = allowlist != None,
+        has_disallowed_list = disallowed_list != None,
     )
     native.sh_test(
         name = src.strip(":") + "_disallowed_imports_test",


### PR DESCRIPTION
Changes - 
- Changed `allowList` logic to check for empty list
- Set  `allowList` `disallowed_list` & `disallowed_prefixes` defaults to None and added None handling 
- If no list is passed in `disallowed_imports_test` an error is thrown
- Refactored `disallowed_imports_test`  in `pkg/server/diagnostics/BUILD.bazel`and `pkg/server/diagnostics/BUILD.bazel`

Fixes #139892