### PR TITLE
workload/schemachange: allow dep error as potential error for ALTER PK

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2870,6 +2870,9 @@ func (og *operationGenerator) alterTableAlterPrimaryKey(
 	// errors.
 	opStmt.potentialExecErrors.add(pgcode.InvalidColumnReference)
 	opStmt.potentialExecErrors.add(pgcode.DuplicateColumn)
+	// When altering a primary key, the implicit rowid column may be dropped,
+	// but triggers could reference it, causing a dependency violation.
+	opStmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
 
 	return opStmt, nil
 }


### PR DESCRIPTION
ALTER PRIMARY KEY has been observed to fail with the following error in the RSW (https://github.com/cockroachdb/cockroach/issues/147514#issuecomment-2949022809):
```
ERROR: cannot drop column "rowid" because trigger "trigger_w0_190" on table "table_w1_104" depends on it (SQLSTATE 2BP01)
```

This change adds that dependency error to the set of potential errors for ALTER PRIMARY KEY operations.

Informs #147514

Epic: none
Release note: none