### PR TITLE
rttanalysis: add benchmarks for `SHOW CREATE ALL TRIGGERS`

### DIFF
--- a/pkg/bench/rttanalysis/orm_queries_bench_test.go
+++ b/pkg/bench/rttanalysis/orm_queries_bench_test.go
@@ -1035,6 +1035,30 @@ func buildNFunctions(n int) string {
 	return b.String()
 }
 
+func buildNTablesWithTriggers(n int) string {
+	b := strings.Builder{}
+	b.WriteString(`
+CREATE OR REPLACE FUNCTION trigger_func()
+RETURNS TRIGGER AS $$
+BEGIN
+  RAISE NOTICE 'Trigger fired for NEW row: %', NEW;
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+`)
+	for i := 0; i < n; i++ {
+		b.WriteString(fmt.Sprintf(`
+CREATE TABLE t%d (a INT, b INT);
+
+CREATE TRIGGER trigger_%d
+AFTER INSERT ON t%d
+FOR EACH ROW
+EXECUTE FUNCTION trigger_func();
+`, i, i, i))
+	}
+	return b.String()
+}
+
 func buildNTypes(n int) string {
 	b := strings.Builder{}
 	for i := 0; i < n; i++ {

--- a/pkg/bench/rttanalysis/testdata/benchmark_expectations
+++ b/pkg/bench/rttanalysis/testdata/benchmark_expectations
@@ -132,5 +132,6 @@ exp,benchmark
 1,VirtualTableQueries/select_crdb_internal.invalid_objects_with_1_fk
 1,VirtualTableQueries/select_crdb_internal.tables_with_1_fk
 0,VirtualTableQueries/show_create_all_routines
+0,VirtualTableQueries/show_create_all_triggers
 5,VirtualTableQueries/virtual_table_cache_with_point_lookups
 10,VirtualTableQueries/virtual_table_cache_with_schema_change

--- a/pkg/bench/rttanalysis/virtual_table_bench_test.go
+++ b/pkg/bench/rttanalysis/virtual_table_bench_test.go
@@ -66,7 +66,14 @@ SELECT * FROM t2;`,
 		{
 			Name:  "show_create_all_routines",
 			Setup: buildNFunctions(100),
-			Stmt:  `SHOW CREATE ALL ROUTINES`,
+			Stmt:  `SHOW CREATE ALL ROUTINES;`,
+		},
+		// This test checks the performance of the crdb_internal virtual tables used by
+		// SHOW CREATE ALL TRIGGERS.
+		{
+			Name:  "show_create_all_triggers",
+			Setup: buildNTablesWithTriggers(100),
+			Stmt:  `SHOW CREATE ALL TRIGGERS;`,
 		},
 	})
 }

--- a/pkg/sql/sem/builtins/show_create_all_triggers_builtin.go
+++ b/pkg/sql/sem/builtins/show_create_all_triggers_builtin.go
@@ -26,7 +26,7 @@ type tableTriggerPair struct {
 
 func getTriggerIds(
 	ctx context.Context, evalPlanner eval.Planner, txn *kv.Txn, dbName string, acc *mon.BoundAccount,
-) (triggerIds []tableTriggerPair, retErr error) { //TODO: Check up on ID field names etc
+) (triggerIds []tableTriggerPair, retErr error) {
 	query := fmt.Sprintf(`
 SELECT trigger_id, table_id 
 FROM %s.crdb_internal.create_trigger_statements 


### PR DESCRIPTION
There were previously no benchmarks to confirm the performance of `SHOW CREATE ALL TRIGGERS` queries. It is important to have these benchmarks,
particularly as the virtual table for create trigger statements is indexed by TableID, and a benchmark
could help to confirm that the index helps
performance in some sense.

Epic: CRDB-49582
Release note: None