### PR TITLE
benchprof: fix nil pointer exception

### DIFF
--- a/pkg/bench/benchprof/benchprof.go
+++ b/pkg/bench/benchprof/benchprof.go
@@ -44,13 +44,16 @@ func (f StopFn) Stop(tb testing.TB) {
 //	    })
 //	}
 func StartAllProfiles(tb testing.TB) StopFn {
-	cpuStop := StartCPUProfile(tb)
-	memStop := StartMemProfile(tb)
-	mutexStop := StartMutexProfile(tb)
+	cpuStopper := StartCPUProfile(tb)
+	memStopper := StartMemProfile(tb)
+	mutexStopper := StartMutexProfile(tb)
+	if cpuStopper == nil && memStopper == nil && mutexStopper == nil {
+		return nil
+	}
 	return func(b testing.TB) {
-		cpuStop(b)
-		memStop(b)
-		mutexStop(b)
+		cpuStopper.Stop(b)
+		memStopper.Stop(b)
+		mutexStopper.Stop(b)
 	}
 }
 


### PR DESCRIPTION
A bug in `benchprof.StartAllProfiles` has been fixed that caused nil
pointer exceptions. Additionally, `benchprof.StartAllProfiles` no longer
allocates a do-nothing `StopFn`.

Release note: None
