### PR TITLE
logictest: deflake zone_config test

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -301,6 +301,10 @@ CREATE TABLE zc (
   b INT
 )
 
+# Prevent fast GC with data.
+statement ok
+INSERT INTO zc VALUES (1,2)
+
 statement ok
 ALTER TABLE zc CONFIGURE ZONE USING gc.ttlseconds = 100000
 
@@ -410,11 +414,19 @@ ALTER DATABASE foo CONFIGURE ZONE USING gc.ttlseconds = 12345
 statement ok
 CREATE TABLE foo.public.bar (x INT PRIMARY KEY)
 
+# Prevent fast GC with data.
+statement ok
+INSERT INTO foo.public.bar VALUES (1)
+
 statement ok
 DROP DATABASE foo CASCADE
 
 statement ok
 CREATE TABLE baz (x INT PRIMARY KEY)
+
+# Prevent fast GC with data.
+statement ok
+INSERT INTO baz VALUES (1)
 
 statement ok
 DROP TABLE baz


### PR DESCRIPTION
Previously, the zone_config logic test was flaky because the spans for the table were empty. Which meant the table descriptor could be cleaned up once the sql.gc_job.wait_for_gc.interval timeout was hit. To make tests faster in logictest this defaults to 3 seconds. This patch modifies the test table data, so that the prefix is only empty after GC has occurred.

Fixes: #148298

Release note: None