### PR TITLE
vecindex: loosen RemoveFromPartition semantics

### DIFF
--- a/pkg/sql/vecindex/cspann/index.go
+++ b/pkg/sql/vecindex/cspann/index.go
@@ -270,7 +270,9 @@ func NewIndex(
 		vi.options.MaxInsertAttempts = 32
 	}
 	if vi.options.MaxDeleteAttempts == 0 {
-		vi.options.MaxDeleteAttempts = 3
+		// Note that fetching the batch and getting the first result from the
+		// batch are both counted as "attempts", so this needs to be at least 2.
+		vi.options.MaxDeleteAttempts = 2
 	}
 
 	if vi.options.MaxPartitionSize < 2 {

--- a/pkg/sql/vecindex/cspann/searcher.go
+++ b/pkg/sql/vecindex/cspann/searcher.go
@@ -422,16 +422,16 @@ func (s *levelSearcher) searchChildPartitions(
 		}
 		s.stats.SearchedPartition(level, count)
 
-		// If searching for vector to delete, skip partitions that are in a state
-		// that does not allow add and remove operations. This is not possible to
-		// do here for the insert case, because we do not actually search the
-		// partition in which to insert; we only search its parent and never get
-		// the metadata for the insert partition itself.
+		// If searching for vector to delete, skip partitions that don't need
+		// vectors deleted from them (because they are draining or deleting). This
+		// is not possible to do here for the insert case, because we do not
+		// actually search the partition in which to insert; we only search its
+		// parent and never get the metadata for the insert partition itself.
 		// TODO(andyk): This should probably be checked in the Store, perhaps by
 		// passing a "forUpdate" parameter to SearchPartitions, so that the Store
 		// doesn't even add vectors from partitions that do not allow updates.
 		if s.idxCtx.forDelete && s.idxCtx.level == level {
-			if !s.idxCtx.tempToSearch[i].StateDetails.State.AllowAddOrRemove() {
+			if s.idxCtx.tempToSearch[i].StateDetails.State.CanSkipRemove() {
 				s.searchSet.RemoveByParent(partitionKey)
 			}
 		}

--- a/pkg/sql/vecindex/cspann/store.go
+++ b/pkg/sql/vecindex/cspann/store.go
@@ -144,7 +144,7 @@ type Store interface {
 
 	// TryRemoveFromPartition removes vectors from the given partition by their
 	// child keys and returns true if any vector is removed. If a key is not
-	// present in the partition, it is a no-op.
+	// present in the partition, it is skipped.
 	//
 	// Before performing any action, TryRemoveFromPartition checks the partition's
 	// metadata and returns a ConditionFailedError if it is not the same as the
@@ -187,11 +187,9 @@ type Txn interface {
 	// is true, fetching the metadata is part of a mutation operation; the store
 	// can perform any needed locking in this case.
 	//
-	// GetPartitionMetadata returns ConditionFailedError if "forUpdate" is true
-	// and the partition is in a state that does not allow updates. It returns
-	// ErrPartitionNotFound if the partition cannot be found, or
-	// ErrRestartOperation if the caller should retry the operation that triggered
-	// this call.
+	// If the partition does not exist, GetPartitionMetadata returns empty
+	// metadata with a Missing state. It returns ErrRestartOperation if the caller
+	// should retry the operation that triggered this call.
 	GetPartitionMetadata(
 		ctx context.Context, treeKey TreeKey, partitionKey PartitionKey, forUpdate bool,
 	) (PartitionMetadata, error)

--- a/pkg/sql/vecindex/cspann/testdata/delete.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/delete.ddt
@@ -94,8 +94,7 @@ vec7: (2, 8)
     │
     └───• vec4 (-4, 5)
 
-# Test case where initial search fails to find vector to delete and it must be
-# retried.
+# Test case where search fails to find vector to delete.
 delete
 vec1: (2, 4)
 ----
@@ -116,6 +115,7 @@ vec1: (2, 4)
     │
     ├───• 4 (1, -2)
     │   │
+    │   ├───• vec1 (MISSING)
     │   └───• vec6 (1, -6)
     │
     └───• 2 (5.5, 3.5)
@@ -141,6 +141,9 @@ vec6
 └───• 9 (3.25, 0.75)
     │
     ├───• 4 (1, -2)
+    │   │
+    │   └───• vec1 (MISSING)
+    │
     └───• 2 (5.5, 3.5)
         │
         ├───• vec3 (4, 3)

--- a/pkg/sql/vecindex/cspann/testdata/search-for-delete.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/search-for-delete.ddt
@@ -1,7 +1,7 @@
 # ----------------------------------------------------------------------
 # Search tree with multiple partitions and duplicate data.
 # ----------------------------------------------------------------------
-new-index dims=2 min-partition-size=1 max-partition-size=4 beam-size=1
+new-index dims=2 min-partition-size=1 max-partition-size=4 beam-size=2
 vec1: (1, 2)
 vec2: (7, 4)
 vec3: (4, 3)
@@ -68,9 +68,9 @@ vec100: (1, 2)
 ----
 vec100: vector not found
 
-# Search for vector with wrong value, which forces internal retry.
+# Search for vector with wrong value that cannot be found with beam_size=2.
 search-for-delete
-vec1:(0, 9)
+vec1:(6, 2)
 ----
 vec1: partition 7
 

--- a/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
+++ b/pkg/sql/vecindex/cspann/testdata/split-non-root-step.ddt
@@ -425,7 +425,7 @@ force-split partition-key=7 parent-partition-key=1 steps=8
         └───• vec2 (3, 5)
 
 # Continue split of child #4. This should only progress to DeletingForSplit,
-# since it cannot be removed from its parent #7, which is still in the
+# since it will not be removed from its parent #7, which is still in the
 # DrainingForSplit state.
 force-split partition-key=4 parent-partition-key=7
 ----

--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -376,6 +376,10 @@ func (s *Store) TryAddToPartition(
 		if !metadata.Equal(&expected) {
 			return cspann.NewConditionFailedError(metadata)
 		}
+		if !metadata.StateDetails.State.AllowAdd() {
+			return errors.AssertionFailedf(
+				"cannot add to partition in state %s that disallows adds", metadata.StateDetails.State)
+		}
 
 		// Do not add vectors that are found to already exist.
 		var exclude cspann.ChildKeyDeDup
@@ -533,6 +537,10 @@ func (s *Store) TryClearPartition(
 		}
 		if !metadata.Equal(&expected) {
 			return cspann.NewConditionFailedError(metadata)
+		}
+		if metadata.StateDetails.State.AllowAdd() {
+			return errors.AssertionFailedf(
+				"cannot clear partition in state %s that allows adds", metadata.StateDetails.State)
 		}
 
 		// Clear all vectors in the partition using DelRange.


### PR DESCRIPTION
#### cspann: do not retry search when deleting vector

Previously, if the search for a vector to delete fails, the index
would fetch a second batch of partitions to search. However, if a
vector cannot be found in the first batch, it's very unlikely to be
found at all, so better to abort at that point. This is important
for the case when a split or merge is in progress and the vector is
found in a draining partition and skipped. It's a waste to keep
searching in that case.

#### vecindex: loosen RemoveFromPartition semantics

Previously, vectors could not be removed from partitions that were
in a draining or deleting state. While this restriction is needed
for adding vectors to prevent "lost update" anomalies, it's not
needed for removing vectors. A future PR will be able to avoid extra
work if this restriction is loosened.

Even though it's OK to remove vectors from partitions in any state,
that doesn't mean it's *useful* to do so. For example, when deleting
a vector from the index, there's no point in deleting it from a
partition that is going to be cleared or deleted anyway.

Distinguish between these various cases by splitting AllowAddOrRemove
into AllowAdd, AllowRemove, and CanSkipRemove.