### PR TITLE
sql/schemachanger: prevent runtime errors adding multiple columns

### DIFF
--- a/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
+++ b/pkg/ccl/schemachangerccl/testdata/end_to_end/alter_table_alter_primary_key_rbr/alter_table_alter_primary_key_rbr.explain
@@ -76,10 +76,10 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":10,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
- │              └── AddColumnToIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 17 elements transitioning toward PUBLIC
@@ -188,10 +188,10 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │              ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":10,"TableID":108}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":10,"Kind":2,"TableID":108}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":10,"Kind":2,"Ordinal":2,"TableID":108}
  │              ├── AddColumnToIndex {"ColumnID":6,"IndexID":10,"Ordinal":1,"TableID":108}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":2,"TableID":108}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":108,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -278,7 +278,6 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         ├── AddIndexPartitionInfo {"Partitioning":{"IndexID":11,"TableID":108}}
  │    │         ├── AddColumnToIndex {"ColumnID":3,"IndexID":11,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":11,"Kind":2,"TableID":108}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":11,"Kind":2,"Ordinal":2,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":11,"Ordinal":1,"TableID":108}
@@ -296,6 +295,7 @@ Schema change plan for ALTER TABLE ‹multiregion_db›.‹public›.‹table_re
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":108}
  │    │         ├── AddColumnToIndex {"ColumnID":6,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":108}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":2,"TableID":108}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":108}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 24 in PostCommitPhase

--- a/pkg/cli/testdata/declarative-rules/deprules
+++ b/pkg/cli/testdata/declarative-rules/deprules
@@ -3603,6 +3603,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence

--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -184,3 +184,49 @@ statement error pgcode 57000 schema changes are disallowed on table "ref" becaus
 ALTER TABLE ref CONFIGURE ZONE USING num_replicas = 11;
 
 subtest end
+
+
+# Validate schema_locked can be unset properly in add column txns.
+subtest regression_147993
+
+statement ok
+CREATE TABLE t_147993 (
+  k INT8 NOT NULL,
+  geom1 GEOMETRY(POINT,4326) NULL,
+  geom2 GEOMETRY(POLYGON,4326) NULL,
+  geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+  geom4 GEOMETRY(LINESTRING,4326) NULL,
+  geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+  geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+  CONSTRAINT t_147993_pkey PRIMARY KEY (k ASC),
+  FAMILY fam (k, geom1, geom2, geom3, geom6)
+) WITH (schema_locked = true);
+
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-25.1
+statement ok
+SELECT  AddGeometryColumn ('t_147993','geom7',4326,'POINT',2),
+        AddGeometryColumn ('t_147993','geom8',4326,'POINT',2);
+
+
+
+skipif config local-legacy-schema-changer
+query TT
+show create table t_147993
+----
+t_147993  CREATE TABLE public.t_147993 (
+            k INT8 NOT NULL,
+            geom1 GEOMETRY(POINT,4326) NULL,
+            geom2 GEOMETRY(POLYGON,4326) NULL,
+            geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+            geom4 GEOMETRY(LINESTRING,4326) NULL,
+            geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+            geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+            geom7 GEOMETRY(POINT,4326) NULL,
+            geom8 GEOMETRY(POINT,4326) NULL,
+            CONSTRAINT t_147993_pkey PRIMARY KEY (k ASC),
+            FAMILY fam (k, geom1, geom2, geom3, geom6, geom4, geom5, geom8, geom7)
+          ) WITH (schema_locked = true);
+
+subtest end

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index_and_column.go
@@ -118,3 +118,28 @@ func init() {
 	)
 
 }
+
+// This rule ensures that index columns depend on each other in increasing order.
+func init() {
+	registerDepRule(
+		"ensure index columns are added in increasing order",
+		scgraph.Precedence,
+		"later-column", "earlier-column",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.IndexColumn)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.IndexColumn)(nil)),
+				JoinOnIndexID(from, to, "table-id", "index-id"),
+				ToPublicOrTransient(from, to),
+				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
+				FilterElements("SmallerColumnIDFirst", from, to, func(from, to *scpb.IndexColumn) bool {
+					// Index columns of the same kind (key, key suffix, or stored) must be
+					// ordered by their ordinal position within that kind. Since key columns,
+					// key suffix columns, and stored columns are stored independently, the
+					// order in which each kind is added does not matter.
+					return from.OrdinalInKind < to.OrdinalInKind && from.Kind == to.Kind
+				}),
+			}
+		})
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3600,6 +3600,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are added in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence
@@ -8537,6 +8553,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are added in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/internal/rules/release_25_2/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/release_25_2/testdata/deprules
@@ -3600,6 +3600,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence
@@ -8521,6 +8537,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -760,6 +760,10 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -775,6 +779,10 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -1115,6 +1115,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -1122,6 +1126,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
@@ -2635,6 +2643,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -2642,6 +2654,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
@@ -3510,6 +3526,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN udfcol;
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -3517,6 +3537,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN udfcol;
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -280,6 +280,10 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -287,6 +291,10 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
@@ -710,6 +718,10 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -717,6 +729,10 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
@@ -44,18 +44,18 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":10,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":11}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":9,"IndexID":11,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":10,"IndexID":12,"IsUnique":true,"SourceIndexID":10,"TableID":104,"TemporaryIndexID":13}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":12,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":10,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":11,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 9 elements transitioning toward PUBLIC
@@ -123,20 +123,20 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":8,"IndexID":10,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":11}}
  │              ├── MaybeAddSplitForIndex {"IndexID":10,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":10,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":10,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":9,"IndexID":11,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":11,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":11,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":11,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":10,"IndexID":12,"IsUnique":true,"SourceIndexID":10,"TableID":104,"TemporaryIndexID":13}}
  │              ├── MaybeAddSplitForIndex {"IndexID":12,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":12,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":10,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":11,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":12,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":10,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":11,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":12,"Ordinal":1,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -221,7 +221,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    └── 29 Mutation operations
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":11,"IndexID":13,"IsUnique":true,"SourceIndexID":10,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":13,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":13,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":13,"Kind":2,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":13,"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
@@ -246,6 +245,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Kind":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"Kind":1,"Ordinal":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":13,"Ordinal":1,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 16 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
@@ -54,12 +54,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":5,"Kind":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":9,"IndexID":8,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":9}}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":10,"IndexID":9,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":5,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Ordinal":1,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Ordinal":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 15 elements transitioning toward PUBLIC
@@ -142,13 +142,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":9,"IndexID":8,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":9}}
  │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":10,"IndexID":9,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":8,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":5,"IndexID":9,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":8,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":9,"Ordinal":1,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase


### PR DESCRIPTION
Previously, index columns would be added in order, but no specific rule ensured they were added in that specific order. This became problematic when schema_locked support was added in the declarative schema changer, since out of order execution can lead to runtime errors. This can be observed if a user uses multiple AddGeometryColumn builtins in a statement. To address this, this patch adds a new explicit rule to ensure index columns are added in an increasing order.

Fixes: #147993

Release note (bug fix): Adding multiple columns with AddGeometryColumn in a single statement would run into runtime errors.