### PR TITLE
workloadccl: remove stale comment around importing fixtures

### DIFF
--- a/pkg/ccl/workloadccl/fixture.go
+++ b/pkg/ccl/workloadccl/fixture.go
@@ -374,17 +374,7 @@ func ImportFixture(
 		defer enableFn()
 	}
 
-	pathPrefix := csvServer
-	if pathPrefix == `` {
-		pathPrefix = `workload://`
-	}
-
-	// Pre-create tables. It's required that we pre-create the tables before we
-	// parallelize the IMPORT because for multi-region setups, the create table
-	// will end up modifying the crdb_internal_region type (to install back
-	// references). If create table is done in parallel with IMPORT, some IMPORT
-	// jobs may fail because the type is being modified concurrently with the
-	// IMPORT. Removing the need to pre-create is being tracked with #70987.
+	// Prepare the tables for ingestion via IMPORT INTO.
 	const maxTableBatchSize = 5000
 	currentTable := 0
 	for currentTable < len(tables) {
@@ -402,6 +392,11 @@ func ImportFixture(
 			return 0, err
 		}
 		currentTable += maxTableBatchSize
+	}
+
+	pathPrefix := csvServer
+	if pathPrefix == `` {
+		pathPrefix = `workload://`
 	}
 
 	// Default to unbounded unless a flag exists for it.


### PR DESCRIPTION
This commit deletes now-stale comment that was added in 09abc26c7e0911a857ae85ad453346c911b49ee9. That change made a switch from using IMPORT TABLE to IMPORT INTO for importing fixtures as a temporary workaround. However, since then we completely deprecated IMPORT TABLE syntax, so the only way to import the data now is to create the tables separately, which makes the comment confusing.

Epic: None
Release note: None