### PR TITLE
kvserver: plumb sst stats by value in EvalAddSSTable

### DIFF
--- a/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
+++ b/pkg/kv/kvserver/batcheval/cmd_add_sstable.go
@@ -187,7 +187,7 @@ func EvalAddSSTable(
 			log.VEventf(ctx, 2, "rewriting timestamps for SSTable [%s,%s) from %s to %s",
 				start.Key, end.Key, sstToReqTS, h.Timestamp)
 			sst, sstReqStatsDelta, err = storage.UpdateSSTTimestamps(
-				ctx, st, sst, sstToReqTS, h.Timestamp, conc, args.MVCCStats)
+				ctx, st, sst, sstToReqTS, h.Timestamp, conc, *args.MVCCStats)
 			if err != nil {
 				return result.Result{}, errors.Wrap(err, "updating SST timestamps")
 			}

--- a/pkg/storage/enginepb/mvcc.go
+++ b/pkg/storage/enginepb/mvcc.go
@@ -142,6 +142,10 @@ func (t TxnMeta) Short() redact.SafeString {
 	return redact.SafeString(t.ID.Short().String())
 }
 
+func (ms MVCCStats) IsEmpty() bool {
+	return ms == MVCCStats{}
+}
+
 // Total returns the range size as the sum of the key and value
 // bytes. This includes all non-live keys and all versioned values,
 // both for point and range keys.

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -1212,7 +1212,7 @@ func UpdateSSTTimestamps(
 	sst []byte,
 	from, to hlc.Timestamp,
 	concurrency int,
-	stats *enginepb.MVCCStats,
+	stats enginepb.MVCCStats,
 ) ([]byte, enginepb.MVCCStats, error) {
 	if from.IsEmpty() {
 		return nil, enginepb.MVCCStats{}, errors.Errorf("from timestamp not given")
@@ -1225,7 +1225,7 @@ func UpdateSSTTimestamps(
 	sstOut.Buffer.Grow(len(sst))
 
 	var statsDelta enginepb.MVCCStats
-	if stats != nil {
+	if !stats.IsEmpty() {
 		// There could be a GCBytesAge delta between the old and new timestamps.
 		// Calculate this delta by subtracting all the relevant stats at the
 		// old timestamp, and then aging the stats to the new timestamp before

--- a/pkg/storage/sst_test.go
+++ b/pkg/storage/sst_test.go
@@ -172,7 +172,7 @@ func runUpdateSSTTimestamps(ctx context.Context, b *testing.B, numKeys int, conc
 		var ms enginepb.MVCCStats
 		var err error
 		res, _, err = UpdateSSTTimestamps(
-			ctx, st, sstFile.Bytes(), sstTimestamp, reqTimestamp, concurrency, &ms)
+			ctx, st, sstFile.Bytes(), sstTimestamp, reqTimestamp, concurrency, ms)
 		if err != nil {
 			require.NoError(b, err) // for performance
 		}


### PR DESCRIPTION
The kvserver client is able to pass a pointer to an empty MVCCStats struct,
which should be treated identically to a nil pointer to an MVCCStats struct.

Epic: none

Release note: none