### PR TITLE
[dnm] tests: sysbench extra allocs experiment

### DIFF
--- a/pkg/sql/tests/sysbench_test.go
+++ b/pkg/sql/tests/sysbench_test.go
@@ -1022,16 +1022,18 @@ func startAllocsProfile(b testing.TB) doneFn {
 func diffProfile(b testing.TB, take func() []byte) func(testing.TB) []byte {
 	// The below is essentially cribbed from pprof.go in net/http/pprof.
 
-	baseBytes := take()
+	baseBytes := take() // NB: parsed only after we've taken the "after" profile
 	if baseBytes == nil {
 		return func(tb testing.TB) []byte { return nil }
 	}
-	pBase, err := profile.ParseData(baseBytes)
-	require.NoError(b, err)
 
 	return func(b testing.TB) []byte {
 		pNew, err := profile.ParseData(take())
 		require.NoError(b, err)
+
+		pBase, err := profile.ParseData(baseBytes)
+		require.NoError(b, err)
+
 		pBase.Scale(-1)
 		pMerged, err := profile.Merge([]*profile.Profile{pBase, pNew})
 		require.NoError(b, err)


### PR DESCRIPTION
```
./dev bench ./pkg/sql/tests --filter '^BenchmarkSysbench/SQL/1node_local//oltp_point_select' --test-args '-test.cpu=10 -test.count=10 -test.benchtime=10000x' 2>&1 | tee bench.txt
```

```
$ benchstat -col '/extraAllocs' bench.txt
goos: linux
goarch: amd64
cpu: Intel(R) Xeon(R) CPU @ 3.10GHz
                                              │      0      │               1               │               2               │               4               │                 8                  │                 16                 │
                                              │   sec/op    │   sec/op     vs base          │   sec/op     vs base          │   sec/op     vs base          │   sec/op     vs base               │   sec/op     vs base               │
Sysbench/SQL/1node_local/oltp_point_select-10   247.2µ ± 1%   247.9µ ± 1%  ~ (p=0.739 n=10)   247.0µ ± 1%  ~ (p=0.838 n=10)   248.4µ ± 1%  ~ (p=0.315 n=10)   248.8µ ± 1%  +0.67% (p=0.023 n=10)   250.5µ ± 0%  +1.34% (p=0.000 n=10)

                                              │     0      │               1                │               2                │               4                │               8                │               16               │
                                              │  errs/op   │  errs/op    vs base            │  errs/op    vs base            │  errs/op    vs base            │  errs/op    vs base            │  errs/op    vs base            │
Sysbench/SQL/1node_local/oltp_point_select-10   0.000 ± 0%   0.000 ± 0%  ~ (p=1.000 n=10) ¹   0.000 ± 0%  ~ (p=1.000 n=10) ¹   0.000 ± 0%  ~ (p=1.000 n=10) ¹   0.000 ± 0%  ~ (p=1.000 n=10) ¹   0.000 ± 0%  ~ (p=1.000 n=10) ¹
¹ all samples are equal

                                              │      0       │                1                │               2                │                  4                  │               8                │                 16                  │
                                              │     B/op     │     B/op       vs base          │     B/op      vs base          │     B/op      vs base               │     B/op      vs base          │     B/op      vs base               │
Sysbench/SQL/1node_local/oltp_point_select-10   22.60Ki ± 1%   22.65Ki ± 22%  ~ (p=0.469 n=10)   22.72Ki ± 1%  ~ (p=0.073 n=10)   22.79Ki ± 1%  +0.84% (p=0.014 n=10)   22.96Ki ± 3%  ~ (p=0.565 n=10)   23.31Ki ± 2%  +3.14% (p=0.003 n=10)

                                              │     0      │                 1                 │                 2                 │                 4                 │              8               │                16                 │
                                              │ allocs/op  │ allocs/op   vs base               │ allocs/op   vs base               │ allocs/op   vs base               │ allocs/op   vs base          │ allocs/op   vs base               │
Sysbench/SQL/1node_local/oltp_point_select-10   181.0 ± 1%   182.0 ± 5%  +0.55% (p=0.019 n=10)   183.0 ± 1%  +1.10% (p=0.000 n=10)   185.0 ± 1%  +2.21% (p=0.001 n=10)   189.0 ± 5%  ~ (p=0.263 n=10)   196.0 ± 4%  +8.29% (p=0.000 n=10)
```

So with 16 additional allocations, median latency increases from 247.9us to 250.5us, i.e. 2.6u for 16 units, or 162ns per allocation (it truly is just one allocation, even though it looks like it should be 2, I checked via profiling).

So for this particular workload, allocations alone are not going to be nearly enough. If we removed all 181 initial allocations, we'd get only a 29us improvement, which is less than 10%.

Of course not all allocations are created equal, and we're dealing with the smallest possible allocation here.