### PR TITLE
sql: revert unredact error in temp object cleanup

### DIFF
--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -627,7 +627,7 @@ func (c *TemporaryObjectCleaner) Start(ctx context.Context, stopper *stop.Stoppe
 			select {
 			case <-nextTickCh:
 				if err := c.doTemporaryObjectCleanup(ctx, stopper.ShouldQuiesce()); err != nil {
-					log.Warningf(ctx, "failed to clean temp objects: %v", redact.Safe(err))
+					log.Warningf(ctx, "failed to clean temp objects: %v", err)
 				}
 			case <-stopper.ShouldQuiesce():
 				return


### PR DESCRIPTION
Removed the `redact.Safe(err)` added in this
PR: https://github.com/cockroachdb/cockroach/pull/148037.

Informs: #146588
Release note: None