### PR TITLE
kvcoord: correctly clear lock info on complete rollback

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -1716,7 +1716,7 @@ func (li *lockedKeyInfo) rollbackSequence(seq enginepb.TxnSeq) bool {
 	for i := range li.heldStrengths {
 		if li.heldStrengths[i] >= seq {
 			li.heldStrengths[i] = notHeldSentinel
-		} else {
+		} else if li.heldStrengths[i] != notHeldSentinel {
 			stillHeld = true
 		}
 	}

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -2671,6 +2671,15 @@ func TestLockKeyInfo(t *testing.T) {
 		require.False(t, lki.rollbackSequence(1))
 		require.False(t, lki.ts.IsSet())
 
+		// Also test rollback with only one lock type acquired.
+		lki = newLockedKeyInfo(lock.Shared, 2, ts1)
+		require.False(t, lki.rollbackSequence(1))
+		require.False(t, lki.ts.IsSet())
+
+		lki = newLockedKeyInfo(lock.Exclusive, 2, ts1)
+		require.False(t, lki.rollbackSequence(1))
+		require.False(t, lki.ts.IsSet())
+
 		lki = newLockedKeyInfo(lock.Shared, 2, ts1)
 		lki.acquireLock(lock.Exclusive, 3, ts2)
 		require.True(t, lki.rollbackSequence(3))

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1969,7 +1969,7 @@ func TestTxnWriteBufferBatchRequestValidation(t *testing.T) {
 
 	tests := []testCase{
 		{
-			name: "batch with OriginTimestamp",
+			name: "batch with OriginTimestamp in WriteOptions",
 			ba: func() *kvpb.BatchRequest {
 				header := kvpb.Header{
 					Txn: &txn,
@@ -1981,7 +1981,7 @@ func TestTxnWriteBufferBatchRequestValidation(t *testing.T) {
 			},
 		},
 		{
-			name: "batch with OriginID",
+			name: "batch with OriginID in WriteOptions",
 			ba: func() *kvpb.BatchRequest {
 				header := kvpb.Header{
 					Txn: &txn,
@@ -1990,6 +1990,20 @@ func TestTxnWriteBufferBatchRequestValidation(t *testing.T) {
 					},
 				}
 				return &kvpb.BatchRequest{Header: header}
+			},
+		},
+		{
+			name: "batch with OriginTimestamp in ConditionalPutRequest",
+			ba: func() *kvpb.BatchRequest {
+				header := kvpb.Header{
+					Txn: &txn,
+				}
+				b := &kvpb.BatchRequest{Header: header}
+				r := &kvpb.ConditionalPutRequest{
+					OriginTimestamp: hlc.Timestamp{WallTime: 1},
+				}
+				b.Add(r)
+				return b
 			},
 		},
 		{
@@ -2048,6 +2062,15 @@ func TestTxnWriteBufferBatchRequestValidation(t *testing.T) {
 					ScanFormat:    kvpb.COL_BATCH_RESPONSE,
 					RequestHeader: kvpb.RequestHeader{Key: keyA, EndKey: keyC, Sequence: txn.Sequence},
 				}
+				b.Add(r)
+				return b
+			},
+		},
+		{
+			name: "batch with unsupported request",
+			ba: func() *kvpb.BatchRequest {
+				b := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}
+				r := &kvpb.TruncateLogRequest{}
 				b.Add(r)
 				return b
 			},


### PR DESCRIPTION
Previously, we were not completely removing the lock key info on
complete rollbacks in some cases. This isn't necessarily a problem
overall because we could assert on the lower timestamp, but the code
intended to handle the complete rollback case and now it does.

Epic: none
Release note: None