### PR TITLE
gossip: consolidate `GossipClient` RPC client creation

### DIFF
--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@org_golang_google_grpc//:grpc",
     ],
 )
 


### PR DESCRIPTION
This commit consolidates `GossipClient` RPC client creation logic in gossip package. It is a continuation of the work done in #147606.

Epic: CRDB-48923
Fixes: #148201
Release note: none