### PR TITLE
release-25.2: sql/schemachanger: prevent runtime errors adding multiple columns

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -184,3 +184,52 @@ statement error pgcode 57000 schema changes are disallowed on table "ref" becaus
 ALTER TABLE ref CONFIGURE ZONE USING num_replicas = 11;
 
 subtest end
+
+
+# Validate schema_locked can be unset properly in add column txns.
+subtest regression_147993
+
+statement ok
+CREATE TABLE t_147993 (
+  k INT8 NOT NULL,
+  geom1 GEOMETRY(POINT,4326) NULL,
+  geom2 GEOMETRY(POLYGON,4326) NULL,
+  geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+  geom4 GEOMETRY(LINESTRING,4326) NULL,
+  geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+  geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+  CONSTRAINT t_147993_pkey PRIMARY KEY (k ASC),
+  FAMILY fam (k, geom1, geom2, geom3, geom6)
+) WITH (schema_locked = true);
+
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-25.1
+skipif config local-mixed-24.3
+statement ok
+SELECT  AddGeometryColumn ('t_147993','geom7',4326,'POINT',2),
+        AddGeometryColumn ('t_147993','geom8',4326,'POINT',2);
+
+
+
+skipif config local-legacy-schema-changer
+skipif config local-mixed-25.1
+skipif config local-mixed-24.3
+query TT
+show create table t_147993
+----
+t_147993  CREATE TABLE public.t_147993 (
+            k INT8 NOT NULL,
+            geom1 GEOMETRY(POINT,4326) NULL,
+            geom2 GEOMETRY(POLYGON,4326) NULL,
+            geom3 GEOMETRY(MULTIPOLYGON,4326) NULL,
+            geom4 GEOMETRY(LINESTRING,4326) NULL,
+            geom5 GEOMETRY(MULTIPOINT,4326) NULL,
+            geom6 GEOMETRY(MULTILINESTRING,4326) NULL,
+            geom7 GEOMETRY(POINT,4326) NULL,
+            geom8 GEOMETRY(POINT,4326) NULL,
+            CONSTRAINT t_147993_pkey PRIMARY KEY (k ASC),
+            FAMILY fam (k, geom1, geom2, geom3, geom6, geom4, geom5, geom8, geom7)
+          ) WITH (schema_locked = true)
+
+subtest end

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index_and_column.go
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/dep_add_index_and_column.go
@@ -118,3 +118,28 @@ func init() {
 	)
 
 }
+
+// This rule ensures that index columns depend on each other in increasing order.
+func init() {
+	registerDepRule(
+		"ensure index columns are added in increasing order",
+		scgraph.Precedence,
+		"later-column", "earlier-column",
+		func(from, to NodeVars) rel.Clauses {
+			return rel.Clauses{
+				from.Type((*scpb.IndexColumn)(nil)),
+				from.JoinTargetNode(),
+				to.Type((*scpb.IndexColumn)(nil)),
+				JoinOnIndexID(from, to, "table-id", "index-id"),
+				ToPublicOrTransient(from, to),
+				StatusesToPublicOrTransient(from, scpb.Status_PUBLIC, to, scpb.Status_PUBLIC),
+				FilterElements("SmallerColumnIDFirst", from, to, func(from, to *scpb.IndexColumn) bool {
+					// Index columns of the same kind (key, key suffix, or stored) must be
+					// ordered by their ordinal position within that kind. Since key columns,
+					// key suffix columns, and stored columns are stored independently, the
+					// order in which each kind is added does not matter.
+					return from.OrdinalInKind < to.OrdinalInKind && from.Kind == to.Kind
+				}),
+			}
+		})
+}

--- a/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
+++ b/pkg/sql/schemachanger/scplan/internal/rules/current/testdata/deprules
@@ -3600,6 +3600,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are added in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence
@@ -8537,6 +8553,22 @@ deprules
     - SmallerSeqNumFirst(*scpb.DatabaseZoneConfig, *scpb.DatabaseZoneConfig)($later-seqNum, $earlier-seqNum)
     - joinTargetNode($later-seqNum, $later-seqNum-Target, $later-seqNum-Node)
     - joinTargetNode($earlier-seqNum, $earlier-seqNum-Target, $earlier-seqNum-Node)
+- name: ensure index columns are added in increasing order
+  from: later-column-Node
+  kind: Precedence
+  to: earlier-column-Node
+  query:
+    - $later-column[Type] = '*scpb.IndexColumn'
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - $earlier-column[Type] = '*scpb.IndexColumn'
+    - joinOnIndexID($later-column, $earlier-column, $table-id, $index-id)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - ToPublicOrTransient($later-column-Target, $earlier-column-Target)
+    - $later-column-Node[CurrentStatus] = PUBLIC
+    - $earlier-column-Node[CurrentStatus] = PUBLIC
+    - SmallerColumnIDFirst(*scpb.IndexColumn, *scpb.IndexColumn)($later-column, $earlier-column)
+    - joinTargetNode($later-column, $later-column-Target, $later-column-Node)
+    - joinTargetNode($earlier-column, $earlier-column-Target, $earlier-column-Node)
 - name: ensure index zone configs are in increasing seqNum order
   from: later-seqNum-Node
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_alter_primary_key
@@ -760,6 +760,10 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 2}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -775,6 +779,10 @@ ALTER TABLE t ALTER PRIMARY KEY USING COLUMNS (k);
   to:   [PrimaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 2, TemporaryIndexID: 3, SourceIndexID: 1}, TRANSIENT_ABSENT]
   kind: Precedence
   rule: dependents removed before index
+- from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 104, ColumnID: 3, IndexID: 3}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 3, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
+++ b/pkg/sql/schemachanger/scplan/testdata/alter_table_drop_column
@@ -1115,6 +1115,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -1122,6 +1126,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v1 CASCADE;
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
@@ -2635,6 +2643,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -2642,6 +2654,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN v2 CASCADE;
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 4, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
@@ -3510,6 +3526,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN udfcol;
   kind: Precedence
   rule: dependents removed before index
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 3}, PUBLIC]
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -3517,6 +3537,10 @@ ALTER TABLE defaultdb.foo DROP COLUMN udfcol;
   to:   [PrimaryIndex:{DescID: 107, IndexID: 3, ConstraintID: 3, TemporaryIndexID: 4, SourceIndexID: 1}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
+  to:   [IndexColumn:{DescID: 107, ColumnID: 3, IndexID: 4}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 107, ColumnID: 2, IndexID: 4}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 107, IndexID: 4, ConstraintID: 4, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/scplan/testdata/create_index
+++ b/pkg/sql/schemachanger/scplan/testdata/create_index
@@ -280,6 +280,10 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -287,6 +291,10 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence
@@ -710,6 +718,10 @@ deps
 CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
 ----
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 2}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 2}, PUBLIC]
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, BACKFILLED]
   kind: Precedence
   rule: index-column added to index before index is backfilled
@@ -717,6 +729,10 @@ CREATE INDEX id1 ON defaultdb.t1 (id, name) STORING (money)
   to:   [SecondaryIndex:{DescID: 104, IndexID: 2, ConstraintID: 0, TemporaryIndexID: 3, SourceIndexID: 1, RecreateSourceIndexID: 0}, PUBLIC]
   kind: Precedence
   rule: index dependents exist before index becomes public
+- from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
+  to:   [IndexColumn:{DescID: 104, ColumnID: 2, IndexID: 3}, PUBLIC]
+  kind: Precedence
+  rule: ensure index columns are added in increasing order
 - from: [IndexColumn:{DescID: 104, ColumnID: 1, IndexID: 3}, PUBLIC]
   to:   [TemporaryIndex:{DescID: 104, IndexID: 3, ConstraintID: 1, SourceIndexID: 1}, WRITE_ONLY]
   kind: Precedence

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx/alter_table_add_primary_key_drop_rowid_with_secondary_idx.explain
@@ -40,18 +40,18 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":4,"TableID":104}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 9 elements transitioning toward PUBLIC
@@ -114,20 +114,20 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
  │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
  │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -201,7 +201,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    └── 17 Mutation operations
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":8,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
@@ -214,6 +213,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 16 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx_locked/alter_table_add_primary_key_drop_rowid_with_secondary_idx_locked.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_add_primary_key_drop_rowid_with_secondary_idx_locked/alter_table_add_primary_key_drop_rowid_with_secondary_idx_locked.explain
@@ -44,18 +44,18 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── MakePublicColumnNotNullValidated {"ColumnID":3,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 9 elements transitioning toward PUBLIC
@@ -123,20 +123,20 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":6,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":7}}
  │              ├── MaybeAddSplitForIndex {"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":6,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":6,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":7,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":7,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":7,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":7,"Kind":2,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":7,"IndexID":8,"IsUnique":true,"SourceIndexID":6,"TableID":104,"TemporaryIndexID":9}}
  │              ├── MaybeAddSplitForIndex {"IndexID":8,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":8,"Kind":2,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":6,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":7,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":4,"IndexID":8,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":6,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":7,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":8,"Ordinal":1,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase
@@ -210,7 +210,6 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │    └── 17 Mutation operations
  │    │         ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":8,"IndexID":9,"IsUnique":true,"SourceIndexID":6,"TableID":104}}
  │    │         ├── MaybeAddSplitForIndex {"IndexID":9,"TableID":104}
- │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":9,"Kind":2,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":9,"TableID":104}
  │    │         ├── MakeAbsentIndexBackfilling {"IsSecondaryIndex":true}
@@ -223,6 +222,7 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ADD PRIM
  │    │         ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":1,"TableID":104}
  │    │         ├── AddColumnToIndex {"ColumnID":4,"IndexID":5,"Kind":1,"Ordinal":1,"TableID":104}
+ │    │         ├── AddColumnToIndex {"ColumnID":1,"IndexID":9,"Ordinal":1,"TableID":104}
  │    │         ├── SetJobStateOnDescriptor {"DescriptorID":104}
  │    │         └── UpdateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  │    ├── Stage 9 of 16 in PostCommitPhase

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_alter_primary_key_using_hash/alter_table_alter_primary_key_using_hash.explain
@@ -29,12 +29,12 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              ├── AddColumnComputeExpression {"ComputeExpression":{"ColumnID":3,"TableID":104}}
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":5}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":5,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":4,"TableID":104}
- │              └── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+ │              └── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
  ├── PreCommitPhase
  │    ├── Stage 1 of 2 in PreCommitPhase
  │    │    ├── 10 elements transitioning toward PUBLIC
@@ -78,13 +78,13 @@ Schema change plan for ALTER TABLE ‹defaultdb›.‹public›.‹t› ALTER PR
  │              ├── MakeAbsentIndexBackfilling {"Index":{"ConstraintID":5,"IndexID":4,"IsUnique":true,"SourceIndexID":1,"TableID":104,"TemporaryIndexID":5}}
  │              ├── MaybeAddSplitForIndex {"IndexID":4,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":4,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
  │              ├── MakeAbsentTempIndexDeleteOnly {"Index":{"ConstraintID":6,"IndexID":5,"IsUnique":true,"SourceIndexID":1,"TableID":104}}
  │              ├── MaybeAddSplitForIndex {"IndexID":5,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":1,"IndexID":5,"Kind":2,"TableID":104}
- │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":4,"TableID":104}
  │              ├── AddColumnToIndex {"ColumnID":3,"IndexID":5,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":4,"Ordinal":1,"TableID":104}
+ │              ├── AddColumnToIndex {"ColumnID":2,"IndexID":5,"Ordinal":1,"TableID":104}
  │              ├── SetJobStateOnDescriptor {"DescriptorID":104,"Initialize":true}
  │              └── CreateSchemaChangerJob {"RunningStatus":"PostCommitPhase ..."}
  ├── PostCommitPhase


### PR DESCRIPTION
Previously, index columns would be added in order, but no specific rule ensured they were added in that specific order. This became problematic when schema_locked support was added in the declarative schema changer, since out of order execution can lead to runtime errors. This can be observed if a user uses multiple AddGeometryColumn builtins in a statement. To address this, this patch adds a new explicit rule to ensure index columns are added in an increasing order.

Fixes: #147993

Release note (bug fix): Adding multiple columns with AddGeometryColumn in a single statement would run into runtime errors.
Release justification: low risk fix to prevent cases where AddGeometryColumn will fail on schema_locked tables.