### PR TITLE
rpc,upgrade: add `NodeDialerNoBreaker` interface

### DIFF
--- a/pkg/rpc/rpcbase/nodedialer.go
+++ b/pkg/rpc/rpcbase/nodedialer.go
@@ -21,3 +21,10 @@ const TODODRPC = false
 type NodeDialer interface {
 	Dial(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
 }
+
+// NodeDialerNoBreaker interface defines methods for dialing peer nodes using their
+// node IDs. This interface is similar to NodeDialer but does not check the
+// breaker before dialing.
+type NodeDialerNoBreaker interface {
+	DialNoBreaker(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
+}

--- a/pkg/upgrade/upgradecluster/BUILD.bazel
+++ b/pkg/upgrade/upgradecluster/BUILD.bazel
@@ -27,7 +27,6 @@ go_library(
         "//pkg/util/retry",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
-        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/pkg/upgrade/upgradecluster/cluster.go
+++ b/pkg/upgrade/upgradecluster/cluster.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
-	"google.golang.org/grpc"
 )
 
 // Cluster mediates interacting with a cockroach cluster.
@@ -37,7 +36,7 @@ type ClusterConfig struct {
 	NodeLiveness livenesspb.NodeVitalityInterface
 
 	// Dialer constructs connections to other nodes.
-	Dialer NodeDialer
+	Dialer rpcbase.NodeDialer
 
 	// RangeDescScanner paginates through all range descriptors.
 	RangeDescScanner rangedesc.Scanner
@@ -48,12 +47,6 @@ type ClusterConfig struct {
 	// to expose only relevant, vetted bits of kv.DB. It'll make our tests less
 	// "integration-ey".
 	DB *kv.DB
-}
-
-// NodeDialer abstracts connecting to other nodes in the cluster.
-type NodeDialer interface {
-	// Dial returns a grpc connection to the given node.
-	Dial(context.Context, roachpb.NodeID, rpcbase.ConnectionClass) (*grpc.ClientConn, error)
 }
 
 // New constructs a new Cluster with the provided dependencies.

--- a/pkg/upgrade/upgradecluster/helper_test.go
+++ b/pkg/upgrade/upgradecluster/helper_test.go
@@ -29,7 +29,7 @@ func (n NoopDialer) Dial(
 	return nil, nil
 }
 
-var _ NodeDialer = NoopDialer{}
+var _ rpcbase.NodeDialer = NoopDialer{}
 
 func TestHelperEveryNode(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/upgrade/upgradecluster/tenant_cluster.go
+++ b/pkg/upgrade/upgradecluster/tenant_cluster.go
@@ -129,7 +129,7 @@ import (
 //     again in the next release.
 type TenantCluster struct {
 	// Dialer allows for the construction of connections to other SQL pods.
-	Dialer          NodeDialer
+	Dialer          rpcbase.NodeDialer
 	InstanceReader  *instancestorage.Reader
 	instancesAtBump []sqlinstance.InstanceInfo
 	DB              *kv.DB
@@ -138,7 +138,7 @@ type TenantCluster struct {
 // TenantClusterConfig configures a TenantCluster.
 type TenantClusterConfig struct {
 	// Dialer allows for the construction of connections to other SQL pods.
-	Dialer NodeDialer
+	Dialer rpcbase.NodeDialer
 
 	// InstanceReader is used to retrieve all SQL pods for a given tenant.
 	InstanceReader *instancestorage.Reader


### PR DESCRIPTION
Currently, `NodeDialer` interface only has `Dial()` method which most code paths use. But there are also code paths that use `DialNoBreaker()` method. To support those cases, this commit adds a new interface `NodeDialerNoBreaker`.

Epic: CRDB-48923
Informs: https://github.com/cockroachdb/cockroach/issues/147757
Release note: none