### PR TITLE
sql/schemachangerccl: deflake multi-region backup tests

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/BUILD.bazel
@@ -15,7 +15,7 @@ go_test(
     ],
     exec_properties = {"test.Pool": "heavy"},
     shard_count = 48,
-    tags = ["cpu:3"],
+    tags = ["cpu:4"],
     deps = [
         "//pkg/ccl",
         "//pkg/ccl/schemachangerccl",


### PR DESCRIPTION
Increase the CPU cost per test so that fewer multi-region schema changer backup / restore tests run concurrently. This should reduce some flakes.

Fixes: #148192

Release note: None