### PR TITLE
roachtest: fix close body

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/profile.go
+++ b/pkg/cmd/roachtest/roachtestutil/profile.go
@@ -340,7 +340,6 @@ func getProfileWithTimeout(
 		resp, err := client.Get(ctx, url)
 		if err != nil {
 			latestError = err
-			resp.Body.Close()
 			continue
 		}
 


### PR DESCRIPTION
Previously, we were attempting to close the body on a nil response. This caused a panic. On an error there is no response, hence no body to close.

Epic: None
Release note: None