### PR TITLE
kvcoord: decompose replicated locking requests in txnWriteBuffer 

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -2442,6 +2442,20 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: distsender.rpc.err.exclusionviolationerrtype
+      exported_name: distsender_rpc_err_exclusionviolationerrtype
+      description: |
+        Number of ExclusionViolationErrType errors received replica-bound RPCs
+
+        This counts how often error of the specified type was received back from replicas
+        as part of executing possibly range-spanning requests. Failures to reach the target
+        replica will be accounted for as 'roachpb.CommunicationErrType' and unclassified
+        errors as 'roachpb.InternalErrType'.
+      y_axis_label: Errors
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: distsender.rpc.err.indeterminatecommiterrtype
       exported_name: distsender_rpc_err_indeterminatecommiterrtype
       description: |
@@ -9610,6 +9624,14 @@ layers:
     - name: txn.restarts.commitdeadlineexceeded
       exported_name: txn_restarts_commitdeadlineexceeded
       description: Number of restarts due to a transaction exceeding its deadline
+      y_axis_label: Restarted Transactions
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: txn.restarts.exclusionviolation
+      exported_name: txn_restarts_exclusionviolation
+      description: Number of restarts due to an exclusion violation
       y_axis_label: Restarted Transactions
       type: COUNTER
       unit: COUNT

--- a/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
+++ b/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
@@ -1,0 +1,106 @@
+# LogicTest: !3node-tenant
+# cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
+
+statement ok
+SET CLUSTER SETTING sql.txn.write_buffering_for_read_committed.enabled=true
+
+statement ok
+SET CLUSTER SETTING kv.lock_table.unreplicated_lock_reliability.split.enabled=false
+
+statement ok
+CREATE TABLE t (pk INT PRIMARY KEY)
+
+statement ok
+GRANT ALL ON t TO testuser
+
+subtest read_committed_discovers_lost_lock_at_commit
+user testuser
+
+statement ok
+SET kv_transaction_buffered_writes_enabled=true
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+INSERT INTO t VALUES (1)
+
+user root
+
+# This split clears the lock table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (10)
+
+# This write should block but doesn't because of the lost lock.
+statement ok
+INSERT INTO t VALUES (1)
+
+user testuser
+
+# Add another write to t to ensure we are propogating the ts correctly.
+# Note that currently we don't detect the failure here. If we add the lock loss
+# detection to locking gets we could.
+statement ok
+UPSERT INTO t VALUES (1)
+
+# Lock loss detection should detect the lost lock on commit when we go to
+# write the value.
+statement error write exclusion on key
+COMMIT
+
+subtest read_committed_discovers_lost_lock_at_mid_txn_flush
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+INSERT INTO t VALUES (2)
+
+user root
+
+# This split clears the lock table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (8)
+
+# This write should block but doesn't because of the lost lock.
+statement ok
+INSERT INTO t VALUES (2)
+
+user testuser
+
+# Lock loss detection should detect the lost lock when we
+# flush the buffer because of a DeleteRangeRequest
+statement error write exclusion on key
+DELETE FROM t WHERE pk > 10
+
+statement ok
+ROLLBACK
+
+subtest serializable_observes_write_too_old
+user testuser
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE
+
+statement ok
+INSERT INTO t VALUES (3)
+
+user root
+
+# This split clears the lock table.
+statement ok
+ALTER TABLE t SPLIT AT VALUES (7)
+
+# This write should block but doesn't because of the lost lock.
+statement ok
+INSERT INTO t VALUES (3)
+
+user testuser
+
+# A serializable transaction should see a WriteTooOld error here since the read timestamp doesn't move.
+statement error WriteTooOld
+DELETE FROM t WHERE pk > 10
+
+statement ok
+ROLLBACK

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 35,
+    shard_count = 36,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 34,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2701,6 +2701,13 @@ func TestReadCommittedLogic_zone_config_system_tenant(
 	runLogicTest(t, "zone_config_system_tenant")
 }
 
+func TestReadCommittedLogicCCL_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestReadCommittedLogicCCL_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2687,6 +2687,13 @@ func TestRepeatableReadLogic_zone_config_system_tenant(
 	runLogicTest(t, "zone_config_system_tenant")
 }
 
+func TestRepeatableReadLogicCCL_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestRepeatableReadLogicCCL_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-schema-locked/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-schema-locked/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 32,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-schema-locked/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-schema-locked/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 34,
+    shard_count = 35,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -89,6 +89,13 @@ func TestCCLLogic_auto_rehoming(
 	runCCLLogicTest(t, "auto_rehoming")
 }
 
+func TestCCLLogic_buffered_writes_lock_loss(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "buffered_writes_lock_loss")
+}
+
 func TestCCLLogic_builtins(
 	t *testing.T,
 ) {

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -887,6 +887,9 @@ func (tc *TxnCoordSender) handleRetryableErrLocked(ctx context.Context, pErr *kv
 	case *kvpb.ReadWithinUncertaintyIntervalError:
 		tc.metrics.RestartsReadWithinUncertainty.Inc()
 
+	case *kvpb.ExclusionViolationError:
+		tc.metrics.RestartsExclusionViolation.Inc()
+
 	case *kvpb.TransactionAbortedError:
 		tc.metrics.RestartsTxnAborted.Inc()
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
 	"github.com/cockroachdb/cockroach/pkg/storage/mvcceval"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
@@ -1070,6 +1071,16 @@ type requestRecord struct {
 func (rr requestRecord) toResp(
 	ctx context.Context, twb *txnWriteBuffer, br kvpb.ResponseUnion, txn *roachpb.Transaction,
 ) (kvpb.ResponseUnion, *kvpb.Error) {
+	assertTrue(txn != nil, "unexpectedly nil transaction")
+
+	// TODO(review): We could only set exclusion timestamps for transactions that
+	// need them. But, I think this shouldn't be required. In a serializable
+	// transaction, the ReadTimestamp only moves on a read refresh. If that read
+	// refresh succeeds, then the exclusion condition must still hold and should
+	// still hold at the time of commit (right?).
+	//
+	// exclusionTimestampRequired := txn.IsoLevel.ToleratesWriteSkew()
+	exclusionTimestampRequired := true
 	var ru kvpb.ResponseUnion
 	switch req := rr.origRequest.(type) {
 	case *kvpb.ConditionalPutRequest:
@@ -1100,14 +1111,23 @@ func (rr requestRecord) toResp(
 			pErr.SetErrorIndex(int32(rr.index))
 			return kvpb.ResponseUnion{}, pErr
 		}
+		exclusionTS := hlc.Timestamp{}
+		if exclusionTimestampRequired {
+			exclusionTS = txn.ReadTimestamp
+		}
+
 		// The condition was satisfied; buffer the write and return a
 		// synthesized response.
 		ru.MustSetInner(&kvpb.ConditionalPutResponse{})
-		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq, exclusionTS)
 
 	case *kvpb.PutRequest:
+		exclusionTS := hlc.Timestamp{}
+		if req.MustAcquireExclusiveLock && exclusionTimestampRequired {
+			exclusionTS = txn.ReadTimestamp
+		}
 		ru.MustSetInner(&kvpb.PutResponse{})
-		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq, exclusionTS)
 
 	case *kvpb.DeleteRequest:
 		// To correctly populate FoundKey in the response, we must prefer any
@@ -1139,10 +1159,15 @@ func (rr requestRecord) toResp(
 			// clarify the behaviour on DeleteRequest.
 			foundKey = false
 		}
+		exclusionTS := hlc.Timestamp{}
+		if req.MustAcquireExclusiveLock && exclusionTimestampRequired {
+			exclusionTS = txn.ReadTimestamp
+		}
+
 		ru.MustSetInner(&kvpb.DeleteResponse{
 			FoundKey: foundKey,
 		})
-		twb.addToBuffer(req.Key, roachpb.Value{}, req.Sequence, req.KVNemesisSeq)
+		twb.addToBuffer(req.Key, roachpb.Value{}, req.Sequence, req.KVNemesisSeq, exclusionTS)
 
 	case *kvpb.GetRequest:
 		val, served := twb.maybeServeRead(req.Key, req.Sequence)
@@ -1239,7 +1264,11 @@ func (rr requestRecords) Summary() string {
 
 // addToBuffer adds a write to the given key to the buffer.
 func (twb *txnWriteBuffer) addToBuffer(
-	key roachpb.Key, val roachpb.Value, seq enginepb.TxnSeq, kvNemSeq kvnemesisutil.Container,
+	key roachpb.Key,
+	val roachpb.Value,
+	seq enginepb.TxnSeq,
+	kvNemSeq kvnemesisutil.Container,
+	ts hlc.Timestamp,
 ) {
 	it := twb.buffer.MakeIter()
 	seek := twb.seekItemForSpan(key, nil)
@@ -1250,12 +1279,16 @@ func (twb *txnWriteBuffer) addToBuffer(
 		bw := it.Cur()
 		val := bufferedValue{val: val, seq: seq, kvNemesisSeq: kvNemSeq}
 		bw.vals = append(bw.vals, val)
+		if bw.ts.IsEmpty() {
+			bw.ts = ts
+		}
 		twb.bufferSize += val.size()
 	} else {
 		twb.bufferIDAlloc++
 		bw := &bufferedWrite{
 			id:   twb.bufferIDAlloc,
 			key:  key,
+			ts:   ts,
 			vals: []bufferedValue{{val: val, seq: seq, kvNemesisSeq: kvNemSeq}},
 		}
 		twb.buffer.Set(bw)
@@ -1394,6 +1427,14 @@ type bufferedWrite struct {
 	// endKey as a comparator. We could then remove this unnecessary field here,
 	// and also in the keyLocks struct.
 	endKey roachpb.Key // used in btree iteration
+
+	// ts, if non-zero, is lowest timestamp at which we had exclusive access.
+	//
+	// TODO(review): Are we OK with requiring exclusion across savepoint
+	// rollbacks? If not, we'll need to track this on a per-value level and then
+	// and flush time send the lowest value when writing in the key. That's not hard
+	// but it isn't clear to me what behavior we expect.
+	ts hlc.Timestamp
 	// TODO(arul): instead of this slice, consider adding a small (fixed size,
 	// maybe 1) array instead.
 	vals []bufferedValue // sorted in increasing sequence number order
@@ -1431,7 +1472,7 @@ func (bv *bufferedValue) size() int64 {
 	return int64(len(bv.val.RawBytes)) + bufferedValueStructOverhead
 }
 
-func (bv *bufferedValue) toRequestUnion(key roachpb.Key) kvpb.RequestUnion {
+func (bv *bufferedValue) toRequestUnion(key roachpb.Key, ts hlc.Timestamp) kvpb.RequestUnion {
 	var ru kvpb.RequestUnion
 	if bv.val.IsPresent() {
 		// TODO(arul): we could allocate PutRequest objects all at once when we're
@@ -1448,6 +1489,7 @@ func (bv *bufferedValue) toRequestUnion(key roachpb.Key) kvpb.RequestUnion {
 		putAlloc.put.Value = bv.val
 		putAlloc.put.Sequence = bv.seq
 		putAlloc.put.KVNemesisSeq = bv.kvNemesisSeq
+		putAlloc.put.ExpectExclusionSince = ts
 		putAlloc.union.Put = &putAlloc.put
 		ru.Value = &putAlloc.union
 	} else {
@@ -1458,6 +1500,7 @@ func (bv *bufferedValue) toRequestUnion(key roachpb.Key) kvpb.RequestUnion {
 		delAlloc.del.Key = key
 		delAlloc.del.Sequence = bv.seq
 		delAlloc.del.KVNemesisSeq = bv.kvNemesisSeq
+		delAlloc.del.ExpectExclusionSince = ts
 		delAlloc.union.Delete = &delAlloc.del
 		ru.Value = &delAlloc.union
 	}
@@ -1485,7 +1528,7 @@ func (bw *bufferedWrite) SetEndKey(v []byte)  { bw.endKey = v }
 func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 	// As we store values in increasing sequence number order, the most recent
 	// write should be the last value in the slice.
-	return bw.vals[len(bw.vals)-1].toRequestUnion(bw.key)
+	return bw.vals[len(bw.vals)-1].toRequestUnion(bw.key, bw.ts)
 }
 
 // toAllRevisionRequests returns requests for all revisions of the buffered
@@ -1495,7 +1538,7 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 func (bw *bufferedWrite) toAllRevisionRequests() []kvpb.RequestUnion {
 	rus := make([]kvpb.RequestUnion, 0, len(bw.vals))
 	for _, val := range bw.vals {
-		rus = append(rus, val.toRequestUnion(bw.key))
+		rus = append(rus, val.toRequestUnion(bw.key, bw.ts))
 	}
 	return rus
 }

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -638,6 +638,7 @@ func TestTxnWriteBufferServesPointReadsLocally(t *testing.T) {
 	// Perform a read on keyC. This should be sent to the KV layer, as no write
 	// for this key has been buffered.
 	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
 	getC := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyC}}
 	ba.Add(getC)
 
@@ -761,6 +762,7 @@ func TestTxnWriteBufferServesPointReadsAfterScan(t *testing.T) {
 
 	// Perform a read on keyC.
 	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
 	getC := &kvpb.GetRequest{RequestHeader: kvpb.RequestHeader{Key: keyC, Sequence: txn.Sequence}}
 	ba.Add(getC)
 
@@ -1139,8 +1141,9 @@ func TestTxnWriteBufferDecomposesConditionalPuts(t *testing.T) {
 			require.Equal(t, keyA, getReq.Key)
 			require.Equal(t, txn.Sequence, getReq.Sequence)
 			require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
-
-			return ba.CreateReply(), nil
+			br := ba.CreateReply()
+			br.Txn = ba.Txn
+			return br, nil
 		})
 
 		br, pErr := twb.SendLocked(ctx, ba)
@@ -1214,7 +1217,9 @@ func TestTxnWriteBufferDecomposesConditionalPutsExpectingNoRow(t *testing.T) {
 		require.Equal(t, txn.Sequence, getReq.Sequence)
 		require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
 		require.True(t, getReq.LockNonExisting)
-		return ba.CreateReply(), nil
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
 	})
 
 	br, pErr := twb.SendLocked(ctx, ba)
@@ -1284,7 +1289,9 @@ func TestTxnWriteBufferRespectsMustAcquireExclusiveLock(t *testing.T) {
 		require.Equal(t, txn.Sequence, getReq.Sequence)
 		require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
 		require.True(t, getReq.LockNonExisting)
-		return ba.CreateReply(), nil
+		br := ba.CreateReply()
+		br.Txn = ba.Txn
+		return br, nil
 	})
 
 	br, pErr := twb.SendLocked(ctx, ba)
@@ -1365,6 +1372,7 @@ func TestTxnWriteBufferMustSortBatchesBySequenceNumber(t *testing.T) {
 			}
 		}
 		br = ba.CreateReply()
+		br.Txn = ba.Txn
 		return br, nil
 	})
 
@@ -1744,6 +1752,7 @@ func TestTxnWriteBufferRollbackToSavepoint(t *testing.T) {
 
 	// Add some new writes. A second write to keyA and a new one to keyB.
 	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
 	txn.Sequence++
 	putA2 := putArgs(keyA, valA2, txn.Sequence)
 	ba.Add(putA2)
@@ -2223,4 +2232,107 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 		},
 		)
 	}
+}
+
+// TestTxnWriteBufferChecksForExclusionLoss verifies that decomposed
+// writes attach an exclusion timestamp to their final batch.
+func TestTxnWriteBufferChecksForExclusionLoss(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+
+	txn := makeTxnProto()
+	txn.Sequence = 10
+	keyA := roachpb.Key("a")
+	keyB := roachpb.Key("b")
+	keyC := roachpb.Key("c")
+
+	valStr := "val"
+
+	// Requests that require an exclusion timestamp:
+	//
+	// - ConditionalPut
+	// - PutMustAcquireExclusiveLock
+	// - DeleteMustAcquireExclusiveLock
+	//
+
+	ba := &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(cputArgs(keyA, valStr, "", txn.Sequence))
+
+	putReq := putArgs(keyB, valStr, txn.Sequence)
+	putReq.MustAcquireExclusiveLock = true
+	ba.Add(putReq)
+
+	delReq := delArgs(keyC, txn.Sequence)
+	delReq.MustAcquireExclusiveLock = true
+	ba.Add(delReq)
+
+	initialReadTimestamp := txn.ReadTimestamp
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 3)
+		resp := ba.CreateReply()
+		resp.Txn = ba.Txn
+		return resp, nil
+	})
+
+	br, pErr := twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Another write on keyB
+	txn.BumpReadTimestamp(initialReadTimestamp.Next())
+	txn.Sequence++
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	putReq = putArgs(keyB, valStr, txn.Sequence)
+	putReq.MustAcquireExclusiveLock = true
+	ba.Add(putReq)
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 1)
+		resp := ba.CreateReply()
+		resp.Txn = ba.Txn
+		return resp, nil
+	})
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
+
+	// Commit the transaction and verify that the request has the expected exclusion timestamp.
+	txn.BumpReadTimestamp(initialReadTimestamp.Next())
+	ba = &kvpb.BatchRequest{}
+	ba.Header = kvpb.Header{Txn: &txn}
+	ba.Add(&kvpb.EndTxnRequest{Commit: true})
+
+	mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+		require.Len(t, ba.Requests, 4)
+
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+		putReq := ba.Requests[0].GetInner().(*kvpb.PutRequest)
+		require.Equal(t, keyA, putReq.Key)
+		require.Equal(t, initialReadTimestamp, putReq.ExpectExclusionSince)
+
+		require.IsType(t, &kvpb.DeleteRequest{}, ba.Requests[1].GetInner())
+		delReq := ba.Requests[1].GetInner().(*kvpb.DeleteRequest)
+		require.Equal(t, keyC, delReq.Key)
+		require.Equal(t, initialReadTimestamp, delReq.ExpectExclusionSince)
+
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[2].GetInner())
+		putReq = ba.Requests[2].GetInner().(*kvpb.PutRequest)
+		require.Equal(t, keyB, putReq.Key)
+		require.Equal(t, initialReadTimestamp, putReq.ExpectExclusionSince)
+
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[3].GetInner())
+
+		resp := ba.CreateReply()
+		resp.Txn = ba.Txn
+		return resp, nil
+	})
+
+	br, pErr = twb.SendLocked(ctx, ba)
+	require.Nil(t, pErr)
+	require.NotNil(t, br)
 }

--- a/pkg/kv/kvclient/kvcoord/txn_metrics.go
+++ b/pkg/kv/kvclient/kvcoord/txn_metrics.go
@@ -48,6 +48,7 @@ type TxnMetrics struct {
 	RestartsAsyncWriteFailure      telemetry.CounterWithMetric
 	RestartsCommitDeadlineExceeded telemetry.CounterWithMetric
 	RestartsReadWithinUncertainty  telemetry.CounterWithMetric
+	RestartsExclusionViolation     telemetry.CounterWithMetric
 	RestartsTxnAborted             telemetry.CounterWithMetric
 	RestartsTxnPush                telemetry.CounterWithMetric
 	RestartsUnknown                telemetry.CounterWithMetric
@@ -258,6 +259,12 @@ var (
 		Measurement: "Restarted Transactions",
 		Unit:        metric.Unit_COUNT,
 	}
+	metaRestartsExclusionViolation = metric.Metadata{
+		Name:        "txn.restarts.exclusionviolation",
+		Help:        "Number of restarts due to an exclusion violation",
+		Measurement: "Restarted Transactions",
+		Unit:        metric.Unit_COUNT,
+	}
 	metaRestartsTxnAborted = metric.Metadata{
 		Name:        "txn.restarts.txnaborted",
 		Help:        "Number of restarts due to an abort by a concurrent transaction (usually due to deadlock)",
@@ -371,6 +378,7 @@ func MakeTxnMetrics(histogramWindow time.Duration) TxnMetrics {
 		RestartsAsyncWriteFailure:            telemetry.NewCounterWithMetric(metaRestartsAsyncWriteFailure),
 		RestartsCommitDeadlineExceeded:       telemetry.NewCounterWithMetric(metaRestartsCommitDeadlineExceeded),
 		RestartsReadWithinUncertainty:        telemetry.NewCounterWithMetric(metaRestartsReadWithinUncertainty),
+		RestartsExclusionViolation:           telemetry.NewCounterWithMetric(metaRestartsExclusionViolation),
 		RestartsTxnAborted:                   telemetry.NewCounterWithMetric(metaRestartsTxnAborted),
 		RestartsTxnPush:                      telemetry.NewCounterWithMetric(metaRestartsTxnPush),
 		RestartsUnknown:                      telemetry.NewCounterWithMetric(metaRestartsUnknown),

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2521,11 +2521,45 @@ func (writeOptions *WriteOptions) GetOriginTimestamp() hlc.Timestamp {
 	return writeOptions.OriginTimestamp
 }
 
-func (r *ConditionalPutRequest) Validate() error {
+func (r *ConditionalPutRequest) Validate(_ Header) error {
 	if !r.OriginTimestamp.IsEmpty() {
 		if r.AllowIfDoesNotExist {
 			return errors.AssertionFailedf("invalid ConditionalPutRequest: AllowIfDoesNotExist and non-empty OriginTimestamp are incompatible")
 		}
+	}
+	return nil
+}
+
+func (r *PutRequest) Validate(bh Header) error {
+	if err := validateExclusionTimestampForBatch(r.ExpectExclusionSince, bh); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid PutRequest")
+	}
+	return nil
+}
+
+func (r *DeleteRequest) Validate(bh Header) error {
+	if err := validateExclusionTimestampForBatch(r.ExpectExclusionSince, bh); err != nil {
+		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid DeleteRequest")
+	}
+	return nil
+}
+
+func validateExclusionTimestampForBatch(ts hlc.Timestamp, h Header) error {
+	if ts.IsEmpty() {
+		return nil
+	}
+
+	// TODO(ssd): It would be nice to put this first, but then we fail the
+	// gcassert linter, I assume because the code gets optimized away.
+	if !buildutil.CrdbTestBuild {
+		return nil
+	}
+
+	// CanForwardReadTimestamp implies we haven't served a read, so it makes no
+	// sense that ExpectExclusionSince would be set since it is the result of a
+	// locking read.
+	if h.CanForwardReadTimestamp {
+		return errors.New("unexpected ExpectExclusionSince in batch with CanForwardReadTimestamp set")
 	}
 	return nil
 }

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2531,7 +2531,7 @@ func (r *ConditionalPutRequest) Validate(_ Header) error {
 }
 
 func (r *GetRequest) Validate(_ Header) error {
-	if !r.ExpectExclusionSince.IsEmpty() && r.KeyLockingStrength != lock.None {
+	if !r.ExpectExclusionSince.IsEmpty() && r.KeyLockingStrength == lock.None {
 		return errors.AssertionFailedf("invalid GetRequest: ExpectExclusionSince is non-empty for non-locking request")
 	}
 	return nil

--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2530,6 +2530,13 @@ func (r *ConditionalPutRequest) Validate(_ Header) error {
 	return nil
 }
 
+func (r *GetRequest) Validate(_ Header) error {
+	if !r.ExpectExclusionSince.IsEmpty() && r.KeyLockingStrength != lock.None {
+		return errors.AssertionFailedf("invalid GetRequest: ExpectExclusionSince is non-empty for non-locking request")
+	}
+	return nil
+}
+
 func (r *PutRequest) Validate(bh Header) error {
 	if err := validateExclusionTimestampForBatch(r.ExpectExclusionSince, bh); err != nil {
 		return errors.NewAssertionErrorWithWrappedErrf(err, "invalid PutRequest")

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -292,6 +292,13 @@ message PutRequest {
   // no lower than "exclusive" needs to be acquired on the key, even if it
   // doesn't exist.
   bool must_acquire_exclusive_lock = 5;
+
+  // ExpectExclusionSince, if set, indicates that the request should return an
+  // error if this key has been written to at a timestamp at or after the given
+  // timestamp. This is different from the ReadTimestamp of the transaction in
+  // that it allows a writer to verify an unreplicated lock acquired at an
+  // earlier timestamp has provided the require protection.
+  util.hlc.Timestamp expect_exclusion_since = 6 [(gogoproto.nullable) = false];
 }
 
 // A PutResponse is the return value from the Put() method.
@@ -411,6 +418,13 @@ message DeleteRequest {
   //
   // TODO(ssd): Separate the behaviour of FoundKey to not depend on this flag.
   bool must_acquire_exclusive_lock = 2;
+
+  // ExpectExclusionSince, if set, indicates that the request should return an
+  // error if this key has been written to at a timestamp at or after the given
+  // timestamp. This is different from the ReadTimestamp of the transaction in
+  // that it allows a writer to verify an unreplicated lock acquired at an
+  // earlier timestamp has provided the require protection.
+  util.hlc.Timestamp expect_exclusion_since = 3 [(gogoproto.nullable) = false];
 }
 
 // A DeleteResponse is the return value from the Delete() method.

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -223,6 +223,13 @@ message GetRequest {
   // LockNonExisting indicates whether the Get request should acquire a lock
   // on keys that don't exist.
   bool lock_non_existing = 5;
+
+  // ExpectExclusionSince, if set, indicates that the request should return an
+  // error if this key has been written to at a timestamp at or after the given
+  // timestamp. This is different from the ReadTimestamp of the transaction in
+  // that it allows a writer to verify an unreplicated lock acquired at an
+  // earlier timestamp has provided the require protection.
+  util.hlc.Timestamp expect_exclusion_since = 6 [(gogoproto.nullable) = false];
 }
 
 // A GetResponse is the return value from the Get() method.

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -108,6 +108,15 @@ func (ba *BatchRequest) EarliestActiveTimestamp() hlc.Timestamp {
 				// NB: StartTime.Next() because StartTime is exclusive.
 				ts.Backward(t.StartTime.Next())
 			}
+		case *GetRequest:
+			// A GetRequest with ExpectExclusionSince set need to be able to observe
+			// MVCC versions from the specified time to correctly detect isolation
+			// violations.
+			//
+			// See the example in RefreshRequest for more details.
+			if !t.ExpectExclusionSince.IsEmpty() {
+				ts.Backward(t.ExpectExclusionSince.Next())
+			}
 		case *PutRequest:
 			// A PutRequest with ExpectExclusionSince set need to be able to observe MVCC
 			// versions from the specified time to correctly detect isolation

--- a/pkg/kv/kvpb/errordetailtype_string.go
+++ b/pkg/kv/kvpb/errordetailtype_string.go
@@ -49,6 +49,7 @@ func _() {
 	_ = x[LockConflictErrType-45]
 	_ = x[ReplicaUnavailableErrType-46]
 	_ = x[ProxyFailedErrType-47]
+	_ = x[ExclusionViolationErrType-48]
 	_ = x[CommunicationErrType-22]
 	_ = x[InternalErrType-25]
 }
@@ -127,6 +128,8 @@ func (i ErrorDetailType) String() string {
 		return "ReplicaUnavailableErrType"
 	case ProxyFailedErrType:
 		return "ProxyFailedErrType"
+	case ExclusionViolationErrType:
+		return "ExclusionViolationErrType"
 	case CommunicationErrType:
 		return "CommunicationErrType"
 	case InternalErrType:

--- a/pkg/kv/kvpb/errors.go
+++ b/pkg/kv/kvpb/errors.go
@@ -297,6 +297,8 @@ const (
 	LockConflictErrType                     ErrorDetailType = 45
 	ReplicaUnavailableErrType               ErrorDetailType = 46
 	ProxyFailedErrType                      ErrorDetailType = 47
+	ExclusionViolationErrType               ErrorDetailType = 48
+
 	// When adding new error types, don't forget to update NumErrors below.
 
 	// CommunicationErrType indicates a gRPC error; this is not an ErrorDetail.
@@ -306,7 +308,7 @@ const (
 	// detail. The value 25 is chosen because it's reserved in the errors proto.
 	InternalErrType ErrorDetailType = 25
 
-	NumErrors int = 48
+	NumErrors int = 49
 )
 
 // Register the migration of all errors that used to be in the roachpb package
@@ -1854,6 +1856,51 @@ func NewSnapshotReservationTimeoutError(
 	}
 }
 
+// NewExclusionViolationError creates a new ExclusionViolationError. This error
+// is returned by requests that encounter an existing value written at a
+// timestamp at which they expected to have an exclusive lock on the key. This
+// error implies that the lock was lost, which is possible for unreplicated locks.
+func NewExclusionViolationError(
+	exclusionTS, actualTS hlc.Timestamp, key roachpb.Key,
+) *ExclusionViolationError {
+	return &ExclusionViolationError{
+		ExclusionTimestamp: exclusionTS,
+		ActualTimestamp:    actualTS,
+		Key:                key.Clone(),
+	}
+}
+
+func (e *ExclusionViolationError) SafeFormatError(p errors.Printer) (next error) {
+	p.Printf("write exclusion on key %s expected since %s but found more recent write at %s",
+		e.Key,
+		e.ExclusionTimestamp,
+		e.ActualTimestamp,
+	)
+	return nil
+}
+
+func (e *ExclusionViolationError) Error() string {
+	return redact.Sprint(e).StripMarkers()
+}
+
+func (*ExclusionViolationError) canRestartTransaction() TransactionRestart {
+	return TransactionRestart_IMMEDIATE
+}
+
+// Type is part of the ErrorDetailInterface.
+func (e *ExclusionViolationError) Type() ErrorDetailType {
+	return ExclusionViolationErrType
+}
+
+// RetryTimestamp returns the timestamp that should be used to retry an
+// operation after encountering a WriteTooOldError.
+func (e *ExclusionViolationError) RetryTimestamp() hlc.Timestamp {
+	return e.ActualTimestamp.Next()
+}
+
+var _ ErrorDetailInterface = &ExclusionViolationError{}
+var _ transactionRestartError = &ExclusionViolationError{}
+
 func init() {
 	encode := func(ctx context.Context, err error) (msgPrefix string, safeDetails []string, payload proto.Message) {
 		errors.As(err, &payload) // payload = err.(proto.Message)
@@ -1914,3 +1961,4 @@ var _ errors.SafeFormatter = &ReplicaUnavailableError{}
 var _ errors.SafeFormatter = &ProxyFailedError{}
 var _ errors.SafeFormatter = &KeyCollisionError{}
 var _ errors.SafeFormatter = &SnapshotReservationTimeoutError{}
+var _ errors.SafeFormatter = &ExclusionViolationError{}

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -793,8 +793,8 @@ message InsufficientSpaceError {
 }
 
 
-// PebbleCorruptionError indicates that pebble thinks that there is a data                                                                                                                                                                                  
-// corruption.                                                                                                                                                                                                                                                
+// PebbleCorruptionError indicates that pebble thinks that there is a data
+// corruption.
 message PebbleCorruptionError {
   optional int64 store_id = 1 [(gogoproto.nullable) = false,
     (gogoproto.customname) = "StoreID",
@@ -803,4 +803,16 @@ message PebbleCorruptionError {
   optional bool is_remote = 3 [(gogoproto.nullable) = false];
   optional string extra_msg = 4 [(gogoproto.nullable) = false];
 }
-   
+
+// ExclusionViolationError indicates that a key was written to at a timestamp at
+// which a caller assumed it had an exclusive lock on the key.
+message ExclusionViolationError {
+  // ExclusionTimestamp is the timestamp at which the request expected its
+  // exclusive access started.
+  optional util.hlc.Timestamp exclusion_timestamp = 1 [(gogoproto.nullable) = false];
+  // ActualTimestamp is the timestamp at which the request found a write that
+  // violated its exclusive access.
+  optional util.hlc.Timestamp actual_timestamp = 2 [(gogoproto.nullable) = false];
+  // Key is the key on which exclusion was violated.
+  optional bytes key = 3 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.Key"];
+}

--- a/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_conditional_put.go
@@ -54,7 +54,7 @@ func ConditionalPut(
 		ts = h.Timestamp
 	}
 
-	if err := args.Validate(); err != nil {
+	if err := args.Validate(h); err != nil {
 		return result.Result{}, err
 	}
 

--- a/pkg/kv/kvserver/batcheval/cmd_delete.go
+++ b/pkg/kv/kvserver/batcheval/cmd_delete.go
@@ -28,11 +28,16 @@ func Delete(
 	h := cArgs.Header
 	reply := resp.(*kvpb.DeleteResponse)
 
+	if err := args.Validate(h); err != nil {
+		return result.Result{}, err
+	}
+
 	opts := storage.MVCCWriteOptions{
 		Txn:                            h.Txn,
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		ExclusionTimestamp:             args.ExpectExclusionSince,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		OriginID:                       h.WriteOptions.GetOriginID(),
 		OriginTimestamp:                h.WriteOptions.GetOriginTimestamp(),

--- a/pkg/kv/kvserver/batcheval/cmd_get.go
+++ b/pkg/kv/kvserver/batcheval/cmd_get.go
@@ -48,7 +48,7 @@ func Get(
 	// MoreRecentPolicy to ExclusionViolationErrorOnMoreRecent to ensure that an
 	// exclusion violation error is returned if a write has occurred since the
 	// exclusion timestamp.
-	if !args.ExpectExclusionSince.Empty() {
+	if !args.ExpectExclusionSince.IsEmpty() {
 		readTimestamp = args.ExpectExclusionSince
 		moreRecentPolicy = storage.ExclusionViolationErrorOnMoreRecent
 	} else if args.KeyLockingStrength != lock.None {

--- a/pkg/kv/kvserver/batcheval/cmd_put.go
+++ b/pkg/kv/kvserver/batcheval/cmd_put.go
@@ -51,11 +51,16 @@ func Put(
 		ts = h.Timestamp
 	}
 
+	if err := args.Validate(h); err != nil {
+		return result.Result{}, err
+	}
+
 	opts := storage.MVCCWriteOptions{
 		Txn:                            h.Txn,
 		LocalTimestamp:                 cArgs.Now,
 		Stats:                          cArgs.Stats,
 		ReplayWriteTimestampProtection: h.AmbiguousReplayProtection,
+		ExclusionTimestamp:             args.ExpectExclusionSince,
 		OmitInRangefeeds:               cArgs.OmitInRangefeeds,
 		OriginID:                       h.WriteOptions.GetOriginID(),
 		OriginTimestamp:                h.WriteOptions.GetOriginTimestamp(),

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -241,7 +241,7 @@ func (ts *txnState) resetForNewSQLTxn(
 			if err := ts.setIsolationLevelLocked(isoLevel); err != nil {
 				panic(err)
 			}
-			if isoLevel != isolation.Serializable {
+			if isoLevel != isolation.Serializable && !allowBufferedWritesAlways.Get(&tranCtx.settings.SV) {
 				// TODO(#143497): we currently only support buffered writes
 				// under serializable isolation.
 				bufferedWritesEnabled = false

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1230,13 +1230,28 @@ type LockTableView interface {
 	Close()
 }
 
+// MVCCGetMoreRecentPolicy determines how MVCCGet should handle more recent
+// versions of a key.
+type MVCCGetMoreRecentPolicy int
+
+const (
+	// IgnoreMoreRecent indicates that MVCCGet should ignore more recent versions of a key.
+	IgnoreMoreRecent MVCCGetMoreRecentPolicy = iota
+	// WriteTooOldErrorOnMoreRecent indicates that MVCCGet should return a WriteTooOldErrorOnMoreRecent
+	// if a more recent version of a key is found.
+	WriteTooOldErrorOnMoreRecent
+	// ExclusionViolationErrorOnMoreRecent indicates that MVCCGet should return an ExclusionLostError
+	// if a more recent version of a key is found.
+	ExclusionViolationErrorOnMoreRecent
+)
+
 // MVCCGetOptions bundles options for the MVCCGet family of functions.
 type MVCCGetOptions struct {
 	// See the documentation for MVCCGet for information on these parameters.
 	Inconsistent     bool
 	SkipLocked       bool
 	Tombstones       bool
-	FailOnMoreRecent bool
+	MoreRecentPolicy MVCCGetMoreRecentPolicy
 	Txn              *roachpb.Transaction
 	ScanStats        *kvpb.ScanStats
 	Uncertainty      uncertainty.Interval
@@ -1302,7 +1317,7 @@ func (opts *MVCCGetOptions) validate() error {
 	if opts.Inconsistent && opts.SkipLocked {
 		return errors.Errorf("cannot allow inconsistent reads with skip locked option")
 	}
-	if opts.Inconsistent && opts.FailOnMoreRecent {
+	if opts.Inconsistent && opts.MoreRecentPolicy != IgnoreMoreRecent {
 		return errors.Errorf("cannot allow inconsistent reads with fail on more recent option")
 	}
 	if opts.DontInterleaveIntents && opts.SkipLocked {
@@ -1572,7 +1587,7 @@ func mvccGet(
 		skipLocked:        opts.SkipLocked,
 		tombstones:        opts.Tombstones,
 		rawMVCCValues:     opts.ReturnRawMVCCValues,
-		failOnMoreRecent:  opts.FailOnMoreRecent,
+		moreRecentPolicy:  opts.MoreRecentPolicy,
 		keyBuf:            mvccScanner.keyBuf,
 		decodeMVCCHeaders: true,
 	}
@@ -4452,6 +4467,10 @@ func mvccScanInit(
 	if opts.MemoryAccount != nil {
 		memAccount = opts.MemoryAccount
 	}
+	moreRecentPolicy := IgnoreMoreRecent
+	if opts.FailOnMoreRecent {
+		moreRecentPolicy = WriteTooOldErrorOnMoreRecent
+	}
 	*mvccScanner = pebbleMVCCScanner{
 		parent:           iter,
 		memAccount:       memAccount,
@@ -4470,7 +4489,7 @@ func mvccScanInit(
 		inconsistent:     opts.Inconsistent,
 		skipLocked:       opts.SkipLocked,
 		tombstones:       opts.Tombstones,
-		failOnMoreRecent: opts.FailOnMoreRecent,
+		moreRecentPolicy: moreRecentPolicy,
 		keyBuf:           mvccScanner.keyBuf,
 		// NB: If the `results` argument passed to this function is a pointer to
 		// mvccScanner.alloc.pebbleResults, we don't want to overwrite any

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2396,6 +2396,7 @@ func mvccPutInternal(
 	// definition for rationale.
 	readTimestamp := timestamp
 	writeTimestamp := timestamp
+	exclusionTimestamp := opts.ExclusionTimestamp
 	if opts.Txn != nil {
 		readTimestamp = opts.Txn.ReadTimestamp
 		if readTimestamp != timestamp {
@@ -2665,6 +2666,9 @@ func mvccPutInternal(
 			writeTimestamp.Forward(metaTimestamp.Next())
 			writeTooOldErr := kvpb.NewWriteTooOldError(readTimestamp, writeTimestamp, key)
 			return false, roachpb.LockAcquisition{}, writeTooOldErr
+		} else if !exclusionTimestamp.IsEmpty() && exclusionTimestamp.LessEq(metaTimestamp) {
+			// TODO(ssd): Does the timestamp check above need to be inclusive or exclusive?
+			return false, roachpb.LockAcquisition{}, kvpb.NewExclusionViolationError(exclusionTimestamp, metaTimestamp, key)
 		} else /* meta.Txn == nil && metaTimestamp.Less(readTimestamp) */ {
 			// If a valueFn is specified, read the existing value using iter.
 			opts := MVCCGetOptions{
@@ -4612,6 +4616,7 @@ type MVCCWriteOptions struct {
 	// See the comment on mvccPutInternal for details on these parameters.
 	Txn                            *roachpb.Transaction
 	LocalTimestamp                 hlc.ClockTimestamp
+	ExclusionTimestamp             hlc.Timestamp
 	Stats                          *enginepb.MVCCStats
 	ReplayWriteTimestampProtection bool
 	OmitInRangefeeds               bool

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -1244,6 +1244,7 @@ func cmdDelete(e *evalCtx) error {
 			Stats:                          e.ms,
 			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 			MaxLockConflicts:               e.getMaxLockConflicts(),
+			ExclusionTimestamp:             e.getTsWithName("expect-exclusion-since"),
 		}
 		foundKey, acq, err := storage.MVCCDelete(e.ctx, rw, key, ts, opts)
 		if err == nil || errors.HasType(err, &kvpb.WriteTooOldError{}) {
@@ -1508,6 +1509,7 @@ func cmdPut(e *evalCtx) error {
 			Stats:                          e.ms,
 			ReplayWriteTimestampProtection: e.getAmbiguousReplay(),
 			MaxLockConflicts:               e.getMaxLockConflicts(),
+			ExclusionTimestamp:             e.getTsWithName("expect-exclusion-since"),
 		}
 		acq, err := storage.MVCCPut(e.ctx, rw, key, ts, val, opts)
 		if err != nil {

--- a/pkg/storage/mvcc_history_test.go
+++ b/pkg/storage/mvcc_history_test.go
@@ -86,21 +86,32 @@ var (
 // check_for_acquire_lock t=<name> k=<key> str=<strength> [maxLockConflicts=<int>] [targetLockConflictBytes=<int>]
 // acquire_lock           t=<name> k=<key> str=<strength> [maxLockConflicts=<int>] [targetLockConflictBytes=<int>]
 //
-// cput           [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> v=<string> [raw] [cond=<string>]
-// del            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key>
-// del_range      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> end=<key> [max=<max>] [returnKeys]
-// del_range_ts   [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> end=<key> [idempotent] [noCoveredStats]
-// del_range_pred [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> end=<key> [startTime=<int>,max=<int>,maxBytes=<int>,rangeThreshold=<int>]
-// increment      [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> [inc=<val>]
-// put            [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>] k=<key> v=<string> [raw]
+// cput [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>]
+// [targetLockConflictBytes=<int>] k=<key> v=<string> [raw] [cond=<string>]
+// del [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>]
+// [targetLockConflictBytes=<int>] k=<key>
+// del_range [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>]
+// [targetLockConflictBytes=<int>] k=<key> end=<key> [max=<max>] [returnKeys]
+// del_range_ts [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> end=<key> [idempotent]
+// [noCoveredStats]
+// del_range_pred [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] k=<key> end=<key>
+// [startTime=<int>,max=<int>,maxBytes=<int>,rangeThreshold=<int>]
+// increment [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>]
+// [targetLockConflictBytes=<int>] k=<key> [inc=<val>]
+// put [t=<name>] [ts=<int>[,<int>]] [localTs=<int>[,<int>]] [resolve [status=<txnstatus>]] [ambiguousReplay] [maxLockConflicts=<int>] k=<key> v=<string> [raw]
 // put_rangekey   ts=<int>[,<int>] [localTs=<int>[,<int>]] k=<key> end=<key> [syntheticBit]
 // put_blind_inline	k=<key> v=<string> [prev=<string>]
-// get            [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [inconsistent] [skipLocked] [tombstones] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [maxKeys=<int>] [targetBytes=<int>] [allowEmpty]
-// scan           [t=<name>] [ts=<int>[,<int>]]                         [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent] [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [wholeRows[=<int>]] [allowEmpty]
-// export         [k=<key>] [end=<key>] [ts=<int>[,<int>]] [kTs=<int>[,<int>]] [startTs=<int>[,<int>]] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>] [allRevisions] [targetSize=<int>] [maxSize=<int>] [stopMidKey] [fingerprint]
+// get [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [inconsistent] [skipLocked] [tombstones] [failOnMoreRecent]
+// [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [maxKeys=<int>] [targetBytes=<int>] [allowEmpty]
+// scan [t=<name>] [ts=<int>[,<int>]] [resolve [status=<txnstatus>]] k=<key> [end=<key>] [inconsistent] [skipLocked] [tombstones] [reverse] [failOnMoreRecent]
+// [localUncertaintyLimit=<int>[,<int>]] [globalUncertaintyLimit=<int>[,<int>]] [max=<max>] [targetbytes=<target>] [wholeRows[=<int>]] [allowEmpty]
+// export [k=<key>] [end=<key>] [ts=<int>[,<int>]] [kTs=<int>[,<int>]] [startTs=<int>[,<int>]] [maxLockConflicts=<int>] [targetLockConflictBytes=<int>]
+// [allRevisions] [targetSize=<int>] [maxSize=<int>] [stopMidKey] [fingerprint]
 //
-// iter_new       [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]] [minTimestamp=<int>[,<int>]] [maxTimestamp=<int>[,<int>]]
-// iter_new_incremental [k=<key>] [end=<key>] [startTs=<int>[,<int>]] [endTs=<int>[,<int>]] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]] [intents=error|aggregate|emit]
+// iter_new [k=<key>] [end=<key>] [prefix] [kind=key|keyAndIntents] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly] [maskBelow=<int>[,<int>]]
+// [minTimestamp=<int>[,<int>]] [maxTimestamp=<int>[,<int>]]
+// iter_new_incremental [k=<key>] [end=<key>] [startTs=<int>[,<int>]] [endTs=<int>[,<int>]] [types=pointsOnly|pointsWithRanges|pointsAndRanges|rangesOnly]
+// [maskBelow=<int>[,<int>]] [intents=error|aggregate|emit]
 // iter_seek_ge   k=<key> [ts=<int>[,<int>]]
 // iter_seek_lt   k=<key> [ts=<int>[,<int>]]
 // iter_next
@@ -1396,8 +1407,24 @@ func cmdGet(e *evalCtx) error {
 		opts.Tombstones = true
 	}
 	if e.hasArg("failOnMoreRecent") {
-		opts.FailOnMoreRecent = true
+		opts.MoreRecentPolicy = storage.WriteTooOldErrorOnMoreRecent
 	}
+
+	if e.hasArg("moreRecentPolicy") {
+		var moreRecentPolicyStr string
+		e.scanArg("moreRecentPolicy", &moreRecentPolicyStr)
+		switch moreRecentPolicyStr {
+		case "ignoreMoreRecent":
+			opts.MoreRecentPolicy = storage.IgnoreMoreRecent
+		case "writeTooOldErrorOnMoreRecent":
+			opts.MoreRecentPolicy = storage.WriteTooOldErrorOnMoreRecent
+		case "exclusionViolationErrorOnMoreRecent":
+			opts.MoreRecentPolicy = storage.ExclusionViolationErrorOnMoreRecent
+		default:
+			e.Fatalf("unknown moreRecentPolicy: %s", moreRecentPolicyStr)
+		}
+	}
+
 	opts.Uncertainty = uncertainty.Interval{
 		GlobalLimit: e.getTsWithName("globalUncertaintyLimit"),
 		LocalLimit:  hlc.ClockTimestamp(e.getTsWithName("localUncertaintyLimit")),

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -95,7 +95,7 @@ func TestMVCCScanWithManyVersionsAndSeparatedIntents(t *testing.T) {
 		ts:               ts,
 		inconsistent:     false,
 		tombstones:       false,
-		failOnMoreRecent: false,
+		moreRecentPolicy: IgnoreMoreRecent,
 	}
 	var results pebbleResults
 	mvccScanner.init(nil /* txn */, uncertainty.Interval{}, &results)

--- a/pkg/storage/testdata/mvcc_histories/del_with_exclusion_ts
+++ b/pkg/storage/testdata/mvcc_histories/del_with_exclusion_ts
@@ -1,0 +1,78 @@
+# Write at a timestamp above the exclusion timestamp results in a write exclusion error.
+run ok
+put k=a v=v1 ts=2
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+del k=a ts=3 expect-exclusion-since=1
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "a" expected since 1.000000000,0 but found more recent write at 2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from a different transaction still results in a LockConflictError.
+run ok
+with t=A k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+del k=a ts=3 expect-exclusion-since=1
+----
+>> at end:
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from the same transaction is allowed.
+run ok
+with t=B k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run ok
+txn_advance t=B ts=3
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+txn_step t=B
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+del t=B k=a ts=2 expect-exclusion-since=1
+----
+del: "a": found key true
+del: lock acquisition = {a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
+>> at end:
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/3.000000000,0 -> /<empty>

--- a/pkg/storage/testdata/mvcc_histories/put_with_exclusion_ts
+++ b/pkg/storage/testdata/mvcc_histories/put_with_exclusion_ts
@@ -1,0 +1,77 @@
+# Write at a timestamp above the exclusion timestamp results in a write exclusion error.
+run ok
+put k=a v=v1 ts=2
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+put k=a v=v2 ts=3 expect-exclusion-since=1
+----
+>> at end:
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "a" expected since 1.000000000,0 but found more recent write at 2.000000000,0
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from a different transaction still results in a LockConflictError.
+run ok
+with t=A k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run error
+put k=a v=v2 ts=3 expect-exclusion-since=1
+----
+>> at end:
+meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+error: (*kvpb.LockConflictError:) conflicting locks on "a"
+
+run ok
+clear_range k=a end=z
+----
+>> at end:
+<no data>
+
+# Intent at a timestamp above the exclusion timestamp from the same transaction is allowed.
+run ok
+with t=B k=a
+  txn_begin ts=2
+  put v=v1
+----
+put: lock acquisition = {a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
+data: "a"/2.000000000,0 -> /BYTES/v1
+
+run ok
+txn_advance t=B ts=3
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+txn_step t=B
+----
+>> at end:
+txn: "B" meta={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 gul=0,0
+
+run ok
+put t=B k=a v=v2 ts=2 expect-exclusion-since=1
+----
+put: lock acquisition = {a id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
+>> at end:
+meta: "a"/0,0 -> txn={id=00000002 key="a" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
+data: "a"/3.000000000,0 -> /BYTES/v2

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -21,7 +21,7 @@ meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=
 data: "k2"/10.000000000,0 -> /BYTES/v
 
 # Test cases:
-# 
+#
 # for k in (k1, k2):
 #   for op in (get, scan):
 #     for ts in (9, 10, 11):
@@ -50,6 +50,12 @@ get k=k1 ts=10,0 failOnMoreRecent
 ----
 get: "k1" -> <no data>
 error: (*kvpb.WriteTooOldError:) WriteTooOldError: write for key "k1" at timestamp 10.000000000,0 too old; must write at or above 10.000000000,1
+
+run error
+get k=k1 ts=10,0 moreRecentPolicy=exclusionViolationErrorOnMoreRecent
+----
+get: "k1" -> <no data>
+error: (*kvpb.ExclusionViolationError:) write exclusion on key "k1" expected since 10.000000000,0 but found more recent write at 10.000000000,0
 
 run ok
 get k=k1 ts=11,0
@@ -164,7 +170,7 @@ scan: "k2"-"k3" -> <no data>
 error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 # More test cases:
-# 
+#
 # span = [k1, k3)
 # op   = scan
 # for ts in (9, 10, 11):
@@ -211,6 +217,12 @@ error: (*kvpb.LockConflictError:) conflicting locks on "k2"
 
 run error
 get k=k1 ts=9,0 inconsistent failOnMoreRecent
+----
+get: "k1" -> <no data>
+error: (*withstack.withStack:) cannot allow inconsistent reads with fail on more recent option
+
+run error
+get k=k1 ts=9,0 inconsistent moreRecentPolicy=exclusionViolationErrorOnMoreRecent
 ----
 get: "k1" -> <no data>
 error: (*withstack.withStack:) cannot allow inconsistent reads with fail on more recent option


### PR DESCRIPTION
Replicated locking requests can be decomposed into an unreplicated locking
request and a replicated locking request.

This change implements this decomposition for user-initiated replicated scans
and gets.

- Get requests with replicated locking strength are converted to gets with
  unreplicated locking strength and then a replicated locking get is added to
  the buffer. This buffered get can also be used to serve future reads.

- [Reverse]Scan requests with replicated locking strength are converted to scans
  with unreplicated locking strength. Replicated locking gets are then buffered
  for every returned row. We attempt to prevent the scan request from overwhelming
  the buffer by reducing the target bytes to the remaining buffer size in this
  case.

Buffering the read responses likely needs more thought around memory management,
but it has the nice property that a sequence such as:

    BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED;
    SELECT * FOR UPDATE WHERE pk = 1
    UPDATE v = 2 WHERE pk = 1
    COMMIT

May be decomposed into:

    Batch1: Get(Locking=Unreplicated)
    Batch2: Put, EndTxn

Providing this same benefit to SSI transaction would require us to directly
buffer the result of user-initiated unreplicated, locking scans and gets. Here,
we only buffer results from read requests that the txnWriteBuffer transformed in
some way.

Informs https://github.com/cockroachdb/cockroach/issues/142977

TODO:

- [ ] We need to correctly handle rollback of the locked request
- [ ] We need to correctly track lock levels.

Release note: None