### PR TITLE
release-25.2: sqlstats: lower default sql stats flush batch size

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/cluster_settings.go
@@ -30,7 +30,7 @@ var SQLStatsFlushBatchSize = settings.RegisterIntSetting(
 	settings.ApplicationLevel,
 	"sql.stats.flush.batch_size",
 	"the number of rows to flush per upsert",
-	50,
+	10,
 	settings.NonNegativeInt)
 
 // MinimumInterval is the cluster setting that controls the minimum interval


### PR DESCRIPTION
Backport 1/1 commits from #147994 on behalf of @kyle-a-wong.

----

In the drt-scale cluster, a batch size of 50 caused sql stats flushing to be slow because it increased contention when sql stats flushes occurred. This is because in a cluster of this size, there is a higher chance for an individual node to be flushing at any given time.

We observed that lowering the batch size to 10 decreased the amount of contention while still providing decreased flush latency.

Epic: None
Release note: None


----

Release justification: