### PR TITLE
aceeptance: add script to build and push the acceptance image

### DIFF
--- a/pkg/acceptance/testdata/README.md
+++ b/pkg/acceptance/testdata/README.md
@@ -16,12 +16,10 @@ need to update the image.
 ## Updating the `acceptance` image
 
 - (One-time setup) Depending on how your Docker instance is configured, you may have to run `docker run --privileged --rm tonistiigi/binfmt --install all`. This will install `qemu` emulators on your system for platforms besides your native one.
-- Build the image for both platforms and publish the cross-platform manifest. Note that the non-native build for your image will be very slow since it will have to emulate.
-```
-    TAG=$(date +%Y%m%d-%H%M%S)
-    docker buildx create --use
-    docker buildx build --push --platform linux/amd64,linux/arm64 -t us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance:$TAG .
-```
+- Ask someone from the Engineering Productivity team to build the image for
+  both platforms and publish the cross-platform manifest by running
+  `build-push-acceptance.sh`. Note that the non-native build for your image will
+  be very slow since it will have to emulate.
 
 No need to have your changes reviewed before you push an image, as we pin the
 container version to use in `../util_docker.go`. Once your changes are ready for

--- a/pkg/acceptance/testdata/build-push-acceptance.sh
+++ b/pkg/acceptance/testdata/build-push-acceptance.sh
@@ -7,14 +7,12 @@
 
 set -xeuo pipefail
 
-TARGET=$1
+REPO=us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance
 TAG=$(date +%Y%m%d-%H%M%S)
-REPO="us-east1-docker.pkg.dev/crl-ci-images/cockroach/acceptance-gss-$TARGET"
-
 if which podman; then
-  podman build --platform linux/amd64,linux/arm64 --manifest $REPO:$TAG ./$TARGET
+  podman build --platform linux/amd64,linux/arm64 --manifest $REPO:$TAG ./
   podman manifest push $REPO:$TAG $REPO:$TAG
 else
   docker buildx create --use
-  docker buildx build --push --platform linux/amd64,linux/arm64 -t $REPO:$TAG ./$TARGET
+  docker buildx build --push --platform linux/amd64,linux/arm64 -t $REPO:$TAG ./
 fi


### PR DESCRIPTION
Previously, README.md contained instructions to build the acceptance image, but they were outdated.

This commit adds a script that can be used to build and push the acceptance image and adds the process instructions to README.md.

Additionally, updated the script that builds and pushes the GSS images.

Release note: none
Epic: none