### PR TITLE
sql/rls: push leakproof projections through permeable Barriers

### DIFF
--- a/pkg/sql/opt/norm/project_funcs.go
+++ b/pkg/sql/opt/norm/project_funcs.go
@@ -962,3 +962,14 @@ func (c *CustomFuncs) UnbindFiltersFromProjections(
 	newFilters := c.f.RemapCols(&filters, colMap).(*memo.FiltersExpr)
 	return *newFilters
 }
+
+// HasAllLeakProofProjections returns true if every projection given uses
+// leakproof expressions.
+func (c *CustomFuncs) HasAllLeakProofProjections(projections memo.ProjectionsExpr) bool {
+	for i := range projections {
+		if !projections[i].ScalarProps().VolatilitySet.IsLeakproof() {
+			return false
+		}
+	}
+	return true
+}

--- a/pkg/sql/opt/norm/rules/project.opt
+++ b/pkg/sql/opt/norm/rules/project.opt
@@ -351,3 +351,23 @@ $input
     (FoldIsNullProjectionsItems $projections $input)
     $passthrough
 )
+
+# PushLeakproofProjectionsIntoPermeableBarrier moves a Project below a Barrier
+# when all projection expressions are leakproof and the Barrier is marked as
+# permeable. This is safe because leakproof expressions cannot reveal
+# information through their evaluation, and a permeable Barrier allows such
+# projections to pass through it.
+[PushLeakproofProjectionsIntoPermeableBarrier, Normalize]
+(Project
+    (Barrier
+        $input:*
+        $leakproofPermeable:* & (If $leakproofPermeable)
+    )
+    $projections:* & (HasAllLeakProofProjections $projections)
+    $passthrough:*
+)
+=>
+(Barrier
+    (Project $input $projections $passthrough)
+    $leakproofPermeable
+)

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -31,6 +31,30 @@ CREATE TABLE assn_cast (
 )
 ----
 
+exec-ddl
+CREATE TABLE rls (x INT PRIMARY KEY, y INT, alice_has_access BOOL);
+----
+
+exec-ddl
+CREATE INDEX ON rls(y);
+----
+
+exec-ddl
+ALTER TABLE rls ENABLE ROW LEVEL SECURITY;
+----
+
+exec-ddl
+CREATE POLICY select_policy_alice
+ON rls
+FOR SELECT
+TO alice
+USING (alice_has_access);
+----
+
+exec-ddl
+CREATE ROLE alice;
+----
+
 # --------------------------------------------------
 # EliminateJoinUnderProjectLeft
 # --------------------------------------------------
@@ -2018,3 +2042,103 @@ sort
       │    └── fd: (1)-->(2)
       └── projections
            └── y:2 IS NULL [as=nulls_ordering_y:7, outer=(2)]
+
+# --------------------------------------------------
+# PushLeakproofProjectionsIntoPermeableBarrier
+# --------------------------------------------------
+
+exec-ddl
+SET ROLE alice;
+----
+
+# All expressions in projection are leakproof
+norm expect=PushLeakproofProjectionsIntoPermeableBarrier
+SELECT CASE WHEN y = 20 THEN 10 ELSE 0 END FROM rls
+----
+barrier
+ ├── columns: case:6
+ └── project
+      ├── columns: case:6
+      ├── select
+      │    ├── columns: y:2 alice_has_access:3!null
+      │    ├── fd: ()-->(3)
+      │    ├── scan rls
+      │    │    └── columns: y:2 alice_has_access:3
+      │    └── filters
+      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+      └── projections
+           └── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]
+
+# Only some expressions in projection are leakproof
+norm expect-not=PushLeakproofProjectionsIntoPermeableBarrier
+SELECT CASE WHEN y = 20 THEN 10 ELSE 0 END, y/0 FROM rls
+----
+project
+ ├── columns: case:6 "?column?":7
+ ├── immutable
+ ├── barrier
+ │    ├── columns: x:1!null y:2 alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2,4,5)
+ │    └── select
+ │         ├── columns: x:1!null y:2 alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         ├── key: (1)
+ │         ├── fd: ()-->(3), (1)-->(2,4,5)
+ │         ├── scan rls
+ │         │    ├── columns: x:1!null y:2 alice_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-5)
+ │         └── filters
+ │              └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ └── projections
+      ├── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]
+      └── y:2 / 0 [as="?column?":7, outer=(2), immutable]
+
+# All expressions in projection are not leakproof
+norm expect-not=PushLeakproofProjectionsIntoPermeableBarrier
+SELECT y/0 FROM rls
+----
+project
+ ├── columns: "?column?":6
+ ├── immutable
+ ├── barrier
+ │    ├── columns: x:1!null y:2 alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2,4,5)
+ │    └── select
+ │         ├── columns: x:1!null y:2 alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         ├── key: (1)
+ │         ├── fd: ()-->(3), (1)-->(2,4,5)
+ │         ├── scan rls
+ │         │    ├── columns: x:1!null y:2 alice_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2-5)
+ │         └── filters
+ │              └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ └── projections
+      └── y:2 / 0 [as="?column?":6, outer=(2), immutable]
+
+# All expressions in projection are leakproof and we have passthrough columns
+norm expect=PushLeakproofProjectionsIntoPermeableBarrier
+SELECT x, y, CASE WHEN y = 20 THEN 10 ELSE 0 END FROM rls
+----
+barrier
+ ├── columns: x:1!null y:2 case:6
+ ├── key: (1)
+ ├── fd: (1)-->(2), (2)-->(6)
+ └── project
+      ├── columns: case:6 x:1!null y:2
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)-->(6)
+      ├── select
+      │    ├── columns: x:1!null y:2 alice_has_access:3!null
+      │    ├── key: (1)
+      │    ├── fd: ()-->(3), (1)-->(2)
+      │    ├── scan rls
+      │    │    ├── columns: x:1!null y:2 alice_has_access:3
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2,3)
+      │    └── filters
+      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+      └── projections
+           └── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -2547,22 +2547,18 @@ project
 norm expect=PushLeakproofFiltersIntoPermeableBarrier
 SELECT * FROM rls WHERE y = 20;
 ----
-project
+barrier
  ├── columns: x:1!null y:2!null alice_has_access:3!null
  ├── key: (1)
  ├── fd: ()-->(2,3)
- └── barrier
-      ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
+ └── select
+      ├── columns: x:1!null y:2!null alice_has_access:3!null
       ├── key: (1)
-      ├── fd: ()-->(2,3), (1)-->(4,5)
-      └── select
-           ├── columns: x:1!null y:2!null alice_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
-           ├── key: (1)
-           ├── fd: ()-->(2,3), (1)-->(4,5)
-           ├── scan rls
-           │    ├── columns: x:1!null y:2 alice_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-           │    ├── key: (1)
-           │    └── fd: (1)-->(2-5)
-           └── filters
-                ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-                └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
+      ├── fd: ()-->(2,3)
+      ├── scan rls
+      │    ├── columns: x:1!null y:2 alice_has_access:3
+      │    ├── key: (1)
+      │    └── fd: (1)-->(2,3)
+      └── filters
+           ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+           └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -2110,17 +2110,15 @@ CREATE POLICY p1 ON ob USING (user_has_access);
 norm
 SELECT * FROM ob WHERE y = 20;
 ----
-project
+barrier
  ├── columns: x:1!null y:2!null user_has_access:3!null
- └── barrier
-      ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
-      └── select
-           ├── columns: x:1!null y:2!null user_has_access:3!null crdb_internal_mvcc_timestamp:4 tableoid:5
-           ├── scan ob
-           │    └── columns: x:1!null y:2 user_has_access:3 crdb_internal_mvcc_timestamp:4 tableoid:5
-           └── filters
-                ├── user_has_access:3
-                └── y:2 = 20
+ └── select
+      ├── columns: x:1!null y:2!null user_has_access:3!null
+      ├── scan ob
+      │    └── columns: x:1!null y:2 user_has_access:3
+      └── filters
+           ├── user_has_access:3
+           └── y:2 = 20
 
 # Barrier needed. Try to expose with a division by zero error.
 norm


### PR DESCRIPTION
Adds a normalization rule to push a Project operator below a Barrier when all projection expressions are leakproof and the Barrier is marked as permeable. This is needed to optimizer RLS queries since those have Barriers added to support the RLS filter. This rule will help bubble the Barrier up the plan tree.

The rule is applied if all projections are leakproof. I wasn't able to split the projection into leakproof and non-leakproof like the PushLeakproofFiltersIntoPermeableBarrier rule does for filter. I didn't know how to split the passthrough columns that go along with the projection.

Informs #146952

Epic: CRDB-48807
Release note: none