### PR TITLE
cli: consolidate `InitClient` RPC client creation

### DIFF
--- a/pkg/cli/init.go
+++ b/pkg/cli/init.go
@@ -50,7 +50,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	if err := dialAndCheckHealth(ctx); err != nil {
 		return err
 	}
-	conn, finish, err := getClientGRPCConn(ctx, serverCfg)
+	conn, finish, err := newClientConn(ctx, serverCfg)
 	if err != nil {
 		return err
 	}
@@ -64,7 +64,7 @@ func runInit(cmd *cobra.Command, args []string) error {
 	}
 
 	// Actually perform cluster initialization.
-	c := serverpb.NewInitClient(conn)
+	c := conn.NewInitClient()
 	if _, err = c.Bootstrap(ctx, &serverpb.BootstrapRequest{
 		InitType: typ,
 	}); err != nil {


### PR DESCRIPTION
This commit consolidates `InitClient` RPC client creation logic in the cli package. It is a continuation of the work done in #147606.

Epic: CRDB-48923
Fixes: #148185
Release note: none