### PR TITLE
release: retry rcodesign notary-submit in macos signing scripts

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release_on_linux.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign_staged_macos_release_on_linux.sh
@@ -15,6 +15,7 @@ fi
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname $(dirname "${0}"))))))"
 source "$dir/teamcity-support.sh"  # For log_into_gcloud
+source "$dir/shlib.sh"
 
 curr_dir=$(pwd)
 
@@ -72,7 +73,7 @@ for product in cockroach cockroach-sql; do
     tar -czf "$target" "$base"
 
     zip crl.zip "$base/$product"
-    rcodesign notary-submit \
+    retry rcodesign notary-submit \
       --api-key-file "$curr_dir/.secrets/api_key.json" \
       --wait \
       crl.zip

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-sign.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-darwin-sign.sh
@@ -17,6 +17,7 @@ fi
 
 dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
 source "$dir/release/teamcity-support.sh"
+source "$dir/shlib.sh"
 
 tc_start_block "Variable Setup"
 
@@ -83,7 +84,7 @@ for product in cockroach cockroach-sql; do
       --code-signature-flags runtime \
       "$product-$build_name.$platform/$product"
     zip -r crl.zip "$product-$build_name.$platform/$product"
-    rcodesign notary-submit --api-key-file "$secrets_dir/api_key.json" --wait crl.zip
+    retry rcodesign notary-submit --api-key-file "$secrets_dir/api_key.json" --wait crl.zip
     tar -czf "$product-$build_name.$platform.tgz" "$product-$build_name.$platform"
     shasum --algorithm 256 "$product-$build_name.$platform.tgz" > "$product-$build_name.$platform.tgz.sha256sum"
     gsutil cp "$product-$build_name.$platform.tgz" "gs://$gcs_bucket/$product-$build_name.$platform.tgz"


### PR DESCRIPTION
Previously, the `rcodesign notary-submit` command was run without retry logic, which could lead to failures if the submission encountered transient issues. This commit introduces a retry mechanism to improve the robustness of the signing process.

Release note: none
Epic: none