### PR TITLE
build, microbench-ci: update token retrieval

### DIFF
--- a/.github/workflows/microbenchmarks-ci.yaml
+++ b/.github/workflows/microbenchmarks-ci.yaml
@@ -1,6 +1,6 @@
 name: Microbenchmarks CI
 on:
-  pull_request_target:
+  pull_request:
     types: [ opened, reopened, synchronize ]
     branches: [ master ]
 concurrency:
@@ -91,7 +91,6 @@ jobs:
         env:
           BASE_SHA: ${{ needs.base.outputs.merge_base }}
           HEAD_SHA: ${{ env.HEAD }}
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           GITHUB_REPO: "cockroachdb/cockroach"
           GITHUB_PR_NUMBER: ${{ github.event.pull_request.number }}
       - name: Clean up

--- a/build/github/microbenchmarks/compare.sh
+++ b/build/github/microbenchmarks/compare.sh
@@ -21,6 +21,12 @@ for sha in "${shas[@]}"; do
   gcloud storage cp -r "gs://${storage_bucket}/artifacts/${sha}/${BUILD_ID}/*" "${working_dir}/${sha}/artifacts/"
 done
 
+# Retrieve token (with logging disabled)
+set +x
+GITHUB_TOKEN=$(gcloud secrets versions access 1 --secret=cockroach-microbench-ga-token)
+export GITHUB_TOKEN
+set -x
+
 # Compare the microbenchmarks
 ./build/github/microbenchmarks/util.sh compare \
   --working-dir="$working_dir" \
@@ -30,6 +36,9 @@ done
   --old="$BASE_SHA" \
   --new="$HEAD_SHA" \
   --post
+
+# Clear the token
+unset GITHUB_TOKEN
 
 cat "$output_dir/summary.md" > "$GITHUB_STEP_SUMMARY"
 


### PR DESCRIPTION
This change updates the token retrieval to use gcloud instead of relying on
target_pull_request to provide a token with the required permissions, to add
labels or post to a PR.

Epic: None
Release note: None