### PR TITLE
crosscluster: do not panic on poorly formatted inline certs

### DIFF
--- a/pkg/crosscluster/streamclient/client.go
+++ b/pkg/crosscluster/streamclient/client.go
@@ -306,10 +306,10 @@ func WithLogical() Option {
 	}
 }
 
-func processOptions(opts []Option) *options {
-	ret := &options{}
+func processOptions(opts []Option) options {
+	ret := options{}
 	for _, o := range opts {
-		o(ret)
+		o(&ret)
 	}
 	return ret
 }

--- a/pkg/crosscluster/streamclient/partitioned_stream_client.go
+++ b/pkg/crosscluster/streamclient/partitioned_stream_client.go
@@ -44,16 +44,16 @@ type partitionedStreamClient struct {
 func NewPartitionedStreamClient(
 	ctx context.Context, remote ClusterUri, opts ...Option,
 ) (*partitionedStreamClient, error) {
-	options := processOptions(opts)
-	conn, config, err := newPGConnForClient(ctx, remote.URL(), options)
+	streamOpts := processOptions(opts)
+	conn, config, err := newPGConnForClient(ctx, remote.URL(), streamOpts)
 	if err != nil {
 		return nil, err
 	}
 	client := partitionedStreamClient{
 		clusterUri: remote,
 		pgxConfig:  config,
-		compressed: options.compressed,
-		logical:    options.logical,
+		compressed: streamOpts.compressed,
+		logical:    streamOpts.logical,
 	}
 	client.mu.activeSubscriptions = make(map[*partitionedStreamSubscription]struct{})
 	client.mu.srcConn = conn

--- a/pkg/crosscluster/streamclient/pgconn.go
+++ b/pkg/crosscluster/streamclient/pgconn.go
@@ -31,7 +31,7 @@ const (
 )
 
 func newPGConnForClient(
-	ctx context.Context, remote url.URL, options *options,
+	ctx context.Context, remote url.URL, options options,
 ) (*pgx.Conn, *pgx.ConnConfig, error) {
 	config, err := setupPGXConfig(remote, options)
 	if err != nil {
@@ -44,7 +44,7 @@ func newPGConnForClient(
 	return conn, config, nil
 }
 
-func setupPGXConfig(remote url.URL, options *options) (*pgx.ConnConfig, error) {
+func setupPGXConfig(remote url.URL, options options) (*pgx.ConnConfig, error) {
 	noInlineCertURI, tlsInfo, err := uriWithInlineTLSCertsRemoved(remote)
 	if err != nil {
 		return nil, err
@@ -107,6 +107,9 @@ func uriWithInlineTLSCertsRemoved(remote url.URL) (url.URL, *tlsCerts, error) {
 		// are deprecated in the stdlib. For now, I've skipped
 		// it.
 		block, _ := pem.Decode([]byte(key))
+		if block == nil {
+			return url.URL{}, nil, errors.New("unable to decode sslkey PEM data")
+		}
 		pemKey := pem.EncodeToMemory(block)
 		keyPair, err := tls.X509KeyPair([]byte(cert), pemKey)
 		if err != nil {

--- a/pkg/crosscluster/streamclient/span_config_stream_client.go
+++ b/pkg/crosscluster/streamclient/span_config_stream_client.go
@@ -43,8 +43,8 @@ func NewSpanConfigStreamClient(
 ) (SpanConfigClient, error) {
 	remote := remoteUri.URL()
 
-	options := processOptions(opts)
-	conn, config, err := newPGConnForClient(ctx, remote, options)
+	streamOpts := processOptions(opts)
+	conn, config, err := newPGConnForClient(ctx, remote, streamOpts)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Previously, when parsing inline SSL certificates in an external connection, if the certificate was not formatted correctly we would run into a panic from a nil pointer. This fixes the parser to properly surface an error instead of crashing.

Epic: CRDB-50820

Fixes: #145949

Release note: CockroachDB now raises an error when encountering improper inline SSL credentials instead of panicking.