### PR TITLE
cli: skip cpu.pprof validation in TestZipIncludeAndExcludeFilesDataDrivern

### DIFF
--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -1,5 +1,5 @@
-#include all filters
---include-files=*
+#include all filters. We are excluding cpu.pprof file to avoid flakiness in tests.
+--include-files=* --exclude-files=cpu.pprof
 ----
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
@@ -40,7 +40,6 @@ debug/hot-ranges-tenant.sh
 debug/hot-ranges.sh
 debug/liveness.json
 debug/nodes.json
-debug/nodes/1/cpu.pprof
 debug/nodes/1/crdb_internal.active_range_feeds.txt
 debug/nodes/1/crdb_internal.cluster_replication_node_stream_checkpoints.txt
 debug/nodes/1/crdb_internal.cluster_replication_node_stream_spans.txt
@@ -290,8 +289,8 @@ debug/hot-ranges.sh
 debug/pprof-summary.sh
 debug/tenant_ranges.err.txt
 
-#exclude only log files
---exclude-files=*.log
+#exclude only log files. We are excluding cpu.pprof file to avoid flakiness in tests.
+--exclude-files=*.log,cpu.pprof
 ----
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
@@ -332,7 +331,6 @@ debug/hot-ranges-tenant.sh
 debug/hot-ranges.sh
 debug/liveness.json
 debug/nodes.json
-debug/nodes/1/cpu.pprof
 debug/nodes/1/crdb_internal.active_range_feeds.txt
 debug/nodes/1/crdb_internal.cluster_replication_node_stream_checkpoints.txt
 debug/nodes/1/crdb_internal.cluster_replication_node_stream_spans.txt
@@ -412,8 +410,8 @@ debug/system.zones.txt
 debug/tenant_ranges.err.txt
 
 
-#exclude only txt files
---exclude-files=*.txt
+#exclude only txt files. We are excluding cpu.pprof file to avoid flakiness in tests.
+--exclude-files=*.txt,cpu.pprof
 ----
 debug/debug_zip_command_flags.txt
 debug/events.json
@@ -421,7 +419,6 @@ debug/hot-ranges-tenant.sh
 debug/hot-ranges.sh
 debug/liveness.json
 debug/nodes.json
-debug/nodes/1/cpu.pprof
 debug/nodes/1/details.json
 debug/nodes/1/gossip.json
 debug/nodes/1/heap.pprof
@@ -435,8 +432,8 @@ debug/settings.json
 debug/tenant_ranges.err.txt
 
 
-#exclude only json files
---exclude-files=*.json
+#exclude only json files. We are excluding cpu.pprof file to avoid flakiness in tests.
+--exclude-files=*.json,cpu.pprof
 ----
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
@@ -474,7 +471,6 @@ debug/crdb_internal.zones.txt
 debug/debug_zip_command_flags.txt
 debug/hot-ranges-tenant.sh
 debug/hot-ranges.sh
-debug/nodes/1/cpu.pprof
 debug/nodes/1/crdb_internal.active_range_feeds.txt
 debug/nodes/1/crdb_internal.cluster_replication_node_stream_checkpoints.txt
 debug/nodes/1/crdb_internal.cluster_replication_node_stream_spans.txt


### PR DESCRIPTION
This patch skips cpu.pprof validation in
TestZipIncludeAndExcludeFilesDataDriven to avoid flakiness in test execution.

Epic: none
Fixes: #147324
Release note: None