### PR TITLE
pkg/util/log: introduce crdb-v1-zip-upload format decoder

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1566,7 +1566,7 @@ func init() {
 		"Name of the cluster to associate with the debug zip artifacts. This can be used to identify data in the upstream observability tool.")
 	f.Var(&debugZipUploadOpts.from, "from", "oldest timestamp to include (inclusive)")
 	f.Var(&debugZipUploadOpts.to, "to", "newest timestamp to include (inclusive)")
-	f.StringVar(&debugZipUploadOpts.logFormat, "log-format", "crdb-v1",
+	f.StringVar(&debugZipUploadOpts.logFormat, "log-format", "crdb-v1-zip-upload",
 		"log format of the input files")
 	// the log-format flag is depricated. It will
 	// eventually be removed completely. keeping it hidden for now incase we ever

--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1574,6 +1574,9 @@ func init() {
 	f.Lookup("log-format").Hidden = true
 	f.StringVar(&debugZipUploadOpts.gcpProjectID, "gcp-project-id",
 		defaultGCPProjectID, "GCP project ID to use to send debug.zip logs to GCS")
+	// --dry-run is a hidden flag that is only meant to be used for testing and diagnostics
+	f.BoolVar(&debugZipUploadOpts.dryRun, "dry-run", false, "run in dry-run mode without making any actual uploads")
+	f.Lookup("dry-run").Hidden = true
 
 	f = debugDecodeKeyCmd.Flags()
 	f.Var(&decodeKeyOptions.encoding, "encoding", "key argument encoding")

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -124,6 +124,7 @@ var debugZipUploadOpts = struct {
 	from, to             timestampValue
 	logFormat            string
 	maxConcurrentUploads int
+	dryRun               bool
 }{
 	maxConcurrentUploads: system.NumCPU() * 4,
 }
@@ -217,6 +218,10 @@ func runDebugZipUpload(cmd *cobra.Command, args []string) error {
 		artifactsToUpload = debugZipUploadOpts.include
 	}
 
+	if debugZipUploadOpts.dryRun {
+		fmt.Println("DRY RUN MODE: No actual uploads will be performed")
+	}
+
 	// run the upload functions for each artifact type. This can run sequentially.
 	// All the concurrency is contained within the upload functions.
 	for _, artType := range artifactsToUpload {
@@ -237,6 +242,10 @@ func validateZipUploadReadiness() error {
 		includeLookup     = map[string]struct{}{}
 		artifactsToUpload = zipArtifactTypes
 	)
+
+	if debugZipUploadOpts.dryRun {
+		return nil
+	}
 
 	if len(debugZipUploadOpts.include) > 0 {
 		artifactsToUpload = debugZipUploadOpts.include
@@ -896,6 +905,11 @@ func startWriterPool(
 // writing to GCS. The concurrency has to be handled by the caller.
 // This function implements the logUploadFunc signature.
 var gcsLogUpload = func(ctx context.Context, sig logUploadSig) (int, error) {
+	data := bytes.Join(sig.logLines, []byte("\n"))
+	if debugZipUploadOpts.dryRun {
+		return len(data), nil
+	}
+
 	gcsClient, closeGCSClient, err := newGCSClient(ctx)
 	if err != nil {
 		return 0, err
@@ -910,7 +924,6 @@ var gcsLogUpload = func(ctx context.Context, sig logUploadSig) (int, error) {
 	retryOpts := base.DefaultRetryOptions()
 	retryOpts.MaxRetries = zipUploadRetries
 
-	data := bytes.Join(sig.logLines, []byte("\n"))
 	for retry := retry.Start(retryOpts); retry.Next(); {
 		objectWriter := gcsClient.Bucket(ddArchiveBucketName).Object(filename).NewWriter(ctx)
 		w := gzip.NewWriter(objectWriter)
@@ -1137,6 +1150,10 @@ func makeDDTag(key, value string) string {
 // There is also some error handling logic in this function. This is a variable so that
 // we can mock this function in the tests.
 var doUploadReq = func(req *http.Request) ([]byte, error) {
+	if debugZipUploadOpts.dryRun {
+		return []byte("{}"), nil
+	}
+
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return nil, err

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -483,7 +483,7 @@ func processLogFile(
 			debugZipUploadOpts.tags..., // user provided tags
 		), getUploadType(currentTimestamp))
 		if err != nil {
-			fmt.Println(err)
+			fmt.Println("logEntryToJSON:", err)
 			continue
 		}
 

--- a/pkg/util/log/formats.go
+++ b/pkg/util/log/formats.go
@@ -29,6 +29,7 @@ type logFormatter interface {
 
 // FormatParsers maps the user facing format names to the internal representation.
 var FormatParsers = map[string]string{
+	"crdb-v1-zip-upload":  "v1-zip-upload",
 	"crdb-v1":             "v1",
 	"crdb-v1-count":       "v1",
 	"crdb-v1-tty":         "v1",

--- a/pkg/util/log/log_decoder.go
+++ b/pkg/util/log/log_decoder.go
@@ -92,6 +92,12 @@ func NewEntryDecoderWithFormat(
 		}
 		decoder.scanner.Split(decoder.split)
 		d = decoder
+	case "v1-zip-upload":
+		decoder := &entryDecoderV1ZipUpload{
+			reader:          bufio.NewReader(in),
+			sensitiveEditor: getEditor(editMode),
+		}
+		d = decoder
 	case "json":
 		d = &entryDecoderJSON{
 			decoder:         json.NewDecoder(in),


### PR DESCRIPTION
1. **pkg/cli (debug-zip): add dry-run mode for debug zip uploads**

    Introduce a `--dry-run` flag to the debug zip upload command. This
    allows us to simulate the upload process without performing actual
    uploads. The dry-run mode is used only for debugging/testing. This flag
    is hidden from the help text

    Epic: None
    Release note: None

---

2. **pkg/util/log: introduce crdb-v1-zip-upload format decoder**

    Introduces a new log format decoder (`crdb-v1-zip-upload`) specifically
    for debug zip uploads that removes the 64KB token size limitation of
    `bufio.Scanner`. The new decoder uses `bufio.Reader` to handle
    arbitrarily large log entries without truncation.

    Truncation of logs can lead to partial log entries, which might be
    acceptable in some cases. However, logs in JSON format may break their
    validity if they are only partially available. We had also encountered
    an issue with JSON marshalling due to this. This change addresses that
    issue.

    `crdb-v1-zip-upload` is only used internally by debug zip upload
    operations and not used in general log processing.

    Jira: CRDB-51108, CRDB-51109
    Release note: None