### PR TITLE
release: install helm for generating PRs

### DIFF
--- a/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
+++ b/build/teamcity/internal/cockroach/release/process/update_versions_impl.sh
@@ -25,10 +25,13 @@ fi
 # run git fetch in order to get all remote branches
 git fetch --tags -q origin
 
-# install gh
+# install gh and helm
 curl -fsSL -o /tmp/gh.tar.gz https://github.com/cli/cli/releases/download/v2.32.1/gh_2.32.1_linux_amd64.tar.gz
 echo "5c9a70b6411cc9774f5f4e68f9227d5d55ca0bfbd00dfc6353081c9b705c8939  /tmp/gh.tar.gz" | sha256sum -c -
 tar --strip-components 1 -xf /tmp/gh.tar.gz
+curl -fsSL -o /tmp/helm.tar.gz https://get.helm.sh/helm-v3.14.1-linux-amd64.tar.gz
+echo "75496ea824f92305ff7d28af37f4af57536bf5138399c824dff997b9d239dd42  /tmp/helm.tar.gz" | sha256sum -c -
+tar -C bin --strip-components 1 -xf /tmp/helm.tar.gz linux-amd64/helm
 export PATH=$PWD/bin:$PATH
 
 bazel build --config=crosslinux //pkg/cmd/release


### PR DESCRIPTION
With https://github.com/cockroachdb/helm-charts/pull/519, we require helm to be installed. This commit adds the installation of helm to the update_versions_impl.sh script, which is used to generate PRs for updating versions in the CockroachDB repository.

Release note: none
Epic: none