### PR TITLE
changefeedccl: fix table drop shutdown for enriched envelope

### DIFF
--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -540,6 +540,9 @@ func getDescriptors(
 		return nil
 	}
 	if err := execCfg.InternalDB.DescsTxn(ctx, f, isql.WithPriority(admissionpb.NormalPri)); err != nil {
+		if errors.Is(err, catalog.ErrDescriptorDropped) {
+			err = changefeedbase.WithTerminalError(err)
+		}
 		return nil, nil, nil, err
 	}
 	return tableDescriptor, dbDescriptor, schemaDescriptor, nil


### PR DESCRIPTION
Fixes a bug where feeds with enriched envelopes
and a `source` field could treat table drops as
transient errors.

Fixes: #148216
Release note: None
