### PR TITLE
WORKSPACE: update pgo profile

### DIFF
--- a/WORKSPACE
+++ b/WORKSPACE
@@ -196,6 +196,7 @@ go_download_sdk(
 go_rules_dependencies()
 
 go_register_toolchains()
+
 go_register_nogo(nogo = "@com_github_cockroachdb_cockroach//:crdb_nogo")
 
 ###############################
@@ -335,10 +336,10 @@ load(
 
 http_archive(
     name = "rules_license",
+    sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
     urls = [
         "https://storage.googleapis.com/public-bazel-artifacts/bazel/rules_license-1.0.0.tar.gz",
     ],
-    sha256 = "26d4021f6898e23b82ef953078389dd49ac2b5618ac564ade4ef87cced147b38",
 )
 
 # keep
@@ -640,8 +641,8 @@ load("//build:pgo.bzl", "pgo_profile")
 
 pgo_profile(
     name = "pgo_profile",
-    url = "https://storage.googleapis.com/cockroach-profiles/20250408173855.pprof",
-    sha256 = "7bbc17e28141f38f742e2834f4d0cdb0f589df91daeb0de64da9e35f824f58af",
+    sha256 = "57414977040f9ed887a4e2b0434ca97f0047229928d8456a25acb3e08b4a71f2",
+    url = "https://storage.googleapis.com/cockroach-profiles/20250616172238-909ceb6ada01354d34416f1087fc256a066daa17.pb.gz",
 )
 
 # Download and register the FIPS enabled Go toolchain at the end to avoid toolchain conflicts for gazelle.


### PR DESCRIPTION
Release note: none
Fixes: REL-2730

```
                                                 │ benchstat_old.txt │         benchstat.txt         │
                                                 │    queries/sec    │ queries/sec  vs base          │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64         22.99k ± 4%   22.43k ± 2%  ~ (p=0.314 n=20)

                                                 │ benchstat_old.txt │         benchstat.txt         │
                                                 │     txns/sec      │  txns/sec    vs base          │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64         1.150k ± 4%   1.121k ± 2%  ~ (p=0.314 n=20)

                                                 │ benchstat_old.txt │        benchstat.txt         │
                                                 │      ms/min       │   ms/min    vs base          │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          13.82 ± 4%   13.50 ± 4%  ~ (p=0.151 n=20)

                                                 │ benchstat_old.txt │        benchstat.txt         │
                                                 │      ms/avg       │   ms/avg    vs base          │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          55.67 ± 4%   57.07 ± 2%  ~ (p=0.304 n=20)

                                                 │ benchstat_old.txt │           benchstat.txt           │
                                                 │      ms/p95       │   ms/p95    vs base               │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64          86.00 ± 4%   89.16 ± 4%  +3.67% (p=0.042 n=20)

                                                 │ benchstat_old.txt │         benchstat.txt         │
                                                 │      ms/max       │   ms/max     vs base          │
Sysbench/a=oltp_read_write/nodes=3/cpu=8/conc=64         244.6 ± 38%   235.5 ± 18%  ~ (p=0.925 n=20)

```