### PR TITLE
release-24.3.15-rc: release-24.3: crosscluster/logical: zero catchup/initial scan metrics on flow shutdown

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -248,6 +248,15 @@ func (r *logicalReplicationResumer) ingest(
 		return err
 	}
 
+	defer func() {
+		if l := payload.MetricsLabel; l != "" {
+			metrics.LabeledScanningRanges.Update(map[string]string{"label": l}, 0)
+			metrics.LabeledCatchupRanges.Update(map[string]string{"label": l}, 0)
+		}
+		metrics.ScanningRanges.Update(0)
+		metrics.CatchupRanges.Update(0)
+	}()
+
 	err = ctxgroup.GoAndWait(ctx, execPlan, replanner, startHeartbeat)
 	if errors.Is(err, sql.ErrPlanChanged) {
 		metrics.ReplanCount.Inc(1)


### PR DESCRIPTION
Backport 1/1 commits from #147991.

/cc @cockroachdb/release

---

Backport 1/1 commits from #147912.

/cc @cockroachdb/release

---

Informs #147620

Release note: none

