### PR TITLE
release-25.1: workload/schemachanger: treat dependency error as potential error in column rename

### DIFF
--- a/pkg/workload/schemachange/error_screening.go
+++ b/pkg/workload/schemachange/error_screening.go
@@ -392,43 +392,6 @@ func (og *operationGenerator) colIsRefByComputed(
 	return colIsRefByGeneratedExpr, nil
 }
 
-func (og *operationGenerator) columnIsDependedOnByView(
-	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name,
-) (bool, error) {
-	return og.scanBool(ctx, tx, `SELECT EXISTS(
-		SELECT source.column_id
-			FROM (
-			   SELECT DISTINCT column_id
-			     FROM (
-			           SELECT unnest(
-			                   string_to_array(
-			                    rtrim(
-			                     ltrim(
-			                      fd.dependedonby_details,
-			                      'Columns: ['
-			                     ),
-			                     ']'
-			                    ),
-			                    ' '
-			                   )::INT8[]
-			                  ) AS column_id
-			             FROM crdb_internal.forward_dependencies
-			                   AS fd
-			            WHERE fd.descriptor_id
-			                  = $1::REGCLASS
-                    AND fd.dependedonby_type != 'sequence'
-			            )
-			 ) AS cons
-			 INNER JOIN (
-			   SELECT ordinal_position AS column_id
-			     FROM information_schema.columns
-			    WHERE table_schema = $2
-			      AND table_name = $3
-			      AND column_name = $4
-			  ) AS source ON source.column_id = cons.column_id
-)`, tableName.String(), tableName.Schema(), tableName.Object(), columnName)
-}
-
 func (og *operationGenerator) colIsPrimaryKey(
 	ctx context.Context, tx pgx.Tx, tableName *tree.TableName, columnName tree.Name,
 ) (bool, error) {

--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -2134,17 +2134,17 @@ func (og *operationGenerator) renameColumn(ctx context.Context, tx pgx.Tx) (*opS
 	if err != nil {
 		return nil, err
 	}
-	columnIsDependedOnByView, err := og.columnIsDependedOnByView(ctx, tx, tableName, srcColumnName)
-	if err != nil {
-		return nil, err
-	}
 
 	stmt := makeOpStmt(OpStmtDDL)
 	stmt.expectedExecErrors.addAll(codesWithConditions{
 		{pgcode.UndefinedColumn, !srcColumnExists},
 		{pgcode.DuplicateColumn, destColumnExists && srcColumnName != destColumnName},
-		{pgcode.DependentObjectsStillExist, columnIsDependedOnByView},
 	})
+	// The column may be referenced in a view or trigger, which can lead to a
+	// dependency error. This is particularly hard to detect in cases where renaming
+	// a column that is part of a hash-sharded primary key triggers a cascading rename
+	// of the crdb_internal shard column, which might be used indirectly by other objects.
+	stmt.potentialExecErrors.add(pgcode.DependentObjectsStillExist)
 
 	stmt.sql = fmt.Sprintf(`ALTER TABLE %s RENAME COLUMN %s TO %s`,
 		tableName.String(), srcColumnName.String(), destColumnName.String())


### PR DESCRIPTION
Backport 1/1 commits from #147979 on behalf of @spilchen.

----

We previously enforced a strict check to determine if a column being renamed was used by another object. However, this check was incomplete. When the column is part of a hash-sharded primary key, renaming it triggers a rename of the corresponding crdb_internal shard column. If another object (e.g., a trigger) depends on the shard column, the dependency isn’t detected via the original column.

Rather than try to add this dependency finding logic. I now treat dependency errors as potential errors unconditionally when renaming a column.

Informs #147514
Fixes: #148078

Epic: none
Release note: none

----

Release justification: low risk test only change