### PR TITLE
release-25.2: application_api: Fix TestHotRanges2Response

### DIFF
--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -351,26 +351,31 @@ func TestHotRanges2Response(t *testing.T) {
 	if len(hotRangesResp.Ranges) == 0 {
 		t.Fatalf("didn't get hot range responses from any nodes")
 	}
-	lastQPS := math.MaxFloat64
+	cpuSupport := grunning.Supported
+	lastCPU := math.MaxFloat64
 	for _, r := range hotRangesResp.Ranges {
 		if r.RangeID == 0 {
 			t.Errorf("unexpected empty range id: %d", r.RangeID)
 		}
+
 		if r.QPS > 0 {
 			if r.ReadsPerSecond == 0 && r.WritesPerSecond == 0 && r.ReadBytesPerSecond == 0 && r.WriteBytesPerSecond == 0 {
 				t.Errorf("qps %.2f > 0, expected either reads=%.2f, writes=%.2f, readBytes=%.2f or writeBytes=%.2f to be non-zero",
 					r.QPS, r.ReadsPerSecond, r.WritesPerSecond, r.ReadBytesPerSecond, r.WriteBytesPerSecond)
 			}
-			// If the architecture doesn't support sampling CPU, it
-			// will also be zero.
-			if grunning.Supported && r.CPUTimePerSecond == 0 {
+
+			if cpuSupport && r.CPUTimePerSecond == 0 {
 				t.Errorf("qps %.2f > 0, expected cpu=%.2f to be non-zero", r.QPS, r.CPUTimePerSecond)
 			}
 		}
-		if r.QPS > lastQPS {
-			t.Errorf("unexpected increase in qps between ranges; prev=%.2f, current=%.2f", lastQPS, r.QPS)
+
+		// Ranges in response should be sorted by cpu.
+		if cpuSupport {
+			if r.CPUTimePerSecond > lastCPU {
+				t.Errorf("unexpected increase in cpu between ranges; prev=%.2f, current=%.2f", lastCPU, r.CPUTimePerSecond)
+			}
+			lastCPU = r.CPUTimePerSecond
 		}
-		lastQPS = r.QPS
 	}
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #148091.

/cc @cockroachdb/release

Release justification: fix test in release branch

---

Previously the test checked that ranges were sorted by QPS. The hot ranges status server endpoint sorts the response by CPU time.

Fixes: #146917

Release note: None
