### PR TITLE
execbuilder: add "average lookup ratio" parallelization heuristic for lookup joins

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
@@ -1,0 +1,208 @@
+# LogicTest: multiregion-9node-3region-3azs
+
+# Set the closed timestamp interval to be short to shorten the amount of time
+# we need to wait for the system config to propagate.
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.side_transport_interval = '10ms';
+
+statement ok
+SET CLUSTER SETTING kv.closed_timestamp.target_duration = '10ms';
+
+statement ok
+SET CLUSTER SETTING kv.rangefeed.closed_timestamp_refresh_interval = '10ms';
+
+statement ok
+CREATE DATABASE multi_region_test_db PRIMARY REGION "ca-central-1" REGIONS "ap-southeast-2", "us-east-1" SURVIVE REGION FAILURE;
+
+statement ok
+USE multi_region_test_db
+
+statement ok
+CREATE TABLE great_grandparent (
+  i INT NOT NULL PRIMARY KEY,
+  gg INT NOT NULL,
+  UNIQUE INDEX (gg),
+  FAMILY (i, gg)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE grandparent (
+  g INT NOT NULL PRIMARY KEY,
+  gg INT NOT NULL REFERENCES great_grandparent (gg) ON DELETE CASCADE ON UPDATE CASCADE,
+  INDEX (gg),
+  FAMILY (g, gg)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE parent (
+  p INT NOT NULL PRIMARY KEY,
+  g INT NOT NULL REFERENCES grandparent (g) ON DELETE CASCADE ON UPDATE CASCADE,
+  INDEX (g),
+  FAMILY (p, g)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE child (
+  c INT NOT NULL PRIMARY KEY,
+  p INT NOT NULL REFERENCES parent (p) ON DELETE CASCADE ON UPDATE CASCADE,
+  INDEX (p),
+  FAMILY (c, p)
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO great_grandparent (i, gg, crdb_region) VALUES (1, 1, 'us-east-1'), (2, 2, 'us-east-1'), (3, 3, 'us-east-1');
+INSERT INTO grandparent (g, gg, crdb_region) VALUES (10, 1, 'us-east-1'), (20, 2, 'us-east-1'), (30, 3, 'us-east-1');
+INSERT INTO parent (p, g, crdb_region) VALUES (100, 10, 'us-east-1'), (200, 20, 'us-east-1'), (300, 30, 'us-east-1');
+INSERT INTO child (c, p, crdb_region) VALUES (1000, 100, 'us-east-1'), (2000, 200, 'us-east-1'), (3000, 300, 'us-east-1');
+
+statement ok
+ANALYZE great_grandparent;
+
+statement ok
+ANALYZE grandparent;
+
+statement ok
+ANALYZE parent;
+
+statement ok
+ANALYZE child;
+
+query T
+EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • delete
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ from: great_grandparent
+│   │
+│   └── • buffer
+│       │ columns: (i, gg, crdb_region)
+│       │ label: buffer 1
+│       │
+│       └── • union all
+│           │ columns: (i, gg, crdb_region)
+│           │ estimated row count: 1
+│           │ limit: 1
+│           │
+│           ├── • scan
+│           │     columns: (i, gg, crdb_region)
+│           │     estimated row count: 0 (<0.01% of the table; stats collected <hidden> ago)
+│           │     table: great_grandparent@great_grandparent_pkey
+│           │     spans: /"@"/1/0
+│           │
+│           └── • scan
+│                 columns: (i, gg, crdb_region)
+│                 estimated row count: 1 (33% of the table; stats collected <hidden> ago)
+│                 table: great_grandparent@great_grandparent_pkey
+│                 spans: /"\x80"/1/0 /"\xc0"/1/0
+│                 parallel
+│
+└── • fk-cascade
+    │ fk: grandparent_gg_fkey
+    │
+    └── • root
+        │ columns: ()
+        │
+        ├── • delete
+        │   │ columns: ()
+        │   │ estimated row count: 0 (missing stats)
+        │   │ from: grandparent
+        │   │
+        │   └── • buffer
+        │       │ columns: (g, gg, crdb_region)
+        │       │ label: buffer 1
+        │       │
+        │       └── • project
+        │           │ columns: (g, gg, crdb_region)
+        │           │
+        │           └── • lookup join (inner)
+        │               │ columns: (gg, g, gg, crdb_region)
+        │               │ estimated row count: 3
+        │               │ table: grandparent@grandparent_gg_idx
+        │               │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (gg = gg)
+        │               │
+        │               └── • distinct
+        │                   │ columns: (gg)
+        │                   │ estimated row count: 10
+        │                   │ distinct on: gg
+        │                   │
+        │                   └── • project
+        │                       │ columns: (gg)
+        │                       │
+        │                       └── • scan buffer
+        │                             columns: (i, gg, crdb_region)
+        │                             estimated row count: 100
+        │                             label: buffer 1000000
+        │
+        └── • fk-cascade
+            │ fk: parent_g_fkey
+            │
+            └── • root
+                │ columns: ()
+                │
+                ├── • delete
+                │   │ columns: ()
+                │   │ estimated row count: 0 (missing stats)
+                │   │ from: parent
+                │   │
+                │   └── • buffer
+                │       │ columns: (p, g, crdb_region)
+                │       │ label: buffer 1
+                │       │
+                │       └── • project
+                │           │ columns: (p, g, crdb_region)
+                │           │
+                │           └── • lookup join (inner)
+                │               │ columns: (g, p, g, crdb_region)
+                │               │ estimated row count: 3
+                │               │ table: parent@parent_g_idx
+                │               │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (g = g)
+                │               │
+                │               └── • distinct
+                │                   │ columns: (g)
+                │                   │ estimated row count: 10
+                │                   │ distinct on: g
+                │                   │
+                │                   └── • project
+                │                       │ columns: (g)
+                │                       │
+                │                       └── • scan buffer
+                │                             columns: (g, gg, crdb_region)
+                │                             estimated row count: 100
+                │                             label: buffer 1000000
+                │
+                └── • fk-cascade
+                    │ fk: child_p_fkey
+                    │
+                    └── • delete
+                        │ columns: ()
+                        │ estimated row count: 0 (missing stats)
+                        │ from: child
+                        │
+                        └── • project
+                            │ columns: (c, p, crdb_region)
+                            │
+                            └── • lookup join (inner)
+                                │ columns: (p, c, p, crdb_region)
+                                │ estimated row count: 3
+                                │ table: child@child_p_idx
+                                │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (p = p)
+                                │
+                                └── • distinct
+                                    │ columns: (p)
+                                    │ estimated row count: 10
+                                    │ distinct on: p
+                                    │
+                                    └── • project
+                                        │ columns: (p)
+                                        │
+                                        └── • scan buffer
+                                              columns: (p, g, crdb_region)
+                                              estimated row count: 100
+                                              label: buffer 1000000

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_cascade
@@ -58,15 +58,36 @@ INSERT INTO child (c, p, crdb_region) VALUES (1000, 100, 'us-east-1'), (2000, 20
 statement ok
 ANALYZE great_grandparent;
 
+# Only the scan in the main query is parallelized when we don't have stats on
+# the descendant tables.
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+1
+
 statement ok
 ANALYZE grandparent;
+
+# Now we also should parallelize lookup join into the grandparent table.
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+2
 
 statement ok
 ANALYZE parent;
 
+# Now we also should parallelize lookup join into the parent table.
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+3
+
 statement ok
 ANALYZE child;
 
+# Finally, all three lookup joins as well as the scan in the main query should
+# be parallelized.
 query T
 EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1;
 ----
@@ -126,6 +147,7 @@ vectorized: true
         │               │ estimated row count: 3
         │               │ table: grandparent@grandparent_gg_idx
         │               │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (gg = gg)
+        │               │ parallel
         │               │
         │               └── • distinct
         │                   │ columns: (gg)
@@ -163,6 +185,7 @@ vectorized: true
                 │               │ estimated row count: 3
                 │               │ table: parent@parent_g_idx
                 │               │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (g = g)
+                │               │ parallel
                 │               │
                 │               └── • distinct
                 │                   │ columns: (g)
@@ -193,6 +216,7 @@ vectorized: true
                                 │ estimated row count: 3
                                 │ table: child@child_p_idx
                                 │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (p = p)
+                                │ parallel
                                 │
                                 └── • distinct
                                     │ columns: (p)
@@ -206,3 +230,106 @@ vectorized: true
                                               columns: (p, g, crdb_region)
                                               estimated row count: 100
                                               label: buffer 1000000
+
+statement ok
+SET parallelize_multi_key_lookup_joins_avg_lookup_ratio = 0;
+
+# Only the scan in the main query is parallelized when the "average lookup
+# ratio" heuristic is disabled.
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+1
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_avg_lookup_ratio;
+
+# All three lookup joins as well as the scan in the main query should be
+# parallelized.
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+4
+
+# Inject the table stats for grandparent table to simulate the case when each
+# region stores 100k rows each. The lookup into the table should still be
+# parallelized (if it's not, then we're using the wrong ColumnIDs when
+# retrieving column stats).
+statement ok
+ALTER TABLE grandparent INJECT STATISTICS '[
+    {
+        "avg_size": 4,
+        "columns": [
+            "crdb_region"
+        ],
+        "created_at": "2025-01-01 00:00:00.000000",
+        "distinct_count": 3,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 300000
+    },
+    {
+        "avg_size": 2,
+        "columns": [
+            "gg"
+        ],
+        "created_at": "2025-01-01 00:00:00.000000",
+        "distinct_count": 300000,
+        "histo_buckets": [
+            {"distinct_range": 0, "num_eq": 1, "num_range": 0, "upper_bound": "1"},
+            {"distinct_range": 299999, "num_eq": 1, "num_range": 299999, "upper_bound": "300000"}
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 300000
+    }
+]'
+
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+4
+
+# Now simulate a scenario where many rows have NULLs in the lookup column 'gg'.
+# The lookup into the table should still be parallelized (if it's not, then
+# we're incorrectly considering NULLs in the heuristic).
+statement ok
+ALTER TABLE grandparent INJECT STATISTICS '[
+    {
+        "avg_size": 4,
+        "columns": [
+            "crdb_region"
+        ],
+        "created_at": "2025-01-01 00:00:00.000000",
+        "distinct_count": 3,
+        "histo_col_type": "",
+        "name": "__auto__",
+        "null_count": 0,
+        "row_count": 1000000
+    },
+    {
+        "avg_size": 2,
+        "columns": [
+            "gg"
+        ],
+        "created_at": "2025-01-01 00:00:00.000000",
+        "distinct_count": 300000,
+        "histo_buckets": [
+            {"distinct_range": 0, "num_eq": 1, "num_range": 0, "upper_bound": "1"},
+            {"distinct_range": 299999, "num_eq": 1, "num_range": 299999, "upper_bound": "300000"}
+        ],
+        "histo_col_type": "INT8",
+        "histo_version": 3,
+        "name": "__auto__",
+        "null_count": 700000,
+        "row_count": 1000000
+    }
+]'
+
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) DELETE FROM great_grandparent WHERE i = 1] WHERE info LIKE '%parallel%';
+----
+4

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3582,7 +3582,7 @@ ALTER TABLE xyz INJECT STATISTICS '[
 
 # Regression test for #105942.
 query T retry
-EXPLAIN SELECT
+EXPLAIN (VERBOSE) SELECT
   xyz.str,
   abc.id,
   abc.id1,
@@ -3603,20 +3603,28 @@ WHERE
 distribution: local
 vectorized: true
 ·
-• lookup join
-│ estimated row count: 1
-│ table: xyz@xyz_id2_str_abc_id_idx
-│ equality: (crdb_region, id2) = (crdb_region, id2)
-│ pred: ((abc_id = id) AND (id2 = '68088706-02c6-47d1-b993-a421cd761f2b')) AND (crdb_region = 'ap-southeast-2')
+• project
+│ columns: (str, id, id1, id2, created_at, updated_at)
 │
-└── • index join
-    │ estimated row count: 0
-    │ table: abc@abc_pkey
+└── • lookup join (inner)
+    │ columns: (id, id1, created_at, updated_at, id2, crdb_region, str, abc_id, id2, crdb_region)
+    │ estimated row count: 1
+    │ table: xyz@xyz_id2_str_abc_id_idx
+    │ equality: (crdb_region, id2) = (crdb_region, id2)
+    │ pred: ((abc_id = id) AND (id2 = '68088706-02c6-47d1-b993-a421cd761f2b')) AND (crdb_region = 'ap-southeast-2')
     │
-    └── • scan
-          estimated row count: 0 (0.37% of the table; stats collected <hidden> ago)
-          table: abc@abc_id1_id2_idx
-          spans: [/'ap-southeast-2'/'6da4f356-e526-4b78-b9f9-bbb1a7fc12d6'/'68088706-02c6-47d1-b993-a421cd761f2b' - /'ap-southeast-2'/'6da4f356-e526-4b78-b9f9-bbb1a7fc12d6'/'68088706-02c6-47d1-b993-a421cd761f2b']
+    └── • index join
+        │ columns: (id, id1, created_at, updated_at, id2, crdb_region)
+        │ estimated row count: 0
+        │ table: abc@abc_pkey
+        │ key columns: crdb_region, id
+        │ parallel
+        │
+        └── • scan
+              columns: (id, id1, id2, crdb_region)
+              estimated row count: 0 (0.37% of the table; stats collected <hidden> ago)
+              table: abc@abc_id1_id2_idx
+              spans: /"@"/"m\xa4\xf3V\xe5&Kx\xb9\xf9\xbb\xb1\xa7\xfc\x12\xd6"/"h\b\x87\x06\x02\xc6Gѹ\x93\xa4!\xcdv\x1f+"-/"@"/"m\xa4\xf3V\xe5&Kx\xb9\xf9\xbb\xb1\xa7\xfc\x12\xd6"/"h\b\x87\x06\x02\xc6Gѹ\x93\xa4!\xcdv\x1f+"/PrefixEnd
 
 # The following should use a string of 4 lookup/index joins with a cost under 200.
 query T retry

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3626,6 +3626,22 @@ vectorized: true
               table: abc@abc_id1_id2_idx
               spans: /"@"/"m\xa4\xf3V\xe5&Kx\xb9\xf9\xbb\xb1\xa7\xfc\x12\xd6"/"h\b\x87\x06\x02\xc6Gѹ\x93\xa4!\xcdv\x1f+"-/"@"/"m\xa4\xf3V\xe5&Kx\xb9\xf9\xbb\xb1\xa7\xfc\x12\xd6"/"h\b\x87\x06\x02\xc6Gѹ\x93\xa4!\xcdv\x1f+"/PrefixEnd
 
+# Same query as above but ensure that the "average lookup ratio" parallelization
+# heuristic applies to the SELECT statement (both the index join and the lookup
+# join should be parallelized).
+statement ok
+SET parallelize_multi_key_lookup_joins_only_on_mr_mutations = false;
+
+query I
+SELECT count(*) FROM [
+  EXPLAIN (VERBOSE) SELECT xyz.str, abc.id, abc.id1, abc.id2, abc.created_at, abc.updated_at FROM abc JOIN xyz ON xyz.abc_id = abc.id AND xyz.id2 = abc.id2 AND xyz.crdb_region = abc.crdb_region WHERE abc.id1 = '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6' AND abc.id2 = '68088706-02c6-47d1-b993-a421cd761f2b' AND abc.crdb_region = 'ap-southeast-2' AND xyz.crdb_region = 'ap-southeast-2'
+] WHERE info LIKE '%parallel%';
+----
+2
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_only_on_mr_mutations;
+
 # The following should use a string of 4 lookup/index joins with a cost under 200.
 query T retry
 EXPLAIN(opt,verbose) SELECT

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 29,
+    shard_count = 30,
     tags = ["cpu:4"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/multiregion-9node-3region-3azs/generated_test.go
@@ -223,6 +223,13 @@ func TestCCLLogic_regional_by_row_auto_rehoming(
 	runCCLLogicTest(t, "regional_by_row_auto_rehoming")
 }
 
+func TestCCLLogic_regional_by_row_cascade(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "regional_by_row_cascade")
+}
+
 func TestCCLLogic_regional_by_row_hash_sharded_index(
 	t *testing.T,
 ) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -3871,6 +3871,22 @@ func (m *sessionDataMutator) SetParallelizeMultiKeyLookupJoinsEnabled(val bool) 
 	m.data.ParallelizeMultiKeyLookupJoinsEnabled = val
 }
 
+func (m *sessionDataMutator) SetParallelizeMultiKeyLookupJoinsAvgLookupRatio(val float64) {
+	m.data.ParallelizeMultiKeyLookupJoinsAvgLookupRatio = val
+}
+
+func (m *sessionDataMutator) SetParallelizeMultiKeyLookupJoinsMaxLookupRatio(val float64) {
+	m.data.ParallelizeMultiKeyLookupJoinsMaxLookupRatio = val
+}
+
+func (m *sessionDataMutator) SetParallelizeMultiKeyLookupJoinsAvgLookupRowSize(val int64) {
+	m.data.ParallelizeMultiKeyLookupJoinsAvgLookupRowSize = val
+}
+
+func (m *sessionDataMutator) SetParallelizeMultiKeyLookupJoinsOnlyOnMRMutations(val bool) {
+	m.data.ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations = val
+}
+
 // TODO(harding): Remove this when costing scans based on average column size
 // is fully supported.
 func (m *sessionDataMutator) SetCostScansWithDefaultColSize(val bool) {

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4080,7 +4080,11 @@ optimizer_use_provided_ordering_fix                              on
 optimizer_use_trigram_similarity_optimization                    on
 optimizer_use_virtual_computed_column_stats                      on
 override_multi_region_zone_config                                off
+parallelize_multi_key_lookup_joins_avg_lookup_ratio              10
+parallelize_multi_key_lookup_joins_avg_lookup_row_size           100 KiB
 parallelize_multi_key_lookup_joins_enabled                       off
+parallelize_multi_key_lookup_joins_max_lookup_ratio              10000
+parallelize_multi_key_lookup_joins_only_on_mr_mutations          on
 password_encryption                                              scram-sha-256
 pg_trgm.similarity_threshold                                     0.3
 plan_cache_mode                                                  auto

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3083,7 +3083,11 @@ optimizer_use_provided_ordering_fix                              on             
 optimizer_use_trigram_similarity_optimization                    on                  NULL      NULL        NULL        string
 optimizer_use_virtual_computed_column_stats                      on                  NULL      NULL        NULL        string
 override_multi_region_zone_config                                off                 NULL      NULL        NULL        string
+parallelize_multi_key_lookup_joins_avg_lookup_ratio              10                  NULL      NULL        NULL        string
+parallelize_multi_key_lookup_joins_avg_lookup_row_size           100 KiB             NULL      NULL        NULL        string
 parallelize_multi_key_lookup_joins_enabled                       off                 NULL      NULL        NULL        string
+parallelize_multi_key_lookup_joins_max_lookup_ratio              10000               NULL      NULL        NULL        string
+parallelize_multi_key_lookup_joins_only_on_mr_mutations          on                  NULL      NULL        NULL        string
 password_encryption                                              scram-sha-256       NULL      NULL        NULL        string
 pg_trgm.similarity_threshold                                     0.3                 NULL      NULL        NULL        string
 plan_cache_mode                                                  auto                NULL      NULL        NULL        string
@@ -3320,7 +3324,11 @@ optimizer_use_provided_ordering_fix                              on             
 optimizer_use_trigram_similarity_optimization                    on                  NULL  user     NULL      on                  on
 optimizer_use_virtual_computed_column_stats                      on                  NULL  user     NULL      on                  on
 override_multi_region_zone_config                                off                 NULL  user     NULL      off                 off
+parallelize_multi_key_lookup_joins_avg_lookup_ratio              10                  NULL  user     NULL      10                  10
+parallelize_multi_key_lookup_joins_avg_lookup_row_size           100 KiB             B     user     NULL      100 KiB             100 KiB
 parallelize_multi_key_lookup_joins_enabled                       off                 NULL  user     NULL      off                 off
+parallelize_multi_key_lookup_joins_max_lookup_ratio              10000               NULL  user     NULL      10000               10000
+parallelize_multi_key_lookup_joins_only_on_mr_mutations          on                  NULL  user     NULL      on                  on
 password_encryption                                              scram-sha-256       NULL  user     NULL      scram-sha-256       scram-sha-256
 pg_trgm.similarity_threshold                                     0.3                 NULL  user     NULL      0.3                 0.3
 plan_cache_mode                                                  auto                NULL  user     NULL      auto                auto
@@ -3548,7 +3556,11 @@ optimizer_use_provided_ordering_fix                              NULL    NULL   
 optimizer_use_trigram_similarity_optimization                    NULL    NULL     NULL     NULL        NULL
 optimizer_use_virtual_computed_column_stats                      NULL    NULL     NULL     NULL        NULL
 override_multi_region_zone_config                                NULL    NULL     NULL     NULL        NULL
+parallelize_multi_key_lookup_joins_avg_lookup_ratio              NULL    NULL     NULL     NULL        NULL
+parallelize_multi_key_lookup_joins_avg_lookup_row_size           NULL    NULL     NULL     NULL        NULL
 parallelize_multi_key_lookup_joins_enabled                       NULL    NULL     NULL     NULL        NULL
+parallelize_multi_key_lookup_joins_max_lookup_ratio              NULL    NULL     NULL     NULL        NULL
+parallelize_multi_key_lookup_joins_only_on_mr_mutations          NULL    NULL     NULL     NULL        NULL
 password_encryption                                              NULL    NULL     NULL     NULL        NULL
 pg_trgm.similarity_threshold                                     NULL    NULL     NULL     NULL        NULL
 plan_cache_mode                                                  NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -187,7 +187,11 @@ optimizer_use_provided_ordering_fix                              on
 optimizer_use_trigram_similarity_optimization                    on
 optimizer_use_virtual_computed_column_stats                      on
 override_multi_region_zone_config                                off
+parallelize_multi_key_lookup_joins_avg_lookup_ratio              10
+parallelize_multi_key_lookup_joins_avg_lookup_row_size           100 KiB
 parallelize_multi_key_lookup_joins_enabled                       off
+parallelize_multi_key_lookup_joins_max_lookup_ratio              10000
+parallelize_multi_key_lookup_joins_only_on_mr_mutations          on
 password_encryption                                              scram-sha-256
 pg_trgm.similarity_threshold                                     0.3
 plan_cache_mode                                                  auto

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2709,6 +2709,143 @@ func (b *Builder) handleRemoteLookupJoinError(join *memo.LookupJoinExpr) (err er
 	return nil
 }
 
+// shouldParallelizeLookupJoin returns whether the execution engine should
+// parallelize lookup join reads across ranges. The joiner has a choice to make
+// between getting DistSender-level parallelism for its lookup batches and
+// setting row and memory limits (due to implementation limitations, you can't
+// have both at the same time). Note that the Streamer API overcomes these
+// limitations, so this parallelization recommendation doesn't have any
+// influence if the execution engine uses the Streamer.
+//
+// The goal of this function is to determine whether the lookup join is likely
+// to be "safe" for parallelization, meaning that it's extremely unlikely to OOM
+// the node performing the lookup.
+func (b *Builder) shouldParallelizeLookupJoin(
+	join *memo.LookupJoinExpr, lookupOrdinals exec.TableColumnOrdinalSet,
+) bool {
+	if join.LookupColsAreTableKey {
+		// We choose parallelism when we know that each lookup returns at most
+		// one row.
+		return true
+	}
+	sd := b.evalCtx.SessionData()
+	if sd.ParallelizeMultiKeyLookupJoinsEnabled {
+		// This setting unconditionally enables the parallelism.
+		return true
+	}
+
+	// See whether the "average lookup ratio" heuristic is applicable.
+	allowedAvgRatio := sd.ParallelizeMultiKeyLookupJoinsAvgLookupRatio
+	if allowedAvgRatio == 0 {
+		// The "average lookup ratio" heuristic is disabled.
+		log.VEventf(b.ctx, 2, "the average lookup ratio heuristic disabled, not parallelizing")
+		return false
+	}
+	if len(join.KeyCols) == 0 && join.EqualityLookupCols.Len() == 0 {
+		// If we don't have any columns constrained via an equality condition,
+		// then we're performing a range lookup, for which it's hard to estimate
+		// the lookup ratio, so we disable the parallelism.
+		log.VEventf(b.ctx, 2, "no equality lookup columns, not parallelizing")
+		return false
+	}
+	md := b.mem.Metadata()
+	table := md.Table(join.Table)
+	// Out of caution, we currently utilize the heuristic only for mutations of
+	// multi-region tables.
+	// TODO(#149849): remove this check so that the heuristic is applicable in
+	// all cases.
+	if sd.ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations {
+		if !table.IsMultiregion() || !b.flags.IsSet(exec.PlanFlagContainsMutation) {
+			log.VEventf(b.ctx, 2, "either not multi-region or not a mutation, not parallelizing")
+			return false
+		}
+	}
+	// Estimate the average lookup ratio - we want to know how many looked up
+	// rows each input row will result in, and if it's relatively small, then
+	// we'll consider the lookup join "safe" for parallelization.
+	tableStats, ok := memo.GetTableStats(md, join.Table)
+	if !ok || !tableStats.Available {
+		// We don't have the table stats to make an informed decision, so we
+		// choose the safer option of disabling parallelism.
+		log.VEventf(b.ctx, 2, "lookup table stats are unavailable, not parallelizing")
+		return false
+	}
+	var equalityLookupCols opt.ColSet
+	// Only one of {EqualityLookupCols, KeyCols} is set.
+	if len(join.KeyCols) > 0 {
+		idx := table.Index(join.Index)
+		for i := 0; i < len(join.KeyCols); i++ {
+			ord := idx.Column(i).Ordinal()
+			equalityLookupCols.Add(join.Table.ColumnID(ord))
+		}
+	} else {
+		equalityLookupCols = join.EqualityLookupCols
+	}
+	colStat, ok := tableStats.ColStats.Lookup(equalityLookupCols)
+	if !ok {
+		// We have table stats but don't have column stats for the equality
+		// columns, so we can't make an informed decision.
+		log.VEventf(b.ctx, 2, "equality lookup column stats are unavailable, not parallelizing")
+		return false
+	}
+	if colStat.DistinctCount == 1 && colStat.NullCount > 0 {
+		// It appears that we only have NULLs in the lookup columns, we'll
+		// consider such case safe since we cannot look up those rows.
+		log.VEventf(b.ctx, 2, "only NULLs in lookup columns, parallelizing")
+		return true
+	}
+	rowCount, distinctCount := tableStats.RowCount, colStat.DistinctCount
+	if colStat.NullCount > 0 {
+		// Ignore rows with NULLs in the lookup columns since we cannot look
+		// them up.
+		rowCount -= colStat.NullCount
+		distinctCount -= 1
+	}
+	// We assume that each unique combination of values in lookup equality
+	// columns will result in the same lookup ratio.
+	estimatedAvgRatio := rowCount / distinctCount
+	if estimatedAvgRatio > allowedAvgRatio {
+		log.VEventf(b.ctx, 2, "lookup join estimated avg ratio %.2f exceeds allowed %.2f, not parallelizing", estimatedAvgRatio, allowedAvgRatio)
+		return false
+	}
+
+	// Guardrail 1: if we have a possible heavy hitter for the lookup equality
+	// columns, then ensure that its frequency doesn't exceed the allowed
+	// maximum. In absence of the histogram this guardrail is disabled.
+	if allowedMaxRatio := sd.ParallelizeMultiKeyLookupJoinsMaxLookupRatio; allowedMaxRatio != 0 && colStat.Histogram != nil {
+		estimatedMaxRatio := colStat.Histogram.MaxFrequency(true /* ignoreNulls */)
+		if estimatedMaxRatio > allowedMaxRatio {
+			log.VEventf(b.ctx, 2, "lookup join estimated max ratio %.2f exceeds allowed %.2f, not parallelizing", estimatedMaxRatio, allowedMaxRatio)
+			return false
+		}
+	}
+
+	// Guardrail 2: ensure that the estimated average lookup row size doesn't
+	// exceed the allowed size. In absence of the AvgColSizes this guardrail is
+	// disabled.
+	if allowedAvgRowSize := sd.ParallelizeMultiKeyLookupJoinsAvgLookupRowSize; allowedAvgRowSize != 0 && len(tableStats.AvgColSizes) > 0 {
+		var estimatedAvgRowSize uint64
+		lookupOrdinals.ForEach(func(lookupCol int) {
+			if len(tableStats.AvgColSizes) <= lookupCol {
+				if buildutil.CrdbTestBuild {
+					panic(errors.AssertionFailedf(
+						"lookup column ordinal %d not present in AvgColSizes", lookupCol,
+					))
+				}
+				return
+			}
+			estimatedAvgRowSize += tableStats.AvgColSizes[lookupCol]
+		})
+		if estimatedAvgRowSize > uint64(allowedAvgRowSize) {
+			log.VEventf(b.ctx, 2, "lookup join estimated avg row size %d exceeds allowed %d, not parallelizing", estimatedAvgRowSize, allowedAvgRowSize)
+			return false
+		}
+	}
+
+	log.VEventf(b.ctx, 2, "lookup join estimated avg ratio %.2f, parallelizing", estimatedAvgRatio)
+	return true
+}
+
 func (b *Builder) buildLookupJoin(
 	join *memo.LookupJoinExpr,
 ) (_ execPlan, outputCols colOrdMap, err error) {
@@ -2872,17 +3009,7 @@ func (b *Builder) buildLookupJoin(
 		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("lookup join can't provide required ordering")
 	}
 	reverse := requiredDirection == ordering.ReverseDirection
-	// The joiner has a choice to make between getting DistSender-level
-	// parallelism for its lookup batches and setting row and memory limits (due
-	// to implementation limitations, you can't have both at the same time).
-	var parallelize bool
-	if join.LookupColsAreTableKey {
-		// We choose parallelism when we know that each lookup returns at most
-		// one row.
-		parallelize = true
-	} else if b.evalCtx.SessionData().ParallelizeMultiKeyLookupJoinsEnabled {
-		parallelize = true
-	}
+	parallelize := b.shouldParallelizeLookupJoin(join, lookupOrdinals)
 	for _, c := range reqOrdering {
 		if c.ColIdx >= numInputCols {
 			// We need to maintain lookup ordering, in which case we cannot use

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3418,7 +3418,6 @@ func (b *Builder) buildRecursiveCTE(
 	// To implement exec.RecursiveCTEIterationFn, we create a special Builder.
 
 	innerBldTemplate := &Builder{
-		ctx:     b.ctx,
 		mem:     b.mem,
 		catalog: b.catalog,
 		semaCtx: b.semaCtx,
@@ -3430,9 +3429,10 @@ func (b *Builder) buildRecursiveCTE(
 		withExprs: b.withExprs[:len(b.withExprs):len(b.withExprs)],
 	}
 
-	fn := func(ef exec.Factory, bufferRef exec.Node) (exec.Plan, error) {
+	fn := func(ctx context.Context, ef exec.Factory, bufferRef exec.Node) (exec.Plan, error) {
 		// Use a separate builder each time.
 		innerBld := *innerBldTemplate
+		innerBld.ctx = ctx
 		innerBld.factory = ef
 		innerBld.addBuiltWithExpr(rec.WithID, initialCols, bufferRef)
 		// TODO(mgartner): I think colOrdsAlloc can be reused for each recursive

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -27,7 +27,13 @@ ALTER TABLE def INJECT STATISTICS '[
     "columns": ["f"],
     "created_at": "2018-01-01 1:00:00.00000+00:00",
     "row_count": 10000,
-    "distinct_count": 10000
+    "distinct_count": 10000,
+    "avg_size": 3,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 1, "num_range": 0, "distinct_range": 0, "upper_bound": "1"},
+      {"num_eq": 1, "num_range": 9998, "distinct_range": 9998, "upper_bound": "10000"}
+    ]
   }
 ]'
 
@@ -41,28 +47,14 @@ ALTER TABLE def_e_decimal INJECT STATISTICS '[
   }
 ]'
 
-query T
-EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
-----
-distribution: local
-vectorized: true
-·
-• lookup join (inner)
-│ columns: (a, b, c, d, e, f)
-│ estimated row count: 99
-│ table: def@def_pkey
-│ equality: (b) = (f)
-│
-└── • scan
-      columns: (a, b, c)
-      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
-      table: abc@abc_pkey
-      spans: FULL SCAN
+subtest parallelization_decision
 
-# Same as above but with lookup join parallelization.
+# Enable the "average lookup ratio" heuristic for all statements.
 statement ok
-SET parallelize_multi_key_lookup_joins_enabled = true;
+SET parallelize_multi_key_lookup_joins_only_on_mr_mutations = false;
 
+# By default, this lookup join is considered to be safe to parallelize (based on
+# the average lookup ratio).
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
 ----
@@ -82,8 +74,64 @@ vectorized: true
       table: abc@abc_pkey
       spans: FULL SCAN
 
+# Now disable the average lookup ratio heuristic but verify that override still
+# applies.
+statement ok
+SET parallelize_multi_key_lookup_joins_avg_lookup_ratio = 0;
+
+statement ok
+SET parallelize_multi_key_lookup_joins_enabled = true;
+
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b] WHERE info LIKE '%parallel%'
+----
+1
+
 statement ok
 RESET parallelize_multi_key_lookup_joins_enabled;
+
+# Same as the first case but with reduced allowed avg lookup ratio
+# (parallelization should be disabled).
+statement ok
+SET parallelize_multi_key_lookup_joins_avg_lookup_ratio = 0.001;
+
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b] WHERE info LIKE '%parallel%'
+----
+0
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_avg_lookup_ratio;
+
+# Now parallelization should be disabled due to max lookup ratio being exceeded.
+statement ok
+SET parallelize_multi_key_lookup_joins_max_lookup_ratio = 0.001;
+
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b] WHERE info LIKE '%parallel%'
+----
+0
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_max_lookup_ratio;
+
+# Now parallelization should be disabled due to avg lookup row size being
+# exceeded.
+statement ok
+SET parallelize_multi_key_lookup_joins_avg_lookup_row_size = 1;
+
+query I
+SELECT count(*) FROM [EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b] WHERE info LIKE '%parallel%'
+----
+0
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_avg_lookup_row_size;
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_only_on_mr_mutations;
+
+subtest end
 
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -285,7 +285,7 @@ type KVOption struct {
 // RecursiveCTEIterationFn creates a plan for an iteration of WITH RECURSIVE,
 // given the result of the last iteration (as a node created by
 // ConstructBuffer).
-type RecursiveCTEIterationFn func(ef Factory, bufferRef Node) (Plan, error)
+type RecursiveCTEIterationFn func(ctx context.Context, ef Factory, bufferRef Node) (Plan, error)
 
 // ApplyJoinPlanRightSideFn creates a plan for an iteration of ApplyJoin, given
 // a row produced from the left side. The plan is guaranteed to produce the

--- a/pkg/sql/opt/memo/statistics_builder.go
+++ b/pkg/sql/opt/memo/statistics_builder.go
@@ -621,12 +621,19 @@ func (sb *statisticsBuilder) colStatLeaf(
 // | Table |
 // +-------+
 
+// GetTableStats returns the statistics for the given table if already available
+// in the metadata.
+func GetTableStats(md *opt.Metadata, tabID opt.TableID) (*props.Statistics, bool) {
+	stats, ok := md.TableAnnotation(tabID, statsAnnID).(*props.Statistics)
+	return stats, ok
+}
+
 // makeTableStatistics returns the available statistics for the given table.
 // Statistics are derived lazily and are cached in the metadata, since they may
 // be accessed multiple times during query optimization. For more details, see
 // props.Statistics.
 func (sb *statisticsBuilder) makeTableStatistics(tabID opt.TableID) *props.Statistics {
-	stats, ok := sb.md.TableAnnotation(tabID, statsAnnID).(*props.Statistics)
+	stats, ok := GetTableStats(sb.md, tabID)
 	if ok {
 		// Already made.
 		return stats

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -450,6 +450,10 @@ define LookupJoinPrivate {
     # table (and thus each left row matches with at most one table row).
     LookupColsAreTableKey bool
 
+    # EqualityLookupCols indicates the ColumnIDs of index columns that were
+    # constrained via equality conditions. It'll only be set if LookupExpr is.
+    EqualityLookupCols ColSet
+
     # At most one of Is{First,Second}JoinInPairedJoiner can be true.
     #
     # IsFirstJoinInPairedJoiner is true if this is the first (i.e., lower in the

--- a/pkg/sql/opt/props/histogram.go
+++ b/pkg/sql/opt/props/histogram.go
@@ -238,9 +238,18 @@ func (h *Histogram) maxDistinctValuesCount() float64 {
 }
 
 // MaxFrequency returns the maximum value of NumEq across all histogram buckets.
-func (h *Histogram) MaxFrequency() float64 {
+// ignoreNulls controls whether the "fake" bucket that we create for NULLs (if
+// any are present) should be ignored.
+func (h *Histogram) MaxFrequency(ignoreNulls bool) float64 {
+	if len(h.buckets) == 0 {
+		return 0
+	}
+	var startIdx int
+	if ignoreNulls && h.buckets[0].UpperBound == tree.DNull {
+		startIdx = 1
+	}
 	var mf float64
-	for i := range h.buckets {
+	for i := startIdx; i < len(h.buckets); i++ {
 		if numEq := h.numEq(i); numEq > mf {
 			mf = numEq
 		}

--- a/pkg/sql/opt/props/histogram_test.go
+++ b/pkg/sql/opt/props/histogram_test.go
@@ -183,7 +183,7 @@ func TestHistogram(t *testing.T) {
 	if distinct != expected {
 		t.Fatalf("expected %f but found %f", expected, distinct)
 	}
-	maxFrequency, expected := h.MaxFrequency(), float64(35)
+	maxFrequency, expected := h.MaxFrequency(false /* ignoreNulls */), float64(35)
 	if maxFrequency != expected {
 		t.Fatalf("expected %f but found %f", expected, maxFrequency)
 	}
@@ -391,7 +391,7 @@ func TestHistogram(t *testing.T) {
 			if testData[i].distinct != distinct {
 				t.Fatalf("expected %f but found %f", testData[i].distinct, distinct)
 			}
-			maxFrequency := roundVal(filtered.MaxFrequency())
+			maxFrequency := roundVal(filtered.MaxFrequency(false /* ignoreNulls */))
 			if testData[i].maxFrequency != maxFrequency {
 				t.Fatalf("expected %f but found %f", testData[i].maxFrequency, maxFrequency)
 			}

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -235,7 +235,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~47KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~48KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -343,7 +343,7 @@ SELECT *
 FROM stu, abc, xyz, pqr
 WHERE u = a AND a = x AND x = p
 ----
-memo (optimized, ~41KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~42KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+6) (merge-join G3 G2 G5 inner-join,+6,+3) (lookup-join G3 G5 stu@uts,keyCols=[6],outCols=(1-3,6-8,12-14,18-22))
  │    └── [presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (merge-join G2="[ordering: +3]" G3="[ordering: +(6|12|18)]" G5 inner-join,+3,+6)
@@ -1949,7 +1949,7 @@ inner-join (lookup xyz@xy)
 memo disable=(EliminateJoinUnderProjectLeft,EliminateJoinUnderProjectRight)
 SELECT * FROM stu AS l JOIN stu AS r ON (l.s, l.t, l.u) = (r.s, r.t, r.u)
 ----
-memo (optimized, ~20KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
+memo (optimized, ~21KB, required=[presentation: s:1,t:2,u:3,s:6,t:7,u:8])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+2,+3,+6,+7,+8) (merge-join G2 G3 G5 inner-join,+3,+2,+1,+8,+7,+6) (lookup-join G2 G5 stu [as=r],keyCols=[1 2 3],outCols=(1-3,6-8)) (lookup-join G2 G5 stu@uts [as=r],keyCols=[3 2 1],outCols=(1-3,6-8)) (merge-join G3 G2 G5 inner-join,+6,+7,+8,+1,+2,+3) (merge-join G3 G2 G5 inner-join,+8,+7,+6,+3,+2,+1) (lookup-join G3 G5 stu [as=l],keyCols=[6 7 8],outCols=(1-3,6-8)) (lookup-join G3 G5 stu@uts [as=l],keyCols=[8 7 6],outCols=(1-3,6-8))
  │    └── [presentation: s:1,t:2,u:3,s:6,t:7,u:8]
  │         ├── best: (merge-join G2="[ordering: +1,+2,+3]" G3="[ordering: +6,+7,+8]" G5 inner-join,+1,+2,+3,+6,+7,+8)

--- a/pkg/sql/recursive_cte.go
+++ b/pkg/sql/recursive_cte.go
@@ -135,17 +135,21 @@ func (n *recursiveCTENode) Next(params runParams) (bool, error) {
 		rows:                lastWorkingRows,
 		label:               n.label,
 	}
-	newPlan, err := n.genIterationFn(newExecFactory(params.ctx, params.p), buf)
+
+	// Create a separate tracing span that will be used when planning and
+	// running this iteration. Note that we'll still use the "outer" params.ctx
+	// when accessing rows in the container.
+	n.iterationCount++
+	opName := "recursive-cte-iteration-" + strconv.Itoa(n.iterationCount)
+	planAndRunCtx, sp := tracing.ChildSpan(params.ctx, opName)
+	defer sp.Finish()
+
+	newPlan, err := n.genIterationFn(planAndRunCtx, newExecFactory(planAndRunCtx, params.p), buf)
 	if err != nil {
 		return false, err
 	}
-
-	n.iterationCount++
-	opName := "recursive-cte-iteration-" + strconv.Itoa(n.iterationCount)
-	ctx, sp := tracing.ChildSpan(params.ctx, opName)
-	defer sp.Finish()
 	if err := runPlanInsidePlan(
-		ctx, params, newPlan.(*planComponents), rowResultWriter(n),
+		planAndRunCtx, params, newPlan.(*planComponents), rowResultWriter(n),
 		nil /* deferredRoutineSender */, "", /* stmtForDistSQLDiagram */
 	); err != nil {
 		return false, err

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -699,6 +699,35 @@ message LocalOnlySessionData {
   // full-size vectors. It acts as a multiplier on a base limit derived from the
   // search beam size and the top-k results requested by the query.
   int32 vector_search_rerank_multiplier = 178;
+  // ParallelizeMultiKeyLookupJoinsAvgLookupRatio controls the average lookup
+  // ratio of the lookup join (i.e. the number of looked up rows we get for each
+  // input row) that we consider "safe" for parallelization across ranges. If
+  // the estimated average lookup ratio exceeds this, then the parallelization
+  // is disabled. Setting it to zero disables this parallelization heuristic.
+  // This setting only has impact on multi-key lookup joins that are not powered
+  // by the streamer.
+  double parallelize_multi_key_lookup_joins_avg_lookup_ratio = 179;
+  // ParallelizeMultiKeyLookupJoinsMaxLookupRatio adds a guardrail to the
+  // heuristic of ParallelizeMultiKeyLookupJoinsAvgLookupRatio so that if the
+  // estimated maximum lookup ratio for a single input row exceeds this, then
+  // the heuristic is disabled. In other words, if the lookup table has some
+  // "heavy hitters", this setting controls their frequency at which we still
+  // consider the heuristic "safe". Setting it to zero disables the guardrail.
+  double parallelize_multi_key_lookup_joins_max_lookup_ratio = 180;
+  // ParallelizeMultiKeyLookupJoinsAvgLookupRowSize adds a guardrail to the
+  // heuristic of ParallelizeMultiKeyLookupJoinsAvgLookupRatio so that if the
+  // estimated average lookup row size exceeds this, then the heuristic is
+  // disabled. In other words, since the looked up rows could be very large in
+  // size, this setting controls the size threshold that we still consider to be
+  // "safe" for parallelization heuristic. Setting it to zero disables the
+  // guardrail.
+  int64 parallelize_multi_key_lookup_joins_avg_lookup_row_size = 181;
+  // ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations, if set, indicates that the
+  // "average lookup ratio" parallelization heuristic (as controlled via 3 knobs
+  // above) should only apply to mutations of multi-region tables. If false,
+  // then the heuristic applies to all statements (both read-only and
+  // mutations), regardless of the table being multi-region.
+  bool parallelize_multi_key_lookup_joins_only_on_mr_mutations = 182 [(gogoproto.customname) = "ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations"];
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -2437,6 +2437,94 @@ var varGen = map[string]sessionVar{
 		},
 	},
 
+	// CockroachDB extension.
+	`parallelize_multi_key_lookup_joins_avg_lookup_ratio`: {
+		GetStringVal: makeFloatGetStringValFn(`parallelize_multi_key_lookup_joins_avg_lookup_ratio`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			if f < 0 {
+				return pgerror.Newf(
+					pgcode.InvalidParameterValue, "parallelize_multi_key_lookup_joins_avg_lookup_ratio must be non-negative",
+				)
+			}
+			m.SetParallelizeMultiKeyLookupJoinsAvgLookupRatio(f)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatFloatAsPostgresSetting(evalCtx.SessionData().ParallelizeMultiKeyLookupJoinsAvgLookupRatio), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatFloatAsPostgresSetting(10)
+		},
+	},
+
+	// CockroachDB extension.
+	`parallelize_multi_key_lookup_joins_max_lookup_ratio`: {
+		GetStringVal: makeFloatGetStringValFn(`parallelize_multi_key_lookup_joins_max_lookup_ratio`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			f, err := strconv.ParseFloat(s, 64)
+			if err != nil {
+				return err
+			}
+			if f < 0 {
+				return pgerror.Newf(
+					pgcode.InvalidParameterValue, "parallelize_multi_key_lookup_joins_max_lookup_ratio must be non-negative",
+				)
+			}
+			m.SetParallelizeMultiKeyLookupJoinsMaxLookupRatio(f)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatFloatAsPostgresSetting(evalCtx.SessionData().ParallelizeMultiKeyLookupJoinsMaxLookupRatio), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return formatFloatAsPostgresSetting(10000)
+		},
+	},
+
+	// CockroachDB extension.
+	`parallelize_multi_key_lookup_joins_avg_lookup_row_size`: {
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			size, err := humanizeutil.ParseBytes(s)
+			if err != nil {
+				return err
+			}
+			if size < 0 {
+				return errors.New("parallelize_multi_key_lookup_joins_avg_lookup_row_size must be non-negative")
+			}
+			m.SetParallelizeMultiKeyLookupJoinsAvgLookupRowSize(size)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return string(humanizeutil.IBytes(evalCtx.SessionData().ParallelizeMultiKeyLookupJoinsAvgLookupRowSize)), nil
+		},
+		Unit:         "B",
+		GetStringVal: makeByteSizeVarGetter("parallelize_multi_key_lookup_joins_avg_lookup_row_size"),
+		GlobalDefault: func(sv *settings.Values) string {
+			return string(humanizeutil.IBytes(100 << 10 /* 100 KiB */))
+		},
+	},
+
+	// CockroachDB extension.
+	`parallelize_multi_key_lookup_joins_only_on_mr_mutations`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`parallelize_multi_key_lookup_joins_only_on_mr_mutations`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("parallelize_multi_key_lookup_joins_only_on_mr_mutations", s)
+			if err != nil {
+				return err
+			}
+			m.SetParallelizeMultiKeyLookupJoinsOnlyOnMRMutations(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations), nil
+		},
+		GlobalDefault: globalTrue,
+	},
+
 	// TODO(harding): Remove this when costing scans based on average column size
 	// is fully supported.
 	// CockroachDB extension.


### PR DESCRIPTION
**sql: use correct context in recursive CTE iterations**

Previously, the `execbuilder.Builder` that we use in recursive CTE
iterations referenced the same context that the Builder captured on the
main query path. This is problematic since that context might have
a tracing span that's already been finished. This commit fixes this
issue by explicitly passing the context argument into the iteration
function. This was only exposed because we added some logging in the
following commit but has been present for a while now.

**logictest: extend a few EXPLAIN tests a bit**

This commit adjusts a few existing EXPLAIN tests to use VERBOSE as well as
adds another RBR setup with CASCADE FKs. These will be used to highlight
the parallelization change in the multi-key lookup joins in the
following commit.

**execbuilder: add "average lookup ratio" parallelization heuristic for lookup joins**

The DistSender API forces its users to make a choice between cross-range
parallelism (which is needed for performance) and setting memory limits
(which is needed for stability). Streamer was introduced to address this
limitation, but it comes with some requirements, one of which is that it
needs to have access to LeafTxns. However, mutation statements must run
in the RootTxn, so we never use the Streamer for those and fall back to
using the DistSender API directly (via `txnKVFetcher`). There, we
currently have the following heuristic:
- if we know that each input row results in at most one lookup row, then
we consider such a lookup to be "safe" parallelization, so we disable
usage of memory limits on the BatchHeader. This is the case for index
joins (when we always expect to get exactly one looked up row) as well
as lookup joins that have "equality columns are key" property (when we
expect at most one looked up row).
- otherwise, if we have a multi-key lookup join, we use the default
fetcher memory limits (TargetBytes of 10MiB), which disables cross-range
parallelism.

Most commonly this will affect mutation statements and will have a more
pronouanced effect on the multi-region tables, so this commit extends the
heuristic for when we consider it to be "safe" for parallelization.

Namely, we now calculate the average lookup ratio based on the lookup
equality columns and the available table / column statistics, and if the
ratio doesn't exceed the allowed limit, then we'll enable the
parallelism. To a certain degree, this heuristic resembles the "equality
columns are key" heuristic that we already utilize, but instead of
a guaranteed maximum on the lookup ratio we use the estimated average.

What we're trying to prevent with the existing and the new heuristics is
the case when we construct such a KV batch that the KV response will
overwhelm (read "will OOM") the node issuing the KV batch. In the
existing heuristic we say that "if lookup ratio is guaranteed to not
exceed one, then it should be safe".

I believe that the new heuristic should be safe in practice for most
deployments due to the following reasons:
- we already have an implicit limiting behavior in the join reader due
to its execution model (it first buffers some number of rows, up to
2MiB in size when not using the streamer, deduplicates the lookup spans,
and performs the lookup of all those spans in a single KV batch).
Empirical testing shows that we expect to have at most 25k lookups in
that single KV batch.
- this will have impact only when the streamer is not used, which most
commonly will mean we're executing a mutation, and in our docs we
advocate for not performing large mutations. (I'm stretching things
a bit here since even if we modify small amount of data, to compute that
we might read a lot, which could be destabilizing if we disable KV
limits. Yet a similar argument could be made that our current
"equality columns are key" heuristic is not safe - it's possible to
construct a scenario where we look up large amounts of data.)

In order to prevent this new heuristic from exploding in some edge
cases, two guardrails are added:
- in order to handle a scenario where the lookup ratio is not evenly
distributed (i.e. different input rows can result in vastly different
number of looked up rows), we'll disable the heuristic if the max lookup
ratio exceeds the allowed limit.
- in order to handle a scenario where looked rows are very large, we'll
disable the heuristic if the estimated average lookup row size exceeds
the allowed limit. (Note that we don't have this kind of protection in
the existing heuristics.)

I plan to do some more empirical runs to fine-tune the default values of
the newly added session variables, but the current defaults are:
- `parallelize_multi_key_lookup_joins_avg_lookup_ratio = 10`
- `parallelize_multi_key_lookup_joins_max_lookup_ratio = 10000`
- `parallelize_multi_key_lookup_joins_avg_lookup_row_size = 100 KiB`.

In order to de-risk rollout of this feature, we will initially apply the
new heuristic only to mutations of multi-region tables. New session
variable `parallelize_multi_key_lookup_joins_only_on_mr_mutations` can
be set to `false` to apply the heuristic to all statements, regardless
of the table being multi-region.

Fixes: #134351.
Epic: CRDB-44104

Release note (performance improvement): Mutation statements (UPDATEs and
DELETEs) that perform lookup joins into multi-region tables (perhaps as
part of a CASCADE) are now more likely to parallelize the lookups across
ranges which improves their performance.