### PR TITLE
kvserver: add kv.closed_timestamp.dampening_inaccurate

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -11986,6 +11986,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: kv.closed_timestamp.dampening_inaccurate
+      exported_name: kv_closed_timestamp_dampening_inaccurate
+      description: Number of times dampening closed timestamp policy of closed timestamp policy takes effect
+      y_axis_label: Events
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: kv.closed_timestamp.max_behind_nanos
       exported_name: kv_closed_timestamp_max_behind_nanos
       description: Largest latency between realtime and replica max closed timestamp

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -11690,6 +11690,14 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: follower_reads.misses_count
+      exported_name: follower_reads_misses_count
+      description: Number of follower reads missed by follower replicas due to too low closed timestamp
+      y_axis_label: Read Ops
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: follower_reads.success_count
       exported_name: follower_reads_success_count
       description: Number of reads successfully processed by any replica

--- a/pkg/kv/kvserver/closedts/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
         "//pkg/settings",
         "//pkg/util/hlc",
         "//pkg/util/metamorphic",
+        "//pkg/util/metric",
     ],
 )
 

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -513,6 +513,12 @@ var (
 		Measurement: "Read Ops",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaFollowerReadsMisses = metric.Metadata{
+		Name:        "follower_reads.misses_count",
+		Help:        "Number of follower reads missed by follower replicas due to too low closed timestamp",
+		Measurement: "Read Ops",
+		Unit:        metric.Unit_COUNT,
+	}
 
 	// Server-side transaction metrics.
 	metaCommitWaitBeforeCommitTriggerCount = metric.Metadata{
@@ -2850,7 +2856,8 @@ type StoreMetrics struct {
 	RecentReplicaQueriesPerSecond  *metric.ManualWindowHistogram
 
 	// Follower read metrics.
-	FollowerReadsCount *metric.Counter
+	FollowerReadsCount  *metric.Counter
+	FollowerReadsMisses *metric.Counter
 
 	// Server-side transaction metrics.
 	CommitWaitsBeforeCommitTrigger                           *metric.Counter
@@ -3583,7 +3590,8 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		),
 
 		// Follower reads metrics.
-		FollowerReadsCount: metric.NewCounter(metaFollowerReadsCount),
+		FollowerReadsCount:  metric.NewCounter(metaFollowerReadsCount),
+		FollowerReadsMisses: metric.NewCounter(metaFollowerReadsMisses),
 
 		// Server-side transaction metrics.
 		CommitWaitsBeforeCommitTrigger:                           metric.NewCounter(metaCommitWaitBeforeCommitTriggerCount),

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -2536,6 +2536,13 @@ throttled they do count towards 'delay.total' and 'delay.enginebackpressure'.
 		Unit:        metric.Unit_COUNT,
 	}
 
+	metaClosedTimestampDampeningInaccuracy = metric.Metadata{
+		Name:        "kv.closed_timestamp.dampening_inaccurate",
+		Help:        "Number of times dampening closed timestamp policy of closed timestamp policy takes effect",
+		Measurement: "Events",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	// Replica circuit breaker.
 	metaReplicaCircuitBreakerCurTripped = metric.Metadata{
 		Name: "kv.replica_circuit_breaker.num_tripped_replicas",
@@ -3173,8 +3180,9 @@ type StoreMetrics struct {
 	ClosedTimestampMaxBehindNanos *metric.Gauge
 
 	// Closed timestamp policy change on ranges metrics.
-	ClosedTimestampPolicyChange       *metric.Counter
-	ClosedTimestampLatencyInfoMissing *metric.Counter
+	ClosedTimestampPolicyChange        *metric.Counter
+	ClosedTimestampLatencyInfoMissing  *metric.Counter
+	ClosedTimestampDampeningInaccuracy *metric.Counter
 
 	// Replica circuit breaker.
 	ReplicaCircuitBreakerCurTripped *metric.Gauge
@@ -4001,8 +4009,9 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		SplitsWithEstimatedStats:     metric.NewCounter(metaSplitEstimatedStats),
 		SplitEstimatedTotalBytesDiff: metric.NewCounter(metaSplitEstimatedTotalBytesDiff),
 
-		ClosedTimestampPolicyChange:       metric.NewCounter(metaClosedTimestampPolicyChange),
-		ClosedTimestampLatencyInfoMissing: metric.NewCounter(metaClosedTimestampLatencyInfoMissing),
+		ClosedTimestampPolicyChange:        metric.NewCounter(metaClosedTimestampPolicyChange),
+		ClosedTimestampLatencyInfoMissing:  metric.NewCounter(metaClosedTimestampLatencyInfoMissing),
+		ClosedTimestampDampeningInaccuracy: metric.NewCounter(metaClosedTimestampDampeningInaccuracy),
 	}
 	sm.categoryIterMetrics.init(storeRegistry)
 

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1367,6 +1367,9 @@ func (r *Replica) RefreshPolicy(latencies map[roachpb.NodeID]time.Duration) {
 			oldPolicy,
 			maxLatency,
 			closedts.PolicySwitchWhenLatencyExceedsBucketFraction.Get(&r.store.GetStoreConfig().Settings.SV),
+			func() {
+				r.store.metrics.ClosedTimestampDampeningInaccuracy.Inc(1)
+			},
 		)
 	}
 	oldPolicy := *r.cachedClosedTimestampPolicy.Load()

--- a/pkg/kv/kvserver/replica_follower_read.go
+++ b/pkg/kv/kvserver/replica_follower_read.go
@@ -132,6 +132,7 @@ func (r *Replica) canServeFollowerRead(
 		// Signal the clients that we want an update so that future requests can succeed.
 		log.Eventf(ctx, "can't serve follower read; closed timestamp too low by: %s; maxClosed: %s ts: %s uncertaintyLimit: %s",
 			tsDiff, maxClosed, ba.Timestamp, uncertaintyLimitStr)
+		r.store.metrics.FollowerReadsMisses.Inc(1)
 		return false
 	}
 


### PR DESCRIPTION
**kvserver: add kv.closed_timestamp.dampening_inaccurate**

Previously, we added dampening to prevent frequent policy switching near latency
bucket boundaries, but it is hard to tell when this happens and this can make
things inaccurate. This patch adds metrics to track when such dampening is
triggered.

Resolves: #146291
Release note: none

---

**kvserver: logs when closed ts policy is unexpected**

Previously, we introduced a policy refresher to compute range closed
timestamp policies async, instead of on-demand. This can introduce
inaccuracies if policies aren't refreshed frequently enough. This patch adds
logs to capture when that happens, and logs cases where the global read
policy in use doesn't match the range config's IsGlobalRead field.

Part of: #146291
Release note: none

---

**kvserver: add follower_reads.misses_count**

Previously, it was hard to tell when follower reads failed due to a closed
timestamp being too low. This patch adds a metric to track such misses.

Part of: #146291
Release note: none

