### PR TITLE
kvserver: remove logging "stream sender is stopped"

### DIFF
--- a/pkg/kv/kvserver/rangefeed/stream.go
+++ b/pkg/kv/kvserver/rangefeed/stream.go
@@ -89,10 +89,9 @@ func (s *PerRangeEventSink) SendError(err *kvpb.Error) {
 		log.KvDistribution.Fatalf(context.Background(),
 			"unexpected: SendWithoutBlocking called with non-error event")
 	}
-	if err := s.wrapped.sendBuffered(ev, nil); err != nil {
-		log.KvDistribution.Infof(context.Background(),
-			"failed to send rangefeed error to client: %v", err)
-	}
+	// Silence the error: expected to happen when the buffered sender is closed or
+	// stopped.
+	_ = s.wrapped.sendBuffered(ev, nil)
 }
 
 // transformRangefeedErrToClientError converts a rangefeed error to a client

--- a/pkg/kv/kvserver/rangefeed/stream_manager.go
+++ b/pkg/kv/kvserver/rangefeed/stream_manager.go
@@ -189,6 +189,7 @@ func (sm *StreamManager) Stop(ctx context.Context) {
 	sm.sender.cleanup(ctx)
 	sm.streams.Lock()
 	defer sm.streams.Unlock()
+	log.KvDistribution.VInfof(ctx, 2, "stopping stream manager: disconnecting %d streams", len(sm.streams.m))
 	rangefeedClosedErr := kvpb.NewError(
 		kvpb.NewRangeFeedRetryError(kvpb.RangeFeedRetryError_REASON_RANGEFEED_CLOSED))
 	sm.metrics.ActiveMuxRangeFeed.Dec(int64(len(sm.streams.m)))


### PR DESCRIPTION
Previously, we logged an error every time SendBuffered failed, which happens
after the buffered sender has been stopped. When gRPC shuts down, buffered
sender would be stopped, and registrations are signaled to disconnect and
would attempt to send error messages back to the an already stopped sender,
resulting in noisy error logs. This patch removes this log line and adds
a new vmodule log line during streamManager.Stop().

Epic: none
Release note: none