### PR TITLE
db-console: update hot ranges link to understanding hotspots page in …

### DIFF
--- a/pkg/ui/workspaces/db-console/src/util/docs.ts
+++ b/pkg/ui/workspaces/db-console/src/util/docs.ts
@@ -124,9 +124,7 @@ export const recomputeDocsURLs = () => {
   reduceStorageOfTimeSeriesDataOperationalFlags = docsURL(
     "operational-faqs.html#can-i-reduce-or-disable-the-storage-of-time-series-data",
   );
-  performanceBestPracticesHotSpots = docsURL(
-    "performance-best-practices-overview.html#hot-spots",
-  );
+  performanceBestPracticesHotSpots = docsURL("understand-hotspots.html");
   uiDebugPages = docsURL("ui-debug-pages.html");
   readsAndWritesOverviewPage = docsURLNoVersion(
     "architecture/reads-and-writes-overview.html#important-concepts",


### PR DESCRIPTION
…the docs

Previously we pointed the "learn more" link in the hot ranges page to an older page about hotspots. This change moves that link to a newer, more up to date reference guide.

Epic: none
Fixes: #147926

Release note (ui change): updates the "learn more" link in the hot ranges page to point to a newer, more up to date reference guide about hotspots.