### PR TITLE
roachtest: guarantee deleting user-table sst in OR recovery

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -545,7 +545,7 @@ func testOnlineRestoreRecovery(ctx context.Context, t test.Test, c cluster.Clust
 			return errors.Wrap(err, "failed to remove pausepoint for online restore")
 		}
 
-		if err := d.deleteRandomSST(ctx, t.L(), dbConn, collection); err != nil {
+		if err := d.deleteUserTableSST(ctx, t.L(), dbConn, collection); err != nil {
 			return err
 		}
 		if _, err := dbConn.ExecContext(ctx, "RESUME JOB $1", downloadJobID); err != nil {


### PR DESCRIPTION
As illuminated in #148408, deleting an SST that backs a temporary system table before the download phase completes may still result in a successful download phase. Our current OR recovery roachtest deletes SSTs at random, so it is possible for the test to flake because of this. This updates the test to always delete the last SST in `SHOW BACKUP`, which should always cover a user table instead.

Epic: CRDB-51394

Release note: None