### PR TITLE
kvserver: enable kv.rangefeed.buffered_sender.enabled by default

### DIFF
--- a/pkg/kv/kvserver/replica_rangefeed.go
+++ b/pkg/kv/kvserver/replica_rangefeed.go
@@ -90,7 +90,7 @@ var RangefeedUseBufferedSender = settings.RegisterBoolSetting(
 	"kv.rangefeed.buffered_sender.enabled",
 	"use buffered sender for all range feeds instead of buffering events "+
 		"separately per client per range",
-	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", false),
+	metamorphic.ConstantWithTestBool("kv.rangefeed.buffered_sender.enabled", true),
 )
 
 func init() {


### PR DESCRIPTION
This patch enables kv.rangefeed.buffered_sender.enabled by default. We've gained
confidence in the feature through scale testing and enabling it metamorphically
since v25.2. We also currently don't believe enabling this feature would cause
any performance regressions or negative impact.

Epic: none
Release note: none