### PR TITLE
roachtest: set pausepoint before backups in OR recovery roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -198,7 +198,7 @@ func WaitForState(
 				return nil
 			}
 			if timeutil.Since(startTime) > maxWait {
-				return errors.Newf("job %d did not reach state %s after %s", jobID, state, maxWait)
+				return errors.Newf("job %d still in state %s after %s", jobID, state, maxWait)
 			}
 			ticker.Reset(5 * time.Second)
 		case <-ctx.Done():


### PR DESCRIPTION
The OR recovery roachtests were encountering intermittent failures where the download job was found in a succeeded state when the test was waiting for it to pause. It was determined this was occurring whenever a full cluster backup/restore was performed. Because the pausepoint was set _after_ the backups were taken, this meant that the link phase of OR in a full cluster restore would wipe the pausepoints before the download phase. This patch moves the pausepoint setting so that it is set before the backups and therefore will be preserved after a full cluster OR.

Fixes: #147557

Release note: None