### PR TITLE
sql: unredact error in temp object cleanup log message

### DIFF
--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -627,7 +627,7 @@ func (c *TemporaryObjectCleaner) Start(ctx context.Context, stopper *stop.Stoppe
 			select {
 			case <-nextTickCh:
 				if err := c.doTemporaryObjectCleanup(ctx, stopper.ShouldQuiesce()); err != nil {
-					log.Warningf(ctx, "failed to clean temp objects: %v", err)
+					log.Warningf(ctx, "failed to clean temp objects: %v", redact.Safe(err))
 				}
 			case <-stopper.ShouldQuiesce():
 				return


### PR DESCRIPTION
Previously the error was redacted showing "‹×›"
instead of actual error details.

Fixes: #146588
Release note: None