### PR TITLE
TEAMS: update admission control labels

### DIFF
--- a/TEAMS.yaml
+++ b/TEAMS.yaml
@@ -29,6 +29,8 @@ cockroachdb/kv:
     'cockroachdb/kv-triage ': unittest
     cockroachdb/kv-prs: other
   label: T-kv
+cockroachdb/admission-control:
+  label: T-kv,A-admission-control
 cockroachdb/spatial:
   label: T-spatial
 cockroachdb/dev-inf:
@@ -38,8 +40,6 @@ cockroachdb/drp-eng:
 cockroachdb/multiregion:
   label: T-multiregion
 cockroachdb/storage:
-  aliases:
-    cockroachdb/admission-control: other
   label: T-storage
 cockroachdb/test-eng:
   label: T-testeng

--- a/pkg/cmd/bazci/githubpost/githubpost.go
+++ b/pkg/cmd/bazci/githubpost/githubpost.go
@@ -79,9 +79,7 @@ func DefaultFormatter(ctx context.Context, f Failure) (issues.IssueFormatter, is
 					mentions = append(mentions, "@"+string(tm.Name()))
 				}
 			}
-			if tm.Label != "" {
-				labels = append(labels, tm.Label)
-			}
+			labels = append(labels, tm.Labels()...)
 		}
 	}
 	return issues.UnitTestFormatter, issues.PostRequest{

--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -248,9 +248,7 @@ func (g *githubIssues) createPostRequest(
 			if mentionTeam {
 				mention = append(mention, "@"+string(alias))
 			}
-			if label := teams[alias].Label; label != "" {
-				labels = append(labels, label)
-			}
+			labels = append(labels, teams[alias].Labels()...)
 		}
 	}
 

--- a/pkg/internal/team/TEAMS.yaml
+++ b/pkg/internal/team/TEAMS.yaml
@@ -29,6 +29,8 @@ cockroachdb/kv:
     'cockroachdb/kv-triage ': unittest
     cockroachdb/kv-prs: other
   label: T-kv
+cockroachdb/admission-control:
+  label: T-kv,A-admission-control
 cockroachdb/spatial:
   label: T-spatial
 cockroachdb/dev-inf:
@@ -38,8 +40,6 @@ cockroachdb/drp-eng:
 cockroachdb/multiregion:
   label: T-multiregion
 cockroachdb/storage:
-  aliases:
-    cockroachdb/admission-control: other
   label: T-storage
 cockroachdb/test-eng:
   label: T-testeng

--- a/pkg/internal/team/team.go
+++ b/pkg/internal/team/team.go
@@ -31,14 +31,23 @@ type Team struct {
 	// does not contain TeamName.
 	Aliases map[Alias]Purpose `yaml:"aliases"`
 	// GitHub label will be added to issues posted for this team.
+	// Multiple labels can be specified, separated by commas.
 	Label string `yaml:"label"`
-	// SilenceMentions is true if @-mentions should be supressed for this team.
+	// SilenceMentions is true if @-mentions should be suppressed for this team.
 	SilenceMentions bool `yaml:"silence_mentions"`
 }
 
 // Name returns the main Alias of the team.
 func (t Team) Name() Alias {
 	return t.TeamName
+}
+
+// Labels returns the list of labels (possibly empty).
+func (t Team) Labels() []string {
+	if t.Label == "" {
+		return nil
+	}
+	return strings.Split(t.Label, ",")
 }
 
 // Map contains the in-memory representation of TEAMS.yaml.


### PR DESCRIPTION
Add support for multiple github issue labels in teams and update
admission-control team labels.

Epic: none
Release note: None