### PR TITLE
release-24.3: crosscluster/logical: wipe status on clean pause

### DIFF
--- a/pkg/ccl/crosscluster/logical/logical_replication_job.go
+++ b/pkg/ccl/crosscluster/logical/logical_replication_job.go
@@ -84,6 +84,7 @@ func (r *logicalReplicationResumer) handleResumeError(
 	ctx context.Context, execCtx sql.JobExecContext, err error,
 ) error {
 	if err == nil {
+		r.updateRunningStatus(ctx, "")
 		return nil
 	}
 	r.updateRunningStatus(ctx, redact.Sprintf("pausing after error: %s", err.Error()))


### PR DESCRIPTION
Backport 1/1 commits from #147989.

/cc @cockroachdb/release

---

If the user pauses the LDR job, the status may be stale, like "catching up on 110 out of 230 ranges"

Epic: none

Release note: none
