### PR TITLE
cli(debug.zip): update Datadog link for table dumps

### DIFF
--- a/pkg/cli/testdata/upload/tables
+++ b/pkg/cli/testdata/upload/tables
@@ -34,6 +34,6 @@ Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Logs API Hook: https://http-intake.logs.us5.datadoghq.com/api/v2/logs
 Upload ID: abc-20241114000000
-View as logs here: https://us5.datadoghq.com/logs?query=source:debug-zip&upload_id:abc-20241114000000
-View as tables here: https://us5.datadoghq.com/dashboard/ipq-44t-ez8/table-dumps-from-debug-zip?tpl_var_upload_id%5B0%5D=abc-20241114000000
+View as logs here: https://us5.datadoghq.com/logs?query=source:debug-zip upload_id:abc-20241114000000&from_ts=1728950400000&to_ts=1731542400000
+View as tables here:https://us5.datadoghq.com/dashboard/jrz-h9w-5em/table-dumps-from-debug-zip?tpl_var_upload_id=abc-20241114000000&from_ts=1728950400000&to_ts=1731542400000
 debug zip upload debugDir --dd-api-key=dd-api-key --dd-app-key=dd-app-key --cluster=ABC --include=tables

--- a/pkg/cli/zip_upload.go
+++ b/pkg/cli/zip_upload.go
@@ -752,8 +752,15 @@ func uploadZipTables(ctx context.Context, uploadID string, debugDirPath string) 
 	uploadWG.Wait()
 	close(uploadChan)
 
-	fmt.Printf("\nView as tables here: https://us5.datadoghq.com/dashboard/ipq-44t-ez8/table-dumps-from-debug-zip?tpl_var_upload_id%%5B0%%5D=%s\n", uploadID)
-	fmt.Printf("View as logs here: https://us5.datadoghq.com/logs?query=source:debug-zip&upload_id:%s\n", uploadID)
+	toUnixTimestamp := getCurrentTime().UnixMilli()
+	//create timestamp for T-30 days.
+	fromUnixTimestamp := toUnixTimestamp - (30 * 24 * 60 * 60 * 1000)
+
+	fmt.Printf("\nView as tables here:"+
+		"https://us5.datadoghq.com/dashboard/jrz-h9w-5em/table-dumps-from-debug-zip?tpl_var_upload_id=%s&from_ts=%d&to_ts=%d\n",
+		uploadID, fromUnixTimestamp, toUnixTimestamp)
+	fmt.Printf("View as logs here: https://us5.datadoghq.com/logs?query=source:debug-zip upload_id:%s&from_ts=%d&to_ts=%d\n",
+		uploadID, fromUnixTimestamp, toUnixTimestamp)
 	return nil
 }
 

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -212,6 +212,10 @@ func TestUploadZipEndToEnd(t *testing.T) {
 				includeFlag = "--include=misc"
 			}
 
+			defer testutils.TestingHook(&getCurrentTime, func() time.Time {
+				return time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC)
+			})()
+
 			debugDir, cleanup := setupZipDir(t, testInput)
 			defer cleanup()
 


### PR DESCRIPTION
This patch updates the Datadog dashboard and log explorer links which are generated as part of debug.zip Datadog upload. The table dump dashboard link contains filtering based on upload_id along with default timeframe of 1 month.

Epic: None
Part of: CRDB-51113
Release note: None