### PR TITLE
server,ui: increase max result size for sql over http requests

### DIFF
--- a/pkg/ccl/serverccl/testdata/api_v2_sql
+++ b/pkg/ccl/serverccl/testdata/api_v2_sql
@@ -12,7 +12,7 @@ sql admin
   "application_name": "$ api-v2-sql",
   "database": "system",
   "execute": false,
-  "max_result_size": 10000,
+  "max_result_size": 100000,
   "separate_txns": false,
   "statements": [
    {

--- a/pkg/server/api_v2_sql.go
+++ b/pkg/server/api_v2_sql.go
@@ -306,7 +306,8 @@ func (a *apiV2Server) execSQL(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 	if requestPayload.MaxResultSize == 0 {
-		requestPayload.MaxResultSize = 10000
+		// Default to 100 kb if no MaxResultSize is provided.
+		requestPayload.MaxResultSize = 100_000
 	}
 	if len(requestPayload.Statements) == 0 {
 		topLevelError(errors.New("no statements specified"), http.StatusBadRequest)

--- a/pkg/server/testdata/api_v2_sql
+++ b/pkg/server/testdata/api_v2_sql
@@ -10,7 +10,7 @@ sql admin
   "application_name": "$ api-v2-sql",
   "database": "system",
   "execute": false,
-  "max_result_size": 10000,
+  "max_result_size": 100000,
   "separate_txns": false,
   "statements": [
    {

--- a/pkg/ui/workspaces/cluster-ui/src/api/schedulesApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/schedulesApi.ts
@@ -10,7 +10,7 @@ import { RequestError } from "../util";
 
 import {
   executeInternalSql,
-  MAX_RESULT_SIZE,
+  LARGE_RESULT_SIZE,
   SqlExecutionRequest,
   sqlResultsAreEmpty,
 } from "./sqlApi";
@@ -74,7 +74,7 @@ export function getSchedules(req: {
         arguments: args,
       },
     ],
-    max_result_size: MAX_RESULT_SIZE,
+    max_result_size: LARGE_RESULT_SIZE,
     execute: true,
   };
   return executeInternalSql<ScheduleColumns>(request).then(result => {

--- a/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
+++ b/pkg/ui/workspaces/cluster-ui/src/api/sqlApi.ts
@@ -90,7 +90,7 @@ export function executeSql<RowType>(
 
 export const INTERNAL_SQL_API_APP = "$ internal-console";
 export const LONG_TIMEOUT = "300s";
-export const LARGE_RESULT_SIZE = 50000; // 50 kib
+export const LARGE_RESULT_SIZE = 1_000_000; // 1 Mb
 export const MAX_RESULT_SIZE = 2_147_483_647; // Max result size is max int32, which is 2Gib
 export const FALLBACK_DB = "system";
 


### PR DESCRIPTION
The default for max result size for the sql over http v2 API was previously set to 10kb, which was frequently resulting in incomplete results / error messages in db console. Additionally, db console used 50kb to as the
"LARGE_RESULT_SIZE" value for many of db consoles sql over http requests. This has also been seen to result in errors like "Not all insights are displayed because the maximum number of insights was reached in the console." in the db console insights page.

This change increases the default on the server side from 10kb to 100kb and the value of "LARGE_RESULT_SIZE" from 50kb to 1Mb

Resolves: #146875
Epic: None
Release note: None