### PR TITLE
roachtest: Add db-console/mixed-version-endpoints roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/registry.go
+++ b/pkg/cmd/roachtest/tests/registry.go
@@ -176,6 +176,7 @@ func RegisterTests(r registry.Registry) {
 	registerSqlStatsMixedVersion(r)
 	registerDbConsoleCypress(r)
 	registerDBConsoleEndpoints(r)
+	registerDBConsoleEndpointsMixedVersion(r)
 	registerTTLRestart(r)
 	perturbation.RegisterTests(r)
 }


### PR DESCRIPTION
This commit registers a mixed-version variation of the db-console/endpoints roachtest.

Part of: #145536

Release note: None