### PR TITLE
roachtest: increase timeout for schemachange/bulkingest

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -330,7 +330,7 @@ func makeIndexAddTpccTest(
 func registerSchemaChangeBulkIngest(r registry.Registry) {
 	// Allow a long running time to account for runs that use a
 	// cockroach build with runtime assertions enabled.
-	r.Add(makeSchemaChangeBulkIngestTest(r, 12, 4_000_000_000, 2*time.Hour))
+	r.Add(makeSchemaChangeBulkIngestTest(r, 12, 4_000_000_000, 5*time.Hour))
 }
 
 func makeSchemaChangeBulkIngestTest(


### PR DESCRIPTION
We recently made this test run on a larger table, so it needs more time now.

fixes https://github.com/cockroachdb/cockroach/issues/147767
Releae note: None