### PR TITLE
release-25.2: crosscluster/logical: wipe status on clean pause

### DIFF
--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -100,6 +100,7 @@ func (r *logicalReplicationResumer) handleResumeError(
 	ctx context.Context, execCtx sql.JobExecContext, err error,
 ) error {
 	if err == nil {
+		r.updateStatusMessage(ctx, "")
 		return nil
 	}
 	if jobs.IsPermanentJobError(err) {


### PR DESCRIPTION
Backport 1/1 commits from #147989.

/cc @cockroachdb/release

---

If the user pauses the LDR job, the status may be stale, like "catching up on 110 out of 230 ranges"

Epic: none

Release note: none
