### PR TITLE
changefeedccl: increase assertPayloadsTimeout under deadlock

### DIFF
--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -59,6 +59,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
@@ -420,7 +421,7 @@ func assertPayloadsBaseErr(
 }
 
 func assertPayloadsTimeout() time.Duration {
-	if util.RaceEnabled {
+	if util.RaceEnabled || syncutil.DeadlockEnabled {
 		return 5 * time.Minute
 	}
 	return 30 * time.Second


### PR DESCRIPTION
This patch increases the assertPayloadsTimeout when the test is running
under deadlock to match the timeout of 5m used when running under race.

Epic: None

Release note: None