### PR TITLE
kvserver: register `StoreLiveness` service with DRPC server

### DIFF
--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -248,9 +248,10 @@ func createTestStoreWithoutStart(
 		livenessInterval, heartbeatInterval := cfg.StoreLivenessDurations()
 		supportGracePeriod := rpcContext.StoreLivenessWithdrawalGracePeriod()
 		options := storeliveness.NewOptions(livenessInterval, heartbeatInterval, supportGracePeriod)
-		transport := storeliveness.NewTransport(
-			cfg.AmbientCtx, stopper, cfg.Clock, cfg.NodeDialer, grpcServer, nil, /* knobs */
+		transport, err := storeliveness.NewTransport(
+			cfg.AmbientCtx, stopper, cfg.Clock, cfg.NodeDialer, grpcServer, drpcServer, nil, /* knobs */
 		)
+		require.NoError(t, err)
 		knobs := cfg.TestingKnobs.StoreLivenessKnobs
 		cfg.StoreLiveness = storeliveness.NewNodeContainer(stopper, options, transport, knobs)
 	}

--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -37,6 +37,7 @@ go_library(
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_x_exp//maps",
     ],

--- a/pkg/kv/kvserver/storeliveness/transport_test.go
+++ b/pkg/kv/kvserver/storeliveness/transport_test.go
@@ -119,14 +119,18 @@ func (tt *transportTester) AddNodeWithoutGossip(
 	tt.clocks[nodeID] = clockWithManualSource{manual: manual, clock: clock}
 	grpcServer, err := rpc.NewServer(context.Background(), tt.nodeRPCContext)
 	require.NoError(tt.t, err)
-	transport := NewTransport(
+	drpcServer, err := rpc.NewDRPCServer(context.Background(), tt.nodeRPCContext)
+	require.NoError(tt.t, err)
+	transport, err := NewTransport(
 		log.MakeTestingAmbientCtxWithNewTracer(),
 		tt.stopper,
 		clock,
 		nodedialer.New(tt.nodeRPCContext, gossip.AddressResolver(tt.gossip)),
 		grpcServer,
+		drpcServer,
 		nil, /* knobs */
 	)
+	require.NoError(tt.t, err)
 	tt.transports[nodeID] = transport
 
 	listener, err := netutil.ListenAndServeGRPC(stopper, grpcServer, util.TestAddr)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -657,9 +657,13 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		livenessInterval, heartbeatInterval := cfg.StoreLivenessDurations()
 		supportGracePeriod := rpcContext.StoreLivenessWithdrawalGracePeriod()
 		options := storeliveness.NewOptions(livenessInterval, heartbeatInterval, supportGracePeriod)
-		transport := storeliveness.NewTransport(
-			cfg.AmbientCtx, stopper, clock, kvNodeDialer, grpcServer.Server, nil, /* knobs */
+		transport, err := storeliveness.NewTransport(
+			cfg.AmbientCtx, stopper, clock, kvNodeDialer,
+			grpcServer.Server, drpcServer.DRPCServer, nil, /* knobs */
 		)
+		if err != nil {
+			return nil, err
+		}
 		nodeRegistry.AddMetricStruct(transport.Metrics())
 		var knobs *storeliveness.TestingKnobs
 		if storeKnobs := cfg.TestingKnobs.Store; storeKnobs != nil {

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -208,10 +208,13 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 		livenessInterval, heartbeatInterval := cfg.StoreLivenessDurations()
 		supportGracePeriod := cfg.RPCContext.StoreLivenessWithdrawalGracePeriod()
 		options := storeliveness.NewOptions(livenessInterval, heartbeatInterval, supportGracePeriod)
-		transport := storeliveness.NewTransport(
+		transport, err := storeliveness.NewTransport(
 			cfg.AmbientCtx, ltc.stopper, ltc.Clock,
-			nil /* dialer */, nil /* grpcServer */, nil, /* knobs */
+			nil /* dialer */, nil /* grpcServer */, nil /* drpcServer */, nil, /* knobs */
 		)
+		if err != nil {
+			t.Fatal(err)
+		}
 		knobs := cfg.TestingKnobs.StoreLivenessKnobs
 		cfg.StoreLiveness = storeliveness.NewNodeContainer(ltc.stopper, options, transport, knobs)
 	}


### PR DESCRIPTION
Enable the `StoreLiveness` service on the DRPC server in addition to gRPC. This is controlled by `rpc.experimental_drpc.enabled` (off by default).

This change is part of a series and is similar to: https://github.com/cockroachdb/cockroach/pull/146926

Note: This only registers the service; the client is not updated to use the DRPC client, so this service will not have any functional effect.

Epic: CRDB-48925
Release note: None