### PR TITLE
workload: add last-duration flag to tpcc check

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -471,6 +471,7 @@ func runTPCC(
 		cmd := roachtestutil.NewCommand("%s workload check %s", test.DefaultCockroachPath, opts.getWorkloadCmd()).
 			MaybeFlag(opts.DB != "", "db", opts.DB).
 			MaybeOption(opts.ExpensiveChecks, "expensive-checks").
+			Flag("last-duration", opts.Duration).
 			Flag("warehouses", opts.Warehouses).
 			Arg("{pgurl:1}")
 

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -182,6 +182,37 @@ func (w *waitSetter) String() string {
 	}
 }
 
+// lastDurationSetter is a pflag.Value implementation that sets the last
+// duration of a workload run for consistency checks. It is used to determine
+// which consistency checks to skip for long duration workloads. It sets the
+// `isLongDurationWorkload` field on the `tpcc` to true if the duration is
+// greater than or equal to the long duration workload threshold.
+type lastDurationSetter struct {
+	val  *time.Duration
+	tpcc *tpcc
+}
+
+// Set implements the pflag.Value interface.
+func (p *lastDurationSetter) Set(val string) error {
+	duration, err := time.ParseDuration(val)
+	if err != nil {
+		return err
+	}
+	p.val = &duration
+	p.tpcc.isLongDurationWorkload = duration >= longDurationWorkloadThreshold
+	return nil
+}
+
+// String implements the pflag.Value interface.
+func (p *lastDurationSetter) String() string {
+	return p.val.String()
+}
+
+// Type implements the pflag.Value interface.
+func (p *lastDurationSetter) Type() string {
+	return "duration"
+}
+
 var _ pgx.QueryTracer = fileLoggerQueryTracer{}
 
 type fileLoggerQueryTracer struct {
@@ -267,6 +298,7 @@ var tpccMeta = workload.Meta{
 			`txn-retries`:              {RuntimeOnly: true},
 			`repair-order-ids`:         {RuntimeOnly: true},
 			`expensive-checks`:         {RuntimeOnly: true, CheckConsistencyOnly: true},
+			`last-duration`:            {RuntimeOnly: true, CheckConsistencyOnly: true},
 			`local-warehouses`:         {RuntimeOnly: true},
 			`regions`:                  {RuntimeOnly: true},
 			`survival-goal`:            {RuntimeOnly: true},
@@ -321,6 +353,7 @@ var tpccMeta = workload.Meta{
 			"This is an optional parameter to specify AOST; used exclusively in conjunction with the TPC-C consistency "+
 				"check. Example values are (\"'-1m'\", \"'-1h'\")")
 		g.flags.BoolVar(&g.literalImplementation, "literal-implementation", false, "If true, use a literal implementation of the TPC-C kit instead of an optimized version")
+		g.flags.Var(&lastDurationSetter{val: &[]time.Duration{0}[0], tpcc: g}, "last-duration", "The duration of the previous workload run (Used to determine which consistency checks to skip for long duration workloads).")
 
 		RandomSeed.AddFlag(&g.flags)
 		g.connFlags = workload.NewConnFlags(&g.flags)


### PR DESCRIPTION
Previously, if a workload is run with a long duration, some of the consistency
checks would be skipped. This check is only done when running a workload, but
some tests also run a separate post check.

This post check is not aware of the previous workload's duration and will run
the checks even if the workload is run with a long duration.

This change adds a new flag, `last-duration`, which can be used to set the
duration of the previous workload run. This flag can be used during a post
consistency check to determine which checks to skip for long duration workloads.

Fixes: #147397

Epic: None
Release note: None