### PR TITLE
sql: lift lookup join parallelization into execbuilder

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_hash_sharded_index_query_plan
@@ -72,6 +72,7 @@ vectorized: true
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -150,6 +151,7 @@ vectorized: true
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -244,6 +246,7 @@ vectorized: true
             │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
@@ -297,6 +300,7 @@ vectorized: true
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, column2, val_cast, user_id_default)
@@ -420,6 +424,7 @@ vectorized: true
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
@@ -505,6 +510,7 @@ vectorized: true
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
@@ -671,6 +677,7 @@ vectorized: true
 │                           │ equality cols are key
 │                           │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
 │                           │ locking strength: for update
+│                           │ parallel
 │                           │
 │                           └── • render
 │                               │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
@@ -803,6 +810,7 @@ vectorized: true
                 │ equality cols are key
                 │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, column1, column2)
@@ -956,6 +964,7 @@ vectorized: true
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
@@ -1018,6 +1027,7 @@ vectorized: true
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, column3, crdb_internal_email_shard_16_comp)
@@ -1033,6 +1043,7 @@ vectorized: true
                     │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
                     │ equality cols are key
                     │ lookup condition: (part IN ('new york', 'seattle')) AND (column1 = id)
+                    │ parallel
                     │
                     └── • render
                         │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)
@@ -1158,6 +1169,7 @@ vectorized: true
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
 │                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+│                   │ parallel
 │                   │
 │                   └── • render
 │                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
@@ -1414,6 +1426,7 @@ vectorized: true
 │                                   │ equality cols are key
 │                                   │ lookup condition: ((part IN ('new york', 'seattle')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                                   │ locking strength: for update
+│                                   │ parallel
 │                                   │
 │                                   └── • render
 │                                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, column1, column2, column3)
@@ -1638,6 +1651,7 @@ vectorized: true
 │                       │ equality cols are key
 │                       │ lookup condition: (part IN ('new york', 'seattle')) AND (column1 = id)
 │                       │ locking strength: for update
+│                       │ parallel
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16_comp, column1, column2, column3)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_hash_sharded_index_query_plan
@@ -76,6 +76,7 @@ vectorized: true
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
+                │ parallel
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -83,6 +84,7 @@ vectorized: true
                     │ table: t_parent@t_parent_pkey
                     │ equality cols are key
                     │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
+                    │ parallel
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -161,6 +163,7 @@ vectorized: true
                 │ table: t_parent@t_parent_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
+                │ parallel
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -168,6 +171,7 @@ vectorized: true
                     │ table: t_parent@t_parent_pkey
                     │ equality cols are key
                     │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (pid = id)
+                    │ parallel
                     │
                     └── • render
                         │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -258,6 +262,7 @@ vectorized: true
             │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+            │ parallel
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
@@ -265,6 +270,7 @@ vectorized: true
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
@@ -318,6 +324,7 @@ vectorized: true
                 │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                │ parallel
                 │
                 └── • lookup join (anti)
                     │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
@@ -325,6 +332,7 @@ vectorized: true
                     │ table: t_gen_random_uuid@t_gen_random_uuid_pkey
                     │ equality cols are key
                     │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_user_id_shard_16_eq = crdb_internal_user_id_shard_16)) AND (user_id_default = user_id)
+                    │ parallel
                     │
                     └── • render
                         │ columns: (crdb_internal_user_id_shard_16_eq, crdb_internal_user_id_shard_16_comp, val_cast, user_id_default, crdb_region_default)
@@ -452,6 +460,7 @@ vectorized: true
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+            │ parallel
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
@@ -459,6 +468,7 @@ vectorized: true
                 │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
@@ -553,6 +563,7 @@ vectorized: true
             │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+            │ parallel
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
@@ -560,6 +571,7 @@ vectorized: true
                 │ table: t_unique_hash_pk@t_unique_hash_pk_pkey
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
@@ -735,6 +747,7 @@ vectorized: true
 │                           │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
 │                           │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
 │                           │ locking strength: for update
+│                           │ parallel
 │                           │
 │                           └── • render
 │                               │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
@@ -866,6 +879,7 @@ vectorized: true
             │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_id_shard_16_eq = crdb_internal_id_shard_16)) AND (column1 = id)
             │ locking strength: for update
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_id_shard_16_eq, crdb_internal_id_shard_16_comp, crdb_region_default, column1)
@@ -1023,6 +1037,7 @@ vectorized: true
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+            │ parallel
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
@@ -1030,6 +1045,7 @@ vectorized: true
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
@@ -1103,6 +1119,7 @@ vectorized: true
             │ table: t_unique_hash_sec_key@idx_uniq_hash_email
             │ equality cols are key
             │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+            │ parallel
             │
             └── • lookup join (anti)
                 │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
@@ -1110,6 +1127,7 @@ vectorized: true
                 │ table: t_unique_hash_sec_key@idx_uniq_hash_email
                 │ equality cols are key
                 │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_email_shard_16_eq, column1, column2, crdb_region_default, crdb_internal_email_shard_16_comp)
@@ -1125,6 +1143,7 @@ vectorized: true
                         │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
                         │ equality cols are key
                         │ lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column1 = id)
+                        │ parallel
                         │
                         └── • lookup join (anti)
                             │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
@@ -1132,6 +1151,7 @@ vectorized: true
                             │ table: t_unique_hash_sec_key@t_unique_hash_sec_key_pkey
                             │ equality cols are key
                             │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column1 = id)
+                            │ parallel
                             │
                             └── • render
                                 │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
@@ -1266,6 +1286,7 @@ vectorized: true
 │                   │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                   │ equality cols are key
 │                   │ lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+│                   │ parallel
 │                   │
 │                   └── • lookup join (anti)
 │                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
@@ -1273,6 +1294,7 @@ vectorized: true
 │                       │ table: t_unique_hash_sec_key@idx_uniq_hash_email
 │                       │ equality cols are key
 │                       │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
+│                       │ parallel
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
@@ -1539,6 +1561,7 @@ vectorized: true
 │                                   │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                                   │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (crdb_internal_email_shard_16_eq = crdb_internal_email_shard_16)) AND (column2 = email)
 │                                   │ locking strength: for update
+│                                   │ parallel
 │                                   │
 │                                   └── • render
 │                                       │ columns: (crdb_internal_email_shard_16_eq, crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)
@@ -1773,6 +1796,7 @@ vectorized: true
 │                       │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column1 = id)
 │                       │ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column1 = id)
 │                       │ locking strength: for update
+│                       │ parallel
 │                       │
 │                       └── • render
 │                           │ columns: (crdb_internal_email_shard_16_comp, crdb_region_default, column1, column2)

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -3335,6 +3335,10 @@ func (dsp *DistSQLPlanner) planIndexJoin(
 	// planning is done.
 	p.AddProjection(pkCols, execinfrapb.Ordering{}, planInfo.finalizeLastStageCb)
 
+	if buildutil.CrdbTestBuild && !planInfo.parallelize {
+		return errors.AssertionFailedf("index join should always have parallelize=true")
+	}
+
 	joinReaderSpec := execinfrapb.JoinReaderSpec{
 		Type:              descpb.InnerJoin,
 		LockingStrength:   planInfo.fetch.lockingStrength,
@@ -3342,6 +3346,7 @@ func (dsp *DistSQLPlanner) planIndexJoin(
 		LockingDurability: planInfo.fetch.lockingDurability,
 		MaintainOrdering:  len(planInfo.reqOrdering) > 0,
 		LimitHint:         planInfo.limitHint,
+		Parallelize:       planInfo.parallelize,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(planInfo.fetch.catalogCols))
@@ -3425,6 +3430,9 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 		if planInfo.reqOrdering[i].ColIdx >= numInputCols {
 			// We need to maintain the index ordering on each lookup.
 			maintainLookupOrdering = true
+			if planInfo.parallelize {
+				return errors.AssertionFailedf("parallelization should have been disabled")
+			}
 			break
 		}
 	}
@@ -3444,6 +3452,7 @@ func (dsp *DistSQLPlanner) planLookupJoin(
 		LimitHint:                         planInfo.limitHint,
 		RemoteOnlyLookups:                 planInfo.remoteOnlyLookups,
 		ReverseScans:                      planInfo.reverseScans,
+		Parallelize:                       planInfo.parallelize,
 	}
 
 	fetchColIDs := make([]descpb.ColumnID, len(planInfo.fetch.catalogCols))

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -843,6 +843,7 @@ func (e *distSQLSpecExecFactory) ConstructIndexJoin(
 	reqOrdering exec.OutputOrdering,
 	locking opt.Locking,
 	limitHint int64,
+	parallelize bool,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(input)
 	tabDesc := table.(*optTable).desc
@@ -865,6 +866,7 @@ func (e *distSQLSpecExecFactory) ConstructIndexJoin(
 		keyCols:     keyCols,
 		reqOrdering: ReqOrdering(reqOrdering),
 		limitHint:   limitHint,
+		parallelize: parallelize,
 	}
 
 	recommendation := canDistribute
@@ -902,6 +904,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 	limitHint int64,
 	remoteOnlyLookups bool,
 	reverseScans bool,
+	parallelize bool,
 ) (exec.Node, error) {
 	physPlan, plan := getPhysPlan(input)
 	var planNodesToClose []planNode
@@ -950,6 +953,7 @@ func (e *distSQLSpecExecFactory) ConstructLookupJoin(
 			limitHint:                  limitHint,
 			remoteOnlyLookups:          remoteOnlyLookups,
 			reverseScans:               reverseScans,
+			parallelize:                parallelize,
 		}
 		if onCond != tree.DBoolTrue {
 			planInfo.onCond = onCond

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -346,7 +346,9 @@ message JoinReaderSpec {
   // Indicates that for each input row, the join reader should return looked-up
   // rows in sorted order. This is only applicable to lookup joins for which
   // more than one lookup row may be associated with a given input row. It can
-  // only be set to true if maintain_ordering is also true.
+  // only be set to true if maintain_ordering is also true. It cannot be set
+  // when Parallelize is set.
+  //
   // maintain_lookup_ordering can be used if the output needs to be ordered by
   // a prefix of input columns followed by index (lookup) columns without
   // requiring a (buffered) sort.
@@ -362,6 +364,13 @@ message JoinReaderSpec {
   // reverse order. This is only useful if a lookup can return more than one
   // row.
   optional bool reverse_scans = 25 [(gogoproto.nullable) = false];
+
+  // If set, indicates that the DistSender-level cross-range parallelism should
+  // be enabled (which means that the TargetBytes limit cannot be used by the
+  // fetcher). It cannot be set when MaintainLookupOrdering is set.
+  //
+  // Note that this field has no effect when the Streamer API is used.
+  optional bool parallelize = 26 [(gogoproto.nullable) = false];
 
   reserved 5, 7, 12, 13, 18;
 }

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -37,6 +37,8 @@ type indexJoinPlanningInfo struct {
 
 	limitHint int64
 
+	parallelize bool // expected to always be true
+
 	// finalizeLastStageCb will be nil in the spec factory.
 	finalizeLastStageCb func(*physicalplan.PhysicalPlan)
 }

--- a/pkg/sql/lookup_join.go
+++ b/pkg/sql/lookup_join.go
@@ -85,6 +85,13 @@ type lookupJoinPlanningInfo struct {
 	// can return more than one row.
 	reverseScans bool
 
+	// If set, indicates that the DistSender-level cross-range parallelism
+	// should be enabled (which means that the TargetBytes limit cannot be used
+	// by the fetcher). The caller is responsible for ensuring this is safe
+	// (from OOM perspective). Note that this field has no effect when the
+	// Streamer API is used.
+	parallelize bool
+
 	// finalizeLastStageCb will be nil in the spec factory.
 	finalizeLastStageCb func(*physicalplan.PhysicalPlan)
 }

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2487,9 +2487,13 @@ func (b *Builder) buildIndexJoin(
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
 	}
+	// We know that there's exactly one lookup row for each input row, so we
+	// assume it's always safe to get the DistSender-level parallelism.
+	const parallelize = true
 	var res execPlan
 	res.root, err = b.factory.ConstructIndexJoin(
-		input.root, tab, keyCols, needed, reqOrdering, locking, join.RequiredPhysical().LimitHintInt64(),
+		input.root, tab, keyCols, needed, reqOrdering, locking,
+		join.RequiredPhysical().LimitHintInt64(), parallelize,
 	)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err
@@ -2869,6 +2873,25 @@ func (b *Builder) buildLookupJoin(
 		return execPlan{}, colOrdMap{}, errors.AssertionFailedf("lookup join can't provide required ordering")
 	}
 	reverse := requiredDirection == ordering.ReverseDirection
+	// The joiner has a choice to make between getting DistSender-level
+	// parallelism for its lookup batches and setting row and memory limits (due
+	// to implementation limitations, you can't have both at the same time).
+	var parallelize bool
+	if join.LookupColsAreTableKey {
+		// We choose parallelism when we know that each lookup returns at most
+		// one row.
+		parallelize = true
+	} else if b.evalCtx.SessionData().ParallelizeMultiKeyLookupJoinsEnabled {
+		parallelize = true
+	}
+	for _, c := range reqOrdering {
+		if c.ColIdx >= numInputCols {
+			// We need to maintain lookup ordering, in which case we cannot use
+			// the DistSender-level parallelism.
+			parallelize = false
+			break
+		}
+	}
 	var res execPlan
 	res.root, err = b.factory.ConstructLookupJoin(
 		joinType,
@@ -2888,6 +2911,7 @@ func (b *Builder) buildLookupJoin(
 		join.RequiredPhysical().LimitHintInt64(),
 		join.RemoteOnlyLookups,
 		reverse,
+		parallelize,
 	)
 	if err != nil {
 		return execPlan{}, colOrdMap{}, err

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -340,6 +340,7 @@ vectorized: true
         │ table: xyz@xyz_pkey
         │ key columns: x
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (x, y)
@@ -370,6 +371,7 @@ vectorized: true
         │ table: xyz@xyz_pkey
         │ key columns: x
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (x, y)
@@ -404,6 +406,7 @@ vectorized: true
         │ table: xyz@xyz_pkey
         │ key columns: x
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (x, y)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -992,6 +992,7 @@ vectorized: true
     │ estimated row count: 10 (missing stats)
     │ table: tc@tc_pkey
     │ key columns: rowid
+    │ parallel
     │
     └── • scan
           columns: (a, rowid)
@@ -1020,6 +1021,7 @@ vectorized: true
     │ estimated row count: 10 (missing stats)
     │ table: tc@tc_pkey
     │ key columns: rowid
+    │ parallel
     │
     └── • scan
           columns: (a, rowid)

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -388,6 +388,7 @@ vectorized: true
                     │ table: bc@bc_pkey
                     │ equality: (?column?) = (b)
                     │ equality cols are key
+                    │ parallel
                     │
                     └── • distinct
                         │ columns: (c_comp, "?column?")
@@ -1762,6 +1763,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: g@g_pkey
     │ key columns: rowid
+    │ parallel
     │
     └── • scan
           columns: (rowid)

--- a/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/fk_read_committed
@@ -179,6 +179,7 @@ vectorized: true
             │ equality cols are key
             │ locking strength: for share
             │ locking durability: guaranteed
+            │ parallel
             │
             └── • project
                 │ columns: (j_new)

--- a/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/hash_sharded_index
@@ -1098,6 +1098,7 @@ vectorized: true
                     │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
                     │ equality cols are key
                     │ locking strength: for update
+                    │ parallel
                     │
                     └── • render
                         │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
@@ -1144,6 +1145,7 @@ vectorized: true
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
@@ -1202,6 +1204,7 @@ vectorized: true
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_b_shard_8_eq, column1, column2, crdb_internal_b_shard_8_comp)
@@ -1216,6 +1219,7 @@ vectorized: true
                     │ table: t_hash_indexed@t_hash_indexed_pkey
                     │ equality: (column1) = (a)
                     │ equality cols are key
+                    │ parallel
                     │
                     └── • render
                         │ columns: (crdb_internal_b_shard_8_comp, column1, column2)
@@ -1300,6 +1304,7 @@ vectorized: true
             │ table: t_hash_indexed@idx_t_hash_indexed
             │ equality: (crdb_internal_b_shard_8_eq, column2) = (crdb_internal_b_shard_8, b)
             │ equality cols are key
+            │ parallel
             │
             └── • render
                 │ columns: (crdb_internal_b_shard_8_eq, crdb_internal_b_shard_8_comp, column1, column2)
@@ -1368,6 +1373,7 @@ vectorized: true
                 │ table: t_parent_pk@t_parent_pk_pkey
                 │ equality: (crdb_internal_id_shard_16_eq, pid) = (crdb_internal_id_shard_16, id)
                 │ equality cols are key
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_id_shard_16_eq, pid)
@@ -1437,6 +1443,7 @@ vectorized: true
                 │ table: t_parent_sec@idx_t_parent_sec_real_id
                 │ equality: (crdb_internal_real_id_shard_16_eq, pid) = (crdb_internal_real_id_shard_16, real_id)
                 │ equality cols are key
+                │ parallel
                 │
                 └── • render
                     │ columns: (crdb_internal_real_id_shard_16_eq, pid)
@@ -1527,6 +1534,7 @@ vectorized: true
                 │ equality: (rowid_default) = (rowid)
                 │ equality cols are key
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • values
                       columns: (column1, rowid_default, crdb_internal_a_shard_16_comp)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_index
@@ -243,6 +243,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -261,6 +262,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -279,6 +281,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -297,6 +300,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -315,6 +319,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -333,6 +338,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -353,6 +359,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -383,6 +390,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -410,6 +418,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -428,6 +437,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -455,6 +465,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -482,6 +493,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -516,6 +528,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -548,6 +561,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -577,6 +591,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ pred: (b->'a') @> '[1, 2]'
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -607,6 +622,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -634,6 +650,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -657,6 +674,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -706,6 +724,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -733,6 +752,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -813,6 +833,7 @@ vectorized: true
 │ estimated row count: 111 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -842,6 +863,7 @@ vectorized: true
 │ estimated row count: 333 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -869,6 +891,7 @@ vectorized: true
 │ estimated row count: 12 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -896,6 +919,7 @@ vectorized: true
 │ estimated row count: 12 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -923,6 +947,7 @@ vectorized: true
 │ estimated row count: 12 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -953,6 +978,7 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -980,6 +1006,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ pred: b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1006,6 +1033,7 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1035,6 +1063,7 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1062,6 +1091,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ pred: b @> '{"a": {"b": "c", "d": "e"}, "f": "g"}'
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1088,6 +1118,7 @@ vectorized: true
 │ table: d@d_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1116,6 +1147,7 @@ vectorized: true
 │ estimated row count: 12 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1143,6 +1175,7 @@ vectorized: true
 │ estimated row count: 12 (missing stats)
 │ table: d@d_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1179,6 +1212,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • sort
         │ columns: (a)
@@ -1216,6 +1250,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -1239,6 +1274,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -1262,6 +1298,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: (b->1) = '[1, 2]'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1292,6 +1329,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -1315,6 +1353,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -1343,6 +1382,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • sort
             │ columns: (a)
@@ -1376,6 +1416,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • sort
             │ columns: (a)
@@ -1409,6 +1450,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • sort
             │ columns: (a)
@@ -1438,6 +1480,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: ((b->0)->1) = '[1, 2]'
+    │ parallel
     │
     └── • sort
         │ columns: (a)
@@ -1473,6 +1516,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: ((b->0) = '[1, 2]') AND ((b->1) = '[1]')
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1505,6 +1549,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -1530,6 +1575,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1562,6 +1608,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1594,6 +1641,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1626,6 +1674,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: (b->0) @> '[1, 2]'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1656,6 +1705,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1688,6 +1738,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: ((b->0) @> '[1, 2]') AND ((b->1) <@ '[1]')
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1786,6 +1837,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -1821,6 +1873,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -1858,6 +1911,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -1893,6 +1947,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -1928,6 +1983,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -1963,6 +2019,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2001,6 +2058,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2036,6 +2094,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2071,6 +2130,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b = '[[0, 1, 2]]'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2104,6 +2164,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -2130,6 +2191,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -2153,6 +2215,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b = '[1, 2]'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2186,6 +2249,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -2212,6 +2276,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2247,6 +2312,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2279,6 +2345,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b = '{"a": 1, "b": 2}'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2309,6 +2376,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b = '{"a": {"b": "c"}, "d": "e"}'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2342,6 +2410,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -2368,6 +2437,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -2392,6 +2462,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b = '[[0, 1, 2], [0, 1, 2], "s"]'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2429,6 +2500,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2464,6 +2536,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2500,6 +2573,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2535,6 +2609,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2570,6 +2645,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: d@d_pkey
         │ key columns: a
+        │ parallel
         │
         └── • project
             │ columns: (a)
@@ -2603,6 +2679,7 @@ vectorized: true
     │ equality: (a) = (a)
     │ equality cols are key
     │ pred: b = '[[0, 1, 2], [0, 1, 2], "s"]'
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2773,6 +2850,7 @@ vectorized: true
 │ estimated row count: 110 (missing stats)
 │ table: e@e_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a)
@@ -2849,6 +2927,7 @@ vectorized: true
 │ table: e@e_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -2875,6 +2954,7 @@ vectorized: true
 │ table: e@e_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -2906,6 +2986,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: e@e_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -2929,6 +3010,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: e@e_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -2961,6 +3043,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: e@e_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -2984,6 +3067,7 @@ vectorized: true
     │ estimated row count: 111 (missing stats)
     │ table: e@e_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -3016,6 +3100,7 @@ vectorized: true
     │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -3058,6 +3143,7 @@ vectorized: true
     │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -3081,6 +3167,7 @@ vectorized: true
     │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -3113,6 +3200,7 @@ vectorized: true
     │ estimated row count: 0
     │ table: d@d_pkey
     │ key columns: a
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -3161,6 +3249,7 @@ vectorized: true
 │ estimated row count: 333 (missing stats)
 │ table: e@e_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -3207,6 +3296,7 @@ vectorized: true
 │ estimated row count: 333 (missing stats)
 │ table: e@e_pkey
 │ key columns: a
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -3267,6 +3357,7 @@ vectorized: true
         │ estimated row count: 111 (missing stats)
         │ table: geo_table@geo_table_pkey
         │ key columns: k
+        │ parallel
         │
         └── • project
             │ columns: (k)
@@ -3343,6 +3434,7 @@ vectorized: true
     │ equality: (k) = (k)
     │ equality cols are key
     │ pred: st_intersects(geom, geom)
+    │ parallel
     │
     └── • project
         │ columns: (k, geom, k)

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_geospatial
@@ -114,6 +114,7 @@ vectorized: true
             │ equality: (rk1, rk2) = (rk1, rk2)
             │ equality cols are key
             │ pred: st_intersects(geom, geom1) OR st_dwithin(geom1, geom, 2.0)
+            │ parallel
             │
             └── • project
                 │ columns: (lk, geom1, rk1, rk2)
@@ -163,6 +164,7 @@ vectorized: true
             │ equality: (rk1, rk2) = (rk1, rk2)
             │ equality cols are key
             │ pred: st_intersects(geom1, geom) AND st_dwithin(geom, geom1, 2.0)
+            │ parallel
             │
             └── • project
                 │ columns: (lk, geom1, rk1, rk2)
@@ -204,6 +206,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: (st_intersects(geom1, geom) AND st_covers(geom2, geom)) AND (st_dfullywithin(geom, geom1, 100.0) OR st_intersects('0101000000000000000000F03F000000000000F03F', geom))
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom1, geom2, rk1, rk2)
@@ -242,6 +245,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_intersects(geom2, geom)
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom2, rk1, rk2, cont)
@@ -279,6 +283,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_intersects(geom1, geom)
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2, cont)
@@ -431,6 +436,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_intersects(geom2, geom)
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom2, rk1, rk2, cont)
@@ -470,6 +476,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: st_covers(geom1, geom)
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2, cont)
@@ -511,6 +518,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: geom1 ~ geom
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2)
@@ -547,6 +555,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: geom ~ geom1
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2)
@@ -583,6 +592,7 @@ vectorized: true
         │ equality: (rk1, rk2) = (rk1, rk2)
         │ equality cols are key
         │ pred: geom && geom1
+        │ parallel
         │
         └── • project
             │ columns: (lk, geom1, rk1, rk2)

--- a/pkg/sql/opt/exec/execbuilder/testdata/join_order
+++ b/pkg/sql/opt/exec/execbuilder/testdata/join_order
@@ -48,6 +48,7 @@ vectorized: true
 │ table: cy@cy_pkey
 │ equality: (c) = (c)
 │ equality cols are key
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, c, d, b, x)
@@ -55,6 +56,7 @@ vectorized: true
     │ table: bx@bx_pkey
     │ equality: (b) = (b)
     │ equality cols are key
+    │ parallel
     │
     └── • scan
           columns: (a, b, c, d)
@@ -77,6 +79,7 @@ vectorized: true
 │ table: cy@cy_pkey
 │ equality: (c) = (c)
 │ equality cols are key
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, c, d, b, x)
@@ -84,6 +87,7 @@ vectorized: true
     │ table: bx@bx_pkey
     │ equality: (b) = (b)
     │ equality cols are key
+    │ parallel
     │
     └── • scan
           columns: (a, b, c, d)

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -26,6 +26,7 @@ vectorized: true
         │ estimated row count: 30 (missing stats)
         │ table: t@t_pkey
         │ key columns: k
+        │ parallel
         │
         └── • scan
               columns: (k, v)
@@ -256,6 +257,7 @@ vectorized: true
     │ estimated row count: 10 (missing stats)
     │ table: t@t_pkey
     │ key columns: k
+    │ parallel
     │
     └── • scan
           columns: (k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join
@@ -59,6 +59,32 @@ vectorized: true
       table: abc@abc_pkey
       spans: FULL SCAN
 
+# Same as above but with lookup join parallelization.
+statement ok
+SET parallelize_multi_key_lookup_joins_enabled = true;
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (a, b, c, d, e, f)
+│ estimated row count: 99
+│ table: def@def_pkey
+│ equality: (b) = (f)
+│ parallel
+│
+└── • scan
+      columns: (a, b, c)
+      estimated row count: 100 (100% of the table; stats collected <hidden> ago)
+      table: abc@abc_pkey
+      spans: FULL SCAN
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_enabled;
+
 query T
 EXPLAIN (VERBOSE) SELECT * FROM abc JOIN def ON f = b AND e = c
 ----
@@ -71,6 +97,7 @@ vectorized: true
 │ table: def@def_pkey
 │ equality: (b, c) = (f, e)
 │ equality cols are key
+│ parallel
 │
 └── • scan
       columns: (a, b, c)
@@ -459,6 +486,7 @@ vectorized: true
     │ equality: (a, b, c, d) = (a, b, c, d)
     │ equality cols are key
     │ pred: c > 0
+    │ parallel
     │
     └── • filter
         │ columns: (a, b, c, d)
@@ -799,6 +827,7 @@ vectorized: true
         │ table: large@large_pkey
         │ equality: (a, b) = (a, b)
         │ equality cols are key
+        │ parallel
         │
         └── • lookup join (inner)
             │ columns: (a, a, b)
@@ -921,6 +950,7 @@ vectorized: true
         │ table: large@large_pkey
         │ equality: (a, b) = (a, b)
         │ equality cols are key
+        │ parallel
         │
         └── • lookup join (left outer)
             │ columns: (c, a, b)
@@ -977,6 +1007,7 @@ vectorized: true
         │ equality: (a, b) = (a, b)
         │ equality cols are key
         │ pred: d < 30
+        │ parallel
         │
         └── • lookup join (left outer)
             │ columns: (c, a, b, cont)
@@ -1007,6 +1038,7 @@ vectorized: true
     │ equality: (a, b) = (a, b)
     │ equality cols are key
     │ pred: d < 30
+    │ parallel
     │
     └── • lookup join (inner)
         │ columns: (c, a, b, cont)
@@ -1037,6 +1069,7 @@ vectorized: true
     │ equality: (a, b) = (a, b)
     │ equality cols are key
     │ pred: d < 30
+    │ parallel
     │
     └── • lookup join (left outer)
         │ columns: (c, a, b, cont)
@@ -1113,6 +1146,7 @@ vectorized: true
     │ equality: (d) = (d)
     │ equality cols are key
     │ pred: a = a
+    │ parallel
     │
     └── • filter
         │ columns: (a, d, e)
@@ -1351,6 +1385,7 @@ vectorized: true
 │ table: def@def_pkey
 │ equality: (a, c) = (f, e)
 │ equality cols are key
+│ parallel
 │
 └── • scan
       columns: (a, b, c)
@@ -1370,6 +1405,7 @@ vectorized: true
 │ table: def@def_pkey
 │ equality: (a, c) = (f, e)
 │ equality cols are key
+│ parallel
 │
 └── • scan
       columns: (a, b, c)
@@ -2098,6 +2134,7 @@ vectorized: true
         │ table: tab4@tab4_col3_col4_key
         │ equality: (col0, lookup_join_const_col_@17) = (col3, col4)
         │ equality cols are key
+        │ parallel
         │
         └── • render
             │ columns: ("lookup_join_const_col_@17", pk, col0, col3)
@@ -2111,6 +2148,7 @@ vectorized: true
                 │ estimated row count: 10 (missing stats)
                 │ table: tab4@tab4_pkey
                 │ key columns: pk
+                │ parallel
                 │
                 └── • scan
                       columns: (pk, col3)

--- a/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_local
+++ b/pkg/sql/opt/exec/execbuilder/testdata/lookup_join_local
@@ -1,0 +1,36 @@
+# LogicTest: local
+
+# Verify that lookup joins that need to maintain lookup ordering do not
+# parallelize.
+
+statement ok
+CREATE TABLE xyz (x INT, y INT, z INT, PRIMARY KEY(x, y DESC, z));
+
+statement ok
+CREATE TABLE uv (u INT, v INT, PRIMARY KEY(u, v DESC));
+
+statement ok
+SET parallelize_multi_key_lookup_joins_enabled = true;
+
+query T
+EXPLAIN (VERBOSE) SELECT * FROM xyz INNER LOOKUP JOIN uv ON x = u ORDER BY x, y DESC, z, u, v DESC
+----
+distribution: local
+vectorized: true
+·
+• lookup join (inner)
+│ columns: (x, y, z, u, v)
+│ ordering: +x,-y,+z,-v
+│ estimated row count: 10,000 (missing stats)
+│ table: uv@uv_pkey
+│ equality: (x) = (u)
+│
+└── • scan
+      columns: (x, y, z)
+      ordering: +x,-y,+z
+      estimated row count: 1,000 (missing stats)
+      table: xyz@xyz_pkey
+      spans: FULL SCAN
+
+statement ok
+RESET parallelize_multi_key_lookup_joins_enabled;

--- a/pkg/sql/opt/exec/execbuilder/testdata/orderby
+++ b/pkg/sql/opt/exec/execbuilder/testdata/orderby
@@ -1101,6 +1101,7 @@ vectorized: true
             │ table: kv@kv_pkey
             │ equality: (column1) = (k)
             │ equality cols are key
+            │ parallel
             │
             └── • values
                   columns: (column1)
@@ -1166,6 +1167,7 @@ vectorized: true
     │ estimated row count: 10 (missing stats)
     │ table: xyz@xyz_pkey
     │ key columns: rowid
+    │ parallel
     │
     └── • scan
           columns: (y, z, rowid)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select
@@ -1624,6 +1624,7 @@ vectorized: true
     │ estimated row count: 2 (missing stats)
     │ table: a@a_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a, item)
@@ -1648,6 +1649,7 @@ vectorized: true
     │ estimated row count: 110 (missing stats)
     │ table: a@a_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a, price)
@@ -1834,6 +1836,7 @@ vectorized: true
     │ estimated row count: 110 (missing stats)
     │ table: a@a_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a, price)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update
@@ -786,6 +786,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ parallel
     │
     └── • distinct
         │ columns: (b)
@@ -813,6 +814,7 @@ vectorized: true
     │ table: t@t_pkey
     │ equality: (b) = (a)
     │ equality cols are key
+    │ parallel
     │
     └── • distinct
         │ columns: (b)
@@ -842,6 +844,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ parallel
     │
     └── • distinct
         │ columns: (b)
@@ -869,6 +872,7 @@ vectorized: true
     │ table: t@t_pkey
     │ equality: (b) = (a)
     │ equality cols are key
+    │ parallel
     │
     └── • distinct
         │ columns: (b)
@@ -1692,6 +1696,7 @@ vectorized: true
 │ table: indexed@indexed_pkey
 │ key columns: a
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -1712,6 +1717,7 @@ vectorized: true
 │ table: indexed@indexed_pkey
 │ key columns: a
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -1740,6 +1746,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -1764,6 +1771,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ locking strength: for update
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -1786,6 +1794,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b)
@@ -1829,6 +1838,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -1862,6 +1872,7 @@ vectorized: true
     │ table: inverted@inverted_pkey
     │ key columns: a
     │ locking strength: for update
+    │ parallel
     │
     └── • project
         │ columns: (a)
@@ -1896,6 +1907,7 @@ vectorized: true
     │ equality cols are key
     │ pred: b @> b
     │ locking strength: for update
+    │ parallel
     │
     └── • project
         │ columns: (a, b, c, a)
@@ -1964,6 +1976,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • project
     │ columns: (a)
@@ -2552,6 +2565,7 @@ vectorized: true
 │ key columns: a
 │ locking strength: for update
 │ locking wait policy: skip locked
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -2578,6 +2592,7 @@ vectorized: true
     │ key columns: a
     │ locking strength: for update
     │ locking wait policy: skip locked
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -2720,6 +2735,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • filter
     │ columns: (a, b)
@@ -2747,6 +2763,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -2767,6 +2784,7 @@ vectorized: true
 │ table: u@u_pkey
 │ key columns: a
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -2788,6 +2806,7 @@ vectorized: true
 │ equality: (b) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -2810,6 +2829,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b, c)
@@ -2818,6 +2838,7 @@ vectorized: true
     │ equality: (b) = (a)
     │ equality cols are key
     │ pred: c < a
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -2839,6 +2860,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b)
@@ -2866,6 +2888,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b, c)
@@ -2873,6 +2896,7 @@ vectorized: true
     │ table: u@u_pkey
     │ equality: (b) = (a)
     │ equality cols are key
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -2894,6 +2918,7 @@ vectorized: true
 │ equality: (a) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, a, b)
@@ -2901,6 +2926,7 @@ vectorized: true
     │ table: t@t_pkey
     │ equality: (b) = (a)
     │ equality cols are key
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -2922,6 +2948,7 @@ vectorized: true
 │ equality: (b) = (a)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)
@@ -2958,6 +2985,7 @@ vectorized: true
     │ equality: (x) = (x)
     │ equality cols are key
     │ locking strength: for update
+    │ parallel
     │
     └── • scan
           columns: (x, y)
@@ -2999,6 +3027,7 @@ vectorized: true
     │ equality: (x) = (x)
     │ equality cols are key
     │ locking strength: for share
+    │ parallel
     │
     └── • project
         │ columns: (x, y)
@@ -3008,6 +3037,7 @@ vectorized: true
             │ estimated row count: 10 (missing stats)
             │ table: xyz@xyz_pkey
             │ key columns: x
+            │ parallel
             │
             └── • scan
                   columns: (x, z)
@@ -3028,6 +3058,7 @@ vectorized: true
 │ table: xyz@xyz_pkey
 │ key columns: x
 │ locking strength: for share
+│ parallel
 │
 └── • scan
       columns: (x, z)
@@ -3049,6 +3080,7 @@ vectorized: true
 │ equality: (x) = (x)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (a, b, x)
@@ -3056,6 +3088,7 @@ vectorized: true
     │ table: xyz@xyz_pkey
     │ equality: (b) = (x)
     │ equality cols are key
+    │ parallel
     │
     └── • scan
           columns: (a, b)
@@ -3077,6 +3110,7 @@ vectorized: true
 │ equality: (b) = (x)
 │ equality cols are key
 │ locking strength: for update
+│ parallel
 │
 └── • scan
       columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_for_update_read_committed
@@ -226,6 +226,7 @@ vectorized: true
 │       │ equality cols are key
 │       │ locking strength: for update
 │       │ locking durability: guaranteed
+│       │ parallel
 │       │
 │       └── • project
 │           │ columns: (person, aisle)
@@ -236,6 +237,7 @@ vectorized: true
 │               │ table: supermarket@supermarket_pkey
 │               │ equality: (person) = (person)
 │               │ equality cols are key
+│               │ parallel
 │               │
 │               └── • scan buffer
 │                     columns: (person)
@@ -294,6 +296,7 @@ vectorized: true
     │ equality cols are key
     │ locking strength: for update
     │ locking durability: guaranteed
+    │ parallel
     │
     └── • project
         │ columns: (person, aisle)
@@ -303,6 +306,7 @@ vectorized: true
             │ estimated row count: 10 (missing stats)
             │ table: supermarket@supermarket_pkey
             │ key columns: person
+            │ parallel
             │
             └── • scan
                   columns: (person, starts_with)
@@ -354,6 +358,7 @@ vectorized: true
     │ equality cols are key
     │ locking strength: for update
     │ locking durability: guaranteed
+    │ parallel
     │
     └── • project
         │ columns: (person, aisle)
@@ -364,6 +369,7 @@ vectorized: true
             │ table: supermarket@supermarket_pkey
             │ equality: (person) = (person)
             │ equality cols are key
+            │ parallel
             │
             └── • project
                 │ columns: (person, starts_with, ends_with)

--- a/pkg/sql/opt/exec/execbuilder/testdata/select_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/select_index
@@ -212,6 +212,7 @@ vectorized: true
     │   │ estimated row count: 10 (missing stats)
     │   │ table: t@t_pkey
     │   │ key columns: a, b
+    │   │ parallel
     │   │
     │   └── • scan
     │         columns: (a, b, c)
@@ -224,6 +225,7 @@ vectorized: true
         │ estimated row count: 10 (missing stats)
         │ table: t@t_pkey
         │ key columns: a, b
+        │ parallel
         │
         └── • scan
               columns: (a, b, c)
@@ -845,6 +847,7 @@ vectorized: true
 │ estimated row count: 20 (missing stats)
 │ table: test2@test2_pkey
 │ key columns: id
+│ parallel
 │
 └── • revscan
       columns: (id, k)
@@ -1148,6 +1151,7 @@ vectorized: true
 │ estimated row count: 10 (missing stats)
 │ table: xy@xy_pkey
 │ key columns: rowid
+│ parallel
 │
 └── • scan
       columns: (y, rowid)
@@ -1166,6 +1170,7 @@ vectorized: true
 │ estimated row count: 10 (missing stats)
 │ table: xy@xy_pkey
 │ key columns: rowid
+│ parallel
 │
 └── • scan
       columns: (y, rowid)
@@ -1187,6 +1192,7 @@ vectorized: true
     │ estimated row count: 10 (missing stats)
     │ table: xy@xy_pkey
     │ key columns: rowid
+    │ parallel
     │
     └── • scan
           columns: (y, rowid)
@@ -1472,6 +1478,7 @@ vectorized: true
 │ estimated row count: 5 (missing stats)
 │ table: noncover@noncover_pkey
 │ key columns: a
+│ parallel
 │
 └── • limit
     │ columns: (a, c)
@@ -1555,6 +1562,7 @@ vectorized: true
 │ estimated row count: 1
 │ table: t2@t2_pkey
 │ key columns: a
+│ parallel
 │
 └── • filter
     │ columns: (a, b, c)
@@ -1596,6 +1604,7 @@ vectorized: true
 │ estimated row count: 1
 │ table: t2@t2_pkey
 │ key columns: a
+│ parallel
 │
 └── • scan
       columns: (a, b, c)
@@ -1731,6 +1740,7 @@ vectorized: true
     │ estimated row count: 90 (missing stats)
     │ table: t3@t3_pkey
     │ key columns: k
+    │ parallel
     │
     └── • scan
           columns: (k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/straight_join
+++ b/pkg/sql/opt/exec/execbuilder/testdata/straight_join
@@ -53,6 +53,7 @@ vectorized: true
 │ table: t2@t2_pkey
 │ equality: (x) = (x)
 │ equality cols are key
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (x, x, y)
@@ -79,6 +80,7 @@ vectorized: true
 │ table: t2@t2_pkey
 │ equality: (x) = (x)
 │ equality cols are key
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (x, x, y)

--- a/pkg/sql/opt/exec/execbuilder/testdata/subquery
+++ b/pkg/sql/opt/exec/execbuilder/testdata/subquery
@@ -93,6 +93,7 @@ vectorized: true
 │       │ table: abc@abc_pkey
 │       │ equality: (any_not_null) = (a)
 │       │ equality cols are key
+│       │ parallel
 │       │
 │       └── • group (scalar)
 │           │ columns: (any_not_null)

--- a/pkg/sql/opt/exec/execbuilder/testdata/topk
+++ b/pkg/sql/opt/exec/execbuilder/testdata/topk
@@ -35,6 +35,7 @@ vectorized: true
 │ estimated row count: 10 (missing stats)
 │ table: t@t_pkey
 │ key columns: k
+│ parallel
 │
 └── • scan
       columns: (k, v)
@@ -128,6 +129,7 @@ vectorized: true
     │ estimated row count: 1,000 (missing stats)
     │ table: t@t_pkey
     │ key columns: k
+    │ parallel
     │
     └── • scan
           columns: (k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/triggers
+++ b/pkg/sql/opt/exec/execbuilder/testdata/triggers
@@ -960,6 +960,7 @@ quality of service: regular
         │           │ table: parent@parent_pkey
         │           │ equality: (fk_new) = (k)
         │           │ equality cols are key
+        │           │ parallel
         │           │
         │           └── • filter
         │               │ columns: (fk_new)

--- a/pkg/sql/opt/exec/execbuilder/testdata/tuple
+++ b/pkg/sql/opt/exec/execbuilder/testdata/tuple
@@ -140,6 +140,7 @@ vectorized: true
     │ estimated row count: 80 (missing stats)
     │ table: abc@abc_pkey
     │ key columns: rowid
+    │ parallel
     │
     └── • scan
           columns: (a, b, rowid)

--- a/pkg/sql/opt/exec/execbuilder/testdata/udf
+++ b/pkg/sql/opt/exec/execbuilder/testdata/udf
@@ -126,6 +126,7 @@ vectorized: true
     │ equality: (any_not_null) = (a)
     │ equality cols are key
     │ pred: sub_fn() = 3
+    │ parallel
     │
     └── • filter
         │ columns: (any_not_null)

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -386,6 +386,7 @@ vectorized: true
             │ table: uniq@uniq_v_key
             │ equality: (column2) = (v)
             │ equality cols are key
+            │ parallel
             │
             └── • hash join (right anti)
                 │ columns: (column1, column2, column3, column4, column5)
@@ -1064,6 +1065,7 @@ vectorized: true
         │ table: uniq_enum@uniq_enum_pkey
         │ equality cols are key
         │ lookup condition: (r IN ('us-east', 'us-west', 'eu-west')) AND (column3 = i)
+        │ parallel
         │
         └── • lookup join (anti)
             │ columns: (column1, column2, column3, column4)
@@ -1071,6 +1073,7 @@ vectorized: true
             │ table: uniq_enum@uniq_enum_r_s_j_key
             │ equality cols are key
             │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
+            │ parallel
             │
             └── • values
                   columns: (column1, column2, column3, column4)
@@ -1503,6 +1506,7 @@ vectorized: true
                     │ table: uniq_partial_enum@uniq_partial_enum_pkey
                     │ equality: (column1, column2) = (r, a)
                     │ equality cols are key
+                    │ parallel
                     │
                     └── • values
                           columns: (column1, column2, column3, column4)
@@ -4324,6 +4328,7 @@ vectorized: true
 │                       │ equality: (column1, column3) = (r, i)
 │                       │ equality cols are key
 │                       │ locking strength: for update
+│                       │ parallel
 │                       │
 │                       └── • values
 │                             columns: (column1, column2, column3, column4)
@@ -4441,6 +4446,7 @@ vectorized: true
 │                       │ equality cols are key
 │                       │ lookup condition: ((r IN ('us-east', 'us-west', 'eu-west')) AND (column2 = s)) AND (column4 = j)
 │                       │ locking strength: for update
+│                       │ parallel
 │                       │
 │                       └── • values
 │                             columns: (column1, column2, column3, column4)
@@ -4953,6 +4959,7 @@ vectorized: true
 │                       │ equality: (column1, column2) = (r, a)
 │                       │ equality cols are key
 │                       │ locking strength: for update
+│                       │ parallel
 │                       │
 │                       └── • values
 │                             columns: (column1, column2, column3, column4)
@@ -5034,6 +5041,7 @@ vectorized: true
             │ table: uniq_partial_enum@uniq_partial_enum_pkey
             │ equality: (r, a) = (r, a)
             │ equality cols are key
+            │ parallel
             │
             └── • lookup join (left outer)
                 │ columns: (arbiter_unique_b_distinct, column1, column2, column3, column4, r, a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -263,6 +263,7 @@ vectorized: true
         │ table: xyz@xyz_pkey
         │ key columns: x
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (x, y)
@@ -298,6 +299,7 @@ vectorized: true
         │ table: xyz@xyz_pkey
         │ key columns: x
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (x, y)
@@ -337,6 +339,7 @@ vectorized: true
         │ table: xyz@xyz_pkey
         │ key columns: x
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (x, y)
@@ -542,6 +545,7 @@ vectorized: true
             │ estimated row count: 1,000 (missing stats)
             │ table: t38799@t38799_pkey
             │ key columns: a
+            │ parallel
             │
             └── • scan
                   columns: (a, b)

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -218,6 +218,7 @@ vectorized: true
             │ equality: (column1) = (a)
             │ equality cols are key
             │ locking strength: for update
+            │ parallel
             │
             └── • render
                 │ columns: (d_comp, b_default, c_default, column1)
@@ -353,6 +354,7 @@ vectorized: true
                     │ estimated row count: 1,000 (missing stats)
                     │ table: indexed@indexed_pkey
                     │ key columns: a
+                    │ parallel
                     │
                     └── • scan
                           columns: (a, b, d)
@@ -512,6 +514,7 @@ vectorized: true
                     │ estimated row count: 1,000 (missing stats)
                     │ table: indexed@indexed_pkey
                     │ key columns: a
+                    │ parallel
                     │
                     └── • scan
                           columns: (a, b, d)
@@ -672,6 +675,7 @@ vectorized: true
         │ table: indexed@secondary
         │ equality: (d_comp, column2) = (d, b)
         │ equality cols are key
+        │ parallel
         │
         └── • cross join (anti)
             │ columns: (column1, column2, column3, d_comp)
@@ -893,6 +897,7 @@ vectorized: true
         │ table: table38627@table38627_pkey
         │ equality: (a) = (a)
         │ equality cols are key
+        │ parallel
         │
         └── • scan
               columns: (a, b)
@@ -945,6 +950,7 @@ vectorized: true
             │ table: tdup@tdup_y_z_key
             │ equality: (column2, column3) = (y, z)
             │ equality cols are key
+            │ parallel
             │
             └── • distinct
                 │ columns: (column1, column2, column3)
@@ -1005,6 +1011,7 @@ vectorized: true
             │ table: target@target_b_c_key
             │ equality: (y, z) = (b, c)
             │ equality cols are key
+            │ parallel
             │
             └── • distinct
                 │ columns: (x, y, z)

--- a/pkg/sql/opt/exec/execbuilder/testdata/vector_search
+++ b/pkg/sql/opt/exec/execbuilder/testdata/vector_search
@@ -78,6 +78,7 @@ vectorized: true
             │ table: t@t_pkey
             │ equality: (k) = (k)
             │ equality cols are key
+            │ parallel
             │
             └── • vector search
                   columns: (k)
@@ -113,6 +114,7 @@ vectorized: true
             │ table: t@t_pkey
             │ equality: (k) = (k)
             │ equality cols are key
+            │ parallel
             │
             └── • vector search
                   columns: (k)
@@ -152,6 +154,7 @@ vectorized: true
             │ table: t_multi_col@t_multi_col_pkey
             │ equality: (x, y) = (x, y)
             │ equality cols are key
+            │ parallel
             │
             └── • vector search
                   columns: (x, y)
@@ -192,6 +195,7 @@ vectorized: true
             │ table: t_multi_col@t_multi_col_pkey
             │ equality: (x, y) = (x, y)
             │ equality cols are key
+            │ parallel
             │
             └── • vector search
                   columns: (x, y)

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual_columns
@@ -137,6 +137,7 @@ vectorized: true
     │ estimated row count: 333 (missing stats)
     │ table: t_idx@t_idx_pkey
     │ key columns: a
+    │ parallel
     │
     └── • scan
           columns: (a)
@@ -177,6 +178,7 @@ vectorized: true
 │ table: t_idx@t_idx_pkey
 │ equality: (a) = (a)
 │ equality cols are key
+│ parallel
 │
 └── • lookup join (inner)
     │ columns: (column1, a, v)
@@ -391,6 +393,7 @@ vectorized: true
         │ table: t_idx@t_idx_pkey
         │ key columns: a
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -423,6 +426,7 @@ vectorized: true
         │ table: t_idx@t_idx_pkey
         │ key columns: a
         │ locking strength: for update
+        │ parallel
         │
         └── • scan
               columns: (a)
@@ -625,6 +629,7 @@ vectorized: true
                 │ table: t_idx@t_idx_pkey
                 │ key columns: a
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • scan
                       columns: (a)
@@ -797,6 +802,7 @@ vectorized: true
         │ table: t@t_pkey
         │ equality: (column1) = (a)
         │ equality cols are key
+        │ parallel
         │
         └── • render
             │ columns: (v_comp, column1, column2)
@@ -855,6 +861,7 @@ vectorized: true
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • render
                     │ columns: (v_comp, column1, column2)
@@ -915,6 +922,7 @@ vectorized: true
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • render
                     │ columns: (v_comp, column1, column2)
@@ -968,6 +976,7 @@ vectorized: true
             │ equality: (column1) = (a)
             │ equality cols are key
             │ locking strength: for update
+            │ parallel
             │
             └── • render
                 │ columns: (v_comp, w_comp, column1, column2, column3)
@@ -1043,6 +1052,7 @@ vectorized: true
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
@@ -1090,6 +1100,7 @@ vectorized: true
             │ table: t_idx@t_idx_pkey
             │ equality: (column1) = (a)
             │ equality cols are key
+            │ parallel
             │
             └── • lookup join (anti)
                 │ columns: (v_comp, w_comp, column1, column2, column3)
@@ -1097,6 +1108,7 @@ vectorized: true
                 │ table: t_idx@t_idx_w_key
                 │ equality: (w_comp) = (w)
                 │ equality cols are key
+                │ parallel
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
@@ -1166,6 +1178,7 @@ vectorized: true
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)
@@ -1242,6 +1255,7 @@ vectorized: true
                 │ equality: (column1) = (a)
                 │ equality cols are key
                 │ locking strength: for update
+                │ parallel
                 │
                 └── • render
                     │ columns: (v_comp, w_comp, column1, column2, column3)

--- a/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
+++ b/pkg/sql/opt/exec/execbuilder/tests/local/generated_test.go
@@ -400,6 +400,13 @@ func TestExecBuild_lookup_join_limit(
 	runExecBuildLogicTest(t, "lookup_join_limit")
 }
 
+func TestExecBuild_lookup_join_local(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runExecBuildLogicTest(t, "lookup_join_local")
+}
+
 func TestExecBuild_lookup_join_spans(
 	t *testing.T,
 ) {

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -287,6 +287,7 @@ define IndexJoin {
     ReqOrdering exec.OutputOrdering
     Locking opt.Locking
     LimitHint int64
+    Parallelize bool
 }
 
 # LookupJoin performs a lookup join.
@@ -326,6 +327,7 @@ define LookupJoin {
     LimitHint int64
     RemoteOnlyLookups bool
     ReverseScans bool
+    Parallelize bool
 }
 
 # InvertedJoin performs a lookup join into an inverted index.

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -682,6 +682,7 @@ func (ef *execFactory) ConstructIndexJoin(
 	reqOrdering exec.OutputOrdering,
 	locking opt.Locking,
 	limitHint int64,
+	parallelize bool,
 ) (exec.Node, error) {
 	tabDesc := table.(*optTable).desc
 	colCfg := makeScanColumnsConfig(table, tableCols)
@@ -713,6 +714,7 @@ func (ef *execFactory) ConstructIndexJoin(
 			keyCols:     keyCols,
 			reqOrdering: ReqOrdering(reqOrdering),
 			limitHint:   limitHint,
+			parallelize: parallelize,
 		},
 	}
 
@@ -738,6 +740,7 @@ func (ef *execFactory) ConstructLookupJoin(
 	limitHint int64,
 	remoteOnlyLookups bool,
 	reverseScans bool,
+	parallelize bool,
 ) (exec.Node, error) {
 	if table.IsVirtualTable() {
 		return constructVirtualTableLookupJoin(
@@ -781,6 +784,7 @@ func (ef *execFactory) ConstructLookupJoin(
 			limitHint:                  limitHint,
 			remoteOnlyLookups:          remoteOnlyLookups,
 			reverseScans:               reverseScans,
+			parallelize:                parallelize,
 		},
 	}
 	if onCond != tree.DBoolTrue {

--- a/pkg/sql/rowexec/joinreader.go
+++ b/pkg/sql/rowexec/joinreader.go
@@ -323,26 +323,42 @@ func newJoinReader(
 	default:
 		return nil, errors.AssertionFailedf("unsupported joinReaderType")
 	}
-	// The joiner has a choice to make between getting DistSender-level
-	// parallelism for its lookup batches and setting row and memory limits (due
-	// to implementation limitations, you can't have both at the same time). We
-	// choose parallelism when we know that each lookup returns at most one row:
-	// in case of indexJoinReaderType, we know that there's exactly one lookup
-	// row for each input row. Similarly, in case of spec.LookupColumnsAreKey,
-	// we know that there's at most one lookup row per input row. In other
-	// cases, we disable parallelism and use the TargetBytes limit.
-	parallelize := spec.LookupColumnsAreKey || readerType == indexJoinReaderType
-	if flowCtx.EvalCtx.SessionData().ParallelizeMultiKeyLookupJoinsEnabled {
-		parallelize = true
+	parallelize := spec.Parallelize
+	if !parallelize {
+		// The joiner has a choice to make between getting DistSender-level
+		// parallelism for its lookup batches and setting row and memory limits
+		// (due to implementation limitations, you can't have both at the same
+		// time). We choose parallelism when we know that each lookup returns at
+		// most one row: in case of indexJoinReaderType, we know that there's
+		// exactly one lookup row for each input row. Similarly, in case of
+		// spec.LookupColumnsAreKey, we know that there's at most one lookup row
+		// per input row. In other cases, we disable parallelism and use the
+		// TargetBytes limit.
+		// TODO(yuzefovich): remove this once compatibility with 25.2 is no
+		// longer needed - the execbuilder is now fully-responsible for making
+		// this determination.
+		parallelize = spec.LookupColumnsAreKey || readerType == indexJoinReaderType
+		if flowCtx.EvalCtx.SessionData().ParallelizeMultiKeyLookupJoinsEnabled {
+			parallelize = true
+		}
+		if spec.MaintainLookupOrdering {
+			// We need to disable parallelism for the traditional fetcher in
+			// order to ensure the lookups are ordered.
+			parallelize = false
+		}
 	}
 	if spec.MaintainLookupOrdering {
-		// MaintainLookupOrdering indicates the output of the lookup joiner
-		// should be sorted by <inputCols>, <lookupCols>. It doesn't make sense
-		// for MaintainLookupOrdering to be true when MaintainOrdering is not.
-		//
-		// Additionally, we need to disable parallelism for the traditional
-		// fetcher in order to ensure the lookups are ordered.
-		spec.MaintainOrdering, parallelize = true, false
+		if !spec.MaintainOrdering {
+			// MaintainLookupOrdering indicates the output of the lookup joiner
+			// should be sorted by <inputCols>, <lookupCols>. It doesn't make
+			// sense for MaintainLookupOrdering to be true when MaintainOrdering
+			// is not.
+			return nil, errors.AssertionFailedf("MaintainLookupOrdering requires that MaintainOrdering is set")
+		}
+		if spec.Parallelize {
+			// Parallelization must have been disabled in the execbuilder.
+			return nil, errors.AssertionFailedf("Parallelize requires that MaintainLookupOrdering is not set")
+		}
 	}
 	useStreamer, txn, err := flowCtx.UseStreamer(ctx)
 	if err != nil {

--- a/pkg/sql/sessiondatapb/session_data.proto
+++ b/pkg/sql/sessiondatapb/session_data.proto
@@ -79,6 +79,8 @@ message SessionData {
   // parallelize lookup batches under all circumstances. Enabling this will
   // increase the speed of lookup joins when each input row might get multiple
   // looked up rows at the cost of increased memory usage.
+  // TODO(yuzefovich): this field can be moved into the local part of
+  // SessionData when compatibility with 25.2 is no longer needed.
   bool parallelize_multi_key_lookup_joins_enabled = 19;
   // TrigramSimilarityThreshold configures the value that's used to compare
   // trigram similarities to in order to evaluate the string % string overload.

--- a/pkg/sql/testdata/sql_activity/sql_activity_job_queries
+++ b/pkg/sql/testdata/sql_activity/sql_activity_job_queries
@@ -550,6 +550,7 @@ vectorized: true
                     │ table: statement_statistics@primary
                     │ equality: (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id) = (crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id)
                     │ equality cols are key
+                    │ parallel
                     │
                     └── • lookup join (inner)
                         │ columns: (aggregated_ts, fingerprint_id, app_name, cnt_rank, lat_rank, combined_rank, contention_rank, cpu_rank, p99_rank, contention_mean, cpu_mean, p99_latency, aggregated_ts, fingerprint_id, transaction_fingerprint_id, plan_hash, app_name, node_id, crdb_internal_aggregated_ts_app_name_fingerprint_id_node_id_plan_hash_transaction_fingerprint_id_shard_8)


### PR DESCRIPTION
In preparation for expanding the heuristic for when it's safe to parallelize cross-range reads in the lookup join, this commit lifts the decision into the execbuilder. As a reminder, when Streamer API is not used, we currently choose to enable parallelism when an input row can result in at most one lookup row (which is the case for index joins as well as lookup joins when equality columns form a key), also when the session variable enables it for multi-lookup case. Previously, this was determined when creating the JoinReader, and now we make this determination in the execbuilder. We add a new field to the processor spec based on the execbuilder argument (for compatibility with 25.2 release we also keep the old logic for now).

Additionally, this commit enhances the EXPLAIN output to show `parallel` attribute in VERBOSE mode when applicable (when the streamer is used as well as when Parallelize is set to true by the execbuilder). This improvement was part of the reason to lifting the determination up there (so that `parallelize` boolean argument to ConstructLookupJoin is captured by the explain factory).

Informs: #134351.
Epic: None

Release note: None