### PR TITLE
roachprod: improve instances filtering when listing on IBM

### DIFF
--- a/pkg/roachprod/vm/ibm/helpers.go
+++ b/pkg/roachprod/vm/ibm/helpers.go
@@ -833,7 +833,7 @@ func (p *Provider) listRegion(l *logger.Logger, r string, opts vm.ListOptions) (
 			}
 		}
 
-		valid, reason := i.isRoachprodAndValidStatus()
+		valid, reason := i.isValidStatus()
 		if !valid {
 			l.Printf("WARN: discarding instance %s in region %s (%s)", *i.instance.CRN, r, reason)
 			continue


### PR DESCRIPTION
Cloud instance listing on IBM was previously filtering out VMs that lacked the `roachprod` tag. However, the IBM API occasionally returns a successful response for tagging requests without actually acting on it. This inconsistency resulted in some VMs being skipped in the garbage colelction process because lacking the required tags.

This PR removes the dependency on the `roachprod` tag, and all resources within the `roachprod` resource group are now considered game for garbage collection.

Epic: none
Release note: None