### PR TITLE
release-24.3: execbuilder: fix a silly bug around finding the most recent full stat

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -407,8 +407,9 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 				// The first stat is the most recent full one.
 				var first int
 				for first < tab.StatisticCount() &&
-					tab.Statistic(first).IsPartial() ||
-					(tab.Statistic(first).IsForecast() && !b.evalCtx.SessionData().OptimizerUseForecasts) {
+					(tab.Statistic(first).IsPartial() ||
+						(tab.Statistic(first).IsMerged() && !b.evalCtx.SessionData().OptimizerUseMergedPartialStatistics) ||
+						(tab.Statistic(first).IsForecast() && !b.evalCtx.SessionData().OptimizerUseForecasts)) {
 					first++
 				}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1381,7 +1381,7 @@ distribution: local
 vectorized: true
 ·
 • scan
-  estimated row count: 4 (36% of the table; stats collected <hidden> ago)
+  estimated row count: 4 (40% of the table; stats collected <hidden> ago)
   table: ka@ka_a_idx
   spans: [/6 - ]
 
@@ -1420,3 +1420,38 @@ vectorized: true
   estimated row count: 1 (9.1% of the table; stats collected <hidden> ago)
   table: ka@ka_a_idx
   spans: [/10 - /10]
+
+subtest regression_148316
+
+# Ensure we can run DELETE statement on system.table_statistics.
+statement ok
+INSERT INTO system.users VALUES ('node', NULL, true, 3);
+
+statement ok
+GRANT node TO root;
+
+# Keep only partial stats on the target table.
+statement ok
+DELETE FROM system.table_statistics WHERE name NOT LIKE '%partial%' AND "tableID" = 'ka'::REGCLASS::OID;
+
+query TT
+SELECT statistics_name, column_names FROM [SHOW STATISTICS FOR TABLE ka] ORDER BY created
+----
+ka_partialstat  {a}
+
+# Ensure that the system table is read on the next query.
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
+query T
+EXPLAIN SELECT * FROM ka WHERE a = 10
+----
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: ka@ka_a_idx
+  spans: [/10 - /10]
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #148329 on behalf of @yuzefovich.

----

This commit fixes a bug that was added in 3bc0992225673c2e8c80288a5c619d78f8b928cd. In short, in a complicated logical expression we had `v1 && v2 || v3` when we wanted `v1 && (v2 || v3)`. This allowed us to hit an index of bounds when evaluating `v3`, which in this concrete case could mean that we iterated over all stats and didn't find any full ones.

There are two other places with similar conditionals, and they have the correct usage of parenthesis, so I didn't change the structure overall. I did find that we want to also skip the merged stat, depending on the session variable.

Also the bug seems quite difficult to hit, so I omitted the release note.

Fixes: #148316.

Release note: None

----

Release justification: low-risk bug fix.