### PR TITLE
testutils: add roachtest analyzer

### DIFF
--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -208,5 +208,6 @@ nogo(
         "//pkg/testutils/lint/passes/returnerrcheck",
         "//pkg/testutils/lint/passes/shadow",
         "//pkg/testutils/lint/passes/unconvert",
+        "//pkg/testutils/lint/passes/roachtest",
     ],
 )

--- a/build/bazelutil/nogo_config.json
+++ b/build/bazelutil/nogo_config.json
@@ -15,6 +15,15 @@
             "pkg/.*_generated\\.go$": "generated code"
         }
     },
+    "roachtestgo": {
+        "exclude_files": {
+            "pkg/cmd/roachtest/roachtestutil/task": "task manager implements goroutine management",
+            "pkg/cmd/roachtest/roachtestutil/mixedversion": "part of the roachtest framework",
+            "pkg/cmd/roachtest/operations": "operations do not run under the managed roachtest framework",
+            "pkg/cmd/roachtest/[^/]+\\.go$": "roachtest framework",
+            "_test\\.go$": "tests"
+        }
+    },
     "deepequalerrors": {
         "exclude_files": {
             "external/": "exclude all third-party code for all analyzers",

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2454,6 +2454,7 @@ GO_TARGETS = [
     "//pkg/testutils/lint/passes/returncheck:returncheck",
     "//pkg/testutils/lint/passes/returnerrcheck:returnerrcheck",
     "//pkg/testutils/lint/passes/returnerrcheck:returnerrcheck_test",
+    "//pkg/testutils/lint/passes/roachtest:roachtest",
     "//pkg/testutils/lint/passes/shadow:shadow",
     "//pkg/testutils/lint/passes/staticcheck:staticcheck",
     "//pkg/testutils/lint/passes/unconvert:unconvert",

--- a/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
         "//pkg/cmd/roachtest/cluster",
         "//pkg/cmd/roachtest/option",
         "//pkg/cmd/roachtest/roachtestflags",
+        "//pkg/cmd/roachtest/roachtestutil/task",
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/kv/kvpb",
@@ -32,7 +33,6 @@ go_library(
         "//pkg/testutils",
         "//pkg/testutils/sqlutils",
         "//pkg/util",
-        "//pkg/util/ctxgroup",
         "//pkg/util/httputil",
         "//pkg/util/humanizeutil",
         "//pkg/util/protoutil",
@@ -46,7 +46,6 @@ go_library(
         "@com_github_prometheus_common//expfmt",
         "@com_github_stretchr_testify//require",
         "@org_golang_x_exp//maps",
-        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -299,7 +299,7 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 				m.Go(
 					func(ctx context.Context, l *logger.Logger) error {
 						var err error
-						profiles[typ], err = roachtestutil.GetProfile(ctx, c, l, typ,
+						profiles[typ], err = roachtestutil.GetProfile(ctx, t, c, typ,
 							collectionDuration, c.CRDBNodes())
 						return err
 					},

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2854,7 +2854,8 @@ func TestLint(t *testing.T) {
 		}
 	})
 
-	// Test forbidden roachtest imports.
+	// Test forbidden roachtest imports. The mixedversion and task packages are
+	// allowed because they are part of the roachtest framework.
 	t.Run("TestRoachtestForbiddenImports", func(t *testing.T) {
 		t.Parallel()
 
@@ -2890,7 +2891,8 @@ func TestLint(t *testing.T) {
 			filter,
 			stream.Sort(),
 			stream.Uniq(),
-			stream.Grep(`cockroach/pkg/cmd/roachtest/(tests|operations): `),
+			stream.Grep(`cockroach/pkg/cmd/roachtest/.*: `),
+			stream.GrepNot(`cockroach/pkg/cmd/roachtest/roachtestutil/(mixedversion|task): `),
 		), func(s string) {
 			pkgStr := strings.Split(s, ": ")
 			_, importedPkg := pkgStr[0], pkgStr[1]

--- a/pkg/testutils/lint/passes/forbiddenmethod/naked_go.go
+++ b/pkg/testutils/lint/passes/forbiddenmethod/naked_go.go
@@ -16,72 +16,84 @@ import (
 	"golang.org/x/tools/go/ast/inspector"
 )
 
-const nakedGoPassName = "nakedgo"
-
 // NakedGoAnalyzer prevents use of the `go` keyword.
-var NakedGoAnalyzer = &analysis.Analyzer{
-	Name:     nakedGoPassName,
-	Doc:      "Prevents direct use of the 'go' keyword. Goroutines should be launched through Stopper.",
-	Requires: []*analysis.Analyzer{inspect.Analyzer},
-	Run: func(pass *analysis.Pass) (interface{}, error) {
-		inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
-		inspect.Preorder([]ast.Node{
-			(*ast.GoStmt)(nil),
-		}, func(n ast.Node) {
-			node := n.(*ast.GoStmt)
+var NakedGoAnalyzer = NewNakedGoAnalyzer(
+	"nakedgo",
+	"Use of go keyword not allowed, use a Stopper instead",
+	"Prevents direct use of the 'go' keyword. Goroutines should be launched through Stopper.",
+	nil,
+)
 
-			const debug = false
+type FilterFunc func(pass *analysis.Pass) bool
 
-			// NB: we're not using passesutil.HasNoLintComment because it
-			// has false negatives (i.e. comments apply to infractions that
-			// they were clearly not intended for).
-			//
-			// The approach here is inspired by `analysistest.check` - the
-			// nolint comment has to be on the same line as the *end* of the
-			// `*GoStmt`.
-			f := passesutil.FindContainingFile(pass, n)
-			cm := ast.NewCommentMap(pass.Fset, node, f.Comments)
-			var cc *ast.Comment
-			for _, cg := range cm[n] {
-				for _, c := range cg.List {
-					if c.Pos() < node.Go {
-						// The current comment is "before" the `go` invocation, so it's
-						// not relevant for silencing the lint.
-						continue
-					}
-					if cc == nil || cc.Pos() > node.Go {
-						// This comment is after, but closer to the `go` invocation than
-						// previous candidate.
-						cc = c
-						if debug {
-							fmt.Printf("closest comment now %d-%d: %s\n", cc.Pos(), cc.End(), cc.Text)
+func NewNakedGoAnalyzer(name, message, doc string, filter FilterFunc) *analysis.Analyzer {
+	return &analysis.Analyzer{
+		Name:     name,
+		Doc:      doc,
+		Requires: []*analysis.Analyzer{inspect.Analyzer},
+		Run: func(pass *analysis.Pass) (interface{}, error) {
+			if filter != nil && !filter(pass) {
+				return nil, nil
+			}
+			inspect := pass.ResultOf[inspect.Analyzer].(*inspector.Inspector)
+			inspect.Preorder([]ast.Node{
+				(*ast.GoStmt)(nil),
+			}, func(n ast.Node) {
+				node := n.(*ast.GoStmt)
+
+				const debug = false
+
+				// NB: we're not using passesutil.HasNoLintComment because it
+				// has false negatives (i.e. comments apply to infractions that
+				// they were clearly not intended for).
+				//
+				// The approach here is inspired by `analysistest.check` - the
+				// nolint comment has to be on the same line as the *end* of the
+				// `*GoStmt`.
+				f := passesutil.FindContainingFile(pass, n)
+				cm := ast.NewCommentMap(pass.Fset, node, f.Comments)
+				var cc *ast.Comment
+				for _, cg := range cm[n] {
+					for _, c := range cg.List {
+						if c.Pos() < node.Go {
+							// The current comment is "before" the `go` invocation, so it's
+							// not relevant for silencing the lint.
+							continue
+						}
+						if cc == nil || cc.Pos() > node.Go {
+							// This comment is after, but closer to the `go` invocation than
+							// previous candidate.
+							cc = c
+							if debug {
+								fmt.Printf("closest comment now %d-%d: %s\n", cc.Pos(), cc.End(), cc.Text)
+							}
 						}
 					}
 				}
-			}
-			if cc != nil && strings.Contains(cc.Text, "nolint:"+nakedGoPassName) {
-				if debug {
-					fmt.Printf("GoStmt at: %d-%d\n", n.Pos(), n.End())
-					fmt.Printf("GoStmt.Go at: %d\n", node.Go)
-					fmt.Printf("GoStmt.Call at: %d-%d\n", node.Call.Pos(), node.Call.End())
-				}
-
-				goPos := pass.Fset.Position(node.End())
-				cmPos := pass.Fset.Position(cc.Pos())
-
-				if goPos.Line == cmPos.Line {
+				if cc != nil && strings.Contains(cc.Text, "nolint:"+name) {
 					if debug {
-						fmt.Printf("suppressing lint because of %d-%d: %s\n", cc.Pos(), cc.End(), cc.Text)
+						fmt.Printf("GoStmt at: %d-%d\n", n.Pos(), n.End())
+						fmt.Printf("GoStmt.Go at: %d\n", node.Go)
+						fmt.Printf("GoStmt.Call at: %d-%d\n", node.Call.Pos(), node.Call.End())
 					}
-					return
-				}
-			}
 
-			pass.Report(analysis.Diagnostic{
-				Pos:     n.Pos(),
-				Message: "Use of go keyword not allowed, use a Stopper instead",
+					goPos := pass.Fset.Position(node.End())
+					cmPos := pass.Fset.Position(cc.Pos())
+
+					if goPos.Line == cmPos.Line {
+						if debug {
+							fmt.Printf("suppressing lint because of %d-%d: %s\n", cc.Pos(), cc.End(), cc.Text)
+						}
+						return
+					}
+				}
+
+				pass.Report(analysis.Diagnostic{
+					Pos:     n.Pos(),
+					Message: message,
+				})
 			})
-		})
-		return nil, nil
-	},
+			return nil, nil
+		},
+	}
 }

--- a/pkg/testutils/lint/passes/roachtest/BUILD.bazel
+++ b/pkg/testutils/lint/passes/roachtest/BUILD.bazel
@@ -1,0 +1,12 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "roachtest",
+    srcs = ["naked_go.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/roachtest",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/testutils/lint/passes/forbiddenmethod",
+        "@org_golang_x_tools//go/analysis",
+    ],
+)

--- a/pkg/testutils/lint/passes/roachtest/naked_go.go
+++ b/pkg/testutils/lint/passes/roachtest/naked_go.go
@@ -1,0 +1,23 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package roachtest
+
+import (
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/lint/passes/forbiddenmethod"
+	"golang.org/x/tools/go/analysis"
+)
+
+// RoachtestGoAnalyzer prevents use of the `go` keyword in roachtest.
+var Analyzer = forbiddenmethod.NewNakedGoAnalyzer(
+	"roachtestgo",
+	"Use of go keyword not allowed in roachtest, use the Task interface instead",
+	"Prevents direct use of the 'go' keyword in roachtest. Goroutines should be launched through the Task interface supplied by the roachtest framework.",
+	func(pass *analysis.Pass) bool {
+		return strings.Contains(pass.Pkg.Path(), "cmd/roachtest")
+	},
+)


### PR DESCRIPTION
Previously, there was no linter that would detect use of the `go` keyword in
roachtest. All roachtest goroutines must be launched through the `Task` interface
provided by the roachtest framework.

This change reuses a linter from the `lint passes forbiddenmethod` package to
detect use of the `go` keyword in roachtest.

The roachtest go analyzer only operates on the roachtest package, with a filter
hardcoded in the analyzer. Thus we can still add excludes in the nogo config to
allow goroutines in some roachtest packages that are part of the framework.

Epic: None
Release note: None