### PR TITLE
dev: add --cpu, rename --cpus to --bazel-cpus

### DIFF
--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=111
+DEV_VERSION=112
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/datadriven_test.go
+++ b/pkg/cmd/dev/datadriven_test.go
@@ -44,6 +44,14 @@ const (
 // suited for flows that do (reading a list of go files in the bazel generated
 // sandbox and copying them over one-by-one).
 func TestDataDriven(t *testing.T) {
+	// Set --cpu default value to 10 for duration of this test so that it does
+	// not depend on the current value of GOMAXPROCS, which can vary across
+	// systems.
+	defer func(n int) {
+		cpuDefaultVal = n
+	}(cpuDefaultVal)
+	cpuDefaultVal = 10
+
 	verbose := testing.Verbose()
 	testdata := datapathutils.TestDataPath(t, "datadriven")
 	datadriven.Walk(t, testdata, func(t *testing.T, path string) {

--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -387,9 +387,6 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
-	if stress {
-		d.warnAboutChangeInStressBehavior(timeout)
-	}
 
 	// Do not log --build_event_binary_file=... because it is not relevant to the actual call
 	// from the user perspective.

--- a/pkg/cmd/dev/testdata/datadriven/bench
+++ b/pkg/cmd/dev/testdata/datadriven/bench
@@ -2,35 +2,35 @@ exec
 dev bench pkg/spanconfig/...
 ----
 echo $HOME/.cache
-bazel test pkg/spanconfig/...:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=. --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/spanconfig/...:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=. --test_sharding_strategy=disabled --test_arg -test.cpu=10 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/sql/parser --filter=BenchmarkParse
 ----
 echo $HOME/.cache
-bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu=10 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/sql/parser --filter=BenchmarkParse --stream-output=false
 ----
 echo $HOME/.cache
-bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output errors
+bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu=10 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output errors
 
 exec
 dev bench pkg/bench -f=BenchmarkTracing/1node/scan/trace=off --count=2 --bench-time=10x --bench-mem=false
 ----
 echo $HOME/.cache
-bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.count=2 --test_arg -test.benchtime=10x --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu=10 --test_arg -test.count=2 --test_arg -test.benchtime=10x --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
-dev bench pkg/spanconfig/spanconfigkvsubscriber -f=BenchmarkSpanConfigDecoder --cpus=10 --ignore-cache=false -v --timeout=50s
+dev bench pkg/spanconfig/spanconfigkvsubscriber -f=BenchmarkSpanConfigDecoder --bazel-cpu=10 --cpu 1 --ignore-cache=false -v --timeout=50s
 ----
 echo $HOME/.cache
-bazel test --local_cpu_resources=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.v --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test --local_resources=cpu=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.cpu=1 --test_arg -test.v --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/bench -f='BenchmarkTracing/1node/scan/trace=off' --test-args '-test.memprofile=mem.out -test.cpuprofile=cpu.out'
 ----
 bazel info workspace --color=no
 echo $HOME/.cache
-bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_arg -test.cpuprofile=cpu.out --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu=10 --test_arg -test.benchmem --crdb_test_off --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_arg -test.cpuprofile=cpu.out --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed

--- a/pkg/cmd/dev/testdata/datadriven/dev-build
+++ b/pkg/cmd/dev/testdata/datadriven/dev-build
@@ -13,7 +13,7 @@ cp sandbox/pkg/cmd/cockroach-short/cockroach-short_/cockroach-short crdb-checkou
 exec
 dev build cockroach-short --cpus=12
 ----
-bazel build --local_cpu_resources=12 //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
+bazel build --local_resources=cpu=12 //pkg/cmd/cockroach-short:cockroach-short --build_event_binary_file=/tmp/path
 bazel info workspace --color=no
 mkdir crdb-checkout/bin
 bazel info bazel-bin --color=no

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -5,7 +5,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-bazel test //pkg/sql/logictest/tests/... //pkg/ccl/logictestccl/tests/... //pkg/sql/opt/exec/execbuilder/tests/... --test_env=GOTRACEBACK=all --test_output errors
+bazel test //pkg/sql/logictest/tests/... //pkg/ccl/logictestccl/tests/... //pkg/sql/opt/exec/execbuilder/tests/... --test_env=GOTRACEBACK=all --test_arg -test.cpu=10 --test_output errors
 
 exec
 dev testlogic ccl
@@ -14,7 +14,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-bazel test //pkg/ccl/logictestccl/tests/... --test_env=GOTRACEBACK=all --test_output errors
+bazel test //pkg/ccl/logictestccl/tests/... --test_env=GOTRACEBACK=all --test_arg -test.cpu=10 --test_output errors
 
 exec
 dev testlogic ccl opt
@@ -23,7 +23,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-bazel test //pkg/ccl/logictestccl/tests/... //pkg/sql/opt/exec/execbuilder/tests/... --test_env=GOTRACEBACK=all --test_output errors
+bazel test //pkg/ccl/logictestccl/tests/... //pkg/sql/opt/exec/execbuilder/tests/... --test_env=GOTRACEBACK=all --test_arg -test.cpu=10 --test_output errors
 
 exec
 dev testlogic base --ignore-cache 
@@ -32,7 +32,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --nocache_test_results --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --nocache_test_results --test_arg -test.cpu=10 --test_output errors
 
 exec
 dev testlogic base --show-sql
@@ -41,7 +41,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -test.cpu=10 --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
@@ -50,28 +50,16 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -test.cpu=10 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
-dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --cpus 8
+dev testlogic base --files=auto_span_config_reconciliation --stress --timeout 1m --bazel-cpu 8 --cpu 1
 ----
 bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_timeout=60 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
-
-exec
-dev testlogic base --files=auto_span_config_reconciliation --stress
-----
-bazel info workspace --color=no
-bazel info workspace --color=no
-bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
-bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_resources=cpu=8 --test_arg -show-sql --test_arg -test.cpu=1 --test_timeout=60 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
@@ -80,8 +68,7 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -test.cpu=10 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
 dev testlogic base --files=auto_span_config_reconciliation --stress
@@ -90,5 +77,13 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -test.cpu=10 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
+
+exec
+dev testlogic base --files=auto_span_config_reconciliation --stress
+----
+bazel info workspace --color=no
+bazel info workspace --color=no
+bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
+bazel run //pkg/gen:schemachanger
+bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_arg -test.cpu=10 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -282,9 +282,6 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
-	if stress {
-		d.warnAboutChangeInStressBehavior(timeout)
-	}
 	if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -12,6 +12,7 @@ import (
 	"log"
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"time"
 
@@ -63,7 +64,7 @@ func makeTestLogicCmd(runE func(cmd *cobra.Command, args []string) error) *cobra
 	testLogicCmd.Flags().Bool(showDiffFlag, false, "generate a diff for expectation mismatches when possible")
 	testLogicCmd.Flags().Bool(flexTypesFlag, false, "tolerate when a result column is produced with a different numeric type")
 	testLogicCmd.Flags().Bool(workmemFlag, false, "disable randomization of sql.distsql.temp_storage.workmem")
-
+	addCPUFlag(testLogicCmd)
 	addCommonBuildFlags(testLogicCmd)
 	return testLogicCmd
 }
@@ -74,6 +75,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 
 	var (
 		bigtest        = mustGetFlagBool(cmd, bigtestFlag)
+		cpu            = mustGetFlagInt(cmd, cpuFlag)
 		configs        = mustGetFlagStringSlice(cmd, configsFlag)
 		files          = mustGetFlagString(cmd, filesFlag)
 		ignoreCache    = mustGetFlagBool(cmd, ignoreCacheFlag)
@@ -245,6 +247,7 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	if stress && streamOutput {
 		return fmt.Errorf("cannot combine --%s and --%s", stressFlag, streamOutputFlag)
 	}
+	args = append(args, "--test_arg", "-test.cpu="+strconv.Itoa(cpu))
 	if showDiff {
 		args = append(args, "--test_arg", "-show-diff")
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -238,16 +238,6 @@ func sendBepDataToBeaverHubIfNeeded(bepFilepath string) error {
 	return nil
 }
 
-func (d *dev) warnAboutChangeInStressBehavior(timeout time.Duration) {
-	if e := d.os.Getenv("DEV_I_UNDERSTAND_ABOUT_STRESS"); e == "" {
-		log.Printf("NOTE: The behavior of `dev test --stress` has changed. The new default behavior is to run the test 1,000 times in parallel (500 for logictests), stopping if any of the tests fail. The number of runs can be tweaked with the `--count` parameter to `dev`.")
-		if timeout > 0 {
-			log.Printf("WARNING: The behavior of --timeout under --stress has changed. --timeout controls the timeout of the test, not the entire `stress` invocation.")
-		}
-		log.Printf("Set DEV_I_UNDERSTAND_ABOUT_STRESS=1 to squelch this message")
-	}
-}
-
 // This function retrieves the merge-base hash between the current branch and master
 func (d *dev) getMergeBaseHash(ctx context.Context) (string, error) {
 	// List files changed against `master`

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -23,6 +23,7 @@ import (
 
 // Common testing flags.
 const (
+	cpuFlag     = "cpu"
 	filterFlag  = "filter"
 	timeoutFlag = "timeout"
 	shortFlag   = "short"
@@ -30,8 +31,9 @@ const (
 
 var (
 	// Shared flags.
-	numCPUs    int
-	pgoEnabled bool
+	deprecatedNumCPU int // DEPRECATED: use --bazel-cpu instead
+	numBazelCPU      int
+	pgoEnabled       bool
 )
 
 var archivedCdepConfigurations = []configuration{
@@ -164,11 +166,22 @@ func (d *dev) getArchivedCdepString(bazelBin string) (string, error) {
 }
 
 func addCommonBuildFlags(cmd *cobra.Command) {
-	cmd.Flags().IntVar(&numCPUs, "cpus", 0, "cap the number of CPU cores used for building and testing at the Bazel level (note that this has no impact on GOMAXPROCS or the functionality of any build or test action under the Bazel level)")
+	cmd.Flags().IntVar(&deprecatedNumCPU, "cpus", 0,
+		"DEPRECATED: use --bazel-cpu instead (or --cpu for GOMAXPROCS)")
+	cmd.Flags().IntVar(&numBazelCPU, "bazel-cpu", 0, "cap the number of CPU cores used for building and testing at the Bazel level (note that this has no impact on GOMAXPROCS or the functionality of any build or test action under the Bazel level)")
 	cmd.Flags().BoolVar(&pgoEnabled, "pgo", false, "build with profile-guided optimization (PGO)")
 }
 
+var cpuDefaultVal = runtime.GOMAXPROCS(0) // overridden for testing
+
+func addCPUFlag(cmd *cobra.Command) {
+	cmd.Flags().IntP(cpuFlag, "", cpuDefaultVal,
+		"the GOMAXPROCS value to use when running tests and benchmarks "+
+			"(default is the number of CPU cores on the machine)")
+}
+
 func addCommonTestFlags(cmd *cobra.Command) {
+	addCPUFlag(cmd)
 	cmd.Flags().StringP(filterFlag, "f", "", "run unit tests matching this regex")
 	cmd.Flags().Duration(timeoutFlag, 0*time.Minute, "timeout for test")
 	cmd.Flags().Bool(shortFlag, false, "run only short tests")
@@ -263,8 +276,12 @@ func (d *dev) getMergeBaseHash(ctx context.Context) (string, error) {
 }
 
 func addCommonBazelArguments(args *[]string) {
-	if numCPUs != 0 {
-		*args = append(*args, fmt.Sprintf("--local_cpu_resources=%d", numCPUs))
+	if deprecatedNumCPU != 0 {
+		*args = append(*args, fmt.Sprintf("--local_resources=cpu=%d", deprecatedNumCPU))
+		log.Printf("WARNING: --cpus will be removed, use --bazel-cpu instead (or --cpu for GOMAXPROCS)")
+	}
+	if numBazelCPU != 0 {
+		*args = append(*args, fmt.Sprintf("--local_resources=cpu=%d", numBazelCPU))
 	}
 	if pgoEnabled {
 		*args = append(*args, "--config=pgo")


### PR DESCRIPTION
This renames --cpus to --bazel-cpus and introduces --cpu for test and bench
which passes through as `-test.cpu`.

We also tweak the --stress setting to add bazel parameters to achieve the
concurrency desired by the --bazel-cpu flag. Additionally, we try to be helpful
by printing a suggestion whenever --bazel-cpu should likely be passed.

See https://cockroachlabs.slack.com/archives/C023S0V4YEB/p1747901999530639?thread_ts=1729687990.393749&cid=C023S0V4YEB.

Epic: none
Release note: none