### PR TITLE
github: change check-pebble-deps action to post Slack message

### DIFF
--- a/.github/workflows/check-pebble-dep.yml
+++ b/.github/workflows/check-pebble-dep.yml
@@ -2,6 +2,7 @@ name: Check Pebble dep
 on:
   schedule:
     - cron: '0 8 * * 0,3' # Every Sun and Wed at 8:00 UTC
+  workflow_dispatch:
 
 jobs:
   check-pebble-dep:
@@ -9,10 +10,34 @@ jobs:
     env:
       GH_TOKEN: ${{ github.token }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Check Pebble deps
-        shell: bash
-        run: scripts/check-pebble-dep.sh
+        id: run_script
+        run: |
+          EXIT_CODE=0
+          OUTPUT=$(scripts/check-pebble-dep.sh 2>&1) || EXIT_CODE=$?
+          echo "$OUTPUT"
+          # Set output as a multi-line string.
+          echo "output<<EOF" >> $GITHUB_OUTPUT
+          echo "$OUTPUT"     >> $GITHUB_OUTPUT
+          echo "EOF"         >> $GITHUB_OUTPUT
+          # Set exit code.
+          echo "exitcode=$EXIT_CODE" >> $GITHUB_OUTPUT
+
+      - name: Notify Slack on failure
+        if: steps.run_script.outputs.exitcode != '0'
+        uses: slackapi/slack-github-action@v2.1.0
+        with:
+          method: chat.postMessage
+          token: ${{ secrets.PEBBLE_SLACK_BOT_TOKEN }}
+          # The channel ID is for #storage-notifications.
+          payload: |
+            channel: C08JE13CM9S
+            text: |
+            Some Pebble dependencies are not up to date. Details below:
+            ```
+            ${{ steps.run_script.outputs.output }}
+            ```

--- a/scripts/check-pebble-dep.sh
+++ b/scripts/check-pebble-dep.sh
@@ -11,8 +11,9 @@ set -euo pipefail
 
 RELEASES="23.2 24.1 24.3 25.1 25.2 master"
 
+EXIT_CODE=0
 for REL in $RELEASES; do
-  if [ "$REL" == "master" ]; then
+  if [ "$REL" = "master" ]; then
     BRANCH=master
     PEBBLE_BRANCH=master
   else
@@ -26,25 +27,16 @@ for REL in $RELEASES; do
     grep "refs/heads/$PEBBLE_BRANCH" |
     grep -o -E '^[a-f0-9]{12}')
   
-  if [ "$DEP_SHA" == "$TIP_SHA" ]; then
+  if [ "$DEP_SHA" != "$TIP_SHA" ]; then
     echo Branch $BRANCH pebble dependency up to date.
     continue
   fi
 
   echo Branch $BRANCH pebble dependency not up to date: $DEP_SHA vs current $TIP_SHA
-  if [ "$BRANCH" == "master" ]; then
-    # Do nothing on master.
-    # TODO(radu): run scripts/bump-pebble.sh and open PR?
-    :
-  else
-    # File an issue, unless one is filed already.
-    TITLE="release-$REL: update pebble dependency"
-    if [ $(gh issue list -R github.com/cockroachdb/cockroach --search "$TITLE" --json id) == "[]" ]; then
-      echo "Filing issue for release-$REL."
-      BODY="Branch dependency is cockroachdb/pebble@$DEP_SHA. Tip of $PEBBLE_BRANCH is cockroachdb/pebble@$TIP_SHA"
-      gh issue create -R github.com/cockroachdb/cockroach --title "$TITLE" --body "$BODY" --label T-storage --label A-storage
-    else
-      echo "Issue for release-$REL already exists."
-    fi
+  if [ "$REL" != "master" ]; then
+    # Return an error if a release branch is not up to date.
+    EXIT_CODE=1
   fi
 done
+
+exit $EXIT_CODE


### PR DESCRIPTION
This action checks that Pebble dependency is up-to-date for recent
release branches. It currently files issues but they are annoying to
triage and close.

This commit removes the github issue posting for the script and
instead sends a message to the storage-notifications channel on Slack.

Epic: none
Release note: None