### PR TITLE
sql/logictest: skip udf_in_index test under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/udf_in_index
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_index
@@ -1,5 +1,7 @@
 # LogicTest: !local-mixed-25.2
 
+skip under race #148278
+
 # Set up functions that inspect function dependencies.
 statement ok
 CREATE VIEW v_col_fn_ids AS


### PR DESCRIPTION
The udf_in_index logic test currently triggers a data race, which can create unnecessary noise in test output and CI results. To reduce this noise, this test is being skipped for now.

The test will be re-enabled once the underlying issue is addressed.

Informs #148278

Epic: none
Release note: none