### PR TITLE
parser: remove IMPORT TABLE and IMPORT non-INTO support

### DIFF
--- a/docs/generated/sql/bnf/import_dump.bnf
+++ b/docs/generated/sql/bnf/import_dump.bnf
@@ -1,9 +1,5 @@
 import_stmt ::=
-	'IMPORT' import_format file_location 'WITH' kv_option_list
-	| 'IMPORT' import_format file_location 
-	| 'IMPORT' 'TABLE' table_name 'FROM' import_format file_location 'WITH' kv_option_list
-	| 'IMPORT' 'TABLE' table_name 'FROM' import_format file_location 
-	| 'IMPORT' 'INTO' table_name '(' insert_column_list ')' import_format 'DATA' '(' file_location ( ( ',' file_location ) )* ')' 'WITH' kv_option_list
+	'IMPORT' 'INTO' table_name '(' insert_column_list ')' import_format 'DATA' '(' file_location ( ( ',' file_location ) )* ')' 'WITH' kv_option_list
 	| 'IMPORT' 'INTO' table_name '(' insert_column_list ')' import_format 'DATA' '(' file_location ( ( ',' file_location ) )* ')' 
 	| 'IMPORT' 'INTO' table_name import_format 'DATA' '(' file_location ( ( ',' file_location ) )* ')' 'WITH' kv_option_list
 	| 'IMPORT' 'INTO' table_name import_format 'DATA' '(' file_location ( ( ',' file_location ) )* ')' 

--- a/docs/generated/sql/bnf/stmt_block.bnf
+++ b/docs/generated/sql/bnf/stmt_block.bnf
@@ -238,9 +238,7 @@ explain_stmt ::=
 	| 'EXPLAIN' 'ANALYSE' '(' explain_option_list ')' explainable_stmt
 
 import_stmt ::=
-	'IMPORT' import_format string_or_placeholder opt_with_options
-	| 'IMPORT' 'TABLE' table_name 'FROM' import_format string_or_placeholder opt_with_options
-	| 'IMPORT' 'INTO' table_name '(' insert_column_list ')' import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
+	'IMPORT' 'INTO' table_name '(' insert_column_list ')' import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
 	| 'IMPORT' 'INTO' table_name import_format 'DATA' '(' string_or_placeholder_list ')' opt_with_options
 
 insert_stmt ::=
@@ -719,23 +717,19 @@ explainable_stmt ::=
 explain_option_list ::=
 	( explain_option_name ) ( ( ',' explain_option_name ) )*
 
+insert_column_list ::=
+	( insert_column_item ) ( ( ',' insert_column_item ) )*
+
 import_format ::=
 	name
 
-string_or_placeholder ::=
-	non_reserved_word_or_sconst
-	| 'PLACEHOLDER'
+string_or_placeholder_list ::=
+	( string_or_placeholder ) ( ( ',' string_or_placeholder ) )*
 
 opt_with_options ::=
 	'WITH' kv_option_list
 	| 'WITH' 'OPTIONS' '(' kv_option_list ')'
 	| 
-
-insert_column_list ::=
-	( insert_column_item ) ( ( ',' insert_column_item ) )*
-
-string_or_placeholder_list ::=
-	( string_or_placeholder ) ( ( ',' string_or_placeholder ) )*
 
 insert_target ::=
 	table_name_opt_idx
@@ -774,6 +768,10 @@ reset_session_stmt ::=
 
 reset_csetting_stmt ::=
 	'RESET' 'CLUSTER' 'SETTING' var_name
+
+string_or_placeholder ::=
+	non_reserved_word_or_sconst
+	| 'PLACEHOLDER'
 
 opt_with_restore_options ::=
 	'WITH' restore_options_list
@@ -2032,15 +2030,11 @@ drop_policy_stmt ::=
 explain_option_name ::=
 	non_reserved_word
 
-non_reserved_word_or_sconst ::=
-	non_reserved_word
-	| 'SCONST'
+insert_column_item ::=
+	column_name
 
 kv_option_list ::=
 	( kv_option ) ( ( ',' kv_option ) )*
-
-insert_column_item ::=
-	column_name
 
 session_var ::=
 	'identifier'
@@ -2058,6 +2052,10 @@ session_var ::=
 var_name ::=
 	name
 	| name attrs
+
+non_reserved_word_or_sconst ::=
+	non_reserved_word
+	| 'SCONST'
 
 restore_options_list ::=
 	( restore_options ) ( ( ',' restore_options ) )*
@@ -2925,14 +2923,14 @@ non_reserved_word ::=
 	| col_name_keyword
 	| type_func_name_keyword
 
+column_name ::=
+	name
+
 kv_option ::=
 	name '=' string_or_placeholder
 	| name
 	| 'SCONST' '=' string_or_placeholder
 	| 'SCONST'
-
-column_name ::=
-	name
 
 session_var_parts ::=
 	( '.' 'identifier' ) ( ( '.' 'identifier' ) )*

--- a/pkg/internal/sqlsmith/bulkio.go
+++ b/pkg/internal/sqlsmith/bulkio.go
@@ -258,7 +258,6 @@ func makeImport(s *Smither) (tree.Statement, bool) {
 
 	return &tree.Import{
 		Table:      tree.NewUnqualifiedTableName(tab),
-		Into:       true,
 		FileFormat: "CSV",
 		Files:      files,
 		Options: tree.KVOptions{

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -714,6 +714,7 @@ message ImportDetails {
   bool schemas_published = 24;
   bool tables_published = 13;
 
+  // TODO(yuzefovich): remove this.
   bool parse_bundle_schema = 14;
 
   // DefaultIntSize is the integer type that a "naked" int will be resolved

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -38,7 +38,6 @@ go_library(
         "//pkg/jobs/joberror",
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler",
-        "//pkg/keys",
         "//pkg/kv",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",

--- a/pkg/sql/parser/help_test.go
+++ b/pkg/sql/parser/help_test.go
@@ -591,7 +591,7 @@ func TestContextualHelp(t *testing.T) {
 		{`RESTORE foo FROM LATEST IN '/bar' ??`, `RESTORE`},
 		{`RESTORE DATABASE ??`, `RESTORE`},
 
-		{`IMPORT TABLE ??`, `IMPORT`},
+		{`IMPORT INTO ??`, `IMPORT`},
 
 		{`EXPORT ??`, `EXPORT`},
 		{`EXPORT INTO CSV 'a' ??`, `EXPORT`},

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4144,12 +4144,12 @@ import_stmt:
  IMPORT INTO table_name '(' insert_column_list ')' import_format DATA '(' string_or_placeholder_list ')' opt_with_options
   {
     name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.Import{Table: &name, Into: true, IntoCols: $5.nameList(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
+    $$.val = &tree.Import{Table: &name, IntoCols: $5.nameList(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}
   }
 | IMPORT INTO table_name import_format DATA '(' string_or_placeholder_list ')' opt_with_options
   {
     name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.Import{Table: &name, Into: true, IntoCols: nil, FileFormat: $4, Files: $7.exprs(), Options: $9.kvOptions()}
+    $$.val = &tree.Import{Table: &name, IntoCols: nil, FileFormat: $4, Files: $7.exprs(), Options: $9.kvOptions()}
   }
 | IMPORT error // SHOW HELP: IMPORT
 

--- a/pkg/sql/parser/sql.y
+++ b/pkg/sql/parser/sql.y
@@ -4136,45 +4136,12 @@ alter_unsupported_stmt:
 // %Help: IMPORT - load data from file in a distributed manner
 // %Category: CCL
 // %Text:
-// -- Import both schema and table data:
-// IMPORT [ TABLE <tablename> FROM ]
-//        <format> <datafile>
-//        [ WITH <option> [= <value>] [, ...] ]
-//
-// Formats:
-//    MYSQLDUMP
-//    PGDUMP
-//
-// Options:
-//    distributed = '...'
-//    temp = '...'
-//
 // Use CREATE TABLE followed by IMPORT INTO to create and import into a table
 // from external files that only have table data.
 //
 // %SeeAlso: CREATE TABLE, WEBDOCS/import-into.html
 import_stmt:
- IMPORT import_format '(' string_or_placeholder ')' opt_with_options
-  {
-    /* SKIP DOC */
-    $$.val = &tree.Import{Bundle: true, FileFormat: $2, Files: tree.Exprs{$4.expr()}, Options: $6.kvOptions()}
-  }
-| IMPORT import_format string_or_placeholder opt_with_options
-  {
-    $$.val = &tree.Import{Bundle: true, FileFormat: $2, Files: tree.Exprs{$3.expr()}, Options: $4.kvOptions()}
-  }
-| IMPORT TABLE table_name FROM import_format '(' string_or_placeholder ')' opt_with_options
-  {
-    /* SKIP DOC */
-    name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.Import{Bundle: true, Table: &name, FileFormat: $5, Files: tree.Exprs{$7.expr()}, Options: $9.kvOptions()}
-  }
-| IMPORT TABLE table_name FROM import_format string_or_placeholder opt_with_options
-  {
-    name := $3.unresolvedObjectName().ToTableName()
-    $$.val = &tree.Import{Bundle: true, Table: &name, FileFormat: $5, Files: tree.Exprs{$6.expr()}, Options: $7.kvOptions()}
-  }
-| IMPORT INTO table_name '(' insert_column_list ')' import_format DATA '(' string_or_placeholder_list ')' opt_with_options
+ IMPORT INTO table_name '(' insert_column_list ')' import_format DATA '(' string_or_placeholder_list ')' opt_with_options
   {
     name := $3.unresolvedObjectName().ToTableName()
     $$.val = &tree.Import{Table: &name, Into: true, IntoCols: $5.nameList(), FileFormat: $7, Files: $10.exprs(), Options: $12.kvOptions()}

--- a/pkg/sql/parser/testdata/import_export
+++ b/pkg/sql/parser/testdata/import_export
@@ -1,22 +1,4 @@
 parse
-IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'
-----
-IMPORT TABLE foo FROM PGDUMPCREATE '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT TABLE foo FROM PGDUMPCREATE ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
-IMPORT TABLE foo FROM PGDUMPCREATE '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT TABLE _ FROM PGDUMPCREATE '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
-IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
-
-parse
-IMPORT TABLE foo FROM PGDUMPCREATE ('nodelocal://0/foo/bar') WITH temp = 'path/to/temp'
-----
-IMPORT TABLE foo FROM PGDUMPCREATE '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT TABLE foo FROM PGDUMPCREATE ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
-IMPORT TABLE foo FROM PGDUMPCREATE '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT TABLE _ FROM PGDUMPCREATE '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
-IMPORT TABLE foo FROM PGDUMPCREATE 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
-
-parse
 IMPORT INTO foo(id, email) CSV DATA ('path/to/some/file', $1) WITH temp = 'path/to/temp'
 ----
 IMPORT INTO foo(id, email) CSV DATA ('*****', $1) WITH OPTIONS (temp = 'path/to/temp') -- normalized!
@@ -33,42 +15,6 @@ IMPORT INTO foo CSV DATA (('*****'), ($1)) WITH OPTIONS (temp = ('path/to/temp')
 IMPORT INTO foo CSV DATA ('_', $1) WITH OPTIONS (temp = '_') -- literals removed
 IMPORT INTO _ CSV DATA ('*****', $1) WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
 IMPORT INTO foo CSV DATA ('path/to/some/file', $1) WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
-
-parse
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'
-----
-IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
-IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
-
-parse
-EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH temp = 'path/to/temp'
-----
-EXPLAIN IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-EXPLAIN IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
-EXPLAIN IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-EXPLAIN IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
-EXPLAIN IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
-
-parse
-IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH temp = 'path/to/temp'
-----
-IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
-IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
-
-parse
-IMPORT PGDUMP ('nodelocal://0/foo/bar') WITH OPTIONS (temp = 'path/to/temp')
-----
-IMPORT PGDUMP '*****' WITH OPTIONS (temp = 'path/to/temp') -- normalized!
-IMPORT PGDUMP ('*****') WITH OPTIONS (temp = ('path/to/temp')) -- fully parenthesized
-IMPORT PGDUMP '_' WITH OPTIONS (temp = '_') -- literals removed
-IMPORT PGDUMP '*****' WITH OPTIONS (_ = 'path/to/temp') -- identifiers removed
-IMPORT PGDUMP 'nodelocal://0/foo/bar' WITH OPTIONS (temp = 'path/to/temp') -- passwords exposed
 
 parse
 EXPORT INTO CSV 'a' FROM TABLE a

--- a/pkg/sql/sem/tree/import.go
+++ b/pkg/sql/sem/tree/import.go
@@ -8,11 +8,9 @@ package tree
 // Import represents a IMPORT statement.
 type Import struct {
 	Table      *TableName
-	Into       bool
 	IntoCols   NameList
 	FileFormat string
 	Files      Exprs
-	Bundle     bool
 	Options    KVOptions
 }
 
@@ -22,39 +20,23 @@ var _ Statement = &Import{}
 func (node *Import) Format(ctx *FmtCtx) {
 	ctx.WriteString("IMPORT ")
 
-	if node.Bundle {
-		if node.Table != nil {
-			ctx.WriteString("TABLE ")
-			ctx.FormatNode(node.Table)
-			ctx.WriteString(" FROM ")
-		}
-		ctx.WriteString(node.FileFormat)
-		ctx.WriteByte(' ')
-		ctx.FormatURIs(node.Files)
+	ctx.WriteString("INTO ")
+	ctx.FormatNode(node.Table)
+	if node.IntoCols != nil {
+		ctx.WriteByte('(')
+		ctx.FormatNode(&node.IntoCols)
+		ctx.WriteString(") ")
 	} else {
-		if node.Into {
-			ctx.WriteString("INTO ")
-			ctx.FormatNode(node.Table)
-			if node.IntoCols != nil {
-				ctx.WriteByte('(')
-				ctx.FormatNode(&node.IntoCols)
-				ctx.WriteString(") ")
-			} else {
-				ctx.WriteString(" ")
-			}
-		} else {
-			ctx.WriteString("TABLE ")
-			ctx.FormatNode(node.Table)
-		}
-		ctx.WriteString(node.FileFormat)
-		ctx.WriteString(" DATA ")
-		if len(node.Files) == 1 {
-			ctx.WriteString("(")
-		}
-		ctx.FormatURIs(node.Files)
-		if len(node.Files) == 1 {
-			ctx.WriteString(")")
-		}
+		ctx.WriteString(" ")
+	}
+	ctx.WriteString(node.FileFormat)
+	ctx.WriteString(" DATA ")
+	if len(node.Files) == 1 {
+		ctx.WriteString("(")
+	}
+	ctx.FormatURIs(node.Files)
+	if len(node.Files) == 1 {
+		ctx.WriteString(")")
 	}
 
 	if node.Options != nil {

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -2267,25 +2267,17 @@ func (node *Import) doc(p *PrettyCfg) pretty.Doc {
 	items := make([]pretty.TableRow, 0, 5)
 	items = append(items, p.row("IMPORT", pretty.Nil))
 
-	if node.Bundle {
-		if node.Table != nil {
-			items = append(items, p.row("TABLE", p.Doc(node.Table)))
-			items = append(items, p.row("FROM", pretty.Nil))
-		}
-		items = append(items, p.row(node.FileFormat, p.Doc(&node.Files)))
-	} else if node.Into {
-		into := p.Doc(node.Table)
-		if node.IntoCols != nil {
-			into = p.nestUnder(into, p.bracket("(", p.Doc(&node.IntoCols), ")"))
-		}
-		items = append(items, p.row("INTO", into))
-		data := p.bracketKeyword(
-			"DATA", " (",
-			p.Doc(&node.Files),
-			")", "",
-		)
-		items = append(items, p.row(node.FileFormat, data))
+	into := p.Doc(node.Table)
+	if node.IntoCols != nil {
+		into = p.nestUnder(into, p.bracket("(", p.Doc(&node.IntoCols), ")"))
 	}
+	items = append(items, p.row("INTO", into))
+	data := p.bracketKeyword(
+		"DATA", " (",
+		p.Doc(&node.Files),
+		")", "",
+	)
+	items = append(items, p.row(node.FileFormat, data))
 
 	if node.Options != nil {
 		items = append(items, p.row("WITH", p.Doc(&node.Options)))

--- a/pkg/sql/sem/tree/unsupported_error.go
+++ b/pkg/sql/sem/tree/unsupported_error.go
@@ -8,8 +8,7 @@ package tree
 var _ error = &UnsupportedError{}
 
 // UnsupportedError is an error object which is returned by some unimplemented SQL
-// statements. It is currently only used to skip over PGDUMP statements during
-// an import.
+// statements.
 type UnsupportedError struct {
 	Err         error
 	FeatureName string


### PR DESCRIPTION
**parser: remove IMPORT TABLE and IMPORT non-INTO support**

PGDUMP and MYSQLDUMP code is now being removed, so remove the parser support.

Release note (sql change): IMPORT TABLE as well PGDUMP and MYSQLDUMP
formats of IMPORT are now fully removed. These have been deprecated
since 23.2.

**tree: remove unused Into and Bundle fields of Import**

Also update one spot under assumption that `tree.Import.Table` is now
always non-nil.

Epic: None