### PR TITLE
roachtest: separate panic node step into panic step and restart step

### DIFF
--- a/pkg/cmd/roachtest/option/node_list_option.go
+++ b/pkg/cmd/roachtest/option/node_list_option.go
@@ -63,6 +63,24 @@ func (n NodeListOption) Merge(o NodeListOption) NodeListOption {
 	return r
 }
 
+func (n NodeListOption) Intersect(o NodeListOption) NodeListOption {
+	set := make(map[int]struct{}, len(o))
+	for _, node := range o {
+		set[node] = struct{}{}
+	}
+
+	var result NodeListOption
+	seen := make(map[int]struct{}, len(n))
+	for _, node := range n {
+		if _, ok := set[node]; ok {
+			result = append(result, node)
+			seen[node] = struct{}{}
+		}
+	}
+
+	return result
+}
+
 // RandNode returns a random node from the NodeListOption.
 func (n NodeListOption) RandNode() NodeListOption {
 	return NodeListOption{n[rand.Intn(len(n))]}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
@@ -47,6 +48,8 @@ type (
 		connFunc        func(int) *gosql.DB
 		stepLogger      *logger.Logger
 		clusterVersions *atomic.Value
+		monitor         test.Monitor
+		nodes           option.NodeListOption
 	}
 
 	// Helper is the struct passed to `stepFunc`s (user-provided or
@@ -67,6 +70,17 @@ type (
 	}
 )
 
+func (s *Service) randomAvailableNode(rng *rand.Rand) int {
+	nodes := s.AvailableNodes()
+	return nodes.SeededRandNode(rng)[0]
+}
+
+// AvailableNodes uses the monitor implementation to return the
+// set of available nodes as determined by their expected health.
+func (s *Service) AvailableNodes() option.NodeListOption {
+	return s.monitor.AvailableNodes(s.Descriptor.Name).Intersect(s.nodes)
+}
+
 // Connect returns a connection pool to the given node. Note that
 // these connection pools are managed by the framework and therefore
 // *must not* be closed. They are closed automatically when the test
@@ -79,7 +93,7 @@ func (s *Service) Connect(node int) *gosql.DB {
 // cluster. Do *not* call `Close` on the pool returned (see comment on
 // `Connect` function).
 func (s *Service) RandomDB(rng *rand.Rand) (int, *gosql.DB) {
-	node := s.Descriptor.Nodes.SeededRandNode(rng)[0]
+	node := s.randomAvailableNode(rng)
 	return node, s.Connect(node)
 }
 
@@ -89,7 +103,8 @@ func (s *Service) RandomDB(rng *rand.Rand) (int, *gosql.DB) {
 func (s *Service) prepareQuery(
 	rng *rand.Rand, nodes option.NodeListOption, query string, args ...any,
 ) (*gosql.DB, error) {
-	node := nodes.SeededRandNode(rng)[0]
+	availableNodes := s.AvailableNodes().Intersect(nodes)
+	node := availableNodes.SeededRandNode(rng)[0]
 	db := s.Connect(node)
 
 	v, err := s.NodeVersion(node)
@@ -122,7 +137,8 @@ func (s *Service) Exec(rng *rand.Rand, query string, args ...interface{}) error 
 func (s *Service) ExecWithGateway(
 	rng *rand.Rand, nodes option.NodeListOption, query string, args ...interface{},
 ) error {
-	db, err := s.prepareQuery(rng, nodes, query, args...)
+	availableNodes := s.AvailableNodes().Intersect(nodes)
+	db, err := s.prepareQuery(rng, availableNodes, query, args...)
 	if err != nil {
 		return err
 	}
@@ -174,6 +190,10 @@ func (h *Helper) DefaultService() *Service {
 	}
 
 	return h.System
+}
+
+func (h *Helper) AvailableNodes() option.NodeListOption {
+	return h.DefaultService().AvailableNodes()
 }
 
 func (h *Helper) Context() *ServiceContext {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper_test.go
@@ -9,6 +9,7 @@ import (
 	"sync/atomic"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/stretchr/testify/require"
 )
@@ -70,8 +71,12 @@ func TestClusterVersionAtLeast(t *testing.T) {
 			clusterVersions.Store([]roachpb.Version{currentVersion})
 			runner := testTestRunner()
 			runner.systemService.clusterVersions = &clusterVersions
+			descriptor := &ServiceDescriptor{
+				Name:  "test",
+				Nodes: option.NodeListOption{1, 2, 3, 4},
+			}
 
-			h := runner.newHelper(ctx, nilLogger, Context{System: &ServiceContext{Finalizing: false}})
+			h := runner.newHelper(ctx, nilLogger, Context{System: &ServiceContext{Finalizing: false, Descriptor: descriptor}})
 
 			supportedFeature, err := h.ClusterVersionAtLeast(rng, tc.minVersion)
 			if tc.expectedErr == "" {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -548,6 +548,17 @@ func DisableAllClusterSettingMutators() CustomOption {
 	}
 }
 
+// DisableAllFailureInjectionMutators will disable all available failure injection mutators.
+func DisableAllFailureInjectionMutators() CustomOption {
+	return func(opts *testOptions) {
+		names := []string{}
+		for _, m := range failureInjectionMutators {
+			names = append(names, m.Name())
+		}
+		DisableMutators(names...)(opts)
+	}
+}
+
 // WithTag allows callers give the mixedversion test instance a
 // `tag`. The tag is used as prefix in the log messages emitted by
 // this upgrade test. This is only useful when running multiple

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -213,6 +213,8 @@ const (
 	spanConfigTenantLimit = 50000
 )
 
+// failureInjectionMutators includes a list of all
+// failure injection mutators.
 var failureInjectionMutators = []mutator{
 	panicNodeMutator{},
 }
@@ -255,15 +257,14 @@ var clusterSettingMutators = []mutator{
 
 // planMutators includes a list of all known `mutator`
 // implementations. A subset of these mutations might be enabled in
-// any mixedversion test plan.
-var planMutators = append(
-	append([]mutator{
-		preserveDowngradeOptionRandomizerMutator{},
-	},
-		failureInjectionMutators...,
-	),
-	clusterSettingMutators...,
-)
+// planMutators includes a list of all known `mutator`
+// implementations. A subset of these mutations might be enabled in
+var planMutators = func() []mutator {
+	mutators := []mutator{preserveDowngradeOptionRandomizerMutator{}}
+	mutators = append(mutators, clusterSettingMutators...)
+	mutators = append(mutators, failureInjectionMutators...)
+	return mutators
+}()
 
 // Plan returns the TestPlan used to upgrade the cluster from the
 // first to the final version in the `versions` field. The test plan
@@ -439,7 +440,7 @@ func (p *testPlanner) Plan() *TestPlan {
 	// panic failure).
 	for _, mut := range planMutators {
 		if p.mutatorEnabled(mut) {
-			if _, found := failureInjections[mut.Name()]; found && len(p.currentContext.System.Descriptor.Nodes) < 3 {
+			if _, found := failureInjections[mut.Name()]; found && len(p.currentContext.Nodes()) < 3 {
 				continue
 			}
 			mutations := mut.Generate(p.prng, testPlan, p)
@@ -1360,6 +1361,37 @@ func (ss stepSelector) Filter(predicate func(*singleStep) bool) stepSelector {
 	}
 
 	return result
+}
+
+// Cut finds the first step that matches the predicate given, returning
+// new selectors for the steps before and after the matching step. It also
+// returns a new selector for the matching cut step. If no step matches the
+// predicate, Cut returns `ss`, nil, nil.
+func (ss stepSelector) Cut(predicate func(*singleStep) bool) (before, after, cut stepSelector) {
+	predicateFound := false
+	for _, s := range ss {
+		if predicateFound {
+			after = append(after, s)
+		} else if predicate(s) {
+			predicateFound = true
+			cut = append(cut, s)
+		} else {
+			before = append(before, s)
+		}
+	}
+	return before, after, cut
+}
+
+// CutAfter is like Cut but the cut step is merged with the `after` selector
+func (ss stepSelector) CutAfter(predicate func(*singleStep) bool) (stepSelector, stepSelector) {
+	before, after, cut := ss.Cut(predicate)
+	return before, append(cut, after...)
+}
+
+// CutBefore is like Cut but the cut step is merged with the `before` selector
+func (ss stepSelector) CutBefore(predicate func(*singleStep) bool) (stepSelector, stepSelector) {
+	before, after, cut := ss.Cut(predicate)
+	return append(before, cut...), after
 }
 
 // RandomStep returns a new selector that selects a single step,

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -553,7 +553,7 @@ func Test_stepSelectorFilter(t *testing.T) {
 			name:                   "no filter",
 			predicate:              func(*singleStep) bool { return true },
 			expectedAllSteps:       true,
-			expectedRandomStepType: restartWithNewBinaryStep{},
+			expectedRandomStepType: runHookStep{},
 		},
 		{
 			name: "filter eliminates all steps",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -508,6 +508,13 @@ func (tr *testRunner) loggerFor(step *singleStep) (*logger.Logger, error) {
 	return prefixedLoggerWithFilename(tr.logger, prefix, filepath.Join(logPrefix, name))
 }
 
+// getAvailableNodes returns the nodes that are available for the given service descriptor.
+func (tr *testRunner) getAvailableNodes(
+	serviceDescriptor *ServiceDescriptor,
+) option.NodeListOption {
+	return serviceDescriptor.Nodes.Intersect(tr.monitor.AvailableNodes(serviceDescriptor.Name))
+}
+
 // refreshBinaryVersions updates the `binaryVersions` field for every
 // service with the binary version running on each node of the
 // cluster. We use the `atomic` package here as this function may be
@@ -518,7 +525,7 @@ func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *servic
 	defer cancel()
 
 	group := ctxgroup.WithContext(connectionCtx)
-	for j, node := range service.descriptor.Nodes {
+	for j, node := range tr.getAvailableNodes(service.descriptor) {
 		group.GoCtx(func(ctx context.Context) error {
 			bv, err := clusterupgrade.BinaryVersion(ctx, tr.conn(node, service.descriptor.Name))
 			if err != nil {
@@ -527,7 +534,6 @@ func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *servic
 					node, service.descriptor.Name, err,
 				)
 			}
-
 			newBinaryVersions[j] = bv
 			return nil
 		})
@@ -550,7 +556,7 @@ func (tr *testRunner) refreshClusterVersions(ctx context.Context, service *servi
 	defer cancel()
 
 	group := ctxgroup.WithContext(connectionCtx)
-	for j, node := range service.descriptor.Nodes {
+	for j, node := range tr.getAvailableNodes(service.descriptor) {
 		group.GoCtx(func(ctx context.Context) error {
 			cv, err := clusterupgrade.ClusterVersion(ctx, tr.conn(node, service.descriptor.Name))
 			if err != nil {
@@ -609,7 +615,7 @@ func (tr *testRunner) maybeInitConnections(service *serviceRuntime) error {
 	}
 
 	cc := map[int]*gosql.DB{}
-	for _, node := range service.descriptor.Nodes {
+	for _, node := range tr.getAvailableNodes(service.descriptor) {
 		conn, err := tr.cluster.ConnE(
 			tr.ctx, tr.logger, node, option.VirtualClusterName(service.descriptor.Name),
 		)
@@ -635,6 +641,7 @@ func (tr *testRunner) newHelper(
 		connFunc := func(node int) *gosql.DB {
 			return tr.conn(node, sc.Descriptor.Name)
 		}
+		nodes := sc.Descriptor.Nodes
 
 		return &Service{
 			ServiceContext: sc,
@@ -643,6 +650,8 @@ func (tr *testRunner) newHelper(
 			connFunc:        connFunc,
 			stepLogger:      l,
 			clusterVersions: cv,
+			monitor:         tr.monitor,
+			nodes:           nodes,
 		}
 	}
 

--- a/pkg/cmd/roachtest/test/test_monitor.go
+++ b/pkg/cmd/roachtest/test/test_monitor.go
@@ -11,4 +11,5 @@ import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 type Monitor interface {
 	ExpectProcessDead(nodes option.NodeListOption, opts ...option.OptionFunc)
 	ExpectProcessAlive(nodes option.NodeListOption, opts ...option.OptionFunc)
+	AvailableNodes(virtualClusterName string) option.NodeListOption
 }

--- a/pkg/cmd/roachtest/test_monitor_test.go
+++ b/pkg/cmd/roachtest/test_monitor_test.go
@@ -31,6 +31,9 @@ func (s *stubTestMonitorError) ExpectProcessAlive(
 	nodes option.NodeListOption, opts ...option.OptionFunc,
 ) {
 }
+func (s *stubTestMonitorError) AvailableNodes(virtualClusterName string) option.NodeListOption {
+	return option.NodeListOption{}
+}
 
 func (s *stubTestMonitorError) WaitForNodeDeath() error {
 	return errors.New("test error")

--- a/pkg/cmd/roachtest/tests/mixed_version_c2c.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_c2c.go
@@ -124,12 +124,15 @@ func InitC2CMixed(
 		return 0.0
 	}
 
+	// This test has the source and destination clusters interacting with each other
+	// through specific nodes, so it is incompatible with failure injections.
 	sourceMvt := mixedversion.NewTest(ctx, t, t.L(), c, c.Range(1, sp.srcNodes),
 		mixedversion.AlwaysUseLatestPredecessors,
 		mixedversion.NumUpgrades(expectedMajorUpgrades),
 		mixedversion.EnabledDeploymentModes(mixedversion.SharedProcessDeployment),
 		mixedversion.WithTag("source"),
 		mixedversion.WithSkipVersionProbability(boolToProb(sourceVersionSkips)),
+		mixedversion.DisableAllFailureInjectionMutators(),
 	)
 
 	destMvt := mixedversion.NewTest(ctx, t, t.L(), c, c.Range(sp.srcNodes+1, sp.srcNodes+sp.dstNodes),
@@ -138,6 +141,7 @@ func InitC2CMixed(
 		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 		mixedversion.WithTag("dest"),
 		mixedversion.WithSkipVersionProbability(boolToProb(destVersionSkips)),
+		mixedversion.DisableAllFailureInjectionMutators(),
 	)
 
 	return &c2cMixed{

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1650,9 +1650,23 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts,
 ) (int, error) {
 	runSQL := func(stmt string) (string, error) {
-		results, err := startOpts.StorageCluster.ExecSQL(
-			ctx, l, startOpts.StorageCluster.Nodes[:1], SystemInterfaceName, 0, DefaultAuthMode(), "", /* database */
-			[]string{"--format", "csv", "-e", stmt})
+		var results []*RunResultDetails
+		var err error
+		// It is possible to target a storage node that is currently down, so
+		// we should attempt connecting to all storage nodes before erroring out.
+		for n := 0; n < len(startOpts.StorageCluster.Nodes); n++ {
+			results, err = startOpts.StorageCluster.ExecSQL(
+				ctx, l, startOpts.StorageCluster.Nodes[n:n+1], SystemInterfaceName, 0, DefaultAuthMode(), "", /* database */
+				[]string{"--format", "csv", "-e", stmt})
+			if err == nil && results[0].Err == nil {
+				return results[0].CombinedOut, nil
+			}
+			if err != nil {
+				l.Printf("failed to execute SQL statement %q on node %d: %s", stmt, n, err)
+			} else if results[0].Err != nil {
+				l.Printf("failed to execute SQL statement %q on node %d: %s", stmt, n, err)
+			}
+		}
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
As previously mentioned in #147641, the panic node mutator was done in one step (panicking the node and restarting it). This change splits that step into two steps, allowing for a node to be dead for an extended period of time before restarting in a later step.

Teamcity: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel/20145889?hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true
Epic: none
Release note: none
