### PR TITLE
release-25.2: pkg/roachpb: implement SafeFormat for additional types

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4770,7 +4770,7 @@ func TestDistSenderSlowLogMessage(t *testing.T) {
 	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x"), EndKey: roachpb.RKey("z")}
 	{
 		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) [‹"a"›] to` +
-			` r9:‹{x-z}› [<no replicas>, next=0, gen=0]; resp: ‹(err: boom)›`
+			` r9:{‹x›-‹z›} [<no replicas>, next=0, gen=0]; resp: ‹(err: boom)›`
 		var s redact.StringBuilder
 		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, nil /* err */, br)
 		act := s.RedactableString()

--- a/pkg/kv/kvpb/errors_test.go
+++ b/pkg/kv/kvpb/errors_test.go
@@ -284,7 +284,7 @@ func TestErrorRedaction(t *testing.T) {
 		},
 		{
 			err:    &BatchTimestampBeforeGCError{},
-			expect: "batch timestamp 0,0 must be after replica GC threshold 0,0 (r0: ‹/Min›)",
+			expect: "batch timestamp 0,0 must be after replica GC threshold 0,0 (r0: /Min)",
 		},
 		{
 			err:    &TxnAlreadyEncounteredErrorError{},
@@ -324,7 +324,7 @@ func TestErrorRedaction(t *testing.T) {
 		},
 		{
 			err:    &MVCCHistoryMutationError{},
-			expect: "unexpected MVCC history mutation in span ‹/Min›",
+			expect: "unexpected MVCC history mutation in span /Min",
 		},
 		{
 			err:    &UnhandledRetryableError{},

--- a/pkg/kv/kvpb/testdata/replica_unavailable_error.txt
+++ b/pkg/kv/kvpb/testdata/replica_unavailable_error.txt
@@ -1,4 +1,4 @@
 echo
 ----
 replica unavailable: (n1,s2):3 unable to serve request to r123:/M{in-ax} [(n1,s2):1, next=2, gen=0]: slow proposal
-replica unavailable: (n1,s2):3 unable to serve request to r123:‹/M{in-ax}› [(n1,s2):1, next=2, gen=0]: slow proposal
+replica unavailable: (n1,s2):3 unable to serve request to r123:/M{in-ax} [(n1,s2):1, next=2, gen=0]: slow proposal

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/barrier
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/barrier
@@ -53,7 +53,7 @@ sequence req=barrier2
 ----
 [2] sequence barrier2: sequencing request
 [2] sequence barrier2: waiting on latches without acquiring
-[2] sequence barrier2: waiting to acquire write latch ‹{a-f}›@0,0 for request Barrier [‹"a"›,‹"f"›), held by read latch ‹c›@15.000000000,1 for request Get [‹"c"›]
+[2] sequence barrier2: waiting to acquire write latch {‹a›-‹f›}@0,0 for request Barrier [‹"a"›,‹"f"›), held by read latch ‹c›@15.000000000,1 for request Get [‹"c"›]
 [2] sequence barrier2: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=read1
@@ -96,7 +96,7 @@ sequence req=barrier1
 ----
 [2] sequence barrier1: sequencing request
 [2] sequence barrier1: waiting on latches without acquiring
-[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0 for request Barrier [‹"a"›,‹"f"›), held by read latch ‹c›@10.000000000,1 for request Get [‹"c"›]
+[2] sequence barrier1: waiting to acquire write latch {‹a›-‹f›}@0,0 for request Barrier [‹"a"›,‹"f"›), held by read latch ‹c›@10.000000000,1 for request Get [‹"c"›]
 [2] sequence barrier1: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=read1
@@ -143,7 +143,7 @@ sequence req=barrier1
 ----
 [2] sequence barrier1: sequencing request
 [2] sequence barrier1: waiting on latches without acquiring
-[2] sequence barrier1: waiting to acquire write latch ‹{a-f}›@0,0 for request Barrier [‹"a"›,‹"f"›), held by write latch ‹c›@10.000000000,1 for request Put [‹"c"›], [txn: 00000001]
+[2] sequence barrier1: waiting to acquire write latch {‹a›-‹f›}@0,0 for request Barrier [‹"a"›,‹"f"›), held by write latch ‹c›@10.000000000,1 for request Put [‹"c"›], [txn: 00000001]
 [2] sequence barrier1: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/basic
@@ -143,7 +143,7 @@ sequence req=req4
 ----
 [3] sequence req4: sequencing request
 [3] sequence req4: acquiring latches
-[3] sequence req4: waiting to acquire write latch ‹k›@10.000000000,1 for request Put [‹"k"›], [txn: 00000001], held by read latch ‹k{-2}›@14.000000000,1 for request Get [‹"k"›], Scan [‹"k"›,‹"k2"›), [txn: 00000003]
+[3] sequence req4: waiting to acquire write latch ‹k›@10.000000000,1 for request Put [‹"k"›], [txn: 00000001], held by read latch ‹k›{-‹2›}@14.000000000,1 for request Get [‹"k"›], Scan [‹"k"›,‹"k2"›), [txn: 00000003]
 [3] sequence req4: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-latch-manager
@@ -251,13 +251,13 @@ sequence req=req7
 ----
 [4] sequence req7: sequencing request
 [4] sequence req7: acquiring latches
-[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1 for request Put [‹"k"›], held by read latch ‹{a-m}›@14.000000000,1 for request Scan [‹"a"›,‹"m"›)
+[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1 for request Put [‹"k"›], held by read latch {‹a›-‹m›}@14.000000000,1 for request Scan [‹"a"›,‹"m"›)
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req5
 ----
 [-] finish req5: finishing request
-[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1 for request Put [‹"k"›], held by read latch ‹{c-z}›@16.000000000,1 for request Scan [‹"c"›,‹"z"›)
+[4] sequence req7: waiting to acquire write latch ‹k›@12.000000000,1 for request Put [‹"k"›], held by read latch {‹c›-‹z›}@16.000000000,1 for request Scan [‹"c"›,‹"z"›)
 [4] sequence req7: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=req6

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/optimistic
@@ -172,7 +172,7 @@ sequence req=req6 eval-kind=pess-after-opt
 ----
 [8] sequence req6: re-sequencing request after optimistic sequencing failed
 [8] sequence req6: optimistic failed, so waiting for latches
-[8] sequence req6: waiting to acquire read latch ‹{a-e}›@12.000000000,1 for request Scan [‹"a"›,‹"e"›), [txn: 00000002], held by write latch ‹d›@10.000000000,1 for request Put [‹"d"›], [txn: 00000003]
+[8] sequence req6: waiting to acquire read latch {‹a›-‹e›}@12.000000000,1 for request Scan [‹"a"›,‹"e"›), [txn: 00000002], held by write latch ‹d›@10.000000000,1 for request Put [‹"d"›], [txn: 00000003]
 [8] sequence req6: blocked on select in spanlatch.(*Manager).waitForSignal
 
 debug-advance-clock ts=123

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err
@@ -27,7 +27,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
+[2] sequence readbf: waiting to acquire read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -38,7 +38,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err_indirect
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_err_indirect
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
+[2] sequence readbf: waiting to acquire read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -37,7 +37,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc
@@ -45,7 +45,7 @@ poison req=putc
 [-] poison putc: poisoning request
 [2] sequence readbf: encountered poisoned latch; continuing to wait
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
-[3] sequence pute: sequencing complete, returned error: encountered poisoned latch ‹{b-f}›@11.000000000,1
+[3] sequence pute: sequencing complete, returned error: encountered poisoned latch {‹b›-‹f›}@11.000000000,1
 
 finish req=putc
 ----

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_disjoint
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_disjoint
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
+[2] sequence readbf: waiting to acquire read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0 poison-policy=wait
@@ -37,7 +37,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 poison req=putc

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_overlapping
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/poison_policy_wait_overlapping
@@ -26,7 +26,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
+[2] sequence readbf: waiting to acquire read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=put2 ts=11,0 poison-policy=wait

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks_latches
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/shared_locks_latches
@@ -696,7 +696,7 @@ sequence req=req36
 ----
 [36] sequence req36: sequencing request
 [36] sequence req36: acquiring latches
-[36] sequence req36: waiting to acquire write latch ‹/Local/RangeID/1/r/ReplicatedSharedLocksTransactionLatch/"00000002-0000-0000-0000-000000000000"›@0,0 for request Scan(Shared,Replicated) [‹"a"›,‹"f"›), [txn: 00000002], held by write latch ‹/Local/RangeID/1/r/ReplicatedSharedLocksTransactionLatch/"00000002-0000-0000-0000-000000000000"›@0,0 for request Get(Shared,Replicated) [‹"c"›], [txn: 00000002]
+[36] sequence req36: waiting to acquire write latch /Local/RangeID‹/1›/‹r›/‹ReplicatedSharedLocksTransactionLatch›/"00000002-0000-0000-0000-000000000000"@0,0 for request Scan(Shared,Replicated) [‹"a"›,‹"f"›), [txn: 00000002], held by write latch /Local/RangeID‹/1›/‹r›/‹ReplicatedSharedLocksTransactionLatch›/"00000002-0000-0000-0000-000000000000"@0,0 for request Get(Shared,Replicated) [‹"c"›], [txn: 00000002]
 [36] sequence req36: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request name=req37 txn=txn1 ts=11,1

--- a/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/slow_latch_observability
+++ b/pkg/kv/kvserver/concurrency/testdata/concurrency_manager/slow_latch_observability
@@ -28,7 +28,7 @@ sequence req=readbf
 ----
 [2] sequence readbf: sequencing request
 [2] sequence readbf: acquiring latches
-[2] sequence readbf: waiting to acquire read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
+[2] sequence readbf: waiting to acquire read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›), held by write latch ‹c›@10.000000000,0 for request Put [‹"c"›]
 [2] sequence readbf: blocked on select in spanlatch.(*Manager).waitForSignal
 
 new-request txn=none name=pute ts=11,0
@@ -39,7 +39,7 @@ sequence req=pute
 ----
 [3] sequence pute: sequencing request
 [3] sequence pute: acquiring latches
-[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch ‹{b-f}›@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
+[3] sequence pute: waiting to acquire write latch ‹e›@11.000000000,0 for request Put [‹"e"›], held by read latch {‹b›-‹f›}@11.000000000,1 for request Scan [‹"b"›,‹"f"›)
 [3] sequence pute: blocked on select in spanlatch.(*Manager).waitForSignal
 
 finish req=putc

--- a/pkg/kv/kvserver/spanlatch/manager_test.go
+++ b/pkg/kv/kvserver/spanlatch/manager_test.go
@@ -782,6 +782,6 @@ func TestLatchStringAndSafeformat(t *testing.T) {
 		prev: nil,
 	}
 	require.EqualValues(t, `00011{-\x00}@0.000000010,0 for request Get ["a"]`, la.String())
-	require.EqualValues(t, `‹00011{-\x00}›@0.000000010,0 for request Get [‹"a"›]`, redact.Sprint(la))
-	require.EqualValues(t, `‹×›@0.000000010,0 for request Get [‹×›]`, redact.Sprint(la).Redact())
+	require.EqualValues(t, `‹00011›{-‹\x00›}@0.000000010,0 for request Get [‹"a"›]`, redact.Sprint(la))
+	require.EqualValues(t, `‹×›{-‹×›}@0.000000010,0 for request Get [‹×›]`, redact.Sprint(la).Redact())
 }

--- a/pkg/kv/kvserver/store_rebalancer_test.go
+++ b/pkg/kv/kvserver/store_rebalancer_test.go
@@ -1831,9 +1831,9 @@ func TestStoreRebalancerHotRangesLogging(t *testing.T) {
 
 	hottestRanges := rr.TopLoad(objectiveProvider.Objective().ToDimension())
 	require.Equal(t, redact.RedactableString(
-		"\t1: r3:‹/Meta1› replicas=[(n1,s1):1,(n2,s2):2,(n3,s3):3] load=[batches/s=300.0 request_cpu/s=300ms raft_cpu/s=0µs write(keys)/s=0.0 write(bytes)/s=0 B read(keys)/s=0.0 read(bytes)/s=0 B]"+
-			"\n\t2: r2:‹/Meta1› replicas=[(n2,s2):2,(n4,s4):4,(n6,s6):6] load=[batches/s=200.0 request_cpu/s=200ms raft_cpu/s=0µs write(keys)/s=0.0 write(bytes)/s=0 B read(keys)/s=0.0 read(bytes)/s=0 B]"+
-			"\n\t3: r1:‹/Meta1› replicas=[(n1,s1):1,(n3,s3):3,(n5,s5):5] load=[batches/s=100.0 request_cpu/s=100ms raft_cpu/s=0µs write(keys)/s=0.0 write(bytes)/s=0 B read(keys)/s=0.0 read(bytes)/s=0 B]",
+		"\t1: r3:/Meta1 replicas=[(n1,s1):1,(n2,s2):2,(n3,s3):3] load=[batches/s=300.0 request_cpu/s=300ms raft_cpu/s=0µs write(keys)/s=0.0 write(bytes)/s=0 B read(keys)/s=0.0 read(bytes)/s=0 B]"+
+			"\n\t2: r2:/Meta1 replicas=[(n2,s2):2,(n4,s4):4,(n6,s6):6] load=[batches/s=200.0 request_cpu/s=200ms raft_cpu/s=0µs write(keys)/s=0.0 write(bytes)/s=0 B read(keys)/s=0.0 read(bytes)/s=0 B]"+
+			"\n\t3: r1:/Meta1 replicas=[(n1,s1):1,(n3,s3):3,(n5,s5):5] load=[batches/s=100.0 request_cpu/s=100ms raft_cpu/s=0µs write(keys)/s=0.0 write(bytes)/s=0 B read(keys)/s=0.0 read(bytes)/s=0 B]",
 	), formatHotRanges(hottestRanges))
 }
 

--- a/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
+++ b/pkg/kv/kvserver/testdata/replica_unavailable_error.txt
@@ -1,3 +1,3 @@
 echo
 ----
-replica unavailable: (n1,s10):1 unable to serve request to r10:‹{a-z}› [(n1,s10):1, (n2,s20):2, next=3, gen=0]: lost quorum (down: (n2,s20):2); closed timestamp: 1136214245.000000000,0 (2006-01-02 15:04:05); raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","leadEpoch":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: probe failed
+replica unavailable: (n1,s10):1 unable to serve request to r10:{‹a›-‹z›} [(n1,s10):1, (n2,s20):2, next=3, gen=0]: lost quorum (down: (n2,s20):2); closed timestamp: 1136214245.000000000,0 (2006-01-02 15:04:05); raft status: {"id":"0","term":0,"vote":"0","commit":0,"lead":"0","leadEpoch":"0","raftState":"StateFollower","applied":0,"progress":{},"leadtransferee":"0"}: probe failed

--- a/pkg/roachpb/data.go
+++ b/pkg/roachpb/data.go
@@ -289,7 +289,17 @@ const (
 	extendedPreludeSize    = extendedMVCCValLenSize + 1
 )
 
-var _ redact.SafeFormatter = ValueType(0)
+var _ redact.SafeFormatter = new(ValueType)
+var _ redact.SafeFormatter = new(LockStateInfo)
+var _ redact.SafeFormatter = new(RKey)
+var _ redact.SafeFormatter = new(Key)
+var _ redact.SafeFormatter = new(StoreProperties)
+var _ redact.SafeFormatter = new(Transaction)
+var _ redact.SafeFormatter = new(ChangeReplicasTrigger)
+var _ redact.SafeFormatter = new(Lease)
+var _ redact.SafeFormatter = new(Span)
+var _ redact.SafeFormatter = new(RSpan)
+var _ redact.SafeFormatter = new(LockAcquisition)
 
 // Safeformat implements the redact.SafeFormatter interface.
 func (t ValueType) SafeFormat(w redact.SafePrinter, _ rune) {
@@ -2377,6 +2387,11 @@ func (m *LockAcquisition) Empty() bool {
 	return m.Span.Equal(Span{})
 }
 
+func (m LockAcquisition) SafeFormat(w redact.SafePrinter, _ rune) {
+	w.Printf("{span=%v %v durability=%v strength=%v ignored=%v}",
+		m.Span, m.Txn, m.Durability, m.Strength, m.IgnoredSeqNums)
+}
+
 // MakeLockUpdate makes a lock update from the given txn and span.
 //
 // See also txn.LocksAsLockUpdates().
@@ -2600,8 +2615,13 @@ func (s Span) AsRange() interval.Range {
 }
 
 func (s Span) String() string {
+	return redact.StringWithoutMarkers(s)
+}
+
+// SafeFormat implements the redact.SafeFormatter interface.
+func (s Span) SafeFormat(w redact.SafePrinter, _ rune) {
 	const maxChars = math.MaxInt32
-	return PrettyPrintRange(s.Key, s.EndKey, maxChars).StripMarkers()
+	w.Print(PrettyPrintRange(s.Key, s.EndKey, maxChars))
 }
 
 // SplitOnKey returns two spans where the left span has EndKey and right span
@@ -2797,8 +2817,12 @@ func (rs RSpan) ContainsKeyRange(start, end RKey) bool {
 }
 
 func (rs RSpan) String() string {
+	return redact.StringWithoutMarkers(rs)
+}
+
+func (rs RSpan) SafeFormat(w redact.SafePrinter, r rune) {
 	const maxChars = math.MaxInt32
-	return PrettyPrintRange(Key(rs.Key), Key(rs.EndKey), maxChars).StripMarkers()
+	w.Print(PrettyPrintRange(Key(rs.Key), Key(rs.EndKey), maxChars))
 }
 
 // Intersect returns the intersection of the current span and the

--- a/pkg/roachpb/string_test.go
+++ b/pkg/roachpb/string_test.go
@@ -70,7 +70,7 @@ func TestRangeDescriptorStringRedact(t *testing.T) {
 	}
 
 	require.EqualValues(t,
-		`r1:‹{c-g}› [(n1,s1):?, (n2,s2):?, (n3,s3):?, next=0, gen=0]`,
+		`r1:{‹c›-‹g›} [(n1,s1):?, (n2,s2):?, (n3,s3):?, next=0, gen=0]`,
 		redact.Sprint(desc),
 	)
 }

--- a/pkg/storage/testdata/mvcc_histories/ambiguous_writes
+++ b/pkg/storage/testdata/mvcc_histories/ambiguous_writes
@@ -16,7 +16,7 @@ with t=A k=a
   put v=first
 ----
 >> put v=first t=A k=a
-put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+89
 >> at end:
 txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
@@ -55,7 +55,7 @@ with t=B k=k
   initput k=k ts=0,1 v=k1 ambiguousReplay
 ----
 >> initput k=k ts=0,1 v=k1 ambiguousReplay t=B k=k
-initput: lock acquisition = {k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 Replicated Intent []}
+initput: lock acquisition = {span=k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 live_count=+1 live_bytes=+64 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+100
 >> at end:
 txn: "B" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
@@ -82,7 +82,7 @@ with t=C k=k
   cput v=k2 cond=k1
 ----
 >> cput v=k2 cond=k1 t=C k=k
-cput: lock acquisition = {k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0 Replicated Intent []}
+cput: lock acquisition = {span=k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+50 live_bytes=+43 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+100
 >> at end:
 txn: "C" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,2 min=0,0 seq=0} lock=true stat=PENDING rts=0,2 wto=false gul=0,0
@@ -124,7 +124,7 @@ with t=D k=k
   put v=k3
 ----
 >> put v=k3 t=D k=k
-put: lock acquisition = {k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+51 gc_bytes_age=+1843 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+97
 >> at end:
 txn: "D" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
@@ -175,7 +175,7 @@ with t=E k=k
 ----
 >> del resolve t=E k=k
 del: "k": found key true
-del: lock acquisition = {k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "k" -> resolved key = true
 stats: key_bytes=+12 val_count=+1 live_count=-1 live_bytes=-21 gc_bytes_age=+3168
 >> at end:
@@ -217,7 +217,7 @@ with t=F k=k
   put v=k5
 ----
 >> put v=k5 t=F k=k
-put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+95
 >> at end:
 txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
@@ -238,7 +238,7 @@ with t=F k=k
 ----
 >> del ambiguousReplay t=F k=k
 del: "k": found key true
-del: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1 Replicated Intent []}
+del: lock acquisition = {span=k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+6 live_count=-1 live_bytes=-72 gc_bytes_age=+7410 intent_bytes=-7
 >> at end:
 txn: "F" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
@@ -322,7 +322,7 @@ with t=G k=k
   del_range k=a end=z returnKeys
 ----
 >> del_range k=a end=z returnKeys t=G k=k
-del_range: lock acquisitions = [{a id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0 Replicated Intent []} {k id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0 Replicated Intent []}]
+del_range: lock acquisitions = [{span=a id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]} {span=k id=00000007 key="k" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,1 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}]
 del_range: "a"-"z" -> deleted 2 key(s)
 del_range: returned "a"
 del_range: returned "k"

--- a/pkg/storage/testdata/mvcc_histories/clear_range
+++ b/pkg/storage/testdata/mvcc_histories/clear_range
@@ -9,15 +9,15 @@ with t=A v=abc resolve
   put  k=c
 put k=i v=inline
 ----
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a" -> resolved key = true
-put: lock acquisition = {a/123 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a/123 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a/123" -> resolved key = true
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "b" -> resolved key = true
-put: lock acquisition = {b/123 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b/123 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "b/123" -> resolved key = true
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "c" -> resolved key = true
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/conditional_put_with_txn_enable_separated
@@ -12,7 +12,7 @@ with t=A
   cput k=k v=v
 ----
 >> cput k=k v=v t=A
-cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1 Replicated Intent []}
+cput: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+58 live_count=+1 live_bytes=+72 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=-23
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
@@ -29,7 +29,7 @@ with t=A
   cput k=k v=v2 cond=v
 ----
 >> cput k=k v=v2 cond=v t=A
-cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2 Replicated Intent []}
+cput: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+11 live_bytes=+11 intent_bytes=+1
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=123.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
@@ -46,7 +46,7 @@ with t=A
   cput k=k v=v3
 ----
 >> cput k=k v=v3 t=A
-cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1 Replicated Intent []}
+cput: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-10 live_bytes=-10
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=123.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=123.000000000,0 wto=false gul=0,0
@@ -103,7 +103,7 @@ with t=A
 >> put k=c v=value ts=1
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+10 live_count=+1 live_bytes=+24
 >> cput k=c v=cput cond=value t=A
-cput: lock acquisition = {c id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1 Replicated Intent []}
+cput: lock acquisition = {span=c id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+49 gc_bytes_age=+2156 intent_count=+1 intent_bytes=+21 lock_count=+1 lock_age=+98
 >> at end:
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
@@ -125,7 +125,7 @@ txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.0
 >> txn_step t=A
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 >> cput k=c v=cput cond=value t=A
-cput: lock acquisition = {c id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
+cput: lock acquisition = {span=c id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 meta: "c"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=9 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "c"/3.000000000,0 -> /BYTES/cput
 data: "c"/1.000000000,0 -> /BYTES/value

--- a/pkg/storage/testdata/mvcc_histories/delete_range
+++ b/pkg/storage/testdata/mvcc_histories/delete_range
@@ -56,7 +56,7 @@ with t=A
   txn_remove
 ----
 >> del_range k=b end=c returnKeys t=A
-del_range: lock acquisitions = [{b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=46.000000000,0 min=0,0 seq=0 Replicated Intent []} {b/123 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=46.000000000,0 min=0,0 seq=0 Replicated Intent []}]
+del_range: lock acquisitions = [{span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=46.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]} {span=b/123 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=46.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}]
 del_range: "b"-"c" -> deleted 2 key(s)
 del_range: returned "b"
 del_range: returned "b/123"
@@ -155,7 +155,7 @@ with t=A
   txn_remove
 ----
 >> del_range k=c end=z returnKeys t=A
-del_range: lock acquisitions = [{d id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=48.000000000,0 min=0,0 seq=0 Replicated Intent []} {d/123 id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=48.000000000,0 min=0,0 seq=0 Replicated Intent []}]
+del_range: lock acquisitions = [{span=d id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=48.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]} {span=d/123 id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=48.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}]
 del_range: "c"-"z" -> deleted 2 key(s)
 del_range: returned "d"
 del_range: returned "d/123"

--- a/pkg/storage/testdata/mvcc_histories/delete_range_predicate
+++ b/pkg/storage/testdata/mvcc_histories/delete_range_predicate
@@ -30,7 +30,7 @@ with t=A
 ----
 del: "a": found key true
 del: "g": found key true
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {k-p}/[4.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/deletes
+++ b/pkg/storage/testdata/mvcc_histories/deletes
@@ -9,7 +9,7 @@ with t=A
 ----
 >> del k=a resolve t=A
 del: "a": found key false
-del: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a" -> resolved key = true
 stats: key_count=+1 key_bytes=+14 val_count=+1 gc_bytes_age=+784
 >> at end:
@@ -214,7 +214,7 @@ with t=A
   del k=a
 ----
 del: "a": found key false
-del: lock acquisition = {a id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=a id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=49.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000008 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=0} ts=50.000000000,0 del=true klen=12 vlen=0 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/export
+++ b/pkg/storage/testdata/mvcc_histories/export
@@ -43,11 +43,11 @@ with t=A
 del: "a": found key true
 del: "b": found key false
 del: "h": found key true
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/export_fingerprint
+++ b/pkg/storage/testdata/mvcc_histories/export_fingerprint
@@ -43,11 +43,11 @@ with t=A
 del: "a": found key true
 del: "b": found key false
 del: "h": found key true
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_full_range
@@ -107,7 +107,7 @@ with t=A
   txn_begin ts=10
   put k=B v=O
 ----
-put: lock acquisition = {B id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=B id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
 meta: "B"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} ts=10.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range
@@ -110,7 +110,7 @@ with t=A k=c
   txn_begin ts=4,0
   put v=1
 ----
-put: lock acquisition = {c id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="c" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
 data: "a"/5.000000000,0 -> /BYTES/12

--- a/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
+++ b/pkg/storage/testdata/mvcc_histories/gc_clear_range_errors
@@ -24,7 +24,7 @@ with t=A k=a
   txn_begin ts=4,0
   put v=1
 ----
-put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=4.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=4.000000000,0 min=0,0 seq=0} ts=4.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/idempotent_transactions
+++ b/pkg/storage/testdata/mvcc_histories/idempotent_transactions
@@ -7,7 +7,7 @@ with t=a k=a
   put v=first
 ----
 >> put v=first t=a k=a
-put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+61 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+89
 >> put v=first t=a k=a
 stats: no change
@@ -41,7 +41,7 @@ with t=a k=a
   check_intent
 ----
 >> put v=second t=a k=a
-put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+17 live_bytes=+17 intent_bytes=+1
 >> put v=first t=a k=a
 stats: no change
@@ -76,7 +76,7 @@ with t=a k=i
 ----
 >> increment t=a k=i
 inc: current value = 1
-inc: lock acquisition = {i id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2 Replicated Intent []}
+inc: lock acquisition = {span=i id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+59 live_count=+1 live_bytes=+73 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> increment t=a k=i
 inc: current value = 1
@@ -111,7 +111,7 @@ with t=a k=i
 ----
 >> increment t=a k=i
 inc: current value = 2
-inc: lock acquisition = {i id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3 Replicated Intent []}
+inc: lock acquisition = {span=i id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_bytes=+10
 >> increment t=a k=i
 inc: current value = 2
@@ -163,7 +163,7 @@ with t=a k=i2
 ----
 >> increment t=a k=i2
 inc: current value = 2
-inc: lock acquisition = {i2 id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4 Replicated Intent []}
+inc: lock acquisition = {span=i2 id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+53 gc_bytes_age=+1602 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> increment t=a k=i2
 inc: current value = 2
@@ -201,7 +201,7 @@ with t=a k=i2
 ----
 >> increment t=a k=i2
 inc: current value = 3
-inc: lock acquisition = {i2 id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=5 Replicated Intent []}
+inc: lock acquisition = {span=i2 id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=5 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_bytes=+10
 >> increment t=a k=i2
 inc: current value = 3

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums
@@ -15,12 +15,12 @@ with t=A
   put       k=k/30 v=30
   txn_step  seq=40
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k/10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k/20 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {k/30 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k/10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k/20 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k/30 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -259,9 +259,9 @@ with t=B
   check_intent k=l
   get          k=l
 ----
-put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 meta: "l" -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=30} ts=20.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "l" -> /BYTES/c @20.000000000,0
 >> at end:
@@ -328,9 +328,9 @@ with t=C
   check_intent k=m
   get          k=m
 ----
-put: lock acquisition = {m id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {m id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {m id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=m id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 meta: "m" -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=30} ts=30.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "m" -> /BYTES/c @30.000000000,0
 >> at end:
@@ -382,9 +382,9 @@ with t=D
   get          k=n
 ----
 get: "m" -> /BYTES/a @30.000000000,0
-put: lock acquisition = {n id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {n id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {n id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=n id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 meta: "n" -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=40.000000000,0 min=0,0 seq=30} ts=40.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "n" -> /BYTES/c @40.000000000,0
 >> at end:
@@ -477,12 +477,12 @@ with t=E
 ----
 get: "n" -> /BYTES/c @45.000000000,0
 get: "o" -> <no data>
-put: lock acquisition = {n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
 data: "k"/14.000000000,0 -> {localTs=11.000000000,0}/BYTES/b
@@ -559,9 +559,9 @@ with t=E
   put             k=o v=c
   check_intent    k=o
 ----
-put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent [{5 6}]}
-put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent [{5 6}]}
-put: lock acquisition = {o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 Replicated Intent [{5 6}]}
+put: lock acquisition = {span=o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[{5 6}]}
+put: lock acquisition = {span=o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[{5 6}]}
+put: lock acquisition = {span=o id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[{5 6}]}
 meta: "o" -> txn={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
 txn: "E" meta={id=00000005 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0 isn=1
@@ -618,8 +618,8 @@ with t=F k=o
   check_intent
   get
 ----
-put: lock acquisition = {o id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {o id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=o id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=o id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 meta: "o" -> txn={id=00000006 key="o" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "o" -> /BYTES/b @50.000000000,0
 >> at end:
@@ -685,8 +685,8 @@ with t=G k=p
   check_intent
   get
 ----
-put: lock acquisition = {p id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {p id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=p id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=p id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 meta: "p" -> txn={id=00000007 key="p" iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "p" -> /BYTES/b @50.000000000,0
 >> at end:
@@ -729,8 +729,8 @@ with t=H k=q
   check_intent
   get
 ----
-put: lock acquisition = {q id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {q id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=q id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=q id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 meta: "q" -> txn={id=00000008 key="q" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "q" -> /BYTES/b @50.000000000,0
 >> at end:
@@ -773,8 +773,8 @@ with t=I k=r
   check_intent
   get
 ----
-put: lock acquisition = {r id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {r id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=r id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=r id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 meta: "r" -> txn={id=00000009 key="r" iso=Serializable pri=0.00000000 epo=1 ts=50.000000000,0 min=0,0 seq=20} ts=50.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "r" -> /BYTES/b @50.000000000,0
 >> at end:

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_abort
@@ -14,8 +14,8 @@ with t=A k=k
   resolve_intent status=ABORTED
   get
 ----
-put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "k" -> resolved key = true
 get: "k" -> <no data>
 >> at end:

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_commit
@@ -23,22 +23,22 @@ with t=A
   resolve_intent k=k/30
 ----
 >> put k=k v=a t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> put k=k/10 v=10 t=A
-put: lock acquisition = {k/10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k/10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=b t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_bytes=+10
 >> put k=k/20 v=20 t=A
-put: lock acquisition = {k/20 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k/20 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=c t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+12 live_bytes=+12
 >> put k=k/30 v=30 t=A
-put: lock acquisition = {k/30 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k/30 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> resolve_intent k=k t=A
 resolve_intent: "k" -> resolved key = true
@@ -95,22 +95,22 @@ with t=A
   resolve_intent k=k/30
 ----
 >> put k=k v=a t=A
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> put k=k/10 v=10 t=A
-put: lock acquisition = {k/10 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k/10 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=b t=A
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_bytes=+10
 >> put k=k/20 v=20 t=A
-put: lock acquisition = {k/20 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k/20 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> put k=k v=c t=A
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+12 live_bytes=+12
 >> put k=k/30 v=30 t=A
-put: lock acquisition = {k/30 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k/30 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+17 val_count=+1 val_bytes=+57 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+89
 >> resolve_intent k=k t=A
 resolve_intent: "k" -> resolved key = true
@@ -152,8 +152,8 @@ with t=B k=b
   check_intent
   get
 ----
-put: lock acquisition = {b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 meta: "b" -> txn={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20} ts=12.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 get: "b" -> /BYTES/b @12.000000000,0
 >> at end:

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_cput
@@ -17,7 +17,7 @@ with t=A
   txn_ignore_seqs seqs=(5-15)
   txn_step  seq=20
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -40,7 +40,7 @@ error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\0
 run ok
 cput t=A k=k cond=first v=b
 ----
-cput: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent [{5 15}]}
+cput: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[{5 15}]}
 >> at end:
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/b
@@ -65,8 +65,8 @@ with t=B
   txn_ignore_seqs seqs=(15-25)
   txn_step  seq=30
 ----
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -89,7 +89,7 @@ error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\0
 run ok
 cput t=B k=k cond=a v=c
 ----
-cput: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent [{15 25}]}
+cput: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[{15 25}]}
 >> at end:
 meta: "k"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c
@@ -116,9 +116,9 @@ with t=C
   txn_ignore_seqs seqs=(15-35)
   txn_step  seq=40
 ----
-put: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "C" meta={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -150,7 +150,7 @@ error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\0
 run ok
 cput t=C k=k cond=a v=c
 ----
-cput: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40 Replicated Intent [{15 35}]}
+cput: lock acquisition = {span=k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40 durability=Replicated strength=Intent ignored=[{15 35}]}
 >> at end:
 meta: "k"/0,0 -> txn={id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}{20 /BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c
@@ -176,8 +176,8 @@ with t=D
   txn_ignore_seqs seqs=(5-25)
   txn_step  seq=30
 ----
-put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "D" meta={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0 isn=1
 meta: "k"/0,0 -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
@@ -209,7 +209,7 @@ error: (*kvpb.ConditionFailedError:) unexpected value: raw_bytes:"\000\000\000\0
 run ok
 cput t=D k=k cond=first v=c
 ----
-cput: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent [{5 25}]}
+cput: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[{5 25}]}
 >> at end:
 meta: "k"/0,0 -> txn={id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30} ts=11.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k"/11.000000000,0 -> /BYTES/c

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_delete
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_delete
@@ -20,11 +20,11 @@ with t=A
   resolve_intent k=k
 ----
 >> put k=k v=a t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> del k=k t=A
 del: "k": found key true
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+4 live_count=-1 live_bytes=-70 gc_bytes_age=+6586 intent_bytes=-6
 >> resolve_intent k=k t=A
 resolve_intent: "k" -> resolved key = true
@@ -62,10 +62,10 @@ with t=A
 ----
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+del: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 gc_bytes_age=+5696 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+89
 >> put k=k v=a t=A
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_count=+1 live_bytes=+74 gc_bytes_age=-5696 intent_bytes=+6
 >> resolve_intent k=k t=A
 resolve_intent: "k" -> resolved key = true
@@ -103,11 +103,11 @@ with t=A
 ----
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+del: lock acquisition = {span=k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+50 gc_bytes_age=+5696 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+89
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+del: lock acquisition = {span=k id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+4 gc_bytes_age=+356
 >> resolve_intent k=k t=A
 resolve_intent: "k" -> resolved key = true
@@ -148,17 +148,17 @@ with t=A
   resolve_intent k=k
 ----
 >> put k=k v=a t=A
-put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+89
 >> del k=k t=A
 del: "k": found key true
-del: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
+del: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+4 live_count=-1 live_bytes=-70 gc_bytes_age=+6586 intent_bytes=-6
 >> put k=k v=b t=A
-put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+12 live_count=+1 live_bytes=+86 gc_bytes_age=-6586 intent_bytes=+6
 >> put k=k v=c t=A
-put: lock acquisition = {k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40 Replicated Intent []}
+put: lock acquisition = {span=k id=00000004 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=40 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+12 live_bytes=+12
 >> resolve_intent k=k t=A
 resolve_intent: "k" -> resolved key = true

--- a/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/ignored_seq_nums_with_local_timestamps
@@ -10,9 +10,9 @@ with t=A
   txn_step  seq=25
   put       k=k v=c localTs=25,0
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=15 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=15 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} lock=true stat=PENDING rts=50.000000000,0 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=50.000000000,0 min=0,0 seq=25} ts=50.000000000,0 del=false klen=12 vlen=19 ih={{15 {localTs=15.000000000,0}/BYTES/a}{20 {localTs=20.000000000,0}/BYTES/b}} mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/increment
+++ b/pkg/storage/testdata/mvcc_histories/increment
@@ -38,11 +38,11 @@ with k=k t=a ts=0,1
 ----
 >> increment k=k t=a ts=0,1
 inc: current value = 1
-inc: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=1 Replicated Intent []}
+inc: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+51 live_count=+1 live_bytes=+65 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+100
 >> increment k=k t=a ts=0,1
 inc: current value = 2
-inc: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2 Replicated Intent []}
+inc: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_bytes=+10
 >> at end:
 txn: "a" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=2} lock=true stat=PENDING rts=0,1 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_history_enable_separated
@@ -7,7 +7,7 @@ with t=A
   txn_remove
 ----
 >> put k=a v=default resolve t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a" -> resolved key = true
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+12 live_count=+1 live_bytes=+26
 >> at end:
@@ -32,7 +32,7 @@ with t=A
 >> txn_begin ts=2 t=A
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=first k=a t=A
-put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=10 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default
@@ -40,7 +40,7 @@ stats: key_bytes=+12 val_count=+1 val_bytes=+58 live_bytes=+46 gc_bytes_age=+235
 >> txn_step k=a t=A
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=second k=a t=A
-put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=1} ts=2.000000000,0 del=false klen=12 vlen=11 ih={{0 /BYTES/first}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/2.000000000,0 -> /BYTES/second
 data: "a"/1.000000000,0 -> /BYTES/default
@@ -49,7 +49,7 @@ stats: val_bytes=+17 live_bytes=+17 intent_bytes=+1
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> del k=a t=A
 del: "a": found key true
-del: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3 Replicated Intent []}
+del: lock acquisition = {span=a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=3} ts=2.000000000,0 del=true klen=12 vlen=0 ih={{0 /BYTES/first}{1 /BYTES/second}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/2.000000000,0 -> /<empty>
 data: "a"/1.000000000,0 -> /BYTES/default
@@ -57,7 +57,7 @@ stats: val_bytes=+6 live_count=-1 live_bytes=-89 gc_bytes_age=+9310 intent_bytes
 >> txn_step n=6 k=a t=A
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put v=first k=a t=A
-put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9 Replicated Intent []}
+put: lock acquisition = {span=a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9 durability=Replicated strength=Intent ignored=[]}
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=9} ts=2.000000000,0 del=false klen=12 vlen=10 ih={{0 /BYTES/first}{1 /BYTES/second}{3 /<empty>}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "a"/2.000000000,0 -> /BYTES/first
 data: "a"/1.000000000,0 -> /BYTES/default

--- a/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/intent_with_write_tracing_enable_separated
@@ -6,7 +6,7 @@ with t=A
 >> txn_begin ts=2 t=A
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put k=k1 v=v1 t=A
-put: lock acquisition = {k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,0 min=0,0 seq=0} ts=2.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "k1"/2.000000000,0 -> /BYTES/v1
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+98
@@ -24,12 +24,12 @@ txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.0
 >> txn_step t=A
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=2.000000000,0 wto=false gul=0,0
 >> put k=k1 v=v1 t=A
-put: lock acquisition = {k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k1"/3.000000000,0 -> /BYTES/v1
 stats: val_bytes=+13 live_bytes=+13 lock_age=-1
 >> put k=k2 v=v2 t=A
-put: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -54,7 +54,7 @@ with t=A
   put k=k3 v=v33
 ----
 >> put k=k3 v=v33 t=A
-put: lock acquisition = {k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 ih={{0 /BYTES/v1}} mergeTs=<nil> txnDidNotUpdateMeta=false
 data: "k1"/3.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=1} ts=3.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/is_span_empty
+++ b/pkg/storage/testdata/mvcc_histories/is_span_empty
@@ -18,7 +18,7 @@ with t=A
 del_range_ts k=d end=f ts=2
 ----
 del: "b": found key false
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
 rangekey: {d-f}/[2.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
+++ b/pkg/storage/testdata/mvcc_histories/iter_prefix_next_key
@@ -37,8 +37,8 @@ with t=A
   put k=b v=b7
   put k=d v=d7
 ----
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {c-e}/[6.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/local_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/local_timestamp
@@ -255,40 +255,40 @@ with t=A ts=20 localTs=10
   put k=k12 v=v
 ----
 >> put k=k1 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k2 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k3 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k4 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k5 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k5 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k5 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k6 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k6 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k6 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k7 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k7 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k7 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k8 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k9 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k9 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k9 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+82 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k10 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k11 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k11 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k11 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> put k=k12 v=v t=A ts=20 localTs=10
-put: lock acquisition = {k12 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k12 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+16 val_count=+1 val_bytes=+67 live_count=+1 live_bytes=+83 intent_count=+1 intent_bytes=+31 lock_count=+1 lock_age=+80
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
@@ -342,40 +342,40 @@ with t=A localTs=20
   put k=k12 v=v2
 ----
 >> put k=k1 v=v2 t=A localTs=20
-put: lock acquisition = {k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k2 v=v2 t=A localTs=20
-put: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k3 v=v2 t=A localTs=20
-put: lock acquisition = {k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k4 v=v2 t=A localTs=20
-put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k5 v=v2 t=A localTs=20
-put: lock acquisition = {k5 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k5 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k6 v=v2 t=A localTs=20
-put: lock acquisition = {k6 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k6 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k7 v=v2 t=A localTs=20
-put: lock acquisition = {k7 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k7 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k8 v=v2 t=A localTs=20
-put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k9 v=v2 t=A localTs=20
-put: lock acquisition = {k9 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k9 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k10 v=v2 t=A localTs=20
-put: lock acquisition = {k10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k10 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k11 v=v2 t=A localTs=20
-put: lock acquisition = {k11 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k11 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> put k=k12 v=v2 t=A localTs=20
-put: lock acquisition = {k12 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k12 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+26 live_bytes=+26 intent_bytes=+1 lock_age=-10
 >> at end:
 meta: "k1"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=30.000000000,0 min=0,0 seq=1} ts=30.000000000,0 del=false klen=12 vlen=20 ih={{0 {localTs=10.000000000,0}/BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/max_keys
+++ b/pkg/storage/testdata/mvcc_histories/max_keys
@@ -125,18 +125,18 @@ with t=A ts=11,0 max=3
   scan      k=k end=o
   scan      k=k end=o reverse=true
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 scan: "k" -> /BYTES/b @11.000000000,0
 scan: "l" -> /BYTES/b @11.000000000,0
 scan: "m" -> /BYTES/b @11.000000000,0
@@ -217,15 +217,15 @@ with t=B ts=12,0 max=3
   txn_step  seq=20
   scan      k=k end=o
 ----
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 scan: "k" -> /BYTES/b @12.000000000,0
 scan: "l" -> /BYTES/b @12.000000000,0
 scan: "m" -> /BYTES/b @12.000000000,0

--- a/pkg/storage/testdata/mvcc_histories/merges
+++ b/pkg/storage/testdata/mvcc_histories/merges
@@ -11,7 +11,7 @@ with t=A
   put        k=a v=abc resolve
   txn_remove
 ----
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a" -> resolved key = true
 >> at end:
 data: "a"/11.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/no_read_after_abort_enable_separated
@@ -10,7 +10,7 @@ with t=A k=a
 >> txn_begin ts=22 t=A k=a
 txn: "A" meta={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=22.000000000,0 wto=false gul=0,0
 >> put v=cde t=A k=a
-put: lock acquisition = {a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 meta: "a"/0,0 -> txn={id=00000001 key="a" iso=Serializable pri=0.00000000 epo=0 ts=22.000000000,0 min=0,0 seq=0} ts=22.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/22.000000000,0 -> /BYTES/cde
 >> resolve_intent status=ABORTED t=A k=a

--- a/pkg/storage/testdata/mvcc_histories/put_after_rollback
+++ b/pkg/storage/testdata/mvcc_histories/put_after_rollback
@@ -11,10 +11,10 @@ with t=A k=k2
   get
 ----
 >> put v=a t=A k=k2
-put: lock acquisition = {k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+99
 >> put v=b t=A k=k2
-put: lock acquisition = {k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20 Replicated Intent [{5 15}]}
+put: lock acquisition = {span=k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[{5 15}]}
 stats: val_bytes=-2 live_bytes=-2
 get: "k2" -> /BYTES/b @1.000000000,0
 get: "k2" -> <no data>
@@ -33,11 +33,11 @@ with t=A k=k3
   del
 ----
 >> put v=a t=A k=k3
-put: lock acquisition = {k3 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=30 Replicated Intent [{5 25}]}
+put: lock acquisition = {span=k3 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[{5 25}]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+99
 >> del t=A k=k3
 del: "k3": found key false
-del: lock acquisition = {k3 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40 Replicated Intent [{5 35}]}
+del: lock acquisition = {span=k3 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40 durability=Replicated strength=Intent ignored=[{5 35}]}
 stats: val_bytes=-8 live_count=-1 live_bytes=-75 gc_bytes_age=+6633 intent_bytes=-6
 >> at end:
 txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=40} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0 isn=1
@@ -58,13 +58,13 @@ with t=A k=k4
   cput      v=c
 ----
 >> put v=a t=A k=k4
-put: lock acquisition = {k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=50 Replicated Intent [{5 35}]}
+put: lock acquisition = {span=k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=50 durability=Replicated strength=Intent ignored=[{5 35}]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+60 live_count=+1 live_bytes=+75 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+99
 >> cput v=b cond=a t=A k=k4
-cput: lock acquisition = {k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=51 Replicated Intent [{5 35}]}
+cput: lock acquisition = {span=k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=51 durability=Replicated strength=Intent ignored=[{5 35}]}
 stats: val_bytes=+10 live_bytes=+10
 >> cput v=c t=A k=k4
-cput: lock acquisition = {k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60 Replicated Intent [{5 55}]}
+cput: lock acquisition = {span=k4 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60 durability=Replicated strength=Intent ignored=[{5 55}]}
 stats: val_bytes=-12 live_bytes=-12
 >> at end:
 txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=60} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0 isn=1
@@ -97,17 +97,17 @@ with t=B k=k5
 >> put k=k5 v=foo ts=3
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+8 live_count=+1 live_bytes=+23
 >> put v=a t=B k=k5
-put: lock acquisition = {k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+60 live_bytes=+52 gc_bytes_age=+1900 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+95
 >> put v=b t=B k=k5
-put: lock acquisition = {k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=20 Replicated Intent []}
+put: lock acquisition = {span=k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+10 live_bytes=+10
 >> put v=c t=B k=k5
-put: lock acquisition = {k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=30 Replicated Intent [{15 25}]}
+put: lock acquisition = {span=k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[{15 25}]}
 stats: no change
 meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=30} ts=5.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> put v=d t=B k=k5
-put: lock acquisition = {k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40 Replicated Intent [{5 35}]}
+put: lock acquisition = {span=k5 id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40 durability=Replicated strength=Intent ignored=[{5 35}]}
 stats: no change
 meta: "k5" -> txn={id=00000002 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=40} ts=5.000000000,0 del=false klen=12 vlen=6 ih={{10 /BYTES/a}} mergeTs=<nil> txnDidNotUpdateMeta=false
 >> resolve_intent status=COMMITTED t=B k=k5

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_sequence
@@ -17,8 +17,8 @@ with t=A
   put  k=k v=v2
   get  k=k ts=3
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5 durability=Replicated strength=Intent ignored=[]}
 get: "k" -> /BYTES/v2 @1.000000000,0
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=5} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -44,7 +44,7 @@ with t=A k=k
   put v=v3
   check_intent exists
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=1.000000000,0 min=0,0 seq=4 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=1.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[]}
 meta: "k" -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=1.000000000,0 min=0,0 seq=4} ts=1.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false
 >> at end:
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=1.000000000,0 min=0,0 seq=4} ts=1.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_timestamp
+++ b/pkg/storage/testdata/mvcc_histories/put_new_epoch_lower_timestamp
@@ -17,7 +17,7 @@ with t=A
   put  k=k v=v
   get  k=k ts=3
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[]}
 get: "k" -> /BYTES/v @5.000000000,0
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -41,7 +41,7 @@ with t=A
   put k=k v=v2
   get k=k
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 get: "k" -> /BYTES/v2 @5.000000000,0
 >> at end:
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=5.000000000,0 min=0,0 seq=0} ts=5.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/put_out_of_order
+++ b/pkg/storage/testdata/mvcc_histories/put_out_of_order
@@ -10,7 +10,7 @@ with t=A
   put         ts=1 k=k v=v
 ----
 >> put ts=1 k=k v=v t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+56 live_count=+1 live_bytes=+70 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+98
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -26,7 +26,7 @@ with t=A
   put         ts=1 k=k v=v2
 ----
 >> put ts=1 k=k v=v2 t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+13 live_bytes=+13 intent_bytes=+1
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -50,7 +50,7 @@ with t=A
   put ts=1 k=k v=v2
 ----
 >> put ts=1 k=k v=v2 t=A
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=2 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=2.000000000,1 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+13 live_bytes=+13
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/put_with_txn
+++ b/pkg/storage/testdata/mvcc_histories/put_with_txn
@@ -7,7 +7,7 @@ with t=A k=k
   get  ts=1
 ----
 >> put v=v t=A k=k
-put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+49 live_count=+1 live_bytes=+63 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+100
 get: "k" -> /BYTES/v @0,1
 get: "k" -> /BYTES/v @0,1

--- a/pkg/storage/testdata/mvcc_histories/range_key_clear
+++ b/pkg/storage/testdata/mvcc_histories/range_key_clear
@@ -41,10 +41,10 @@ with t=A
 del: "a": found key true
 del: "b": found key false
 del: "h": found key true
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace_nometamorphiciter
+++ b/pkg/storage/testdata/mvcc_histories/range_key_iter_intent_without_provisional_norace_nometamorphiciter
@@ -18,8 +18,8 @@ put k=f ts=1 v=f1
 put_rangekey k=b end=d ts=5
 put_rangekey k=e end=g ts=5
 ----
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 rangekey: {b-d}/[5.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_conflicts
@@ -45,7 +45,7 @@ stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 live_count=-5 l
 >> del_range_ts k=c end=k ts=5
 stats: range_key_count=+1 range_key_bytes=+22 range_val_count=+2 gc_bytes_age=+2108
 >> put k=g v=7 t=A ts=7
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+54 live_count=+1 live_bytes=+68 gc_bytes_age=-194 intent_count=+1 intent_bytes=+18 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets
@@ -32,7 +32,7 @@ put k=o ts=6 v=o6
 ----
 del: "b": found key false
 del: "a": found key false
-put: lock acquisition = {e id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=e id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {a-c}/[2.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_gets_complex
@@ -82,13 +82,13 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> put k=k ts=5 v=k5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
 >> put k=d v=d7 t=A
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=f v=f7 t=A
-put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter
@@ -80,22 +80,22 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del_range_ts k=m end=n ts=3 localTs=2
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 range_val_bytes=+13 gc_bytes_age=+2522
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=d v=d7 t=A
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=l v=l7 t=A
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=m v=l7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=n7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_incremental
@@ -83,22 +83,22 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> del_range_ts k=m end=n ts=3 localTs=2
 stats: range_key_count=+1 range_key_bytes=+13 range_val_count=+1 range_val_bytes=+13 gc_bytes_age=+2522
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-192 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=l v=l7 t=A
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=d v=d8 t=B
-put: lock acquisition = {d id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=d id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+92
 >> put k=m v=m8 t=B
-put: lock acquisition = {m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+92
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_iter_reverse_intent_seek_rangekeychanged_regression
@@ -21,7 +21,7 @@ with t=A
   txn_begin k=b ts=3
   put k=b v=b3
 ----
-put: lock acquisition = {b id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -147,7 +147,7 @@ with t=A
   txn_begin k=b ts=3
   put k=b v=b3
 ----
-put: lock acquisition = {b id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans
@@ -30,7 +30,7 @@ with t=A
 ----
 del: "b": found key false
 del: "a": found key false
-put: lock acquisition = {e id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=e id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="e" iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {a-c}/[2.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_complex
@@ -82,13 +82,13 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 >> put k=k ts=5 v=k5
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_bytes=+21
 >> put k=d v=d7 t=A
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-190 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=f v=f7 t=A
-put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=j v=j7 t=A
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_reverse_skip_regression
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_scans_reverse_skip_regression
@@ -29,7 +29,7 @@ with t=A
   txn_begin k=b ts=3
   put k=b v=b3
 ----
-put: lock acquisition = {b id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[1.000000000,0=/<empty>]
@@ -58,7 +58,7 @@ with t=A
   txn_begin k=b ts=3
   put k=b v=b3
 ----
-put: lock acquisition = {b id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000002 key="b" iso=Serializable pri=0.00000000 epo=0 ts=3.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=3.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[2.000000000,0=/<empty> 1.000000000,0=/<empty>]
@@ -94,7 +94,7 @@ with t=A
   txn_begin k=b ts=1
   put k=b v=b1
 ----
-put: lock acquisition = {b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000003 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[4.000000000,0=/<empty> 2.000000000,0=/<empty>]
@@ -146,7 +146,7 @@ with t=A
   txn_begin k=b ts=1
   put k=b v=b1
 ----
-put: lock acquisition = {b id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000004 key="b" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 rangekey: {a-b}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_abort
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_commit
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_pushed
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_abort
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_commit
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_resolve_range_pushed
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_stats_intent_rewrite
@@ -109,67 +109,67 @@ stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+7 live_count=+1 live_b
 del: "r": found key false
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+9 gc_bytes_age=+2162
 >> put k=a v=a7 t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=b v=b7 t=A
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=c v=c7 t=A
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=d t=A
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=e t=A
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=f localTs=5.9 t=A
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=g v=g7 t=A
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=h v=h7 t=A
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-194 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=i v=i7 t=A
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-198 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=j t=A
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=k t=A
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 gc_bytes_age=+5572 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=l localTs=5.9 t=A
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6777 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> put k=m v=m7 t=A
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=n v=n7 t=A
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_bytes=+48 gc_bytes_age=+1767 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> put k=o v=o7 t=A
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+55 live_count=+1 live_bytes=+69 gc_bytes_age=-188 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+93
 >> del k=p t=A
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_count=+1 key_bytes=+14 val_count=+1 val_bytes=+48 gc_bytes_age=+5766 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=q t=A
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+48 live_count=-1 live_bytes=-21 gc_bytes_age=+7533 intent_count=+1 intent_bytes=+12 lock_count=+1 lock_age=+93
 >> del k=r localTs=5.9 t=A
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+61 gc_bytes_age=+6787 intent_count=+1 intent_bytes=+25 lock_count=+1 lock_age=+93
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
@@ -257,67 +257,67 @@ with t=A ts=8
   del k=r
 ----
 >> put k=a v=a8 t=A ts=8
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> put k=b v=b8 t=A ts=8
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-19 lock_age=-1
 >> put k=c v=c8 t=A ts=8
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> del k=d t=A ts=8
 del: "d": found key false
-del: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-62 lock_age=-1
 >> del k=e t=A ts=8
 del: "e": found key true
-del: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-81 lock_age=-1
 >> del k=f t=A ts=8
 del: "f": found key false
-del: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> put k=g v=g8 t=A ts=8
-put: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> put k=h v=h8 t=A ts=8
-put: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> put k=i v=i8 t=A ts=8
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> del k=j t=A ts=8
 del: "j": found key false
-del: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-62 lock_age=-1
 >> del k=k t=A ts=8
 del: "k": found key false
-del: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-62 lock_age=-1
 >> del k=l t=A ts=8
 del: "l": found key false
-del: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> put k=m v=m8 t=A ts=8
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> put k=n v=n8 t=A ts=8
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-19 lock_age=-1
 >> put k=o v=o8 t=A ts=8
-put: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: lock_age=-1
 >> del k=p t=A ts=8
 del: "p": found key false
-del: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-62 lock_age=-1
 >> del k=q t=A ts=8
 del: "q": found key true
-del: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: gc_bytes_age=-81 lock_age=-1
 >> del k=r t=A ts=8
 del: "r": found key false
-del: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-13 gc_bytes_age=-1271 intent_bytes=-13 lock_age=-1
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=8.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=8.000000000,0 wto=false gul=0,0
@@ -406,66 +406,66 @@ with t=A ts=9
 ----
 >> del k=a t=A ts=9
 del: "a": found key false
-del: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=b t=A ts=9
 del: "b": found key true
-del: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5623 intent_bytes=-7 lock_age=-1
 >> del k=c t=A ts=9
 del: "c": found key false
-del: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> put k=d v=d9 t=A ts=9
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=e v=e9 t=A ts=9
-put: lock acquisition = {e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=e id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes=+7 lock_age=-1
 >> put k=f v=f9 t=A ts=9
-put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> del k=g t=A ts=9
 del: "g": found key false
-del: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=h t=A ts=9
 del: "h": found key false
-del: lock acquisition = {h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=h id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=i t=A ts=9
 del: "i": found key false
-del: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> put k=j v=j9 t=A ts=9
-put: lock acquisition = {j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=j id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=k v=k9 t=A ts=9
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=l v=l9 t=A ts=9
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> del k=m t=A ts=9
 del: "m": found key false
-del: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> del k=n t=A ts=9
 del: "n": found key true
-del: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5623 intent_bytes=-7 lock_age=-1
 >> del k=o t=A ts=9
 del: "o": found key false
-del: lock acquisition = {o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=o id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=-7 live_count=-1 live_bytes=-69 gc_bytes_age=+5642 intent_bytes=-7 lock_age=-1
 >> put k=p v=p9 t=A ts=9
-put: lock acquisition = {p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=p id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> put k=q v=q9 t=A ts=9
-put: lock acquisition = {q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=q id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5723 intent_bytes=+7 lock_age=-1
 >> put k=r v=r9 t=A ts=9
-put: lock acquisition = {r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=r id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 stats: val_bytes=+7 live_count=+1 live_bytes=+69 gc_bytes_age=-5704 intent_bytes=+7 lock_age=-1
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=2 ts=9.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=9.000000000,0 wto=false gul=0,0

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes
@@ -29,8 +29,8 @@ with t=A
 ----
 del: "a": found key true
 del: "g": found key true
-put: lock acquisition = {d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=d id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=7.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=7.000000000,0 wto=false gul=0,0
 rangekey: {k-p}/[4.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
+++ b/pkg/storage/testdata/mvcc_histories/range_tombstone_writes_idempotent
@@ -32,7 +32,7 @@ with t=A
 del: "a": found key false
 del: "f": found key false
 del: "n": found key false
-put: lock acquisition = {i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=i id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=6.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=6.000000000,0 wto=false gul=0,0
 rangekey: {a-d}/[3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
+++ b/pkg/storage/testdata/mvcc_histories/read_after_write_enable_separated
@@ -11,7 +11,7 @@ with t=A
 >> txn_begin ts=11 t=A
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=11.000000000,0 wto=false gul=0,0
 >> put v=abc k=a t=A
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0} ts=11.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true
 data: "a"/11.000000000,0 -> /BYTES/abc
 >> get k=a t=A
@@ -29,13 +29,13 @@ with t=A resolve
   put   k=c   v=hhh
   txn_remove
 ----
-put: lock acquisition = {a/1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a/1 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a/1" -> resolved key = true
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "b" -> resolved key = true
-put: lock acquisition = {b/2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=b/2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "b/2" -> resolved key = true
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "c" -> resolved key = true
 >> at end:
 data: "a"/11.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
+++ b/pkg/storage/testdata/mvcc_histories/read_fail_on_more_recent
@@ -13,7 +13,7 @@ with t=A
   txn_begin ts=10,0
   put k=k2 v=v
 ----
-put: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
 data: "k1"/10.000000000,0 -> /BYTES/v

--- a/pkg/storage/testdata/mvcc_histories/replace_point_tombstones_with_range_tombstones
+++ b/pkg/storage/testdata/mvcc_histories/replace_point_tombstones_with_range_tombstones
@@ -45,9 +45,9 @@ del: "i": found key false
 del: "k": found key false
 del: "l": found key false
 del: "n": found key false
-put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 del: "g": found key false
-del: lock acquisition = {g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=g id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 rangekey: {h-o}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]
@@ -145,9 +145,9 @@ del: "i": found key false
 del: "k": found key false
 del: "l": found key false
 del: "n": found key false
-put: lock acquisition = {f id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=f id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 del: "g": found key false
-del: lock acquisition = {g id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 Replicated Intent []}
+del: lock acquisition = {span=g id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=5.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=5.000000000,0 wto=false gul=0,0
 rangekey: {h-o}/[4.000000000,0=/<empty> 3.000000000,0=/<empty>]

--- a/pkg/storage/testdata/mvcc_histories/replicated_locks
+++ b/pkg/storage/testdata/mvcc_histories/replicated_locks
@@ -307,7 +307,7 @@ run stats ok
 put t=A k=k4 v=v4
 ----
 >> put t=A k=k4 v=v4
-put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1 Replicated Intent [{0 0}]}
+put: lock acquisition = {span=k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[{0 0}]}
 stats: key_count=+1 key_bytes=+15 val_count=+1 val_bytes=+59 live_count=+1 live_bytes=+74 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+90
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1
@@ -361,7 +361,7 @@ with t=A
   put k=k4 v=v4_prime
 ----
 >> put k=k4 v=v4_prime t=A
-put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2 Replicated Intent [{0 0}]}
+put: lock acquisition = {span=k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[{0 0}]}
 stats: val_bytes=+17 live_bytes=+17 intent_bytes=+6
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
@@ -579,10 +579,10 @@ with t=A
   put k=k3 v=v3
 ----
 >> put k=k2 v=v2 t=A
-put: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3 Replicated Intent [{1 2}]}
+put: lock acquisition = {span=k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[{1 2}]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+52 gc_bytes_age=+1710 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+90
 >> put k=k3 v=v3 t=A
-put: lock acquisition = {k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3 Replicated Intent [{1 2}]}
+put: lock acquisition = {span=k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[{1 2}]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+52 gc_bytes_age=+1710 intent_count=+1 intent_bytes=+19 lock_count=+1 lock_age=+90
 >> at end:
 data: "k1"/5.000000000,0 -> /BYTES/v1
@@ -604,11 +604,11 @@ with t=A
 ----
 >> del k=k2 t=A
 del: "k2": found key true
-del: lock acquisition = {k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4 Replicated Intent [{1 2}]}
+del: lock acquisition = {span=k2 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[{1 2}]}
 stats: val_bytes=+4 live_count=-1 live_bytes=-74 gc_bytes_age=+7020 intent_bytes=-7
 >> del k=k3 t=A
 del: "k3": found key true
-del: lock acquisition = {k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4 Replicated Intent [{1 2}]}
+del: lock acquisition = {span=k3 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[{1 2}]}
 stats: val_bytes=+4 live_count=-1 live_bytes=-74 gc_bytes_age=+7020 intent_bytes=-7
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=1 ts=10.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
@@ -994,7 +994,7 @@ with t=C
 >> acquire_lock k=k2 str=shared t=C
 stats: lock_count=+1 lock_bytes=+69 lock_age=+88
 >> put k=k2 v=v2_2 t=C
-put: lock acquisition = {k2 id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=12.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+59 live_bytes=+52 gc_bytes_age=+1672 intent_count=+1 intent_bytes=+21 lock_count=+1 lock_age=+88
 >> acquire_lock k=k2 str=shared t=C
 stats: no change

--- a/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
+++ b/pkg/storage/testdata/mvcc_histories/resolve_intent_pagination
@@ -11,12 +11,12 @@ with t=A
   put k=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee v=e
   put k=f v=f
 ----
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {dddddddddddddddddddddddddddddddddddddddddddddddddd id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=b id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=c id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=dddddddddddddddddddddddddddddddddddddddddddddddddd id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=eeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeeee id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=f id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -181,8 +181,8 @@ with t=B
   put k=b v=b
   acquire_lock k=c str=shared
 ----
-put: lock acquisition = {a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {b id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=b id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=0} ts=1.000000000,0 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/skip_locked
+++ b/pkg/storage/testdata/mvcc_histories/skip_locked
@@ -36,8 +36,8 @@ put k=k6 v=v7 ts=13,0
 add_unreplicated_lock k=k4 t=E str=exclusive
 add_unreplicated_lock k=k6 t=D str=shared
 ----
-put: lock acquisition = {k2 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0 Replicated Intent []}
-put: lock acquisition = {k3 id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k3 id=00000003 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=14.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 data: "k1"/11.000000000,0 -> /BYTES/v1
 meta: "k2"/0,0 -> txn={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=13.000000000,0 min=0,0 seq=0} ts=13.000000000,0 del=false klen=12 vlen=7 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/target_bytes
+++ b/pkg/storage/testdata/mvcc_histories/target_bytes
@@ -575,18 +575,18 @@ with t=A ts=11,0 targetbytes=32
   scan      k=k end=o
   scan      k=k end=o reverse=true
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
-put: lock acquisition = {n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=l id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=m id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=n id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=11.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[]}
 scan: "k" -> /BYTES/b @11.000000000,0
 scan: resume span ["l","o") RESUME_BYTE_LIMIT nextBytes=25
 scan: 25 bytes (target 32)

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval
@@ -22,7 +22,7 @@ with k=k2
   txn_begin t=A ts=20,0
   put t=A v=v4
 ----
-put: lock acquisition = {k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k2 id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="k2" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit
@@ -79,7 +79,7 @@ with k=k5
   txn_begin t=A ts=20,0
   put t=A v=v10
 ----
-put: lock acquisition = {k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
@@ -100,7 +100,7 @@ with k=k6
   txn_begin t=B ts=20,0
   put t=B v=v12
 ----
-put: lock acquisition = {k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
@@ -124,7 +124,7 @@ with k=k7
   txn_begin t=C ts=20,0
   put t=C v=v14 localTs=10,0
 ----
-put: lock acquisition = {k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
@@ -151,7 +151,7 @@ with k=k8
   txn_begin t=D ts=20,0
   put t=D v=v16 localTs=10,0
 ----
-put: lock acquisition = {k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2

--- a/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
+++ b/pkg/storage/testdata/mvcc_histories/uncertainty_interval_with_local_uncertainty_limit_disable_local_timestamps
@@ -79,7 +79,7 @@ with k=k5
   txn_begin t=A ts=20,0
   put t=A v=v10
 ----
-put: lock acquisition = {k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k5 id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key="k5" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
@@ -100,7 +100,7 @@ with k=k6
   txn_begin t=B ts=20,0
   put t=B v=v12
 ----
-put: lock acquisition = {k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k6 id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "B" meta={id=00000002 key="k6" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
@@ -124,7 +124,7 @@ with k=k7
   txn_begin t=C ts=20,0
   put t=C v=v14 localTs=10,0
 ----
-put: lock acquisition = {k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k7 id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "C" meta={id=00000003 key="k7" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2
@@ -151,7 +151,7 @@ with k=k8
   txn_begin t=D ts=20,0
   put t=D v=v16 localTs=10,0
 ----
-put: lock acquisition = {k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k8 id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "D" meta={id=00000004 key="k8" iso=Serializable pri=0.00000000 epo=0 ts=20.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=20.000000000,0 wto=false gul=0,0
 data: "k1"/20.000000000,0 -> /BYTES/v2

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_diff_txn
@@ -9,7 +9,7 @@ with t=B
   txn_begin  ts=44
   put   k=a v=zzz
 ----
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "B" meta={id=00000002 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0} lock=true stat=PENDING rts=44.000000000,0 wto=false gul=0,0
 meta: "a"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=33.000000000,0 min=0,0 seq=0} ts=33.000000000,0 del=false klen=12 vlen=8 mergeTs=<nil> txnDidNotUpdateMeta=true

--- a/pkg/storage/testdata/mvcc_histories/update_existing_key_in_txn
+++ b/pkg/storage/testdata/mvcc_histories/update_existing_key_in_txn
@@ -3,7 +3,7 @@ with t=A
   txn_begin ts=0,1
   put k=k v=v
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=0,1 min=0,0 seq=0} ts=0,1 del=false klen=12 vlen=6 mergeTs=<nil> txnDidNotUpdateMeta=true
@@ -18,7 +18,7 @@ with t=A
   txn_step
   put k=k v=v
 ----
-put: lock acquisition = {k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1 durability=Replicated strength=Intent ignored=[]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=0,1 wto=false gul=0,0
 meta: "k"/0,0 -> txn={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} ts=1.000000000,0 del=false klen=12 vlen=6 ih={{0 /BYTES/v}} mergeTs=<nil> txnDidNotUpdateMeta=false

--- a/pkg/storage/testdata/mvcc_histories/verify_locks
+++ b/pkg/storage/testdata/mvcc_histories/verify_locks
@@ -56,7 +56,7 @@ stats: lock_count=+1 lock_bytes=+69 lock_age=+90
 >> acquire_lock k=k3 str=exclusive t=A
 stats: lock_count=+1 lock_bytes=+69 lock_age=+90
 >> put k=k4 v=v_new t=A
-put: lock acquisition = {k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10 Replicated Intent []}
+put: lock acquisition = {span=k4 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10 durability=Replicated strength=Intent ignored=[]}
 stats: key_bytes=+12 val_count=+1 val_bytes=+60 live_bytes=+53 gc_bytes_age=+1710 intent_count=+1 intent_bytes=+22 lock_count=+1 lock_age=+90
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=10} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0
@@ -267,9 +267,9 @@ with t=A
   txn_step seq=30
   put k=k8 v=v8_third
 ----
-put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20 Replicated Intent [{5 15}]}
-put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=25 Replicated Intent [{5 15}]}
-put: lock acquisition = {k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30 Replicated Intent [{5 15}]}
+put: lock acquisition = {span=k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=20 durability=Replicated strength=Intent ignored=[{5 15}]}
+put: lock acquisition = {span=k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=25 durability=Replicated strength=Intent ignored=[{5 15}]}
+put: lock acquisition = {span=k8 id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30 durability=Replicated strength=Intent ignored=[{5 15}]}
 >> at end:
 txn: "A" meta={id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=10.000000000,0 min=0,0 seq=30} lock=true stat=PENDING rts=10.000000000,0 wto=false gul=0,0 isn=1
 data: "k1"/5.000000000,0 -> /BYTES/v1

--- a/pkg/storage/testdata/mvcc_histories/write_too_old
+++ b/pkg/storage/testdata/mvcc_histories/write_too_old
@@ -9,7 +9,7 @@ with t=A
   put  k=a v=abc resolve
   txn_remove
 ----
-put: lock acquisition = {a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 Replicated Intent []}
+put: lock acquisition = {span=a id=00000001 key=/Min iso=Serializable pri=0.00000000 epo=0 ts=44.000000000,0 min=0,0 seq=0 durability=Replicated strength=Intent ignored=[]}
 resolve_intent: "a" -> resolved key = true
 >> at end:
 data: "a"/44.000000000,0 -> /BYTES/abc

--- a/pkg/storage/testdata/mvcc_histories/write_with_sequence
+++ b/pkg/storage/testdata/mvcc_histories/write_with_sequence
@@ -17,8 +17,8 @@ with t=t k=k
   txn_step seq=1
   put v=v1 batched
 ----
-put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 Replicated Intent []}
-put: lock acquisition = {k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
+put: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 put: batch after write is empty
 >> at end:
 txn: "t" meta={id=00000001 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=1} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -45,8 +45,8 @@ with t=t k=k
   txn_step seq=2
   put v=v1 batched
 ----
-put: lock acquisition = {k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 Replicated Intent []}
-put: lock acquisition = {k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
+put: lock acquisition = {span=k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 put: batch after write is empty
 >> at end:
 txn: "t" meta={id=00000002 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -72,8 +72,8 @@ with t=t k=k
   txn_step seq=2
   put v=v2 batched
 ----
-put: lock acquisition = {k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 Replicated Intent []}
-put: lock acquisition = {k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
+put: lock acquisition = {span=k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 put: batch after write is empty
 >> at end:
 txn: "t" meta={id=00000003 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -100,8 +100,8 @@ with t=t k=k
   put v=v2
   put v=v2 batched
 ----
-put: lock acquisition = {k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 Replicated Intent []}
-put: lock acquisition = {k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
+put: lock acquisition = {span=k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 put: batch after write is empty
 >> at end:
 txn: "t" meta={id=00000004 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -127,8 +127,8 @@ with t=t k=k
   put v=v2
   put v=v3 batched
 ----
-put: lock acquisition = {k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 Replicated Intent []}
-put: lock acquisition = {k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
+put: lock acquisition = {span=k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
 put: batch after write is empty
 >> at end:
 txn: "t" meta={id=00000005 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0
@@ -157,9 +157,9 @@ with t=t k=k
   txn_step
   put v=v4 batched
 ----
-put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 Replicated Intent []}
-put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 Replicated Intent []}
-put: lock acquisition = {k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4 Replicated Intent []}
+put: lock acquisition = {span=k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=2 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=3 durability=Replicated strength=Intent ignored=[]}
+put: lock acquisition = {span=k id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4 durability=Replicated strength=Intent ignored=[]}
 put: batch after write is non-empty
 >> at end:
 txn: "t" meta={id=00000006 key="k" iso=Serializable pri=0.00000000 epo=0 ts=1.000000000,0 min=0,0 seq=4} lock=true stat=PENDING rts=1.000000000,0 wto=false gul=0,0


### PR DESCRIPTION
Backport 1/1 commits from #147739.

/cc @cockroachdb/release

---

This is a continuation of https://github.com/cockroachdb/cockroach/pull/141409

---

Implemented SafeFormat method for the following types:

  * Span
  * RSpan
  * LockAcquisition

Additionally, added assertions for the redact.SafeFormatter interface for these and other types. This enhances logging safety by ensuring the proper redaction of sensitive information.

Naturally, this required updating a few test fixtures. This commit includes those changes as well.


Fixes: CRDB-51160
Epic: CRDB-37533
Release note: None

---

**NOTE**

- The before and after versions of the logs can be seen in the updated test fixtures
- Most of the changes in diff are test fixture updates. The only code changes is in `pkg/roachpb/data.go`

---

Release justification: This commit significantly reduces over redaction of logs that contain Spans and RSpans.
