### PR TITLE
cspann: add GetCentroidDistances method to Quantizer interface

### DIFF
--- a/pkg/sql/vecindex/cspann/partition.go
+++ b/pkg/sql/vecindex/cspann/partition.go
@@ -282,6 +282,6 @@ func (p *Partition) Clear() int {
 // CreateEmptyPartition returns an empty partition for the given quantizer and
 // level.
 func CreateEmptyPartition(quantizer quantize.Quantizer, metadata PartitionMetadata) *Partition {
-	quantizedSet := quantizer.NewQuantizedVectorSet(0, metadata.Centroid)
+	quantizedSet := quantizer.NewSet(0, metadata.Centroid)
 	return NewPartition(metadata, quantizer, quantizedSet, []ChildKey(nil), []ValueBytes(nil))
 }

--- a/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
@@ -71,5 +71,6 @@ go_test(
         "//pkg/util/vector",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_stretchr_testify//require",
+        "@org_gonum_v1_gonum//floats/scalar",
     ],
 )

--- a/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
+++ b/pkg/sql/vecindex/cspann/quantize/BUILD.bazel
@@ -8,6 +8,7 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/vecindex/vecpb:vecpb_proto",
         "//pkg/util/vector:vector_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
@@ -20,6 +21,7 @@ go_proto_library(
     proto = ":quantize_proto",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/util/vector",
         "@com_github_gogo_protobuf//gogoproto",
     ],

--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -7,6 +7,7 @@ syntax = "proto3";
 package cockroach.sql.vecindex.quantize;
 option go_package = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize";
 
+import "sql/vecindex/vecpb/vec.proto";
 import "util/vector/vector.proto";
 import "gogoproto/gogo.proto";
 
@@ -32,6 +33,9 @@ message RaBitQCodeSet {
 message RaBitQuantizedVectorSet {
   option (gogoproto.equal) = true;
 
+  // Metric specifies the metric used to compute similarity between vectors in
+  // the set.
+  cockroach.sql.vecindex.vecpb.DistanceMetric metric = 1;
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
@@ -39,27 +43,27 @@ message RaBitQuantizedVectorSet {
   // The caller is responsible for converting this to a spherical centroid when
   // that's needed.
   // NOTE: The centroid should be treated as immutable.
-  repeated float centroid = 1;
+  repeated float centroid = 2;
   // Codes is a set of RaBitQ quantization codes, with one code per quantized
   // vector in the set.
-  RaBitQCodeSet codes = 2 [(gogoproto.nullable) = false];
+  RaBitQCodeSet codes = 3 [(gogoproto.nullable) = false];
   // CodeCounts records the count of "1" bits in each of the quantization codes.
-  repeated uint32 code_counts = 3;
+  repeated uint32 code_counts = 4;
   // CentroidDistances is a slice of the exact Euclidean distances (non-squared)
   // of the original full-size vectors from the centroid.
-  repeated float centroid_distances = 4;
+  repeated float centroid_distances = 5;
   // QuantizedDotProducts is a slice of the exact inner products between the
   // original full-size vectors and their corresponding quantized vectors.
   // NOTE: These values have been inverted (1/inner_product) to avoid expensive
   // division during distance estimation.
-  repeated float quantized_dot_products = 5;
+  repeated float quantized_dot_products = 6;
   // CentroidDotProducts is a slice of the exact inner products between the
   // original full-size vectors and the centroid.
   // NOTE: This is always nil when using the L2Squared distance metric.
-  repeated float centroid_dot_products = 6;
+  repeated float centroid_dot_products = 7;
   // CentroidNorm is the L2 norm of the mean centroid.
   // NOTE: This is always nil when using the L2Squared distance metric.
-  float centroid_norm = 7;
+  float centroid_norm = 8;
 }
 
 // UnQuantizedVectorSet trivially implements the QuantizedVectorSet interface,

--- a/pkg/sql/vecindex/cspann/quantize/quantize.proto
+++ b/pkg/sql/vecindex/cspann/quantize/quantize.proto
@@ -35,9 +35,9 @@ message RaBitQuantizedVectorSet {
   // Centroid is the average of vectors in the set, representing its "center of
   // mass". Note that the centroid is computed when a vector set is created and
   // is not updated when vectors are added or removed.
-  // NOTE: By default, this is the mean centroid for the L2Squared distance
-  // metric, but is the spherical centroid for InnerProduct and Cosine metrics.
-  // The spherical centroid is simply the mean centroid, but normalized.
+  // NOTE: This is always the mean centroid, regardless of the distance metric.
+  // The caller is responsible for converting this to a spherical centroid when
+  // that's needed.
   // NOTE: The centroid should be treated as immutable.
   repeated float centroid = 1;
   // Codes is a set of RaBitQ quantization codes, with one code per quantized
@@ -55,7 +55,11 @@ message RaBitQuantizedVectorSet {
   repeated float quantized_dot_products = 5;
   // CentroidDotProducts is a slice of the exact inner products between the
   // original full-size vectors and the centroid.
+  // NOTE: This is always nil when using the L2Squared distance metric.
   repeated float centroid_dot_products = 6;
+  // CentroidNorm is the L2 norm of the mean centroid.
+  // NOTE: This is always nil when using the L2Squared distance metric.
+  float centroid_norm = 7;
 }
 
 // UnQuantizedVectorSet trivially implements the QuantizedVectorSet interface,

--- a/pkg/sql/vecindex/cspann/quantize/quantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer.go
@@ -41,9 +41,9 @@ type Quantizer interface {
 	//       vectors.
 	QuantizeInSet(w *workspace.T, quantizedSet QuantizedVectorSet, vectors vector.Set)
 
-	// NewQuantizedVectorSet returns a new empty vector set preallocated to the
-	// number of vectors specified.
-	NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet
+	// NewSet returns a new empty vector set preallocated to the number of vectors
+	// specified.
+	NewSet(capacity int, centroid vector.T) QuantizedVectorSet
 
 	// EstimateDistances returns the estimated distances of the query vector from
 	// each data vector represented in the given quantized vector set, as well as

--- a/pkg/sql/vecindex/cspann/quantize/quantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer.go
@@ -61,6 +61,18 @@ type Quantizer interface {
 		distances []float32,
 		errorBounds []float32,
 	)
+
+	// GetCentroidDistances returns the exact distance of each vector in
+	// "quantizedSet" from that set's centroid, according to the quantizer's
+	// distance metric (e.g. L2Squared or Cosine). By default, it returns
+	// distances to the mean centroid. However, if "spherical" is true and the
+	// distance metric is Cosine or InnerProduct, then it returns distances to
+	// the spherical centroid instead.
+	//
+	// The caller is responsible for allocating the "distances" slice with length
+	// equal to the number of quantized vectors in "quantizedSet". The centroid
+	// distances will be copied into that slice.
+	GetCentroidDistances(quantizedSet QuantizedVectorSet, distances []float32, spherical bool)
 }
 
 // QuantizedVectorSet is the compressed form of an original set of full-size

--- a/pkg/sql/vecindex/cspann/quantize/quantizer_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer_test.go
@@ -41,6 +41,9 @@ func TestQuantizers(t *testing.T) {
 			case "estimate-distances":
 				return state.estimateDistances(t, d)
 
+			case "get-centroid-distances":
+				return state.getCentroidDistances(t, d)
+
 			case "calculate-recall":
 				return state.calculateRecall(t, d)
 
@@ -168,6 +171,73 @@ func (s *testState) estimateDistances(t *testing.T, d *datadriven.TestData) stri
 
 	buf.WriteString("Cosine\n")
 	doTest(vecpb.CosineDistance, 4)
+
+	return buf.String()
+}
+
+func (s *testState) getCentroidDistances(t *testing.T, d *datadriven.TestData) string {
+	var dims int
+	var err error
+	var vectors vector.Set
+	for _, arg := range d.CmdArgs {
+		switch arg.Key {
+		case "dims":
+			require.Len(t, arg.Vals, 1)
+			dims, err = strconv.Atoi(arg.Vals[0])
+			require.NoError(t, err)
+
+			// Parse the input vectors.
+			vectors = vector.MakeSet(dims)
+			for _, line := range strings.Split(d.Input, "\n") {
+				line = strings.TrimSpace(line)
+				if len(line) == 0 {
+					continue
+				}
+
+				vec, err := vector.ParseVector(line)
+				require.NoError(t, err)
+				vectors.Add(vec)
+			}
+
+		default:
+			t.Fatalf("unknown arg: %s", arg.Key)
+		}
+	}
+
+	var buf bytes.Buffer
+	doTest := func(metric vecpb.DistanceMetric) {
+		rabitQ := quantize.NewRaBitQuantizer(dims, 42, metric)
+		quantizedSet := rabitQ.Quantize(&s.Workspace, vectors).(*quantize.RaBitQuantizedVectorSet)
+
+		buf.WriteString("  Centroid = ")
+		utils.WriteVector(&buf, quantizedSet.Centroid, 4)
+		buf.WriteByte('\n')
+
+		buf.WriteString("  Mean Centroid Distances = ")
+		distances := make([]float32, quantizedSet.GetCount())
+		rabitQ.GetCentroidDistances(quantizedSet, distances, false /* spherical */)
+		utils.WriteVector(&buf, distances, 4)
+		buf.WriteByte('\n')
+
+		buf.WriteString("  Spherical Centroid Distances = ")
+		rabitQ.GetCentroidDistances(quantizedSet, distances, true /* spherical */)
+		utils.WriteVector(&buf, distances, 4)
+		buf.WriteByte('\n')
+	}
+
+	buf.WriteString("L2Squared\n")
+	doTest(vecpb.L2SquaredDistance)
+
+	buf.WriteString("InnerProduct\n")
+	doTest(vecpb.InnerProductDistance)
+
+	// For cosine distance, normalize the input vectors.
+	for i := range vectors.Count {
+		num32.Normalize(vectors.At(i))
+	}
+
+	buf.WriteString("Cosine\n")
+	doTest(vecpb.CosineDistance)
 
 	return buf.String()
 }

--- a/pkg/sql/vecindex/cspann/quantize/quantizer_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/quantizer_test.go
@@ -103,7 +103,7 @@ func (s *testState) estimateDistances(t *testing.T, d *datadriven.TestData) stri
 
 		// Now add the vectors one-by-one and ensure that distances and error
 		// bounds stay the same.
-		quantizedSet = quantizer.NewQuantizedVectorSet(vectors.Count, centroid)
+		quantizedSet = quantizer.NewSet(vectors.Count, centroid)
 		for i := range vectors.Count {
 			quantizer.QuantizeInSet(&s.Workspace, quantizedSet, vectors.Slice(i, 1))
 		}

--- a/pkg/sql/vecindex/cspann/quantize/rabitq.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq.go
@@ -112,7 +112,7 @@ func (q *RaBitQuantizer) Quantize(w *workspace.T, vectors vector.Set) QuantizedV
 		centroid = vectors.Centroid(make(vector.T, vectors.Dims))
 	}
 
-	quantizedSet := q.NewQuantizedVectorSet(vectors.Count, centroid)
+	quantizedSet := q.NewSet(vectors.Count, centroid)
 	q.quantizeHelper(w, quantizedSet.(*RaBitQuantizedVectorSet), vectors)
 	return quantizedSet
 }
@@ -124,8 +124,8 @@ func (q *RaBitQuantizer) QuantizeInSet(
 	q.quantizeHelper(w, quantizedSet.(*RaBitQuantizedVectorSet), vectors)
 }
 
-// NewQuantizedVectorSet implements the Quantizer interface
-func (q *RaBitQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+// NewSet implements the Quantizer interface
+func (q *RaBitQuantizer) NewSet(capacity int, centroid vector.T) QuantizedVectorSet {
 	codeWidth := RaBitQCodeSetWidth(q.GetDims())
 	dataBuffer := make([]uint64, 0, capacity*codeWidth)
 	if capacity <= 1 {

--- a/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/stretchr/testify/require"
+	"gonum.org/v1/gonum/floats/scalar"
 )
 
 // Basic tests.
@@ -77,13 +78,12 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 	})
 
 	t.Run("empty quantized set with capacity", func(t *testing.T) {
-		quantizer := NewRaBitQuantizer(65, 42, vecpb.L2SquaredDistance)
+		quantizer := NewRaBitQuantizer(65, 42, vecpb.InnerProductDistance)
 		centroid := make([]float32, 65)
 		for i := range centroid {
 			centroid[i] = float32(i)
 		}
-		quantizedSet := quantizer.NewQuantizedVectorSet(
-			5, centroid).(*RaBitQuantizedVectorSet)
+		quantizedSet := quantizer.NewQuantizedVectorSet(5, centroid).(*RaBitQuantizedVectorSet)
 		require.Equal(t, centroid, quantizedSet.Centroid)
 		require.Equal(t, 0, quantizedSet.Codes.Count)
 		require.Equal(t, 2, quantizedSet.Codes.Width)
@@ -91,6 +91,8 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 		require.Equal(t, 5, cap(quantizedSet.CodeCounts))
 		require.Equal(t, 5, cap(quantizedSet.CentroidDistances))
 		require.Equal(t, 5, cap(quantizedSet.QuantizedDotProducts))
+		require.Equal(t, 5, cap(quantizedSet.CentroidDotProducts))
+		require.Equal(t, float64(299.07), scalar.Round(float64(quantizedSet.CentroidNorm), 2))
 	})
 }
 

--- a/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitq_test.go
@@ -83,7 +83,7 @@ func TestRaBitQuantizerSimple(t *testing.T) {
 		for i := range centroid {
 			centroid[i] = float32(i)
 		}
-		quantizedSet := quantizer.NewQuantizedVectorSet(5, centroid).(*RaBitQuantizedVectorSet)
+		quantizedSet := quantizer.NewSet(5, centroid).(*RaBitQuantizedVectorSet)
 		require.Equal(t, centroid, quantizedSet.Centroid)
 		require.Equal(t, 0, quantizedSet.Codes.Count)
 		require.Equal(t, 2, quantizedSet.Codes.Width)
@@ -198,7 +198,7 @@ func TestRaBitQuantizerInnerProduct(t *testing.T) {
 	require.Equal(t, []float32{1.41, 3.16, 2.83}, testutils.RoundFloats(errorBounds, 2))
 
 	// Call NewQuantizedSet and ensure capacity.
-	quantizedSet = quantizer.NewQuantizedVectorSet(
+	quantizedSet = quantizer.NewSet(
 		5, quantizedSet.Centroid).(*RaBitQuantizedVectorSet)
 	require.Equal(t, 5, cap(quantizedSet.CentroidDotProducts))
 
@@ -233,7 +233,7 @@ func TestRaBitQuantizerCosine(t *testing.T) {
 	// Call NewQuantizedSet and ensure capacity.
 	centroid := slices.Clone(quantizedSet.Centroid)
 	num32.Normalize(centroid)
-	quantizedSet = quantizer.NewQuantizedVectorSet(5, centroid).(*RaBitQuantizedVectorSet)
+	quantizedSet = quantizer.NewSet(5, centroid).(*RaBitQuantizedVectorSet)
 	require.Equal(t, 5, cap(quantizedSet.CentroidDotProducts))
 
 	// Add vectors to already-created set.

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
@@ -135,6 +135,7 @@ func (vs *RaBitQuantizedVectorSet) ReplaceWithLast(offset int) {
 // Clone implements the QuantizedVectorSet interface.
 func (vs *RaBitQuantizedVectorSet) Clone() QuantizedVectorSet {
 	return &RaBitQuantizedVectorSet{
+		Metric:               vs.Metric,
 		Centroid:             vs.Centroid, // Centroid is immutable
 		Codes:                vs.Codes.Clone(),
 		CodeCounts:           slices.Clone(vs.CodeCounts),
@@ -167,14 +168,16 @@ func (vs *RaBitQuantizedVectorSet) Clear(centroid vector.T) {
 	vs.CentroidDistances = vs.CentroidDistances[:0]
 	vs.QuantizedDotProducts = vs.QuantizedDotProducts[:0]
 	vs.CentroidDotProducts = vs.CentroidDotProducts[:0]
-	if &vs.Centroid[0] != &centroid[0] {
-		vs.CentroidNorm = num32.Norm(centroid)
+	if vs.Metric != vecpb.L2SquaredDistance {
+		if &vs.Centroid[0] != &centroid[0] {
+			vs.CentroidNorm = num32.Norm(centroid)
+		}
 	}
 }
 
 // AddUndefined adds the given number of quantized vectors to this set. The new
 // quantized vector information should be set to defined values before use.
-func (vs *RaBitQuantizedVectorSet) AddUndefined(count int, distanceMetric vecpb.DistanceMetric) {
+func (vs *RaBitQuantizedVectorSet) AddUndefined(count int) {
 	newCount := len(vs.CodeCounts) + count
 	vs.Codes.AddUndefined(count)
 	vs.CodeCounts = slices.Grow(vs.CodeCounts, count)
@@ -183,7 +186,7 @@ func (vs *RaBitQuantizedVectorSet) AddUndefined(count int, distanceMetric vecpb.
 	vs.CentroidDistances = vs.CentroidDistances[:newCount]
 	vs.QuantizedDotProducts = slices.Grow(vs.QuantizedDotProducts, count)
 	vs.QuantizedDotProducts = vs.QuantizedDotProducts[:newCount]
-	if distanceMetric != vecpb.L2SquaredDistance {
+	if vs.Metric != vecpb.L2SquaredDistance {
 		// L2Squared doesn't need this.
 		vs.CentroidDotProducts = slices.Grow(vs.CentroidDotProducts, count)
 		vs.CentroidDotProducts = vs.CentroidDotProducts[:newCount]

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
+	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/errors"
 )
@@ -140,6 +141,7 @@ func (vs *RaBitQuantizedVectorSet) Clone() QuantizedVectorSet {
 		CentroidDistances:    slices.Clone(vs.CentroidDistances),
 		QuantizedDotProducts: slices.Clone(vs.QuantizedDotProducts),
 		CentroidDotProducts:  slices.Clone(vs.CentroidDotProducts),
+		CentroidNorm:         vs.CentroidNorm,
 	}
 }
 
@@ -165,6 +167,9 @@ func (vs *RaBitQuantizedVectorSet) Clear(centroid vector.T) {
 	vs.CentroidDistances = vs.CentroidDistances[:0]
 	vs.QuantizedDotProducts = vs.QuantizedDotProducts[:0]
 	vs.CentroidDotProducts = vs.CentroidDotProducts[:0]
+	if &vs.Centroid[0] != &centroid[0] {
+		vs.CentroidNorm = num32.Norm(centroid)
+	}
 }
 
 // AddUndefined adds the given number of quantized vectors to this set. The new

--- a/pkg/sql/vecindex/cspann/quantize/rabitqpb_test.go
+++ b/pkg/sql/vecindex/cspann/quantize/rabitqpb_test.go
@@ -62,10 +62,11 @@ func TestRaBitCodeSet(t *testing.T) {
 
 func TestRaBitQuantizedVectorSet(t *testing.T) {
 	var quantizedSet RaBitQuantizedVectorSet
+	quantizedSet.Metric = vecpb.L2SquaredDistance
 	quantizedSet.Centroid = []float32{1, 2, 3}
 	quantizedSet.Codes.Width = 3
 
-	quantizedSet.AddUndefined(5, vecpb.L2SquaredDistance)
+	quantizedSet.AddUndefined(5)
 	copy(quantizedSet.Codes.At(4), []uint64{1, 2, 3})
 	quantizedSet.CodeCounts[4] = 15
 	quantizedSet.CentroidDistances[4] = 1.23
@@ -107,7 +108,8 @@ func TestRaBitQuantizedVectorSet(t *testing.T) {
 	// Test InnerProduct distance metric, which uses the CentroidDotProducts
 	// field (L2Squared does not use it).
 	quantizedSet.Clear(quantizedSet.Centroid)
-	quantizedSet.AddUndefined(2, vecpb.InnerProductDistance)
+	quantizedSet.Metric = vecpb.InnerProductDistance
+	quantizedSet.AddUndefined(2)
 	copy(quantizedSet.Codes.At(1), []uint64{1, 2, 3})
 	quantizedSet.CodeCounts[1] = 15
 	quantizedSet.CentroidDistances[1] = 1.23

--- a/pkg/sql/vecindex/cspann/quantize/testdata/estimate-distances.ddt
+++ b/pkg/sql/vecindex/cspann/quantize/testdata/estimate-distances.ddt
@@ -103,7 +103,28 @@ Cosine
   (-1, 0): exact is 2, estimate is 2 ± 0.7071
   (1, 0): exact is 0, estimate is 0 ± 0.7071
 
-# Query vector is equal to the centroid.
+# Query vector is equal to the centroid at the origin.
+estimate-distances query=[0,0]
+[-2,0]
+[2,0]
+----
+L2Squared
+  Query = (0, 0)
+  Centroid = (0, 0)
+  (-2, 0): exact is 4, estimate is 4
+  (2, 0): exact is 4, estimate is 4
+InnerProduct
+  Query = (0, 0)
+  Centroid = (0, 0)
+  (-2, 0): exact is 0, estimate is 0
+  (2, 0): exact is 0, estimate is 0
+Cosine
+  Query = (0, 0)
+  Centroid = (0, 0)
+  (-1, 0): exact is 1, estimate is 1
+  (1, 0): exact is 1, estimate is 1
+
+# Query vector is equal to the centroid at a non-origin point.
 estimate-distances query=[2,2]
 [0,2]
 [4,2]

--- a/pkg/sql/vecindex/cspann/quantize/testdata/get-centroid-distances.ddt
+++ b/pkg/sql/vecindex/cspann/quantize/testdata/get-centroid-distances.ddt
@@ -1,0 +1,54 @@
+# Centroid is at [0,0].
+get-centroid-distances dims=2
+[-2,0]
+[2,0]
+----
+L2Squared
+  Centroid = (0, 0)
+  Mean Centroid Distances = (4, 4)
+  Spherical Centroid Distances = (4, 4)
+InnerProduct
+  Centroid = (0, 0)
+  Mean Centroid Distances = (0, 0)
+  Spherical Centroid Distances = (0, 0)
+Cosine
+  Centroid = (0, 0)
+  Mean Centroid Distances = (1, 1)
+  Spherical Centroid Distances = (1, 1)
+
+# Centroid is at [0,2].
+get-centroid-distances dims=2
+[-2,2]
+[2,2]
+----
+L2Squared
+  Centroid = (0, 2)
+  Mean Centroid Distances = (4, 4)
+  Spherical Centroid Distances = (4, 4)
+InnerProduct
+  Centroid = (0, 2)
+  Mean Centroid Distances = (-4, -4)
+  Spherical Centroid Distances = (-2, -2)
+Cosine
+  Centroid = (0, 0.7071)
+  Mean Centroid Distances = (0.2929, 0.2929)
+  Spherical Centroid Distances = (0.2929, 0.2929)
+
+# Centroid is at [3,4].
+get-centroid-distances dims=2
+[2,6]
+[4,3]
+[3,3]
+----
+L2Squared
+  Centroid = (3, 4)
+  Mean Centroid Distances = (5, 2, 1)
+  Spherical Centroid Distances = (5, 2, 1)
+InnerProduct
+  Centroid = (3, 4)
+  Mean Centroid Distances = (-30, -24, -21)
+  Spherical Centroid Distances = (-6, -4.8, -4.2)
+Cosine
+  Centroid = (0.6078, 0.7519)
+  Mean Centroid Distances = (0.0634, 0.0305, 0.0056)
+  Spherical Centroid Distances = (0.0634, 0.0305, 0.0056)

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer.go
@@ -69,8 +69,8 @@ func (q *UnQuantizer) QuantizeInSet(
 	unquantizedSet.AddSet(vectors)
 }
 
-// NewQuantizedVectorSet implements the Quantizer interface
-func (q *UnQuantizer) NewQuantizedVectorSet(capacity int, centroid vector.T) QuantizedVectorSet {
+// NewSet implements the Quantizer interface
+func (q *UnQuantizer) NewSet(capacity int, centroid vector.T) QuantizedVectorSet {
 	dataBuffer := make([]float32, 0, capacity*q.GetDims())
 	unquantizedSet := &UnQuantizedVectorSet{
 		Vectors: vector.MakeSetFromRawData(dataBuffer, q.GetDims()),

--- a/pkg/sql/vecindex/cspann/quantize/unquantizer.go
+++ b/pkg/sql/vecindex/cspann/quantize/unquantizer.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/num32"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
+	"github.com/cockroachdb/errors"
 )
 
 // UnQuantizer trivially implements the Quantizer interface, storing the
@@ -98,4 +99,12 @@ func (q *UnQuantizer) EstimateDistances(
 
 	// Distances are exact, so error bounds are always zero.
 	num32.Zero(errorBounds)
+}
+
+// GetCentroidDistances implements the Quantizer interface.
+func (q *UnQuantizer) GetCentroidDistances(
+	quantizedSet QuantizedVectorSet, distances []float32, spherical bool,
+) {
+	// This method is never called by the vector index.
+	panic(errors.AssertionFailedf("GetCentroidDistances is not implemented by the Unquantizer"))
 }

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -118,7 +118,7 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 
 		switch quantizedSet.(type) {
 		case *quantize.UnQuantizedVectorSet:
-			decodedSet = quantizer.NewQuantizedVectorSet(set.Count, decodedMetadata.Centroid)
+			decodedSet = quantizer.NewSet(set.Count, decodedMetadata.Centroid)
 			for range set.Count {
 				remainder, err = vecencoding.DecodeUnquantizerVectorToSet(
 					remainder, decodedSet.(*quantize.UnQuantizedVectorSet),
@@ -128,7 +128,7 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 			// Verify remaining bytes match trailing data
 			require.Equal(t, trailingData, testutils.NormalizeSlice(remainder))
 		case *quantize.RaBitQuantizedVectorSet:
-			decodedSet = quantizer.NewQuantizedVectorSet(set.Count, decodedMetadata.Centroid)
+			decodedSet = quantizer.NewSet(set.Count, decodedMetadata.Centroid)
 			for range set.Count {
 				remainder, err = vecencoding.DecodeRaBitQVectorToSet(
 					remainder,

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -94,15 +94,7 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 				buf, err = vecencoding.EncodeUnquantizerVector(buf, set.At(i))
 				require.NoError(t, err)
 			case *quantize.RaBitQuantizedVectorSet:
-				var centroidDotProduct float32
-				if distMetric != vecpb.L2SquaredDistance {
-					centroidDotProduct = quantizedSet.CentroidDotProducts[i]
-				}
-				buf = vecencoding.EncodeRaBitQVector(buf,
-					quantizedSet.CodeCounts[i], quantizedSet.CentroidDistances[i],
-					quantizedSet.QuantizedDotProducts[i], centroidDotProduct,
-					quantizedSet.Codes.At(i), distMetric,
-				)
+				buf = vecencoding.EncodeRaBitQVectorFromSet(buf, quantizedSet, i)
 			}
 		}
 
@@ -131,9 +123,7 @@ func testEncodeDecodeRoundTripImpl(t *testing.T, rnd *rand.Rand, set vector.Set)
 			decodedSet = quantizer.NewSet(set.Count, decodedMetadata.Centroid)
 			for range set.Count {
 				remainder, err = vecencoding.DecodeRaBitQVectorToSet(
-					remainder,
-					decodedSet.(*quantize.RaBitQuantizedVectorSet),
-					distMetric,
+					remainder, decodedSet.(*quantize.RaBitQuantizedVectorSet),
 				)
 				require.NoError(t, err)
 			}
@@ -188,6 +178,7 @@ func testingAssertPartitionsEqual(t *testing.T, l, r *cspann.Partition) {
 	case *quantize.RaBitQuantizedVectorSet:
 		rightSet, ok := q2.(*quantize.RaBitQuantizedVectorSet)
 		require.True(t, ok, "quantized set types do not match")
+		require.Equal(t, leftSet.Metric, rightSet.Metric)
 		require.Equal(t, leftSet.CodeCounts, rightSet.CodeCounts, "code counts do not match")
 		require.Equal(t, leftSet.Codes, rightSet.Codes, "codes do not match")
 		require.Equal(t, leftSet.QuantizedDotProducts, rightSet.QuantizedDotProducts,

--- a/pkg/sql/vecindex/vecstore/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/BUILD.bazel
@@ -28,7 +28,6 @@ go_library(
         "//pkg/sql/vecindex/cspann/quantize",
         "//pkg/sql/vecindex/cspann/workspace",
         "//pkg/sql/vecindex/vecencoding",
-        "//pkg/sql/vecindex/vecpb",
         "//pkg/util/log",
         "//pkg/util/unique",
         "//pkg/util/vector",

--- a/pkg/sql/vecindex/vecstore/codec.go
+++ b/pkg/sql/vecindex/vecstore/codec.go
@@ -34,7 +34,7 @@ func makeStoreCodec(quantizer quantize.Quantizer) storeCodec {
 // possible.
 func (sc *storeCodec) Init(centroid vector.T, minCapacity int) {
 	if sc.tmpVectorSet == nil {
-		sc.tmpVectorSet = sc.quantizer.NewQuantizedVectorSet(minCapacity, centroid)
+		sc.tmpVectorSet = sc.quantizer.NewSet(minCapacity, centroid)
 	} else {
 		sc.tmpVectorSet.Clear(centroid)
 	}

--- a/pkg/sql/vecindex/vecstore/codec.go
+++ b/pkg/sql/vecindex/vecstore/codec.go
@@ -10,7 +10,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/quantize"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/cspann/workspace"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecencoding"
-	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/vector"
 	"github.com/cockroachdb/errors"
 )
@@ -56,9 +55,7 @@ func (sc *storeCodec) DecodeVector(encodedVector []byte) ([]byte, error) {
 			encodedVector, sc.tmpVectorSet.(*quantize.UnQuantizedVectorSet))
 	case *quantize.RaBitQuantizer:
 		return vecencoding.DecodeRaBitQVectorToSet(
-			encodedVector,
-			sc.tmpVectorSet.(*quantize.RaBitQuantizedVectorSet),
-			sc.quantizer.GetDistanceMetric(),
+			encodedVector, sc.tmpVectorSet.(*quantize.RaBitQuantizedVectorSet),
 		)
 	}
 	return nil, errors.Errorf("unknown quantizer type %T", sc.quantizer)
@@ -75,21 +72,7 @@ func (sc *storeCodec) EncodeVector(w *workspace.T, v vector.T, centroid vector.T
 	case *quantize.UnQuantizedVectorSet:
 		return vecencoding.EncodeUnquantizerVector([]byte{}, t.Vectors.At(0))
 	case *quantize.RaBitQuantizedVectorSet:
-		metric := sc.quantizer.GetDistanceMetric()
-		var centroidDotProduct float32
-		if metric != vecpb.L2SquaredDistance {
-			// CentroidDotProducts is only defined for non-L2 distance metrics.
-			centroidDotProduct = t.CentroidDotProducts[0]
-		}
-		return vecencoding.EncodeRaBitQVector(
-			[]byte{},
-			t.CodeCounts[0],
-			t.CentroidDistances[0],
-			t.QuantizedDotProducts[0],
-			centroidDotProduct,
-			t.Codes.At(0),
-			metric,
-		), nil
+		return vecencoding.EncodeRaBitQVectorFromSet([]byte{}, t, 0), nil
 	default:
 		return nil, errors.Errorf("unknown quantizer type %T", t)
 	}


### PR DESCRIPTION
#### quantize: track distance metric in RaBitQuantizedSet

Include the distance metric in RaBitQuantizedSet, since its needed for
methods like Clear and AddUndefined. Also, clean up the encoding methods
for RaBitQVector a bit.

#### quantize: rename NewQuantizedVectorSet to NewSet

Rename the NewQuantizedVectorSet method on the Quantizer interface to
NewSet. "QuantizedVector" is already implied by context and consistent
with other methdods like "QuantizeInSet".

#### quantize: add GetCentroidDistances method to Quantizer interface

GetCentroidDistances returns the exact distance of each vector in a quantized
set to the centroid of that set, according to the quantizer's distance metric
(e.g. L2Squared or Cosine). It also supports distance to the spherical centroid
for Cosine and InnerProduct metrics. This method will be used in a later PR by
the partition split code.