### PR TITLE
execinfrapb: minor cleanup of Expression

### DIFF
--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -68,15 +68,14 @@ func ConvertToMappedSpecOrdering(
 }
 
 // Expression is the representation of a SQL expression.
+//
 // See data.proto for the corresponding proto definition. Its automatic type
 // declaration is suppressed in the proto via the typedecl=false option, so that
 // we can add the LocalExpr field which is not serialized. It never needs to be
-// serialized because we only use it in the case where we know we won't need to
-// send it, as a proto, to another machine.
+// serialized because it's just an optimization on the gateway to avoid
+// redundant deserialization (Expr will be set when protos are sent to remote
+// nodes).
 type Expression struct {
-	// Version is unused.
-	Version string
-
 	// Expr, if present, is the string representation of this expression.
 	// SQL expressions are passed as a string, with ordinal references
 	// (@1, @2, @3 ..) used for "input" variables.

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -40,12 +40,11 @@ message Expression {
   option (gogoproto.typedecl) = false;
   option (gogoproto.goproto_stringer) = false;
 
-  // TODO(radu): TBD how this will be used
-  optional string version = 1 [(gogoproto.nullable) = false];
-
   // SQL expressions are passed as a string, with ordinal references
   // (@1, @2, @3 ..) used for "input" variables.
   optional string expr = 2 [(gogoproto.nullable) = false];
+
+  reserved 1;
 }
 
 // Ordering defines an order - specifically a list of column indices and


### PR DESCRIPTION
Removed unused version field and fix up a comment.

Epic: None
Release note: None