### PR TITLE
crosscluster/logical: wipe status on clean pause

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -98,6 +98,7 @@ func (r *logicalReplicationResumer) handleResumeError(
 	ctx context.Context, execCtx sql.JobExecContext, err error,
 ) error {
 	if err == nil {
+		r.updateStatusMessage(ctx, "")
 		return nil
 	}
 	if jobs.IsPermanentJobError(err) {


### PR DESCRIPTION
If the user pauses the LDR job, the status may be stale, like "catching up on 110 out of 230 ranges"

Epic: none

Release note: none