### PR TITLE
roachtest: add buffered-writes variants of TPCC bench

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -131,6 +131,12 @@ type TestSpec struct {
 	// to epoch leases.
 	Leases LeaseType
 
+	// WriteOptimization specifies what kind of write optimization to use.
+	// Defaults to pipelining. This is currently used only in benchmark tests.
+	// If used in a non-benchmark test, this setting will be overwritten to enable
+	// pipelining and additionally, with 50% probability, buffering.
+	WriteOptimization WriteOptimizationType
+
 	// SkipPostValidations is a bit-set of post-validations that should be skipped
 	// after the test completes. This is useful for tests that are known to be
 	// incompatible with some validations. By default, tests will run all
@@ -283,6 +289,35 @@ const (
 //
 // The list does not contain aliases like "default" and "metamorphic".
 var LeaseTypes = []LeaseType{EpochLeases, ExpirationLeases, LeaderLeases}
+
+// WriteOptimizationType specifies the type of write optimization to use.
+type WriteOptimizationType int
+
+func (w WriteOptimizationType) String() string {
+	switch w {
+	case DefaultWriteOptimization:
+		return "default"
+	case Pipelining:
+		return "pipelining"
+	case Buffering:
+		return "buffering"
+	case PipeliningBuffering:
+		return "pipelining-buffering"
+	default:
+		return fmt.Sprintf("writeoptimization-%d", w)
+	}
+}
+
+const (
+	// DefaultWriteOptimization uses the default cluster settings.
+	DefaultWriteOptimization = WriteOptimizationType(iota)
+	// Pipelining uses write pipelining.
+	Pipelining
+	// Buffering uses client-side write buffering.
+	Buffering
+	// PipeliningBuffering uses both buffering and pipelining.
+	PipeliningBuffering
+)
 
 // CloudSet represents a set of clouds.
 //

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -933,6 +933,22 @@ func (r *testRunner) runWorker(
 					t.Fatalf("unknown lease type %s", leases)
 				}
 
+				// Choose which write optimization to use. These are currently used only
+				// in benchmark tests. For non-benchmark tests, write buffering will be
+				// enabled metamorphically below.
+				switch testSpec.WriteOptimization {
+				case registry.DefaultWriteOptimization:
+				case registry.Pipelining:
+					c.clusterSettings["kv.transaction.write_pipelining.enabled"] = "true"
+					c.clusterSettings["kv.transaction.write_buffering.enabled"] = "false"
+				case registry.Buffering:
+					c.clusterSettings["kv.transaction.write_buffering.enabled"] = "true"
+					c.clusterSettings["kv.transaction.write_pipelining.enabled"] = "false"
+				case registry.PipeliningBuffering:
+					c.clusterSettings["kv.transaction.write_pipelining.enabled"] = "true"
+					c.clusterSettings["kv.transaction.write_buffering.enabled"] = "true"
+				}
+
 				// Apply metamorphic settings not explicitly defined by the test.
 				// These settings should only be applied to non-benchmark tests.
 				if !testSpec.Benchmark {


### PR DESCRIPTION
This commit adds the following variants of TPCC bench:
- write buffering enabled, pipelining enabled (by default),
- write buffering enabled, pipelining disabled.

The former will help us compare the performance of buffered writes to the default setup, and the latter will inform our decision to replace pipelining with buffering altogether.

Part of: #148235
Release note: None