### PR TITLE
sql: update SHOW users/roles to support provisioned users

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -9830,13 +9830,13 @@ func TestBackupRestoreSystemUsers(t *testing.T) {
 			{"app_role", "app", "false"},
 			{"app_role", "test_role", "false"},
 		})
-		sqlDBRestore.CheckQueryResults(t, "SHOW USERS", [][]string{
-			{"admin", "", "{}"},
-			{"app", "", "{admin,app_role}"},
-			{"app_role", "NOLOGIN", "{}"},
-			{"root", "", "{admin}"},
-			{"test", "", "{}"},
-			{"test_role", "NOLOGIN", "{app_role}"},
+		sqlDBRestore.CheckQueryResults(t, "SELECT username, options, member_of from [SHOW USERS] ORDER BY username", [][]string{
+			{"admin", "{}", "{}"},
+			{"app", "{}", "{admin,app_role}"},
+			{"app_role", "{NOLOGIN}", "{}"},
+			{"root", "{}", "{admin}"},
+			{"test", "{}", "{}"},
+			{"test_role", "{NOLOGIN}", "{app_role}"},
 		})
 	})
 
@@ -9860,13 +9860,13 @@ func TestBackupRestoreSystemUsers(t *testing.T) {
 			{"test", "false"},
 			{"test_role", "true"},
 		})
-		sqlDBRestore1.CheckQueryResults(t, "SHOW USERS", [][]string{
-			{"admin", "", "{}"},
-			{"app", "", "{}"},
-			{"app_role", "", "{}"},
-			{"root", "", "{admin}"},
-			{"test", "", "{}"},
-			{"test_role", "", "{}"},
+		sqlDBRestore1.CheckQueryResults(t, "SELECT username, options, member_of from [SHOW USERS] ORDER BY username", [][]string{
+			{"admin", "{}", "{}"},
+			{"app", "{}", "{}"},
+			{"app_role", "{}", "{}"},
+			{"root", "{}", "{admin}"},
+			{"test", "{}", "{}"},
+			{"test_role", "{}", "{}"},
 		})
 	})
 	_, sqlDBRestore2, cleanupEmptyCluster2 := backupRestoreTestSetupEmpty(t, singleNode, tempDir, InitManualReplication, base.TestClusterArgs{})
@@ -9888,14 +9888,14 @@ func TestBackupRestoreSystemUsers(t *testing.T) {
 			{"test_role", "true"},
 			{"testuser", "false"},
 		})
-		sqlDBRestore2.CheckQueryResults(t, "SHOW USERS", [][]string{
-			{"admin", "", "{}"},
-			{"app", "", "{}"},
-			{"app_role", "", "{}"},
-			{"root", "", "{admin}"},
-			{"test", "", "{}"},
-			{"test_role", "", "{}"},
-			{"testuser", "", "{}"},
+		sqlDBRestore2.CheckQueryResults(t, "SELECT username, options, member_of from [SHOW USERS] ORDER BY username", [][]string{
+			{"admin", "{}", "{}"},
+			{"app", "{}", "{}"},
+			{"app_role", "{}", "{}"},
+			{"root", "{}", "{admin}"},
+			{"test", "{}", "{}"},
+			{"test_role", "{}", "{}"},
+			{"testuser", "{}", "{}"},
 		})
 	})
 }

--- a/pkg/backup/testdata/backup-restore/system-users
+++ b/pkg/backup/testdata/backup-restore/system-users
@@ -10,14 +10,14 @@ GRANT developer TO abbey;
 ----
 
 query-sql
-SHOW ROLES
+select username, options, member_of from [SHOW ROLES]
 ----
-abbey  {developer}
-admin  {}
-developer CREATEDB, NOLOGIN {}
-root  {admin}
-testuser NOLOGIN {}
-testuser2 CONTROLJOB, CREATEDB, NOLOGIN {}
+admin {} {}
+developer {CREATEDB,NOLOGIN} {}
+testuser {NOLOGIN} {}
+testuser2 {CONTROLJOB,CREATEDB,NOLOGIN} {}
+root {} {admin}
+abbey {} {developer}
 
 query-sql
 SHOW GRANTS ON ROLE developer
@@ -38,14 +38,14 @@ RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://1/test/'
 ----
 
 query-sql cluster=s2
-SHOW ROLES
+select username, options, member_of from [SHOW ROLES]
 ----
-abbey  {developer}
-admin  {}
-developer CREATEDB, NOLOGIN {}
-root  {admin}
-testuser NOLOGIN {}
-testuser2 CONTROLJOB, CREATEDB, NOLOGIN {}
+admin {} {}
+developer {CREATEDB,NOLOGIN} {}
+testuser {NOLOGIN} {}
+testuser2 {CONTROLJOB,CREATEDB,NOLOGIN} {}
+root {} {admin}
+abbey {} {developer}
 
 query-sql cluster=s2
 SHOW GRANTS ON ROLE developer

--- a/pkg/ccl/testccl/authccl/testdata/ldap
+++ b/pkg/ccl/testccl/authccl/testdata/ldap
@@ -435,7 +435,7 @@ ok
 query_row
 SELECT options FROM [SHOW ROLES] AS r WHERE EXISTS (SELECT 1 FROM unnest(r.member_of) AS m(role_name) WHERE role_name = 'ldap-parent-synced')
 ----
-PROVISIONSRC=ldap:localhost
+[PROVISIONSRC=ldap:localhost]
 
 subtest end
 

--- a/pkg/sql/delegate/BUILD.bazel
+++ b/pkg/sql/delegate/BUILD.bazel
@@ -43,6 +43,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/delegate",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
         "//pkg/security/username",
@@ -56,6 +57,7 @@ go_library(
         "//pkg/sql/pgrepl/pgreplparser",
         "//pkg/sql/pgwire/pgcode",
         "//pkg/sql/pgwire/pgerror",
+        "//pkg/sql/pgwire/pgnotice",
         "//pkg/sql/privilege",
         "//pkg/sql/roleoption",
         "//pkg/sql/sem/catconstants",

--- a/pkg/sql/delegate/show_roles.go
+++ b/pkg/sql/delegate/show_roles.go
@@ -6,6 +6,8 @@
 package delegate
 
 import (
+	"github.com/cockroachdb/cockroach/pkg/clusterversion"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgnotice"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqltelemetry"
 )
@@ -14,15 +16,24 @@ import (
 // Privileges: SELECT on system.users.
 func (d *delegator) delegateShowRoles() (tree.Statement, error) {
 	sqltelemetry.IncrementShowCounter(sqltelemetry.Roles)
-	return d.parse(`
+	selectClause := `
 SELECT
 	u.username,
-	IFNULL(string_agg(o.option || COALESCE('=' || o.value, ''), ', ' ORDER BY o.option), '') AS options,
-	ARRAY (SELECT role FROM system.role_members AS rm WHERE rm.member = u.username ORDER BY 1) AS member_of
+	COALESCE(array_remove(array_agg(o.option || COALESCE('=' || o.value, '') ORDER BY o.option), NULL), ARRAY[]::STRING[]) AS options,
+	ARRAY (SELECT role FROM system.role_members AS rm WHERE rm.member = u.username ORDER BY 1) AS member_of`
+	selectLastLoginTime := `,
+	u.estimated_last_login_time`
+	endingClauses := `
 FROM
 	system.users AS u LEFT JOIN system.role_options AS o ON u.username = o.username
 GROUP BY
 	u.username
 ORDER BY 1;
-`)
+`
+	if d.evalCtx.Settings.Version.IsActive(d.ctx, clusterversion.V25_3) {
+		d.evalCtx.ClientNoticeSender.BufferClientNotice(d.ctx, pgnotice.Newf(
+			"estimated_last_login_time is computed on a best effort basis; it is not guaranteed to capture every login event"))
+		return d.parse(selectClause + selectLastLoginTime + endingClauses)
+	}
+	return d.parse(selectClause + endingClauses)
 }

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -1,48 +1,52 @@
 statement ok
 CREATE USER user1
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user1     ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user1     {}       {}        NULL
 
 statement ok
 DROP USER user1
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
 
 statement ok
 CREATE USER user1
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user1     ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user1     {}       {}        NULL
 
 statement ok
 DROP USER USEr1
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
 
 statement error user "user1" does not exist
 DROP USER user1
@@ -83,43 +87,46 @@ CREATE USER user3
 statement ok
 CREATE USER user4
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user1     ·        {}
-user2     ·        {}
-user3     ·        {}
-user4     ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user1     {}       {}        NULL
+user2     {}       {}        NULL
+user3     {}       {}        NULL
+user4     {}       {}        NULL
 
 statement ok
 DROP USER user1,user2
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user3     ·        {}
-user4     ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user3     {}       {}        NULL
+user4     {}       {}        NULL
 
 statement error user "user1" does not exist
 DROP USER user1,user3
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user3     ·        {}
-user4     ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user3     {}       {}        NULL
+user4     {}       {}        NULL
 
 statement ok
 CREATE USER user1
@@ -148,13 +155,14 @@ statement ok
 PREPARE du AS DROP USER user4;
 EXECUTE du
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -24,14 +24,15 @@ DROP ROLE admin, root
 statement ok
 CREATE ROLE myrole
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW ROLES
 ----
-username  options  member_of
-admin     ·        {}
-myrole    NOLOGIN  {}
-root      ·        {admin}
-testuser  ·        {}
+username  options   member_of estimated_last_login_time
+admin     {}        {}        NULL
+myrole    {NOLOGIN} {}        NULL
+root      {}        {admin}   NULL
+testuser  {}        {}        NULL
 
 statement error a role/user named myrole already exists
 CREATE ROLE myrole
@@ -54,25 +55,27 @@ CREATE USER IF NOT EXISTS myrole
 statement error pq: cannot drop roles/users admin, myrole: grants still exist on .*
 DROP ROLE admin, myrole
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW ROLES
 ----
-username  options  member_of
-admin     ·        {}
-myrole    NOLOGIN  {}
-root      ·        {admin}
-testuser  ·        {}
+username  options   member_of estimated_last_login_time
+admin     {}        {}        NULL
+myrole    {NOLOGIN} {}        NULL
+root      {}        {admin}   NULL
+testuser  {}        {}        NULL
 
 statement ok
 DROP ROLE myrole
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW ROLES
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
 
 statement error pq: role/user "myrole" does not exist
 DROP ROLE myrole
@@ -101,13 +104,20 @@ DROP ROLE IF EXISTS rolec, roled, rolee
 statement ok
 DROP ROLE rolea, roleb
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW ROLES
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+
+skipif config local-mixed-25.2
+query T noticetrace
+SHOW ROLES
+----
+NOTICE: estimated_last_login_time is computed on a best effort basis; it is not guaranteed to capture every login event
 
 statement ok
 CREATE USER testuser2
@@ -491,16 +501,17 @@ role   member    isAdmin
 admin  root      true
 roled  testuser  false
 
-query TTT rowsort
+skipif config local-mixed-25.2
+query TTTT rowsort
 SHOW ROLES
 ----
-admin      ·        {}
-roleb      NOLOGIN  {}
-roled      NOLOGIN  {}
-rolee      NOLOGIN  {}
-root       ·        {admin}
-testuser   ·        {roled}
-testuser2  ·        {}
+admin      {}         {}       NULL
+roleb      {NOLOGIN}  {}       NULL
+roled      {NOLOGIN}  {}       NULL
+rolee      {NOLOGIN}  {}       NULL
+root       {}         {admin}  NULL
+testuser   {}         {roled}  NULL
+testuser2  {}         {}       NULL
 
 statement ok
 DROP ROLE roleb

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -490,13 +490,14 @@ v           CREATE VIEW public.v (
             ) AS SELECT id FROM system.public.descriptor;
 
 
-query TTT colnames
+skipif config local-mixed-25.2
+query TTTT colnames
 SELECT * FROM [SHOW USERS] ORDER BY 1
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
 
 
 query TTTI colnames

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -5,25 +5,33 @@ SHOW is_superuser
 ----
 on
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
 
 statement ok
 CREATE USER user1
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user1     ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user1     {}       {}        NULL
+
+skipif config local-mixed-25.2
+query T noticetrace
+SHOW USERS
+----
+NOTICE: estimated_last_login_time is computed on a best effort basis; it is not guaranteed to capture every login event
 
 statement error pgcode 42710 a role/user named admin already exists
 CREATE USER admin
@@ -88,19 +96,20 @@ statement error user "blix" does not exist
 PREPARE chpw2 AS ALTER USER blix WITH PASSWORD $1;
   EXECUTE chpw2('baz')
 
-query TTT colnames,rowsort
+skipif config local-mixed-25.2
+query TTTT colnames,rowsort
 SHOW USERS
 ----
-username  options  member_of
-admin     ·        {}
-foo       ·        {}
-foo-bar   ·        {}
-root      ·        {admin}
-testuser  ·        {}
-user1     ·        {}
-user2     ·        {}
-user3     ·        {}
-ομηρος    ·        {}
+username  options  member_of estimated_last_login_time
+admin     {}       {}        NULL
+foo       {}       {}        NULL
+foo-bar   {}       {}        NULL
+root      {}       {admin}   NULL
+testuser  {}       {}        NULL
+user1     {}       {}        NULL
+user2     {}       {}        NULL
+user3     {}       {}        NULL
+ομηρος    {}       {}        NULL
 
 statement error "": username is empty
 CREATE USER ""

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -791,17 +791,18 @@ vectorized: true
                     └── • sort
                         │ estimated row count: 3
                         │ order: +username,+option
+                        │ already ordered: +username
                         │
                         └── • render
                             │
-                            └── • hash join (left outer)
+                            └── • merge join (left outer)
                                 │ estimated row count: 3
                                 │ equality: (username) = (username)
                                 │ left cols are key
                                 │
                                 ├── • scan
                                 │     estimated row count: 3 (100% of the table; stats collected <hidden> ago)
-                                │     table: users@users_user_id_idx
+                                │     table: users@primary
                                 │     spans: FULL SCAN
                                 │
                                 └── • scan

--- a/pkg/sql/pgwire/pgwire_test.go
+++ b/pkg/sql/pgwire/pgwire_test.go
@@ -544,11 +544,11 @@ func TestPGPreparedQuery(t *testing.T) {
 			baseTest.SetArgs("def"),
 			baseTest.SetArgs("waa"),
 		}},
-		{"SHOW USERS", []preparedQueryTest{
-			baseTest.Results("abc", "", "{}").
-				Results("admin", "", "{}").
-				Results("root", "", "{admin}").
-				Results("woo", "", "{}"),
+		{"SELECT username, options, member_of from [SHOW USERS] ORDER BY username", []preparedQueryTest{
+			baseTest.Results("abc", "{}", "{}").
+				Results("admin", "{}", "{}").
+				Results("root", "{}", "{admin}").
+				Results("woo", "{}", "{}"),
 		}},
 		{"DROP USER abc, woo", []preparedQueryTest{
 			baseTest.SetArgs(),


### PR DESCRIPTION
The SHOW users/roles view currently does not have a mechanism to filter users
via the role options that are assigned to them. This support is needed as we
will be adding `PROVISIONSRC` role option in #148200 and this needs to have
filters support. Additionally, we will be populating the last login
time(estimated) for the `system.users` table and this value will be piped here
as well. Since this value is computed on a best effort basis; it is not
guaranteed to capture every login event, and we will be adding a notice
mentioning the same.

informs #147602
fixes #147599
Epic CRDB-21590

Release note (enterprise change): The SHOW ROLES command now includes a column
that shows the estimated time that the user last logged in. Additionally,
the `options` column is now returned as an array of strings, rather than as
a single comma-separated string.

The data can be queried with a query such as:
```
root@localhost:26257/defaultdb> select * from [show roles] as r WHERE EXISTS (SELECT 1 FROM unnest(r.options) AS m(option) where option like 'SUBJECT=cn%');
    username  |            options             | member_of | estimated_last_login_time
  ------------+--------------------------------+-----------+----------------------------
    testuser  | {NOLOGIN,SUBJECT=cn=testuser}  | {admin}   | NULL
  (1 row)
```