### PR TITLE
workload/schemachange: allow self deps in tableHasDependencies for DROP TABLE

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2049,7 +2049,8 @@ func (og *operationGenerator) dropTable(ctx context.Context, tx pgx.Tx) (*opStmt
 	if err != nil {
 		return nil, err
 	}
-	tableHasDependencies, err := og.tableHasDependencies(ctx, tx, tableName, true /* includeFKs */)
+	tableHasDependencies, err := og.tableHasDependencies(ctx, tx, tableName, true, /* includeFKs */
+		true /* skipSelfRef */)
 	if err != nil {
 		return nil, err
 	}
@@ -2081,7 +2082,8 @@ func (og *operationGenerator) dropView(ctx context.Context, tx pgx.Tx) (*opStmt,
 	if err != nil {
 		return nil, err
 	}
-	viewHasDependencies, err := og.tableHasDependencies(ctx, tx, viewName, true /* includeFKs */)
+	viewHasDependencies, err := og.tableHasDependencies(ctx, tx, viewName, true, /* includeFKs */
+		true /* skipSelfRef */)
 	if err != nil {
 		return nil, err
 	}
@@ -2348,7 +2350,8 @@ func (og *operationGenerator) renameTable(ctx context.Context, tx pgx.Tx) (*opSt
 		return nil, err
 	}
 
-	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcTableName, false /* includeFKs */)
+	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcTableName, false, /* includeFKs */
+		false /* skipSelfRef */)
 	if err != nil {
 		return nil, err
 	}
@@ -2398,7 +2401,8 @@ func (og *operationGenerator) renameView(ctx context.Context, tx pgx.Tx) (*opStm
 		return nil, err
 	}
 
-	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcViewName, true /* includeFKs */)
+	srcTableHasDependencies, err := og.tableHasDependencies(ctx, tx, srcViewName, true, /* includeFKs */
+		false /* skipSelfRef */)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
This is a follow-up from #147834, which didn't have a complete fix. It was flagging DROP TABLE as having a dependency, when in fact it had a self-dependency, but it doesn't block the DROP TABLE (seen in this occurrence https://github.com/cockroachdb/cockroach/issues/147514#issuecomment-2948236246)

 
This change updates tableHasDependencies to optionally include self-referencing dependencies when skipSelfRef is false. This is needed for DROP TABLE, where self-dependencies (e.g., from triggers) are safe to ignore because they are cleaned up as part of the drop.

In contrast, RENAME TABLE must still block on these, since the dependent reference would not be updated by the rename.

The function now takes a skipSelfRef flag to distinguish these cases, and excludes only self-dependencies when skipSelfRef is true.

Informs #147514

Epic: None
Release note: none