### PR TITLE
storage: add value separation cluster settings

### DIFF
--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -95,7 +95,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Write
 	// Write a MVCC value to be deleted with a known value size.
 	keyF := mvccKey("f")
 	keyF.Timestamp.WallTime = 1
-	valueF := MVCCValue{Value: roachpb.Value{RawBytes: []byte("fvalue")}}
+	valueF := MVCCValue{Value: roachpb.MakeValueFromString("fvalue")}
 	encodedValueF, err := EncodeMVCCValue(valueF)
 	require.NoError(t, err)
 	require.NoError(t, e.PutMVCC(keyF, valueF))
@@ -313,7 +313,7 @@ func TestBatchRepr(t *testing.T) {
 			"merge(c\x00)",
 			"put(e\x00,)",
 			"single_delete(d\x00)",
-			"delete-sized(f\x00\x00\x00\x00\x00\x00\x00\x00\x01\t,17)",
+			"delete-sized(f\x00\x00\x00\x00\x00\x00\x00\x00\x01\t,22)",
 		}
 		require.Equal(t, expOps, ops)
 

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -414,7 +414,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 					Key:       roachpb.Key("foobar"),
 					Timestamp: hlc.Timestamp{WallTime: 1711383740550067000, Logical: 2},
 				},
-				MVCCValue{Value: roachpb.Value{RawBytes: []byte("hello world")}},
+				MVCCValue{Value: roachpb.MakeValueFromBytes([]byte("hello world"))},
 			),
 		},
 		{
@@ -429,7 +429,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 						LocalTimestamp:   hlc.ClockTimestamp{WallTime: 1711383740550069000},
 						OmitInRangefeeds: true,
 					},
-					Value: roachpb.Value{RawBytes: []byte("hello world")},
+					Value: roachpb.MakeValueFromString("hello world"),
 				},
 			),
 		},
@@ -446,7 +446,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 					ValBytes: 100,
 				},
 				MVCCValue{
-					Value: roachpb.Value{RawBytes: []byte("hello world")},
+					Value: roachpb.MakeValueFromString("hello world"),
 				},
 			),
 		},

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1105,7 +1105,7 @@ func TestCreateCheckpoint_SpanConstrained(t *testing.T) {
 	for i := 1; i <= maxTableID; i++ {
 		require.NoError(t, b.PutMVCC(
 			MVCCKey{Key: key(i), Timestamp: hlc.Timestamp{WallTime: int64(i)}},
-			MVCCValue{Value: roachpb.Value{RawBytes: randutil.RandBytes(rng, 100)}},
+			MVCCValue{Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, 100))},
 		))
 	}
 	require.NoError(t, b.Commit(true /* sync */))
@@ -1640,7 +1640,7 @@ func TestScanLocks(t *testing.T) {
 	for k, str := range locks {
 		var err error
 		if str == lock.Intent {
-			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.Value{RawBytes: roachpb.Key(k)}, MVCCWriteOptions{Txn: txn1})
+			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.MakeValueFromBytes(roachpb.Key(k)), MVCCWriteOptions{Txn: txn1})
 		} else {
 			err = MVCCAcquireLock(ctx, eng, &txn1.TxnMeta, txn1.IgnoredSeqNums, str, roachpb.Key(k), nil, 0, 0)
 		}
@@ -2135,7 +2135,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 	keyB := roachpb.Key("b")
 	keyC := roachpb.Key("c")
 	keyD := roachpb.Key("d")
-	val := roachpb.Value{RawBytes: []byte{'v'}}
+	val := roachpb.MakeValueFromString("v")
 
 	testCases := []struct {
 		name                  string
@@ -2356,7 +2356,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 	aboveReadSeqNumber := enginepb.TxnSeq(3)
 
 	keyA := roachpb.Key("a")
-	val := roachpb.Value{RawBytes: []byte{'v'}}
+	val := roachpb.MakeValueFromString("v")
 
 	testCases := []struct {
 		name                  string

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -348,6 +348,33 @@ var concurrentDownloadCompactions = settings.RegisterIntSetting(
 	settings.IntWithMinimum(1),
 )
 
+var (
+	valueSeparationEnabled = settings.RegisterBoolSetting(
+		settings.SystemVisible,
+		"storage.value_separation.enabled",
+		"(experimental) whether or not values may be separated into blob files; "+
+			"requires columnar blocks to be enabled",
+		metamorphic.ConstantWithTestBool(
+			"storage.value_separation.enabled", false), /* defaultValue */
+	)
+	valueSeparationMinimumSize = settings.RegisterIntSetting(
+		settings.SystemVisible,
+		"storage.value_separation.minimum_size",
+		"the minimum size of a value that will be separated into a blob file",
+		int64(metamorphic.ConstantWithTestRange("storage.value_separation.minimum_size",
+			1<<10 /* 1 KiB (default) */, 25 /* 25 bytes (minimum) */, 1<<20 /* 1 MiB (maximum) */)),
+		settings.IntWithMinimum(1),
+	)
+	valueSeparationMaxReferenceDepth = settings.RegisterIntSetting(
+		settings.SystemVisible,
+		"storage.value_separation.max_reference_depth",
+		"the max reference depth bounds the number of unique, overlapping blob files referenced within a sstable;"+
+			" lower values improve scan performance but increase write amplification",
+		int64(metamorphic.ConstantWithTestRange("storage.value_separation.max_reference_depth", 10 /* default */, 2, 20)),
+		settings.IntWithMinimum(2),
+	)
+)
+
 // EngineComparer is a pebble.Comparer object that implements MVCC-specific
 // comparator settings for use with Pebble.
 var EngineComparer = func() pebble.Comparer {
@@ -452,7 +479,6 @@ func DefaultPebbleOptions() *pebble.Options {
 	// for why this was disabled, and what needs to be changed to reenable it.
 	// This issue tracks re-enablement: https://github.com/cockroachdb/pebble/issues/4139
 	opts.Experimental.MultiLevelCompactionHeuristic = pebble.NoMultiLevel{}
-
 	opts.Experimental.UserKeyCategories = userKeyCategories
 
 	opts.Levels[0] = pebble.LevelOptions{
@@ -800,6 +826,16 @@ func newPebble(ctx context.Context, cfg engineConfig) (p *Pebble, err error) {
 	}
 	cfg.opts.Experimental.EnableDeleteOnlyCompactionExcises = func() bool {
 		return deleteCompactionsCanExcise.Get(&cfg.settings.SV)
+	}
+	cfg.opts.Experimental.ValueSeparationPolicy = func() pebble.ValueSeparationPolicy {
+		if !valueSeparationEnabled.Get(&cfg.settings.SV) {
+			return pebble.ValueSeparationPolicy{}
+		}
+		return pebble.ValueSeparationPolicy{
+			Enabled:               true,
+			MinimumSize:           int(valueSeparationMinimumSize.Get(&cfg.settings.SV)),
+			MaxBlobReferenceDepth: int(valueSeparationMaxReferenceDepth.Get(&cfg.settings.SV)),
+		}
 	}
 
 	auxDir := cfg.opts.FS.PathJoin(cfg.env.Dir, base.AuxiliaryDir)

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -219,7 +219,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		GlobalUncertaintyLimit: ts1,
 	}
 	ui1 := uncertainty.Interval{GlobalLimit: txn1.GlobalUncertaintyLimit}
-	val := roachpb.Value{RawBytes: bytes.Repeat([]byte("v"), 1000)}
+	val := roachpb.MakeValueFromBytes(bytes.Repeat([]byte{'v'}, 1000))
 	func() {
 		batch := eng.NewBatch()
 		defer batch.Close()


### PR DESCRIPTION
Add new cluster settings for enabling and configuring value separation.

Close #147709.
Epic: CRDB-20379
Release note (ops change): Introduces new cluster settings for enabling the preview feature of value separation.