### PR TITLE
jobs: remove deprecated custom per-job auth

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -113,11 +113,8 @@ func alterChangefeedPlanHook(
 		if err != nil {
 			return err
 		}
-		getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
-			return &jobPayload, nil
-		}
-		err = jobsauth.AuthorizeAllowLegacyAuth(
-			ctx, p, jobID, getLegacyPayload, jobPayload.UsernameProto.Decode(), jobPayload.Type(), jobsauth.ControlAccess, globalPrivileges,
+		err = jobsauth.Authorize(
+			ctx, p, jobID, jobPayload.UsernameProto.Decode(), jobsauth.ControlAccess, globalPrivileges,
 		)
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3740,6 +3740,7 @@ func TestChangefeedJobControl(t *testing.T) {
 		asUser(t, f, `adminUser`, func(userDB *sqlutils.SQLRunner) {
 			userDB.Exec(t, "PAUSE job $1", currentFeed.JobID())
 			waitForJobState(userDB, t, currentFeed.JobID(), "paused")
+			userDB.Exec(t, "ALTER JOB $1 OWNER TO feedowner", currentFeed.JobID())
 		})
 		asUser(t, f, `userWithAllGrants`, func(userDB *sqlutils.SQLRunner) {
 			userDB.Exec(t, "RESUME job $1", currentFeed.JobID())
@@ -3750,10 +3751,10 @@ func TestChangefeedJobControl(t *testing.T) {
 			waitForJobState(userDB, t, currentFeed.JobID(), "running")
 		})
 		asUser(t, f, `userWithSomeGrants`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "user userwithsomegrants does not have CHANGEFEED privilege on relation table_b", "PAUSE job $1", currentFeed.JobID())
+			userDB.ExpectErr(t, "does not have privileges for job", "PAUSE job $1", currentFeed.JobID())
 		})
 		asUser(t, f, `regularUser`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "user regularuser does not have CHANGEFEED privilege on relation (table_a|table_b)", "PAUSE job $1", currentFeed.JobID())
+			userDB.ExpectErr(t, "does not have privileges for job", "PAUSE job $1", currentFeed.JobID())
 		})
 		closeCf()
 

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1736,6 +1736,7 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 
 		`CREATE USER adminUser`,
 		`GRANT ADMIN TO adminUser`,
+		`CREATE ROLE feedowner`,
 
 		`CREATE USER otherAdminUser`,
 		`GRANT ADMIN TO otherAdminUser`,
@@ -1747,6 +1748,7 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 		`CREATE USER jobController with CONTROLJOB`,
 
 		`CREATE USER userWithAllGrants`,
+		`GRANT feedowner TO userWithAllGrants`,
 		`GRANT CHANGEFEED ON table_a TO userWithAllGrants`,
 		`GRANT CHANGEFEED ON table_b TO userWithAllGrants`,
 

--- a/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
+++ b/pkg/ccl/changefeedccl/show_changefeed_jobs_test.go
@@ -568,7 +568,6 @@ func TestShowChangefeedJobsAuthorization(t *testing.T) {
 			require.NoError(t, err)
 			jobID = successfulFeed.(cdctest.EnterpriseTestFeed).JobID()
 		}
-		rootDB := sqlutils.MakeSQLRunner(s.DB)
 
 		// Create a changefeed and assert who can see it.
 		asUser(t, f, `feedCreator`, func(userDB *sqlutils.SQLRunner) {
@@ -579,22 +578,12 @@ func TestShowChangefeedJobsAuthorization(t *testing.T) {
 			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{{expectedJobIDStr}})
 		})
 		asUser(t, f, `userWithAllGrants`, func(userDB *sqlutils.SQLRunner) {
-			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{{expectedJobIDStr}})
+			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{})
 		})
 		asUser(t, f, `userWithSomeGrants`, func(userDB *sqlutils.SQLRunner) {
 			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{})
 		})
 		asUser(t, f, `jobController`, func(userDB *sqlutils.SQLRunner) {
-			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{{expectedJobIDStr}})
-		})
-		asUser(t, f, `regularUser`, func(userDB *sqlutils.SQLRunner) {
-			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{})
-		})
-
-		// Assert behavior when one of the tables is dropped.
-		rootDB.Exec(t, "DROP TABLE table_b")
-		// Having CHANGEFEED on only table_a is now sufficient.
-		asUser(t, f, `userWithSomeGrants`, func(userDB *sqlutils.SQLRunner) {
 			userDB.CheckQueryResults(t, `SELECT job_id FROM [SHOW CHANGEFEED JOBS]`, [][]string{{expectedJobIDStr}})
 		})
 		asUser(t, f, `regularUser`, func(userDB *sqlutils.SQLRunner) {

--- a/pkg/crosscluster/producer/replication_manager.go
+++ b/pkg/crosscluster/producer/replication_manager.go
@@ -442,7 +442,7 @@ func (r *replicationStreamManagerImpl) AuthorizeViaJob(
 	}
 
 	if err := jobsauth.Authorize(
-		ctx, planHook, jobspb.JobID(streamID), planHook.User(), jobspb.TypeReplicationStreamProducer, jobsauth.ControlAccess, globalPrivileges,
+		ctx, planHook, jobspb.JobID(streamID), planHook.User(), jobsauth.ControlAccess, globalPrivileges,
 	); err != nil {
 		return err
 	}

--- a/pkg/jobs/jobsauth/BUILD.bazel
+++ b/pkg/jobs/jobsauth/BUILD.bazel
@@ -13,7 +13,6 @@ go_library(
         "//pkg/sql/pgwire/pgerror",
         "//pkg/sql/privilege",
         "//pkg/sql/roleoption",
-        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 

--- a/pkg/jobs/jobsauth/authorization_test.go
+++ b/pkg/jobs/jobsauth/authorization_test.go
@@ -149,21 +149,6 @@ func (a *testAuthAccessor) User() username.SQLUsername {
 	return a.user
 }
 
-func makeChangefeedPayload(owner string, tableIDs []descpb.ID) *jobspb.Payload {
-	specs := make([]jobspb.ChangefeedTargetSpecification, len(tableIDs))
-	for i, tableID := range tableIDs {
-		specs[i] = jobspb.ChangefeedTargetSpecification{
-			TableID: tableID,
-		}
-	}
-	return &jobspb.Payload{
-		Details: jobspb.WrapPayloadDetails(jobspb.ChangefeedDetails{
-			TargetSpecifications: specs,
-		}),
-		UsernameProto: username.MakeSQLUsernameFromPreNormalizedString(owner).EncodeProto(),
-	}
-}
-
 func makeBackupPayload(owner string) *jobspb.Payload {
 	return &jobspb.Payload{
 		Details:       jobspb.WrapPayloadDetails(jobspb.BackupDetails{}),
@@ -247,38 +232,6 @@ func TestAuthorization(t *testing.T) {
 			accessLevel: jobsauth.ControlAccess,
 		},
 		{
-			name:                 "changefeed-privilege-on-all-tables",
-			user:                 username.MakeSQLUsernameFromPreNormalizedString("user1"),
-			roleOptions:          map[roleoption.Option]struct{}{},
-			admins:               map[string]struct{}{},
-			changeFeedPrivileges: map[descpb.ID]struct{}{0: {}, 1: {}, 2: {}},
-
-			payload:     makeChangefeedPayload("user2", []descpb.ID{0, 1, 2}),
-			accessLevel: jobsauth.ControlAccess,
-		},
-		{
-			name:                 "changefeed-privilege-on-some-tables",
-			user:                 username.MakeSQLUsernameFromPreNormalizedString("user1"),
-			roleOptions:          map[roleoption.Option]struct{}{},
-			admins:               map[string]struct{}{},
-			changeFeedPrivileges: map[descpb.ID]struct{}{0: {}, 1: {}},
-
-			payload:     makeChangefeedPayload("user2", []descpb.ID{0, 1, 2}),
-			accessLevel: jobsauth.ControlAccess,
-			userErr:     pgerror.New(pgcode.InsufficientPrivilege, "foo"),
-		},
-		{
-			name:                 "changefeed-priv-on-some-tables-with-dropped",
-			user:                 username.MakeSQLUsernameFromPreNormalizedString("user1"),
-			roleOptions:          map[roleoption.Option]struct{}{},
-			admins:               map[string]struct{}{},
-			changeFeedPrivileges: map[descpb.ID]struct{}{0: {}, 1: {}},
-			droppedDescriptors:   map[descpb.ID]struct{}{2: {}},
-
-			payload:     makeChangefeedPayload("user2", []descpb.ID{0, 1, 2}),
-			accessLevel: jobsauth.ControlAccess,
-		},
-		{
 			name:   "viewjob-required-for-read-access",
 			user:   username.MakeSQLUsernameFromPreNormalizedString("user1"),
 			admins: map[string]struct{}{},
@@ -354,10 +307,9 @@ func TestAuthorization(t *testing.T) {
 			ctx := context.Background()
 			globalPrivileges, err := jobsauth.GetGlobalJobPrivileges(ctx, testAuth)
 			assert.NoError(t, err)
-			err = jobsauth.AuthorizeAllowLegacyAuth(
+			err = jobsauth.Authorize(
 				ctx, testAuth, 0,
-				func(ctx context.Context) (*jobspb.Payload, error) { return tc.payload, nil },
-				tc.payload.UsernameProto.Decode(), tc.payload.Type(), tc.accessLevel, globalPrivileges,
+				tc.payload.UsernameProto.Decode(), tc.accessLevel, globalPrivileges,
 			)
 			assert.Equal(t, pgerror.GetPGCode(tc.userErr), pgerror.GetPGCode(err))
 		})

--- a/pkg/settings/registry.go
+++ b/pkg/settings/registry.go
@@ -270,6 +270,7 @@ var retiredSettings = map[InternalKey]struct{}{
 
 	// removed as of 25.3
 	"sql.metrics.max_stmt_fingerprints_per_explicit_txn": {},
+	"sql.jobs.legacy_per_job_access_via_details.enabled": {},
 }
 
 // grandfatheredDefaultSettings is the list of "grandfathered" existing sql.defaults

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -68,11 +68,8 @@ func (n *controlJobsNode) startExec(params runParams) error {
 
 		if err := reg.UpdateJobWithTxn(params.ctx, jobspb.JobID(jobID), params.p.InternalSQLTxn(),
 			func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-				getLegacyPayload := func(ctx context.Context) (*jobspb.Payload, error) {
-					return md.Payload, nil
-				}
-				if err := jobsauth.AuthorizeAllowLegacyAuth(params.ctx, params.p,
-					md.ID, getLegacyPayload, md.Payload.UsernameProto.Decode(), md.Payload.Type(), jobsauth.ControlAccess, globalPrivileges); err != nil {
+				if err := jobsauth.Authorize(params.ctx, params.p,
+					md.ID, md.Payload.UsernameProto.Decode(), jobsauth.ControlAccess, globalPrivileges); err != nil {
 					return err
 				}
 				switch n.desiredStatus {


### PR DESCRIPTION
This was deprecated a couple releases ago in favor of using more standard approaches of either a) telling users to grant or revoke membership in a role that has ownership of a job to manage access to that job or b) features built on top of jobs can have their own control statements that perform their own auth checks before modifying or creating jobs if they so choose.

With this having been deprecated for a couple of major releases now with the public docs suggesting using role membership instead, it can now be deleted to simplify the auth checks the jobs system needs to perform, paving the way for replacing the complex logic in the vtable for SHOW JOBS with a simple view instead.

Release note (ops change): Non-admin users no longer have access to changefeed jobs they do not own and which are not owned by a role of which they are a member, regardless of whether they have the changefeed privilege on the table or tables those jobs may be watching.
Epic: CRDB-48791.