### PR TITLE
sql: minor cleanup of readers

### DIFF
--- a/pkg/sql/colfetcher/cfetcher.go
+++ b/pkg/sql/colfetcher/cfetcher.go
@@ -586,15 +586,15 @@ func cFetcherFirstBatchLimit(limitHint rowinfra.RowLimit, maxKeysPerRow uint32) 
 func (cf *cFetcher) StartScan(
 	ctx context.Context,
 	spans roachpb.Spans,
-	limitBatches bool,
+	parallelize bool,
 	batchBytesLimit rowinfra.BytesLimit,
 	limitHint rowinfra.RowLimit,
 ) error {
 	if len(spans) == 0 {
 		return errors.AssertionFailedf("no spans")
 	}
-	if !limitBatches && batchBytesLimit != rowinfra.NoBytesLimit {
-		return errors.AssertionFailedf("batchBytesLimit set without limitBatches")
+	if parallelize && batchBytesLimit != rowinfra.NoBytesLimit {
+		return errors.AssertionFailedf("TargetBytes limit requested with parallelize=true")
 	}
 
 	firstBatchLimit := cFetcherFirstBatchLimit(limitHint, cf.table.spec.MaxKeysPerRow)

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -221,11 +221,10 @@ func (s *ColBatchScan) Init(ctx context.Context) {
 		s.Ctx, s.flowCtx, "colbatchscan", s.processorID,
 		&s.ContentionEventsListener, &s.ScanStatsListener, &s.TenantConsumptionListener,
 	)
-	limitBatches := !s.parallelize
 	if err := s.cf.StartScan(
 		s.Ctx,
 		s.Spans,
-		limitBatches,
+		s.parallelize,
 		s.batchBytesLimit,
 		s.limitHint,
 	); err != nil {

--- a/pkg/sql/colfetcher/colbatch_scan.go
+++ b/pkg/sql/colfetcher/colbatch_scan.go
@@ -169,14 +169,14 @@ func newColBatchScanBase(
 		s.MakeSpansCopy()
 	}
 
-	if spec.LimitHint > 0 || spec.BatchBytesLimit > 0 {
+	if spec.LimitHint > 0 {
 		// Parallelize shouldn't be set when there's a limit hint, but double-check
 		// just in case.
 		spec.Parallelize = false
 	}
 	var batchBytesLimit rowinfra.BytesLimit
 	if !spec.Parallelize {
-		batchBytesLimit = rowinfra.BytesLimit(spec.BatchBytesLimit)
+		batchBytesLimit = rowinfra.BytesLimit(flowCtx.Cfg.TestingKnobs.TableReaderBatchBytesLimit)
 		if batchBytesLimit == 0 {
 			batchBytesLimit = rowinfra.GetDefaultBatchBytesLimit(flowCtx.EvalCtx.TestingKnobs.ForceProductionValues)
 		}

--- a/pkg/sql/colfetcher/index_join.go
+++ b/pkg/sql/colfetcher/index_join.go
@@ -215,7 +215,7 @@ func (s *ColIndexJoin) Next() coldata.Batch {
 			if err := s.cf.StartScan(
 				s.Ctx,
 				spans,
-				false, /* limitBatches */
+				true, /* parallelize */
 				rowinfra.NoBytesLimit,
 				rowinfra.NoRowLimit,
 			); err != nil {

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -2467,9 +2467,6 @@ func (dsp *DistSQLPlanner) planTableReaders(
 		}
 
 		tr.Parallelize = info.parallelize
-		if !tr.Parallelize {
-			tr.BatchBytesLimit = dsp.distSQLSrv.TestingKnobs.TableReaderBatchBytesLimit
-		}
 		tr.IgnoreMisplannedRanges = ignoreMisplannedRanges
 		p.TotalEstimatedScannedRows += info.estimatedRowCount
 
@@ -3444,7 +3441,6 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 		MaintainLookupOrdering:            maintainLookupOrdering,
 		LeftJoinWithPairedJoiner:          planInfo.isSecondJoinInPairedJoiner,
 		OutputGroupContinuationForLeftRow: planInfo.isFirstJoinInPairedJoiner,
-		LookupBatchBytesLimit:             dsp.distSQLSrv.TestingKnobs.JoinReaderBatchBytesLimit,
 		LimitHint:                         planInfo.limitHint,
 		RemoteOnlyLookups:                 planInfo.remoteOnlyLookups,
 		ReverseScans:                      planInfo.reverseScans,

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -74,11 +74,6 @@ message TableReaderSpec {
   // limit hint.
   optional bool parallelize = 12 [(gogoproto.nullable) = false];
 
-  // batch_bytes_limit, if non-zero, controls the TargetBytes limits that the
-  // TableReader will use for its scans. If zero, then the server-side default
-  // is used. If parallelize is set, this cannot be set.
-  optional int64 batch_bytes_limit = 17 [(gogoproto.nullable) = false];
-
   // If non-zero, this enables inconsistent historical scanning where different
   // batches can be read with different timestamps. This is used for
   // long-running table statistics which may outlive the TTL. Using this setting
@@ -124,7 +119,7 @@ message TableReaderSpec {
   // leaseholder of the beginning of the key spans to be scanned).
   optional bool ignore_misplanned_ranges = 22 [(gogoproto.nullable) = false];
 
-  reserved 1, 2, 4, 6, 7, 8, 13, 14, 15, 16, 19;
+  reserved 1, 2, 4, 6, 7, 8, 13, 14, 15, 16, 17, 19;
 }
 
 // FiltererSpec is the specification for a processor that filters input rows
@@ -303,17 +298,9 @@ message JoinReaderSpec {
   // variables @(N+1) to @(N+M) refer to fetched columns.
   optional Expression on_expr = 4 [(gogoproto.nullable) = false];
 
-  // This used to be used for an extra index filter expression. It was removed
-  // in DistSQL version 24.
-  reserved 5;
-
   // For lookup joins. Only JoinType_INNER and JoinType_LEFT_OUTER are
   // supported.
   optional sqlbase.JoinType type = 6 [(gogoproto.nullable) = false];
-
-  // This field used to be a visibility level of the columns that should be
-  // produced. We now produce the columns in the FetchSpec.
-  reserved 7;
 
   // Indicates the row-level locking strength to be used by the join. If set to
   // FOR_NONE, no row-level locking should be performed.
@@ -335,8 +322,6 @@ message JoinReaderSpec {
   // optimizations.
   optional bool maintain_ordering = 11 [(gogoproto.nullable) = false];
 
-  reserved 12, 13;
-
   // LeftJoinWithPairedJoiner is used when a left {outer,anti,semi} join is
   // being achieved by pairing two joins, and this is the second join. See
   // the comment above.
@@ -348,13 +333,6 @@ message JoinReaderSpec {
   // OutputGroupContinuationForLeftRow is true, MaintainOrdering must also
   // be true.
   optional bool output_group_continuation_for_left_row = 15 [(gogoproto.nullable) = false];
-
-  // lookup_batch_bytes_limit, if non-zero, controls the TargetBytes limits that
-  // the joiner will use for its lookups. If zero, then the server-side default
-  // is used. Note that, regardless of this setting, bytes limits are not always
-  // used for lookups - it depends on whether the joiner decides it wants
-  // DistSender-parallelism or not.
-  optional int64 lookup_batch_bytes_limit = 18 [(gogoproto.nullable) = false];
 
   // A hint for how many rows the consumer of the join reader output might
   // need. This is used to size the initial batches of input rows to try to
@@ -384,6 +362,8 @@ message JoinReaderSpec {
   // reverse order. This is only useful if a lookup can return more than one
   // row.
   optional bool reverse_scans = 25 [(gogoproto.nullable) = false];
+
+  reserved 5, 7, 12, 13, 18;
 }
 
 // SorterSpec is the specification for a "sorting aggregator". A sorting

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -115,11 +115,15 @@ type joinReader struct {
 
 	// fetcher wraps the row.Fetcher used to perform lookups. This enables the
 	// joinReader to wrap the fetcher with a stat collector when necessary.
-	fetcher            rowFetcher
-	alloc              tree.DatumAlloc
-	rowAlloc           rowenc.EncDatumRowAlloc
-	shouldLimitBatches bool
-	readerType         joinReaderType
+	fetcher  rowFetcher
+	alloc    tree.DatumAlloc
+	rowAlloc rowenc.EncDatumRowAlloc
+	// parallelize, if true, indicates that the KV lookups will be parallelized
+	// across ranges when using the DistSender API. It has no influence on the
+	// behavior when using the Streamer API (when the lookups are always
+	// parallelized).
+	parallelize bool
+	readerType  joinReaderType
 
 	// txn is the transaction used by the join reader.
 	txn *kv.Txn
@@ -326,18 +330,19 @@ func newJoinReader(
 	// in case of indexJoinReaderType, we know that there's exactly one lookup
 	// row for each input row. Similarly, in case of spec.LookupColumnsAreKey,
 	// we know that there's at most one lookup row per input row. In other
-	// cases, we use limits.
-	shouldLimitBatches := !spec.LookupColumnsAreKey && readerType == lookupJoinReaderType
+	// cases, we disable parallelism and use the TargetBytes limit.
+	parallelize := spec.LookupColumnsAreKey || readerType == indexJoinReaderType
 	if flowCtx.EvalCtx.SessionData().ParallelizeMultiKeyLookupJoinsEnabled {
-		shouldLimitBatches = false
+		parallelize = true
 	}
 	if spec.MaintainLookupOrdering {
-		// MaintainLookupOrdering indicates the output of the lookup joiner should
-		// be sorted by <inputCols>, <lookupCols>. It doesn't make sense for
-		// MaintainLookupOrdering to be true when MaintainOrdering is not.
-		// Additionally, we need to disable parallelism for the traditional fetcher
-		// in order to ensure the lookups are ordered, so set shouldLimitBatches.
-		spec.MaintainOrdering, shouldLimitBatches = true, true
+		// MaintainLookupOrdering indicates the output of the lookup joiner
+		// should be sorted by <inputCols>, <lookupCols>. It doesn't make sense
+		// for MaintainLookupOrdering to be true when MaintainOrdering is not.
+		//
+		// Additionally, we need to disable parallelism for the traditional
+		// fetcher in order to ensure the lookups are ordered.
+		spec.MaintainOrdering, parallelize = true, false
 	}
 	useStreamer, txn, err := flowCtx.UseStreamer(ctx)
 	if err != nil {
@@ -354,7 +359,7 @@ func newJoinReader(
 		input:                               input,
 		lookupCols:                          lookupCols,
 		outputGroupContinuationForLeftRow:   spec.OutputGroupContinuationForLeftRow,
-		shouldLimitBatches:                  shouldLimitBatches,
+		parallelize:                         parallelize,
 		readerType:                          readerType,
 		txn:                                 txn,
 		usesStreamer:                        useStreamer,
@@ -862,8 +867,8 @@ func (jr *joinReader) getBatchBytesLimit() rowinfra.BytesLimit {
 		// BatchRequests.
 		return rowinfra.NoBytesLimit
 	}
-	if !jr.shouldLimitBatches {
-		// We deem it safe to not limit the batches in order to get the
+	if jr.parallelize {
+		// We deem it safe to not use the TargetBytes limit in order to get the
 		// DistSender-level parallelism.
 		return rowinfra.NoBytesLimit
 	}
@@ -1047,11 +1052,13 @@ func (jr *joinReader) readInput() (
 	//    fetcher only accepts a limit if the spans are sorted), and
 	// b) Pebble has various optimizations for Seeks in sorted order.
 	if jr.readerType == indexJoinReaderType && jr.maintainOrdering {
-		// Assert that the index join doesn't have shouldLimitBatches set. Since we
-		// didn't sort above, the fetcher doesn't support a limit.
-		if jr.shouldLimitBatches {
+		// Assert that the index join has 'parallelize=true' set. Since we
+		// didn't sort above, the fetcher doesn't support the TargetBytes limit
+		// (which would be set via getBatchBytesLimit() if 'parallelize' was
+		// false).
+		if !jr.parallelize {
 			err := errors.AssertionFailedf("index join configured with both maintainOrdering and " +
-				"shouldLimitBatched; this shouldn't have happened as the implementation doesn't support it")
+				"parallelize=false; this shouldn't have happened as the implementation doesn't support it")
 			jr.MoveToDraining(err)
 			return jrStateUnknown, nil, jr.DrainHelper()
 		}

--- a/pkg/sql/rowexec/tablereader.go
+++ b/pkg/sql/rowexec/tablereader.go
@@ -199,17 +199,14 @@ func (tr *tableReader) startScan(ctx context.Context) error {
 	if cb := tr.FlowCtx.Cfg.TestingKnobs.TableReaderStartScanCb; cb != nil {
 		cb()
 	}
-	limitBatches := !tr.parallelize
-	var bytesLimit rowinfra.BytesLimit
-	if !limitBatches {
-		bytesLimit = rowinfra.NoBytesLimit
-	} else {
+	bytesLimit := rowinfra.NoBytesLimit
+	if !tr.parallelize {
 		bytesLimit = rowinfra.BytesLimit(tr.FlowCtx.Cfg.TestingKnobs.TableReaderBatchBytesLimit)
 		if bytesLimit == 0 {
 			bytesLimit = rowinfra.GetDefaultBatchBytesLimit(tr.FlowCtx.EvalCtx.TestingKnobs.ForceProductionValues)
 		}
 	}
-	log.VEventf(ctx, 1, "starting scan with limitBatches %t", limitBatches)
+	log.VEventf(ctx, 1, "starting scan with parallelize=%t", tr.parallelize)
 	var err error
 	if tr.maxTimestampAge == 0 {
 		err = tr.fetcher.StartScan(


### PR DESCRIPTION
**rowexec: remove a couple testing knobs from processor protos**

This commit removes TableReaderSpec.BatchBytesLimit and
JoinReaderSpec.LookupBatchBytesLimit that are only used in tests. Given
that we have access to the testing knobs on each node that creates the
necessary processor, we can just consult that directly. This removal
avoids the possible confusion for how and when these fields are used.

**sql: clarify fetcher parallelization**

I find "limit batches" terminology a bit confusing, so this commit
switches places where we use to "parallelize" which indicates that the
DistSender-level cross-range parallelism should be used, which in turn
means that TargetBytes limit cannot be set (i.e. "should _not_ limit
batches").

Epic: None
Release note: None