### PR TITLE
dev: remove stale --oss flag from ui subcommand

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=110
+DEV_VERSION=111
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/testdata/datadriven/ui
+++ b/pkg/cmd/dev/testdata/datadriven/ui
@@ -17,22 +17,6 @@ pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
 pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=ccl --env.target=http://localhost:8080 --port 3000
 
 exec
-dev ui watch --oss
-----
-bazel info workspace --color=no
-pnpm --dir crdb-checkout/pkg/ui install
-bazel build //pkg/ui/workspaces/cluster-ui:cluster-ui-lib
-bazel info bazel-bin --color=no
-bazel info workspace --color=no
-cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.js crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.js
-cp sandbox/pkg/ui/workspaces/db-console/src/js/protos.d.ts crdb-checkout/pkg/ui/workspaces/db-console/src/js/protos.d.ts
-rm -rf crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-cp -r sandbox/pkg/ui/workspaces/cluster-ui/dist crdb-checkout/pkg/ui/workspaces/cluster-ui/dist
-pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run build:watch
-pnpm --dir crdb-checkout/pkg/ui/workspaces/cluster-ui run tsc:watch
-pnpm --dir crdb-checkout/pkg/ui/workspaces/db-console exec webpack-dev-server --config webpack.config.js --mode development --env.WEBPACK_SERVE --env.dist=oss --env.target=http://localhost:8080 --port 3000
-
-exec
 dev ui watch --secure
 ----
 bazel info workspace --color=no

--- a/pkg/cmd/dev/ui.go
+++ b/pkg/cmd/dev/ui.go
@@ -17,12 +17,6 @@ import (
 	"github.com/spf13/cobra"
 )
 
-const (
-	// ossFlag is the name of the boolean long (GNU-style) flag that builds only
-	// the open-source parts of the UI.
-	ossFlag = "oss"
-)
-
 // makeUICmd initializes the top-level 'ui' subcommand.
 func makeUICmd(d *dev) *cobra.Command {
 	uiCmd := &cobra.Command{
@@ -288,11 +282,6 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
-			isOss, err := cmd.Flags().GetBool(ossFlag)
-			if err != nil {
-				return err
-			}
-
 			// Ensure node dependencies are up-to-date.
 			err = d.exec.CommandContextInheritingStdStreams(
 				ctx,
@@ -309,13 +298,11 @@ Replaces 'make ui-watch'.`,
 			args := []string{
 				"build",
 				"//pkg/ui/workspaces/cluster-ui:cluster-ui-lib",
-			}
-			if !isOss {
-				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib")
-				args = append(args, "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files")
-				args = append(args, "//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client")
-				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files")
-				args = append(args, "//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl")
+				"//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl-lib",
+				"//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client_files",
+				"//pkg/ui/workspaces/db-console/src/js:crdb-protobuf-client",
+				"//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl_files",
+				"//pkg/ui/workspaces/db-console/ccl/src/js:crdb-protobuf-client-ccl",
 			}
 			logCommand("bazel", args...)
 			err = d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...)
@@ -325,7 +312,7 @@ Replaces 'make ui-watch'.`,
 				return err
 			}
 
-			if err := arrangeFilesForWatchers(d, isOss); err != nil {
+			if err := arrangeFilesForWatchers(d); err != nil {
 				log.Fatalf("failed to arrange files for watchers: %v", err)
 				return err
 			}
@@ -382,13 +369,6 @@ Replaces 'make ui-watch'.`,
 				}
 			}
 
-			var webpackDist string
-			if isOss {
-				webpackDist = "oss"
-			} else {
-				webpackDist = "ccl"
-			}
-
 			args = []string{
 				"--dir",
 				dirs.dbConsole,
@@ -399,7 +379,7 @@ Replaces 'make ui-watch'.`,
 				// Polyfill WEBPACK_SERVE for webpack v4; it's set in webpack v5 via
 				// `webpack serve`.
 				"--env.WEBPACK_SERVE",
-				"--env.dist=" + webpackDist,
+				"--env.dist=ccl",
 				"--env.target=" + dbTarget,
 				"--port", port,
 			}
@@ -425,7 +405,6 @@ Replaces 'make ui-watch'.`,
 	watchCmd.Flags().Int16P(portFlag, "p", 3000, "port to serve UI on")
 	watchCmd.Flags().String(dbTargetFlag, "http://localhost:8080", "url to proxy DB requests to")
 	watchCmd.Flags().Bool(secureFlag, false, "serve via HTTPS")
-	watchCmd.Flags().Bool(ossFlag, false, "build only the open-source parts of the UI")
 	watchCmd.Flags().StringArray(
 		clusterUiDestinationsFlag,
 		[]string{},
@@ -482,7 +461,7 @@ func makeUIStorybookCmd(d *dev) *cobra.Command {
 				return err
 			}
 
-			if err := arrangeFilesForWatchers(d /* ossOnly */, false); err != nil {
+			if err := arrangeFilesForWatchers(d); err != nil {
 				log.Fatalf("failed to arrange files for watchers: %v", err)
 				return err
 			}
@@ -745,7 +724,7 @@ func makeUICleanCmd(d *dev) *cobra.Command {
 // mode) to be executed from directly within a pkg/ui/workspaces/... directory.
 //
 // See https://github.com/bazelbuild/rules_nodejs/issues/2028
-func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
+func arrangeFilesForWatchers(d *dev) error {
 	bazelBin, err := d.getBazelBin(d.cli.Context(), []string{})
 	if err != nil {
 		return err
@@ -771,10 +750,6 @@ func arrangeFilesForWatchers(d *dev, ossOnly bool) error {
 		ossDst := filepath.Join(dbConsoleDst, relPath)
 		if err := d.os.CopyFile(filepath.Join(dbConsoleSrc, relPath), ossDst); err != nil {
 			return err
-		}
-
-		if ossOnly {
-			continue
 		}
 
 		cclDst := filepath.Join(dbConsoleCclDst, relPath)
@@ -845,7 +820,7 @@ Replaces 'make ui-test' and 'make ui-test-watch'.`,
 					return err
 				}
 
-				err = arrangeFilesForWatchers(d, false /* ossOnly */)
+				err = arrangeFilesForWatchers(d)
 				if err != nil {
 					// nolint:errwrap
 					return fmt.Errorf("unable to arrange files properly for watch-mode testing: %+v", err)


### PR DESCRIPTION
### Overview

This PR removes the deprecated `--oss` flag and its associated logic from the `dev ui` subcommand, resolving a piece of technical debt and simplifying the UI development workflow.
Fixes #136606

### Description of Changes

The `dev ui watch` command and its helpers contained a boolean `--oss` flag and corresponding logic to build only the open-source parts of the UI. This build path is no longer used, as development now exclusively targets the CCL version.

This change fully removes the `--oss` flag and its related logic from `pkg/cmd/dev/ui.go`:
- The `ossFlag` constant has been deleted.
- The `--oss` flag definition and its parsing logic have been removed from the `makeUIWatchCmd` function.
- The build process for `dev ui watch` is now streamlined to always build the CCL version, removing all conditional build arguments.
- As part of the cleanup, the `arrangeFilesForWatchers` helper function was refactored to remove the now-redundant `ossOnly` boolean parameter. This simplified its signature and call sites in the `test` and `storybook` subcommands as well.

### Verification Steps

The changes were thoroughly verified locally to ensure correctness and prevent regressions.

1.  **Environment Setup:**
    *   The local `dev` tool cache (`bin/dev-versions/dev.110`) was manually cleared to ensure the changes to `ui.go` were correctly compiled and loaded.

2.  **Command-Line Verification:**
    *   A local DB cluster was started using `./cockroach start-single-node --insecure`.
    *   The following `./dev ui` commands were executed sequentially, and their outputs were confirmed to match expectations:
        1.  `./dev ui watch --oss`
            *   **Result:** Correctly failed with `ERROR: unknown flag: --oss`.
        2.  `./dev ui watch --db=http://localhost:8080`
            *   **Result:** Successfully launched the DB Console (CCL version), which was accessible and fully functional at `http://localhost:3000`.
        3.  `./dev ui test`
            *   **Result:** All UI unit tests (`db-console` and `cluster-ui`) passed successfully.
        4.  `./dev ui storybook --project db-console`
            *   **Result:** Successfully launched Storybook, which was accessible and functional at `http://localhost:6006`.

All verification steps passed, confirming that the `--oss` flag has been removed cleanly and that the associated refactoring did not introduce any side effects.