### PR TITLE
row: remove InitChecksum for each KV inserted by IMPORT

### DIFF
--- a/pkg/sql/importer/import_stmt_test.go
+++ b/pkg/sql/importer/import_stmt_test.go
@@ -5330,9 +5330,9 @@ func TestImportWorkerFailure(t *testing.T) {
 	)
 }
 
-// TestImportMVCCChecksums verifies that MVCC checksums are correctly
-// computed by issuing a secondary index change that runs a CPut on the
-// index. See #23984.
+// TestImportMVCCChecksums is a regression test for #23984 where we didn't set
+// the MVCC checksums on roachpb.Values produced by the IMPORT when it was
+// required. Doing so is now optional.
 func TestImportMVCCChecksums(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -349,7 +349,6 @@ func NewDatumRowConverter(
 		db:      db,
 	}
 	c.kvInserter = func(kv roachpb.KeyValue) {
-		kv.Value.InitChecksum(kv.Key)
 		c.KvBatch.KVs = append(c.KvBatch.KVs, kv)
 		c.KvBatch.MemSize += int64(cap(kv.Key) + cap(kv.Value.RawBytes))
 	}


### PR DESCRIPTION
I noticed `InitChecksum` call show up in the CPU profile of a node from 300 node cluster when IMPORT is running, and I was confused by it. I did some archaeology, and I think it hasn't been needed for a long time.

For context, prior to 2.0, we effectively required setting the checksum on the Value since evaluation of CPuts compared RawBytes directly, which included the checksum comparison. This was an oversight because the checksum should be optional, and it became such in 33957ae2098a7c799e9ed5d5b6f168f171d0a12b.

However, in order to support IMPORT in mixed-version 1.1-2.0 cluster, in 5ae1bb2817b7dfc62570878238d90e4df934d76b we added the population of the checksum for all KVs produced for insertion. There is a discussion on the PR that this is no longer needed as of the optional checksum change mentioned above.

There is also a very recent discussion about removing this checksum in non-test code altogether since it probably doesn't give us much since we do checksum verification at the storage / network level. See #145541.

It should be safe to not populate the checksum for IMPORT as it seems to be the only place we do so in the SQL land.

Epic: None
Release note: None