### PR TITLE
kv/bulk: extract fields into batch

### DIFF
--- a/pkg/kv/kvserver/kvserverbase/bulk_adder.go
+++ b/pkg/kv/kvserver/kvserverbase/bulk_adder.go
@@ -46,6 +46,8 @@ type BulkAdderOptions struct {
 	// BatchTimestamp is the timestamp to use on AddSSTable requests (which can be
 	// different from the timestamp used to construct the adder which is what is
 	// actually applied to each key).
+	//
+	// TODO(jeffswenson): this setting is a no-op. See comment in `MakeBulkAdder`.
 	BatchTimestamp hlc.Timestamp
 
 	// WriteAtBatchTimestamp will rewrite the SST to use the batch timestamp, even


### PR DESCRIPTION
This extracts per batch state tracking into a `batch` struct. The intent
is to make it clear what state needs to be reset before accepting writes
for the next batch.

Release note: none
Part of: #146828