### PR TITLE
release-25.2.2-rc: changefeedccl: fix table drop shutdown for enriched envelope

### DIFF
--- a/pkg/ccl/changefeedccl/enriched_source_provider.go
+++ b/pkg/ccl/changefeedccl/enriched_source_provider.go
@@ -525,6 +525,9 @@ func getDescriptors(
 		return nil
 	}
 	if err := execCfg.InternalDB.DescsTxn(ctx, f, isql.WithPriority(admissionpb.NormalPri)); err != nil {
+		if errors.Is(err, catalog.ErrDescriptorDropped) {
+			err = changefeedbase.WithTerminalError(err)
+		}
 		return nil, nil, nil, err
 	}
 	return tableDescriptor, dbDescriptor, schemaDescriptor, nil


### PR DESCRIPTION
Backport 1/1 commits from #148302 on behalf of @asg0451.

----

Fixes a bug where feeds with enriched envelopes
and a `source` field could treat table drops as
transient errors.

Fixes: #148216
Release note: None


----

Release justification: This is a genuine failure for a new feature that we added. An edge cases caught by out test suite.