### PR TITLE
kvtenant: replace InternalClient with more specific services' client adapters

### DIFF
--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -222,7 +222,9 @@ type connector struct {
 
 // client represents an RPC client that proxies to a KV instance.
 type client struct {
-	kvpb.RPCInternalClient
+	kvpb.RPCTenantServiceClient
+	kvpb.RPCTenantUsageClient
+	kvpb.RPCTenantSpanConfigClient
 	serverpb.RPCStatusClient
 	serverpb.RPCAdminClient
 	tspb.RPCTimeSeriesClient
@@ -983,10 +985,12 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 					continue
 				}
 				return &client{
-					RPCInternalClient:   kvpb.NewGRPCInternalClientAdapter(conn),
-					RPCStatusClient:     serverpb.NewGRPCStatusClientAdapter(conn),
-					RPCAdminClient:      serverpb.NewGRPCAdminClientAdapter(conn),
-					RPCTimeSeriesClient: tspb.NewGRPCTimeSeriesClientAdapter(conn),
+					RPCTenantServiceClient:    kvpb.NewGRPCInternalToTenantServiceClientAdapter(conn),
+					RPCTenantSpanConfigClient: kvpb.NewGRPCInternalClientAdapter(conn),
+					RPCTenantUsageClient:      kvpb.NewGRPCInternalClientAdapter(conn),
+					RPCStatusClient:           serverpb.NewGRPCStatusClientAdapter(conn),
+					RPCAdminClient:            serverpb.NewGRPCAdminClientAdapter(conn),
+					RPCTimeSeriesClient:       tspb.NewGRPCTimeSeriesClientAdapter(conn),
 				}, nil
 			}
 		}

--- a/pkg/kv/kvpb/BUILD.bazel
+++ b/pkg/kv/kvpb/BUILD.bazel
@@ -10,6 +10,7 @@ go_library(
     srcs = [
         "ambiguous_result_error.go",
         "api.go",
+        "api_adapter.go",
         "batch.go",
         "data.go",
         "errors.go",
@@ -48,6 +49,7 @@ go_library(
         "@com_github_gogo_protobuf//types",
         "@com_github_gogo_status//:status",
         "@com_github_golang_mock//gomock",  # keep
+        "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//metadata",  # keep
     ],

--- a/pkg/kv/kvpb/api_adapter.go
+++ b/pkg/kv/kvpb/api_adapter.go
@@ -1,0 +1,48 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package kvpb
+
+import (
+	"context"
+
+	grpc "google.golang.org/grpc"
+)
+
+type grpcInternalToTenantServiceClientAdapter internalClient
+
+// NewGRPCInternalToTenantServiceClientAdapter creates a new
+// RPCTenantServiceClient that adapts an InternalClient. This is necessary
+// because the response types for streaming methods like TenantSettings are not
+// compatible between RPCInternal_TenantSettingsClient (of adapter returned by
+// NewGRPCInternalClientAdapter) and RPCTenantService_TenantSettingsClient (of
+// RPCTenantServiceClient), even though they are otherwise equivalent.
+func NewGRPCInternalToTenantServiceClientAdapter(conn *grpc.ClientConn) RPCTenantServiceClient {
+	return (*grpcInternalToTenantServiceClientAdapter)(&internalClient{conn})
+}
+
+func (a *grpcInternalToTenantServiceClientAdapter) TenantSettings(
+	ctx context.Context, in *TenantSettingsRequest,
+) (RPCTenantService_TenantSettingsClient, error) {
+	return (*internalClient)(a).TenantSettings(ctx, in)
+}
+
+func (a *grpcInternalToTenantServiceClientAdapter) RangeLookup(
+	ctx context.Context, in *RangeLookupRequest,
+) (*RangeLookupResponse, error) {
+	return (*internalClient)(a).RangeLookup(ctx, in)
+}
+
+func (a *grpcInternalToTenantServiceClientAdapter) GossipSubscription(
+	ctx context.Context, in *GossipSubscriptionRequest,
+) (RPCTenantService_GossipSubscriptionClient, error) {
+	return (*internalClient)(a).GossipSubscription(ctx, in)
+}
+
+func (a *grpcInternalToTenantServiceClientAdapter) GetRangeDescriptors(
+	ctx context.Context, in *GetRangeDescriptorsRequest,
+) (RPCTenantService_GetRangeDescriptorsClient, error) {
+	return (*internalClient)(a).GetRangeDescriptors(ctx, in)
+}


### PR DESCRIPTION
Since we have broken down the `Internal` service into smaller services, this PR uses them in the tenant connector.

This means the `client.InternalClient` will be replaced by `RPCTenantServiceClient`, `RPCTenantUsageClient`, and `RPCTenantSpanConfigClient`, as they are used by the tenant connector. For gRPC, they can be initialized with the gRPC adapter of `InternalClient` returned by `NewGRPCInternalClientAdapter`, as these smaller services are a subset of the `Internal` service.

However, a complication arises with `RPCTenantSpanConfigClient`. We can't simply use the generic `InternalClient` adapter because its streaming methods generate request/response types that embed the service name.

For example: Let's take an example here:

`RPCTenantServiceClient` has this method:

```go
TenantSettings(ctx context.Context, in *TenantSettingsRequest) (RPCTenantService_TenantSettingsClient, error)
```

But `NewGRPCInternalClientAdapter` returns `RPCInternalClient`, which defines:

```go
TenantSettings(ctx context.Context, in *TenantSettingsRequest) (RPCInternal_TenantSettingsClient, error)
```

So they are not compatible, even though `RPCInternal_TenantSettingsClient` and `RPCTenantService_TenantSettingsClient` are equivalent. The solution here is to create an adapter that adapts the `InternalClient` to `RPCTenantServiceClient`.

```go
func (a *grpcInternalToTenantServiceClientAdapter) TenantSettings(
	ctx context.Context, in *TenantSettingsRequest,
) (RPCTenantService_TenantSettingsClient, error) {
	return (*internalClient)(a).TenantSettings(ctx, in)
}
```


Informs: #148726
Release note: none
Epic: CRDB-48923