### PR TITLE
roachprod-microbench: export github variables

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -141,9 +141,9 @@ done
 
 # Post issues to github for triggered builds (triggered builds are always on master)
 if [ -n "${TRIGGERED_BUILD:-}" ]; then
-  GITHUB_BRANCH="master"
-  GITHUB_SHA="${build_sha_arr[0]}"
-  GITHUB_BINARY="experiment"
+  export GITHUB_BRANCH="master"
+  export GITHUB_SHA="${build_sha_arr[0]}"
+  export GITHUB_BINARY="experiment"
 fi
 
 # Execute microbenchmarks


### PR DESCRIPTION
Previously, the github variables were set in the build script, but it was not exported so the binary could not pick it up.

Epic: None
Release note: None