### PR TITLE
kvserver: register `SideTransport` service with DRPC server

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -995,6 +995,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		return nil, err
 	}
 	ctpb.RegisterSideTransportServer(grpcServer.Server, ctReceiver)
+	if err := ctpb.DRPCRegisterSideTransport(drpcServer, ctReceiver.AsDRPCServer()); err != nil {
+		return nil, err
+	}
 
 	// Create blob service for inter-node file sharing.
 	blobService, err := blobs.NewBlobService(cfg.ExternalIODir)


### PR DESCRIPTION
Enable the `SideTransport` service on the DRPC server in addition to gRPC. This is controlled by `rpc.experimental_drpc.enabled` (off by default).

This change is part of a series and is similar to: #146926

Note: This only registers the service; the client is not updated to use the DRPC client, so this service will not have any functional effect.

Epic: CRDB-48925
Release note: None