### PR TITLE
workload/schemachanger: temporarily skip DROP TRIGGER in RSW

### DIFF
--- a/pkg/workload/schemachange/optype.go
+++ b/pkg/workload/schemachange/optype.go
@@ -315,7 +315,7 @@ var opWeights = []int{
 	dropSchema:                        1,
 	dropSequence:                      1,
 	dropTable:                         1,
-	dropTrigger:                       1,
+	dropTrigger:                       0, // TODO(147981): re-enable once we fix orphaning of backref in DROP TRIGGER
 	dropView:                          1,
 	renameIndex:                       1,
 	renameSequence:                    1,


### PR DESCRIPTION
In the random schemachanger workload, you can hit an infinite recursion case when doing a cascading drop with the legacy schema changer. This root cause of this is that DROP TRIGGER can end up orphaning a backref. The fix for the root cause will be addressed in #147981. Until that is fixed, this change will skip DROP TRIGGER so we avoid the infinite recursion.

Fixes #147514

Epic: none
Release note: none