### PR TITLE
opt: convert parameterized lookup joins to placeholder scans

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/mutation.go
+++ b/pkg/sql/opt/exec/execbuilder/mutation.go
@@ -1233,7 +1233,7 @@ func shouldApplyImplicitLockingToUpdateOrDeleteInput(
 	var toLockIndexes intsets.Fast
 	// Try to match the mutation's input expression against the pattern:
 	//
-	//   [Project]* [IndexJoin] (Scan | LookupJoin [LookupJoin] Values)
+	//   [Project]* [IndexJoin] (Scan | PlaceholderScan | LookupJoin [LookupJoin] Values)
 	//
 	// The IndexJoin will only be present if the base expression is a Scan, but
 	// making it an optional prefix to the LookupJoins makes the logic simpler.
@@ -1245,6 +1245,9 @@ func shouldApplyImplicitLockingToUpdateOrDeleteInput(
 	var toLock opt.TableID
 	switch t := input.(type) {
 	case *memo.ScanExpr:
+		toLockIndexes.Add(t.Index)
+		toLock = t.Table
+	case *memo.PlaceholderScanExpr:
 		toLockIndexes.Add(t.Index)
 		toLock = t.Table
 	case *memo.LookupJoinExpr:

--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -500,28 +500,20 @@ quality of service: regular
 │ from: t137352
 │ auto commit
 │
-└── • lookup join
-    │ sql nodes: <hidden>
-    │ kv nodes: <hidden>
-    │ regions: <hidden>
-    │ actual row count: 0
-    │ KV time: 0µs
-    │ KV rows decoded: 0
-    │ KV bytes read: 0 B
-    │ KV gRPC calls: 0
-    │ execution time: 0µs
-    │ estimated max memory allocated: 0 B
-    │ table: t137352@t137352_pkey
-    │ equality: ($1) = (k)
-    │ equality cols are key
-    │ locking strength: for update
-    │
-    └── • values
-          sql nodes: <hidden>
-          regions: <hidden>
-          actual row count: 1
-          execution time: 0µs
-          size: 1 column, 1 row
+└── • scan
+      sql nodes: <hidden>
+      kv nodes: <hidden>
+      regions: <hidden>
+      actual row count: 0
+      KV time: 0µs
+      KV rows decoded: 0
+      KV bytes read: 0 B
+      KV gRPC calls: 0
+      estimated max memory allocated: 0 B
+      missing stats
+      table: t137352@t137352_pkey
+      spans: [/1 - /1]
+      locking strength: for update
 
 statement ok
 INSERT INTO t137352 VALUES (1, 10, 100);

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1025,28 +1025,20 @@ quality of service: regular
 │
 └── • render
     │
-    └── • lookup join
-        │ sql nodes: <hidden>
-        │ kv nodes: <hidden>
-        │ regions: <hidden>
-        │ actual row count: 0
-        │ KV time: 0µs
-        │ KV rows decoded: 0
-        │ KV bytes read: 0 B
-        │ KV gRPC calls: 0
-        │ execution time: 0µs
-        │ estimated max memory allocated: 0 B
-        │ table: t137352@t137352_pkey
-        │ equality: ($1) = (k)
-        │ equality cols are key
-        │ locking strength: for update
-        │
-        └── • values
-              sql nodes: <hidden>
-              regions: <hidden>
-              actual row count: 1
-              execution time: 0µs
-              size: 1 column, 1 row
+    └── • scan
+          sql nodes: <hidden>
+          kv nodes: <hidden>
+          regions: <hidden>
+          actual row count: 0
+          KV time: 0µs
+          KV rows decoded: 0
+          KV bytes read: 0 B
+          KV gRPC calls: 0
+          estimated max memory allocated: 0 B
+          missing stats
+          table: t137352@t137352_pkey
+          spans: [/1 - /1]
+          locking strength: for update
 
 statement ok
 INSERT INTO t137352 VALUES (1, 2, 3);
@@ -1297,29 +1289,20 @@ quality of service: regular
                 │ equality: (k) = (a)
                 │ pred: a = 1
                 │
-                └── • lookup join
-                    │ sql nodes: <hidden>
-                    │ kv nodes: <hidden>
-                    │ regions: <hidden>
-                    │ actual row count: 1
-                    │ KV time: 0µs
-                    │ KV rows decoded: 1
-                    │ KV pairs read: 2
-                    │ KV bytes read: 8 B
-                    │ KV gRPC calls: 1
-                    │ execution time: 0µs
-                    │ estimated max memory allocated: 0 B
-                    │ estimated row count: 1
-                    │ table: t137352@t137352_pkey
-                    │ equality: ($1) = (k)
-                    │ equality cols are key
-                    │
-                    └── • values
-                          sql nodes: <hidden>
-                          regions: <hidden>
-                          actual row count: 1
-                          execution time: 0µs
-                          size: 1 column, 1 row
+                └── • scan
+                      sql nodes: <hidden>
+                      kv nodes: <hidden>
+                      regions: <hidden>
+                      actual row count: 1
+                      KV time: 0µs
+                      KV rows decoded: 1
+                      KV pairs read: 2
+                      KV bytes read: 8 B
+                      KV gRPC calls: 1
+                      estimated max memory allocated: 0 B
+                      estimated row count: 1
+                      table: t137352@t137352_pkey
+                      spans: [/1 - /1]
 
 statement ok
 DELETE FROM t137352 WHERE true;

--- a/pkg/sql/opt/exec/execbuilder/testdata/virtual
+++ b/pkg/sql/opt/exec/execbuilder/testdata/virtual
@@ -539,4 +539,3 @@ vectorized: true
 
 statement ok
 RESET disallow_full_table_scans;
-

--- a/pkg/sql/opt/memo/logical_props_builder.go
+++ b/pkg/sql/opt/memo/logical_props_builder.go
@@ -203,6 +203,15 @@ func (b *logicalPropsBuilder) buildScanProps(scan *ScanExpr, rel *props.Relation
 	}
 }
 
+// buildPlaceholderScanProps is unimplemented. Placeholder expressions are only created
+// in two places:
+//
+//  1. The placeholder fast-path which entirely skips optimization.
+//  2. The ConvertParameterizedLookupJoinToPlaceholderScan exploration rule
+//     which always adds the placeholder scan to an existing memo group, for
+//     which logical properties have already been built.
+//
+// In both cases this function is never called.
 func (b *logicalPropsBuilder) buildPlaceholderScanProps(
 	scan *PlaceholderScanExpr, rel *props.Relational,
 ) {

--- a/pkg/sql/opt/norm/factory_test.go
+++ b/pkg/sql/opt/norm/factory_test.go
@@ -87,9 +87,8 @@ func TestCopyAndReplace(t *testing.T) {
 
 	if e, err := o.Optimize(); err != nil {
 		t.Fatal(err)
-	} else if e.Op() != opt.ProjectOp || e.Child(0).Op() != opt.LookupJoinOp {
-		t.Errorf("expected optimizer to choose a (project (lookup-join)), not (%v (%v))",
-			e.Op(), e.Child(0).Op())
+	} else if e.Op() != opt.PlaceholderScanOp {
+		t.Errorf("expected optimizer to choose a placeholder scan, not %v", e.Op())
 	}
 
 	m := o.Factory().DetachMemo()

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -540,6 +540,9 @@ func (c *coster) ComputeCost(candidate memo.RelExpr, required *physical.Required
 	case opt.ScanOp:
 		cost = c.computeScanCost(candidate.(*memo.ScanExpr), required)
 
+	case opt.PlaceholderScanOp:
+		cost = c.computePlaceholderScanCost(candidate.(*memo.PlaceholderScanExpr), required)
+
 	case opt.SelectOp:
 		cost = c.computeSelectCost(candidate.(*memo.SelectExpr), required)
 
@@ -898,6 +901,50 @@ func (c *coster) computeScanCost(scan *memo.ScanExpr, required *physical.Require
 		}
 	}
 
+	return cost
+}
+
+// computePlaceholderScanCost computes the cost of a placeholder scan. It mimics
+// the logic in computeScanCost that is relevant for placeholder scans.
+func (c *coster) computePlaceholderScanCost(
+	scan *memo.PlaceholderScanExpr, required *physical.Required,
+) memo.Cost {
+	if !scan.Flags.Empty() {
+		panic(errors.AssertionFailedf("expected empty flags for placeholder scan"))
+	}
+
+	stats := scan.Relational().Statistics()
+	rowCount := stats.RowCount
+	const numSpans = 1 // A placeholder scan always has a single span.
+	baseCost := memo.Cost{C: numSpans * randIOCostFactor}
+
+	// Add the IO cost of retrieving and the CPU cost of emitting the rows. The
+	// row cost depends on the size of the columns scanned.
+	perRowCost := c.rowScanCost(scan.Table, scan.Index, scan.Cols)
+
+	// If this is a virtual scan, add the cost of fetching table descriptors.
+	if c.mem.Metadata().Table(scan.Table).IsVirtualTable() {
+		baseCost.C += virtualScanTableDescriptorFetchCost
+	}
+
+	// Add a penalty if the cardinality exceeds the row count estimate. Adding a
+	// few rows worth of cost helps prevent surprising plans for very small tables
+	// or for when stats are stale.
+	//
+	// Note: we add this to the baseCost rather than the rowCount, so that the
+	// number of index columns does not have an outsized effect on the cost of
+	// the scan. See issue #68556.
+	baseCost.Add(c.largeCardinalityCostPenalty(scan.Relational().Cardinality, rowCount))
+
+	if required.LimitHint != 0 {
+		rowCount = math.Min(rowCount, required.LimitHint)
+	}
+
+	cost := baseCost
+	cost.C += rowCount * (seqIOCostFactor + perRowCost.C)
+
+	// TODO(#148315): Consider adding distribution cost for RBR tables.
+	cost.Add(SmallDistributeCost)
 	return cost
 }
 

--- a/pkg/sql/opt/xform/generic_funcs.go
+++ b/pkg/sql/opt/xform/generic_funcs.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/volatility"
 	"github.com/cockroachdb/cockroach/pkg/sql/sessiondatapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/errors"
 )
 
 // GenericRulesEnabled returns true if rules for optimizing generic query plans
@@ -123,4 +124,65 @@ func (c *CustomFuncs) ParameterizedJoinPrivate() *memo.JoinPrivate {
 		Flags:            memo.DisallowMergeJoin,
 		SkipReorderJoins: true,
 	}
+}
+
+// PlaceholderScanSpanAndPrivate returns a span and scan private for a
+// PlaceholderScan expression that is semantically equivalent to the given
+// lookup join with input values. See
+// ConvertParameterizedLookupJoinToPlaceholderScan for more details.
+func (c *CustomFuncs) PlaceholderScanSpanAndPrivate(
+	lookupPrivate *memo.LookupJoinPrivate,
+	values *memo.ValuesExpr,
+	row memo.ScalarListExpr,
+	outputCols opt.ColSet,
+) (span memo.ScalarListExpr, scanPrivate *memo.ScanPrivate, ok bool) {
+	// The lookup join must be an inner join.
+	if lookupPrivate.JoinType != opt.InnerJoinOp {
+		return nil, nil, false
+	}
+	// The lookup join must only have key columns, no lookup expressions.
+	if len(lookupPrivate.KeyCols) == 0 ||
+		lookupPrivate.LookupExpr != nil ||
+		lookupPrivate.RemoteLookupExpr != nil {
+		return nil, nil, false
+	}
+	// The lookup join must not be part of a paired join.
+	if lookupPrivate.IsFirstJoinInPairedJoiner || lookupPrivate.IsSecondJoinInPairedJoiner {
+		return nil, nil, false
+	}
+	// The index must be able to produce all the output columns.
+	md := c.e.f.Metadata()
+	indexCols := md.TableMeta(lookupPrivate.Table).IndexColumns(lookupPrivate.Index)
+	if !outputCols.SubsetOf(indexCols) {
+		return nil, nil, false
+	}
+
+	// Map columns in the input Values expression to the key columns.
+	span = make(memo.ScalarListExpr, len(lookupPrivate.KeyCols))
+	for i, keyCol := range lookupPrivate.KeyCols {
+		for j, valCol := range values.Cols {
+			if keyCol == valCol {
+				if !verifyType(md, keyCol, row[j].DataType()) {
+					// TODO(mgartner): This was added to copy the same check
+					// made while planning the the placeholder fast-path, but it
+					// may not be necessary here because the lookup join may
+					// have already checked this.
+					return nil, nil, false
+				}
+				span[i] = row[j]
+				break
+			}
+		}
+		if span[i] == nil {
+			panic(errors.AssertionFailedf("no value found for key column %d", keyCol))
+		}
+	}
+
+	scanPrivate = &memo.ScanPrivate{
+		Table:   lookupPrivate.Table,
+		Index:   lookupPrivate.Index,
+		Cols:    outputCols.Copy(),
+		Locking: lookupPrivate.Locking,
+	}
+	return span, scanPrivate, true
 }

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -56,3 +56,45 @@
     []
     (OutputCols (Root))
 )
+
+# ConvertParameterizedLookupJoinToPlaceholderScan converts some LookupJoins that
+# ultimately result from GenerateParameterizedJoin into PlaceholderScans. The
+# execution of PlaceholderScans are more efficient than more general-purpose
+# LookupJoins. They also natively support vectorized execution, helping to avoid
+# materialization and columnarization overhead.
+#
+# The rule only applies to inner LookupJoins where all of the following are
+# true:
+#
+#   1. Only key columns are used; no lookup expressions.
+#   2. There is no ON filter.
+#   3. The LookupJoin is not part of a paired join.
+#   4. The lookup index can produce all of the needed output columns.
+#
+[ConvertParameterizedLookupJoinToPlaceholderScan, Explore]
+(Project
+    (LookupJoin
+        $values:(Values [ (Tuple $row:[ ... ]) ])
+        []
+        $lookupPrivate:*
+    )
+    []
+    $outputCols:* &
+        (GenericRulesEnabled) &
+        (HasPlaceholdersOrStableExprs $values) &
+        (Let
+            (
+                $span
+                $scanPrivate
+                $ok
+            ):(PlaceholderScanSpanAndPrivate
+                $lookupPrivate
+                $values
+                $row
+                $outputCols
+            )
+            $ok
+        )
+)
+=>
+(PlaceholderScan $span $scanPrivate)

--- a/pkg/sql/opt/xform/testdata/coster/placeholder-scan
+++ b/pkg/sql/opt/xform/testdata/coster/placeholder-scan
@@ -1,0 +1,1261 @@
+# This tests in this file compare the cost of a scan to the cost of a generic
+# placeholder-scan. The costs should be the same or similar when histograms are
+# not present.
+
+exec-ddl
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  a INT,
+  b INT,
+  c INT,
+  INDEX (a, b)
+)
+----
+
+# --------------------------------------------------
+# Without Histograms
+# --------------------------------------------------
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000
+  },
+  {
+    "columns": ["a"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000
+  },
+  {
+    "columns": ["c"],
+    "created_at": "2019-02-08 04:10:40.001179+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000
+  }
+]'
+----
+
+# --------------------------------------------------
+# Q1
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE k = 1
+----
+scan t
+ ├── columns: k:1!null
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── cost: 9.06
+ ├── key: ()
+ └── fd: ()-->(1)
+
+opt
+SELECT k FROM t WHERE k = $1
+----
+placeholder-scan t
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── cost: 9.06
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── span
+      └── $1
+
+# --------------------------------------------------
+# Q2
+# --------------------------------------------------
+
+opt
+SELECT * FROM t WHERE k = 1
+----
+scan t
+ ├── columns: k:1!null a:2 b:3 c:4
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── cost: 9.09
+ ├── key: ()
+ └── fd: ()-->(1-4)
+
+opt
+SELECT * FROM t WHERE k = $1
+----
+placeholder-scan t
+ ├── columns: k:1!null a:2 b:3 c:4
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── cost: 9.09
+ ├── key: ()
+ ├── fd: ()-->(1-4)
+ └── span
+      └── $1
+
+# --------------------------------------------------
+# Q3
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1
+----
+project
+ ├── columns: k:1!null
+ ├── stats: [rows=1000]
+ ├── cost: 1078.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      ├── cost: 1068.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+opt
+SELECT k FROM t WHERE a = $1
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── stats: [rows=1000]
+ ├── cost: 1078.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── placeholder-scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── has-placeholder
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      ├── cost: 1068.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      └── span
+           └── $1
+
+# --------------------------------------------------
+# Q4
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 ORDER BY b
+----
+project
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── stats: [rows=1000]
+ ├── cost: 1088.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: +3
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      ├── cost: 1078.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3)
+      └── ordering: +3 opt(2) [actual: +3]
+
+# NOTE: Placeholder scans do not provide any orderings, so a sort is added.
+opt
+SELECT k FROM t WHERE a = $1 ORDER BY b
+----
+sort
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── has-placeholder
+ ├── stats: [rows=1000]
+ ├── cost: 1327.52195
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: +3
+ └── project
+      ├── columns: k:1!null b:3
+      ├── has-placeholder
+      ├── stats: [rows=1000]
+      ├── cost: 1088.04001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      └── placeholder-scan t@t_a_b_idx
+           ├── columns: k:1!null a:2!null b:3
+           ├── has-placeholder
+           ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+           ├── cost: 1078.02001
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(2), (1)-->(3)
+           └── span
+                └── $1
+
+# --------------------------------------------------
+# Q5
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 ORDER BY b DESC
+----
+project
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── stats: [rows=1000]
+ ├── cost: 1187.69785
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: -3
+ └── scan t@t_a_b_idx,rev
+      ├── columns: k:1!null a:2!null b:3
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      ├── cost: 1177.67785
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3)
+      └── ordering: -3 opt(2) [actual: -3]
+
+# NOTE: Placeholder scans do not provide any orderings, so a sort is added.
+opt
+SELECT k FROM t WHERE a = $1 ORDER BY b DESC
+----
+sort
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── has-placeholder
+ ├── stats: [rows=1000]
+ ├── cost: 1327.52195
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: -3
+ └── project
+      ├── columns: k:1!null b:3
+      ├── has-placeholder
+      ├── stats: [rows=1000]
+      ├── cost: 1088.04001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      └── placeholder-scan t@t_a_b_idx
+           ├── columns: k:1!null a:2!null b:3
+           ├── has-placeholder
+           ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+           ├── cost: 1078.02001
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(2), (1)-->(3)
+           └── span
+                └── $1
+
+# --------------------------------------------------
+# Q6
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 LIMIT 2
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 2]
+ ├── stats: [rows=2]
+ ├── cost: 10.14
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── limit: 2
+      ├── stats: [rows=2]
+      ├── cost: 10.11
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+# NOTE: Placeholder scans do not yet support limited scans.
+opt
+SELECT k FROM t WHERE a = $1 LIMIT 2
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 2]
+ ├── has-placeholder
+ ├── stats: [rows=2]
+ ├── cost: 20.18
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null a:2!null
+      ├── cardinality: [0 - 2]
+      ├── has-placeholder
+      ├── stats: [rows=2]
+      ├── cost: 20.15
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── placeholder-scan t@t_a_b_idx
+      │    ├── columns: k:1!null a:2!null
+      │    ├── has-placeholder
+      │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │    ├── cost: 20.12
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── limit hint: 2.00
+      │    └── span
+      │         └── $1
+      └── 2
+
+# --------------------------------------------------
+# Q7
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a > 1 AND a < 10
+----
+project
+ ├── columns: k:1!null
+ ├── stats: [rows=8000]
+ ├── cost: 8498.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/3/1: [/2 - /9]
+      ├── stats: [rows=8000, distinct(2)=8, null(2)=0]
+      ├── cost: 8418.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# A generic query plan likely will not be used for queries like this. A
+# placeholder scan is not generated for this query, and without knowing the
+# bounds of the range it is difficult to make an accurate row count estimate.
+opt
+SELECT k FROM t WHERE a > $1 AND a < $2
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── stats: [rows=11111.1]
+ ├── cost: 68912.9899
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── project
+      ├── columns: k:1!null a:2!null
+      ├── has-placeholder
+      ├── stats: [rows=11111.1, distinct(2)=100, null(2)=0]
+      ├── cost: 68801.8588
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      └── inner-join (lookup t@t_a_b_idx)
+           ├── columns: k:1!null a:2!null "$1":7!null "$2":8!null
+           ├── flags: disallow merge join
+           ├── lookup expression
+           │    └── filters
+           │         └── a:2 > "$1":7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+           ├── has-placeholder
+           ├── stats: [rows=11111.1, distinct(2)=100, null(2)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+           ├── cost: 68690.7277
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(7,8), (1)-->(2)
+           ├── values
+           │    ├── columns: "$1":7 "$2":8
+           │    ├── cardinality: [1 - 1]
+           │    ├── has-placeholder
+           │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+           │    ├── cost: 0.02
+           │    ├── key: ()
+           │    ├── fd: ()-->(7,8)
+           │    └── ($1, $2)
+           └── filters
+                └── a:2 < "$2":8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+
+# --------------------------------------------------
+# Q8
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 AND b = 2
+----
+project
+ ├── columns: k:1!null
+ ├── stats: [rows=0.01001]
+ ├── cost: 18.0507107
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── constraint: /2/3/1: [/1/2 - /1/2]
+      ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+      ├── cost: 18.0306106
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: ()-->(2,3)
+
+opt
+SELECT k FROM t WHERE a = $1 AND b = $2
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── stats: [rows=0.01001]
+ ├── cost: 18.0507107
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── placeholder-scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── has-placeholder
+      ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+      ├── cost: 18.0306106
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2,3)
+      └── span
+           ├── $1
+           └── $2
+
+# --------------------------------------------------
+# Q9
+# --------------------------------------------------
+
+opt
+SELECT k, a, b FROM t WHERE a = 1 AND b = 2
+----
+scan t@t_a_b_idx
+ ├── columns: k:1!null a:2!null b:3!null
+ ├── constraint: /2/3/1: [/1/2 - /1/2]
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ ├── cost: 18.0306106
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: ()-->(2,3)
+
+opt
+SELECT k, a, b FROM t WHERE a = $1 AND b = $2
+----
+placeholder-scan t@t_a_b_idx
+ ├── columns: k:1!null a:2!null b:3!null
+ ├── has-placeholder
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ ├── cost: 18.0306106
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── span
+      ├── $1
+      └── $2
+
+# --------------------------------------------------
+# Q10
+# --------------------------------------------------
+
+opt
+SELECT * FROM t WHERE a = 1 AND b = 2
+----
+index-join t
+ ├── columns: k:1!null a:2!null b:3!null c:4
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ ├── cost: 18.1112712
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── constraint: /2/3/1: [/1/2 - /1/2]
+      ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+      ├── cost: 18.0306106
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: ()-->(2,3)
+
+# TODO(mgartner): This query does not yet use a placeholder scan, but could.
+opt
+SELECT * FROM t WHERE a = $1 AND b = $2
+----
+project
+ ├── columns: k:1!null a:2!null b:3!null c:4
+ ├── has-placeholder
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ ├── cost: 28.1614001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null a:2!null b:3!null c:4 "$1":7!null "$2":8!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── has-placeholder
+      ├── stats: [rows=0.01, distinct(2)=0.01, null(2)=0, distinct(3)=0.01, null(3)=0, distinct(7)=0.01, null(7)=0, distinct(8)=0.01, null(8)=0]
+      ├── cost: 28.1413
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2,3,7,8), (1)-->(4), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+      ├── inner-join (lookup t@t_a_b_idx)
+      │    ├── columns: k:1!null a:2!null b:3!null "$1":7!null "$2":8!null
+      │    ├── flags: disallow merge join
+      │    ├── key columns: [7 8] = [2 3]
+      │    ├── has-placeholder
+      │    ├── stats: [rows=0.01, distinct(2)=0.01, null(2)=0, distinct(3)=0.01, null(3)=0, distinct(7)=0.01, null(7)=0, distinct(8)=0.01, null(8)=0]
+      │    ├── cost: 24.0607
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,3,7,8), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+      │    ├── values
+      │    │    ├── columns: "$1":7 "$2":8
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+      │    │    ├── cost: 0.02
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(7,8)
+      │    │    └── ($1, $2)
+      │    └── filters (true)
+      └── filters (true)
+
+# --------------------------------------------------
+# Q11 - Limit hint
+# --------------------------------------------------
+
+# Disable PushLimitIntoFilteredScan to prevent the limit from being pushed into
+# the scan.
+opt disable=PushLimitIntoFilteredScan
+SELECT k FROM t WHERE a = 1 LIMIT 100
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=100]
+ ├── cost: 125.04
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null a:2!null
+      ├── cardinality: [0 - 100]
+      ├── stats: [rows=100]
+      ├── cost: 124.03
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan t@t_a_b_idx
+      │    ├── columns: k:1!null a:2!null
+      │    ├── constraint: /2/3/1: [/1 - /1]
+      │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │    ├── cost: 123.02
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    └── limit hint: 100.00
+      └── 100
+
+opt
+SELECT k FROM t WHERE a = $1 LIMIT 100
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 100]
+ ├── has-placeholder
+ ├── stats: [rows=100]
+ ├── cost: 125.04
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null a:2!null
+      ├── cardinality: [0 - 100]
+      ├── has-placeholder
+      ├── stats: [rows=100]
+      ├── cost: 124.03
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── placeholder-scan t@t_a_b_idx
+      │    ├── columns: k:1!null a:2!null
+      │    ├── has-placeholder
+      │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │    ├── cost: 123.02
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── limit hint: 100.00
+      │    └── span
+      │         └── $1
+      └── 100
+
+# --------------------------------------------------
+# Q12 - virtual table scan
+# --------------------------------------------------
+
+opt
+SELECT * FROM pg_catalog.pg_attribute WHERE attrelid = 1
+----
+scan pg_attribute@pg_attribute_attrelid_idx
+ ├── columns: attrelid:2!null attname:3 atttypid:4 attstattarget:5 attlen:6 attnum:7 attndims:8 attcacheoff:9 atttypmod:10 attbyval:11 attstorage:12 attalign:13 attnotnull:14 atthasdef:15 attidentity:16 attgenerated:17 attisdropped:18 attislocal:19 attinhcount:20 attcollation:21 attacl:22 attoptions:23 attfdwoptions:24 atthasmissing:25 attmissingval:26 attishidden:27
+ ├── constraint: /2/1: [/1 - /1]
+ ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+ ├── cost: 133.32
+ ├── cost-flags: unbounded-cardinality
+ └── fd: ()-->(2)
+
+opt
+SELECT * FROM pg_catalog.pg_attribute WHERE attrelid = $1
+----
+placeholder-scan pg_attribute@pg_attribute_attrelid_idx
+ ├── columns: attrelid:2!null attname:3 atttypid:4 attstattarget:5 attlen:6 attnum:7 attndims:8 attcacheoff:9 atttypmod:10 attbyval:11 attstorage:12 attalign:13 attnotnull:14 atthasdef:15 attidentity:16 attgenerated:17 attisdropped:18 attislocal:19 attinhcount:20 attcollation:21 attacl:22 attoptions:23 attfdwoptions:24 atthasmissing:25 attmissingval:26 attishidden:27
+ ├── has-placeholder
+ ├── stats: [rows=10, distinct(2)=1, null(2)=0]
+ ├── cost: 133.32
+ ├── cost-flags: unbounded-cardinality
+ ├── fd: ()-->(2)
+ └── span
+      └── $1
+
+# --------------------------------------------------
+# With Histograms
+# --------------------------------------------------
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "20000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "40000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "60000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "80000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "100000"}
+    ]
+  },
+  {
+    "columns": ["a"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100000,
+    "distinct_count": 100,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1000, "num_range": 19000, "distinct_range": 19, "upper_bound": "20"},
+      {"num_eq": 1000, "num_range": 19000, "distinct_range": 19, "upper_bound": "40"},
+      {"num_eq": 1000, "num_range": 19000, "distinct_range": 19, "upper_bound": "60"},
+      {"num_eq": 1000, "num_range": 19000, "distinct_range": 19, "upper_bound": "80"},
+      {"num_eq": 1000, "num_range": 19000, "distinct_range": 19, "upper_bound": "100"}
+    ]
+  },
+  {
+    "columns": ["b"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 100000,
+    "distinct_count": 100000,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "20000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "40000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "60000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "80000"},
+      {"num_eq": 1, "num_range": 19999, "distinct_range": 19999, "upper_bound": "100000"}
+    ]
+  }
+]'
+----
+
+# --------------------------------------------------
+# Q1
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE k = 1
+----
+scan t
+ ├── columns: k:1!null
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │   histogram(1)=  0  1
+ │                <--- 1
+ ├── cost: 9.04
+ ├── key: ()
+ └── fd: ()-->(1)
+
+opt
+SELECT k FROM t WHERE k = $1
+----
+placeholder-scan t
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── cost: 9.04
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── span
+      └── $1
+
+# --------------------------------------------------
+# Q2
+# --------------------------------------------------
+
+opt
+SELECT * FROM t WHERE k = 1
+----
+scan t
+ ├── columns: k:1!null a:2 b:3 c:4
+ ├── constraint: /1: [/1 - /1]
+ ├── cardinality: [0 - 1]
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │   histogram(1)=  0  1
+ │                <--- 1
+ ├── cost: 9.06
+ ├── key: ()
+ └── fd: ()-->(1-4)
+
+opt
+SELECT * FROM t WHERE k = $1
+----
+placeholder-scan t
+ ├── columns: k:1!null a:2 b:3 c:4
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── cost: 9.06
+ ├── key: ()
+ ├── fd: ()-->(1-4)
+ └── span
+      └── $1
+
+# --------------------------------------------------
+# Q3
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1
+----
+project
+ ├── columns: k:1!null
+ ├── stats: [rows=1000]
+ ├── cost: 1053.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │   histogram(2)=  0 1000
+      │                <--- 1 -
+      ├── cost: 1043.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+opt
+SELECT k FROM t WHERE a = $1
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── stats: [rows=1000]
+ ├── cost: 1053.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── placeholder-scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── has-placeholder
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      ├── cost: 1043.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      └── span
+           └── $1
+
+# --------------------------------------------------
+# Q4
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 ORDER BY b
+----
+project
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── stats: [rows=1000]
+ ├── cost: 1058.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: +3
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │   histogram(2)=  0 1000
+      │                <--- 1 -
+      ├── cost: 1048.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3)
+      └── ordering: +3 opt(2) [actual: +3]
+
+# NOTE: Placeholder scans do not provide any orderings, so a sort is added.
+opt
+SELECT k FROM t WHERE a = $1 ORDER BY b
+----
+sort
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── has-placeholder
+ ├── stats: [rows=1000]
+ ├── cost: 1297.52195
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: +3
+ └── project
+      ├── columns: k:1!null b:3
+      ├── has-placeholder
+      ├── stats: [rows=1000]
+      ├── cost: 1058.04001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      └── placeholder-scan t@t_a_b_idx
+           ├── columns: k:1!null a:2!null b:3
+           ├── has-placeholder
+           ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+           ├── cost: 1048.02001
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(2), (1)-->(3)
+           └── span
+                └── $1
+
+# --------------------------------------------------
+# Q5
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 ORDER BY b DESC
+----
+project
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── stats: [rows=1000]
+ ├── cost: 1157.69785
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: -3
+ └── scan t@t_a_b_idx,rev
+      ├── columns: k:1!null a:2!null b:3
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │   histogram(2)=  0 1000
+      │                <--- 1 -
+      ├── cost: 1147.67785
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2), (1)-->(3)
+      └── ordering: -3 opt(2) [actual: -3]
+
+# NOTE: Placeholder scans do not provide any orderings, so a sort is added.
+opt
+SELECT k FROM t WHERE a = $1 ORDER BY b DESC
+----
+sort
+ ├── columns: k:1!null  [hidden: b:3]
+ ├── has-placeholder
+ ├── stats: [rows=1000]
+ ├── cost: 1297.52195
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: (1)-->(3)
+ ├── ordering: -3
+ └── project
+      ├── columns: k:1!null b:3
+      ├── has-placeholder
+      ├── stats: [rows=1000]
+      ├── cost: 1058.04001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(3)
+      └── placeholder-scan t@t_a_b_idx
+           ├── columns: k:1!null a:2!null b:3
+           ├── has-placeholder
+           ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+           ├── cost: 1048.02001
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(2), (1)-->(3)
+           └── span
+                └── $1
+
+# --------------------------------------------------
+# Q6
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 LIMIT 2
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 2]
+ ├── stats: [rows=2]
+ ├── cost: 10.09
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/3/1: [/1 - /1]
+      ├── limit: 2
+      ├── stats: [rows=2]
+      ├── cost: 10.06
+      ├── key: (1)
+      └── fd: ()-->(2)
+
+# NOTE: Placeholder scans do not yet support limited scans.
+opt
+SELECT k FROM t WHERE a = $1 LIMIT 2
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 2]
+ ├── has-placeholder
+ ├── stats: [rows=2]
+ ├── cost: 20.13
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null a:2!null
+      ├── cardinality: [0 - 2]
+      ├── has-placeholder
+      ├── stats: [rows=2]
+      ├── cost: 20.1
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── placeholder-scan t@t_a_b_idx
+      │    ├── columns: k:1!null a:2!null
+      │    ├── has-placeholder
+      │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │    ├── cost: 20.07
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── limit hint: 2.00
+      │    └── span
+      │         └── $1
+      └── 2
+
+# --------------------------------------------------
+# Q7
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a > 1 AND a < 10
+----
+project
+ ├── columns: k:1!null
+ ├── stats: [rows=8000]
+ ├── cost: 8298.04001
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null
+      ├── constraint: /2/3/1: [/2 - /9]
+      ├── stats: [rows=8000, distinct(2)=8, null(2)=0]
+      │   histogram(2)=  0  0  7000 1000
+      │                <--- 1 ------ 9 -
+      ├── cost: 8218.02001
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: (1)-->(2)
+
+# A generic query plan likely will not be used for queries like this. A
+# placeholder scan is not generated for this query, and without knowing the
+# bounds of the range it is difficult to make an accurate row count estimate.
+opt
+SELECT k FROM t WHERE a > $1 AND a < $2
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── stats: [rows=11111.1]
+ ├── cost: 68079.6566
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── project
+      ├── columns: k:1!null a:2!null
+      ├── has-placeholder
+      ├── stats: [rows=11111.1, distinct(2)=100, null(2)=0]
+      ├── cost: 67968.5254
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: (1)-->(2)
+      └── inner-join (lookup t@t_a_b_idx)
+           ├── columns: k:1!null a:2!null "$1":7!null "$2":8!null
+           ├── flags: disallow merge join
+           ├── lookup expression
+           │    └── filters
+           │         └── a:2 > "$1":7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+           ├── has-placeholder
+           ├── stats: [rows=11111.1, distinct(2)=100, null(2)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+           ├── cost: 67857.3943
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(7,8), (1)-->(2)
+           ├── values
+           │    ├── columns: "$1":7 "$2":8
+           │    ├── cardinality: [1 - 1]
+           │    ├── has-placeholder
+           │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+           │    ├── cost: 0.02
+           │    ├── key: ()
+           │    ├── fd: ()-->(7,8)
+           │    └── ($1, $2)
+           └── filters
+                └── a:2 < "$2":8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ])]
+
+# --------------------------------------------------
+# Q8
+# --------------------------------------------------
+
+opt
+SELECT k FROM t WHERE a = 1 AND b = 2
+----
+project
+ ├── columns: k:1!null
+ ├── stats: [rows=0.01001]
+ ├── cost: 18.0504104
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── constraint: /2/3/1: [/1/2 - /1/2]
+      ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+      │   histogram(2)=  0 0.01001
+      │                <----- 1 --
+      │   histogram(3)=  0 0.01001
+      │                <----- 2 --
+      ├── cost: 18.0303103
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: ()-->(2,3)
+
+opt
+SELECT k FROM t WHERE a = $1 AND b = $2
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── stats: [rows=0.01001]
+ ├── cost: 18.0504104
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── placeholder-scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── has-placeholder
+      ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+      ├── cost: 18.0303103
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2,3)
+      └── span
+           ├── $1
+           └── $2
+
+# --------------------------------------------------
+# Q9
+# --------------------------------------------------
+
+opt
+SELECT k, a, b FROM t WHERE a = 1 AND b = 2
+----
+scan t@t_a_b_idx
+ ├── columns: k:1!null a:2!null b:3!null
+ ├── constraint: /2/3/1: [/1/2 - /1/2]
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ │   histogram(2)=  0 0.01001
+ │                <----- 1 --
+ │   histogram(3)=  0 0.01001
+ │                <----- 2 --
+ ├── cost: 18.0303103
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── fd: ()-->(2,3)
+
+opt
+SELECT k, a, b FROM t WHERE a = $1 AND b = $2
+----
+placeholder-scan t@t_a_b_idx
+ ├── columns: k:1!null a:2!null b:3!null
+ ├── has-placeholder
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ ├── cost: 18.0303103
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ └── span
+      ├── $1
+      └── $2
+
+# --------------------------------------------------
+# Q10
+# --------------------------------------------------
+
+opt
+SELECT * FROM t WHERE a = 1 AND b = 2
+----
+index-join t
+ ├── columns: k:1!null a:2!null b:3!null c:4
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ │   histogram(2)=  0 0.01001
+ │                <----- 1 --
+ │   histogram(3)=  0 0.01001
+ │                <----- 2 --
+ ├── cost: 18.1108208
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4)
+ └── scan t@t_a_b_idx
+      ├── columns: k:1!null a:2!null b:3!null
+      ├── constraint: /2/3/1: [/1/2 - /1/2]
+      ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+      │   histogram(2)=  0 0.01001
+      │                <----- 1 --
+      │   histogram(3)=  0 0.01001
+      │                <----- 2 --
+      ├── cost: 18.0303103
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      └── fd: ()-->(2,3)
+
+# TODO(mgartner): This query does not yet use a placeholder scan, but could.
+opt
+SELECT * FROM t WHERE a = $1 AND b = $2
+----
+project
+ ├── columns: k:1!null a:2!null b:3!null c:4
+ ├── has-placeholder
+ ├── stats: [rows=0.01001, distinct(2)=0.01001, null(2)=0, distinct(3)=0.01001, null(3)=0, distinct(2,3)=0.01001, null(2,3)=0]
+ ├── cost: 28.1609501
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ ├── fd: ()-->(2,3), (1)-->(4)
+ └── inner-join (lookup t)
+      ├── columns: k:1!null a:2!null b:3!null c:4 "$1":7!null "$2":8!null
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── has-placeholder
+      ├── stats: [rows=0.01, distinct(2)=0.01, null(2)=0, distinct(3)=0.01, null(3)=0, distinct(7)=0.01, null(7)=0, distinct(8)=0.01, null(8)=0]
+      ├── cost: 28.14085
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2,3,7,8), (1)-->(4), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+      ├── inner-join (lookup t@t_a_b_idx)
+      │    ├── columns: k:1!null a:2!null b:3!null "$1":7!null "$2":8!null
+      │    ├── flags: disallow merge join
+      │    ├── key columns: [7 8] = [2 3]
+      │    ├── has-placeholder
+      │    ├── stats: [rows=0.01, distinct(2)=0.01, null(2)=0, distinct(3)=0.01, null(3)=0, distinct(7)=0.01, null(7)=0, distinct(8)=0.01, null(8)=0]
+      │    ├── cost: 24.0604
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,3,7,8), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+      │    ├── values
+      │    │    ├── columns: "$1":7 "$2":8
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── stats: [rows=1, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+      │    │    ├── cost: 0.02
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(7,8)
+      │    │    └── ($1, $2)
+      │    └── filters (true)
+      └── filters (true)
+
+# --------------------------------------------------
+# Q11 - Limit hint
+# --------------------------------------------------
+
+# Disable PushLimitIntoFilteredScan to prevent the limit from being pushed into
+# the scan.
+opt disable=PushLimitIntoFilteredScan
+SELECT k FROM t WHERE a = 1 LIMIT 100
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 100]
+ ├── stats: [rows=100]
+ ├── cost: 122.54
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null a:2!null
+      ├── cardinality: [0 - 100]
+      ├── stats: [rows=100]
+      ├── cost: 121.53
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── scan t@t_a_b_idx
+      │    ├── columns: k:1!null a:2!null
+      │    ├── constraint: /2/3/1: [/1 - /1]
+      │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │    │   histogram(2)=  0 1000
+      │    │                <--- 1 -
+      │    ├── cost: 120.52
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    └── limit hint: 100.00
+      └── 100
+
+opt
+SELECT k FROM t WHERE a = $1 LIMIT 100
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 100]
+ ├── has-placeholder
+ ├── stats: [rows=100]
+ ├── cost: 122.54
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null a:2!null
+      ├── cardinality: [0 - 100]
+      ├── has-placeholder
+      ├── stats: [rows=100]
+      ├── cost: 121.53
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      ├── placeholder-scan t@t_a_b_idx
+      │    ├── columns: k:1!null a:2!null
+      │    ├── has-placeholder
+      │    ├── stats: [rows=1000, distinct(2)=1, null(2)=0]
+      │    ├── cost: 120.52
+      │    ├── cost-flags: unbounded-cardinality
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2)
+      │    ├── limit hint: 100.00
+      │    └── span
+      │         └── $1
+      └── 100

--- a/pkg/sql/opt/xform/testdata/external/hibernate
+++ b/pkg/sql/opt/xform/testdata/external/hibernate
@@ -991,29 +991,14 @@ project
            ├── has-placeholder
            ├── key: ()
            ├── fd: ()-->(1-6,9,12), (1)==(12), (12)==(1)
-           ├── project
+           ├── placeholder-scan phone [as=phones1_]
            │    ├── columns: phones1_.id:9!null person_id:12
            │    ├── cardinality: [0 - 1]
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(9,12)
-           │    └── inner-join (lookup phone [as=phones1_])
-           │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
-           │         ├── flags: disallow merge join
-           │         ├── key columns: [17] = [9]
-           │         ├── lookup columns are key
-           │         ├── cardinality: [0 - 1]
-           │         ├── has-placeholder
-           │         ├── key: ()
-           │         ├── fd: ()-->(9,12,17), (9)==(17), (17)==(9)
-           │         ├── values
-           │         │    ├── columns: "$1":17
-           │         │    ├── cardinality: [1 - 1]
-           │         │    ├── has-placeholder
-           │         │    ├── key: ()
-           │         │    ├── fd: ()-->(17)
-           │         │    └── ($1,)
-           │         └── filters (true)
+           │    └── span
+           │         └── $1
            └── filters (true)
 
 opt
@@ -1056,29 +1041,14 @@ project
            ├── has-placeholder
            ├── key: ()
            ├── fd: ()-->(1-6,9,12), (1)==(12), (12)==(1)
-           ├── project
+           ├── placeholder-scan phone [as=phones1_]
            │    ├── columns: phones1_.id:9!null person_id:12
            │    ├── cardinality: [0 - 1]
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(9,12)
-           │    └── inner-join (lookup phone [as=phones1_])
-           │         ├── columns: phones1_.id:9!null person_id:12 "$1":17!null
-           │         ├── flags: disallow merge join
-           │         ├── key columns: [17] = [9]
-           │         ├── lookup columns are key
-           │         ├── cardinality: [0 - 1]
-           │         ├── has-placeholder
-           │         ├── key: ()
-           │         ├── fd: ()-->(9,12,17), (9)==(17), (17)==(9)
-           │         ├── values
-           │         │    ├── columns: "$1":17
-           │         │    ├── cardinality: [1 - 1]
-           │         │    ├── has-placeholder
-           │         │    ├── key: ()
-           │         │    ├── fd: ()-->(17)
-           │         │    └── ($1,)
-           │         └── filters (true)
+           │    └── span
+           │         └── $1
            └── filters (true)
 
 opt

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -2459,29 +2459,14 @@ project
       │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    ├── key: ()
       │    │    │    │    │    ├── fd: ()-->(1-12,14,15,19,20)
-      │    │    │    │    │    ├── project
+      │    │    │    │    │    ├── placeholder-scan flavors
       │    │    │    │    │    │    ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15
       │    │    │    │    │    │    ├── cardinality: [0 - 1]
       │    │    │    │    │    │    ├── has-placeholder
       │    │    │    │    │    │    ├── key: ()
       │    │    │    │    │    │    ├── fd: ()-->(1-12,14,15)
-      │    │    │    │    │    │    └── inner-join (lookup flavors)
-      │    │    │    │    │    │         ├── columns: flavors.id:1!null name:2!null memory_mb:3!null vcpus:4!null root_gb:5 ephemeral_gb:6 flavorid:7!null swap:8!null rxtx_factor:9 vcpu_weight:10 disabled:11 is_public:12 flavors.created_at:14 flavors.updated_at:15 "$2":37!null
-      │    │    │    │    │    │         ├── flags: disallow merge join
-      │    │    │    │    │    │         ├── key columns: [37] = [1]
-      │    │    │    │    │    │         ├── lookup columns are key
-      │    │    │    │    │    │         ├── cardinality: [0 - 1]
-      │    │    │    │    │    │         ├── has-placeholder
-      │    │    │    │    │    │         ├── key: ()
-      │    │    │    │    │    │         ├── fd: ()-->(1-12,14,15,37), (1)==(37), (37)==(1)
-      │    │    │    │    │    │         ├── values
-      │    │    │    │    │    │         │    ├── columns: "$2":37
-      │    │    │    │    │    │         │    ├── cardinality: [1 - 1]
-      │    │    │    │    │    │         │    ├── has-placeholder
-      │    │    │    │    │    │         │    ├── key: ()
-      │    │    │    │    │    │         │    ├── fd: ()-->(37)
-      │    │    │    │    │    │         │    └── ($2,)
-      │    │    │    │    │    │         └── filters (true)
+      │    │    │    │    │    │    └── span
+      │    │    │    │    │    │         └── $2
       │    │    │    │    │    ├── project
       │    │    │    │    │    │    ├── columns: flavor_projects.flavor_id:19!null project_id:20!null
       │    │    │    │    │    │    ├── cardinality: [0 - 1]

--- a/pkg/sql/opt/xform/testdata/rules/generic
+++ b/pkg/sql/opt/xform/testdata/rules/generic
@@ -12,63 +12,91 @@ CREATE TABLE t (
 ----
 
 # --------------------------------------------------
-# GenerateParameterizedJoin
+# GenerateParameterizedJoin /
+#   ConvertParameterizedLookupJoinToPlaceholderScan
 # --------------------------------------------------
 
-opt expect=GenerateParameterizedJoin
+opt expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan)
 SELECT * FROM t WHERE k = $1
 ----
-project
+placeholder-scan t
  ├── columns: k:1!null i:2 s:3 b:4 t:5
  ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── inner-join (lookup t)
-      ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
-      ├── flags: disallow merge join
-      ├── key columns: [8] = [1]
-      ├── lookup columns are key
-      ├── cardinality: [0 - 1]
-      ├── has-placeholder
-      ├── key: ()
-      ├── fd: ()-->(1-5,8), (1)==(8), (8)==(1)
-      ├── values
-      │    ├── columns: "$1":8
-      │    ├── cardinality: [1 - 1]
-      │    ├── has-placeholder
-      │    ├── key: ()
-      │    ├── fd: ()-->(8)
-      │    └── ($1,)
-      └── filters (true)
+ └── span
+      └── $1
 
-opt expect=GenerateParameterizedJoin
+opt expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan)
 SELECT * FROM t WHERE k = $1::INT
 ----
-project
+placeholder-scan t
  ├── columns: k:1!null i:2 s:3 b:4 t:5
  ├── cardinality: [0 - 1]
  ├── has-placeholder
  ├── key: ()
  ├── fd: ()-->(1-5)
- └── inner-join (lookup t)
-      ├── columns: k:1!null i:2 s:3 b:4 t:5 "$1":8!null
-      ├── flags: disallow merge join
-      ├── key columns: [8] = [1]
-      ├── lookup columns are key
-      ├── cardinality: [0 - 1]
-      ├── has-placeholder
-      ├── key: ()
-      ├── fd: ()-->(1-5,8), (1)==(8), (8)==(1)
-      ├── values
-      │    ├── columns: "$1":8
-      │    ├── cardinality: [1 - 1]
-      │    ├── has-placeholder
-      │    ├── key: ()
-      │    ├── fd: ()-->(8)
-      │    └── ($1,)
-      └── filters (true)
+ └── span
+      └── $1
 
+opt expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan)
+SELECT * FROM t WHERE k = $1 FOR UPDATE
+----
+placeholder-scan t
+ ├── columns: k:1!null i:2 s:3 b:4 t:5
+ ├── locking: for-update
+ ├── cardinality: [0 - 1]
+ ├── volatile, has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-5)
+ └── span
+      └── $1
+
+# TODO(mgartner): This query is not converted to a scan because it does not have
+# a project above the lookup-join, which is required by the match pattern of
+# ConvertParameterizedLookupJoinToPlaceholderScan.
+opt
+SELECT * FROM (VALUES ($1::INT)) AS v(k) JOIN t ON t.k = v.k
+----
+inner-join (lookup t)
+ ├── columns: k:1!null k:2!null i:3 s:4 b:5 t:6
+ ├── key columns: [1] = [2]
+ ├── lookup columns are key
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1-6), (1)==(2), (2)==(1)
+ ├── values
+ │    ├── columns: column1:1
+ │    ├── cardinality: [1 - 1]
+ │    ├── has-placeholder
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── ($1,)
+ └── filters (true)
+
+opt expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan)
+SELECT k FROM t WHERE i = $1 AND s = $2 AND b = $3
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── key: (1)
+ └── placeholder-scan t@t_i_s_b_idx
+      ├── columns: k:1!null i:2!null s:3!null b:4!null
+      ├── has-placeholder
+      ├── key: (1)
+      ├── fd: ()-->(2-4)
+      └── span
+           ├── $1
+           ├── $2
+           └── $3
+
+# TODO(mgartner): This query is not converted to a placeholder scan because
+# ConvertParameterizedLookupJoinToPlaceholderScan does not match a double
+# lookup-join. We could lift this restriction of by adding a rule similar to
+# ConvertParameterizedLookupJoinToPlaceholderScan that matches this pattern.
 opt expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE i = $1 AND s = $2 AND b = $3
 ----
@@ -103,6 +131,11 @@ project
 
 # A placeholder referenced multiple times in the filters should only appear once
 # in the Values expression.
+#
+# TODO(mgartner): This query is not converted to a placeholder scan because the
+# lookup-join has ON filters. We could lift this restriction of
+# ConvertParameterizedLookupJoinToPlaceholderScan by adding a Select expression
+# with the ON filters above the placeholder scan.
 opt expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE k = $1 AND i = $1
 ----
@@ -165,7 +198,7 @@ project
       │    └── filters (true)
       └── filters (true)
 
-opt expect=GenerateParameterizedJoin
+opt expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan)
 SELECT * FROM t WHERE k = (SELECT i FROM t WHERE k = $1)
 ----
 project
@@ -182,29 +215,14 @@ project
       ├── has-placeholder
       ├── key: ()
       ├── fd: ()-->(1-5,8,9), (1)==(9), (9)==(1)
-      ├── project
+      ├── placeholder-scan t
       │    ├── columns: k:8!null i:9
       │    ├── cardinality: [0 - 1]
       │    ├── has-placeholder
       │    ├── key: ()
       │    ├── fd: ()-->(8,9)
-      │    └── inner-join (lookup t)
-      │         ├── columns: k:8!null i:9 "$1":15!null
-      │         ├── flags: disallow merge join
-      │         ├── key columns: [15] = [8]
-      │         ├── lookup columns are key
-      │         ├── cardinality: [0 - 1]
-      │         ├── has-placeholder
-      │         ├── key: ()
-      │         ├── fd: ()-->(8,9,15), (8)==(15), (15)==(8)
-      │         ├── values
-      │         │    ├── columns: "$1":15
-      │         │    ├── cardinality: [1 - 1]
-      │         │    ├── has-placeholder
-      │         │    ├── key: ()
-      │         │    ├── fd: ()-->(15)
-      │         │    └── ($1,)
-      │         └── filters (true)
+      │    └── span
+      │         └── $1
       └── filters (true)
 
 # TODO(mgartner): The rule doesn't apply because the filters do not reference
@@ -282,6 +300,22 @@ exec-ddl
 CREATE INDEX partial_idx ON t(i, t) WHERE i IS NOT NULL AND t IS NOT NULL
 ----
 
+opt expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan)
+SELECT k FROM t WHERE i = $1 AND t = $2
+----
+project
+ ├── columns: k:1!null
+ ├── has-placeholder
+ ├── key: (1)
+ └── placeholder-scan t@partial_idx,partial
+      ├── columns: k:1!null i:2!null t:5!null
+      ├── has-placeholder
+      ├── key: (1)
+      ├── fd: ()-->(2,5)
+      └── span
+           ├── $1
+           └── $2
+
 opt expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE i = $1 AND t = $2
 ----
@@ -321,6 +355,52 @@ DROP INDEX partial_idx
 exec-ddl
 CREATE INDEX partial_idx ON t(s) WHERE k = i
 ----
+
+# TODO(mgartner): This query is not converted to a placeholder scan because
+# ConvertParameterizedLookupJoinToPlaceholderScan does not match a double
+# lookup-join. We could lift this restriction of by adding a rule similar to
+# ConvertParameterizedLookupJoinToPlaceholderScan that matches this pattern.
+opt expect=GenerateParameterizedJoin
+SELECT k FROM t@partial_idx WHERE s = $1 AND k = $2 AND i = $2
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(1)
+ └── project
+      ├── columns: k:1!null i:2!null s:3!null
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1-3)
+      └── inner-join (lookup t)
+           ├── columns: k:1!null i:2!null s:3!null "$1":8!null "$2":9!null
+           ├── key columns: [1] = [1]
+           ├── lookup columns are key
+           ├── cardinality: [0 - 1]
+           ├── has-placeholder
+           ├── key: ()
+           ├── fd: ()-->(1-3,8,9), (1)==(2,9), (2)==(1,9), (9)==(1,2), (3)==(8), (8)==(3)
+           ├── inner-join (lookup t@partial_idx,partial)
+           │    ├── columns: k:1!null s:3!null "$1":8!null "$2":9!null
+           │    ├── flags: disallow merge join
+           │    ├── key columns: [8 9] = [3 1]
+           │    ├── lookup columns are key
+           │    ├── cardinality: [0 - 1]
+           │    ├── has-placeholder
+           │    ├── key: ()
+           │    ├── fd: ()-->(1,3,8,9), (3)==(8), (8)==(3), (1)==(9), (9)==(1)
+           │    ├── values
+           │    │    ├── columns: "$1":8 "$2":9
+           │    │    ├── cardinality: [1 - 1]
+           │    │    ├── has-placeholder
+           │    │    ├── key: ()
+           │    │    ├── fd: ()-->(8,9)
+           │    │    └── ($1, $2)
+           │    └── filters (true)
+           └── filters (true)
 
 opt expect=GenerateParameterizedJoin
 SELECT * FROM t@partial_idx WHERE s = $1 AND k = $2 AND i = $2
@@ -362,6 +442,52 @@ exec-ddl
 DROP INDEX partial_idx
 ----
 
+# NOTE: A placeholder scan is generated but not chosen because the cost is
+# higher than the lookup-join, due to the conservative row count estimate of 330
+# for the group with the inner project (which is the group that the placeholder
+# scan is added to).
+#
+# TODO(mgartner): Tighten the row count estimate of 330. By default there are
+# 1000 rows and 100 distinct values for t, so the row count should be ~10.
+opt no-stable-folds expect=(GenerateParameterizedJoin,ConvertParameterizedLookupJoinToPlaceholderScan) format=(show-stats,show-cost)
+SELECT k FROM t WHERE t = now()
+----
+project
+ ├── columns: k:1!null
+ ├── stable
+ ├── stats: [rows=330]
+ ├── cost: 50.975
+ ├── cost-flags: unbounded-cardinality
+ ├── key: (1)
+ └── project
+      ├── columns: k:1!null t:5!null
+      ├── stable
+      ├── stats: [rows=330, distinct(5)=100, null(5)=0]
+      ├── cost: 47.655
+      ├── cost-flags: unbounded-cardinality
+      ├── key: (1)
+      ├── fd: ()-->(5)
+      └── inner-join (lookup t@t_t_idx)
+           ├── columns: k:1!null t:5!null column8:8!null
+           ├── flags: disallow merge join
+           ├── key columns: [8] = [5]
+           ├── stable
+           ├── stats: [rows=9.9, distinct(5)=1, null(5)=0, distinct(8)=1, null(8)=0]
+           ├── cost: 44.335
+           ├── cost-flags: unbounded-cardinality
+           ├── key: (1)
+           ├── fd: ()-->(5,8), (5)==(8), (8)==(5)
+           ├── values
+           │    ├── columns: column8:8
+           │    ├── cardinality: [1 - 1]
+           │    ├── stable
+           │    ├── stats: [rows=1, distinct(8)=1, null(8)=0]
+           │    ├── cost: 0.02
+           │    ├── key: ()
+           │    ├── fd: ()-->(8)
+           │    └── (now(),)
+           └── filters (true)
+
 opt no-stable-folds expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE t = now()
 ----
@@ -393,6 +519,22 @@ project
       │    │    └── (now(),)
       │    └── filters (true)
       └── filters (true)
+
+opt no-stable-folds expect=GenerateParameterizedJoin
+SELECT k FROM t WHERE i = $1 AND t = now()
+----
+project
+ ├── columns: k:1!null
+ ├── stable, has-placeholder
+ ├── key: (1)
+ └── placeholder-scan t@t_i_t_idx
+      ├── columns: k:1!null i:2!null t:5!null
+      ├── stable, has-placeholder
+      ├── key: (1)
+      ├── fd: ()-->(2,5)
+      └── span
+           ├── $1
+           └── now()
 
 opt no-stable-folds expect=GenerateParameterizedJoin
 SELECT * FROM t WHERE i = $1 AND t = now()
@@ -672,3 +814,106 @@ select
  └── filters
       ├── k:1 = $1 [outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
       └── s:3 = e'\'1\'' [outer=(3), constraints=(/3: [/e'\'1\'' - /e'\'1\'']; tight), fd=()-->(3)]
+
+# --------------------------------------------------
+# ConvertParameterizedLookupJoinToPlaceholderScan
+# --------------------------------------------------
+
+opt expect=ConvertParameterizedLookupJoinToPlaceholderScan
+SELECT t.k FROM (VALUES ($1::INT)) AS v(k) JOIN t ON t.k = v.k
+----
+placeholder-scan t
+ ├── columns: k:2!null
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── span
+      └── $1
+
+opt no-stable-folds expect=ConvertParameterizedLookupJoinToPlaceholderScan
+SELECT t.k FROM (VALUES (quote_literal(1)::INT)) AS v(k) JOIN t ON t.k = v.k
+----
+placeholder-scan t
+ ├── columns: k:2!null
+ ├── cardinality: [0 - 1]
+ ├── stable
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── span
+      └── quote_literal(1)::INT8
+
+# The rule does not match if there are no placeholders or stable expressions in
+# the Values expression.
+opt expect-not=ConvertParameterizedLookupJoinToPlaceholderScan disable=InlineJoinConstantsLeft
+SELECT t.k FROM (VALUES (1)) AS v(k) JOIN t ON t.k = v.k
+----
+project
+ ├── columns: k:2!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── inner-join (lookup t)
+      ├── columns: column1:1!null k:2!null
+      ├── key columns: [1] = [2]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── key: ()
+      ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+      ├── values
+      │    ├── columns: column1:1!null
+      │    ├── cardinality: [1 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(1)
+      │    └── (1,)
+      └── filters (true)
+
+# The rule does not match if the Values expression has more than one row.
+opt expect-not=ConvertParameterizedLookupJoinToPlaceholderScan
+SELECT t.k FROM (VALUES ($1::INT), (10)) AS v(k) JOIN t ON t.k = v.k
+----
+project
+ ├── columns: k:2!null
+ ├── cardinality: [0 - 2]
+ ├── has-placeholder
+ └── inner-join (lookup t)
+      ├── columns: column1:1!null k:2!null
+      ├── key columns: [1] = [2]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 2]
+      ├── has-placeholder
+      ├── fd: (1)==(2), (2)==(1)
+      ├── values
+      │    ├── columns: column1:1
+      │    ├── cardinality: [2 - 2]
+      │    ├── has-placeholder
+      │    ├── ($1,)
+      │    └── (10,)
+      └── filters (true)
+
+# The rule does not match if generic optimizations are disabled.
+opt set=(plan_cache_mode=force_custom_plan) expect-not=ConvertParameterizedLookupJoinToPlaceholderScan
+SELECT t.k FROM (VALUES ($1::INT)) AS v(k) JOIN t ON t.k = v.k
+----
+project
+ ├── columns: k:2!null
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── key: ()
+ ├── fd: ()-->(2)
+ └── inner-join (lookup t)
+      ├── columns: column1:1!null k:2!null
+      ├── key columns: [1] = [2]
+      ├── lookup columns are key
+      ├── cardinality: [0 - 1]
+      ├── has-placeholder
+      ├── key: ()
+      ├── fd: ()-->(1,2), (1)==(2), (2)==(1)
+      ├── values
+      │    ├── columns: column1:1
+      │    ├── cardinality: [1 - 1]
+      │    ├── has-placeholder
+      │    ├── key: ()
+      │    ├── fd: ()-->(1)
+      │    └── ($1,)
+      └── filters (true)


### PR DESCRIPTION
Parameterized lookup joins, which are used in generic query plans, are
now converted to placeholder scans in some cases. These placeholder
scans are more efficient because they cater to a narrower set of
features than general-purpose lookup joins and because they natively
support vectorization. See the new exploration rule for more details.

Release note: None
