### PR TITLE
sql: Index routine create virtual tables by routine IDs.

### DIFF
--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -1027,6 +1027,14 @@ func buildNTables(n int) string {
 	return b.String()
 }
 
+func buildNFunctions(n int) string {
+	b := strings.Builder{}
+	for i := 0; i < n; i++ {
+		b.WriteString(fmt.Sprintf("CREATE FUNCTION fn%d() RETURNS int AS 'SELECT 1' LANGUAGE SQL;\n", i))
+	}
+	return b.String()
+}
+
 func buildNTypes(n int) string {
 	b := strings.Builder{}
 	for i := 0; i < n; i++ {

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -131,5 +131,6 @@ exp,benchmark
 2,UseManyRoles/use_50_roles
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
+0,VirtualTableQueries/show_create_all_routines
 5,VirtualTableQueries/virtual_table_cache_with_point_lookups
 10,VirtualTableQueries/virtual_table_cache_with_schema_change

--- a/pkg/bench/rttanalysis/virtual_table_bench_test.go
+++ b/pkg/bench/rttanalysis/virtual_table_bench_test.go
@@ -59,5 +59,12 @@ SELECT * FROM crdb_internal.tables;
 SELECT * FROM t1;
 SELECT * FROM t2;`,
 		},
+		// This test checks the performance of the crdb_internal virtual tables used by
+		// SHOW CREATE ALL ROUTINES.
+		{
+			Name:  "show_create_all_routines",
+			Setup: buildNFunctions(100),
+			Stmt:  `SHOW CREATE ALL ROUTINES`,
+		},
 	})
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_analyze
@@ -176,7 +176,7 @@ quality of service: regular
         │       │               └── • virtual table
         │       │                     sql nodes: <hidden>
         │       │                     regions: <hidden>
-        │       │                     actual row count: 364
+        │       │                     actual row count: 366
         │       │                     execution time: 0µs
         │       │                     table: pg_class@primary
         │       │


### PR DESCRIPTION
Previously, the internal routine virtual tables,
`crdb_internal.create_function_statements` and
`crdb_internal.create_procedure_statements` were
not indexed. As such, in the functions to query for a routine create statement by the routine ID,
which are necessary for `SHOW CREATE ALL ROUTINES`, the query was on a virtual table that was not indexed and, thus, inefficient. This commit addresses that by adding a function that can be used to build rows of the virtual tables directly from the routine IDs and, thus, can act as a populate function for virtual indexes. This function was added onto the virtual tables and now the query is more efficient.

Epic: CRDB-49582
Release note: None