### PR TITLE
github: fix payload in check-pebble-dep.yml

### DIFF
--- a/.github/workflows/check-pebble-dep.yml
+++ b/.github/workflows/check-pebble-dep.yml
@@ -31,13 +31,14 @@ jobs:
         if: steps.run_script.outputs.exitcode != '0'
         uses: slackapi/slack-github-action@v2.1.0
         with:
+          errors: true
           method: chat.postMessage
           token: ${{ secrets.PEBBLE_SLACK_BOT_TOKEN }}
           # The channel ID is for #storage-notifications.
           payload: |
-            channel: C08JE13CM9S
-            text: |
-            Some Pebble dependencies are not up to date. Details below:
-            ```
-            ${{ steps.run_script.outputs.output }}
-            ```
+            {
+              "channel": "C08JE13CM9S",
+              "text": ${{ toJson(format(
+                'Some Pebble dependencies are not up to date. Details below:\n```{0}```',
+                steps.run_script.outputs.output)) }}
+            }


### PR DESCRIPTION
Epic: none
Release note: None

I verified that the payload gets constructed correctly here: https://github.com/RaduBerinde/workflows/actions/runs/15619021112/job/43998983557
~I don't know why the action didn't fail there though, since I used a bogus token.~ Ah, there is an `errors` option for that:
https://github.com/RaduBerinde/workflows/actions/runs/15619124768/job/43999314443