### PR TITLE
[dnm]: e2e pcr stats

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -342,6 +342,7 @@ func (kv replicateKV) sourceRunCmd(tenantName string, nodes option.NodeListOptio
 		MaybeFlag(kv.debugRunDuration > 0, "duration", kv.debugRunDuration).
 		MaybeFlag(kv.maxQPS > 0, "max-rate", kv.maxQPS).
 		MaybeFlag(kv.readOnly, "prepare-read-only", true).
+		Option("zipfian").
 		Arg("{pgurl%s:%s}", nodes, tenantName).
 		WithEqualsSyntax()
 	return cmd.String()
@@ -1193,7 +1194,7 @@ func registerClusterToCluster(r registry.Registry) {
 				initWithSplitAndScatter: true,
 			},
 			timeout:                              1 * time.Hour,
-			additionalDuration:                   10 * time.Minute,
+			additionalDuration:                   20 * time.Minute,
 			cutover:                              5 * time.Minute,
 			withReaderWorkload:                   replicateKV{readPercent: 100, readOnly: true, tolerateErrors: true},
 			sometimesTestFingerprintMismatchCode: true,

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -843,7 +843,6 @@ func (b *SSTBatcher) addSSTable(
 		}
 	}
 
-
 	work := []*sstSpan{{start: start, end: end, sstBytes: sstBytes, stats: stats}}
 	var files int
 	for len(work) > 0 {
@@ -882,7 +881,7 @@ func (b *SSTBatcher) addSSTable(
 					MVCCStats:                              &item.stats,
 					IngestAsWrites:                         ingestAsWriteBatch,
 					ReturnFollowingLikelyNonEmptySpanStart: true,
-					ComputeStatsDiff: b.ingestAll,
+					ComputeStatsDiff:                       b.ingestAll,
 				}
 				if b.writeAtBatchTS {
 					req.SSTTimestampToRequestTimestamp = batchTS
@@ -962,8 +961,10 @@ func (b *SSTBatcher) addSSTable(
 					if err != nil {
 						return err
 					}
-					if err := addStatsToSplitTables(left, right, item, sendStart); err != nil {
-						return err
+					if (item.stats != enginepb.MVCCStats{}) {
+						if err := addStatsToSplitTables(left, right, item, sendStart); err != nil {
+							return err
+						}
 					}
 					// Add more work.
 					work = append([]*sstSpan{left, right}, work...)

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -2099,6 +2099,8 @@ message AddSSTableRequest {
   // TODO(dt,msbutler,bilal): This is unsupported.
   util.hlc.Timestamp ignore_keys_above_timestamp = 12 [(gogoproto.nullable) = false];
 
+  bool compute_stats_diff = 13 [(gogoproto.customname) = "ComputeStatsDiff"];
+
   reserved 10, 11;
 }
 

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -172,6 +172,10 @@ func EvalAddSSTable(
 		}
 	}
 
+	if err := checkSSTRangeBounds(ctx, sst, start, end); err != nil {
+		return result.Result{}, err
+	}
+
 	// If requested and necessary, rewrite the SST's MVCC timestamps to the
 	// request timestamp. This ensures the writes comply with the timestamp cache
 	// and closed timestamp, i.e. by not writing to timestamps that have already
@@ -194,10 +198,22 @@ func EvalAddSSTable(
 		}
 	}
 
-	var statsDelta enginepb.MVCCStats
 	maxLockConflicts := storage.MaxConflictsPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 	targetLockConflictBytes := storage.TargetBytesPerLockConflictError.Get(&cArgs.EvalCtx.ClusterSettings().SV)
 	checkConflicts := args.DisallowConflicts || !args.DisallowShadowingBelow.IsEmpty()
+
+	leftPeekBound, rightPeekBound := roachpb.Key{}, roachpb.Key{}
+
+	// Get a few vars required for CheckSSTConflicts or ComputeSSTStatsDiff.
+	//
+	// TODO (msbutler): enable prefix seeks for ComputeSSTStatsDiff as well.
+	if checkConflicts || args.ComputeStatsDiff {
+		desc := cArgs.EvalCtx.Desc()
+		leftPeekBound, rightPeekBound = rangeTombstonePeekBounds(
+			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
+	}
+
+	var checkConflictsStatsDelta enginepb.MVCCStats
 	if checkConflicts {
 		// If requested, check for MVCC conflicts with existing keys. This enforces
 		// all MVCC invariants by returning WriteTooOldError for any existing
@@ -207,10 +223,10 @@ func EvalAddSSTable(
 		// Additionally, if DisallowShadowingBelow is set, it will not write
 		// above existing/visible values (but will write above tombstones).
 		//
-		// If the overlap between the ingested SST and the engine is large (i.e.
-		// the SST is wide in keyspace), or if the ingested SST is very small,
-		// use prefix seeks in CheckSSTConflicts. This ends up being more performant
-		// as it avoids expensive seeks with index/data block loading in the common
+		// If the overlap between the ingested SST and the engine is large (i.e. the
+		// SST is wide in keyspace), or if the ingested SST is very small, use
+		// prefix seeks in CheckSSTConflicts. This ends up being more performant as
+		// it avoids expensive seeks with index/data block loading in the common
 		// case of no conflicts.
 		usePrefixSeek := false
 		bytes, err := cArgs.EvalCtx.GetApproximateDiskBytes(start.Key, end.Key)
@@ -224,18 +240,13 @@ func EvalAddSSTable(
 			// bounded with a small number on the SST side.
 			usePrefixSeek = usePrefixSeek || args.MVCCStats.KeyCount < 100
 		}
-		desc := cArgs.EvalCtx.Desc()
-		leftPeekBound, rightPeekBound := rangeTombstonePeekBounds(
-			args.Key, args.EndKey, desc.StartKey.AsRawKey(), desc.EndKey.AsRawKey())
-
 		log.VEventf(ctx, 2, "checking conflicts for SSTable [%s,%s)", start.Key, end.Key)
-		statsDelta, err = storage.CheckSSTConflicts(ctx, sst, readWriter, start, end, leftPeekBound, rightPeekBound,
+		checkConflictsStatsDelta, err = storage.CheckSSTConflicts(ctx, sst, readWriter, start, end, leftPeekBound, rightPeekBound,
 			args.DisallowShadowingBelow, sstTimestamp, maxLockConflicts, targetLockConflictBytes, usePrefixSeek)
-		statsDelta.Add(sstReqStatsDelta)
+		checkConflictsStatsDelta.Add(sstReqStatsDelta)
 		if err != nil {
 			return result.Result{}, errors.Wrap(err, "checking for key collisions")
 		}
-
 	} else {
 		// If not checking for MVCC conflicts, at least check for locks. The
 		// caller is expected to make sure there are no writers across the span,
@@ -250,112 +261,80 @@ func EvalAddSSTable(
 		}
 	}
 
-	// Verify that the keys in the sstable are within the range specified by the
-	// request header, and if the request did not include pre-computed stats,
-	// compute the expected MVCC stats delta of ingesting the SST.
-	sstIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
-		KeyTypes:   storage.IterKeyTypePointsAndRanges,
-		LowerBound: keys.MinKey,
-		UpperBound: keys.MaxKey,
-	})
-	if err != nil {
-		return result.Result{}, err
-	}
-	defer sstIter.Close()
+	// stats will represent the contribution of MVCC stats from the SST to the
+	// range. We assume these stats are not estimates if we:
+	//
+	// 1. Call ComputeSSTStatsDiff below, which computes the exacts stats diff of
+	// the sst, even in the presence of conflicting keys in the local key space.
+	// This computation is likely slower than the second option here, as the
+	// iterators here deal with potentially conflicting key space. Note that this
+	// computation will throw an error if there is a range key in the incoming
+	// sst.
+	//
+	// 2. Call for CheckForSSTConflicts above, which asserts the sst does not
+	// overlap with any underlying keys. Note that the checkConflictsStatsDelta is
+	// a delta between the SST-only statistics and their effect when applied,
+	// which when added to the SST statistics, will adjust them for existing keys
+	// and values. Thus, we still need to compute the sst-only statistics on this
+	// branch. Also note that CheckForSSTConflicts can still return estimates in
+	// certain corner cases.
+	//
+	// While computing stats in this request requires a potentially expensive scan
+	// of the local range, it ensures a healthy allocator that makes good
+	// decisions on when to split/merge or gc a range (etc). Stats estimates may
+	// not be harmful if we assume that most SSTs don't shadow too many keys, so
+	// the error of simply adding the SST stats directly to the range stats is
+	// minimal. In the worst-case, when we retry a whole SST, then it could be
+	// overcounting the entire file, but we can hope that that is rare.
+	//
+	// TODO (msbutler): flesh out definition of "conflicting" keys here.
 
-	// Check that the first key is in the expected range.
-	sstIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
-	if ok, err := sstIter.Valid(); err != nil {
-		return result.Result{}, err
-	} else if ok {
-		if unsafeKey := sstIter.UnsafeKey(); unsafeKey.Less(start) {
-			return result.Result{}, errors.Errorf("first key %s not in request range [%s,%s)",
-				unsafeKey.Key, start.Key, end.Key)
-		}
-	}
-
-	// Get the MVCCStats for the SST being ingested.
 	var stats enginepb.MVCCStats
-	if args.MVCCStats != nil {
-		stats = *args.MVCCStats
-	} else {
-		log.VEventf(ctx, 2, "computing MVCCStats for SSTable [%s,%s)", start.Key, end.Key)
-		stats, err = storage.ComputeStatsForIter(sstIter, h.Timestamp.WallTime)
-		if err != nil {
-			return result.Result{}, errors.Wrap(err, "computing SSTable MVCC stats")
-		}
-	}
-
-	sstIter.SeekGE(end)
-	if ok, err := sstIter.Valid(); err != nil {
-		return result.Result{}, err
-	} else if ok {
-		return result.Result{}, errors.Errorf("last key %s not in request range [%s,%s)",
-			sstIter.UnsafeKey(), start.Key, end.Key)
-	}
-
-	// The above MVCCStats represents what is in this new SST.
-	//
-	// *If* the keys in the SST do not conflict with keys currently in this range,
-	// then adding the stats for this SST to the range stats should yield the
-	// correct overall stats.
-	//
-	// *However*, if the keys in this range *do* overlap with keys already in this
-	// range, then adding the SST semantically *replaces*, rather than adds, those
-	// keys, and the net effect on the stats is not so simple.
-	//
-	// To perfectly compute the correct net stats, you could a) determine the
-	// stats for the span of the existing range that this SST covers and subtract
-	// it from the range's stats, then b) use a merging iterator that reads from
-	// the SST and then underlying range and compute the stats of that merged
-	// span, and then add those stats back in. That would result in correct stats
-	// that reflect the merging semantics when the SST "shadows" an existing key.
-	//
-	// If the underlying range is mostly empty, this isn't terribly expensive --
-	// computing the existing stats to subtract is cheap, as there is little or no
-	// existing data to traverse and b) is also pretty cheap -- the merging
-	// iterator can quickly iterate the in-memory SST.
-	//
-	// However, if the underlying range is _not_ empty, then this is not cheap:
-	// recomputing its stats involves traversing lots of data, and iterating the
-	// merged iterator has to constantly go back and forth to the iterator.
-	//
-	// If we assume that most SSTs don't shadow too many keys, then the error of
-	// simply adding the SST stats directly to the range stats is minimal. In the
-	// worst-case, when we retry a whole SST, then it could be overcounting the
-	// entire file, but we can hope that that is rare. In the worst case, it may
-	// cause splitting an under-filled range that would later merge when the
-	// over-count is fixed.
-	//
-	// We can indicate that these stats contain this estimation using the flag in
-	// the MVCC stats so that later re-computations will not be surprised to find
-	// any discrepancies.
-	//
-	// Callers can trigger such a re-computation to fixup any discrepancies (and
-	// remove the ContainsEstimates flag) after they are done ingesting files by
-	// sending an explicit recompute.
-	//
-	// There is a significant performance win to be achieved by ensuring that the
-	// stats computed are not estimates as it prevents recomputation on splits.
-	// Running AddSSTable with disallowShadowing=true gets us close to this as we
-	// do not allow colliding keys to be ingested. However, in the situation that
-	// two SSTs have KV(s) which "perfectly" shadow an existing key (equal ts and
-	// value), we do not consider this a collision. While the KV would just
-	// overwrite the existing data, the stats would be added to the cumulative
-	// stats of the AddSSTable command, causing a double count for such KVs.
-	// Therefore, we compute the stats for these "skipped" KVs on-the-fly while
-	// checking for the collision condition in C++ and subtract them from the
-	// stats of the SST being ingested before adding them to the running
-	// cumulative for this command. These stats can then be marked as accurate.
-	if checkConflicts {
-		stats.Add(statsDelta)
-		if statsDelta.ContainsEstimates == 0 {
-			stats.ContainsEstimates = 0
-		}
-	} else {
+	stats.Add(checkConflictsStatsDelta)
+	if !(checkConflicts || args.ComputeStatsDiff) {
 		stats.ContainsEstimates++
 	}
+	if args.ComputeStatsDiff {
+		if !checkConflictsStatsDelta.Equal(enginepb.MVCCStats{}) {
+			return result.Result{}, errors.New(
+				"AddSSTableRequest.ComputeStatsDiff cannot be used with DisallowConflicts or DisallowShadowingBelow")
+		}
+		if args.MVCCStats != nil {
+			return result.Result{}, errors.New(
+				"AddSSTableRequest.ComputeStatsDiff cannot be used with precomputed MVCCStats")
+		}
+		stats, err = storage.ComputeSSTStatsDiff(
+			ctx, sst, readWriter, start, end, leftPeekBound, rightPeekBound)
+		if err != nil {
+			return result.Result{}, err
+		}
+	} else if args.MVCCStats != nil {
+		stats.Add(*args.MVCCStats)
+	} else {
+		sstIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+			KeyTypes:   storage.IterKeyTypePointsAndRanges,
+			LowerBound: keys.MinKey,
+			UpperBound: keys.MaxKey,
+		})
+		if err != nil {
+			return result.Result{}, err
+		}
+		defer sstIter.Close()
 
+		sstIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+		if ok, err := sstIter.Valid(); err != nil {
+			return result.Result{}, err
+		} else if ok {
+			// TODO(msbutler): this implies we tolerate ingesting an empty addstable.
+			// Perhaps we should reject empty addstable requests?
+			log.VEventf(ctx, 2, "computing MVCCStats for SSTable [%s,%s)", start.Key, end.Key)
+			sstStats, err := storage.ComputeStatsForIter(sstIter, h.Timestamp.WallTime)
+			if err != nil {
+				return result.Result{}, errors.Wrap(err, "computing SSTable MVCC stats")
+			}
+			stats.Add(sstStats)
+		}
+	}
 	ms.Add(stats)
 
 	var mvccHistoryMutation *kvserverpb.ReplicatedEvalResult_MVCCHistoryMutation
@@ -503,6 +482,39 @@ func EvalAddSSTable(
 			MVCCHistoryMutation: mvccHistoryMutation,
 		},
 	}, nil
+}
+
+// checkSSTRangeBounds verifies that the keys in the sstable are within the
+// range specified by the request header.
+func checkSSTRangeBounds(ctx context.Context, sst []byte, start, end storage.MVCCKey) error {
+	sstIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
+		KeyTypes:   storage.IterKeyTypePointsAndRanges,
+		LowerBound: keys.MinKey,
+		UpperBound: keys.MaxKey,
+	})
+	if err != nil {
+		return err
+	}
+	defer sstIter.Close()
+
+	// Check that the first key is in the expected range.
+	sstIter.SeekGE(storage.MVCCKey{Key: keys.MinKey})
+	if ok, err := sstIter.Valid(); err != nil {
+		return err
+	} else if ok {
+		if unsafeKey := sstIter.UnsafeKey(); unsafeKey.Less(start) {
+			return errors.Errorf("first key %s not in request range [%s,%s)",
+				unsafeKey.Key, start.Key, end.Key)
+		}
+	}
+	sstIter.SeekGE(end)
+	if ok, err := sstIter.Valid(); err != nil {
+		return err
+	} else if ok {
+		return errors.Errorf("last key %s not in request range [%s,%s)",
+			sstIter.UnsafeKey(), start.Key, end.Key)
+	}
+	return err
 }
 
 // assertSSTContents checks that the SST contains expected inputs:

--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -290,6 +290,7 @@ func EvalAddSSTable(
 	// TODO (msbutler): flesh out definition of "conflicting" keys here.
 
 	var stats enginepb.MVCCStats
+	preComputedStats := *args.MVCCStats
 	stats.Add(checkConflictsStatsDelta)
 	if !(checkConflicts || args.ComputeStatsDiff) {
 		stats.ContainsEstimates++
@@ -299,7 +300,7 @@ func EvalAddSSTable(
 			return result.Result{}, errors.New(
 				"AddSSTableRequest.ComputeStatsDiff cannot be used with DisallowConflicts or DisallowShadowingBelow")
 		}
-		if args.MVCCStats != nil {
+		if preComputedStats != (enginepb.MVCCStats{}) {
 			return result.Result{}, errors.New(
 				"AddSSTableRequest.ComputeStatsDiff cannot be used with precomputed MVCCStats")
 		}
@@ -308,8 +309,8 @@ func EvalAddSSTable(
 		if err != nil {
 			return result.Result{}, err
 		}
-	} else if args.MVCCStats != nil {
-		stats.Add(*args.MVCCStats)
+	} else if preComputedStats != (enginepb.MVCCStats{}) {
+		stats.Add(preComputedStats)
 	} else {
 		sstIter, err := storage.NewMemSSTIterator(sst, true /* verify */, storage.IterOptions{
 			KeyTypes:   storage.IterKeyTypePointsAndRanges,

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -148,6 +148,7 @@ go_test(
         "pebble_mvcc_scanner_test.go",
         "pebble_test.go",
         "read_as_of_iterator_test.go",
+        "sst_stats_diff_test.go",
         "sst_test.go",
         "sst_writer_test.go",
         "store_properties_test.go",

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -209,7 +209,7 @@ func ComputeSSTStatsDiff(
 		sstKeySameAsLocal := localIterKey.Key.Compare(sstIterKey.Key) == 0
 		sstKeyShadowsLocal := sstKeySameAsLocal && localIterKey.Timestamp.Less(sstIterKey.Timestamp)
 		prevKeyShadowsSSTKey := prevSSTKey.Key.Compare(sstIterKey.Key) == 0 && sstIterKey.Timestamp.Less(prevSSTKey.Timestamp)
-		prevSSTKey.Key = append(prevSSTKey.Key, sstIterKey.Key...)
+		prevSSTKey.Key = append(prevSSTKey.Key[:0], sstIterKey.Key...)
 		prevSSTKey.Timestamp.WallTime = sstIterKey.Timestamp.WallTime
 		prevSSTKey.Timestamp.Logical = sstIterKey.Timestamp.Logical
 
@@ -222,6 +222,9 @@ func ComputeSSTStatsDiff(
 			continue
 		}
 
+		// ismetaKey suggests the current sstKey is the latest version of a key,
+		// which happens when the previous sst key does not shadow the current sst
+		// key and one of: the sst key shadows a local key or there is no local key.
 		isMetaKey := (sstKeyShadowsLocal || !sstKeySameAsLocal) && !prevKeyShadowsSSTKey
 		sstKeyIsLive := !sstValueIsTombstone && isMetaKey
 

--- a/pkg/storage/sst_stats_diff_test.go
+++ b/pkg/storage/sst_stats_diff_test.go
@@ -1,0 +1,208 @@
+// Copyright 2014 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package storage_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/keys"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/fs"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/kr/pretty"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMVCCComputeSSTStatsDiff(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	st := cluster.MakeTestingClusterSettings()
+
+	rng, _ := randutil.NewPseudoRand()
+
+	engine := storage.NewDefaultInMemForTesting()
+	defer engine.Close()
+
+	randString := func(n int) string {
+		const letters = "abcdefghijklmnopqrstuvwxyz"
+		b := make([]byte, n)
+		for i := range b {
+			b[i] = letters[rng.Intn(len(letters))]
+		}
+		return string(b)
+	}
+
+	// p parses a string of point KVs like "b1a1".
+	p := func(stringifiedKVs string) storageutils.KVs {
+		kvs := storageutils.KVs{}
+		for i := 0; i < len(stringifiedKVs); i += 2 {
+			key := string(stringifiedKVs[i])
+			ts := int64(stringifiedKVs[i+1])
+			value := randString(rng.Intn(10) + 1)
+			kv := storageutils.PointKV(key, int(ts), value)
+			kvs = append(kvs, kv)
+		}
+		return kvs
+	}
+
+	testCases := []struct {
+		name  string
+		sst   storageutils.KVs
+		local storageutils.KVs
+	}{
+		{
+			name:  "emptyKeyspace",
+			sst:   p("a1"),
+			local: p(""),
+		},
+		{
+			name:  "emptyKeySpaceHistory",
+			sst:   p("a2a1"),
+			local: p(""),
+		},
+		{
+			name:  "insert",
+			sst:   p("a1"),
+			local: p("b1"),
+		},
+		{
+			name:  "update",
+			sst:   p("a2"),
+			local: p("a1"),
+		},
+		{
+			name:  "delete",
+			sst:   storageutils.KVs{storageutils.PointKV("a", 2, "")},
+			local: p("a1"),
+		},
+		{
+			name:  "exhaustLocal",
+			sst:   p("b1"),
+			local: p("a1"),
+		},
+		{
+			name:  "exhaustSST",
+			sst:   p("a1"),
+			local: p("b1"),
+		},
+		{
+			name:  "shadow",
+			sst:   p("a1"),
+			local: p("a2"),
+		},
+		{
+			name:  "dupe",
+			sst:   storageutils.KVs{storageutils.PointKV("a", 2, "a2")},
+			local: storageutils.KVs{storageutils.PointKV("a", 2, "a2")},
+		},
+		{
+			name:  "sstHistoryGreaterThanLocal",
+			sst:   p("a3a2"),
+			local: p("a1"),
+		},
+		{
+			name:  "sstHistoryLessThanLocal",
+			sst:   p("a2a1"),
+			local: p("a3"),
+		},
+		{
+			name:  "sstHistoryStraddlesLocal",
+			sst:   p("a3a1"),
+			local: p("a2"),
+		},
+		{
+			name:  "localHistoryGreaterThanSST",
+			sst:   p("a1"),
+			local: p("a3a2"),
+		},
+		{
+			name:  "localHistoryLessThanSST",
+			sst:   p("a3"),
+			local: p("a2a1"),
+		},
+		{
+			name:  "localStraddlesSST",
+			sst:   p("a2"),
+			local: p("a3a1"),
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			testutils.RunTrueAndFalse(t, "randomDeletes", func(t *testing.T, randomDeletes bool) {
+
+				// Clear the engine before each test, so stats collection for each test
+				// is independent.
+				require.NoError(t, engine.Excise(ctx, roachpb.Span{Key: keys.LocalMax, EndKey: roachpb.KeyMax}))
+
+				if tc.name == "dupe" && randomDeletes {
+					t.Log("skipping dupe test with random deletes as it is nonsenical to write a key with the same timestamp but different value")
+					return
+				}
+				localT := tc.local
+				sstT := tc.sst
+				if randomDeletes {
+					deleteSwap := func(kvs storageutils.KVs) storageutils.KVs {
+						for i := range kvs {
+							if rng.Intn(2) == 0 {
+								kv := kvs[i].(storage.MVCCKeyValue)
+								encodedTombstoneValue, err := storage.EncodeMVCCValue(storage.MVCCValue{})
+								require.NoError(t, err)
+								kv.Value = encodedTombstoneValue
+								kvs[i] = kv
+							}
+						}
+						return kvs
+					}
+					// Randomly delete some keys in the local history.
+					localT = deleteSwap(tc.local)
+					sstT = deleteSwap(tc.sst)
+				}
+
+				local, _, _ := storageutils.MakeSST(t, st, localT)
+				require.NoError(t, fs.WriteFile(engine.Env(), "local", local, fs.UnspecifiedWriteCategory))
+				require.NoError(t, engine.IngestLocalFiles(ctx, []string{"local"}))
+
+				baseStats, err := storage.ComputeStats(ctx, engine, keys.LocalMax, roachpb.KeyMax, 0)
+				require.NoError(t, err)
+
+				sst, startUnversioned, endUnversioned := storageutils.MakeSST(t, st, sstT)
+				start := storage.MVCCKey{Key: startUnversioned}
+				end := storage.MVCCKey{Key: endUnversioned}
+
+				statsDelta, err := storage.ComputeSSTStatsDiff(
+					ctx, sst, engine, start, end, nil, nil)
+				require.NoError(t, err)
+
+				require.NoError(t, fs.WriteFile(engine.Env(), "sst", sst, fs.UnspecifiedWriteCategory))
+				require.NoError(t, engine.IngestLocalFiles(ctx, []string{"sst"}))
+
+				expStats, err := storage.ComputeStats(ctx, engine, keys.LocalMax, roachpb.KeyMax, 0)
+				require.NoError(t, err)
+
+				baseStats.Add(statsDelta)
+
+				baseStats.AgeTo(expStats.LastUpdateNanos)
+				t.Logf("sst %s, local %s", sstT, localT)
+				if !baseStats.Equal(expStats) {
+					t.Log("test, expected")
+					pretty.Ldiff(t, baseStats, expStats)
+					t.Errorf("%s: diff(ms, expMS) nontrivial", tc.name)
+				}
+			})
+		})
+	}
+}

--- a/pkg/storage/sst_stats_diff_test.go
+++ b/pkg/storage/sst_stats_diff_test.go
@@ -114,6 +114,11 @@ func TestMVCCComputeSSTStatsDiff(t *testing.T) {
 			local: p("a1"),
 		},
 		{
+			name:  "sstHistoryThreeVersionsGreaterThanLocal",
+			sst:   p("a4a3a2"),
+			local: p("a1"),
+		},
+		{
 			name:  "sstHistoryLessThanLocal",
 			sst:   p("a2a1"),
 			local: p("a3"),


### PR DESCRIPTION
This patch adds the new ComputeSSTStatsDiff utility which will be called in
batcheval.EvalAddSSTable in a future PR to ingest an sst over non empty key
space with an accurate stats update.

Informs #145548

Release note: none