### PR TITLE
kv: extract `TenantService` and register with DRPC server

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3650,17 +3650,38 @@ message JoinNodeResponse {
   roachpb.Version active_version = 4;
 }
 
+// TODO(server): Remove the methods of these serivces from the 'Internal'
+// service once the migration to DRPC complete, making these service the sole
+// definition. Also, update the comments here.
+
+// TODO(server,kv): Improve the code comment documentation of these methods.
+// Many of these methods are simply undocumented.
+
 // KVBatch defines Batch RPCs of Internal service (see below) for DRPC use only.
 //
 // During the gRPC to DRPC migration:
 // - gRPC clients will continue to use the full 'Internal' service client.
 // - DRPC clients targeting Batch* RPCs will use clients generated from this.
-//
-// TODO(server): Remove these methods from the 'Internal' service once the
-// migration to DRPC complete, making this service the sole definition.
 service KVBatch {
   rpc Batch(BatchRequest) returns (BatchResponse) {}
   rpc BatchStream(stream BatchRequest) returns (stream BatchResponse) {}
+}
+
+// TenantService provides RPCs for secondary tenants to access data that is
+// exclusively available in the system tenant. This service is used by the
+// tenant connector.
+service TenantService {
+  // TenantSettings is used by tenants to obtain and stay up to date with tenant
+  // setting overrides.
+  rpc TenantSettings(TenantSettingsRequest) returns (stream TenantSettingsEvent) {}
+
+  rpc GossipSubscription(GossipSubscriptionRequest) returns (stream GossipSubscriptionEvent) {}
+
+  rpc RangeLookup(RangeLookupRequest) returns (RangeLookupResponse) {}
+
+  // GetRangeDescriptors is used by tenants to get range descriptors for their
+  // own ranges.
+  rpc GetRangeDescriptors(GetRangeDescriptorsRequest) returns (stream GetRangeDescriptorsResponse) {}
 }
 
 // Batch and RangeFeed service implemented by nodes for KV API requests.

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -986,6 +986,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	if err := kvpb.DRPCRegisterKVBatch(drpcServer, node.AsDRPCKVBatchServer()); err != nil {
 		return nil, err
 	}
+	if err := kvpb.DRPCRegisterTenantService(drpcServer, node.AsDRPCTenantServiceServer()); err != nil {
+		return nil, err
+	}
 	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)
 	if err := kvserver.DRPCRegisterPerReplica(drpcServer, node.perReplicaServer); err != nil {
 		return nil, err


### PR DESCRIPTION
This is a follow-up to #145195, where we extracted `KVBatch` from the `Internal` service. Here, we do the same with `TenantService`. The TL;DR is that smaller services are easier to maintain and can be more smoothly migrated to DRPC.

We also enable this service on the DRPC server. This is controlled by `rpc.experimental_drpc.enabled` (off by default).

This change is part of a series and is similar to: #146926

Note: This only registers the service; the client is not updated to use the DRPC client, so this service will not have any functional effect.

Epic: CRDB-48925
Release note: None