### PR TITLE
rpc: add DRPC dial methods

### DIFF
--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -51,6 +51,7 @@ import (
 	"google.golang.org/grpc/encoding"
 	"google.golang.org/grpc/metadata"
 	"google.golang.org/grpc/stats"
+	"storj.io/drpc"
 )
 
 // NewServer sets up an RPC server. Depending on the ServerOptions, the Server
@@ -226,7 +227,10 @@ type Context struct {
 
 	localInternalClient RestrictedInternalClient
 
+	// peers is a map of gRPC connections to other nodes.
 	peers peerMap[*grpc.ClientConn]
+	// drpcPeers is a map of DRPC connections to other nodes.
+	drpcPeers peerMap[drpc.Conn]
 
 	// dialbackMap is a map of currently executing dialback connections. This map
 	// is typically empty or close to empty. It only holds entries that are being
@@ -1998,6 +2002,16 @@ func (rpcCtx *Context) GRPCUnvalidatedDial(
 	return rpcCtx.grpcDialNodeInternal(target, 0, locality, rpcbase.SystemClass)
 }
 
+// DRPCUnvalidatedDial uses DRPCDialNode and disables validation of the
+// node ID between client and server. This function should only be
+// used with the gossip client and CLI commands which can talk to any
+// node. This method implies a SystemClass.
+func (rpcCtx *Context) DRPCUnvalidatedDial(
+	target string, locality roachpb.Locality,
+) *DRPCConnection {
+	return rpcCtx.drpcDialNodeInternal(target, 0, locality, rpcbase.SystemClass)
+}
+
 // GRPCDialNode calls grpc.Dial with options appropriate for the
 // context and class (see the comment on ConnectionClass).
 //
@@ -2019,6 +2033,27 @@ func (rpcCtx *Context) GRPCDialNode(
 	return rpcCtx.grpcDialNodeInternal(target, remoteNodeID, remoteLocality, class)
 }
 
+// DRPCDialNode dials a DRPC connection with options appropriate for the
+// context and class (see the comment on ConnectionClass).
+//
+// The remoteNodeID becomes a constraint on the expected node ID of
+// the remote node; this is checked during heartbeats. The caller is
+// responsible for ensuring the remote node ID is known prior to using
+// this function.
+func (rpcCtx *Context) DRPCDialNode(
+	target string,
+	remoteNodeID roachpb.NodeID,
+	remoteLocality roachpb.Locality,
+	class rpcbase.ConnectionClass,
+) *DRPCConnection {
+	if remoteNodeID == 0 && !rpcCtx.TestingAllowNamedRPCToAnonymousServer {
+		log.Fatalf(
+			rpcCtx.makeDialCtx(target, remoteNodeID, class),
+			"%v", errors.AssertionFailedf("invalid node ID 0 in DRPCDialNode()"))
+	}
+	return rpcCtx.drpcDialNodeInternal(target, remoteNodeID, remoteLocality, class)
+}
+
 // GRPCDialPod wraps GRPCDialNode and treats the `remoteInstanceID`
 // argument as a `NodeID` which it converts. This works because the
 // tenant gRPC server is initialized using the `InstanceID` so it
@@ -2033,6 +2068,22 @@ func (rpcCtx *Context) GRPCDialPod(
 	class rpcbase.ConnectionClass,
 ) *GRPCConnection {
 	return rpcCtx.GRPCDialNode(target, roachpb.NodeID(remoteInstanceID), remoteLocality, class)
+}
+
+// DRPCDialPod wraps DRPCDialNode and treats the `remoteInstanceID`
+// argument as a `NodeID` which it converts. This works because the
+// tenant DRPC server is initialized using the `InstanceID` so it
+// accepts our connection as matching the ID we're dialing.
+//
+// Since DRPCDialNode accepts a separate `target` and `NodeID` it
+// requires no further modification to work between pods.
+func (rpcCtx *Context) DRPCDialPod(
+	target string,
+	remoteInstanceID base.SQLInstanceID,
+	remoteLocality roachpb.Locality,
+	class rpcbase.ConnectionClass,
+) *DRPCConnection {
+	return rpcCtx.DRPCDialNode(target, roachpb.NodeID(remoteInstanceID), remoteLocality, class)
 }
 
 // grpcDialNodeInternal connects to the remote node and sets up the async heartbeater.
@@ -2050,8 +2101,37 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 	}
 
 	// Slow path. Race to create a peer.
-	conns := &rpcCtx.peers
+	return rpcDialNodeInternal(
+		rpcCtx, k, newGRPCPeerOptions(rpcCtx, k, remoteLocality),
+	)
+}
 
+// drpcDialNodeInternal connects to the remote node and sets up the async heartbeater.
+// This intentionally takes no `context.Context`; it uses one derived from rpcCtx.masterCtx.
+func (rpcCtx *Context) drpcDialNodeInternal(
+	target string,
+	remoteNodeID roachpb.NodeID,
+	remoteLocality roachpb.Locality,
+	class rpcbase.ConnectionClass,
+) *DRPCConnection {
+	k := peerKey{TargetAddr: target, NodeID: remoteNodeID, Class: class}
+	if p, ok := rpcCtx.drpcPeers.get(k); ok {
+		// There's a cached peer, so we have a cached connection, use it.
+		return p.c
+	}
+
+	// Slow path. Race to create a peer.
+	return rpcDialNodeInternal(
+		rpcCtx, k, newDRPCPeerOptions(rpcCtx, k, remoteLocality),
+	)
+}
+
+// rpcDialNodeInternal is used to dial a new connection to the peer if one
+// doesn't already exist.
+func rpcDialNodeInternal[Conn rpcConn](
+	rpcCtx *Context, k peerKey, peerOpts *peerOptions[Conn],
+) *Connection[Conn] {
+	conns := peerOpts.peers
 	conns.mu.Lock()
 	defer conns.mu.Unlock()
 
@@ -2060,12 +2140,11 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 	}
 
 	// Won race. Actually create a peer.
-
 	if conns.mu.m == nil {
-		conns.mu.m = map[peerKey]*peer[*grpc.ClientConn]{}
+		conns.mu.m = map[peerKey]*peer[Conn]{}
 	}
 
-	p := newPeer(rpcCtx, k, newGRPCPeerOptions(rpcCtx, k, remoteLocality))
+	p := newPeer(rpcCtx, k, peerOpts)
 	// (Asynchronously) Start the probe (= heartbeat loop). The breaker is healthy
 	// right now (it was just created) but the call to `.Probe` will launch the
 	// probe[1] regardless.

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -2065,7 +2065,7 @@ func (rpcCtx *Context) grpcDialNodeInternal(
 		conns.mu.m = map[peerKey]*peer[*grpc.ClientConn]{}
 	}
 
-	p := rpcCtx.newPeer(k, remoteLocality)
+	p := newPeer(rpcCtx, k, newGRPCPeerOptions(rpcCtx, k, remoteLocality))
 	// (Asynchronously) Start the probe (= heartbeat loop). The breaker is healthy
 	// right now (it was just created) but the call to `.Probe` will launch the
 	// probe[1] regardless.

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -12,8 +12,11 @@ import (
 	"net"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/errors"
 	"storj.io/drpc"
 	"storj.io/drpc/drpcconn"
@@ -28,6 +31,14 @@ import (
 
 // Default idle connection timeout for DRPC connections in the pool.
 var defaultDRPCConnIdleTimeout = 5 * time.Minute
+
+type drpcCloseNotifier struct {
+	conn drpc.Conn
+}
+
+func (d *drpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
+	return d.conn.Closed()
+}
 
 func dialDRPC(
 	rpcCtx *Context,
@@ -173,4 +184,83 @@ func (srv *drpcOffServer) Serve(_ context.Context, lis net.Listener) error {
 // when DRPC is disabled.
 func (srv *drpcOffServer) Register(interface{}, drpc.Description) error {
 	return nil
+}
+
+// newDRPDCPeerOptions creates peerOptions for DRPC peers.
+func newDRPCPeerOptions(
+	rpcCtx *Context, k peerKey, locality roachpb.Locality,
+) *peerOptions[drpc.Conn] {
+	pm, _ := rpcCtx.metrics.acquire(k, locality)
+	return &peerOptions[drpc.Conn]{
+		locality: locality,
+		peers:    &rpcCtx.drpcPeers,
+		connOptions: &ConnectionOptions[drpc.Conn]{
+			dial: func(ctx context.Context, target string, _ rpcbase.ConnectionClass) (drpc.Conn, error) {
+				// TODO(server): could use connection class instead of empty key here.
+				pool := drpcpool.New[struct{}, drpcpool.Conn](drpcpool.Options{
+					Expiration: defaultDRPCConnIdleTimeout,
+				})
+				pooledConn := pool.Get(ctx /* unused */, struct{}{}, func(ctx context.Context,
+					_ struct{}) (drpcpool.Conn, error) {
+
+					netConn, err := drpcmigrate.DialWithHeader(ctx, "tcp", target, drpcmigrate.DRPCHeader)
+					if err != nil {
+						return nil, err
+					}
+
+					opts := drpcconn.Options{
+						Manager: drpcmanager.Options{
+							Reader: drpcwire.ReaderOptions{
+								MaximumBufferSize: math.MaxInt,
+							},
+							Stream: drpcstream.Options{
+								MaximumBufferSize: 0, // unlimited
+							},
+							SoftCancel: true, // don't close the transport when stream context is canceled
+						},
+					}
+					var conn *drpcconn.Conn
+					if rpcCtx.ContextOptions.Insecure {
+						conn = drpcconn.NewWithOptions(netConn, opts)
+					} else {
+						tlsConfig, err := rpcCtx.GetClientTLSConfig()
+						if err != nil {
+							return nil, err
+						}
+						// Clone TLS config to avoid modifying a cached TLS config.
+						tlsConfig = tlsConfig.Clone()
+						// TODO(server): remove this hack which is necessary at least in
+						// testing to get TestDRPCSelectQuery to pass.
+						tlsConfig.InsecureSkipVerify = true
+						tlsConn := tls.Client(netConn, tlsConfig)
+						conn = drpcconn.NewWithOptions(tlsConn, opts)
+					}
+
+					return conn, nil
+				})
+				// `pooledConn.Close` doesn't tear down any of the underlying TCP
+				// connections but simply marks the pooledConn handle as returning
+				// errors. When we "close" this conn, we want to tear down all of
+				// the connections in the pool (in effect mirroring the behavior of
+				// gRPC where a single conn is shared).
+				return &closeEntirePoolConn{
+					Conn: pooledConn,
+					pool: pool,
+				}, nil
+			},
+			connEquals: func(a, b drpc.Conn) bool {
+				return a == b
+			},
+			newBatchStreamClient: func(ctx context.Context, cc drpc.Conn) (BatchStreamClient, error) {
+				return kvpb.NewDRPCInternalClientAdapter(cc).BatchStream(ctx)
+			},
+			newCloseNotifier: func(_ *stop.Stopper, cc drpc.Conn) closeNotifier {
+				return &drpcCloseNotifier{conn: cc}
+			},
+		},
+		newHeartbeatClient: func(cc drpc.Conn) RPCHeartbeatClient {
+			return NewDRPCHeartbeatClientAdapter(cc)
+		},
+		pm: pm,
+	}
 }

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -8,6 +8,9 @@ package rpc
 import (
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -47,3 +50,34 @@ func (g *grpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
 }
 
 type GRPCConnection = Connection[*grpc.ClientConn]
+
+// newGRPCPeerOptions creates peerOptions for gRPC peers.
+func newGRPCPeerOptions(
+	rpcCtx *Context, k peerKey, locality roachpb.Locality,
+) *peerOptions[*grpc.ClientConn] {
+	pm, lm := rpcCtx.metrics.acquire(k, locality)
+	return &peerOptions[*grpc.ClientConn]{
+		locality: locality,
+		peers:    &rpcCtx.peers,
+		connOptions: &ConnectionOptions[*grpc.ClientConn]{
+			dial: func(ctx context.Context, target string, class rpcbase.ConnectionClass) (*grpc.ClientConn, error) {
+				additionalDialOpts := []grpc.DialOption{grpc.WithStatsHandler(&statsTracker{lm})}
+				additionalDialOpts = append(additionalDialOpts, rpcCtx.testingDialOpts...)
+				return rpcCtx.grpcDialRaw(ctx, target, class, additionalDialOpts...)
+			},
+			connEquals: func(a, b *grpc.ClientConn) bool {
+				return a == b
+			},
+			newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
+				return kvpb.NewInternalClient(cc).BatchStream(ctx)
+			},
+			newCloseNotifier: func(stopper *stop.Stopper, cc *grpc.ClientConn) closeNotifier {
+				return &grpcCloseNotifier{stopper: stopper, conn: cc}
+			},
+		},
+		newHeartbeatClient: func(cc *grpc.ClientConn) RPCHeartbeatClient {
+			return NewGRPCHeartbeatClientAdapter(cc)
+		},
+		pm: pm,
+	}
+}

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -14,18 +14,15 @@ import (
 	"github.com/VividCortex/ewma"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/util/circuit"
 	"github.com/cockroachdb/cockroach/pkg/util/grpcutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
-	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
-	"google.golang.org/grpc"
 	"google.golang.org/grpc/status"
 	"storj.io/drpc"
 )
@@ -121,15 +118,13 @@ func (p *peer[Conn]) releaseMetricsLocked() {
 // See (*peer).launch for details on the probe (heartbeat loop) itself.
 type peer[Conn rpcConn] struct {
 	peerMetrics
-	k                    peerKey
-	opts                 *ContextOptions
-	heartbeatInterval    time.Duration
-	heartbeatTimeout     time.Duration
-	dial                 func(ctx context.Context, target string, class rpcbase.ConnectionClass) (Conn, error)
-	dialDRPC             func(ctx context.Context, target string, class rpcbase.ConnectionClass) (drpc.Conn, error)
-	newHeartbeatClient   heartbeatClientConstructor[Conn]
-	newBatchStreamClient streamConstructor[*kvpb.BatchRequest, *kvpb.BatchResponse, Conn]
-	newCloseNotifier     closeNotifierConstructor[Conn]
+	k                  peerKey
+	opts               *ContextOptions
+	newHeartbeatClient heartbeatClientConstructor[Conn]
+	heartbeatInterval  time.Duration
+	heartbeatTimeout   time.Duration
+	connOptions        *ConnectionOptions[Conn]
+	drpcDial           dialFunc[drpc.Conn]
 	// b maintains connection health. This breaker's async probe is always
 	// active - it is the heartbeat loop and manages `mu.c.` (including
 	// recreating it after the connection fails and has to be redialed).
@@ -210,6 +205,14 @@ func (p *peer[Conn]) snap() PeerSnap[Conn] {
 	return p.mu.PeerSnap
 }
 
+type peerOptions[Conn rpcConn] struct {
+	locality           roachpb.Locality
+	pm                 peerMetrics
+	newHeartbeatClient heartbeatClientConstructor[Conn]
+	connOptions        *ConnectionOptions[Conn]
+	peers              *peerMap[Conn]
+}
+
 // newPeer returns circuit breaker that trips when connection (associated
 // with provided peerKey) is failed. The breaker's probe *is* the heartbeat loop
 // and is thus running at all times. The exception is a decommissioned node, for
@@ -229,7 +232,7 @@ func (p *peer[Conn]) snap() PeerSnap[Conn] {
 // map, the next attempt to dial the node will start from a blank slate. In
 // other words, even with this theoretical race, the situation will sort itself
 // out quickly.
-func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc.ClientConn] {
+func newPeer[Conn rpcConn](rpcCtx *Context, k peerKey, peerOpts *peerOptions[Conn]) *peer[Conn] {
 	// Initialization here is a bit circular. The peer holds the breaker. The
 	// breaker probe references the peer because it needs to replace the one-shot
 	// Connection when it makes a new connection in the probe. And (all but the
@@ -237,31 +240,18 @@ func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc
 	// Connect method needs to do the short-circuiting (if a Connection is created
 	// while the breaker is tripped, we want to block in Connect only once we've
 	// seen the first heartbeat succeed).
-	pm, lm := rpcCtx.metrics.acquire(k, locality)
-	p := &peer[*grpc.ClientConn]{
-		peerMetrics:        pm,
+	p := &peer[Conn]{
+		peerMetrics:        peerOpts.pm,
 		logDisconnectEvery: log.Every(time.Minute),
 		k:                  k,
 		remoteClocks:       rpcCtx.RemoteClocks,
 		opts:               &rpcCtx.ContextOptions,
-		peers:              &rpcCtx.peers,
-		dial: func(ctx context.Context, target string, class rpcbase.ConnectionClass) (*grpc.ClientConn, error) {
-			additionalDialOpts := []grpc.DialOption{grpc.WithStatsHandler(&statsTracker{lm})}
-			additionalDialOpts = append(additionalDialOpts, rpcCtx.testingDialOpts...)
-			return rpcCtx.grpcDialRaw(ctx, target, class, additionalDialOpts...)
-		},
-		dialDRPC: dialDRPC(rpcCtx),
-		newHeartbeatClient: func(cc *grpc.ClientConn) RPCHeartbeatClient {
-			return NewGRPCHeartbeatClientAdapter(cc)
-		},
-		newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
-			return kvpb.NewInternalClient(cc).BatchStream(ctx)
-		},
-		newCloseNotifier: func(stopper *stop.Stopper, cc *grpc.ClientConn) closeNotifier {
-			return &grpcCloseNotifier{stopper: stopper, conn: cc}
-		},
-		heartbeatInterval: rpcCtx.RPCHeartbeatInterval,
-		heartbeatTimeout:  rpcCtx.RPCHeartbeatTimeout,
+		peers:              peerOpts.peers,
+		connOptions:        peerOpts.connOptions,
+		drpcDial:           dialDRPC(rpcCtx),
+		newHeartbeatClient: peerOpts.newHeartbeatClient,
+		heartbeatInterval:  rpcCtx.RPCHeartbeatInterval,
+		heartbeatTimeout:   rpcCtx.RPCHeartbeatTimeout,
 	}
 	var b *circuit.Breaker
 
@@ -275,8 +265,8 @@ func (rpcCtx *Context) newPeer(k peerKey, locality roachpb.Locality) *peer[*grpc
 		},
 	})
 	p.b = b
-	c := newConnectionToNodeID(p.opts, k, b.Signal, p.newBatchStreamClient)
-	p.mu.PeerSnap = PeerSnap[*grpc.ClientConn]{c: c}
+	c := newConnectionToNodeID(p.opts, k, b.Signal, p.connOptions)
+	p.mu.PeerSnap = PeerSnap[Conn]{c: c}
 
 	return p
 }
@@ -375,7 +365,7 @@ func (p *peer[Conn]) run(ctx context.Context, report func(error), done func()) {
 		func() {
 			p.mu.Lock()
 			defer p.mu.Unlock()
-			p.mu.c = newConnectionToNodeID(p.opts, p.k, p.mu.c.breakerSignalFn, p.newBatchStreamClient)
+			p.mu.c = newConnectionToNodeID(p.opts, p.k, p.mu.c.breakerSignalFn, p.connOptions)
 		}()
 
 		if p.snap().deleteAfter != 0 {
@@ -388,14 +378,14 @@ func (p *peer[Conn]) run(ctx context.Context, report func(error), done func()) {
 }
 
 func (p *peer[Conn]) runOnce(ctx context.Context, report func(error)) error {
-	cc, err := p.dial(ctx, p.k.TargetAddr, p.k.Class)
+	cc, err := p.connOptions.dial(ctx, p.k.TargetAddr, p.k.Class)
 	if err != nil {
 		return err
 	}
 	defer func() {
 		_ = cc.Close() // nolint:grpcconnclose
 	}()
-	dc, err := p.dialDRPC(ctx, p.k.TargetAddr, p.k.Class)
+	dc, err := p.drpcDial(ctx, p.k.TargetAddr, p.k.Class)
 	if err != nil {
 		return err
 	}
@@ -406,7 +396,7 @@ func (p *peer[Conn]) runOnce(ctx context.Context, report func(error)) error {
 	// Set up notifications on a channel when gRPC tears down, so that we
 	// can trigger another instant heartbeat for expedited circuit breaker
 	// tripping.
-	connClosedCh := p.newCloseNotifier(p.opts.Stopper, cc).CloseNotify(ctx)
+	connClosedCh := p.connOptions.newCloseNotifier(p.opts.Stopper, cc).CloseNotify(ctx)
 
 	if p.remoteClocks != nil {
 		p.remoteClocks.OnConnect(ctx, p.k.NodeID)


### PR DESCRIPTION
Refactor `Peer` further to make it easy to support both gRPC and DRPC peers. In this change, gRPC peer continues to dial DRPC connections to keep the changes backward compatible. As part of enabling DRPC support across the codebase, future commits will remove the DRPC-specific code and replace it with generic peer.

This commit also adds DRPC dial methods to `rpc.nodedialer` and `rpc.Context`. In the future commits, helper functions for creation RPC clients are update to create gRPC or DRPC clients base on `rpc.experimental_drpc.enabled` cluster setting.

Epic: CRDB-48923 
Fixes: #148383
Release note: none