### PR TITLE
testutils: update nightly lint test to use IsCustomOrAdhocBuild

### DIFF
--- a/pkg/testutils/lint/nightly_lint_test.go
+++ b/pkg/testutils/lint/nightly_lint_test.go
@@ -25,7 +25,7 @@ func TestNightlyLint(t *testing.T) {
 	// TestHelpURLs checks that all help texts have a valid documentation URL.
 	t.Run("TestHelpURLs", func(t *testing.T) {
 		skip.UnderShort(t)
-		if build.ParsedVersion().IsPrerelease() || build.ParsedVersion().IsCustomOrNightlyBuild() {
+		if build.ParsedVersion().IsPrerelease() || build.ParsedVersion().IsCustomOrAdhocBuild() {
 			skip.IgnoreLint(t, "pre-release or customized build")
 		}
 		if pkgSpecified {


### PR DESCRIPTION
The newer version of `cockroachdb/version` has renamed the method used in the nightly lint test to check for custom builds. This commit updates the method usage.

Release note: none
Fixes: #148251