### PR TITLE
githubpost: remove triage column card

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -2,23 +2,7 @@
 # metadata about the team.
 # Expected structure is available in pkg/internal/team/team.go.
 
-# Finding triage_column_id:
-#   TriageColumnID is the column id of the project column the team uses to
-#   triage issues. To get it, open the project, click the "..." on top of
-#   the project column, and click "Copy column link". That link contains
-#   the ID as the `#column-<ID>` fragment.
-#
-# You can also use:
-#   https://github.com/cockroachlabs/github-find-triage-column-id using
-#   `go install github.com/cockroachlabs/github-find-triage-column-id@latest`.
-#
-#   Then to retrieve triage_column_id from a repo-based project, run:
-#     github-get-column-id --repo "cockroach" --project "Bazel" --column "To do"
-#   Or retrieve the triage_column_id from a organization-based project, run:
-#     github-get-column-id --project "Spatial" --column "Backlog"
-
 cockroachdb/docs:
-  triage_column_id: 3971225
   aliases:
     cockroachdb/docs-infra-prs: other
 cockroachdb/sql-foundations:
@@ -26,15 +10,13 @@ cockroachdb/sql-foundations:
     cockroachdb/sql-syntax-prs: other
     cockroachdb/sqlproxy-prs: other
     cockroachdb/sql-api-prs: other
-  triage_column_id: 19467489
   label: T-sql-foundations
 cockroachdb/sql-queries:
   aliases:
     cockroachdb/sql-queries-prs: other
     cockroachdb/sql-optimizer: other
     cockroachdb/sql-opt-prs: other
-  # SQL Queries team uses GH projects v2, which doesn't have a REST API, so
-  # there is no triage column ID.
+  # SQL Queries team uses GH projects v2.
   # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
   silence_mentions: true
@@ -46,37 +28,28 @@ cockroachdb/kv:
     # into slice form for just this.
     'cockroachdb/kv-triage ': unittest
     cockroachdb/kv-prs: other
-  triage_column_id: 14242655
   label: T-kv
 cockroachdb/spatial:
-  triage_column_id: 9487269
   label: T-spatial
 cockroachdb/dev-inf:
-  triage_column_id: 10210759
   label: T-dev-inf
 cockroachdb/drp-eng:
-  triage_column_id: 14041337
   label: T-drpeng
 cockroachdb/multiregion:
-  triage_column_id: 11926170
   label: T-multiregion
 cockroachdb/storage:
   aliases:
     cockroachdb/admission-control: other
-  triage_column_id: 6668367
   label: T-storage
 cockroachdb/test-eng:
-  triage_column_id: 14041337
   label: T-testeng
 cockroachdb/test-eng-prs:
-  triage_column_id: 14041337
   label: T-testeng
 cockroachdb/security-engineering:
   label: T-security-engineering
 cockroachdb/product-security:
   label: T-product-security
 cockroachdb/disaster-recovery:
-  triage_column_id: 3097123
   label: T-disaster-recovery
 cockroachdb/cdc:
   aliases:
@@ -89,7 +62,6 @@ cockroachdb/server:
     cockroachdb/cli-prs: other
     cockroachdb/server-prs: other
   label: T-db-server
-  triage_column_id: 2521812
 cockroachdb/obs-prs:
   # The observability team uses Jira for managing issues. So there is no triage column ID.
   label: T-observability
@@ -101,20 +73,16 @@ cockroachdb/jobs:
   # see .github/workflows/add-issues-to-project.yml
   label: T-jobs
 cockroachdb/cloud-identity:
-  triage_column_id: 18588697
 cockroachdb/unowned:
   aliases:
     cockroachdb/rfc-prs: other
-  triage_column_id: 0 # TODO
 cockroachdb/migrations:
   label: T-migrations
-  triage_column_id: 18330909
 cockroachdb/release-eng:
   aliases:
     cockroachdb/release-eng-prs: other
     cockroachdb/upgrade-prs: other
   label: T-release
-  triage_column_id: 9149730
 cockroachdb/field-engineering:
   # Field Eng isn't currently using github projects.
   label: T-field-eng

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -60,14 +60,12 @@ func DefaultFormatter(ctx context.Context, f Failure) (issues.IssueFormatter, is
 	repro := fmt.Sprintf("./dev test ./pkg/%s --race --stress -f %s",
 		trimPkg(f.packageName), f.testName)
 
-	var projColID int
 	var mentions []string
 	var labels []string
 	if os.Getenv("SKIP_LABEL_TEST_FAILURE") == "" {
 		labels = append(labels, issues.DefaultLabels...)
 	}
 	if len(teams) > 0 {
-		projColID = teams[0].TriageColumnID
 		for _, tm := range teams {
 			if !tm.SilenceMentions {
 				var hasAliases bool
@@ -93,7 +91,6 @@ func DefaultFormatter(ctx context.Context, f Failure) (issues.IssueFormatter, is
 		Artifacts:       "/", // best we can do for unit tests
 		HelpCommand:     issues.UnitTestHelpCommand(repro),
 		MentionOnCreate: mentions,
-		ProjectColumnID: projColID,
 		Labels:          labels,
 	}
 }

--- a/pkg/cmd/bazci/githubpost/githubpost_test.go
+++ b/pkg/cmd/bazci/githubpost/githubpost_test.go
@@ -392,7 +392,6 @@ TestXXA - 1.00s
 					require.Equal(t, expRepro, actRepro)
 				}
 				assert.Equal(t, c.expIssues[curIssue].mention, req.MentionOnCreate)
-				assert.Equal(t, c.expIssues[curIssue].hasProject, req.ProjectColumnID != 0)
 				assert.Equal(t, c.expIssues[curIssue].labels, req.Labels)
 				// On next invocation, we'll check the next expected issue.
 				curIssue++

--- a/pkg/cmd/roachprod-microbench/github_test.go
+++ b/pkg/cmd/roachprod-microbench/github_test.go
@@ -59,7 +59,6 @@ func formatPostRequest(formatter issues.IssueFormatter, req issues.PostRequest) 
 	// These fields can vary based on the test env so we set them to arbitrary
 	// values here.
 	req.MentionOnCreate = []string{"@test-eng"}
-	req.ProjectColumnID = 0
 
 	data := issues.TemplateData{
 		PostRequest:      req,

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -179,7 +179,6 @@ func (g *githubIssues) createPostRequest(
 	params map[string]string,
 ) (issues.PostRequest, error) {
 	var mention []string
-	var projColID int
 
 	var (
 		issueOwner    = spec.Owner
@@ -253,7 +252,6 @@ func (g *githubIssues) createPostRequest(
 				labels = append(labels, label)
 			}
 		}
-		projColID = teams[sl[0]].TriageColumnID
 	}
 
 	branch := os.Getenv("TC_BUILD_BRANCH")
@@ -288,7 +286,6 @@ func (g *githubIssues) createPostRequest(
 
 	return issues.PostRequest{
 		MentionOnCreate: mention,
-		ProjectColumnID: projColID,
 		PackageName:     "roachtest",
 		TestName:        issueName,
 		Labels:          labels,

--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -35,12 +35,10 @@ var (
 	teamsYaml = `cockroachdb/unowned:
   aliases:
     cockroachdb/rfc-prs: other
-  triage_column_id: 0
 cockroachdb/test-eng:
   label: T-testeng
-  triage_column_id: 14041337
 cockroachdb/dev-inf:
-  triage_column_id: 10210759`
+  label: T-dev-inf`
 
 	validTeamsFn   = func() (team.Map, error) { return loadYamlTeams(teamsYaml) }
 	invalidTeamsFn = func() (team.Map, error) { return loadYamlTeams("invalid yaml") }

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -2,23 +2,7 @@
 # metadata about the team.
 # Expected structure is available in pkg/internal/team/team.go.
 
-# Finding triage_column_id:
-#   TriageColumnID is the column id of the project column the team uses to
-#   triage issues. To get it, open the project, click the "..." on top of
-#   the project column, and click "Copy column link". That link contains
-#   the ID as the `#column-<ID>` fragment.
-#
-# You can also use:
-#   https://github.com/cockroachlabs/github-find-triage-column-id using
-#   `go install github.com/cockroachlabs/github-find-triage-column-id@latest`.
-#
-#   Then to retrieve triage_column_id from a repo-based project, run:
-#     github-get-column-id --repo "cockroach" --project "Bazel" --column "To do"
-#   Or retrieve the triage_column_id from a organization-based project, run:
-#     github-get-column-id --project "Spatial" --column "Backlog"
-
 cockroachdb/docs:
-  triage_column_id: 3971225
   aliases:
     cockroachdb/docs-infra-prs: other
 cockroachdb/sql-foundations:
@@ -26,15 +10,13 @@ cockroachdb/sql-foundations:
     cockroachdb/sql-syntax-prs: other
     cockroachdb/sqlproxy-prs: other
     cockroachdb/sql-api-prs: other
-  triage_column_id: 19467489
   label: T-sql-foundations
 cockroachdb/sql-queries:
   aliases:
     cockroachdb/sql-queries-prs: other
     cockroachdb/sql-optimizer: other
     cockroachdb/sql-opt-prs: other
-  # SQL Queries team uses GH projects v2, which doesn't have a REST API, so
-  # there is no triage column ID.
+  # SQL Queries team uses GH projects v2.
   # See .github/workflows/add-issues-to-project.yml.
   label: T-sql-queries
   silence_mentions: true
@@ -46,37 +28,28 @@ cockroachdb/kv:
     # into slice form for just this.
     'cockroachdb/kv-triage ': unittest
     cockroachdb/kv-prs: other
-  triage_column_id: 14242655
   label: T-kv
 cockroachdb/spatial:
-  triage_column_id: 9487269
   label: T-spatial
 cockroachdb/dev-inf:
-  triage_column_id: 10210759
   label: T-dev-inf
 cockroachdb/drp-eng:
-  triage_column_id: 14041337
   label: T-drpeng
 cockroachdb/multiregion:
-  triage_column_id: 11926170
   label: T-multiregion
 cockroachdb/storage:
   aliases:
     cockroachdb/admission-control: other
-  triage_column_id: 6668367
   label: T-storage
 cockroachdb/test-eng:
-  triage_column_id: 14041337
   label: T-testeng
 cockroachdb/test-eng-prs:
-  triage_column_id: 14041337
   label: T-testeng
 cockroachdb/security-engineering:
   label: T-security-engineering
 cockroachdb/product-security:
   label: T-product-security
 cockroachdb/disaster-recovery:
-  triage_column_id: 3097123
   label: T-disaster-recovery
 cockroachdb/cdc:
   aliases:
@@ -89,7 +62,6 @@ cockroachdb/server:
     cockroachdb/cli-prs: other
     cockroachdb/server-prs: other
   label: T-db-server
-  triage_column_id: 2521812
 cockroachdb/obs-prs:
   # The observability team uses Jira for managing issues. So there is no triage column ID.
   label: T-observability
@@ -101,20 +73,16 @@ cockroachdb/jobs:
   # see .github/workflows/add-issues-to-project.yml
   label: T-jobs
 cockroachdb/cloud-identity:
-  triage_column_id: 18588697
 cockroachdb/unowned:
   aliases:
     cockroachdb/rfc-prs: other
-  triage_column_id: 0 # TODO
 cockroachdb/migrations:
   label: T-migrations
-  triage_column_id: 18330909
 cockroachdb/release-eng:
   aliases:
     cockroachdb/release-eng-prs: other
     cockroachdb/upgrade-prs: other
   label: T-release
-  triage_column_id: 9149730
 cockroachdb/field-engineering:
   # Field Eng isn't currently using github projects.
   label: T-field-eng

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -32,8 +32,6 @@ type Team struct {
 	Aliases map[Alias]Purpose `yaml:"aliases"`
 	// GitHub label will be added to issues posted for this team.
 	Label string `yaml:"label"`
-	// TriageColumnID is the GitHub Column ID to assign issues to.
-	TriageColumnID int `yaml:"triage_column_id"`
 	// SilenceMentions is true if @-mentions should be supressed for this team.
 	SilenceMentions bool `yaml:"silence_mentions"`
 }

--- a/pkg/internal/team/team_test.go
+++ b/pkg/internal/team/team_test.go
@@ -18,10 +18,8 @@ sql:
   aliases:
     sql-alias: other
     sql-roachtest: roachtest
-  triage_column_id: 1
   silence_mentions: true
 test-infra-team:
-  triage_column_id: 2
 `)
 	ret, err := LoadTeams(bytes.NewReader(yamlFile))
 	require.NoError(t, err)
@@ -31,7 +29,6 @@ test-infra-team:
 			"sql-alias":     PurposeOther,
 			"sql-roachtest": PurposeRoachtest,
 		},
-		TriageColumnID:  1,
 		SilenceMentions: true,
 	}
 	require.Equal(t, sqlTeam.TeamName, sqlTeam.Name())
@@ -63,8 +60,7 @@ test-infra-team:
 			"sql-alias":     sqlTeam,
 			"sql-roachtest": sqlTeam,
 			"test-infra-team": {
-				TeamName:       "test-infra-team",
-				TriageColumnID: 2,
+				TeamName: "test-infra-team",
 			},
 		},
 		ret,


### PR DESCRIPTION
The classic GitHub projects and their APIs have been deprecated. The API is no longer functional. Observed in recent roachtest failures:

```
2025/06/07 18:07:31 issues.go:454: could not create GitHub project card: POST https://api.github.com/projects/columns/6668367/cards: 410 Projects (classic) has been deprecated in favor of the new Projects experience. []

```

Remove the triage column IDs and automatic posting to a classic GitHub project.

Epic: none
Release note: None