### PR TITLE
kvserver: don't subsume self-blocking latency in scheduler latency

### DIFF
--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -438,7 +438,8 @@ func (ss *raftSchedulerShard) worker(
 		}
 
 		ss.Lock()
-		if ss.state[id].flags == stateQueued {
+		state = ss.state[id]
+		if state.flags == stateQueued {
 			// No further processing required by the range ID, clear it from the
 			// state map.
 			delete(ss.state, id)
@@ -469,7 +470,6 @@ func (ss *raftSchedulerShard) worker(
 			// can not possibly happen before the current processing is done (i.e.
 			// now). We do not want the scheduler latency to pick up the time spent
 			// handling this replica.
-			state = ss.state[id]
 			state.begin = crtime.NowMono()
 			ss.state[id] = state
 			ss.queue.Push(id)

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -394,7 +394,7 @@ func (ss *raftSchedulerShard) worker(
 		ss.state[id] = raftScheduleState{flags: stateQueued}
 		ss.Unlock()
 
-		if buildutil.CrdbTestBuild && state.queued == 0 {
+		if util.RaceEnabled && state.queued == 0 {
 			// See state.queued for the invariant being checked here.
 			log.Fatalf(ctx, "raftSchedulerShard.worker called with zero queued: %+v", state)
 		}
@@ -506,7 +506,7 @@ func (ss *raftSchedulerShard) enqueue1Locked(
 	if newState.flags&stateQueued == 0 {
 		newState.flags |= stateQueued
 		queued++
-		if buildutil.CrdbTestBuild && newState.queued != 0 {
+		if util.RaceEnabled && newState.queued != 0 {
 			// See newState.queued for the invariant being checked here.
 			log.Fatalf(context.Background(), "raftSchedulerShard.enqueue1Locked called with non-zero queued: %+v", newState)
 		}

--- a/pkg/kv/kvserver/scheduler.go
+++ b/pkg/kv/kvserver/scheduler.go
@@ -24,9 +24,7 @@ import (
 const rangeIDChunkSize = 1000
 
 type testProcessorI interface {
-	processTestEvent(
-		context.Context, roachpb.RangeID, *raftSchedulerShard, raftScheduleState,
-	)
+	processTestEvent(roachpb.RangeID, *raftSchedulerShard, raftScheduleState)
 }
 
 type rangeIDChunk struct {
@@ -436,7 +434,7 @@ func (ss *raftSchedulerShard) worker(
 			processor.processRACv2RangeController(ctx, id)
 		}
 		if buildutil.CrdbTestBuild && state.flags&stateTestIntercept != 0 {
-			processor.(testProcessorI).processTestEvent(ctx, id, ss, state)
+			processor.(testProcessorI).processTestEvent(id, ss, state)
 		}
 
 		ss.Lock()

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -418,8 +418,7 @@ func TestSchedulerEnqueueWhileProcessing(t *testing.T) {
 		statePost := ss.state[id]
 		ss.Unlock()
 
-		// TODO(tbg): enable in follow-up commit.
-		// assert.Zero(t, statePost.begin)
+		assert.Zero(t, statePost.begin)
 		assert.Equal(t, stateQueued|stateTestIntercept, statePost.flags)
 		close(done)
 	}

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -370,7 +370,7 @@ func TestSchedulerBuffering(t *testing.T) {
 func TestSchedulerEnqueueWhileProcessing(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderNonTestBuild(t) // stateTestIntercept needs crdb test build
+	skip.UnderNonTestBuild(t) // stateTestIntercept needs CrdbTestBuild
 
 	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
 	defer cancel()

--- a/pkg/kv/kvserver/scheduler_test.go
+++ b/pkg/kv/kvserver/scheduler_test.go
@@ -198,7 +198,7 @@ func (p *testProcessor) processRACv2RangeController(_ context.Context, rangeID r
 }
 
 func (p *testProcessor) processTestEvent(
-	ctx context.Context, id roachpb.RangeID, ss *raftSchedulerShard, ev raftScheduleState,
+	id roachpb.RangeID, ss *raftSchedulerShard, ev raftScheduleState,
 ) {
 	select {
 	case fn := <-p.testEventCh:


### PR DESCRIPTION
We noticed elevated p99s during scale testing that disappeared when disabling
internal timeseries storage. The theory is that the timeseries replicas are
quite busy, and the scheduler latency was (unintentionally, I argue) picking up
raft **handling** latencies because it wasn't accounting for the case in which
handling a replica was delayed by an inflight handling of that same replica.

This commit addresses this issue, so that the scheduling latency metrics truly
reflect only the scheduling latency.

Fixes #147911
Informs #147758

Release note: None
