### PR TITLE
sql: avoid contention between long mutation and auto stats

### DIFF
--- a/pkg/sql/delete.go
+++ b/pkg/sql/delete.go
@@ -159,10 +159,9 @@ func (d *deleteNode) BatchedNext(params runParams) (bool, error) {
 		}
 		// Remember we're done for the next call to BatchedNext().
 		d.run.done = true
+		// Possibly initiate a run of CREATE STATISTICS.
+		params.ExecCfg().StatsRefresher.NotifyMutation(d.run.td.tableDesc(), int(d.run.td.rowsWritten))
 	}
-
-	// Possibly initiate a run of CREATE STATISTICS.
-	params.ExecCfg().StatsRefresher.NotifyMutation(d.run.td.tableDesc(), d.run.td.lastBatchSize)
 
 	return d.run.td.lastBatchSize > 0, nil
 }

--- a/pkg/sql/insert.go
+++ b/pkg/sql/insert.go
@@ -360,10 +360,9 @@ func (n *insertNode) BatchedNext(params runParams) (bool, error) {
 		}
 		// Remember we're done for the next call to BatchedNext().
 		n.run.done = true
+		// Possibly initiate a run of CREATE STATISTICS.
+		params.ExecCfg().StatsRefresher.NotifyMutation(n.run.ti.tableDesc(), int(n.run.ti.rowsWritten))
 	}
-
-	// Possibly initiate a run of CREATE STATISTICS.
-	params.ExecCfg().StatsRefresher.NotifyMutation(n.run.ti.tableDesc(), n.run.ti.lastBatchSize)
 
 	return n.run.ti.lastBatchSize > 0, nil
 }

--- a/pkg/sql/update.go
+++ b/pkg/sql/update.go
@@ -168,10 +168,9 @@ func (u *updateNode) BatchedNext(params runParams) (bool, error) {
 		}
 		// Remember we're done for the next call to BatchedNext().
 		u.run.done = true
+		// Possibly initiate a run of CREATE STATISTICS.
+		params.ExecCfg().StatsRefresher.NotifyMutation(u.run.tu.tableDesc(), int(u.run.tu.rowsWritten))
 	}
-
-	// Possibly initiate a run of CREATE STATISTICS.
-	params.ExecCfg().StatsRefresher.NotifyMutation(u.run.tu.tableDesc(), u.run.tu.lastBatchSize)
 
 	return u.run.tu.lastBatchSize > 0, nil
 }

--- a/pkg/sql/upsert.go
+++ b/pkg/sql/upsert.go
@@ -133,10 +133,9 @@ func (n *upsertNode) BatchedNext(params runParams) (bool, error) {
 		}
 		// Remember we're done for the next call to BatchedNext().
 		n.run.done = true
+		// Possibly initiate a run of CREATE STATISTICS.
+		params.ExecCfg().StatsRefresher.NotifyMutation(n.run.tw.tableDesc(), int(n.run.tw.rowsWritten))
 	}
-
-	// Possibly initiate a run of CREATE STATISTICS.
-	params.ExecCfg().StatsRefresher.NotifyMutation(n.run.tw.tableDesc(), n.run.tw.lastBatchSize)
 
 	return n.run.tw.lastBatchSize > 0, nil
 }


### PR DESCRIPTION
Previously, when processing large mutations in batches (see `BatchedNext` method), we would notify the stats refresher about the number of rows affected after each batch. If the mutation is long, then this could have triggered the auto stats collection that would contend with the mutation that triggered it. There is actually no reason to try collecting auto stats on those just-mutated rows since in most cases they haven't been committed yet. This commit fixes this issue by notifying the stats refresher about the total number of rows affected when the last batch of the mutation has just been processed. The bug has been present since about 19.1 version.

Note that we generally don't perform well with long mutations, but it seems like a worthwhile improvement nonetheless. We can't remove contention with auto stats triggered by _other_ mutations, but at least we can do so for self-inflicted ones. (Also probably a more important retry reason is the closed TS interval.)

Fixes: #148487.

Release note (bug fix): Large mutation statements (INSERTs, UPDATEs, DELETEs, UPSERTs) are now less likely to encounter contention with automatic table stats collection in some cases. The bug has been present since 19.1 version.