### PR TITLE
*: replace grpc clients with rpc adapters

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -413,7 +413,7 @@ type Node struct {
 	cmd            *exec.Cmd
 	rpcPort, pgURL string // legacy: remove once 1.0.x is no longer tested
 	db             *gosql.DB
-	statusClient   serverpb.StatusClient
+	statusClient   serverpb.RPCStatusClient
 }
 
 // RPCPort returns the RPC + Postgres port.
@@ -469,7 +469,7 @@ func (n *Node) Alive() bool {
 }
 
 // StatusClient returns a StatusClient set up to talk to this node.
-func (n *Node) StatusClient(ctx context.Context) serverpb.StatusClient {
+func (n *Node) StatusClient(ctx context.Context) serverpb.RPCStatusClient {
 	n.Lock()
 	existingClient := n.statusClient
 	n.Unlock()
@@ -483,7 +483,7 @@ func (n *Node) StatusClient(ctx context.Context) serverpb.StatusClient {
 		if err != nil {
 			log.Fatalf(context.Background(), "failed to initialize status client: %s", err)
 		}
-		return serverpb.NewStatusClient(conn)
+		return serverpb.NewGRPCStatusClientAdapter(conn)
 	}
 	return nil // This should never happen
 }

--- a/pkg/blobs/blobspb/rpc_clients.go
+++ b/pkg/blobs/blobspb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialBlobClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// BlobClient.
+// RPCBlobClient.
 func DialBlobClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (BlobClient, error) {
+) (RPCBlobClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewBlobClient(conn), nil
+		return NewGRPCBlobClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/blobs/client.go
+++ b/pkg/blobs/client.go
@@ -47,11 +47,11 @@ var _ BlobClient = &remoteClient{}
 // remoteClient uses the node dialer and blob service clients
 // to Read or Write bulk files from/to other nodes.
 type remoteClient struct {
-	blobClient blobspb.BlobClient
+	blobClient blobspb.RPCBlobClient
 }
 
 // newRemoteClient instantiates a remote blob service client.
-func newRemoteClient(blobClient blobspb.BlobClient) BlobClient {
+func newRemoteClient(blobClient blobspb.RPCBlobClient) BlobClient {
 	return &remoteClient{blobClient: blobClient}
 }
 
@@ -71,7 +71,7 @@ func (c *remoteClient) ReadFile(
 }
 
 type streamWriter struct {
-	s   blobspb.Blob_PutStreamClient
+	s   blobspb.RPCBlob_PutStreamClient
 	buf blobspb.StreamChunk
 }
 

--- a/pkg/blobs/stream.go
+++ b/pkg/blobs/stream.go
@@ -43,7 +43,7 @@ type streamReceiver interface {
 // This is needed as Blob_GetStreamClient does not have a Close() function, whereas
 // the other sender, Blob_PutStreamServer, does.
 type nopSendAndClose struct {
-	blobspb.Blob_GetStreamClient
+	blobspb.RPCBlob_GetStreamClient
 }
 
 func (*nopSendAndClose) SendAndClose(*blobspb.StreamResponse) error {
@@ -52,7 +52,7 @@ func (*nopSendAndClose) SendAndClose(*blobspb.StreamResponse) error {
 
 // newGetStreamReader creates an io.ReadCloser that uses gRPC's streaming API
 // to read chunks of data.
-func newGetStreamReader(client blobspb.Blob_GetStreamClient) ioctx.ReadCloserCtx {
+func newGetStreamReader(client blobspb.RPCBlob_GetStreamClient) ioctx.ReadCloserCtx {
 	return &blobStreamReader{
 		stream: &nopSendAndClose{client},
 	}

--- a/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
+++ b/pkg/ccl/serverccl/statusccl/tenant_grpc_test.go
@@ -135,7 +135,7 @@ func TestTenantGRPCServices(t *testing.T) {
 		conn, err := rpcCtx.GRPCDialNode(grpcAddr, nodeID, roachpb.Locality{}, rpcbase.DefaultClass).Connect(ctx)
 		require.NoError(t, err)
 
-		client := serverpb.NewStatusClient(conn)
+		client := serverpb.NewGRPCStatusClientAdapter(conn)
 
 		resp, err := client.Statements(ctx, &serverpb.StatementsRequest{NodeID: "local"})
 		require.NoError(t, err)
@@ -149,7 +149,7 @@ func TestTenantGRPCServices(t *testing.T) {
 		conn, err := rpcCtx.GRPCDialNode(grpcAddr, server.NodeID(), roachpb.Locality{}, rpcbase.DefaultClass).Connect(ctx)
 		require.NoError(t, err)
 
-		client := serverpb.NewStatusClient(conn)
+		client := serverpb.NewGRPCStatusClientAdapter(conn)
 
 		_, err = client.Statements(ctx, &serverpb.StatementsRequest{NodeID: "local"})
 		require.Errorf(t, err, "statements endpoint should not be accessed on KV node by tenant")

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -279,7 +279,7 @@ func newProxyHandler(
 		dirOpts = append(dirOpts, handler.testingKnobs.dirOpts...)
 	}
 
-	client := tenant.NewDirectoryClient(conn)
+	client := tenant.NewGRPCDirectoryClientAdapter(conn)
 	handler.directoryCache, err = tenant.NewDirectoryCache(ctx, stopper, client, dirOpts...)
 	if err != nil {
 		return nil, err

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -114,7 +114,7 @@ func TenantWatcher(tenantWatcher chan *WatchTenantsResponse) func(opts *dirOptio
 type directoryCache struct {
 	// client is the directory client instance used to make directory server
 	// calls.
-	client DirectoryClient
+	client RPCDirectoryClient
 
 	// stopper is used for graceful shutdown of the pod watcher.
 	stopper *stop.Stopper
@@ -144,7 +144,7 @@ var _ DirectoryCache = &directoryCache{}
 // NOTE: stopper.Stop must be called on the directory when it is no longer
 // needed.
 func NewDirectoryCache(
-	ctx context.Context, stopper *stop.Stopper, client DirectoryClient, opts ...DirOption,
+	ctx context.Context, stopper *stop.Stopper, client RPCDirectoryClient, opts ...DirOption,
 ) (DirectoryCache, error) {
 	dir := &directoryCache{client: client, stopper: stopper}
 
@@ -380,7 +380,7 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 	waitInit.Add(1)
 
 	err := stopper.RunAsyncTask(ctx, "watch-pods-client", func(ctx context.Context) {
-		var client Directory_WatchPodsClient
+		var client RPCDirectory_WatchPodsClient
 		var err error
 		firstRun := true
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
@@ -492,7 +492,7 @@ func (d *directoryCache) updateTenantPodEntry(ctx context.Context, pod *Pod) {
 // notification and update the directory to reflect that change.
 func (d *directoryCache) watchTenants(ctx context.Context, stopper *stop.Stopper) error {
 	return stopper.RunAsyncTask(ctx, "watch-tenants-client", func(ctx context.Context) {
-		var client Directory_WatchTenantsClient
+		var client RPCDirectory_WatchTenantsClient
 		var err error
 		ctx, cancel := stopper.WithCancelOnQuiesce(ctx)
 		defer cancel()

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache_test.go
@@ -697,7 +697,7 @@ func newTestDirectoryCache(
 	require.NoError(t, err)
 	// nolint:grpcconnclose
 	clusterStopper.AddCloser(stop.CloserFn(func() { require.NoError(t, conn.Close() /* nolint:grpcconnclose */) }))
-	client := tenant.NewDirectoryClient(conn)
+	client := tenant.NewGRPCDirectoryClientAdapter(conn)
 	directoryCache, err = tenant.NewDirectoryCache(context.Background(), clusterStopper, client, opts...)
 	require.NoError(t, err)
 	return

--- a/pkg/ccl/sqlproxyccl/tenant/entry.go
+++ b/pkg/ccl/sqlproxyccl/tenant/entry.go
@@ -72,7 +72,7 @@ type tenantEntry struct {
 // Initialize fetches metadata about a tenant, such as its cluster name, and
 // stores that in the entry. If the tenant's metadata is stale, they will be
 // refreshed.
-func (e *tenantEntry) Initialize(ctx context.Context, client DirectoryClient) error {
+func (e *tenantEntry) Initialize(ctx context.Context, client RPCDirectoryClient) error {
 	e.calls.Lock()
 	defer e.calls.Unlock()
 
@@ -112,7 +112,7 @@ func (e *tenantEntry) Initialize(ctx context.Context, client DirectoryClient) er
 
 // RefreshPods makes a synchronous directory server call to fetch the latest
 // information about the tenant's available pods, such as their IP addresses.
-func (e *tenantEntry) RefreshPods(ctx context.Context, client DirectoryClient) error {
+func (e *tenantEntry) RefreshPods(ctx context.Context, client RPCDirectoryClient) error {
 	// Lock so that only one thread at a time will refresh, since there's no
 	// point in multiple threads doing it within a short span of time - it's
 	// likely nothing has changed.
@@ -181,7 +181,7 @@ func (e *tenantEntry) GetPods() []*Pod {
 // errorIfNoPods is true, then EnsureTenantPod returns an error if there are no
 // pods available rather than blocking.
 func (e *tenantEntry) EnsureTenantPod(
-	ctx context.Context, client DirectoryClient, errorIfNoPods bool,
+	ctx context.Context, client RPCDirectoryClient, errorIfNoPods bool,
 ) (pods []*Pod, err error) {
 	const retryDelay = 100 * time.Millisecond
 
@@ -282,7 +282,7 @@ func (e *tenantEntry) ToProto() *Tenant {
 //
 // NOTE: Caller must lock the "calls" mutex before calling fetchPodsLocked.
 func (e *tenantEntry) fetchPodsLocked(
-	ctx context.Context, client DirectoryClient,
+	ctx context.Context, client RPCDirectoryClient,
 ) (tenantPods []*Pod, err error) {
 	// List the pods for the given tenant.
 	//

--- a/pkg/ccl/sqlproxyccl/tenantdirsvr/testutils.go
+++ b/pkg/ccl/sqlproxyccl/tenantdirsvr/testutils.go
@@ -44,7 +44,7 @@ func SetupTestDirectory(
 	stopper.AddCloser(stop.CloserFn(func() {
 		_ = conn.Close() // nolint:grpcconnclose
 	}))
-	client := tenant.NewDirectoryClient(conn)
+	client := tenant.NewGRPCDirectoryClientAdapter(conn)
 	directoryCache, err := tenant.NewDirectoryCache(ctx, stopper, client, opts...)
 	require.NoError(t, err)
 

--- a/pkg/cli/debug_send_kv_batch.go
+++ b/pkg/cli/debug_send_kv_batch.go
@@ -220,7 +220,7 @@ func runSendKVBatch(cmd *cobra.Command, args []string) error {
 }
 
 func sendKVBatchRequestWithTracingOption(
-	ctx context.Context, verboseTrace bool, admin serverpb.AdminClient, ba *kvpb.BatchRequest,
+	ctx context.Context, verboseTrace bool, admin serverpb.RPCAdminClient, ba *kvpb.BatchRequest,
 ) (br *kvpb.BatchResponse, rec tracingpb.Recording, err error) {
 	var sp *tracing.Span
 	if verboseTrace {

--- a/pkg/cli/demo.go
+++ b/pkg/cli/demo.go
@@ -224,7 +224,7 @@ func runDemoInternal(
 			serverCfg.Stores.Specs = nil
 			return setupAndInitializeLoggingAndProfiling(ctx, cmd, false /* isServerCmd */)
 		},
-		func(ctx context.Context, ac serverpb.AdminClient) error {
+		func(ctx context.Context, ac serverpb.RPCAdminClient) error {
 			return drainAndShutdown(ctx, ac, "local" /* targetNode */)
 		},
 	)

--- a/pkg/cli/democluster/demo_cluster.go
+++ b/pkg/cli/democluster/demo_cluster.go
@@ -65,7 +65,7 @@ import (
 
 type serverEntry struct {
 	serverutils.TestServerInterface
-	adminClient    serverpb.AdminClient
+	adminClient    serverpb.RPCAdminClient
 	nodeID         roachpb.NodeID
 	decommissioned bool
 }
@@ -87,7 +87,7 @@ type transientCluster struct {
 
 	stickyVFSRegistry fs.StickyRegistry
 
-	drainAndShutdown func(ctx context.Context, adminClient serverpb.AdminClient) error
+	drainAndShutdown func(ctx context.Context, adminClient serverpb.RPCAdminClient) error
 
 	infoLog  LoggerFn
 	warnLog  LoggerFn
@@ -146,7 +146,7 @@ func NewDemoCluster(
 	warnLog LoggerFn,
 	shoutLog ShoutLoggerFn,
 	startStopper func(ctx context.Context) (*stop.Stopper, error),
-	drainAndShutdown func(ctx context.Context, s serverpb.AdminClient) error,
+	drainAndShutdown func(ctx context.Context, s serverpb.RPCAdminClient) error,
 ) (DemoCluster, error) {
 	c := &transientCluster{
 		demoCtx:          demoCtx,
@@ -1083,9 +1083,9 @@ func (c *transientCluster) DrainAndShutdown(ctx context.Context, nodeID int32) e
 // server than the one referred to by the node ID.
 func (c *transientCluster) findOtherServer(
 	ctx context.Context, nodeID int32, op string,
-) (serverpb.AdminClient, error) {
+) (serverpb.RPCAdminClient, error) {
 	// Find a node to use as the sender.
-	var adminClient serverpb.AdminClient
+	var adminClient serverpb.RPCAdminClient
 	for _, s := range c.servers {
 		if s.adminClient != nil && s.nodeID != roachpb.NodeID(nodeID) {
 			adminClient = s.adminClient

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -455,7 +455,7 @@ func expectNodesDecommissioned(
 
 func runDecommissionNodeImpl(
 	ctx context.Context,
-	c serverpb.AdminClient,
+	c serverpb.RPCAdminClient,
 	wait nodeDecommissionWaitType,
 	checks nodeDecommissionCheckMode,
 	dryRun bool,

--- a/pkg/cli/node.go
+++ b/pkg/cli/node.go
@@ -386,7 +386,7 @@ func runDecommissionNode(cmd *cobra.Command, args []string) error {
 	return nil
 }
 
-func getLocalNodeID(ctx context.Context, s serverpb.StatusClient) (roachpb.NodeID, error) {
+func getLocalNodeID(ctx context.Context, s serverpb.RPCStatusClient) (roachpb.NodeID, error) {
 	var nodeID roachpb.NodeID
 	resp, err := s.Node(ctx, &serverpb.NodeRequest{NodeId: "local"})
 	if err != nil {
@@ -414,7 +414,7 @@ func handleNodeDecommissionSelf(
 }
 
 func expectNodesDecommissioned(
-	ctx context.Context, s serverpb.StatusClient, nodeIDs []roachpb.NodeID, expDecommissioned bool,
+	ctx context.Context, s serverpb.RPCStatusClient, nodeIDs []roachpb.NodeID, expDecommissioned bool,
 ) error {
 	resp, err := s.Nodes(ctx, &serverpb.NodesRequest{})
 	if err != nil {

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -21,7 +21,7 @@ import (
 // underlying RPC connection (gRPC or DRPC), making it easy to swap
 // them without changing the caller code.
 type rpcConn interface {
-	NewStatusClient() serverpb.StatusClient
+	NewStatusClient() serverpb.RPCStatusClient
 	NewAdminClient() serverpb.RPCAdminClient
 	NewInitClient() serverpb.RPCInitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
@@ -35,8 +35,8 @@ type grpcConn struct {
 	conn *grpc.ClientConn
 }
 
-func (c *grpcConn) NewStatusClient() serverpb.StatusClient {
-	return serverpb.NewStatusClient(c.conn)
+func (c *grpcConn) NewStatusClient() serverpb.RPCStatusClient {
+	return serverpb.NewGRPCStatusClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewAdminClient() serverpb.RPCAdminClient {

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -23,7 +23,7 @@ import (
 type rpcConn interface {
 	NewStatusClient() serverpb.StatusClient
 	NewAdminClient() serverpb.RPCAdminClient
-	NewInitClient() serverpb.InitClient
+	NewInitClient() serverpb.RPCInitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
 }
@@ -43,8 +43,8 @@ func (c *grpcConn) NewAdminClient() serverpb.RPCAdminClient {
 	return serverpb.NewGRPCAdminClientAdapter(c.conn)
 }
 
-func (c *grpcConn) NewInitClient() serverpb.InitClient {
-	return serverpb.NewInitClient(c.conn)
+func (c *grpcConn) NewInitClient() serverpb.RPCInitClient {
+	return serverpb.NewGRPCInitClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -24,7 +24,7 @@ type rpcConn interface {
 	NewStatusClient() serverpb.StatusClient
 	NewAdminClient() serverpb.AdminClient
 	NewInitClient() serverpb.InitClient
-	NewTimeSeriesClient() tspb.TimeSeriesClient
+	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
 }
 
@@ -47,8 +47,8 @@ func (c *grpcConn) NewInitClient() serverpb.InitClient {
 	return serverpb.NewInitClient(c.conn)
 }
 
-func (c *grpcConn) NewTimeSeriesClient() tspb.TimeSeriesClient {
-	return tspb.NewTimeSeriesClient(c.conn)
+func (c *grpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {
+	return tspb.NewGRPCTimeSeriesClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewInternalClient() kvpb.InternalClient {

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -22,7 +22,7 @@ import (
 // them without changing the caller code.
 type rpcConn interface {
 	NewStatusClient() serverpb.StatusClient
-	NewAdminClient() serverpb.AdminClient
+	NewAdminClient() serverpb.RPCAdminClient
 	NewInitClient() serverpb.InitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
@@ -39,8 +39,8 @@ func (c *grpcConn) NewStatusClient() serverpb.StatusClient {
 	return serverpb.NewStatusClient(c.conn)
 }
 
-func (c *grpcConn) NewAdminClient() serverpb.AdminClient {
-	return serverpb.NewAdminClient(c.conn)
+func (c *grpcConn) NewAdminClient() serverpb.RPCAdminClient {
+	return serverpb.NewGRPCAdminClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewInitClient() serverpb.InitClient {
@@ -81,7 +81,9 @@ func newClientConn(ctx context.Context, cfg server.Config) (rpcConn, func(), err
 
 // dialAdminClient dials a client connection and returns an AdminClient and a
 // closure that must be invoked to free associated resources.
-func dialAdminClient(ctx context.Context, cfg server.Config) (serverpb.AdminClient, func(), error) {
+func dialAdminClient(
+	ctx context.Context, cfg server.Config,
+) (serverpb.RPCAdminClient, func(), error) {
 	cc, finish, err := newClientConn(ctx, cfg)
 	if err != nil {
 		return nil, nil, err

--- a/pkg/cli/rpc_node_shutdown.go
+++ b/pkg/cli/rpc_node_shutdown.go
@@ -23,7 +23,9 @@ import (
 
 // drainAndShutdown attempts to drain the server and then shut it
 // down.
-func drainAndShutdown(ctx context.Context, c serverpb.AdminClient, targetNode string) (err error) {
+func drainAndShutdown(
+	ctx context.Context, c serverpb.RPCAdminClient, targetNode string,
+) (err error) {
 	hardError, remainingWork, err := doDrain(ctx, c, targetNode)
 	if hardError {
 		return err
@@ -52,7 +54,7 @@ func drainAndShutdown(ctx context.Context, c serverpb.AdminClient, targetNode st
 // proceed with an alternate strategy (it's likely the server has gone
 // away).
 func doDrain(
-	ctx context.Context, c serverpb.AdminClient, targetNode string,
+	ctx context.Context, c serverpb.RPCAdminClient, targetNode string,
 ) (hardError, remainingWork bool, err error) {
 	// The next step is to drain. The timeout is configurable
 	// via --drain-wait.
@@ -109,7 +111,7 @@ func doDrain(
 }
 
 func doDrainNoTimeout(
-	ctx context.Context, c serverpb.AdminClient, targetNode string,
+	ctx context.Context, c serverpb.RPCAdminClient, targetNode string,
 ) (hardError, remainingWork bool, err error) {
 	defer func() {
 		if grpcutil.IsWaitingForInit(err) {
@@ -207,7 +209,7 @@ func doDrainNoTimeout(
 // draining. Use doDrain() prior to perform a drain, or
 // drainAndShutdown() to combine both.
 func doShutdown(
-	ctx context.Context, c serverpb.AdminClient, targetNode string,
+	ctx context.Context, c serverpb.RPCAdminClient, targetNode string,
 ) (hardError bool, err error) {
 	defer func() {
 		if err != nil {

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -53,7 +53,7 @@ type debugZipContext struct {
 	clusterPrinter *zipReporter
 	timeout        time.Duration
 	admin          serverpb.RPCAdminClient
-	status         serverpb.StatusClient
+	status         serverpb.RPCStatusClient
 	prefix         string
 
 	firstNodeSQLConn clisqlclient.Conn

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -52,7 +52,7 @@ type debugZipContext struct {
 	z              *zipper
 	clusterPrinter *zipReporter
 	timeout        time.Duration
-	admin          serverpb.AdminClient
+	admin          serverpb.RPCAdminClient
 	status         serverpb.StatusClient
 	prefix         string
 

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -40,7 +40,7 @@ const (
 // makeClusterWideZipRequests defines the zipRequests that are to be
 // performed just once for the entire cluster.
 func makeClusterWideZipRequests(
-	zr *zipReporter, admin serverpb.RPCAdminClient, status serverpb.StatusClient, prefix string,
+	zr *zipReporter, admin serverpb.RPCAdminClient, status serverpb.RPCStatusClient, prefix string,
 ) []zipRequest {
 	var zipRequests []zipRequest
 

--- a/pkg/cli/zip_cluster_wide.go
+++ b/pkg/cli/zip_cluster_wide.go
@@ -40,7 +40,7 @@ const (
 // makeClusterWideZipRequests defines the zipRequests that are to be
 // performed just once for the entire cluster.
 func makeClusterWideZipRequests(
-	zr *zipReporter, admin serverpb.AdminClient, status serverpb.StatusClient, prefix string,
+	zr *zipReporter, admin serverpb.RPCAdminClient, status serverpb.StatusClient, prefix string,
 ) []zipRequest {
 	var zipRequests []zipRequest
 

--- a/pkg/cli/zip_per_node.go
+++ b/pkg/cli/zip_per_node.go
@@ -132,7 +132,7 @@ func (zc *debugZipContext) collectPerNodeData(
 // makePerNodeZipRequests defines the zipRequests (API requests) that are to be
 // performed once per node.
 func makePerNodeZipRequests(
-	zr *zipReporter, prefix, id string, status serverpb.StatusClient,
+	zr *zipReporter, prefix, id string, status serverpb.RPCStatusClient,
 ) []zipRequest {
 	var zipRequests []zipRequest
 

--- a/pkg/gossip/client_test.go
+++ b/pkg/gossip/client_test.go
@@ -570,7 +570,7 @@ func TestClientSendsHighStampsDiff(t *testing.T) {
 	conn, err := rCtx.GRPCUnvalidatedDial(c.addr.String(), roachpb.Locality{}).Connect(ctxNew)
 	require.NoError(t, err)
 
-	stream, err := NewGossipClient(conn).Gossip(ctx)
+	stream, err := NewGRPCGossipClientAdapter(conn).Gossip(ctx)
 	require.NoError(t, err)
 
 	// Add an info to generate some deltas and allow the request to be sent.

--- a/pkg/gossip/gossip_test.go
+++ b/pkg/gossip/gossip_test.go
@@ -529,7 +529,7 @@ func TestGossipNoForwardSelf(t *testing.T) {
 				return err
 			}
 
-			stream, err := NewGossipClient(conn).Gossip(ctx)
+			stream, err := NewGRPCGossipClientAdapter(conn).Gossip(ctx)
 			if err != nil {
 				return err
 			}
@@ -1008,10 +1008,10 @@ func TestServerSendsHighStampsDiff(t *testing.T) {
 	conn, err := localCxt.GRPCUnvalidatedDial(c.addr.String(), roachpb.Locality{}).Connect(ctx)
 	require.NoError(t, err)
 
-	stream, err := NewGossipClient(conn).Gossip(ctx)
+	stream, err := NewGRPCGossipClientAdapter(conn).Gossip(ctx)
 	require.NoError(t, err)
 
-	requestGossip := func(g *Gossip, stream Gossip_GossipClient) Response {
+	requestGossip := func(g *Gossip, stream RPCGossip_GossipClient) Response {
 		err := c.requestGossip(g, stream)
 		require.NoError(t, err)
 		resp := &Response{}

--- a/pkg/keyvisualizer/keyvispb/rpc_clients.go
+++ b/pkg/keyvisualizer/keyvispb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialKeyVisualizerClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// KeyVisualizerClient.
+// RPCKeyVisualizerClient.
 func DialKeyVisualizerClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (KeyVisualizerClient, error) {
+) (RPCKeyVisualizerClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewKeyVisualizerClient(conn), nil
+		return NewGRPCKeyVisualizerClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -225,7 +225,7 @@ type client struct {
 	kvpb.InternalClient
 	serverpb.StatusClient
 	serverpb.AdminClient
-	tspb.TimeSeriesClient
+	tspb.RPCTimeSeriesClient
 }
 
 // connector is capable of providing information on each of the KV nodes in the
@@ -983,10 +983,10 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 					continue
 				}
 				return &client{
-					InternalClient:   kvpb.NewInternalClient(conn),
-					StatusClient:     serverpb.NewStatusClient(conn),
-					AdminClient:      serverpb.NewAdminClient(conn),
-					TimeSeriesClient: tspb.NewTimeSeriesClient(conn),
+					InternalClient:      kvpb.NewInternalClient(conn),
+					StatusClient:        serverpb.NewStatusClient(conn),
+					AdminClient:         serverpb.NewAdminClient(conn),
+					RPCTimeSeriesClient: tspb.NewGRPCTimeSeriesClientAdapter(conn),
 				}, nil
 			}
 		}

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -223,7 +223,7 @@ type connector struct {
 // client represents an RPC client that proxies to a KV instance.
 type client struct {
 	kvpb.InternalClient
-	serverpb.StatusClient
+	serverpb.RPCStatusClient
 	serverpb.RPCAdminClient
 	tspb.RPCTimeSeriesClient
 }
@@ -984,7 +984,7 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 				}
 				return &client{
 					InternalClient:      kvpb.NewInternalClient(conn),
-					StatusClient:        serverpb.NewStatusClient(conn),
+					RPCStatusClient:     serverpb.NewGRPCStatusClientAdapter(conn),
 					RPCAdminClient:      serverpb.NewGRPCAdminClientAdapter(conn),
 					RPCTimeSeriesClient: tspb.NewGRPCTimeSeriesClientAdapter(conn),
 				}, nil

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -224,7 +224,7 @@ type connector struct {
 type client struct {
 	kvpb.InternalClient
 	serverpb.StatusClient
-	serverpb.AdminClient
+	serverpb.RPCAdminClient
 	tspb.RPCTimeSeriesClient
 }
 
@@ -985,7 +985,7 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 				return &client{
 					InternalClient:      kvpb.NewInternalClient(conn),
 					StatusClient:        serverpb.NewStatusClient(conn),
-					AdminClient:         serverpb.NewAdminClient(conn),
+					RPCAdminClient:      serverpb.NewGRPCAdminClientAdapter(conn),
 					RPCTimeSeriesClient: tspb.NewGRPCTimeSeriesClientAdapter(conn),
 				}, nil
 			}

--- a/pkg/kv/kvserver/client_raft_test.go
+++ b/pkg/kv/kvserver/client_raft_test.go
@@ -4667,7 +4667,7 @@ func TestStoreRangeWaitForApplication(t *testing.T) {
 
 			atomic.StoreInt64(&filterRangeIDAtomic, int64(desc.RangeID))
 			type target struct {
-				client kvserver.PerReplicaClient
+				client kvserver.RPCPerReplicaClient
 				header kvserver.StoreRequestHeader
 			}
 

--- a/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
+++ b/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialSideTransportClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// SideTransportClient.
+// RPCSideTransportClient.
 func DialSideTransportClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (SideTransportClient, error) {
+) (RPCSideTransportClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewSideTransportClient(conn), nil
+		return NewGRPCSideTransportClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -723,7 +723,7 @@ type rpcConn struct {
 	nodeID       roachpb.NodeID
 	testingKnobs connTestingKnobs
 
-	stream   ctpb.SideTransport_PushUpdatesClient
+	stream   ctpb.RPCSideTransport_PushUpdatesClient
 	lastSent ctpb.SeqNum
 	// cancelStreamCtx cleans up the resources (goroutine) associated with stream.
 	// It needs to be called whenever stream is discarded.

--- a/pkg/kv/kvserver/loqrecovery/collect.go
+++ b/pkg/kv/kvserver/loqrecovery/collect.go
@@ -45,7 +45,7 @@ type CollectionStats struct {
 // If logOutput is not nil, this function will write when a node is visited,
 // and when a node needs to be revisited.
 func CollectRemoteReplicaInfo(
-	ctx context.Context, c serverpb.AdminClient, maxConcurrency int, logOutput io.Writer,
+	ctx context.Context, c serverpb.RPCAdminClient, maxConcurrency int, logOutput io.Writer,
 ) (loqrecoverypb.ClusterReplicaInfo, CollectionStats, error) {
 	cc, err := c.RecoveryCollectReplicaInfo(ctx, &serverpb.RecoveryCollectReplicaInfoRequest{
 		MaxConcurrency: int32(maxConcurrency),

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -55,7 +55,7 @@ func IsRetryableError(err error) bool {
 	return errors.Is(err, errMarkRetry)
 }
 
-type visitNodeAdminFn func(nodeID roachpb.NodeID, client serverpb.AdminClient) error
+type visitNodeAdminFn func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error
 
 type visitNodesAdminFn func(ctx context.Context, retryOpts retry.Options, maxConcurrency int32,
 	nodeFilter func(nodeID roachpb.NodeID) bool,
@@ -226,7 +226,7 @@ func serveClusterReplicasParallelFn(
 	forwardReplicaFilter func(*serverpb.RecoveryCollectLocalReplicaInfoResponse) error,
 	replicas, nodes *atomic.Int64,
 ) visitNodeAdminFn {
-	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+	return func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error {
 		log.Infof(ctx, "trying to get info from node n%d", nodeID)
 		var nodeReplicas int64
 		inStream, err := client.RecoveryCollectLocalReplicaInfo(ctx,
@@ -420,7 +420,7 @@ func stagePlanRecoveryNodeStatusParallelFn(
 	plan loqrecoverypb.ReplicaUpdatePlan,
 	foundNodes *threadSafeMap[roachpb.NodeID, bool],
 ) visitNodeAdminFn {
-	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+	return func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error {
 		res, err := client.RecoveryNodeStatus(ctx, &serverpb.RecoveryNodeStatusRequest{})
 		if err != nil {
 			return errors.Mark(err, errMarkRetry)
@@ -442,7 +442,7 @@ func stagePlanRecoveryStagePlanParallelFn(
 	foundNodes *threadSafeMap[roachpb.NodeID, bool],
 	nodeErrors *threadSafeSlice[string],
 ) visitNodeAdminFn {
-	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+	return func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error {
 		foundNodes.Delete(nodeID)
 		res, err := client.RecoveryStagePlan(ctx, &serverpb.RecoveryStagePlanRequest{
 			Plan:                      req.Plan,
@@ -615,7 +615,7 @@ func (s Server) Verify(
 func verifyRecoveryNodeStatusParallelFn(
 	ctx context.Context, nss *threadSafeSlice[loqrecoverypb.NodeRecoveryStatus],
 ) visitNodeAdminFn {
-	return func(nodeID roachpb.NodeID, client serverpb.AdminClient) error {
+	return func(nodeID roachpb.NodeID, client serverpb.RPCAdminClient) error {
 		return timeutil.RunWithTimeout(ctx, redact.Sprintf("retrieve status of n%d", nodeID),
 			retrieveNodeStatusTimeout,
 			func(ctx context.Context) error {
@@ -760,7 +760,7 @@ func visitNodeWithRetry(
 	node roachpb.NodeDescriptor,
 ) error {
 	var err error
-	var ac serverpb.AdminClient
+	var ac serverpb.RPCAdminClient
 	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 		log.Infof(ctx, "visiting node n%d, attempt %d", node.NodeID, r.CurrentAttempt())
 		// Note that we use ConnectNoBreaker here to avoid any race with probe

--- a/pkg/kv/kvserver/loqrecovery/server.go
+++ b/pkg/kv/kvserver/loqrecovery/server.go
@@ -63,7 +63,7 @@ type visitNodesAdminFn func(ctx context.Context, retryOpts retry.Options, maxCon
 ) error
 
 type visitNodeStatusFn func(ctx context.Context, nodeID roachpb.NodeID, retryOpts retry.Options,
-	visitor func(client serverpb.StatusClient) error,
+	visitor func(client serverpb.RPCStatusClient) error,
 ) error
 
 type Server struct {
@@ -531,7 +531,7 @@ func (s Server) Verify(
 	) (serverpb.RangeInfo, error) {
 		var info serverpb.RangeInfo
 		err := s.visitStatusNode(ctx, nID, fanOutConnectionRetryOptions,
-			func(c serverpb.StatusClient) error {
+			func(c serverpb.RPCStatusClient) error {
 				resp, err := c.Range(ctx, &serverpb.RangeRequest{RangeId: int64(rID)})
 				if err != nil {
 					return err
@@ -805,10 +805,10 @@ func visitNodeWithRetry(
 // to the visitor to mark appropriate errors are retryable.
 func makeVisitNode(nd rpcbase.NodeDialerNoBreaker) visitNodeStatusFn {
 	return func(ctx context.Context, nodeID roachpb.NodeID, retryOpts retry.Options,
-		visitor func(client serverpb.StatusClient) error,
+		visitor func(client serverpb.RPCStatusClient) error,
 	) error {
 		var err error
-		var client serverpb.StatusClient
+		var client serverpb.RPCStatusClient
 
 		for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
 			log.Infof(ctx, "visiting node n%d, attempt %d", nodeID, r.CurrentAttempt())

--- a/pkg/kv/kvserver/loqrecovery/server_integration_test.go
+++ b/pkg/kv/kvserver/loqrecovery/server_integration_test.go
@@ -790,7 +790,7 @@ func createRecoveryForRange(
 }
 
 func makeTestRecoveryPlan(
-	ctx context.Context, t *testing.T, ac serverpb.AdminClient,
+	ctx context.Context, t *testing.T, ac serverpb.RPCAdminClient,
 ) loqrecoverypb.ReplicaUpdatePlan {
 	t.Helper()
 	cr, err := ac.Cluster(ctx, &serverpb.ClusterRequest{})

--- a/pkg/kv/kvserver/replica_learner_test.go
+++ b/pkg/kv/kvserver/replica_learner_test.go
@@ -1023,7 +1023,7 @@ func testRaftSnapshotsToNonVoters(t *testing.T, drainReceivingNode bool) {
 	require.Equal(t, receiverMapDelta[""], receiverMapDelta[".recovery"])
 }
 
-func drain(ctx context.Context, t *testing.T, client serverpb.AdminClient, drainingNodeID int) {
+func drain(ctx context.Context, t *testing.T, client serverpb.RPCAdminClient, drainingNodeID int) {
 	stream, err := client.Drain(ctx, &serverpb.DrainRequest{
 		NodeId:  strconv.Itoa(drainingNodeID),
 		DoDrain: true,

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialMultiRaftClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// MultiRaftClient.
+// RPCMultiRaftClient.
 func DialMultiRaftClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (MultiRaftClient, error) {
+) (RPCMultiRaftClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewMultiRaftClient(conn), nil
+		return NewGRPCMultiRaftClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -30,16 +30,16 @@ func DialMultiRaftClient(
 
 // DialPerReplicaClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// PerReplicaClient.
+// RPCPerReplicaClient.
 func DialPerReplicaClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (PerReplicaClient, error) {
+) (RPCPerReplicaClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewPerReplicaClient(conn), nil
+		return NewGRPCPerReplicaClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -46,16 +46,16 @@ func DialPerReplicaClient(
 
 // DialPerStoreClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// PerStoreClient.
+// RPCPerStoreClient.
 func DialPerStoreClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (PerStoreClient, error) {
+) (RPCPerStoreClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewPerStoreClient(conn), nil
+		return NewGRPCPerStoreClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -666,7 +666,7 @@ func SendEmptySnapshot(
 	clusterID uuid.UUID,
 	st *cluster.Settings,
 	tracer *tracing.Tracer,
-	mrc MultiRaftClient,
+	mrc RPCMultiRaftClient,
 	now hlc.Timestamp,
 	desc roachpb.RangeDescriptor,
 	to roachpb.ReplicaDescriptor,

--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialStoreLivenessClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// StoreLivenessClient.
+// RPCStoreLivenessClient.
 func DialStoreLivenessClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (StoreLivenessClient, error) {
+) (RPCStoreLivenessClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewStoreLivenessClient(conn), nil
+		return NewGRPCStoreLivenessClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/kv/kvserver/storeliveness/transport.go
+++ b/pkg/kv/kvserver/storeliveness/transport.go
@@ -344,7 +344,9 @@ func (t *Transport) startProcessNewQueue(
 // designated queue via that stream, exiting when an error is received or when
 // it idles out. All messages remaining in the queue at that point are lost and
 // a new instance of processQueue will be started by the next message to be sent.
-func (t *Transport) processQueue(q *sendQueue, stream slpb.StoreLiveness_StreamClient) (err error) {
+func (t *Transport) processQueue(
+	q *sendQueue, stream slpb.RPCStoreLiveness_StreamClient,
+) (err error) {
 	defer func() {
 		_, closeErr := stream.CloseAndRecv()
 		err = errors.Join(err, closeErr)

--- a/pkg/rpc/connection.go
+++ b/pkg/rpc/connection.go
@@ -26,16 +26,10 @@ type rpcConn interface {
 	comparable
 }
 
-// rpcHeartbeatClient offers a unified Ping interface compatible with both
-// gRPC and DRPC.
-type rpcHeartbeatClient interface {
-	Ping(ctx context.Context, in *PingRequest) (*PingResponse, error)
-}
-
 // heartbeatClientConstructor is a function type that creates a HeartbeatClient
 // for a given rpc connection. This allows us to use different implementations of
 // HeartbeatClient for different types of connections (e.g., gRPC and DRPC).
-type heartbeatClientConstructor[Conn rpcConn] func(Conn) rpcHeartbeatClient
+type heartbeatClientConstructor[Conn rpcConn] func(Conn) RPCHeartbeatClient
 
 // closeNotifier signals via a channel when its underlying gRPC or DRPC connection closes.
 type closeNotifier interface {

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -46,10 +46,4 @@ func (g *grpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
 	return ch
 }
 
-type grpcHeartbeatClient heartbeatClient
-
-func (g *grpcHeartbeatClient) Ping(ctx context.Context, in *PingRequest) (*PingResponse, error) {
-	return (*heartbeatClient)(g).Ping(ctx, in)
-}
-
 type GRPCConnection = Connection[*grpc.ClientConn]

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -251,8 +251,8 @@ func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc
 			return rpcCtx.grpcDialRaw(ctx, target, class, additionalDialOpts...)
 		},
 		dialDRPC: dialDRPC(rpcCtx),
-		newHeartbeatClient: func(cc *grpc.ClientConn) rpcHeartbeatClient {
-			return &grpcHeartbeatClient{cc: cc}
+		newHeartbeatClient: func(cc *grpc.ClientConn) RPCHeartbeatClient {
+			return NewGRPCHeartbeatClientAdapter(cc)
 		},
 		newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
 			return kvpb.NewInternalClient(cc).BatchStream(ctx)
@@ -433,7 +433,7 @@ func (p *peer[Conn]) runOnce(ctx context.Context, report func(error)) error {
 
 func runSingleHeartbeat(
 	ctx context.Context,
-	heartbeatClient rpcHeartbeatClient,
+	heartbeatClient RPCHeartbeatClient,
 	k peerKey,
 	roundTripLatency ewma.MovingAverage,
 	remoteClocks *RemoteClockMonitor, // nil if no RemoteClocks update should be made

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3144,7 +3144,7 @@ func (s *systemAdminServer) EnqueueRange(
 		return client, err
 	}
 	nodeFn := func(ctx context.Context, client interface{}, nodeID roachpb.NodeID) (interface{}, error) {
-		admin := client.(serverpb.AdminClient)
+		admin := client.(serverpb.RPCAdminClient)
 		req := *req
 		req.NodeID = nodeID
 		return admin.EnqueueRange(ctx, &req)
@@ -3722,7 +3722,7 @@ func (s *adminServer) queryTableID(
 // responsibility to convert them to srverrors.ServerErrors.
 func (s *adminServer) dialNode(
 	ctx context.Context, nodeID roachpb.NodeID,
-) (serverpb.AdminClient, error) {
+) (serverpb.RPCAdminClient, error) {
 	return serverpb.DialAdminClient(s.nd, ctx, nodeID)
 }
 

--- a/pkg/server/api_v2_ranges.go
+++ b/pkg/server/api_v2_ranges.go
@@ -205,7 +205,7 @@ func (a *apiV2Server) listRange(w http.ResponseWriter, r *http.Request) {
 		RangeIDs: []roachpb.RangeID{roachpb.RangeID(rangeID)},
 	}
 
-	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeFn := func(ctx context.Context, status serverpb.RPCStatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return status.Ranges(ctx, rangesRequest)
 	}
 	responseFn := func(nodeID roachpb.NodeID, resp interface{}) {
@@ -498,7 +498,7 @@ func (a *apiV2Server) listHotRanges(w http.ResponseWriter, r *http.Request) {
 	}
 
 	remoteRequest := serverpb.HotRangesRequest{Nodes: []string{"local"}}
-	nodeFn := func(ctx context.Context, status serverpb.StatusClient, nodeID roachpb.NodeID) ([]hotRangeInfo, error) {
+	nodeFn := func(ctx context.Context, status serverpb.RPCStatusClient, nodeID roachpb.NodeID) ([]hotRangeInfo, error) {
 		resp, err := status.HotRangesV2(ctx, &remoteRequest)
 		if err != nil || resp == nil {
 			return nil, err

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -846,7 +846,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, true},
 		{"perReplica", func(ctx context.Context, conn *grpc.ClientConn) error {
-			_, err := kvserver.NewPerReplicaClient(conn).CollectChecksum(ctx, &kvserver.CollectChecksumRequest{})
+			_, err := kvserver.NewGRPCPerReplicaClientAdapter(conn).CollectChecksum(ctx, &kvserver.CollectChecksumRequest{})
 			return err
 		}, true},
 		{"raft", func(ctx context.Context, conn *grpc.ClientConn) error {

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -881,7 +881,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, true},
 		{"admin", func(ctx context.Context, conn *grpc.ClientConn) error {
-			_, err := serverpb.NewAdminClient(conn).Databases(ctx, &serverpb.DatabasesRequest{})
+			_, err := serverpb.NewGRPCAdminClientAdapter(conn).Databases(ctx, &serverpb.DatabasesRequest{})
 			return err
 		}, false},
 		{"status", func(ctx context.Context, conn *grpc.ClientConn) error {

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -877,7 +877,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, false},
 		{"init", func(ctx context.Context, conn *grpc.ClientConn) error {
-			_, err := serverpb.NewInitClient(conn).Bootstrap(ctx, &serverpb.BootstrapRequest{})
+			_, err := serverpb.NewGRPCInitClientAdapter(conn).Bootstrap(ctx, &serverpb.BootstrapRequest{})
 			return err
 		}, true},
 		{"admin", func(ctx context.Context, conn *grpc.ClientConn) error {

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -885,7 +885,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, false},
 		{"status", func(ctx context.Context, conn *grpc.ClientConn) error {
-			_, err := serverpb.NewStatusClient(conn).ListSessions(ctx, &serverpb.ListSessionsRequest{})
+			_, err := serverpb.NewGRPCStatusClientAdapter(conn).ListSessions(ctx, &serverpb.ListSessionsRequest{})
 			return err
 		}, false},
 	}

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -859,7 +859,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, true},
 		{"closedTimestamp", func(ctx context.Context, conn *grpc.ClientConn) error {
-			stream, err := ctpb.NewSideTransportClient(conn).PushUpdates(ctx)
+			stream, err := ctpb.NewGRPCSideTransportClientAdapter(conn).PushUpdates(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -868,7 +868,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, true},
 		{"distSQL", func(ctx context.Context, conn *grpc.ClientConn) error {
-			stream, err := execinfrapb.NewDistSQLClient(conn).FlowStream(ctx)
+			stream, err := execinfrapb.NewGRPCDistSQLClientAdapter(conn).FlowStream(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -833,7 +833,7 @@ func TestGRPCAuthentication(t *testing.T) {
 		storageOnly bool
 	}{
 		{"gossip", func(ctx context.Context, conn *grpc.ClientConn) error {
-			stream, err := gossip.NewGossipClient(conn).Gossip(ctx)
+			stream, err := gossip.NewGRPCGossipClientAdapter(conn).Gossip(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -850,7 +850,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, true},
 		{"raft", func(ctx context.Context, conn *grpc.ClientConn) error {
-			stream, err := kvserver.NewMultiRaftClient(conn).RaftMessageBatch(ctx)
+			stream, err := kvserver.NewGRPCMultiRaftClientAdapter(conn).RaftMessageBatch(ctx)
 			if err != nil {
 				return err
 			}

--- a/pkg/server/connectivity_test.go
+++ b/pkg/server/connectivity_test.go
@@ -217,7 +217,7 @@ func TestClusterConnectivity(t *testing.T) {
 						_ = conn.Close() // nolint:grpcconnclose
 					}()
 
-					client := serverpb.NewInitClient(conn)
+					client := serverpb.NewGRPCInitClientAdapter(conn)
 					_, err = client.Bootstrap(context.Background(), &serverpb.BootstrapRequest{})
 					return err
 				})

--- a/pkg/server/drain.go
+++ b/pkg/server/drain.go
@@ -239,7 +239,7 @@ func (s *drainServer) maybeShutdownAfterDrain(
 func delegateDrain(
 	ctx context.Context,
 	req *serverpb.DrainRequest,
-	client serverpb.AdminClient,
+	client serverpb.RPCAdminClient,
 	stream serverpb.Admin_DrainServer,
 ) error {
 	// Retrieve the stream interface to the target node.

--- a/pkg/server/drain_test.go
+++ b/pkg/server/drain_test.go
@@ -178,7 +178,7 @@ INSERT INTO t.test VALUES (3);
 type testDrainContext struct {
 	*testing.T
 	tc         *testcluster.TestCluster
-	c          serverpb.AdminClient
+	c          serverpb.RPCAdminClient
 	connCloser func()
 }
 
@@ -281,7 +281,7 @@ func (t *testDrainContext) assertEqual(expected int, actual int) {
 }
 
 func (t *testDrainContext) getDrainResponse(
-	stream serverpb.Admin_DrainClient,
+	stream serverpb.RPCAdmin_DrainClient,
 ) (*serverpb.DrainResponse, error) {
 	resp, err := stream.Recv()
 	if err != nil {

--- a/pkg/server/index_usage_stats.go
+++ b/pkg/server/index_usage_stats.go
@@ -69,7 +69,7 @@ func (s *statusServer) IndexUsageStatistics(
 		return statusClient.IndexUsageStatistics(ctx, localReq)
 	}
 
-	fetchIndexUsageStats := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	fetchIndexUsageStats := func(ctx context.Context, statusClient serverpb.RPCStatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return statusClient.IndexUsageStatistics(ctx, localReq)
 	}
 
@@ -167,7 +167,7 @@ func (s *statusServer) ResetIndexUsageStats(
 		return statusClient.ResetIndexUsageStats(ctx, localReq)
 	}
 
-	resetIndexUsageStats := func(ctx context.Context, statusClient serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	resetIndexUsageStats := func(ctx context.Context, statusClient serverpb.RPCStatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return statusClient.ResetIndexUsageStats(ctx, localReq)
 	}
 

--- a/pkg/server/key_visualizer_server.go
+++ b/pkg/server/key_visualizer_server.go
@@ -74,7 +74,7 @@ func (s *KeyVisualizerServer) getSamplesFromFanOut(
 	}
 
 	nodeFn := func(ctx context.Context, client interface{}, nodeID roachpb.NodeID) (interface{}, error) {
-		samples, err := client.(keyvispb.KeyVisualizerClient).GetSamples(ctx,
+		samples, err := client.(keyvispb.RPCKeyVisualizerClient).GetSamples(ctx,
 			&keyvispb.GetSamplesRequest{
 				NodeID:             nodeID,
 				CollectedOnOrAfter: timestamp,

--- a/pkg/server/pagination_test.go
+++ b/pkg/server/pagination_test.go
@@ -418,7 +418,7 @@ func TestRPCPaginatorWithTimeout(t *testing.T) {
 
 	s := server.StatusServer().(*systemStatusServer)
 
-	nodeFn := func(ctx context.Context, client serverpb.StatusClient, nodeID roachpb.NodeID) ([]interface{}, error) {
+	nodeFn := func(ctx context.Context, client serverpb.RPCStatusClient, nodeID roachpb.NodeID) ([]interface{}, error) {
 		select {
 		case <-time.After(time.Second * 10):
 		case <-ctx.Done():

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -1,4 +1,4 @@
-# gazelle:go_grpc_compilers //pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler,  @com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway
+# gazelle:go_grpc_compilers //pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler, //pkg/cmd/protoc-gen-go-drpc:protoc-gen-go-drpc_compiler, @com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -54,6 +54,7 @@ go_proto_library(
     compilers = [
         "//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler",
         "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway",
+        "//pkg/cmd/protoc-gen-go-drpc:protoc-gen-go-drpc_compiler",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/server/serverpb",
     proto = ":serverpb_proto",

--- a/pkg/server/serverpb/admin.go
+++ b/pkg/server/serverpb/admin.go
@@ -74,7 +74,9 @@ func (r *RecoveryVerifyResponse_UnavailableRanges) Empty() bool {
 // can't tell what the true prefix for each metric is). Additionally, for histograms
 // we generate the names for the quantiles that are exported (internal TSDB does
 // not support full histograms).
-func GetInternalTimeseriesNamesFromServer(ctx context.Context, ac AdminClient) ([]string, error) {
+func GetInternalTimeseriesNamesFromServer(
+	ctx context.Context, ac RPCAdminClient,
+) ([]string, error) {
 	resp, err := ac.AllMetricMetadata(ctx, &MetricMetadataRequest{})
 	if err != nil {
 		return nil, err

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -66,16 +66,16 @@ func DialStatusClient(
 
 // DialAdminClient establishes a DRPC connection if enabled; otherwise, it
 // falls back to gRPC. The established connection is used to create a
-// AdminClient.
+// RPCAdminClient.
 func DialAdminClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID,
-) (AdminClient, error) {
+) (RPCAdminClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, err
 		}
-		return NewAdminClient(conn), nil
+		return NewGRPCAdminClientAdapter(conn), nil
 	}
 	return nil, nil
 }
@@ -86,13 +86,13 @@ func DialAdminClient(
 // does not check the breaker before dialing the connection.
 func DialAdminClientNoBreaker(
 	nd rpcbase.NodeDialerNoBreaker, ctx context.Context, nodeID roachpb.NodeID,
-) (AdminClient, error) {
+) (RPCAdminClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.DialNoBreaker(ctx, nodeID, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, err
 		}
-		return NewAdminClient(conn), nil
+		return NewGRPCAdminClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -37,29 +37,29 @@ func DialStatusClientNoBreaker(
 	ctx context.Context,
 	nodeID roachpb.NodeID,
 	class rpcbase.ConnectionClass,
-) (StatusClient, error) {
+) (RPCStatusClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.DialNoBreaker(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewStatusClient(conn), nil
+		return NewGRPCStatusClientAdapter(conn), nil
 	}
 	return nil, nil
 }
 
 // DialStatusClient establishes a DRPC connection if enabled; otherwise, it
 // falls back to gRPC. The established connection is used to create a
-// StatusClient.
+// RPCStatusClient.
 func DialStatusClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID,
-) (StatusClient, error) {
+) (RPCStatusClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, err
 		}
-		return NewStatusClient(conn), nil
+		return NewGRPCStatusClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialMigrationClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// MigrationClient.
+// RPCMigrationClient.
 func DialMigrationClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (MigrationClient, error) {
+) (RPCMigrationClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewMigrationClient(conn), nil
+		return NewGRPCMigrationClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/server/span_download.go
+++ b/pkg/server/span_download.go
@@ -62,7 +62,7 @@ func (s *systemStatusServer) DownloadSpan(
 	// Send DownloadSpan request to all stores on all nodes.
 	remoteRequest := *req
 	remoteRequest.NodeID = "local"
-	nodeFn := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.DownloadSpanResponse, error) {
+	nodeFn := func(ctx context.Context, status serverpb.RPCStatusClient, _ roachpb.NodeID) (*serverpb.DownloadSpanResponse, error) {
 		return status.DownloadSpan(ctx, &remoteRequest)
 	}
 	responseFn := func(nodeID roachpb.NodeID, downloadSpanResp *serverpb.DownloadSpanResponse) {

--- a/pkg/server/span_stats_server.go
+++ b/pkg/server/span_stats_server.go
@@ -116,7 +116,7 @@ func (s *systemStatusServer) spanStatsFanOut(
 			return nil, nil
 		}
 
-		resp, err := client.(serverpb.StatusClient).SpanStats(ctx,
+		resp, err := client.(serverpb.RPCStatusClient).SpanStats(ctx,
 			&roachpb.SpanStatsRequest{
 				NodeID: nodeID.String(),
 				Spans:  spansPerNode[nodeID],

--- a/pkg/server/sql_stats.go
+++ b/pkg/server/sql_stats.go
@@ -124,7 +124,7 @@ func (s *statusServer) ResetSQLStats(
 		return status.ResetSQLStats(ctx, localReq)
 	}
 
-	resetSQLStats := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	resetSQLStats := func(ctx context.Context, status serverpb.RPCStatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return status.ResetSQLStats(ctx, localReq)
 	}
 
@@ -186,7 +186,7 @@ func (s *statusServer) DrainSqlStats(
 		return statusCli.DrainSqlStats(ctx, localReq)
 	}
 
-	drainStats := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (*serverpb.DrainStatsResponse, error) {
+	drainStats := func(ctx context.Context, status serverpb.RPCStatusClient, _ roachpb.NodeID) (*serverpb.DrainStatsResponse, error) {
 		return status.DrainSqlStats(ctx, localReq)
 	}
 

--- a/pkg/server/statements.go
+++ b/pkg/server/statements.go
@@ -70,7 +70,7 @@ func (s *statusServer) Statements(
 		return status.Statements(ctx, localReq)
 	}
 
-	nodeStatement := func(ctx context.Context, status serverpb.StatusClient, _ roachpb.NodeID) (interface{}, error) {
+	nodeStatement := func(ctx context.Context, status serverpb.RPCStatusClient, _ roachpb.NodeID) (interface{}, error) {
 		return status.Statements(ctx, localReq)
 	}
 

--- a/pkg/server/storage_api/decommission_test.go
+++ b/pkg/server/storage_api/decommission_test.go
@@ -846,94 +846,94 @@ func TestAdminDecommissionedOperations(t *testing.T) {
 	testcases := []struct {
 		name       string
 		expectCode codes.Code
-		op         func(context.Context, serverpb.AdminClient) error
+		op         func(context.Context, serverpb.RPCAdminClient) error
 	}{
-		{"Cluster", codes.OK, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Cluster", codes.OK, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Cluster(ctx, &serverpb.ClusterRequest{})
 			return err
 		}},
-		{"Databases", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Databases", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Databases(ctx, &serverpb.DatabasesRequest{})
 			return err
 		}},
-		{"DatabaseDetails", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"DatabaseDetails", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.DatabaseDetails(ctx, &serverpb.DatabaseDetailsRequest{Database: "foo"})
 			return err
 		}},
-		{"DataDistribution", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"DataDistribution", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.DataDistribution(ctx, &serverpb.DataDistributionRequest{})
 			return err
 		}},
-		{"Decommission", codes.Internal, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Decommission", codes.Internal, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Decommission(ctx, &serverpb.DecommissionRequest{
 				NodeIDs:          []roachpb.NodeID{srv.NodeID(), decomSrv.NodeID()},
 				TargetMembership: livenesspb.MembershipStatus_DECOMMISSIONED,
 			})
 			return err
 		}},
-		{"DecommissionStatus", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"DecommissionStatus", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.DecommissionStatus(ctx, &serverpb.DecommissionStatusRequest{
 				NodeIDs: []roachpb.NodeID{srv.NodeID(), decomSrv.NodeID()},
 			})
 			return err
 		}},
-		{"EnqueueRange", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"EnqueueRange", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.EnqueueRange(ctx, &serverpb.EnqueueRangeRequest{
 				RangeID: scratchRange.RangeID,
 				Queue:   "replicaGC",
 			})
 			return err
 		}},
-		{"Events", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Events", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Events(ctx, &serverpb.EventsRequest{})
 			return err
 		}},
-		{"Health", codes.OK, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Health", codes.OK, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Health(ctx, &serverpb.HealthRequest{})
 			return err
 		}},
-		{"Jobs", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Jobs", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Jobs(ctx, &serverpb.JobsRequest{})
 			return err
 		}},
-		{"Liveness", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Liveness", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Liveness(ctx, &serverpb.LivenessRequest{})
 			return err
 		}},
-		{"Locations", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Locations", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Locations(ctx, &serverpb.LocationsRequest{})
 			return err
 		}},
-		{"NonTableStats", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"NonTableStats", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.NonTableStats(ctx, &serverpb.NonTableStatsRequest{})
 			return err
 		}},
-		{"QueryPlan", codes.OK, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"QueryPlan", codes.OK, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.QueryPlan(ctx, &serverpb.QueryPlanRequest{Query: "SELECT 1"})
 			return err
 		}},
-		{"RangeLog", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"RangeLog", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.RangeLog(ctx, &serverpb.RangeLogRequest{})
 			return err
 		}},
-		{"Settings", codes.OK, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Settings", codes.OK, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Settings(ctx, &serverpb.SettingsRequest{})
 			return err
 		}},
-		{"TableStats", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"TableStats", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.TableStats(ctx, &serverpb.TableStatsRequest{Database: "foo", Table: "bar"})
 			return err
 		}},
-		{"TableDetails", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"TableDetails", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.TableDetails(ctx, &serverpb.TableDetailsRequest{Database: "foo", Table: "bar"})
 			return err
 		}},
-		{"Users", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Users", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			_, err := c.Users(ctx, &serverpb.UsersRequest{})
 			return err
 		}},
 		// We drain at the end, since it may evict us.
-		{"Drain", codes.PermissionDenied, func(ctx context.Context, c serverpb.AdminClient) error {
+		{"Drain", codes.PermissionDenied, func(ctx context.Context, c serverpb.RPCAdminClient) error {
 			stream, err := c.Drain(ctx, &serverpb.DrainRequest{DoDrain: true})
 			if err != nil {
 				return err

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2646,7 +2646,7 @@ func (ts *testServer) GetAdminClient(test serverutils.TestFataler) serverpb.RPCA
 }
 
 // GetStatusClient is part of the serverutils.ApplicationLayerInterface.
-func (ts *testServer) GetStatusClient(test serverutils.TestFataler) serverpb.StatusClient {
+func (ts *testServer) GetStatusClient(test serverutils.TestFataler) serverpb.RPCStatusClient {
 	conn := ts.RPCClientConn(test, username.RootUserName())
 	return conn.NewStatusClient()
 }
@@ -2694,7 +2694,7 @@ func (t *testTenant) GetAdminClient(test serverutils.TestFataler) serverpb.RPCAd
 }
 
 // GetStatusClient is part of the serverutils.ApplicationLayerInterface.
-func (t *testTenant) GetStatusClient(test serverutils.TestFataler) serverpb.StatusClient {
+func (t *testTenant) GetStatusClient(test serverutils.TestFataler) serverpb.RPCStatusClient {
 	conn := t.RPCClientConn(test, username.RootUserName())
 	return conn.NewStatusClient()
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2640,7 +2640,7 @@ func (ts *testServer) RPCClientConnE(user username.SQLUsername) (serverutils.RPC
 }
 
 // GetAdminClient is part of the serverutils.ApplicationLayerInterface.
-func (ts *testServer) GetAdminClient(test serverutils.TestFataler) serverpb.AdminClient {
+func (ts *testServer) GetAdminClient(test serverutils.TestFataler) serverpb.RPCAdminClient {
 	conn := ts.RPCClientConn(test, username.RootUserName())
 	return conn.NewAdminClient()
 }
@@ -2688,7 +2688,7 @@ func (t *testTenant) RPCClientConnE(user username.SQLUsername) (serverutils.RPCC
 }
 
 // GetAdminClient is part of the serverutils.ApplicationLayerInterface.
-func (t *testTenant) GetAdminClient(test serverutils.TestFataler) serverpb.AdminClient {
+func (t *testTenant) GetAdminClient(test serverutils.TestFataler) serverpb.RPCAdminClient {
 	conn := t.RPCClientConn(test, username.RootUserName())
 	return conn.NewAdminClient()
 }

--- a/pkg/sql/colflow/colrpc/colrpc_test.go
+++ b/pkg/sql/colflow/colrpc/colrpc_test.go
@@ -187,7 +187,7 @@ func TestOutboxInbox(t *testing.T) {
 	}
 
 	streamCtx, streamCancelFn := context.WithCancel(ctx)
-	client := execinfrapb.NewDistSQLClient(conn)
+	client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 	clientStream, err := client.FlowStream(streamCtx)
 	require.NoError(t, err)
 
@@ -505,7 +505,7 @@ func TestInboxHostCtxCancellation(t *testing.T) {
 	outboxCtx, outboxCtxCancel := context.WithCancel(outboxHostCtx)
 
 	// Initiate the FlowStream RPC from the outbox.
-	client := execinfrapb.NewDistSQLClient(conn)
+	client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 	clientStream, err := client.FlowStream(outboxCtx)
 	require.NoError(t, err)
 
@@ -675,7 +675,7 @@ func TestOutboxInboxMetadataPropagation(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			client := execinfrapb.NewDistSQLClient(conn)
+			client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 			clientStream, err := client.FlowStream(ctx)
 			require.NoError(t, err)
 
@@ -782,7 +782,7 @@ func BenchmarkOutboxInbox(b *testing.B) {
 		require.NoError(b, err)
 	}()
 
-	client := execinfrapb.NewDistSQLClient(conn)
+	client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 	clientStream, err := client.FlowStream(ctx)
 	require.NoError(b, err)
 

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -177,7 +177,7 @@ func (o *Outbox) Run(
 	ctx = logtags.AddTag(ctx, "streamID", streamID)
 	log.VEventf(ctx, 2, "Outbox Dialing %s", sqlInstanceID)
 
-	var stream execinfrapb.DistSQL_FlowStreamClient
+	var stream execinfrapb.RPCDistSQL_FlowStreamClient
 	if err := func() error {
 		conn, err := execinfra.GetConnForOutbox(ctx, dialer, sqlInstanceID, connectionTimeout)
 		if err != nil {
@@ -185,7 +185,7 @@ func (o *Outbox) Run(
 			return err
 		}
 
-		client := execinfrapb.NewDistSQLClient(conn)
+		client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 		// We use the flow context for the RPC so that when outbox context is
 		// canceled in case of a graceful shutdown, the gRPC stream keeps on
 		// running. If, however, the flow context is canceled, then the

--- a/pkg/sql/execinfrapb/rpc_clients.go
+++ b/pkg/sql/execinfrapb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialDistSQLClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// DistSQLClient.
+// RPCDistSQLClient.
 func DialDistSQLClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (DistSQLClient, error) {
+) (RPCDistSQLClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewDistSQLClient(conn), nil
+		return NewGRPCDistSQLClientAdapter(conn), nil
 	}
 	return nil, nil
 }

--- a/pkg/sql/flowinfra/cluster_test.go
+++ b/pkg/sql/flowinfra/cluster_test.go
@@ -49,7 +49,7 @@ func runTestClusterFlow(
 	t *testing.T,
 	servers []serverutils.ApplicationLayerInterface,
 	conns []*gosql.DB,
-	clients []execinfrapb.DistSQLClient,
+	clients []execinfrapb.RPCDistSQLClient,
 ) {
 	ctx := context.Background()
 	const numRows = 100
@@ -263,7 +263,7 @@ func TestClusterFlow(t *testing.T) {
 
 	servers := make([]serverutils.ApplicationLayerInterface, numNodes)
 	conns := make([]*gosql.DB, numNodes)
-	clients := make([]execinfrapb.DistSQLClient, numNodes)
+	clients := make([]execinfrapb.RPCDistSQLClient, numNodes)
 	for i := 0; i < numNodes; i++ {
 		s := tc.Server(i).ApplicationLayer()
 		servers[i] = s
@@ -289,7 +289,7 @@ func TestTenantClusterFlow(t *testing.T) {
 
 	pods := make([]serverutils.ApplicationLayerInterface, numPods)
 	podConns := make([]*gosql.DB, numPods)
-	clients := make([]execinfrapb.DistSQLClient, numPods)
+	clients := make([]execinfrapb.RPCDistSQLClient, numPods)
 	tenantID := serverutils.TestTenantID()
 	for i := 0; i < numPods; i++ {
 		pods[i], podConns[i] = serverutils.StartTenant(t, tc.Server(0), base.TestTenantArgs{
@@ -304,7 +304,7 @@ func TestTenantClusterFlow(t *testing.T) {
 		if err != nil {
 			t.Fatal(err)
 		}
-		clients[i] = execinfrapb.NewDistSQLClient(conn)
+		clients[i] = execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 	}
 
 	runTestClusterFlow(t, pods, podConns, clients)
@@ -771,7 +771,7 @@ func BenchmarkInfrastructure(b *testing.B) {
 					}
 					reqs[0].Flow.Processors = append(reqs[0].Flow.Processors, lastProc)
 
-					var clients []execinfrapb.DistSQLClient
+					var clients []execinfrapb.RPCDistSQLClient
 
 					for i := 0; i < numNodes; i++ {
 						s := tc.Server(i)

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -238,7 +238,7 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 			log.VWarningf(ctx, 1, "Outbox Dial connection error, distributed query will fail: %+v", err)
 			return err
 		}
-		client := execinfrapb.NewDistSQLClient(conn)
+		client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 		if log.V(2) {
 			log.Infof(ctx, "outbox: calling FlowStream")
 		}
@@ -261,7 +261,7 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 	// Make sure to always close the stream if it is still usable (if not, then
 	// the field is set to nil).
 	defer func() {
-		if stream, ok := m.stream.(execinfrapb.DistSQL_FlowStreamClient); ok {
+		if stream, ok := m.stream.(execinfrapb.RPCDistSQL_FlowStreamClient); ok {
 			closeErr := stream.CloseSend()
 			if retErr == nil {
 				retErr = closeErr

--- a/pkg/sql/flowinfra/utils_test.go
+++ b/pkg/sql/flowinfra/utils_test.go
@@ -33,7 +33,7 @@ func createDummyStream(
 	t *testing.T,
 ) (
 	serverStream execinfrapb.DistSQL_FlowStreamServer,
-	clientStream execinfrapb.DistSQL_FlowStreamClient,
+	clientStream execinfrapb.RPCDistSQL_FlowStreamClient,
 	cleanup func(),
 ) {
 	stopper := stop.NewStopper()
@@ -50,7 +50,7 @@ func createDummyStream(
 	if err != nil {
 		t.Fatal(err)
 	}
-	client := execinfrapb.NewDistSQLClient(conn)
+	client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 	clientStream, err = client.FlowStream(ctx)
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -157,7 +157,7 @@ type RPCConn interface {
 	NewInitClient() serverpb.InitClient
 	NewTimeSeriesClient() tspb.TimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
-	NewDistSQLClient() execinfrapb.DistSQLClient
+	NewDistSQLClient() execinfrapb.RPCDistSQLClient
 }
 
 // ApplicationLayerInterface defines accessors to the application

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -154,7 +154,7 @@ func (d DeploymentMode) IsExternal() bool {
 type RPCConn interface {
 	NewStatusClient() serverpb.StatusClient
 	NewAdminClient() serverpb.RPCAdminClient
-	NewInitClient() serverpb.InitClient
+	NewInitClient() serverpb.RPCInitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
 	NewDistSQLClient() execinfrapb.RPCDistSQLClient

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -155,7 +155,7 @@ type RPCConn interface {
 	NewStatusClient() serverpb.StatusClient
 	NewAdminClient() serverpb.AdminClient
 	NewInitClient() serverpb.InitClient
-	NewTimeSeriesClient() tspb.TimeSeriesClient
+	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
 	NewDistSQLClient() execinfrapb.RPCDistSQLClient
 }

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -153,7 +153,7 @@ func (d DeploymentMode) IsExternal() bool {
 // them without changing the caller code.
 type RPCConn interface {
 	NewStatusClient() serverpb.StatusClient
-	NewAdminClient() serverpb.AdminClient
+	NewAdminClient() serverpb.RPCAdminClient
 	NewInitClient() serverpb.InitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
 	NewInternalClient() kvpb.InternalClient
@@ -297,7 +297,7 @@ type ApplicationLayerInterface interface {
 
 	// GetAdminClient creates a serverpb.AdminClient connection to the server.
 	// Shorthand for serverpb.AdminClient(.RPCClientConn(t, "root"))
-	GetAdminClient(t TestFataler) serverpb.AdminClient
+	GetAdminClient(t TestFataler) serverpb.RPCAdminClient
 
 	// GetStatusClient creates a serverpb.StatusClient connection to the server.
 	// Shorthand for serverpb.StatusClient(.RPCClientConn(t, "root"))

--- a/pkg/testutils/serverutils/api.go
+++ b/pkg/testutils/serverutils/api.go
@@ -152,7 +152,7 @@ func (d DeploymentMode) IsExternal() bool {
 // underlying RPC connection (gRPC or DRPC), making it easy to swap
 // them without changing the caller code.
 type RPCConn interface {
-	NewStatusClient() serverpb.StatusClient
+	NewStatusClient() serverpb.RPCStatusClient
 	NewAdminClient() serverpb.RPCAdminClient
 	NewInitClient() serverpb.RPCInitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
@@ -301,7 +301,7 @@ type ApplicationLayerInterface interface {
 
 	// GetStatusClient creates a serverpb.StatusClient connection to the server.
 	// Shorthand for serverpb.StatusClient(.RPCClientConn(t, "root"))
-	GetStatusClient(t TestFataler) serverpb.StatusClient
+	GetStatusClient(t TestFataler) serverpb.RPCStatusClient
 
 	// AnnotateCtx annotates a context.
 	AnnotateCtx(context.Context) context.Context

--- a/pkg/testutils/serverutils/rpc_conn.go
+++ b/pkg/testutils/serverutils/rpc_conn.go
@@ -24,8 +24,8 @@ func FromGRPCConn(conn *grpc.ClientConn) RPCConn {
 	return &grpcConn{conn: conn}
 }
 
-func (c *grpcConn) NewStatusClient() serverpb.StatusClient {
-	return serverpb.NewStatusClient(c.conn)
+func (c *grpcConn) NewStatusClient() serverpb.RPCStatusClient {
+	return serverpb.NewGRPCStatusClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewAdminClient() serverpb.RPCAdminClient {

--- a/pkg/testutils/serverutils/rpc_conn.go
+++ b/pkg/testutils/serverutils/rpc_conn.go
@@ -32,8 +32,8 @@ func (c *grpcConn) NewAdminClient() serverpb.RPCAdminClient {
 	return serverpb.NewGRPCAdminClientAdapter(c.conn)
 }
 
-func (c *grpcConn) NewInitClient() serverpb.InitClient {
-	return serverpb.NewInitClient(c.conn)
+func (c *grpcConn) NewInitClient() serverpb.RPCInitClient {
+	return serverpb.NewGRPCInitClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {

--- a/pkg/testutils/serverutils/rpc_conn.go
+++ b/pkg/testutils/serverutils/rpc_conn.go
@@ -44,6 +44,6 @@ func (c *grpcConn) NewInternalClient() kvpb.InternalClient {
 	return kvpb.NewInternalClient(c.conn)
 }
 
-func (c *grpcConn) NewDistSQLClient() execinfrapb.DistSQLClient {
-	return execinfrapb.NewDistSQLClient(c.conn)
+func (c *grpcConn) NewDistSQLClient() execinfrapb.RPCDistSQLClient {
+	return execinfrapb.NewGRPCDistSQLClientAdapter(c.conn)
 }

--- a/pkg/testutils/serverutils/rpc_conn.go
+++ b/pkg/testutils/serverutils/rpc_conn.go
@@ -36,8 +36,8 @@ func (c *grpcConn) NewInitClient() serverpb.InitClient {
 	return serverpb.NewInitClient(c.conn)
 }
 
-func (c *grpcConn) NewTimeSeriesClient() tspb.TimeSeriesClient {
-	return tspb.NewTimeSeriesClient(c.conn)
+func (c *grpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {
+	return tspb.NewGRPCTimeSeriesClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewInternalClient() kvpb.InternalClient {

--- a/pkg/testutils/serverutils/rpc_conn.go
+++ b/pkg/testutils/serverutils/rpc_conn.go
@@ -28,8 +28,8 @@ func (c *grpcConn) NewStatusClient() serverpb.StatusClient {
 	return serverpb.NewStatusClient(c.conn)
 }
 
-func (c *grpcConn) NewAdminClient() serverpb.AdminClient {
-	return serverpb.NewAdminClient(c.conn)
+func (c *grpcConn) NewAdminClient() serverpb.RPCAdminClient {
+	return serverpb.NewGRPCAdminClientAdapter(c.conn)
 }
 
 func (c *grpcConn) NewInitClient() serverpb.InitClient {

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -2031,7 +2031,7 @@ func (tc *TestCluster) GetRaftLeader(
 // GetAdminClient gets the severpb.AdminClient for the specified server.
 func (tc *TestCluster) GetAdminClient(
 	t serverutils.TestFataler, serverIdx int,
-) serverpb.AdminClient {
+) serverpb.RPCAdminClient {
 	return tc.Server(serverIdx).GetAdminClient(t)
 }
 

--- a/pkg/testutils/testcluster/testcluster.go
+++ b/pkg/testutils/testcluster/testcluster.go
@@ -1680,7 +1680,7 @@ func (tc *TestCluster) WaitForNodeStatuses(t serverutils.TestFataler) {
 		if err != nil {
 			return err
 		}
-		client := serverpb.NewStatusClient(conn)
+		client := serverpb.NewGRPCStatusClientAdapter(conn)
 		response, err := client.Nodes(context.Background(), &serverpb.NodesRequest{})
 		if err != nil {
 			return err
@@ -2038,7 +2038,7 @@ func (tc *TestCluster) GetAdminClient(
 // GetStatusClient gets the severpb.StatusClient for the specified server.
 func (tc *TestCluster) GetStatusClient(
 	t serverutils.TestFataler, serverIdx int,
-) serverpb.StatusClient {
+) serverpb.RPCStatusClient {
 	return tc.Server(serverIdx).GetStatusClient(t)
 }
 

--- a/pkg/ts/server_test.go
+++ b/pkg/ts/server_test.go
@@ -784,7 +784,7 @@ func TestServerDump(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	readDataFromDump := func(t *testing.T, dumpClient tspb.TimeSeries_DumpClient) (totalMsgCount int, _ map[string]map[string]tspb.TimeSeriesData) {
+	readDataFromDump := func(t *testing.T, dumpClient tspb.RPCTimeSeries_DumpClient) (totalMsgCount int, _ map[string]map[string]tspb.TimeSeriesData) {
 		t.Helper()
 		// Read data from dump command.
 		resultMap := make(map[string]map[string]tspb.TimeSeriesData)

--- a/pkg/ts/tspb/BUILD.bazel
+++ b/pkg/ts/tspb/BUILD.bazel
@@ -1,4 +1,4 @@
-# gazelle:go_grpc_compilers //pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler,  @com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway
+# gazelle:go_grpc_compilers //pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler, //pkg/cmd/protoc-gen-go-drpc:protoc-gen-go-drpc_compiler, @com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway
 
 load("@io_bazel_rules_go//go:def.bzl", "go_library")
 load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
@@ -30,6 +30,7 @@ go_proto_library(
     compilers = [
         "//pkg/cmd/protoc-gen-gogoroach:protoc-gen-gogoroach_grpc_compiler",
         "@com_github_grpc_ecosystem_grpc_gateway//protoc-gen-grpc-gateway:go_gen_grpc_gateway",
+        "//pkg/cmd/protoc-gen-go-drpc:protoc-gen-go-drpc_compiler",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/ts/tspb",
     proto = ":tspb_proto",

--- a/pkg/ts/tsutil/util.go
+++ b/pkg/ts/tsutil/util.go
@@ -16,7 +16,7 @@ import (
 
 // DumpRawTo is a helper that gob-encodes all messages received from the
 // source stream to the given WriteCloser.
-func DumpRawTo(src tspb.TimeSeries_DumpRawClient, out io.Writer) error {
+func DumpRawTo(src tspb.RPCTimeSeries_DumpRawClient, out io.Writer) error {
 	enc := gob.NewEncoder(out)
 	for {
 		data, err := src.Recv()

--- a/pkg/upgrade/system_upgrade.go
+++ b/pkg/upgrade/system_upgrade.go
@@ -44,7 +44,7 @@ type Cluster interface {
 	ForEveryNodeOrServer(
 		ctx context.Context,
 		op string,
-		fn func(context.Context, serverpb.MigrationClient) error,
+		fn func(context.Context, serverpb.RPCMigrationClient) error,
 	) error
 
 	// ValidateAfterUpdateSystemVersion performs any required validation after

--- a/pkg/upgrade/upgradecluster/cluster.go
+++ b/pkg/upgrade/upgradecluster/cluster.go
@@ -110,7 +110,7 @@ func (c *Cluster) NumNodesOrServers(ctx context.Context) (int, error) {
 
 // ForEveryNodeOrTenantPod is part of the upgrade.Cluster interface.
 func (c *Cluster) ForEveryNodeOrServer(
-	ctx context.Context, op string, fn func(context.Context, serverpb.MigrationClient) error,
+	ctx context.Context, op string, fn func(context.Context, serverpb.RPCMigrationClient) error,
 ) error {
 
 	live, _, err := NodesFromNodeLiveness(ctx, c.c.NodeLiveness)

--- a/pkg/upgrade/upgradecluster/helper_test.go
+++ b/pkg/upgrade/upgradecluster/helper_test.go
@@ -55,7 +55,7 @@ func TestHelperEveryNode(t *testing.T) {
 			MaxRetries:     10,
 		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
-				context.Context, serverpb.MigrationClient,
+				context.Context, serverpb.RPCMigrationClient,
 			) error {
 				mu.Lock()
 				defer mu.Unlock()
@@ -94,7 +94,7 @@ func TestHelperEveryNode(t *testing.T) {
 			MaxRetries:     10,
 		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
-				context.Context, serverpb.MigrationClient,
+				context.Context, serverpb.RPCMigrationClient,
 			) error {
 				mu.Lock()
 				defer mu.Unlock()
@@ -136,7 +136,7 @@ func TestHelperEveryNode(t *testing.T) {
 			MaxRetries:     10,
 		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
-				context.Context, serverpb.MigrationClient,
+				context.Context, serverpb.RPCMigrationClient,
 			) error {
 				mu.Lock()
 				defer mu.Unlock()
@@ -160,7 +160,7 @@ func TestHelperEveryNode(t *testing.T) {
 			MaxRetries:     10,
 		}, func() error {
 			return h.ForEveryNodeOrServer(ctx, "dummy-op", func(
-				context.Context, serverpb.MigrationClient,
+				context.Context, serverpb.RPCMigrationClient,
 			) error {
 				return nil
 			})

--- a/pkg/upgrade/upgradecluster/tenant_cluster.go
+++ b/pkg/upgrade/upgradecluster/tenant_cluster.go
@@ -188,7 +188,7 @@ const BumpClusterVersionOpName = "bump-cluster-version"
 // ForEveryNodeOrServer is part of the upgrade.Cluster interface.
 // TODO(ajstorm): Make the op here more structured.
 func (t *TenantCluster) ForEveryNodeOrServer(
-	ctx context.Context, op string, fn func(context.Context, serverpb.MigrationClient) error,
+	ctx context.Context, op string, fn func(context.Context, serverpb.RPCMigrationClient) error,
 ) error {
 	// Get the list of all SQL instances running. We must do this using the
 	// "NoCache" method, as the upgrade interlock requires a consistent view of
@@ -224,7 +224,7 @@ func (t *TenantCluster) ForEveryNodeOrServer(
 		grp.GoCtx(func(ctx context.Context) error {
 			defer alloc.Release()
 
-			var client serverpb.MigrationClient
+			var client serverpb.RPCMigrationClient
 			retryOpts := retry.Options{
 				InitialBackoff: 1 * time.Millisecond,
 				MaxRetries:     20,

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -586,7 +586,7 @@ func bumpClusterVersion(
 	req := &serverpb.BumpClusterVersionRequest{ClusterVersion: &clusterVersion}
 	op := fmt.Sprintf("bump-cluster-version=%s", req.ClusterVersion.PrettyPrint())
 	return forEveryNodeUntilClusterStable(ctx, op, c, func(
-		ctx context.Context, client serverpb.MigrationClient,
+		ctx context.Context, client serverpb.RPCMigrationClient,
 	) error {
 		_, err := client.BumpClusterVersion(ctx, req)
 		return err
@@ -601,7 +601,7 @@ func validateTargetClusterVersion(
 	req := &serverpb.ValidateTargetClusterVersionRequest{ClusterVersion: &clusterVersion}
 	op := fmt.Sprintf("validate-cluster-version=%s", req.ClusterVersion.PrettyPrint())
 	return forEveryNodeUntilClusterStable(ctx, op, c, func(
-		tx context.Context, client serverpb.MigrationClient,
+		tx context.Context, client serverpb.RPCMigrationClient,
 	) error {
 		_, err := client.ValidateTargetClusterVersion(ctx, req)
 		// The tenant upgrade interlock is new in 23.1, as a result, before
@@ -624,7 +624,7 @@ func forEveryNodeUntilClusterStable(
 	ctx context.Context,
 	op string,
 	c upgrade.Cluster,
-	f func(ctx context.Context, client serverpb.MigrationClient) error,
+	f func(ctx context.Context, client serverpb.RPCMigrationClient) error,
 ) error {
 	log.Infof(ctx, "executing operation %s", redact.Safe(op))
 	return c.UntilClusterStable(ctx, retry.Options{

--- a/pkg/util/tracing/tracingservicepb/rpc_clients.go
+++ b/pkg/util/tracing/tracingservicepb/rpc_clients.go
@@ -14,16 +14,16 @@ import (
 
 // DialTracingClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
-// TracingClient.
+// RPCTracingClient.
 func DialTracingClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
-) (TracingClient, error) {
+) (RPCTracingClient, error) {
 	if !rpcbase.TODODRPC {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
 		}
-		return NewTracingClient(conn), nil
+		return NewGRPCTracingClientAdapter(conn), nil
 	}
 	return nil, nil
 }


### PR DESCRIPTION
gRPC and DRPC clients have different signatures. To unify them, we created a common interface for both types of clients, and replaced the gRPC and DRPC clients with adapters.

Epic: CRDB-48923
Informs: #148353
Release note: none