### PR TITLE
release-23.2: execbuilder: fix a silly bug around finding the most recent full stat

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -431,8 +431,8 @@ func (b *Builder) maybeAnnotateWithEstimates(node exec.Node, e memo.RelExpr) {
 				// The first stat is the most recent full one.
 				var first int
 				for first < tab.StatisticCount() &&
-					tab.Statistic(first).IsPartial() ||
-					(tab.Statistic(first).IsForecast() && !b.evalCtx.SessionData().OptimizerUseForecasts) {
+					(tab.Statistic(first).IsPartial() ||
+						(tab.Statistic(first).IsForecast() && !b.evalCtx.SessionData().OptimizerUseForecasts)) {
 					first++
 				}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1261,3 +1261,34 @@ __merged__       {b}           2022-12-13 15:22:21.988179 +0000 UTC  61         
 # Finally, restore forecasts setting to its previous value.
 statement ok
 SET CLUSTER SETTING sql.stats.forecasts.enabled = $forecastsEnabledPrev
+
+subtest regression_148316
+
+# Ensure we can run DELETE statement on system.table_statistics.
+statement ok
+INSERT INTO system.users VALUES ('node', NULL, true, 3);
+
+statement ok
+GRANT node TO root;
+
+# Keep only partial stats on the target table.
+statement ok
+DELETE FROM system.table_statistics WHERE name NOT LIKE '%partial%' AND "tableID" = 'g'::REGCLASS::OID;
+
+query TT
+SELECT statistics_name, column_names FROM [SHOW STATISTICS FOR TABLE g] ORDER BY created
+----
+partial  {b}
+
+query T
+EXPLAIN SELECT * FROM g WHERE b = 10
+----
+distribution: local
+vectorized: true
+·
+• scan
+  missing stats
+  table: g@g_pkey
+  spans: [/10 - /10]
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #148329.

/cc @cockroachdb/release

---

This commit fixes a bug that was added in 3bc0992225673c2e8c80288a5c619d78f8b928cd. In short, in a complicated logical expression we had `v1 && v2 || v3` when we wanted `v1 && (v2 || v3)`. This allowed us to hit an index of bounds when evaluating `v3`, which in this concrete case could mean that we iterated over all stats and didn't find any full ones.

There are two other places with similar conditionals, and they have the correct usage of parenthesis, so I didn't change the structure overall.

Also the bug seems quite difficult to hit, so I omitted the release note.

Fixes: #148316.

Release note: None

Release justification: critical bug fix: we've seen this bug result in a failure to take a backup (#148316) since it can error out an internal query used by the backup (another example is #148414 with `read-role-with-memberships` internal query). In the extreme, failure to backup data can result in a data loss.