### PR TITLE
sql: add probabilistic transaction tracing

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -1072,6 +1072,7 @@ func (s *Server) newConnExecutor(
 		sessionDataStack:    sdMutIterator.sds,
 		dataMutatorIterator: sdMutIterator,
 		state: txnState{
+			rng:                          rand.New(rand.NewSource(time.Now().UnixNano())),
 			mon:                          txnMon,
 			connCtx:                      ctx,
 			testingForceRealTracingSpans: s.cfg.TestingKnobs.ForceRealTracingSpans,

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -281,6 +281,14 @@ var traceTxnThreshold = settings.RegisterDurationSetting(
 		"client communication (e.g. retries)", 0,
 	settings.WithPublic)
 
+var traceTxnPct = settings.RegisterFloatSetting(
+	settings.ApplicationLevel,
+	"sql.trace.txn.percent",
+	"Percentage of transactions that will be traced",
+	0,
+	settings.NonNegativeFloatWithMaximum(1.0),
+	settings.WithPublic)
+
 // TraceStmtThreshold is identical to traceTxnThreshold except it applies to
 // individual statements in a transaction. The motivation for this setting is
 // to be able to reduce the noise associated with a larger transaction (e.g.


### PR DESCRIPTION
changes transaction trace to be probablistic, using a new cluster setting to define the percentage of transactions that will be traced. This will continue to use the trace transaction threshold value to determine whether or not to log the trace, but it won't cause "always on" tracing for all transactions.

Epic: None
Release note: None