### PR TITLE
roachtest: global monitor expects specific process deaths

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -3027,13 +3027,15 @@ func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Log
 	return nil
 }
 
-// NewMonitor creates a monitor that can watch for unexpected crdb node deaths on m.Wait()
+// NewDeprecatedMonitor creates a monitor that can watch for unexpected crdb node deaths on m.Wait()
 // and provide roachtest safe goroutines.
 //
 // As a general rule, if the user has a workload node, do not monitor it. A
 // monitor's semantics around handling expected node deaths breaks down if it's
 // monitoring a workload node.
-func (c *clusterImpl) NewMonitor(ctx context.Context, opts ...option.Option) cluster.Monitor {
+func (c *clusterImpl) NewDeprecatedMonitor(
+	ctx context.Context, opts ...option.Option,
+) cluster.Monitor {
 	return newMonitor(ctx, c.t, c, false /* expectExactProcessDeath */, opts...)
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2221,7 +2221,10 @@ func (c *clusterImpl) StartE(
 			return errors.Wrap(err, "failed to wait for replication after starting cockroach")
 		}
 	}
-
+	// If starting the cluster was successful, mark the nodes as healthy. N.B. we must wait
+	// until cluster startup succeeds as we may have tests that purposely inject failures into
+	// cluster startup.
+	c.t.Monitor().ExpectProcessAlive(nodes)
 	return nil
 }
 
@@ -2264,6 +2267,15 @@ func (c *clusterImpl) StartServiceForVirtualClusterE(
 			return err
 		}
 	}
+
+	// If we are starting a separate process virtual cluster, we need to
+	// mark each SQL instance as healthy.
+	if len(startOpts.SeparateProcessNodes) > 0 {
+		nodes := startOpts.SeparateProcessNodes
+		virtualClusterName := startOpts.RoachprodOpts.VirtualClusterName
+		sqlInstance := startOpts.RoachprodOpts.SQLInstance
+		c.t.Monitor().ExpectProcessAlive(nodes, option.VirtualClusterName(virtualClusterName), option.SQLInstance(sqlInstance))
+	}
 	return nil
 }
 
@@ -2290,6 +2302,9 @@ func (c *clusterImpl) StopServiceForVirtualClusterE(
 	nodes := c.All()
 	if len(stopOpts.SeparateProcessNodes) > 0 {
 		nodes = stopOpts.SeparateProcessNodes
+		virtualClusterName := stopOpts.RoachprodOpts.VirtualClusterName
+		sqlInstance := stopOpts.RoachprodOpts.SQLInstance
+		c.t.Monitor().ExpectProcessDead(nodes, option.VirtualClusterName(virtualClusterName), option.SQLInstance(sqlInstance))
 	}
 
 	return roachprod.StopServiceForVirtualCluster(
@@ -2396,6 +2411,7 @@ func (c *clusterImpl) StopE(
 		stopOpts.RoachprodOpts.Wait = true
 		stopOpts.RoachprodOpts.GracePeriod = 10
 	}
+	c.t.Monitor().ExpectProcessDead(selectedNodesOrDefault(nodes, c.All()))
 	return errors.Wrap(roachprod.Stop(ctx, l, c.MakeNodes(nodes...), stopOpts.RoachprodOpts), "cluster.StopE")
 }
 
@@ -2423,6 +2439,7 @@ func (c *clusterImpl) SignalE(
 	if c.spec.NodeCount == 0 {
 		return nil // unit tests
 	}
+	c.t.Monitor().ExpectProcessDead(selectedNodesOrDefault(nodes, c.All()))
 	return errors.Wrap(roachprod.Signal(ctx, l, c.MakeNodes(nodes...), sig), "cluster.Signal")
 }
 
@@ -2454,6 +2471,7 @@ func (c *clusterImpl) WipeE(
 	}
 	c.setStatusForClusterOpt("wiping", false, nodes...)
 	defer c.clearStatusForClusterOpt(false)
+	c.t.Monitor().ExpectProcessDead(selectedNodesOrDefault(nodes, c.All()))
 	return roachprod.Wipe(ctx, l, c.MakeNodes(nodes...), c.IsSecure())
 }
 
@@ -3016,7 +3034,7 @@ func (c *clusterImpl) Extend(ctx context.Context, d time.Duration, l *logger.Log
 // monitor's semantics around handling expected node deaths breaks down if it's
 // monitoring a workload node.
 func (c *clusterImpl) NewMonitor(ctx context.Context, opts ...option.Option) cluster.Monitor {
-	return newMonitor(ctx, c.t, c, opts...)
+	return newMonitor(ctx, c.t, c, false /* expectExactProcessDeath */, opts...)
 }
 
 func (c *clusterImpl) StartGrafana(

--- a/pkg/cmd/roachtest/cluster/cluster_interface.go
+++ b/pkg/cmd/roachtest/cluster/cluster_interface.go
@@ -66,7 +66,11 @@ type Cluster interface {
 	Stop(ctx context.Context, l *logger.Logger, stopOpts option.StopOpts, opts ...option.Option)
 	SignalE(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option) error
 	Signal(ctx context.Context, l *logger.Logger, sig int, opts ...option.Option)
-	NewMonitor(context.Context, ...option.Option) Monitor
+
+	// NewDeprecatedMonitor is deprecated: See #118214
+	// Instead, use task.Tasker for goroutine management (e.g. test.Go) and test.Monitor
+	// for monitoring unexpected process deaths (e.g. through the test spec Monitor option)
+	NewDeprecatedMonitor(context.Context, ...option.Option) Monitor
 
 	// Starting virtual clusters.
 

--- a/pkg/cmd/roachtest/clusterstats/mock_cluster_generated_test.go
+++ b/pkg/cmd/roachtest/clusterstats/mock_cluster_generated_test.go
@@ -572,23 +572,23 @@ func (mr *MockClusterMockRecorder) Name() *gomock.Call {
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Name", reflect.TypeOf((*MockCluster)(nil).Name))
 }
 
-// NewMonitor mocks base method.
-func (m *MockCluster) NewMonitor(arg0 context.Context, arg1 ...option.Option) cluster.Monitor {
+// NewDeprecatedMonitor mocks base method.
+func (m *MockCluster) NewDeprecatedMonitor(arg0 context.Context, arg1 ...option.Option) cluster.Monitor {
 	m.ctrl.T.Helper()
 	varargs := []interface{}{arg0}
 	for _, a := range arg1 {
 		varargs = append(varargs, a)
 	}
-	ret := m.ctrl.Call(m, "NewMonitor", varargs...)
+	ret := m.ctrl.Call(m, "NewDeprecatedMonitor", varargs...)
 	ret0, _ := ret[0].(cluster.Monitor)
 	return ret0
 }
 
-// NewMonitor indicates an expected call of NewMonitor.
-func (mr *MockClusterMockRecorder) NewMonitor(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
+// NewDeprecatedMonitor indicates an expected call of NewDeprecatedMonitor.
+func (mr *MockClusterMockRecorder) NewDeprecatedMonitor(arg0 interface{}, arg1 ...interface{}) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
 	varargs := append([]interface{}{arg0}, arg1...)
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewMonitor", reflect.TypeOf((*MockCluster)(nil).NewMonitor), varargs...)
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "NewDeprecatedMonitor", reflect.TypeOf((*MockCluster)(nil).NewDeprecatedMonitor), varargs...)
 }
 
 // Node mocks base method.

--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -17,9 +17,65 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
 	"golang.org/x/sync/errgroup"
 )
+
+// monitorProcess represents a single process that the monitor monitors.
+type monitorProcess struct {
+	node               install.Node
+	virtualClusterName string
+	sqlInstance        int
+}
+
+// MonitorExpectedProcessHealth represents the expected health of a process.
+type MonitorExpectedProcessHealth string
+
+const (
+	ExpectedAlive = MonitorExpectedProcessHealth("process alive")
+	ExpectedDead  = MonitorExpectedProcessHealth("process dead")
+)
+
+// expectedProcessHealth is a concurrent map that stores the expected health of
+// each registered monitorProcess. It is a thin wrapper over syncutil.Map that ensures
+// consistent naming of the system interface.
+type expectedProcessHealth struct {
+	syncutil.Map[monitorProcess, MonitorExpectedProcessHealth]
+}
+
+func newProcess(node install.Node, virtualClusterName string, sqlInstance int) monitorProcess {
+	if virtualClusterName == "" {
+		virtualClusterName = install.SystemInterfaceName
+	}
+	return monitorProcess{
+		node:               node,
+		virtualClusterName: virtualClusterName,
+		sqlInstance:        sqlInstance,
+	}
+}
+
+func (m *expectedProcessHealth) get(
+	node install.Node, virtualClusterName string, sqlInstance int,
+) MonitorExpectedProcessHealth {
+	val, ok := m.Load(newProcess(node, virtualClusterName, sqlInstance))
+	if !ok {
+		// If the process has no expected state, assume it should be healthy.
+		return ExpectedAlive
+	}
+	return *val
+}
+
+func (m *expectedProcessHealth) set(
+	nodes install.Nodes,
+	virtualClusterName string,
+	sqlInstance int,
+	health MonitorExpectedProcessHealth,
+) {
+	for _, node := range nodes {
+		m.Store(newProcess(node, virtualClusterName, sqlInstance), &health)
+	}
+}
 
 // monitorImpl implements the Monitor interface. A monitor both
 // manages "user tasks" -- goroutines provided by tests -- as well as
@@ -46,7 +102,16 @@ type monitorImpl struct {
 	monitorGroup *errgroup.Group // monitor goroutine
 	monitorOnce  sync.Once       // guarantees monitor goroutine is only started once
 
-	expDeaths int32 // atomically
+	// expExactProcessDeath if true indicates that the monitor should expect that a
+	// specified process, as denoted by the triple in expProcessHealth.get, is dead.
+	// Otherwise, the monitor will expect that only a certain number of process deaths.
+	// The former is a stronger assertion used in the new global roachtest monitor,
+	// while the latter should be removed when the deprecated cluster monitor is removed.
+	expExactProcessDeath bool
+	// Deprecated: This field is used by the deprecated cluster monitor to track the number
+	// of expected process deaths, and should be removed when the cluster monitor is removed.
+	expDeaths        int32 // atomically
+	expProcessHealth expectedProcessHealth
 }
 
 func newMonitor(
@@ -58,17 +123,44 @@ func newMonitor(
 		L() *logger.Logger
 	},
 	c cluster.Cluster,
+	expectExactProcessDeath bool,
 	opts ...option.Option,
 ) *monitorImpl {
 	m := &monitorImpl{
-		t:     t,
-		l:     t.L(),
-		nodes: c.MakeNodes(opts...),
+		t:                    t,
+		l:                    t.L(),
+		nodes:                c.MakeNodes(opts...),
+		expExactProcessDeath: expectExactProcessDeath,
+		expProcessHealth:     expectedProcessHealth{},
 	}
 	m.ctx, m.cancel = context.WithCancel(ctx)
 	m.userGroup, _ = errgroup.WithContext(m.ctx)
 	m.monitorGroup, _ = errgroup.WithContext(m.ctx)
 	return m
+}
+
+func (m *monitorImpl) ExpectProcessHealth(
+	nodes install.Nodes, health MonitorExpectedProcessHealth, opts ...option.OptionFunc,
+) {
+	var virtualClusterOptions option.VirtualClusterOptions
+	if err := option.Apply(&virtualClusterOptions, opts...); err != nil {
+		m.t.Fatal(err)
+	}
+	m.expProcessHealth.set(nodes, virtualClusterOptions.VirtualClusterName, virtualClusterOptions.SQLInstance, health)
+}
+
+// ExpectProcessDeath lets the monitor know that a set of processes are about
+// to be killed, and that their deaths should be ignored. Virtual cluster
+// options can be passed to denote a separate process.
+func (m *monitorImpl) ExpectProcessDead(nodes option.NodeListOption, opts ...option.OptionFunc) {
+	m.ExpectProcessHealth(nodes.InstallNodes(), ExpectedDead, opts...)
+}
+
+// ExpectProcessAlive lets the monitor know that a set of processes are
+// expected to be healthy. Virtual cluster options can be passed to denote
+// a separate process.
+func (m *monitorImpl) ExpectProcessAlive(nodes option.NodeListOption, opts ...option.OptionFunc) {
+	m.ExpectProcessHealth(nodes.InstallNodes(), ExpectedAlive, opts...)
 }
 
 // ExpectDeath lets the monitor know that a node is about to be killed, and that
@@ -190,12 +282,16 @@ func (m *monitorImpl) startNodeMonitor() {
 						)
 					}
 				case install.MonitorProcessDead:
-					isExpectedDeath := atomic.AddInt32(&m.expDeaths, -1) >= 0
-					if isExpectedDeath {
-						expectedDeathStr = ": expected"
+					var isExpectedDeath bool
+					if m.expExactProcessDeath {
+						isExpectedDeath = m.expProcessHealth.get(info.Node, e.VirtualClusterName, e.SQLInstance) == ExpectedDead
+					} else {
+						isExpectedDeath = atomic.AddInt32(&m.expDeaths, -1) >= 0
 					}
 
-					if !isExpectedDeath {
+					if isExpectedDeath {
+						expectedDeathStr = ": expected"
+					} else {
 						retErr = fmt.Errorf("unexpected node event: %s", info)
 					}
 				}

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -191,7 +191,7 @@ type TestSpec struct {
 	Randomized bool
 
 	// Monitor specifies whether the test initiates a process monitor. Eventually,
-	// this should replace all instances of `cluster.NewMonitor`. To make this
+	// this should replace all instances of `cluster.NewDeprecatedMonitor`. To make this
 	// transition, tests should be modified to utilize the `test.Monitor` and
 	// `roachtestutil.Task` interfaces provided with each test.
 	Monitor bool

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -283,20 +283,6 @@ func (h *Helper) GoCommand(cmd string, nodes option.NodeListOption) context.Canc
 	}, task.Name(desc))
 }
 
-// ExpectDeath alerts the testing infrastructure that a node is
-// expected to die. Regular restarts as part of the mixedversion
-// testing are already taken into account. This function should only
-// be used by tests that perform their own node restarts or chaos
-// events.
-func (h *Helper) ExpectDeath() {
-	h.ExpectDeaths(1)
-}
-
-// ExpectDeaths is the general version of `ExpectDeath()`.
-func (h *Helper) ExpectDeaths(n int) {
-	h.runner.monitor.ExpectDeaths(n)
-}
-
 // ClusterVersion returns the currently active cluster version. Avoids
 // querying the database if we are not running migrations, since the
 // test runner has cached version of the cluster versions.

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -642,6 +642,10 @@ func NewTest(
 	crdbNodes option.NodeListOption,
 	options ...CustomOption,
 ) *Test {
+	if !t.Spec().(*registry.TestSpec).Monitor {
+		t.Fatal("mixedversion tests require enabling the global test monitor in the test spec")
+	}
+
 	opts := defaultTestOptions()
 	for _, fn := range options {
 		fn(&opts)
@@ -858,7 +862,7 @@ func (t *Test) Run() {
 }
 
 func (t *Test) run(plan *TestPlan) error {
-	return newTestRunner(t.ctx, t.cancel, plan, t.options.tag, t.logger, t.cluster).run()
+	return newTestRunner(t.ctx, t.cancel, plan, t.rt, t.options.tag, t.logger, t.cluster).run()
 }
 
 func (t *Test) plan() (plan *TestPlan, retErr error) {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner_test.go
@@ -119,10 +119,6 @@ func Test_run(t *testing.T) {
 				startSystemID: 9999,
 			}
 
-			runnerCh := make(chan error)
-			defer close(runnerCh)
-			runner.monitor = &crdbMonitor{errCh: runnerCh}
-
 			runErr := runner.run()
 			require.Error(t, runErr)
 

--- a/pkg/cmd/roachtest/test/BUILD.bazel
+++ b/pkg/cmd/roachtest/test/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/roachtestutil/task",
         "//pkg/roachprod/logger",
         "@com_github_cockroachdb_version//:version",

--- a/pkg/cmd/roachtest/test/test_monitor.go
+++ b/pkg/cmd/roachtest/test/test_monitor.go
@@ -5,9 +5,10 @@
 
 package test
 
+import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+
 // Monitor is an interface for monitoring cockroach processes during a test.
 type Monitor interface {
-	ExpectDeath()
-	ExpectDeaths(count int32)
-	ResetDeaths()
+	ExpectProcessDead(nodes option.NodeListOption, opts ...option.OptionFunc)
+	ExpectProcessAlive(nodes option.NodeListOption, opts ...option.OptionFunc)
 }

--- a/pkg/cmd/roachtest/test_monitor.go
+++ b/pkg/cmd/roachtest/test_monitor.go
@@ -19,7 +19,7 @@ type testMonitorImpl struct {
 
 func newTestMonitor(ctx context.Context, t test.Test, c *clusterImpl) *testMonitorImpl {
 	return &testMonitorImpl{
-		monitorImpl: newMonitor(ctx, t, c),
+		monitorImpl: newMonitor(ctx, t, c, true /* expectExactProcessDeath */),
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/acceptance.go
+++ b/pkg/cmd/roachtest/tests/acceptance.go
@@ -29,6 +29,7 @@ func registerAcceptance(r registry.Registry) {
 		timeout            time.Duration
 		encryptionSupport  registry.EncryptionSupport
 		defaultLeases      bool
+		monitor            bool
 		randomized         bool
 		workloadNode       bool
 		incompatibleClouds registry.CloudSet
@@ -75,6 +76,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:            runVersionUpgrade,
 				timeout:       2 * time.Hour, // actually lower in local runs; see `runVersionUpgrade`
 				defaultLeases: true,
+				monitor:       true,
 				randomized:    true,
 				suites:        []string{registry.MixedVersion},
 				// Disabled on IBM because s390x is only built on master
@@ -103,6 +105,7 @@ func registerAcceptance(r registry.Registry) {
 				fn:            runValidateSystemSchemaAfterVersionUpgrade,
 				timeout:       60 * time.Minute,
 				defaultLeases: true,
+				monitor:       true,
 				randomized:    true,
 				numNodes:      1,
 				suites:        []string{registry.MixedVersion},
@@ -157,6 +160,7 @@ func registerAcceptance(r registry.Registry) {
 				Timeout:           10 * time.Minute,
 				CompatibleClouds:  registry.AllClouds.Remove(tc.incompatibleClouds),
 				Suites:            registry.Suites(suites...),
+				Monitor:           tc.monitor,
 				Randomized:        tc.randomized,
 			}
 

--- a/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_bandwidth_overload.go
@@ -95,7 +95,7 @@ func registerDiskBandwidthOverload(r registry.Registry) {
 
 			// Run foreground kv workload, QoS="regular".
 			duration := 90 * time.Minute
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				t.Status(fmt.Sprintf("starting foreground kv workload thread (<%s)", time.Minute))
 				dur := " --duration=" + duration.String()

--- a/pkg/cmd/roachtest/tests/admission_control_disk_iops_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_disk_iops_overload.go
@@ -90,7 +90,7 @@ func registerDiskIOPSOverload(r registry.Registry) {
 
 			// Run foreground kv workload, QoS="regular".
 			duration := 90 * time.Minute
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				t.Status(fmt.Sprintf("starting foreground kv workload thread (<%s)", time.Minute))
 				dur := " --duration=" + duration.String()

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_backup.go
@@ -80,7 +80,7 @@ func registerElasticControlForBackups(r registry.Registry) {
 					t.Status(fmt.Sprintf("during: enabling admission control (<%s)", 30*time.Second))
 					roachtestutil.SetAdmissionControl(ctx, t, c, true)
 
-					m := c.NewMonitor(ctx, c.CRDBNodes())
+					m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 					m.Go(func(ctx context.Context) error {
 						t.Status(fmt.Sprintf("during: creating full backup schedule to run every 20m (<%s)", time.Minute))
 						bucketPrefix := "gs"

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_cdc.go
@@ -105,7 +105,7 @@ func registerElasticControlForCDC(r registry.Registry) {
 					stopFeeds(db) // stop stray feeds (from repeated runs against the same cluster for ex.)
 					defer stopFeeds(db)
 
-					m := c.NewMonitor(ctx, c.CRDBNodes())
+					m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 					m.Go(func(ctx context.Context) error {
 						const iters, changefeeds = 5, 10
 						for i := 0; i < iters; i++ {

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_io.go
@@ -69,7 +69,7 @@ func registerElasticIO(r registry.Registry) {
 			roachtestutil.SetAdmissionControl(ctx, t, c, true)
 			duration := 30 * time.Minute
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			labels := map[string]string{
 				"duration":    fmt.Sprintf("%d", duration.Milliseconds()),
 				"concurrency": "512",

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -39,6 +39,7 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 		Owner:            registry.OwnerKV,
 		Timeout:          3 * time.Hour,
 		Benchmark:        true,
+		Monitor:          true,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
 		Cluster: r.MakeClusterSpec(4, spec.CPU(8),

--- a/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
+++ b/pkg/cmd/roachtest/tests/admission_control_elastic_mixed_version.go
@@ -110,7 +110,7 @@ func registerElasticWorkloadMixedVersion(r registry.Registry) {
 			}
 			runWorkloads := func(ctx2 context.Context) error {
 				const duration = 5 * time.Minute
-				m := c.NewMonitor(ctx, c.CRDBNodes())
+				m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 				m.Go(func(ctx context.Context) error { return runForeground(ctx, duration) })
 				m.Go(func(ctx context.Context) error { return runBackground(ctx, duration) })
 				return m.WaitE()

--- a/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_follower_overload.go
@@ -286,7 +286,7 @@ sudo systemd-run --property=Type=exec \
 	}
 	t.L().Printf("deployed workload")
 
-	wait(c.NewMonitor(ctx, c.CRDBNodes()), phaseDuration)
+	wait(c.NewDeprecatedMonitor(ctx, c.CRDBNodes()), phaseDuration)
 
 	if cfg.ioNemesis {
 		// Limit write throughput on s3 to 20mb/s. This is not enough to keep up
@@ -307,7 +307,7 @@ sudo systemd-run --property=Type=exec \
 		t.L().Printf("installed write throughput limit on n3")
 	}
 
-	wait(c.NewMonitor(ctx, c.CRDBNodes()), phaseDuration)
+	wait(c.NewDeprecatedMonitor(ctx, c.CRDBNodes()), phaseDuration)
 
 	// TODO(aaditya,irfansharif): collect, assert on, and export metrics, using:
 	// https://github.com/cockroachdb/cockroach/pull/80724.

--- a/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_backfill.go
@@ -182,7 +182,7 @@ func registerIndexBackfill(r registry.Registry) {
 					// TODO(irfansharif): These now take closer to an hour after
 					// https://github.com/cockroachdb/cockroach/pull/109085. Do
 					// something about it if customers complain.
-					m := c.NewMonitor(ctx, c.CRDBNodes())
+					m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 					m.Go(func(ctx context.Context) error {
 						t.Status(fmt.Sprintf("starting index creation (<%s)", 30*time.Minute))
 						_, err := db.ExecContext(ctx,

--- a/pkg/cmd/roachtest/tests/admission_control_index_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_index_overload.go
@@ -88,7 +88,7 @@ func registerIndexOverload(r registry.Registry) {
 			}
 
 			t.Status("starting kv workload thread to run for ", testDuration)
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				testDurationStr := " --duration=" + testDuration.String()
 				concurrency := roachtestutil.IfLocal(c, "  --concurrency=8", " --concurrency=2048")

--- a/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
+++ b/pkg/cmd/roachtest/tests/admission_control_intent_resolution.go
@@ -70,7 +70,7 @@ func registerIntentResolutionOverload(r registry.Registry) {
 
 			roachtestutil.SetAdmissionControl(ctx, t, c, true)
 			t.Status("running txn")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				db := c.Conn(ctx, t.L(), len(c.CRDBNodes()))
 				defer db.Close()

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_index_backfill.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_index_backfill.go
@@ -51,7 +51,7 @@ func registerMultiStoreIndexBackfill(r registry.Registry) {
 					"--b 2000 --c 1000 --index-b-c-a=false --files-per-node=10 "+
 					"--batches-by-b=false {pgurl:1}")
 
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			cancelWorkload := m.GoWithCancel(func(ctx context.Context) error {
 				// This should use approx. 20% of the cluster's resources (disk/cpu).
 				if err := c.RunE(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multi_store_overload.go
@@ -58,7 +58,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 			"duration": dur.String(),
 		}
 		histograms := " " + roachtestutil.GetWorkloadHistogramArgs(t, c, labels)
-		m1 := c.NewMonitor(ctx, c.CRDBNodes())
+		m1 := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m1.Go(func(ctx context.Context) error {
 			dbRegular := " --db=db1"
 			concurrencyRegular := roachtestutil.IfLocal(c, "", " --concurrency=8")
@@ -69,7 +69,7 @@ func registerMultiStoreOverload(r registry.Registry) {
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdRegular)
 			return nil
 		})
-		m2 := c.NewMonitor(ctx, c.CRDBNodes())
+		m2 := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m2.Go(func(ctx context.Context) error {
 			dbOverload := " --db=db2"
 			concurrencyOverload := roachtestutil.IfLocal(c, "", " --concurrency=64")

--- a/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
+++ b/pkg/cmd/roachtest/tests/admission_control_multitenant_fairness.go
@@ -211,7 +211,7 @@ func runMultiTenantFairness(
 	defer cleanupFunc()
 
 	t.L().Printf("loading per-tenant data (<%s)", 10*time.Minute)
-	m1 := c.NewMonitor(ctx, c.All())
+	m1 := c.NewDeprecatedMonitor(ctx, c.All())
 	for name, node := range virtualClusters {
 		pgurl := fmt.Sprintf("{pgurl:%d:%s}", node[0], name)
 		name := name
@@ -253,7 +253,7 @@ func runMultiTenantFairness(
 	time.Sleep(waitDur)
 
 	t.L().Printf("running virtual cluster workloads (<%s)", s.duration+time.Minute)
-	m2 := c.NewMonitor(ctx, crdbNode)
+	m2 := c.NewDeprecatedMonitor(ctx, crdbNode)
 	var n int
 	for name, node := range virtualClusters {
 		pgurl := fmt.Sprintf("{pgurl:%d:%s}", node[0], name)

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload.go
@@ -139,7 +139,7 @@ func registerSnapshotOverload(r registry.Registry) {
 			totalWorkloadDuration := totalTransferDuration + (2 * padDuration)
 
 			t.Status(fmt.Sprintf("starting kv workload thread to run for %s (<%s)", totalWorkloadDuration, time.Minute))
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				duration := " --duration=" + totalWorkloadDuration.String()
 				concurrency := roachtestutil.IfLocal(c, "  --concurrency=8", " --concurrency=256")

--- a/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
+++ b/pkg/cmd/roachtest/tests/admission_control_snapshot_overload_io.go
@@ -190,7 +190,7 @@ func runAdmissionControlSnapshotOverloadIO(
 	}
 
 	t.Status(fmt.Sprintf("starting kv workload thread (<%s)", time.Minute))
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 
 		labels := map[string]string{

--- a/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
+++ b/pkg/cmd/roachtest/tests/admission_control_tpcc_overload.go
@@ -56,7 +56,7 @@ func (s tpccOLAPSpec) run(ctx context.Context, t test.Test, c cluster.Cluster) {
 	queryLine := `"` + strings.Replace(tpccOlapQuery, "\n", " ", -1) + `"`
 	c.Run(ctx, option.WithNodes(c.WorkloadNode()), "echo", queryLine, "> "+queryFileName)
 	t.Status("waiting")
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	rampDuration := 2 * time.Minute
 	duration := 3 * time.Minute
 	labels := getTpccLabels(s.Warehouses, rampDuration, duration, map[string]string{"concurrency": strconv.Itoa(s.Concurrency)})

--- a/pkg/cmd/roachtest/tests/allocation_bench.go
+++ b/pkg/cmd/roachtest/tests/allocation_bench.go
@@ -388,7 +388,7 @@ func runAllocationBenchSample(
 	// workloads have completed, or one has errored, the monitor will stop
 	// blocking.
 	specLoad := &spec.load
-	m := c.NewMonitor(ctx, c.Nodes(1, spec.nodes))
+	m := c.NewDeprecatedMonitor(ctx, c.Nodes(1, spec.nodes))
 	for i := range spec.load.events {
 		m.Go(func(ctx context.Context) error {
 			return runAllocationBenchEvent(ctx, t, c, specLoad, i)

--- a/pkg/cmd/roachtest/tests/allocator.go
+++ b/pkg/cmd/roachtest/tests/allocator.go
@@ -44,7 +44,7 @@ func registerAllocator(r registry.Registry) {
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
 
-		m := c.NewMonitor(ctx, c.Range(1, start))
+		m := c.NewDeprecatedMonitor(ctx, c.Range(1, start))
 		m.Go(func(ctx context.Context) error {
 			t.Status("loading fixture")
 			if err := c.RunE(
@@ -91,7 +91,7 @@ func registerAllocator(r registry.Registry) {
 		// Wait for 3x replication, we record the time taken to achieve this.
 		var replicateTime time.Time
 		startTime := timeutil.Now()
-		m = c.NewMonitor(ctx, c.CRDBNodes())
+		m = c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			err := roachtestutil.WaitFor3XReplication(ctx, t.L(), db)
 			replicateTime = timeutil.Now()
@@ -101,7 +101,7 @@ func registerAllocator(r registry.Registry) {
 
 		// Wait for replica count balance, this occurs only following
 		// up-replication finishing.
-		m = c.NewMonitor(ctx, c.CRDBNodes())
+		m = c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			t.Status("waiting for reblance")
 			err := waitForRebalance(ctx, t.L(), db, maxStdDev, allocatorStableSeconds)

--- a/pkg/cmd/roachtest/tests/alterpk.go
+++ b/pkg/cmd/roachtest/tests/alterpk.go
@@ -38,7 +38,7 @@ func registerAlterPK(r registry.Registry) {
 		initDone := make(chan struct{}, 1)
 		pkChangeDone := make(chan struct{}, 1)
 
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			// Load up a relatively small dataset to perform a workload on.
 
@@ -103,7 +103,7 @@ func registerAlterPK(r registry.Registry) {
 			t.Fatal(err)
 		}
 
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			// Start running the workload.
 			runCmd := fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -332,7 +332,7 @@ func registerBackup(r registry.Registry) {
 			tick, perfBuf := initBulkJobPerfArtifacts(2*time.Hour, t, exporter)
 			defer roachtestutil.CloseExporter(ctx, exporter, t, c, perfBuf, c.Node(1), "")
 
-			m := c.NewMonitor(ctx)
+			m := c.NewDeprecatedMonitor(ctx)
 			m.Go(func(ctx context.Context) error {
 				t.Status(`running backup`)
 				// Tick once before starting the backup, and once after to capture the
@@ -393,7 +393,7 @@ func registerBackup(r registry.Registry) {
 				}
 
 				conn := c.Conn(ctx, t.L(), 1)
-				m := c.NewMonitor(ctx)
+				m := c.NewDeprecatedMonitor(ctx)
 				m.Go(func(ctx context.Context) error {
 					t.Status(`running backup`)
 					_, err := conn.ExecContext(ctx, "BACKUP bank.bank INTO $1 WITH KMS=$2",
@@ -402,7 +402,7 @@ func registerBackup(r registry.Registry) {
 				})
 				m.Wait()
 
-				m = c.NewMonitor(ctx)
+				m = c.NewDeprecatedMonitor(ctx)
 				m.Go(func(ctx context.Context) error {
 					t.Status(`restoring from backup`)
 					if _, err := conn.ExecContext(ctx, "CREATE DATABASE restoreDB"); err != nil {
@@ -456,7 +456,7 @@ func registerBackup(r registry.Registry) {
 				dest := importBankData(ctx, rows, t, c)
 
 				conn := c.Conn(ctx, t.L(), 1)
-				m := c.NewMonitor(ctx)
+				m := c.NewDeprecatedMonitor(ctx)
 				m.Go(func(ctx context.Context) error {
 					_, err := conn.ExecContext(ctx, `
 					CREATE DATABASE restoreA;
@@ -469,7 +469,7 @@ func registerBackup(r registry.Registry) {
 				var err error
 				backupPath := fmt.Sprintf("nodelocal://1/kmsbackup/%s/%s", cloudProvider, dest)
 
-				m = c.NewMonitor(ctx)
+				m = c.NewDeprecatedMonitor(ctx)
 				m.Go(func(ctx context.Context) error {
 					switch cloudProvider {
 					case spec.AWS:
@@ -503,7 +503,7 @@ func registerBackup(r registry.Registry) {
 				m.Wait()
 
 				// Restore the encrypted BACKUP using each of KMS URI A and B separately.
-				m = c.NewMonitor(ctx)
+				m = c.NewDeprecatedMonitor(ctx)
 				m.Go(func(ctx context.Context) error {
 					t.Status(`restore using KMSURIA`)
 					if _, err := conn.ExecContext(ctx,

--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -185,7 +185,7 @@ func (bd *backupDriver) runWorkload(ctx context.Context) (func(), error) {
 	bd.t.L().Printf("starting tpcc workload against %d", bd.sp.fixture.WorkloadWarehouses)
 
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
-	m := bd.c.NewMonitor(workloadCtx)
+	m := bd.c.NewDeprecatedMonitor(workloadCtx)
 	m.Go(func(ctx context.Context) error {
 		cmd := roachtestutil.NewCommand("./cockroach workload run tpcc").
 			Arg("{pgurl%s}", bd.c.CRDBNodes()).
@@ -416,7 +416,7 @@ func (bd *backupDriver) fingerprintFixture(ctx context.Context) map[string]strin
 	aost := bd.getLatestAOST(ctx, sql)
 	tables := getDatabaseTables(ctx, bd.t, sql, bd.sp.fixture.DatabaseName())
 
-	m := bd.c.NewMonitor(ctx)
+	m := bd.c.NewDeprecatedMonitor(ctx)
 
 	bd.t.L().Printf("fingerprinting %d tables in %s", len(tables), bd.sp.fixture.DatabaseName())
 	fingerprints := make(map[string]string)

--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -131,7 +131,7 @@ func backupRestoreRoundTrip(
 	})
 
 	c.Start(ctx, t.L(), roachtestutil.MaybeUseMemoryBudget(t, 50), install.MakeClusterSettings(envOption), c.CRDBNodes())
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	m.Go(func(ctx context.Context) error {
 		testUtils, err := setupBackupRestoreTestUtils(
@@ -442,7 +442,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 	t.L().Printf("random seed: %d", seed)
 
 	c.Start(ctx, t.L(), roachtestutil.MaybeUseMemoryBudget(t, 50), install.MakeClusterSettings(), c.CRDBNodes())
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	const jobStatusWait = time.Minute * 5
 
 	m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/buffered_logging.go
+++ b/pkg/cmd/roachtest/tests/buffered_logging.go
@@ -93,7 +93,7 @@ func registerBufferedLogging(r registry.Registry) {
 		c.Run(ctx, option.WithNodes(c.WorkloadNode()), initWorkloadCmd)
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			joinedURLs := strings.Join(workloadPGURLs, " ")
 			runWorkloadCmd := fmt.Sprintf("./cockroach workload run kv --concurrency=32 --duration=1h %s", joinedURLs)

--- a/pkg/cmd/roachtest/tests/cancel.go
+++ b/pkg/cmd/roachtest/tests/cancel.go
@@ -44,14 +44,14 @@ func registerCancel(r registry.Registry) {
 	runCancel := func(ctx context.Context, t test.Test, c cluster.Cluster, tpchQueriesToRun []int, useDistsql bool) {
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.All())
 
-		m := c.NewMonitor(ctx, c.All())
+		m := c.NewDeprecatedMonitor(ctx, c.All())
 		m.Go(func(ctx context.Context) error {
 			conn := c.Conn(ctx, t.L(), 1)
 			defer conn.Close()
 
 			t.Status("restoring TPCH dataset for Scale Factor 1")
 			if err := loadTPCHDataset(
-				ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
+				ctx, t, c, conn, 1 /* sf */, c.NewDeprecatedMonitor(ctx), c.All(), false, /* disableMergeQueue */
 			); err != nil {
 				t.Fatal(err)
 			}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -230,7 +230,7 @@ func (ct *cdcTester) setupSink(args feedArgs) string {
 
 		// Start the server in its own monitor to not block ct.mon.Wait()
 		serverExecCmd := fmt.Sprintf(`go run webhook-server-%d.go`, webhookPort)
-		m := ct.cluster.NewMonitor(ct.ctx, ct.workloadNode)
+		m := ct.cluster.NewDeprecatedMonitor(ct.ctx, ct.workloadNode)
 		m.Go(func(ctx context.Context) error {
 			return ct.cluster.RunE(ct.ctx, option.WithNodes(webhookNode), serverExecCmd, rootFolder)
 		})
@@ -767,7 +767,7 @@ func newCDCTester(ctx context.Context, t test.Test, c cluster.Cluster, opts ...o
 		opt(&tester)
 	}
 
-	tester.mon = c.NewMonitor(ctx, tester.crdbNodes)
+	tester.mon = c.NewDeprecatedMonitor(ctx, tester.crdbNodes)
 
 	changefeedLogger, err := t.L().ChildLogger("changefeed")
 	if err != nil {
@@ -913,7 +913,7 @@ func runCDCBank(ctx context.Context, t test.Test, c cluster.Cluster, cfg cdcBank
 	messageBuf := make(chan *sarama.ConsumerMessage, 4096)
 	const requestedResolved = 100
 
-	m := c.NewMonitor(ctx, crdbNodes)
+	m := c.NewDeprecatedMonitor(ctx, crdbNodes)
 	chaosCancel := func() func() {
 		if !cfg.kafkaChaos {
 			return func() {}
@@ -1060,7 +1060,7 @@ func runCDCInitialScanRollingRestart(
 	racks := install.MakeClusterSettings(install.NumRacksOption(c.Spec().NodeCount))
 	racks.Env = append(racks.Env, `COCKROACH_CHANGEFEED_TESTING_FAST_RETRY=true`)
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), racks)
-	m := c.NewMonitor(ctx, c.All())
+	m := c.NewDeprecatedMonitor(ctx, c.All())
 
 	restart := func(n int) error {
 		cmd := fmt.Sprintf("./cockroach node drain --certs-dir=%s --port={pgport:%d} --self", install.CockroachNodeCertsDir, n)
@@ -1261,7 +1261,7 @@ func runCDCFineGrainedCheckpointingBenchmark(
 	}
 
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
-	m := c.NewMonitor(ctx, c.All())
+	m := c.NewDeprecatedMonitor(ctx, c.All())
 
 	db := c.Conn(ctx, t.L(), 1)
 
@@ -3249,7 +3249,7 @@ func (k kafkaManager) configureHydraOauth(ctx context.Context) (string, string) 
 	if err != nil {
 		k.t.Fatal(err)
 	}
-	mon := k.c.NewMonitor(ctx, k.kafkaSinkNodes)
+	mon := k.c.NewDeprecatedMonitor(ctx, k.kafkaSinkNodes)
 	mon.Go(func(ctx context.Context) error {
 		err := k.c.RunE(ctx, option.WithNodes(k.kafkaSinkNodes), `/home/ubuntu/hydra-serve.sh`)
 		return errors.Wrap(err, "hydra failed")

--- a/pkg/cmd/roachtest/tests/cdc_bench.go
+++ b/pkg/cmd/roachtest/tests/cdc_bench.go
@@ -298,7 +298,7 @@ func runCDCBenchScan(
 	opts, settings := makeCDCBenchOptions(c)
 
 	c.Start(ctx, t.L(), opts, settings, nData)
-	m := c.NewMonitor(ctx, nData.Merge(nCoord))
+	m := c.NewDeprecatedMonitor(ctx, nData.Merge(nCoord))
 
 	conn := c.Conn(ctx, t.L(), nData[0])
 	defer conn.Close()
@@ -482,7 +482,7 @@ func runCDCBenchWorkload(
 	}
 
 	c.Start(ctx, t.L(), opts, settings, nData)
-	m := c.NewMonitor(ctx, nData.Merge(nCoord))
+	m := c.NewDeprecatedMonitor(ctx, nData.Merge(nCoord))
 
 	conn := c.Conn(ctx, t.L(), nData[0])
 	defer conn.Close()

--- a/pkg/cmd/roachtest/tests/clearrange.go
+++ b/pkg/cmd/roachtest/tests/clearrange.go
@@ -60,7 +60,7 @@ func registerClearRange(r registry.Registry) {
 func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressiveChecks bool) {
 	t.Status("restoring fixture")
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
-	m := c.NewMonitor(ctx)
+	m := c.NewDeprecatedMonitor(ctx)
 	m.Go(func(ctx context.Context) error {
 		// NB: on a 10 node cluster, this should take well below 3h.
 		tBegin := timeutil.Now()
@@ -83,7 +83,7 @@ func runClearRange(ctx context.Context, t test.Test, c cluster.Cluster, aggressi
 	}
 
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), settings)
-	m = c.NewMonitor(ctx)
+	m = c.NewDeprecatedMonitor(ctx)
 
 	// Also restore a much smaller table. We'll use it to run queries against
 	// the cluster after having dropped the large table above, verifying that

--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -663,7 +663,7 @@ func (rd *replicationDriver) crdbNodes() option.NodeListOption {
 }
 
 func (rd *replicationDriver) newMonitor(ctx context.Context) cluster.Monitor {
-	m := rd.c.NewMonitor(ctx, rd.crdbNodes())
+	m := rd.c.NewDeprecatedMonitor(ctx, rd.crdbNodes())
 	m.ExpectDeaths(rd.rs.expectedNodeDeaths)
 	return m
 }

--- a/pkg/cmd/roachtest/tests/copy.go
+++ b/pkg/cmd/roachtest/tests/copy.go
@@ -46,7 +46,7 @@ func registerCopy(r registry.Registry) {
 
 		copyTimeout := 10 * time.Minute
 
-		m := c.NewMonitor(ctx, c.All())
+		m := c.NewDeprecatedMonitor(ctx, c.All())
 		m.Go(func(ctx context.Context) error {
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()

--- a/pkg/cmd/roachtest/tests/copyfrom.go
+++ b/pkg/cmd/roachtest/tests/copyfrom.go
@@ -166,7 +166,7 @@ func runCopyFromCRDB(ctx context.Context, t test.Test, c cluster.Cluster, sf int
 	}
 	urls, err := c.InternalPGUrl(ctx, t.L(), c.Node(1), roachprod.PGURLOptions{Auth: install.AuthUserPassword})
 	require.NoError(t, err)
-	m := c.NewMonitor(ctx, c.All())
+	m := c.NewDeprecatedMonitor(ctx, c.All())
 	m.Go(func(ctx context.Context) error {
 		// psql w/ url first doesn't support --db arg so have to do this.
 		urlstr := strings.Replace(urls[0], "?", "/defaultdb?", 1)

--- a/pkg/cmd/roachtest/tests/db_console_cypress.go
+++ b/pkg/cmd/roachtest/tests/db_console_cypress.go
@@ -206,6 +206,7 @@ func registerDbConsoleCypress(r registry.Registry) {
 		// is impossible to test as of 05/2025.
 		CompatibleClouds: registry.AllClouds.NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       false,
 		Run:              runDbConsoleCypressMixedVersions,
 		Timeout:          2 * time.Hour,

--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -100,6 +100,7 @@ func registerDBConsoleEndpointsMixedVersion(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(5, spec.WorkloadNode()),
 		CompatibleClouds: registry.AllClouds,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run:              runDBConsoleMixedVersion,
 		Timeout:          1 * time.Hour,

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -1144,7 +1144,7 @@ func runDecommissionSlow(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// since the decommissions will stall.
 	decomCtx, cancel := context.WithTimeout(ctx, 10*time.Minute)
 	defer cancel()
-	m := c.NewMonitor(decomCtx)
+	m := c.NewDeprecatedMonitor(decomCtx)
 	for nodeID := 2; nodeID <= numNodes; nodeID++ {
 		id := nodeID
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/decommission.go
+++ b/pkg/cmd/roachtest/tests/decommission.go
@@ -119,6 +119,8 @@ func registerDecommission(r registry.Registry) {
 			Cluster:          r.MakeClusterSpec(numNodes),
 			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 			Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+			Monitor:          true,
+			Randomized:       true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runDecommissionMixedVersions(ctx, t, c)
 			},

--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -627,7 +627,7 @@ func runDecommissionBench(
 	setupDecommissionBench(ctx, t, c, benchSpec, pinnedNode, importCmd)
 
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
-	m := c.NewMonitor(workloadCtx, crdbNodes)
+	m := c.NewDeprecatedMonitor(workloadCtx, crdbNodes)
 
 	if !benchSpec.noLoad {
 		m.Go(
@@ -770,7 +770,7 @@ func runDecommissionBenchLong(
 	setupDecommissionBench(ctx, t, c, benchSpec, pinnedNode, importCmd)
 
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
-	m := c.NewMonitor(workloadCtx, crdbNodes)
+	m := c.NewDeprecatedMonitor(workloadCtx, crdbNodes)
 
 	if !benchSpec.noLoad {
 		m.Go(

--- a/pkg/cmd/roachtest/tests/disagg_rebalance.go
+++ b/pkg/cmd/roachtest/tests/disagg_rebalance.go
@@ -46,13 +46,13 @@ func registerDisaggRebalance(r registry.Registry) {
 				"./cockroach workload fixtures import tpcc --warehouses=%d --checks=false {pgurl:1}",
 				warehouses,
 			)
-			m := c.NewMonitor(ctx, c.Range(1, 3))
+			m := c.NewDeprecatedMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
 				return c.RunE(ctx, option.WithNodes(c.Node(1)), cmd)
 			})
 			m.Wait()
 
-			m2 := c.NewMonitor(ctx, c.Range(1, 3))
+			m2 := c.NewDeprecatedMonitor(ctx, c.Range(1, 3))
 
 			m2.Go(func(ctx context.Context) error {
 				t.Status("run tpcc")

--- a/pkg/cmd/roachtest/tests/disk_full.go
+++ b/pkg/cmd/roachtest/tests/disk_full.go
@@ -50,7 +50,7 @@ func registerDiskFull(r registry.Registry) {
 			_ = db.Close()
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf(
 					"./cockroach workload run kv --tolerate-errors --init --read-percent=0"+

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -89,7 +89,7 @@ func runDiskStalledWALFailover(ctx context.Context, t test.Test, c cluster.Clust
 
 	t.Status("starting workload")
 	workloadStartAt := timeutil.Now()
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		c.Run(ctx, option.WithNodes(c.WorkloadNode()), `./cockroach workload run kv --read-percent 0 `+
 			`--duration 60m --concurrency 4096 --ramp=1m --max-rate 4096 --tolerate-errors `+
@@ -289,7 +289,7 @@ func runDiskStalledDetection(
 
 	t.Status("starting workload")
 	workloadStartAt := timeutil.Now()
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		// NB: Since we stall node 1, we run the workload only on nodes 2-3 so
 		// the post-stall QPS isn't affected by the fact that 1/3rd of workload

--- a/pkg/cmd/roachtest/tests/drain.go
+++ b/pkg/cmd/roachtest/tests/drain.go
@@ -131,7 +131,7 @@ func runEarlyExitInConnectionWait(ctx context.Context, t test.Test, c cluster.Cl
 	}
 
 	// Start draining the node.
-	m := c.NewMonitor(ctx, c.Node(nodeToDrain))
+	m := c.NewDeprecatedMonitor(ctx, c.Node(nodeToDrain))
 
 	m.Go(func(ctx context.Context) error {
 		t.Status(fmt.Sprintf("start draining node %d", nodeToDrain))
@@ -262,7 +262,7 @@ func runWarningForConnWait(ctx context.Context, t test.Test, c cluster.Cluster) 
 	connWithSleep, err := pgx.Connect(ctx, pgURL[0])
 	require.NoError(t, err)
 
-	m := c.NewMonitor(ctx, c.Node(nodeToDrain))
+	m := c.NewDeprecatedMonitor(ctx, c.Node(nodeToDrain))
 	m.Go(func(ctx context.Context) error {
 		t.Status(fmt.Sprintf("draining node %d", nodeToDrain))
 		return c.RunE(ctx,

--- a/pkg/cmd/roachtest/tests/drop.go
+++ b/pkg/cmd/roachtest/tests/drop.go
@@ -34,7 +34,7 @@ func registerDrop(r registry.Registry) {
 		settings.Env = append(settings.Env, "COCKROACH_MEMPROF_INTERVAL=15s")
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings)
 
-		m := c.NewMonitor(ctx, c.All())
+		m := c.NewDeprecatedMonitor(ctx, c.All())
 		m.Go(func(ctx context.Context) error {
 			t.WorkerStatus("importing TPCC fixture")
 			c.Run(ctx, option.WithNodes(c.Node(1)), tpccImportCmd("", warehouses, "{pgurl:1}"))

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -249,7 +249,7 @@ func runFailoverChaos(ctx context.Context, t test.Test, c cluster.Cluster, readO
 	// breakers for all ranges by default.
 	settings.ClusterSettings["kv.dist_sender.circuit_breakers.mode"] = "all ranges"
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failers := []Failer{}
 	for _, failureMode := range allFailureModes {
@@ -447,7 +447,7 @@ func runFailoverPartialLeaseGateway(ctx context.Context, t test.Test, c cluster.
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureModeBlackhole, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
@@ -593,7 +593,7 @@ func runFailoverPartialLeaseLeader(ctx context.Context, t test.Test, c cluster.C
 	// breakers for all ranges by default.
 	settings.ClusterSettings["kv.dist_sender.circuit_breakers.mode"] = "all ranges"
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureModeBlackhole, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
@@ -715,7 +715,7 @@ func runFailoverPartialLeaseLiveness(ctx context.Context, t test.Test, c cluster
 	settings := install.MakeClusterSettings()
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureModeBlackhole, settings, rng).(PartialFailer)
 	failer.Setup(ctx)
@@ -832,7 +832,7 @@ func runFailoverNonSystem(
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureMode, settings, rng)
 	failer.Setup(ctx)
@@ -940,7 +940,7 @@ func runFailoverLiveness(
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureMode, settings, rng)
 	failer.Setup(ctx)
@@ -1054,7 +1054,7 @@ func runFailoverSystemNonLiveness(
 	settings.Env = append(settings.Env, "COCKROACH_ENABLE_UNSAFE_TEST_BUILTINS=true")
 	settings.Env = append(settings.Env, "COCKROACH_SCAN_MAX_IDLE_TIME=100ms") // speed up replication
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	failer := makeFailer(t, c, m, failureMode, settings, rng)
 	failer.Setup(ctx)

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -127,6 +127,7 @@ func registerFollowerReads(r registry.Registry) {
 		),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run:              runFollowerReadsMixedVersionSingleRegionTest,
 	})
@@ -142,6 +143,7 @@ func registerFollowerReads(r registry.Registry) {
 		),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run:              runFollowerReadsMixedVersionGlobalTableTest,
 	})

--- a/pkg/cmd/roachtest/tests/import.go
+++ b/pkg/cmd/roachtest/tests/import.go
@@ -124,7 +124,7 @@ func registerImportTPCC(r registry.Registry) {
 		c.Run(ctx, option.WithNodes(c.All()), `./cockroach workload csv-server --port=8081 &> logs/workload-csv-server.log < /dev/null &`)
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx)
+		m := c.NewDeprecatedMonitor(ctx)
 		dul := roachtestutil.NewDiskUsageLogger(t, c)
 		m.Go(dul.Runner)
 
@@ -270,7 +270,7 @@ func registerImportTPCH(r registry.Registry) {
 				}); err != nil {
 					t.Fatal(err)
 				}
-				m := c.NewMonitor(ctx)
+				m := c.NewDeprecatedMonitor(ctx)
 				dul := roachtestutil.NewDiskUsageLogger(t, c)
 				m.Go(dul.Runner)
 

--- a/pkg/cmd/roachtest/tests/import_cancellation.go
+++ b/pkg/cmd/roachtest/tests/import_cancellation.go
@@ -106,7 +106,7 @@ func runImportCancellation(ctx context.Context, t test.Test, c cluster.Cluster) 
 		rootRng: rng,
 		seed:    seed,
 	}
-	m := c.NewMonitor(ctx)
+	m := c.NewDeprecatedMonitor(ctx)
 	t.Status("running imports with seed ", seed)
 	var wg sync.WaitGroup
 	wg.Add(len(tablesToNumFiles))

--- a/pkg/cmd/roachtest/tests/inconsistency.go
+++ b/pkg/cmd/roachtest/tests/inconsistency.go
@@ -86,7 +86,7 @@ func runInconsistency(ctx context.Context, t test.Test, c cluster.Cluster) {
 		"hex:016b1202000174786e2d0000000000000000000000000000000000 "+
 		"hex:120408001000180020002800322a0a10000000000000000000000000000000001a1266616b65207472616e73616374696f6e20302a004a00")
 
-	m := c.NewMonitor(ctx)
+	m := c.NewDeprecatedMonitor(ctx)
 	// If the consistency check "fails to fail", the verbose logging will help
 	// determine why.
 	startOpts := option.DefaultStartOpts()

--- a/pkg/cmd/roachtest/tests/indexes.go
+++ b/pkg/cmd/roachtest/tests/indexes.go
@@ -55,7 +55,7 @@ func registerNIndexes(r registry.Registry, secondaryIndexes int) {
 			conn := c.Conn(ctx, t.L(), 1)
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				secondary := " --secondary-indexes=" + strconv.Itoa(secondaryIndexes)
 				initCmd := "./workload init indexes" + secondary + " {pgurl:1}"

--- a/pkg/cmd/roachtest/tests/inverted_index.go
+++ b/pkg/cmd/roachtest/tests/inverted_index.go
@@ -52,7 +52,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 
 	// First generate random JSON data using the JSON workload.
 	// TODO (lucy): Using a pre-generated test fixture would be much faster
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	cmdWrite := fmt.Sprintf(
 		"./workload run json --read-percent=0 --duration %s {pgurl%s} --batch 200 --sequential",
@@ -76,7 +76,7 @@ func runSchemaChangeInvertedIndex(ctx context.Context, t test.Test, c cluster.Cl
 	m.Wait()
 
 	// Run the workload (with both reads and writes), and create the index at the same time.
-	m = c.NewMonitor(ctx, c.CRDBNodes())
+	m = c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	cmdWriteAndRead := fmt.Sprintf(
 		"./workload run json --read-percent=50 --duration %s {pgurl%s} --sequential",

--- a/pkg/cmd/roachtest/tests/jobs.go
+++ b/pkg/cmd/roachtest/tests/jobs.go
@@ -83,7 +83,7 @@ func runJobsStress(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	done := make(chan struct{})
 	earlyExit := make(chan struct{}, 1)
-	m := c.NewMonitor(ctx)
+	m := c.NewDeprecatedMonitor(ctx)
 
 	m.Go(func(ctx context.Context) error {
 		defer close(done)

--- a/pkg/cmd/roachtest/tests/jobs_util.go
+++ b/pkg/cmd/roachtest/tests/jobs_util.go
@@ -105,7 +105,7 @@ func executeNodeShutdown(
 		return err
 	}
 
-	m := c.NewMonitor(ctx, cfg.crdbNodes)
+	m := c.NewDeprecatedMonitor(ctx, cfg.crdbNodes)
 	m.ExpectDeath()
 	m.Go(func(ctx context.Context) error {
 		ticker := time.NewTicker(1 * time.Second)

--- a/pkg/cmd/roachtest/tests/kv.go
+++ b/pkg/cmd/roachtest/tests/kv.go
@@ -127,7 +127,7 @@ func registerKV(r registry.Registry) {
 		}
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			concurrency := roachtestutil.IfLocal(c, "", " --concurrency="+fmt.Sprint(computeConcurrency(opts)))
 			splits := ""
@@ -422,7 +422,7 @@ func registerKVContention(r registry.Registry) {
 			}
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				// Write to a small number of keys to generate a large amount of
 				// contention. Use a relatively high amount of concurrency and
@@ -471,7 +471,7 @@ func registerKVQuiescenceDead(r registry.Registry) {
 				"sql.stats.automatic_collection.enabled": "false",
 			})
 			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), settings, c.CRDBNodes())
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()
@@ -573,7 +573,7 @@ func registerKVGracefulDraining(r registry.Registry) {
 			// before it starts draining.
 			c.Run(ctx, option.WithNodes(c.Node(1)), "./cockroach workload init kv --splits 100 {pgurl:1}")
 
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.ExpectDeath()
 
 			// specifiedQPS is going to be the --max-rate for the kv workload.
@@ -803,7 +803,7 @@ func registerKVSplits(r registry.Registry) {
 
 				t.Status("running workload")
 				workloadCtx, workloadCancel := context.WithCancel(ctx)
-				m := c.NewMonitor(workloadCtx, c.CRDBNodes())
+				m := c.NewDeprecatedMonitor(workloadCtx, c.CRDBNodes())
 				m.Go(func(ctx context.Context) error {
 					defer workloadCancel()
 					concurrency := roachtestutil.IfLocal(c, "", " --concurrency="+fmt.Sprint(nodes*64))
@@ -832,7 +832,7 @@ func registerKVScalability(r registry.Registry) {
 			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				cmd := fmt.Sprintf("./cockroach workload run kv --init --read-percent=%d "+
 					"--splits=1000 --duration=1m "+fmt.Sprintf("--concurrency=%d", i)+
@@ -895,7 +895,7 @@ func registerKVRangeLookups(r registry.Registry) {
 		err := roachtestutil.WaitFor3XReplication(ctx, t.L(), conns[0])
 		require.NoError(t, err)
 
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			defer close(doneWorkload)
 			defer close(doneInit)
@@ -1053,7 +1053,7 @@ func registerKVRestartImpact(r registry.Registry) {
 			t.Status(fmt.Sprintf("starting kv workload thread to run for %s", testDuration))
 
 			// Three goroutines run and we wait for all to complete.
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.ExpectDeath()
 			m.Go(func(ctx context.Context) error {
 				// Don't include the last node when starting the workload since

--- a/pkg/cmd/roachtest/tests/kvbench.go
+++ b/pkg/cmd/roachtest/tests/kvbench.go
@@ -203,7 +203,7 @@ func runKVBench(ctx context.Context, t test.Test, c cluster.Cluster, b kvBenchSp
 	}
 	s := search.NewLineSearcher(100 /* min */, 10000000 /* max */, b.EstimatedMaxThroughput, initStepSize, precision)
 	searchPredicate := func(maxrate int) (bool, error) {
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		// Restart
 		m.ExpectDeaths(int32(len(c.CRDBNodes())))
 		// Wipe cluster before starting a new run because factors like load-based

--- a/pkg/cmd/roachtest/tests/large_schema_benchmark.go
+++ b/pkg/cmd/roachtest/tests/large_schema_benchmark.go
@@ -180,7 +180,7 @@ func registerLargeSchemaBenchmark(r registry.Registry, numTables int, isMultiReg
 			}
 			// Upload a file containing the ORM queries.
 			require.NoError(t, c.PutString(ctx, LargeSchemaOrmQueries, "ormQueries.sql", 0755, c.WorkloadNode()))
-			mon := c.NewMonitor(ctx, c.All())
+			mon := c.NewDeprecatedMonitor(ctx, c.All())
 			// Upload a file containing the web API calls we want to benchmark.
 			require.NoError(t, c.PutString(ctx,
 				LargeSchemaAPICalls,

--- a/pkg/cmd/roachtest/tests/ledger.go
+++ b/pkg/cmd/roachtest/tests/ledger.go
@@ -38,7 +38,7 @@ func registerLedger(r registry.Registry) {
 			c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
 
 			t.Status("running workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				concurrency := roachtestutil.IfLocal(c, "", " --concurrency="+fmt.Sprint(nodes*32))
 				duration := " --duration=" + roachtestutil.IfLocal(c, "10s", "10m")

--- a/pkg/cmd/roachtest/tests/limit_capacity.go
+++ b/pkg/cmd/roachtest/tests/limit_capacity.go
@@ -85,7 +85,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 
 	c.Run(ctx, option.WithNodes(c.WorkloadNode()), "./cockroach workload init kv --splits=1000 {pgurl:1}")
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	cancels = append(cancels, m.GoWithCancel(func(ctx context.Context) error {
 		t.L().Printf("starting load generator\n")
 		// NB: kv50 with 4kb block size at 5k rate will incur approx. 500mb/s write
@@ -100,7 +100,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 	}))
 
 	t.Status(fmt.Sprintf("waiting %s for baseline workload throughput", initialDuration))
-	wait(c.NewMonitor(ctx, c.CRDBNodes()), initialDuration)
+	wait(c.NewDeprecatedMonitor(ctx, c.CRDBNodes()), initialDuration)
 	qpsInitial := roachtestutil.MeasureQPS(ctx, t, c, 10*time.Second, c.Node(1))
 	t.Status(fmt.Sprintf("initial (single node) qps: %.0f", qpsInitial))
 
@@ -126,7 +126,7 @@ func runLimitCapacity(ctx context.Context, t test.Test, c cluster.Cluster, cfg l
 		}))
 	}
 
-	wait(c.NewMonitor(ctx, c.CRDBNodes()), limitDuration)
+	wait(c.NewDeprecatedMonitor(ctx, c.CRDBNodes()), limitDuration)
 	qpsFinal := roachtestutil.MeasureQPS(ctx, t, c, 10*time.Second, c.Node(1))
 	qpsRelative := qpsFinal / qpsInitial
 	t.Status(fmt.Sprintf("initial qps=%f final qps=%f (%f%%)", qpsInitial, qpsFinal, 100*qpsRelative))

--- a/pkg/cmd/roachtest/tests/logical_data_replication.go
+++ b/pkg/cmd/roachtest/tests/logical_data_replication.go
@@ -271,7 +271,7 @@ func TestLDRBasic(
 
 	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
 	workloadDoneCh := make(chan struct{})
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, 2*time.Minute)
 
 	monitor.Go(func(ctx context.Context) error {
@@ -308,7 +308,7 @@ func TestLDRSchemaChange(
 	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
 
 	workloadDoneCh := make(chan struct{})
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, 2*time.Minute)
 
 	monitor.Go(func(ctx context.Context) error {
@@ -374,7 +374,7 @@ func TestLDRTPCC(
 
 	workloadDoneCh := make(chan struct{})
 	maxExpectedLatency := 3 * time.Minute
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
 
 	monitor.Go(func(ctx context.Context) error {
@@ -427,7 +427,7 @@ func TestLDRCreateTablesTPCC(
 		fmt.Sprintf("./cockroach workload init tpcc --warehouses=%d --fks=false {pgurl:%d:system}", warehouses, setup.left.nodes[0]))
 
 	workloadDoneCh := make(chan struct{})
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	monitor.Go(func(ctx context.Context) error {
 		defer close(workloadDoneCh)
 		// Run workload on the left cluster. Unlike other ldr tests at the moment,
@@ -476,7 +476,7 @@ func TestLDRUpdateHeavy(
 
 	workloadDoneCh := make(chan struct{})
 	maxExpectedLatency := 3 * time.Minute
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
 
 	monitor.Go(func(ctx context.Context) error {
@@ -580,7 +580,7 @@ func TestLDROnNodeShutdown(
 	// Setup latency verifiers, remembering to account for latency spike from killing a node
 	maxExpectedLatency := 5 * time.Minute
 	workloadDoneCh := make(chan struct{})
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	validateLatency := setupLatencyVerifiers(ctx, t, c, monitor, leftJobID, rightJobID, setup, workloadDoneCh, maxExpectedLatency)
 
 	monitor.Go(func(ctx context.Context) error {
@@ -630,7 +630,7 @@ func TestLDROnNetworkPartition(
 
 	leftJobID, rightJobID := setupLDR(ctx, t, c, setup, ldrWorkload, ldrConfig)
 
-	monitor := c.NewMonitor(ctx, setup.CRDBNodes())
+	monitor := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	monitor.Go(func(ctx context.Context) error {
 		return c.RunE(ctx, option.WithNodes(setup.workloadNode), ldrWorkload.workload.sourceRunCmd("system", setup.CRDBNodes()))
 	})
@@ -905,7 +905,7 @@ func setupLDR(
 	if ldrConfig.initialScanTimeout != 0 {
 		initialScanTimeout = ldrConfig.initialScanTimeout
 	}
-	initScanMon := c.NewMonitor(ctx, setup.CRDBNodes())
+	initScanMon := c.NewDeprecatedMonitor(ctx, setup.CRDBNodes())
 	approxInitScanStart := timeutil.Now()
 	t.L().Printf("Waiting for initial scan(s) to complete")
 	initScanMon.Go(func(ctx context.Context) error {
@@ -1007,7 +1007,7 @@ func VerifyCorrectness(
 	}
 	fingerprints := make([]fingerprint, len(ldrWorkload.tableNames))
 
-	m := c.NewMonitor(context.Background(), setup.CRDBNodes())
+	m := c.NewDeprecatedMonitor(context.Background(), setup.CRDBNodes())
 	for i, tableName := range ldrWorkload.tableNames {
 		fingerprints[i] = fingerprint{
 			table: tableName,

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -196,7 +196,7 @@ func runRecoverLossOfQuorum(ctx context.Context, t test.Test, c cluster.Cluster,
 		_, err = db.Exec("SET CLUSTER SETTING sql.trace.stmt.enable_threshold = '30s'")
 	}
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		t.L().Printf("initializing workload")
 
@@ -406,7 +406,7 @@ func runHalfOnlineRecoverLossOfQuorum(
 		_, err = db.Exec("SET CLUSTER SETTING sql.trace.stmt.enable_threshold = '30s'")
 	}
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		t.L().Printf("initializing workload")
 

--- a/pkg/cmd/roachtest/tests/many_splits.go
+++ b/pkg/cmd/roachtest/tests/many_splits.go
@@ -31,7 +31,7 @@ func runManySplits(ctx context.Context, t test.Test, c cluster.Cluster) {
 	err := roachtestutil.WaitFor3XReplication(ctx, t.L(), db)
 	require.NoError(t, err)
 
-	m := c.NewMonitor(ctx, c.All())
+	m := c.NewDeprecatedMonitor(ctx, c.All())
 	m.Go(func(ctx context.Context) error {
 		const numRanges = 2000
 		t.L().Printf("creating %d ranges...", numRanges)

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2774,7 +2774,10 @@ func (mvb *mixedVersionBackup) verifyAllBackups(
 			}
 
 			if isClusterBackup {
-				err := u.resetCluster(ctx, l, v, h.ExpectDeaths, []install.ClusterSettingOption{})
+				// The mixedversion framework uses the global test monitor, which
+				// already handles marking node deaths as expected for simple restarts.
+				expectDeaths := func(numNodes int) {}
+				err := u.resetCluster(ctx, l, v, expectDeaths, []install.ClusterSettingOption{})
 				if err != nil {
 					err := errors.Wrapf(err, "%s", v)
 					l.Printf("error resetting cluster: %v", err)
@@ -2872,6 +2875,7 @@ func registerBackupMixedVersion(r registry.Registry) {
 		CompatibleClouds:          registry.Clouds(spec.GCE, spec.Local),
 		Suites:                    registry.Suites(registry.MixedVersion, registry.Nightly),
 		TestSelectionOptOutSuites: registry.Suites(registry.Nightly),
+		Monitor:                   true,
 		Randomized:                true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			enabledDeploymentModes := []mixedversion.DeploymentMode{

--- a/pkg/cmd/roachtest/tests/mixed_version_c2c.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_c2c.go
@@ -53,6 +53,7 @@ func registerC2CMixedVersions(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, spec.WorkloadNode()),
 		CompatibleClouds: sp.clouds,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runC2CMixedVersions(ctx, t, c, sp)
 		},

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -77,6 +77,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 		Timeout:          3 * time.Hour,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCMixedVersions(ctx, t, c)
@@ -89,6 +90,7 @@ func registerCDCMixedVersions(r registry.Registry) {
 		Timeout:          3 * time.Hour,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runCDCMixedVersionCheckpointing(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -33,6 +33,7 @@ func registerChangeReplicasMixedVersion(r registry.Registry) {
 		// is impossible to test as of 05/2025.
 		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run:              runChangeReplicasMixedVersion,
 		Timeout:          60 * time.Minute,

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -32,6 +32,7 @@ func registerImportMixedVersions(r registry.Registry) {
 		// is impossible to test as of 05/2025.
 		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			warehouses := 100

--- a/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_job_compatibility_in_declarative_schema_changer.go
@@ -34,6 +34,8 @@ func registerDeclarativeSchemaChangerJobCompatibilityInMixedVersion(r registry.R
 		// is impossible to test as of 05/2025.
 		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
+		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runDeclarativeSchemaChangerJobCompatibilityInMixedVersion(ctx, t, c)
 		},

--- a/pkg/cmd/roachtest/tests/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_jobs.go
@@ -30,6 +30,7 @@ func registerJobsMixedVersions(r registry.Registry) {
 		),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runJobsMixedVersions(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/mixed_version_ldr.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_ldr.go
@@ -45,6 +45,7 @@ func registerLDRMixedVersions(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(sp.leftNodes+sp.rightNodes+1, spec.WorkloadNode()),
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runLDRMixedVersions(ctx, t, c, sp)
 		},

--- a/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_multi_region.go
@@ -61,6 +61,7 @@ func registerMultiRegionMixedVersion(r registry.Registry) {
 		EncryptionSupport: registry.EncryptionMetamorphic,
 		CompatibleClouds:  registry.OnlyGCE,
 		Suites:            registry.Suites(registry.MixedVersion, registry.Weekly),
+		Monitor:           true,
 		Randomized:        true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			partitionConfig := fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_schemachange.go
@@ -31,6 +31,7 @@ func registerSchemaChangeMixedVersions(r registry.Registry) {
 		// is impossible to test as of 05/2025.
 		CompatibleClouds:           registry.AllClouds.NoAWS().NoIBM(),
 		Suites:                     registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:                    true,
 		Randomized:                 true,
 		NativeLibs:                 registry.LibGEOS,
 		RequiresDeprecatedWorkload: true, // uses schemachange

--- a/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_sql_stats.go
@@ -43,6 +43,7 @@ func registerSqlStatsMixedVersion(r registry.Registry) {
 		// is impossible to test as of 05/2025.
 		CompatibleClouds: registry.AllClouds.NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run:              runSQLStatsMixedVersion,
 		Timeout:          1 * time.Hour,

--- a/pkg/cmd/roachtest/tests/multi_store_remove.go
+++ b/pkg/cmd/roachtest/tests/multi_store_remove.go
@@ -101,7 +101,7 @@ func runMultiStoreRemove(ctx context.Context, t test.Test, c cluster.Cluster) {
 	// Bring down node 1.
 	t.Status("removing store from n1")
 	node := c.Node(1)
-	m := c.NewMonitor(ctx, node)
+	m := c.NewDeprecatedMonitor(ctx, node)
 	m.ExpectDeaths(1)
 	stopOpts := option.DefaultStopOpts()
 	c.Stop(ctx, t.L(), stopOpts, node)

--- a/pkg/cmd/roachtest/tests/multitenant_distsql.go
+++ b/pkg/cmd/roachtest/tests/multitenant_distsql.go
@@ -86,7 +86,7 @@ func runMultiTenantDistSQL(
 	_, err := storConn.Exec(`ALTER TENANT $1 SET CLUSTER SETTING sql.zone_configs.allow_for_secondary_tenant.enabled = true`, tenantName)
 	require.NoError(t, err)
 
-	m := c.NewMonitor(ctx, c.Nodes(1, 2, 3))
+	m := c.NewDeprecatedMonitor(ctx, c.Nodes(1, 2, 3))
 
 	inst1Conn, err := c.ConnE(ctx, t.L(), 1, option.VirtualClusterName(tenantName))
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/multitenant_tpch.go
+++ b/pkg/cmd/roachtest/tests/multitenant_tpch.go
@@ -48,7 +48,7 @@ func runMultiTenantTPCH(
 		}
 		t.Status("restoring TPCH dataset for Scale Factor 1 in ", setupNames[setupIdx])
 		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), false, /* disableMergeQueue */
+			ctx, t, c, conn, 1 /* sf */, c.NewDeprecatedMonitor(ctx), c.All(), false, /* disableMergeQueue */
 		); err != nil {
 			t.Fatal(err)
 		}

--- a/pkg/cmd/roachtest/tests/multitenant_upgrade.go
+++ b/pkg/cmd/roachtest/tests/multitenant_upgrade.go
@@ -32,6 +32,8 @@ func registerMultiTenantUpgrade(r registry.Registry) {
 		Cluster:          r.MakeClusterSpec(7),
 		CompatibleClouds: registry.CloudsWithServiceRegistration,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
+		Randomized:       true,
 		Owner:            registry.OwnerServer,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runMultitenantUpgrade(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/mvcc_gc.go
+++ b/pkg/cmd/roachtest/tests/mvcc_gc.go
@@ -120,7 +120,7 @@ func runMVCCGC(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.Fatalf("failed to up-replicate cluster: %s", err)
 	}
 
-	m := c.NewMonitor(ctx)
+	m := c.NewDeprecatedMonitor(ctx)
 	m.Go(func(ctx context.Context) error {
 		cmd := roachtestutil.NewCommand("./cockroach workload init kv").
 			Flag("cycle-length", 20000).

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -166,7 +166,7 @@ SELECT $1::INT = ALL (
 	// in case an error occurs.
 	woopsCh := make(chan struct{}, len(serverNodes)-1)
 
-	m := c.NewMonitor(ctx, serverNodes)
+	m := c.NewDeprecatedMonitor(ctx, serverNodes)
 
 	var numConns uint32
 

--- a/pkg/cmd/roachtest/tests/online_restore.go
+++ b/pkg/cmd/roachtest/tests/online_restore.go
@@ -590,7 +590,7 @@ func runRestore(
 	statsCollector, err := createStatCollector(ctx, rd)
 	require.NoError(t, err)
 
-	m := c.NewMonitor(ctx, sp.hardware.getCRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, sp.hardware.getCRDBNodes())
 	var restoreStartTime, restoreEndTime time.Time
 	m.Go(func(ctx context.Context) error {
 		db, err := rd.c.ConnE(ctx, rd.t.L(), rd.c.Node(1)[0])
@@ -652,7 +652,7 @@ func runRestore(
 	restoreEndTime = timeutil.Now()
 
 	workloadCtx, workloadCancel := context.WithCancel(ctx)
-	mDownload := c.NewMonitor(workloadCtx, sp.hardware.getCRDBNodes())
+	mDownload := c.NewDeprecatedMonitor(workloadCtx, sp.hardware.getCRDBNodes())
 
 	var workloadStartTime, workloadEndTime time.Time
 	mDownload.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -619,7 +619,7 @@ func (v variations) runTest(ctx context.Context, t test.Test, c cluster.Cluster)
 	t.Status("T0: starting nodes")
 
 	// Track the three operations that we are sending in this test.
-	m := c.NewMonitor(ctx, v.stableNodes())
+	m := c.NewDeprecatedMonitor(ctx, v.stableNodes())
 
 	// Start the stable nodes and let the perturbation start the target node(s).
 	v.startNoBackup(ctx, t, v.stableNodes())

--- a/pkg/cmd/roachtest/tests/process_lock.go
+++ b/pkg/cmd/roachtest/tests/process_lock.go
@@ -142,10 +142,8 @@ func registerProcessLock(r registry.Registry) {
 								// other operations that were performed
 								// concurrently with the running process did not
 								// corrupt the on-disk state.
-								t.Monitor().ExpectDeath()
 								c.Stop(ctx, l, option.DefaultStopOpts(), c.Node(n))
 								c.Start(ctx, l, startOpts, startSettings, c.Node(n))
-								t.Monitor().ResetDeaths()
 							},
 						}
 						ops[randutil.RandIntInRange(rng, 0, len(ops))]()

--- a/pkg/cmd/roachtest/tests/queue.go
+++ b/pkg/cmd/roachtest/tests/queue.go
@@ -45,7 +45,7 @@ func runQueue(ctx context.Context, t test.Test, c cluster.Cluster) {
 	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(), c.CRDBNodes())
 
 	runQueueWorkload := func(duration time.Duration, initTables bool) {
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			concurrency := roachtestutil.IfLocal(c, "", " --concurrency="+fmt.Sprint(dbNodeCount*64))
 			duration := fmt.Sprintf(" --duration=%s", duration.String())

--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -160,6 +160,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			// is impossible to test as of 05/2025.
 			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 			Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+			Monitor:          true,
 			Randomized:       true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {
@@ -198,6 +199,7 @@ func registerRebalanceLoad(r registry.Registry) {
 			// is impossible to test as of 05/2025.
 			CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 			Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+			Monitor:          true,
 			Randomized:       true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				if c.IsLocal() {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -153,7 +153,7 @@ func registerRestore(r registry.Registry) {
 
 			// Run the disk usage logger in the monitor to guarantee its
 			// having terminated when the test ends.
-			m := c.NewMonitor(ctx)
+			m := c.NewDeprecatedMonitor(ctx)
 			dul := roachtestutil.NewDiskUsageLogger(t, c)
 			m.Go(dul.Runner)
 
@@ -406,7 +406,7 @@ func registerRestore(r registry.Registry) {
 
 				// Run the disk usage logger in the monitor to guarantee its
 				// having terminated when the test ends.
-				m := c.NewMonitor(ctx)
+				m := c.NewDeprecatedMonitor(ctx)
 				dul := roachtestutil.NewDiskUsageLogger(t, c)
 				m.Go(dul.Runner)
 				m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/roachmart.go
+++ b/pkg/cmd/roachtest/tests/roachmart.go
@@ -54,7 +54,7 @@ func registerRoachmart(r registry.Registry) {
 		duration := " --duration=" + roachtestutil.IfLocal(c, "10s", "10m")
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx)
+		m := c.NewDeprecatedMonitor(ctx)
 		for i := range nodes {
 			i := i
 			m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/s3_clone_backup_restore.go
+++ b/pkg/cmd/roachtest/tests/s3_clone_backup_restore.go
@@ -235,7 +235,7 @@ func (v *s3BackupRestoreValidator) validateBackupRestore(ctx context.Context, s 
 	}
 
 	// Run a full backup while running the workload
-	m := v.c.NewMonitor(ctx, v.c.CRDBNodes())
+	m := v.c.NewDeprecatedMonitor(ctx, v.c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		v.t.Status(`running backup `)
 		_, err := conn.ExecContext(ctx,

--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -40,7 +40,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 			db := c.Conn(ctx, t.L(), 1)
 			defer db.Close()
 
-			m := c.NewMonitor(ctx, c.All())
+			m := c.NewDeprecatedMonitor(ctx, c.All())
 			m.Go(func(ctx context.Context) error {
 				t.Status("loading fixture")
 				if _, err := db.Exec(
@@ -60,7 +60,7 @@ func registerSchemaChangeDuringKV(r registry.Registry) {
 				}, task.Name(fmt.Sprintf(`kv-%d`, node)))
 			}
 
-			m = c.NewMonitor(ctx, c.All())
+			m = c.NewDeprecatedMonitor(ctx, c.All())
 			m.Go(func(ctx context.Context) error {
 				t.Status("running schema change tests")
 				return waitForSchemaChanges(ctx, t.L(), db)
@@ -372,7 +372,7 @@ func makeSchemaChangeBulkIngestTest(
 
 			c.Run(ctx, option.WithNodes(c.WorkloadNode()), cmdWrite)
 
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 			indexDuration := length
 			if c.IsLocal() {

--- a/pkg/cmd/roachtest/tests/secondary_indexes.go
+++ b/pkg/cmd/roachtest/tests/secondary_indexes.go
@@ -145,6 +145,7 @@ func registerSecondaryIndexesMultiVersionCluster(r registry.Registry) {
 		// is impossible to test as of 05/2025.
 		CompatibleClouds: registry.AllClouds.NoAWS().NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Randomized:       true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runIndexUpgrade(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/slow_drain.go
+++ b/pkg/cmd/roachtest/tests/slow_drain.go
@@ -108,7 +108,7 @@ func runSlowDrain(ctx context.Context, t test.Test, c cluster.Cluster, duration 
 
 	// Drain the last 5 nodes from the cluster, resulting in immovable leases on
 	// at least one of the nodes.
-	m := c.NewMonitor(ctx)
+	m := c.NewDeprecatedMonitor(ctx)
 	for nodeID := 2; nodeID <= numNodes; nodeID++ {
 		id := nodeID
 		m.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -437,7 +437,7 @@ func runLoadSplits(ctx context.Context, t test.Test, c cluster.Cluster, params s
 	}
 	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
@@ -631,7 +631,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	// Phase 1: start single node, disable splits, make large range.
 	t.Status(fmt.Sprintf("creating large bank table range (%d rows at ~%s each)", rows, humanizeutil.IBytes(rowEstimate)))
 	{
-		m := c.NewMonitor(ctx, c.Node(1))
+		m := c.NewDeprecatedMonitor(ctx, c.Node(1))
 		m.Go(func(ctx context.Context) error {
 
 			// We don't want load based splitting from splitting the range before
@@ -671,7 +671,7 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 	t.Status("waiting for full replication")
 	{
 		c.Start(ctx, t.L(), option.DefaultStartOpts(), settings, c.Range(2, numNodes))
-		m := c.NewMonitor(ctx, c.All())
+		m := c.NewDeprecatedMonitor(ctx, c.All())
 		// NB: we do a round-about thing of making sure that there's at least one
 		// range that has 3 replicas (rather than waiting that there are no ranges
 		// with less than three replicas) because the `bank` table doesn't show
@@ -709,7 +709,7 @@ from [ SHOW RANGES FROM DATABASE bank ] where cardinality(voting_replicas) >= $1
 	expSplits := expRC - 1
 	t.Status(fmt.Sprintf("waiting for %d splits and rebalancing", expSplits))
 	{
-		m := c.NewMonitor(ctx, c.All())
+		m := c.NewDeprecatedMonitor(ctx, c.All())
 		m.Go(func(ctx context.Context) error {
 			setRangeMaxBytes(t, db, minBytes, rangeSize)
 			// Phase 3a: wait for splits.

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -191,7 +191,7 @@ WITH into_db = 'defaultdb', unsafe_restore_incompatible_version;
 			stmt := ""
 			err := func() error {
 				done := make(chan error, 1)
-				m := c.NewMonitor(ctx, c.Node(1))
+				m := c.NewDeprecatedMonitor(ctx, c.Node(1))
 				m.Go(func(context.Context) error {
 					// Generate can potentially panic in bad cases, so
 					// to avoid Go routines from dying we are going

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -333,7 +333,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 			t.Fatal(err)
 		}
 	} else {
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(runWorkload)
 		m.Wait()
 	}

--- a/pkg/cmd/roachtest/tests/tombstones.go
+++ b/pkg/cmd/roachtest/tests/tombstones.go
@@ -66,7 +66,7 @@ func registerPointTombstone(r registry.Registry) {
 			// logical value data.
 			const numOps1MB = 30720
 			t.Status("starting 1MB-value workload")
-			m := c.NewMonitor(ctx, c.CRDBNodes())
+			m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--concurrency 128 --max-rate 512 --tolerate-errors `+
@@ -82,7 +82,7 @@ func registerPointTombstone(r registry.Registry) {
 			// ~500MB of logical value data. The additional per-row overhead
 			// will be higher than above, since we're writing more rows.
 			t.Status("starting 4KB-value workload")
-			m = c.NewMonitor(ctx, c.Range(1, 3))
+			m = c.NewDeprecatedMonitor(ctx, c.Range(1, 3))
 			m.Go(func(ctx context.Context) error {
 				c.Run(ctx, option.WithNodes(c.WorkloadNode()), fmt.Sprintf(`./cockroach workload run kv --read-percent 0 `+
 					`--concurrency 256 --max-rate 1024 --tolerate-errors `+
@@ -96,7 +96,7 @@ func registerPointTombstone(r registry.Registry) {
 			// Delete the initially written 1MB values (eg, ~30 GB)
 			t.Status("deleting previously-written 1MB values")
 			var statsAfterDeletes tableSizeInfo
-			m = c.NewMonitor(ctx, c.CRDBNodes())
+			m = c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				n1Conn := c.Conn(ctx, t.L(), 1)
 				defer n1Conn.Close()
@@ -128,7 +128,7 @@ func registerPointTombstone(r registry.Registry) {
 			// Wait for garbage collection to delete the non-live data.
 			targetSize := uint64(3 << 30) /* 3 GiB */
 			t.Status("waiting for garbage collection and compaction to reduce on-disk size to ", humanize.IBytes(targetSize))
-			m = c.NewMonitor(ctx, c.CRDBNodes())
+			m = c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 			m.Go(func(ctx context.Context) error {
 				ticker := time.NewTicker(10 * time.Second)
 				defer ticker.Stop()

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -411,7 +411,7 @@ func runTPCC(
 		}
 	}
 	setupTPCC(ctx, t, l, c, opts)
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.ExpectDeaths(int32(opts.ExpectedDeaths))
 	rampDur := rampDuration(c.IsLocal())
 	for i := range workloadInstances {
@@ -2071,7 +2071,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 			c.Run(ctx, option.WithNodes(loadNodes), "haproxy -f haproxy.cfg -D")
 		}
 
-		m := c.NewMonitor(ctx, roachNodes)
+		m := c.NewDeprecatedMonitor(ctx, roachNodes)
 		m.Go(func(ctx context.Context) error {
 			t.Status("setting up dataset")
 			return loadTPCCBench(ctx, t, c, db, b, roachNodes, c.Node(loadNodes[0]))
@@ -2118,7 +2118,7 @@ func runTPCCBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpccBen
 		// *abort* the line search and whole tpccbench run. Return the errors
 		// to indicate that the specific warehouse count failed, but that the
 		// line search ought to continue.
-		m := c.NewMonitor(ctx, roachNodes)
+		m := c.NewDeprecatedMonitor(ctx, roachNodes)
 
 		// If we're running chaos in this configuration, modify this config.
 		if b.Chaos {
@@ -2595,7 +2595,7 @@ func runTPCCPublished(
 			rampTime = 1 * time.Second
 		}
 
-		m := c.NewMonitor(ctx, crdbNodes)
+		m := c.NewDeprecatedMonitor(ctx, crdbNodes)
 
 		resultChan := make(chan *tpcc.Result, workloadCount)
 		for wIdx, w := range workers {

--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -740,6 +740,7 @@ func registerTPCC(r registry.Registry) {
 		Suites:            registry.Suites(registry.MixedVersion, registry.Nightly),
 		Cluster:           mixedHeadroomSpec,
 		EncryptionSupport: registry.EncryptionMetamorphic,
+		Monitor:           true,
 		Randomized:        true,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runTPCCMixedHeadroom(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/tpce.go
+++ b/pkg/cmd/roachtest/tests/tpce.go
@@ -201,7 +201,7 @@ func runTPCE(ctx context.Context, t test.Test, c cluster.Cluster, opts tpceOptio
 	}
 
 	if opts.setupType == usingTPCEInit && !t.SkipInit() {
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			estimatedSetupTimeStr := ""
 			if opts.estimatedSetupTime != 0 {
@@ -223,7 +223,7 @@ func runTPCE(ctx context.Context, t test.Test, c cluster.Cluster, opts tpceOptio
 		return
 	}
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		t.Status("running workload")
 		workloadDuration := opts.workloadDuration

--- a/pkg/cmd/roachtest/tests/tpch_concurrency.go
+++ b/pkg/cmd/roachtest/tests/tpch_concurrency.go
@@ -40,7 +40,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 		}
 
 		if err := loadTPCHDataset(
-			ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx, c.CRDBNodes()),
+			ctx, t, c, conn, 1 /* sf */, c.NewDeprecatedMonitor(ctx, c.CRDBNodes()),
 			c.CRDBNodes(), true, /* disableMergeQueue */
 		); err != nil {
 			t.Fatal(err)
@@ -85,7 +85,7 @@ func registerTPCHConcurrency(r registry.Registry) {
 			}
 		}
 
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			t.Status(fmt.Sprintf("running with concurrency = %d", concurrency))
 			// Run each query once on each connection.

--- a/pkg/cmd/roachtest/tests/tpchbench.go
+++ b/pkg/cmd/roachtest/tests/tpchbench.go
@@ -54,7 +54,7 @@ func runTPCHBench(ctx context.Context, t test.Test, c cluster.Cluster, b tpchBen
 	t.Status("starting nodes")
 	c.Start(ctx, t.L(), option.NewStartOpts(option.NoBackupSchedule), install.MakeClusterSettings(), c.CRDBNodes())
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		conn := c.Conn(ctx, t.L(), 1)
 		defer conn.Close()

--- a/pkg/cmd/roachtest/tests/tpchvec.go
+++ b/pkg/cmd/roachtest/tests/tpchvec.go
@@ -554,7 +554,7 @@ func runTPCHVec(ctx context.Context, t test.Test, c cluster.Cluster, testCase tp
 
 	t.Status("restoring TPCH dataset for Scale Factor 1")
 	if err := loadTPCHDataset(
-		ctx, t, c, conn, 1 /* sf */, c.NewMonitor(ctx), c.All(), disableMergeQueue,
+		ctx, t, c, conn, 1 /* sf */, c.NewDeprecatedMonitor(ctx), c.All(), disableMergeQueue,
 	); err != nil {
 		t.Fatal(err)
 	}

--- a/pkg/cmd/roachtest/tests/ttl_restart.go
+++ b/pkg/cmd/roachtest/tests/ttl_restart.go
@@ -83,7 +83,7 @@ func runTTLRestart(ctx context.Context, t test.Test, c cluster.Cluster, numResta
 	settings := install.MakeClusterSettings()
 	c.Start(ctx, t.L(), startOpts, settings, c.CRDBNodes())
 
-	m := c.NewMonitor(ctx, c.CRDBNodes())
+	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 	m.Go(func(ctx context.Context) error {
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()

--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -225,6 +225,7 @@ func registerValidateSystemSchemaAfterVersionUpgradeSeparateProcess(r registry.R
 		Owner:            registry.OwnerSQLFoundations,
 		CompatibleClouds: registry.OnlyGCE,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
+		Monitor:          true,
 		Cluster:          r.MakeClusterSpec(3),
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runValidateSystemSchemaAfterVersionUpgradeSeparateProcess(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/versionupgrade.go
+++ b/pkg/cmd/roachtest/tests/versionupgrade.go
@@ -310,6 +310,7 @@ func registerHTTPRestart(r registry.Registry) {
 		CompatibleClouds: registry.AllClouds.NoIBM(),
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
 		Randomized:       true,
+		Monitor:          true,
 		Run:              runHTTPRestart,
 		Timeout:          1 * time.Hour,
 	})

--- a/pkg/cmd/roachtest/tests/ycsb.go
+++ b/pkg/cmd/roachtest/tests/ycsb.go
@@ -75,7 +75,7 @@ func registerYCSB(r registry.Registry) {
 		require.NoError(t, db.Close())
 
 		t.Status("running workload")
-		m := c.NewMonitor(ctx, c.CRDBNodes())
+		m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 		m.Go(func(ctx context.Context) error {
 			var args string
 			args += " --ramp=" + roachtestutil.IfLocal(c, "0s", "2m")

--- a/pkg/roachprod/install/monitor.go
+++ b/pkg/roachprod/install/monitor.go
@@ -316,7 +316,7 @@ func (m *monitorNode) monitorNode(ctx context.Context, l *logger.Logger) {
 	if err := sess.Wait(); err != nil {
 		// If we got an error waiting for the session but the context
 		// is already canceled, do not send an error through the
-		// channel; context cancelation happens at the user's request
+		// channel; context cancellation happens at the user's request
 		// or when the test finishes. In either case, the monitor
 		// should quiesce. Reporting the error is confusing and can be
 		// noisy in the case of multiple monitors.


### PR DESCRIPTION
This change refactors the global test monitor to expect specific process deaths rather than a number of any process deaths.  This change is to support the failure injection framework (https://github.com/cockroachdb/cockroach/issues/138958) as well as  failure injection in mixed version (https://github.com/cockroachdb/cockroach/issues/148084). In the future, we will want to be able to tell the state of the cluster/nodes from the monitor.

This change also refactors the mixed version tests to use the global monitor, as well as deprecates the old cluster monitor. See individual commits for details.

Informs: https://github.com/cockroachdb/cockroach/issues/118214
Release note: none