### PR TITLE
sql,opt: implement region-column inference

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -66,7 +66,8 @@ CREATE TABLE parent_unique_nullable (
   x INT NOT NULL,
   y INT,
   UNIQUE (x, y),
-  UNIQUE WITHOUT INDEX (x, y, crdb_region)
+  UNIQUE WITHOUT INDEX (x, y, crdb_region),
+  FAMILY (x, y, crdb_region)
 ) LOCALITY REGIONAL BY ROW;
 INSERT INTO parent_unique_nullable (x, y, crdb_region) (SELECT k, v, region FROM parent_default);
 INSERT INTO parent_unique_nullable (x, y, crdb_region) (VALUES
@@ -485,6 +486,1759 @@ CREATE TABLE public.child (
 ) LOCALITY GLOBAL;
 
 statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Test with parent REGIONAL BY TABLE in primary region (default).
+# ==============================================================================
+
+subtest rbt_default
+
+statement ok
+CREATE TABLE child (
+  k INT,
+  v INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbt (region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.region
+  FROM child c LEFT JOIN parent_rbt p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (k) (VALUES (1), (2), (3), (NULL))
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+3     us-east-1       us-east-1
+
+# If the user specifies values for the region column, they override the storage
+# param and no lookup is performed.
+statement ok
+INSERT INTO child (k, crdb_region) (VALUES (4, 'ca-central-1'), (5, 'ap-southeast-2'), (6, 'us-east-1'), (NULL, 'us-east-1'))
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  us-east-1       NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+3     us-east-1       us-east-1
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+statement ok
+UPDATE child SET k = 4 WHERE k IS NULL
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k  child_region    parent_region
+1  ca-central-1    ca-central-1
+2  ap-southeast-2  ap-southeast-2
+3  us-east-1       us-east-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+5  ap-southeast-2  ap-southeast-2
+6  us-east-1       us-east-1
+
+statement ok
+UPDATE child SET k = NULL WHERE k = 4 OR k = 2
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ca-central-1    NULL
+NULL  ca-central-1    NULL
+NULL  ca-central-1    NULL
+1     ca-central-1    ca-central-1
+3     us-east-1       us-east-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+# An UPDATE that doesn't modify any of the columns in the FK does not change
+# the region column.
+statement ok
+UPDATE child SET v = 100 WHERE True;
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ca-central-1    NULL
+NULL  ca-central-1    NULL
+NULL  ca-central-1    NULL
+1     ca-central-1    ca-central-1
+3     us-east-1       us-east-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+# FK validation is performed even when the lookup is elided, so an attempt to
+# insert a row with a region that does not match the parent table will fail.
+statement error pgcode 23503 pq: insert on table "child" violates foreign key constraint "foo"\nDETAIL: Key \(crdb_region, k\)=\('ap-southeast-2', 4\) is not present in table "parent_rbt".
+INSERT INTO child (k, crdb_region) (VALUES (4, 'ap-southeast-2'))
+
+statement ok
+DROP FUNCTION display_child
+
+statement ok
+DROP TABLE child
+
+subtest end
+
+# ==============================================================================
+# Test with parent REGIONAL BY TABLE in secondary region.
+# ==============================================================================
+
+subtest rbt_secondary
+
+statement ok
+CREATE TABLE child (
+  k INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbt (region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.region
+  FROM child c LEFT JOIN parent_rbt p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1), (2), (3), (4), (5), (6), (NULL), (NULL))
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+3     us-east-1       us-east-1
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+statement ok
+UPDATE child SET k = 4 WHERE k IS NULL
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k  child_region    parent_region
+1  ca-central-1    ca-central-1
+2  ap-southeast-2  ap-southeast-2
+3  us-east-1       us-east-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+5  ap-southeast-2  ap-southeast-2
+6  us-east-1       us-east-1
+
+statement ok
+DROP FUNCTION display_child
+
+statement ok
+DROP TABLE child
+
+subtest end
+
+# ==============================================================================
+# Test with parent GLOBAL table.
+# ==============================================================================
+
+subtest global
+
+statement ok
+CREATE TABLE child (
+  k INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_global (region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.region
+  FROM child c LEFT JOIN parent_global p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1), (2), (3), (4), (5), (6), (NULL), (NULL))
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+3     us-east-1       us-east-1
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+statement ok
+UPDATE child SET k = 4 WHERE k IS NULL
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k  child_region    parent_region
+1  ca-central-1    ca-central-1
+2  ap-southeast-2  ap-southeast-2
+3  us-east-1       us-east-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+5  ap-southeast-2  ap-southeast-2
+6  us-east-1       us-east-1
+
+statement ok
+DROP FUNCTION display_child
+
+statement ok
+DROP TABLE child
+
+subtest end
+
+# ==============================================================================
+# Test with parent REGIONAL BY ROW table.
+# ==============================================================================
+
+subtest rbr
+
+statement ok
+CREATE TABLE child (
+  k INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_rbr p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1), (2), (3), (4), (5), (6), (NULL), (NULL))
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+3     us-east-1       us-east-1
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+statement ok
+UPDATE child SET k = 4 WHERE k IS NULL
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k  child_region    parent_region
+1  ca-central-1    ca-central-1
+2  ap-southeast-2  ap-southeast-2
+3  us-east-1       us-east-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+4  ca-central-1    ca-central-1
+5  ap-southeast-2  ap-southeast-2
+6  us-east-1       us-east-1
+
+statement ok
+DROP FUNCTION display_child
+
+statement ok
+DROP TABLE child
+
+subtest end
+
+# ==============================================================================
+# Test with parent multi-column unique constraint containing nullable column.
+# ==============================================================================
+
+subtest rbr_multi_column_with_nullable
+
+statement ok
+CREATE TABLE child (
+  x INT,
+  y INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent_unique_nullable (crdb_region, x, y)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  x INT,
+  y INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.x, c.y, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_unique_nullable p ON c.x = p.x AND c.y = p.y;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1, NULL), (2, 20), (3, 30), (4, 40), (5, 50), (NULL, 60), (NULL, NULL), (NULL, NULL))
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     NULL  ap-southeast-2  NULL
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+UPDATE child SET y = x * 10 WHERE y IS NULL
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+UPDATE child SET x = y // 10 WHERE x IS NULL
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+6     60    us-east-1       us-east-1
+
+statement ok
+UPDATE child SET y = NULL WHERE True
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+1     NULL  ca-central-1    NULL
+2     NULL  ap-southeast-2  NULL
+3     NULL  us-east-1       NULL
+4     NULL  ca-central-1    NULL
+5     NULL  ap-southeast-2  NULL
+6     NULL  us-east-1       NULL
+
+statement ok
+DROP FUNCTION display_child
+
+statement ok
+DROP TABLE child
+
+subtest end
+
+# ==============================================================================
+# Region column inference is compatible with hash-sharded indexes.
+# ==============================================================================
+
+subtest rbr_hash_sharded
+
+statement ok
+CREATE TABLE child (
+  v INT,
+  k INT,
+  INDEX (v) USING HASH,
+  INDEX (k) USING HASH,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  v INT,
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.v, c.k, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_rbr p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (100, 1), (200, 2), (300, 3), (400, 4), (500, 5), (600, 6), (700, NULL), (800, NULL))
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY v
+----
+v    k     child_region    parent_region
+100  1     ca-central-1    ca-central-1
+200  2     ap-southeast-2  ap-southeast-2
+300  3     us-east-1       us-east-1
+400  4     ca-central-1    ca-central-1
+500  5     ap-southeast-2  ap-southeast-2
+600  6     us-east-1       us-east-1
+700  NULL  ap-southeast-2  NULL
+800  NULL  ap-southeast-2  NULL
+
+statement ok
+UPDATE child SET k = 4 WHERE k IS NULL
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY v
+----
+v    k  child_region    parent_region
+100  1  ca-central-1    ca-central-1
+200  2  ap-southeast-2  ap-southeast-2
+300  3  us-east-1       us-east-1
+400  4  ca-central-1    ca-central-1
+500  5  ap-southeast-2  ap-southeast-2
+600  6  us-east-1       us-east-1
+700  4  ca-central-1    ca-central-1
+800  4  ca-central-1    ca-central-1
+
+statement ok
+DROP FUNCTION display_child
+
+statement ok
+DROP TABLE child
+
+subtest end
+
+# ==============================================================================
+# Test with MATCH FULL foreign key constraint.
+# ==============================================================================
+
+subtest rbr_match_full
+
+statement ok
+CREATE TABLE child (
+  x INT,
+  y INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent_unique_nullable (crdb_region, x, y) MATCH FULL
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  x INT,
+  y INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.x, c.y, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_unique_nullable p ON c.x = p.x AND c.y = p.y;
+$$ LANGUAGE SQL STABLE;
+
+# The non-null region column prevents setting other FK columns to NULL.
+statement error pgcode 23503 pq: insert on table "child" violates foreign key constraint "foo"\nDETAIL: MATCH FULL does not allow mixing of null and nonnull key values
+INSERT INTO child (VALUES (NULL, NULL), (NULL, NULL))
+
+statement ok
+INSERT INTO child (VALUES (1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60))
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x  y   child_region    parent_region
+1  10  ca-central-1    ca-central-1
+2  20  ap-southeast-2  ap-southeast-2
+3  30  us-east-1       us-east-1
+4  40  ca-central-1    ca-central-1
+5  50  ap-southeast-2  ap-southeast-2
+6  60  us-east-1       us-east-1
+
+statement ok
+UPDATE child SET x = 3, y = 30 WHERE x = 5 OR x = 6;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x  y   child_region    parent_region
+1  10  ca-central-1    ca-central-1
+2  20  ap-southeast-2  ap-southeast-2
+3  30  us-east-1       us-east-1
+3  30  us-east-1       us-east-1
+3  30  us-east-1       us-east-1
+4  40  ca-central-1    ca-central-1
+
+statement error pgcode 23503 pq: update on table "child" violates foreign key constraint "foo"\nDETAIL: MATCH FULL does not allow mixing of null and nonnull key values
+UPDATE child SET x = NULL WHERE x = 3;
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Test with unvalidated foreign key constraint.
+# ==============================================================================
+
+subtest rbr_unvalidated_fk
+
+statement ok
+SET create_table_with_schema_locked = false;
+
+statement ok
+CREATE TABLE child (
+  x INT,
+  y INT
+) LOCALITY REGIONAL BY ROW;
+
+statement ok
+RESET create_table_with_schema_locked;
+
+statement ok
+INSERT INTO child (VALUES (0, 0), (4, 40), (7, 70))
+
+# The NOT VALID foreign key constraint allows existing rows that do not
+# satisfy the foreign key condition. However, the FK constraint is still used
+# to determine the region column for child rows that have matches.
+statement ok
+ALTER TABLE child ADD CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent_unique_nullable (crdb_region, x, y) NOT VALID
+
+statement ok
+ALTER TABLE child SET (infer_rbr_region_col_using_constraint = 'foo');
+
+statement ok
+INSERT INTO child (VALUES (1, 10), (2, 20), (3, 30), (5, 50), (6, 60), (NULL, 80), (NULL, NULL))
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  x INT,
+  y INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.x, c.y, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_unique_nullable p ON c.x = p.x AND c.y = p.y;
+$$ LANGUAGE SQL STABLE;
+
+# Note the row for which x = 4, which was inserted before the storage param
+# was set.
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  80    ap-southeast-2  NULL
+0     0     ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ap-southeast-2  ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+6     60    us-east-1       us-east-1
+7     70    ap-southeast-2  NULL
+
+# Updating the x = 4 row causes it to use the region from the parent table.
+statement ok
+UPDATE child SET y = 40 WHERE x = 4;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  80    ap-southeast-2  NULL
+0     0     ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+6     60    us-east-1       us-east-1
+7     70    ap-southeast-2  NULL
+
+statement ok
+UPDATE child SET x = 3, y = 30 WHERE x IS NULL;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x  y   child_region    parent_region
+0  0   ap-southeast-2  NULL
+1  10  ca-central-1    ca-central-1
+2  20  ap-southeast-2  ap-southeast-2
+3  30  us-east-1       us-east-1
+3  30  us-east-1       us-east-1
+3  30  us-east-1       us-east-1
+4  40  ca-central-1    ca-central-1
+5  50  ap-southeast-2  ap-southeast-2
+6  60  us-east-1       us-east-1
+7  70  ap-southeast-2  NULL
+
+statement ok
+UPDATE child SET x = NULL WHERE x = 3;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y   child_region    parent_region
+NULL  30  us-east-1       NULL
+NULL  30  us-east-1       NULL
+NULL  30  us-east-1       NULL
+0     0   ap-southeast-2  NULL
+1     10  ca-central-1    ca-central-1
+2     20  ap-southeast-2  ap-southeast-2
+4     40  ca-central-1    ca-central-1
+5     50  ap-southeast-2  ap-southeast-2
+6     60  us-east-1       us-east-1
+7     70  ap-southeast-2  NULL
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Test interaction with computed columns.
+# ==============================================================================
+
+subtest rbr_computed_columns
+
+# Create a child table with a computed column in the foreign key constraint.
+statement ok
+CREATE TABLE child (
+  x INT,
+  y INT GENERATED ALWAYS AS (x * 10) STORED,
+  z INT AS (-x) VIRTUAL,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent_unique_nullable (crdb_region, x, y)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  x INT,
+  y INT,
+  z INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.x, c.y, c.z, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_unique_nullable p ON c.x = p.x AND c.y = p.y;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1), (2), (3), (4), (5), (6), (NULL), (NULL));
+
+query IIITT colnames
+SELECT * FROM display_child() ORDER BY x, y, z, child_region
+----
+x     y     z     child_region    parent_region
+NULL  NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  NULL  ap-southeast-2  NULL
+1     10    -1    ca-central-1    ca-central-1
+2     20    -2    ap-southeast-2  ap-southeast-2
+3     30    -3    us-east-1       us-east-1
+4     40    -4    ca-central-1    ca-central-1
+5     50    -5    ap-southeast-2  ap-southeast-2
+6     60    -6    us-east-1       us-east-1
+
+statement ok
+UPDATE child SET x = 4 WHERE x IS NULL;
+
+query IIITT colnames
+SELECT * FROM display_child() ORDER BY x, y, z, child_region
+----
+x  y   z   child_region    parent_region
+1  10  -1  ca-central-1    ca-central-1
+2  20  -2  ap-southeast-2  ap-southeast-2
+3  30  -3  us-east-1       us-east-1
+4  40  -4  ca-central-1    ca-central-1
+4  40  -4  ca-central-1    ca-central-1
+4  40  -4  ca-central-1    ca-central-1
+5  50  -5  ap-southeast-2  ap-southeast-2
+6  60  -6  us-east-1       us-east-1
+
+statement ok
+UPDATE child SET x = NULL WHERE x = 4 OR x = 2;
+
+query IIITT colnames
+SELECT * FROM display_child() ORDER BY x, y, z, child_region
+----
+x     y     z     child_region    parent_region
+NULL  NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  NULL  ca-central-1    NULL
+NULL  NULL  NULL  ca-central-1    NULL
+NULL  NULL  NULL  ca-central-1    NULL
+1     10    -1    ca-central-1    ca-central-1
+3     30    -3    us-east-1       us-east-1
+5     50    -5    ap-southeast-2  ap-southeast-2
+6     60    -6    us-east-1       us-east-1
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Test interaction with check constraints.
+# ==============================================================================
+
+subtest rbr_check_constraints
+
+# Create a child table with a check constraint that references the region column.
+statement ok
+CREATE TABLE child (
+  k INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k),
+  CONSTRAINT check_region CHECK (crdb_region IN ('ap-southeast-2', 'ca-central-1'))
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_rbr p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1), (2), (4), (5), (NULL), (NULL));
+
+# The check constraint prevents inserting rows in the 'us-east-1' region.
+statement error pgcode 23514 pq: failed to satisfy CHECK constraint \(crdb_region IN \('ap-southeast-2':::public.crdb_internal_region, 'ca-central-1':::public.crdb_internal_region\)\)
+INSERT INTO child (VALUES (3), (6));
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Test interaction with row-level security.
+# ==============================================================================
+
+subtest rbr_row_level_security
+
+# Create a child table with a row-level security policy that references the region column.
+statement ok
+CREATE TABLE child (
+  k INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_rbr p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+ALTER TABLE child FORCE ROW LEVEL SECURITY, ENABLE ROW LEVEL SECURITY;
+
+# Create a row-level security policy that allows access only to rows in the
+# (primary) 'ap-southeast-2' region.
+statement ok
+CREATE POLICY rls_policy ON child FOR ALL TO PUBLIC
+USING (crdb_region = 'ap-southeast-2') WITH CHECK (crdb_region = 'ap-southeast-2');
+
+statement ok
+CREATE USER test_user;
+
+statement ok
+GRANT SELECT, INSERT, UPDATE, DELETE ON child TO test_user;
+
+statement ok
+GRANT SELECT, INSERT, UPDATE, DELETE ON parent_rbr TO test_user;
+
+statement ok
+GRANT ALL ON FUNCTION display_child TO test_user;
+
+statement ok
+SET ROLE test_user;
+
+statement ok
+INSERT INTO child (VALUES (2), (5), (NULL), (NULL));
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+2     ap-southeast-2  ap-southeast-2
+5     ap-southeast-2  ap-southeast-2
+
+statement error pgcode 42501 pq: new row violates row-level security policy for table "child"
+INSERT INTO child (VALUES (1), (3), (4), (6));
+
+statement ok
+SET ROLE root
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+# ==============================================================================
+# Test interaction with partial indexes.
+# ==============================================================================
+
+subtest partial_indexes
+
+# Create a child table with a partial index that references the region column.
+statement ok
+CREATE TABLE child (
+  k INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k),
+  INDEX idx_partial (k) WHERE crdb_region = 'ap-southeast-2'
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_rbr p ON c.k = p.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1), (2), (3), (4), (5), (6), (NULL), (NULL));
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+1     ca-central-1    ca-central-1
+2     ap-southeast-2  ap-southeast-2
+3     us-east-1       us-east-1
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+query I
+SELECT k FROM child@idx_partial WHERE crdb_region = 'ap-southeast-2' ORDER BY k
+----
+NULL
+NULL
+2
+5
+
+statement ok
+UPDATE child SET k = 2 WHERE k = 1 OR k = 3;
+
+query ITT colnames
+SELECT * FROM display_child() ORDER BY k, child_region
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ap-southeast-2  NULL
+2     ap-southeast-2  ap-southeast-2
+2     ap-southeast-2  ap-southeast-2
+2     ap-southeast-2  ap-southeast-2
+4     ca-central-1    ca-central-1
+5     ap-southeast-2  ap-southeast-2
+6     us-east-1       us-east-1
+
+query I
+SELECT k FROM child@idx_partial WHERE crdb_region = 'ap-southeast-2' ORDER BY k
+----
+NULL
+NULL
+2
+2
+2
+5
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Test interaction with triggers.
+# ==============================================================================
+
+subtest rbr_triggers
+
+# Create a child table with BEFORE and AFTER triggers that reference the
+# region column. NOTE: until #133331 is addressed, the crdb_region column
+# must be made visible for it to be displayed by a trigger.
+statement ok
+CREATE TABLE child (
+  k INT,
+  crdb_region crdb_internal_region NOT NULL DEFAULT gateway_region()::crdb_internal_region,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION trigger_fn() RETURNS TRIGGER AS $$
+  BEGIN
+    RAISE NOTICE '% trigger: old: % -> new: %', TG_WHEN, OLD, NEW;
+    RETURN NEW;
+  END;
+$$ LANGUAGE PLpgSQL;
+
+statement ok
+CREATE TRIGGER before_trigger BEFORE INSERT OR UPDATE ON child FOR EACH ROW EXECUTE FUNCTION trigger_fn();
+
+statement ok
+CREATE TRIGGER after_trigger AFTER INSERT OR UPDATE ON child FOR EACH ROW EXECUTE FUNCTION trigger_fn();
+
+# The region-column lookup happens after BEFORE triggers execute, so the
+# looked-up value is only visible to AFTER triggers. BEFORE triggers see the
+# default value 'ap-southeast-2' instead.
+query T noticetrace
+INSERT INTO child (VALUES (1), (2), (3), (NULL));
+----
+NOTICE: BEFORE trigger: old: <NULL> -> new: (1,ap-southeast-2)
+NOTICE: BEFORE trigger: old: <NULL> -> new: (2,ap-southeast-2)
+NOTICE: BEFORE trigger: old: <NULL> -> new: (3,ap-southeast-2)
+NOTICE: BEFORE trigger: old: <NULL> -> new: (,ap-southeast-2)
+NOTICE: AFTER trigger: old: <NULL> -> new: (2,ap-southeast-2)
+NOTICE: AFTER trigger: old: <NULL> -> new: (1,ca-central-1)
+NOTICE: AFTER trigger: old: <NULL> -> new: (3,us-east-1)
+NOTICE: AFTER trigger: old: <NULL> -> new: (,ap-southeast-2)
+
+query T noticetrace
+UPDATE child SET k = 4 WHERE k IS NULL;
+----
+NOTICE: BEFORE trigger: old: (,ap-southeast-2) -> new: (4,ap-southeast-2)
+NOTICE: AFTER trigger: old: (,ap-southeast-2) -> new: (4,ca-central-1)
+
+query T noticetrace
+UPDATE child SET k = NULL WHERE k = 4 OR k = 2;
+----
+NOTICE: BEFORE trigger: old: (2,ap-southeast-2) -> new: (,ap-southeast-2)
+NOTICE: BEFORE trigger: old: (4,ca-central-1) -> new: (,ca-central-1)
+NOTICE: AFTER trigger: old: (2,ap-southeast-2) -> new: (,ap-southeast-2)
+NOTICE: AFTER trigger: old: (4,ca-central-1) -> new: (,ca-central-1)
+
+query ITT colnames
+SELECT c.k, c.crdb_region AS child_region, p.crdb_region AS parent_region
+FROM child c LEFT JOIN parent_rbr p ON c.k = p.k
+ORDER BY c.k, c.crdb_region;
+----
+k     child_region    parent_region
+NULL  ap-southeast-2  NULL
+NULL  ca-central-1    NULL
+1     ca-central-1    ca-central-1
+3     us-east-1       us-east-1
+
+statement ok
+DROP TABLE child;
+
+statement ok
+DROP FUNCTION trigger_fn;
+
+subtest end
+
+# ==============================================================================
+# Show interaction with cascade actions.
+# ==============================================================================
+
+subtest rbr_cascade_actions
+
+statement error pgcode 42830 pq: cannot add a SET NULL cascading action on column "multi_region_test_db.public.child.crdb_region" which has a NOT NULL constraint
+CREATE TABLE child (
+  k INT,
+  v INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k) ON UPDATE SET NULL ON DELETE SET NULL
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE TABLE parent_cascade (k INT PRIMARY KEY) LOCALITY REGIONAL BY ROW;
+
+statement ok
+INSERT INTO parent_cascade (k, crdb_region) (SELECT k, crdb_region FROM parent_rbr);
+
+statement ok
+CREATE TABLE child (
+  k INT,
+  v INT DEFAULT 1000,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_cascade (crdb_region, k) ON UPDATE SET DEFAULT ON DELETE SET DEFAULT
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k INT,
+  v INT,
+  child_region crdb_internal_region,
+  parent_cascade_region crdb_internal_region
+) AS $$
+  SELECT c.k, c.v, c.crdb_region, cd.crdb_region
+  FROM child c LEFT JOIN parent_cascade cd ON c.k = cd.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1, 10), (2, 20), (3, 30), (4, 40), (5, 50), (6, 60));
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY k, v, child_region
+----
+k  v   child_region    parent_cascade_region
+1  10  ca-central-1    ca-central-1
+2  20  ap-southeast-2  ap-southeast-2
+3  30  us-east-1       us-east-1
+4  40  ca-central-1    ca-central-1
+5  50  ap-southeast-2  ap-southeast-2
+6  60  us-east-1       us-east-1
+
+statement ok
+DELETE FROM parent_cascade WHERE k = 3 OR k = 4;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY k, v, child_region
+----
+k     v   child_region    parent_cascade_region
+NULL  30  ap-southeast-2  NULL
+NULL  40  ap-southeast-2  NULL
+1     10  ca-central-1    ca-central-1
+2     20  ap-southeast-2  ap-southeast-2
+5     50  ap-southeast-2  ap-southeast-2
+6     60  us-east-1       us-east-1
+
+statement ok
+UPDATE parent_cascade SET k = k + 2 WHERE k = 1 OR k = 2;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY k, v, child_region
+----
+k     v   child_region    parent_cascade_region
+NULL  10  ap-southeast-2  NULL
+NULL  20  ap-southeast-2  NULL
+NULL  30  ap-southeast-2  NULL
+NULL  40  ap-southeast-2  NULL
+5     50  ap-southeast-2  ap-southeast-2
+6     60  us-east-1       us-east-1
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+statement ok
+DELETE FROM parent_cascade WHERE true;
+INSERT INTO parent_cascade (k, crdb_region) (SELECT k, crdb_region FROM parent_rbr);
+
+statement ok
+CREATE TABLE child (
+  k1 INT,
+  k2 INT,
+  v INT DEFAULT 1000,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k1) REFERENCES parent_rbr (crdb_region, k) ON UPDATE CASCADE ON DELETE CASCADE,
+  CONSTRAINT bar FOREIGN KEY (crdb_region, k2) REFERENCES parent_cascade (crdb_region, k) ON UPDATE CASCADE ON DELETE CASCADE
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  k1 INT,
+  k2 INT,
+  v INT,
+  child_region crdb_internal_region,
+  parent_rbr_region crdb_internal_region,
+  parent_cascade_region crdb_internal_region
+) AS $$
+  SELECT c.k1, c.k2, c.v, c.crdb_region, rbr.crdb_region, cd.crdb_region
+  FROM child c LEFT JOIN parent_rbr rbr ON c.k1 = rbr.k LEFT JOIN parent_cascade cd ON c.k2 = cd.k;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+INSERT INTO child (VALUES (1, 1, 10), (2, 2, 20), (3, 3, 30), (4, 4, 40), (5, 5, 50), (6, 6, 60));
+
+query IIITTT colnames
+SELECT * FROM display_child() ORDER BY k1, k2, v, child_region
+----
+k1  k2  v   child_region    parent_rbr_region  parent_cascade_region
+1   1   10  ca-central-1    ca-central-1       ca-central-1
+2   2   20  ap-southeast-2  ap-southeast-2     ap-southeast-2
+3   3   30  us-east-1       us-east-1          us-east-1
+4   4   40  ca-central-1    ca-central-1       ca-central-1
+5   5   50  ap-southeast-2  ap-southeast-2     ap-southeast-2
+6   6   60  us-east-1       us-east-1          us-east-1
+
+statement ok
+DELETE FROM parent_cascade WHERE k = 3 OR k = 4;
+
+query IIITTT colnames
+SELECT * FROM display_child() ORDER BY k1, k2, v, child_region
+----
+k1  k2  v   child_region    parent_rbr_region  parent_cascade_region
+1   1   10  ca-central-1    ca-central-1       ca-central-1
+2   2   20  ap-southeast-2  ap-southeast-2     ap-southeast-2
+5   5   50  ap-southeast-2  ap-southeast-2     ap-southeast-2
+6   6   60  us-east-1       us-east-1          us-east-1
+
+statement ok
+UPDATE parent_cascade SET k = k + 2 WHERE k = 1 OR k = 2;
+
+query IIITTT colnames
+SELECT * FROM display_child() ORDER BY k1, k2, v, child_region
+----
+k1  k2  v   child_region    parent_rbr_region  parent_cascade_region
+1   3   10  ca-central-1    ca-central-1       ca-central-1
+2   4   20  ap-southeast-2  ap-southeast-2     ap-southeast-2
+5   5   50  ap-southeast-2  ap-southeast-2     ap-southeast-2
+6   6   60  us-east-1       us-east-1          us-east-1
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+statement ok
+DROP TABLE parent_cascade;
+
+subtest end
+
+# ==============================================================================
+# Show implicit locking behavior.
+# ==============================================================================
+
+subtest rbr_implicit_locking
+
+# TODO(drewk): we could push the implicit locking below the LeftJoin added for
+# region column lookup, since it doesn't filter any child rows.
+statement ok
+CREATE TABLE child (
+  k INT,
+  INDEX (k),
+  CONSTRAINT foo FOREIGN KEY (crdb_region, k) REFERENCES parent_rbr (crdb_region, k),
+  FAMILY (k, crdb_region, rowid)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+onlyif config multiregion-9node-3region-3azs
+query T
+EXPLAIN (VERBOSE) UPSERT INTO child (k) VALUES (4);
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • upsert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: child(k, crdb_region, rowid)
+│   │ arbiter constraints: child_pkey
+│   │
+│   └── • buffer
+│       │ columns: (column1, fk_lookup_crdb_region, rowid_default, k, crdb_region, rowid, column1, fk_lookup_crdb_region, crdb_region, check1)
+│       │ label: buffer 1
+│       │
+│       └── • project
+│           │ columns: (column1, fk_lookup_crdb_region, rowid_default, k, crdb_region, rowid, column1, fk_lookup_crdb_region, crdb_region, check1)
+│           │
+│           └── • render
+│               │ columns: (check1, column1, rowid_default, k, crdb_region, rowid, fk_lookup_crdb_region)
+│               │ render check1: fk_lookup_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│               │ render column1: column1
+│               │ render rowid_default: rowid_default
+│               │ render k: k
+│               │ render crdb_region: crdb_region
+│               │ render rowid: rowid
+│               │ render fk_lookup_crdb_region: fk_lookup_crdb_region
+│               │
+│               └── • render
+│                   │ columns: (fk_lookup_crdb_region, column1, rowid_default, k, crdb_region, rowid)
+│                   │ render fk_lookup_crdb_region: CASE WHEN crdb_region IS NOT DISTINCT FROM CAST(NULL AS public.crdb_internal_region) THEN crdb_region ELSE crdb_region END
+│                   │ render column1: column1
+│                   │ render rowid_default: rowid_default
+│                   │ render k: k
+│                   │ render crdb_region: crdb_region
+│                   │ render rowid: rowid
+│                   │
+│                   └── • lookup join (left outer)
+│                       │ columns: (column1, rowid_default, k, crdb_region, k, crdb_region, rowid)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ table: child@child_pkey
+│                       │ equality cols are key
+│                       │ lookup condition: (crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')) AND (rowid_default = rowid)
+│                       │ parallel
+│                       │
+│                       └── • lookup join (left outer)
+│                           │ columns: (column1, rowid_default, k, crdb_region)
+│                           │ estimated row count: 1 (missing stats)
+│                           │ table: parent_rbr@parent_rbr_pkey
+│                           │ equality cols are key
+│                           │ lookup condition: (crdb_region = 'ap-southeast-2') AND (column1 = k)
+│                           │ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column1 = k)
+│                           │ parallel
+│                           │
+│                           └── • values
+│                                 columns: (column1, rowid_default)
+│                                 size: 2 columns, 1 row
+│                                 row 0, expr 0: 4
+│                                 row 0, expr 1: unique_rowid()
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (fk_lookup_crdb_region, column1)
+            │ estimated row count: 0 (missing stats)
+            │ table: parent_rbr@parent_rbr_pkey
+            │ equality: (fk_lookup_crdb_region, column1) = (crdb_region, k)
+            │ equality cols are key
+            │ parallel
+            │
+            └── • project
+                │ columns: (fk_lookup_crdb_region, column1)
+                │
+                └── • scan buffer
+                      columns: (column1, fk_lookup_crdb_region, rowid_default, k, crdb_region, rowid, column1, fk_lookup_crdb_region, crdb_region, check1)
+                      estimated row count: 1 (missing stats)
+                      label: buffer 1
+
+onlyif config multiregion-9node-3region-3azs
+query T
+EXPLAIN (VERBOSE) UPDATE child SET k = 4 WHERE k = 3;
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: child
+│   │ set: k, crdb_region
+│   │
+│   └── • buffer
+│       │ columns: (k, crdb_region, rowid, k_new, fk_lookup_crdb_region, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (k, crdb_region, rowid, k_new, fk_lookup_crdb_region, check1)
+│           │ render check1: fk_lookup_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│           │ render k: k
+│           │ render crdb_region: crdb_region
+│           │ render rowid: rowid
+│           │ render k_new: k_new
+│           │ render fk_lookup_crdb_region: fk_lookup_crdb_region
+│           │
+│           └── • render
+│               │ columns: (fk_lookup_crdb_region, k, crdb_region, rowid, k_new)
+│               │ render fk_lookup_crdb_region: CASE WHEN crdb_region IS NOT DISTINCT FROM CAST(NULL AS public.crdb_internal_region) THEN crdb_region ELSE crdb_region END
+│               │ render k: k
+│               │ render crdb_region: crdb_region
+│               │ render rowid: rowid
+│               │ render k_new: k_new
+│               │
+│               └── • cross join (left outer)
+│                   │ columns: (k_new, k, crdb_region, rowid, k, crdb_region)
+│                   │ estimated row count: 10 (missing stats)
+│                   │
+│                   ├── • render
+│                   │   │ columns: (k_new, k, crdb_region, rowid)
+│                   │   │ render k_new: 4
+│                   │   │ render k: k
+│                   │   │ render crdb_region: crdb_region
+│                   │   │ render rowid: rowid
+│                   │   │
+│                   │   └── • scan
+│                   │         columns: (k, crdb_region, rowid)
+│                   │         estimated row count: 10 (missing stats)
+│                   │         table: child@child_k_idx
+│                   │         spans: /"@"/3-/"@"/4 /"\x80"/3-/"\x80"/4 /"\xc0"/3-/"\xc0"/4
+│                   │
+│                   └── • union all
+│                       │ columns: (k, crdb_region)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ limit: 1
+│                       │
+│                       ├── • scan
+│                       │     columns: (k, crdb_region)
+│                       │     estimated row count: 1 (missing stats)
+│                       │     table: parent_rbr@parent_rbr_pkey
+│                       │     spans: /"@"/4/0
+│                       │
+│                       └── • scan
+│                             columns: (k, crdb_region)
+│                             estimated row count: 1 (missing stats)
+│                             table: parent_rbr@parent_rbr_pkey
+│                             spans: /"\x80"/4/0 /"\xc0"/4/0
+│                             parallel
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (fk_lookup_crdb_region, k_new)
+            │ estimated row count: 0 (missing stats)
+            │ table: parent_rbr@parent_rbr_pkey
+            │ equality: (fk_lookup_crdb_region, k_new) = (crdb_region, k)
+            │ equality cols are key
+            │ parallel
+            │
+            └── • project
+                │ columns: (fk_lookup_crdb_region, k_new)
+                │
+                └── • scan buffer
+                      columns: (k, crdb_region, rowid, k_new, fk_lookup_crdb_region, check1)
+                      estimated row count: 10 (missing stats)
+                      label: buffer 1
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Show interaction with read committed isolation.
+# ==============================================================================
+
+subtest rbr_read_committed
+
+statement ok
+CREATE TABLE child (
+  x INT,
+  y INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent_unique_nullable (crdb_region, x, y),
+  FAMILY (x, y, crdb_region, rowid)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  x INT,
+  y INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.x, c.y, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_unique_nullable p ON c.x = p.x AND c.y = p.y;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED;
+
+# Running in read-committed isolation causes the lookup to use shared locking.
+onlyif config multiregion-9node-3region-3azs
+query T
+EXPLAIN (VERBOSE) INSERT INTO child (VALUES (1, 2));
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • insert
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ into: child(x, y, crdb_region, rowid)
+│   │ uniqueness checks (tombstones): child_pkey
+│   │
+│   └── • buffer
+│       │ columns: (column1, column2, fk_lookup_crdb_region, rowid_default, check1, crdb_region_default)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (column1, column2, fk_lookup_crdb_region, rowid_default, check1, crdb_region_default)
+│           │ render check1: fk_lookup_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│           │ render column1: column1
+│           │ render column2: column2
+│           │ render crdb_region_default: crdb_region_default
+│           │ render rowid_default: rowid_default
+│           │ render fk_lookup_crdb_region: fk_lookup_crdb_region
+│           │
+│           └── • render
+│               │ columns: (fk_lookup_crdb_region, column1, column2, crdb_region_default, rowid_default)
+│               │ render fk_lookup_crdb_region: CASE WHEN crdb_region IS NOT DISTINCT FROM CAST(NULL AS public.crdb_internal_region) THEN crdb_region_default ELSE crdb_region END
+│               │ render column1: column1
+│               │ render column2: column2
+│               │ render crdb_region_default: crdb_region_default
+│               │ render rowid_default: rowid_default
+│               │
+│               └── • cross join (left outer)
+│                   │ columns: (column1, column2, crdb_region_default, rowid_default, x, y, crdb_region)
+│                   │ estimated row count: 1 (missing stats)
+│                   │
+│                   ├── • values
+│                   │     columns: (column1, column2, crdb_region_default, rowid_default)
+│                   │     size: 4 columns, 1 row
+│                   │     row 0, expr 0: 1
+│                   │     row 0, expr 1: 2
+│                   │     row 0, expr 2: 'ap-southeast-2'
+│                   │     row 0, expr 3: unique_rowid()
+│                   │
+│                   └── • union all
+│                       │ columns: (x, y, crdb_region)
+│                       │ estimated row count: 1 (missing stats)
+│                       │ limit: 1
+│                       │
+│                       ├── • scan
+│                       │     columns: (x, y, crdb_region)
+│                       │     estimated row count: 1 (missing stats)
+│                       │     table: parent_unique_nullable@parent_unique_nullable_x_y_key
+│                       │     spans: /"@"/1/2/0
+│                       │     locking strength: for share
+│                       │     locking durability: guaranteed
+│                       │
+│                       └── • scan
+│                             columns: (x, y, crdb_region)
+│                             estimated row count: 1 (missing stats)
+│                             table: parent_unique_nullable@parent_unique_nullable_x_y_key
+│                             spans: /"\x80"/1/2/0 /"\xc0"/1/2/0
+│                             parallel
+│                             locking strength: for share
+│                             locking durability: guaranteed
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (fk_lookup_crdb_region, column1, column2)
+            │ estimated row count: 0 (missing stats)
+            │ table: parent_unique_nullable@parent_unique_nullable_x_y_key
+            │ equality: (fk_lookup_crdb_region, column1, column2) = (crdb_region, x, y)
+            │ equality cols are key
+            │ locking strength: for share
+            │ locking durability: guaranteed
+            │ parallel
+            │
+            └── • project
+                │ columns: (fk_lookup_crdb_region, column1, column2)
+                │
+                └── • scan buffer
+                      columns: (column1, column2, fk_lookup_crdb_region, rowid_default, check1, crdb_region_default)
+                      estimated row count: 1 (missing stats)
+                      label: buffer 1
+
+statement ok
+INSERT INTO child (VALUES (1, NULL), (2, 20), (3, 30), (4, 40), (5, 50), (NULL, 60), (NULL, NULL), (NULL, NULL))
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     NULL  ap-southeast-2  NULL
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+COMMIT;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     NULL  ap-southeast-2  NULL
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED;
+
+# Running in read-committed isolation causes the lookup to use shared locking.
+onlyif config multiregion-9node-3region-3azs
+query T
+EXPLAIN (VERBOSE) UPDATE child SET y = x * 10 WHERE y IS NULL
+----
+distribution: local
+vectorized: true
+·
+• root
+│ columns: ()
+│
+├── • update
+│   │ columns: ()
+│   │ estimated row count: 0 (missing stats)
+│   │ table: child
+│   │ set: y, crdb_region
+│   │
+│   └── • buffer
+│       │ columns: (x, y, crdb_region, rowid, y_new, fk_lookup_crdb_region, check1)
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │ columns: (x, y, crdb_region, rowid, y_new, fk_lookup_crdb_region, check1)
+│           │ render check1: fk_lookup_crdb_region IN ('ap-southeast-2', 'ca-central-1', 'us-east-1')
+│           │ render x: x
+│           │ render y: y
+│           │ render crdb_region: crdb_region
+│           │ render rowid: rowid
+│           │ render y_new: y_new
+│           │ render fk_lookup_crdb_region: fk_lookup_crdb_region
+│           │
+│           └── • render
+│               │ columns: (fk_lookup_crdb_region, x, y, crdb_region, rowid, y_new)
+│               │ render fk_lookup_crdb_region: CASE WHEN crdb_region IS NOT DISTINCT FROM CAST(NULL AS public.crdb_internal_region) THEN crdb_region ELSE crdb_region END
+│               │ render x: x
+│               │ render y: y
+│               │ render crdb_region: crdb_region
+│               │ render rowid: rowid
+│               │ render y_new: y_new
+│               │
+│               └── • lookup join (left outer)
+│                   │ columns: (y_new, x, y, crdb_region, rowid, x, y, crdb_region)
+│                   │ estimated row count: 10 (missing stats)
+│                   │ table: parent_unique_nullable@parent_unique_nullable_x_y_key
+│                   │ equality cols are key
+│                   │ lookup condition: ((crdb_region = 'ap-southeast-2') AND (x = x)) AND (y_new = y)
+│                   │ remote lookup condition: ((crdb_region IN ('ca-central-1', 'us-east-1')) AND (x = x)) AND (y_new = y)
+│                   │ locking strength: for share
+│                   │ locking durability: guaranteed
+│                   │ parallel
+│                   │
+│                   └── • render
+│                       │ columns: (y_new, x, y, crdb_region, rowid)
+│                       │ render y_new: x * 10
+│                       │ render x: x
+│                       │ render y: y
+│                       │ render crdb_region: crdb_region
+│                       │ render rowid: rowid
+│                       │
+│                       └── • filter
+│                           │ columns: (x, y, crdb_region, rowid)
+│                           │ estimated row count: 10 (missing stats)
+│                           │ filter: y IS NULL
+│                           │
+│                           └── • scan
+│                                 columns: (x, y, crdb_region, rowid)
+│                                 estimated row count: 1,000 (missing stats)
+│                                 table: child@child_pkey
+│                                 spans: FULL SCAN
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │ columns: ()
+        │
+        └── • lookup join (anti)
+            │ columns: (fk_lookup_crdb_region, x, y_new)
+            │ estimated row count: 0 (missing stats)
+            │ table: parent_unique_nullable@parent_unique_nullable_x_y_key
+            │ equality: (fk_lookup_crdb_region, x, y_new) = (crdb_region, x, y)
+            │ equality cols are key
+            │ locking strength: for share
+            │ locking durability: guaranteed
+            │ parallel
+            │
+            └── • filter
+                │ columns: (fk_lookup_crdb_region, x, y_new)
+                │ estimated row count: 10 (missing stats)
+                │ filter: (x IS NOT NULL) AND (y_new IS NOT NULL)
+                │
+                └── • project
+                    │ columns: (fk_lookup_crdb_region, x, y_new)
+                    │
+                    └── • scan buffer
+                          columns: (x, y, crdb_region, rowid, y_new, fk_lookup_crdb_region, check1)
+                          estimated row count: 10 (missing stats)
+                          label: buffer 1
+
+statement ok
+UPDATE child SET y = x * 10 WHERE y IS NULL
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+COMMIT;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+DROP FUNCTION display_child;
+
+statement ok
+DROP TABLE child;
+
+subtest end
+
+# ==============================================================================
+# Show interaction with routines.
+# ==============================================================================
+
+subtest rbr_routines
+
+statement ok
+CREATE TABLE child (
+  x INT,
+  y INT,
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent_unique_nullable (crdb_region, x, y)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+
+# Create a function that inserts a row into the child table.
+statement ok
+CREATE FUNCTION insert_child(x INT, y INT) RETURNS VOID AS $$
+  INSERT INTO child (x, y) VALUES ($1, $2);
+$$ LANGUAGE SQL;
+
+# Create a function that updates a row in the child table.
+statement ok
+CREATE FUNCTION update_child(x INT, y INT) RETURNS VOID AS $$
+  UPDATE child SET y = $2 WHERE x = $1;
+$$ LANGUAGE SQL;
+
+statement ok
+CREATE FUNCTION display_child() RETURNS TABLE (
+  x INT,
+  y INT,
+  child_region crdb_internal_region,
+  parent_region crdb_internal_region
+) AS $$
+  SELECT c.x, c.y, c.crdb_region, p.crdb_region
+  FROM child c LEFT JOIN parent_unique_nullable p ON c.x = p.x AND c.y = p.y;
+$$ LANGUAGE SQL STABLE;
+
+statement ok
+SELECT insert_child(a, b) FROM (
+  VALUES (1, NULL), (2, 20), (3, 30), (4, 40), (5, 50), (NULL, 60), (NULL, NULL), (NULL, NULL)
+) AS t(a, b);
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     NULL  ap-southeast-2  NULL
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+SELECT update_child(x, x * 10) FROM child WHERE y IS NULL;
+
+query IITT colnames
+SELECT * FROM display_child() ORDER BY x, y, child_region
+----
+x     y     child_region    parent_region
+NULL  NULL  ap-southeast-2  NULL
+NULL  NULL  ap-southeast-2  NULL
+NULL  60    ap-southeast-2  NULL
+1     10    ca-central-1    ca-central-1
+2     20    ap-southeast-2  ap-southeast-2
+3     30    us-east-1       us-east-1
+4     40    ca-central-1    ca-central-1
+5     50    ap-southeast-2  ap-southeast-2
+
+statement ok
+DROP FUNCTION insert_child;
+DROP FUNCTION update_child;
+DROP FUNCTION display_child;
 DROP TABLE child;
 
 subtest end

--- a/pkg/sql/opt/cat/table.go
+++ b/pkg/sql/opt/cat/table.go
@@ -171,6 +171,13 @@ type Table interface {
 	// different name in a `REGIONAL BY ROW AS` DDL clause.
 	HomeRegionColName() (colName string, ok bool)
 
+	// RegionalByRowUsingConstraint returns the foreign-key constraint that is
+	// used to look up the region for each row in a REGIONAL BY ROW table.
+	// This is only set if the infer_rbr_region_col_using_constraint storage param
+	// is set. If the storage param is not set, or if the table is not
+	// REGIONAL BY ROW, RegionalByRowUsingConstraint returns nil.
+	RegionalByRowUsingConstraint() ForeignKeyConstraint
+
 	// GetDatabaseID returns the owning database id of the table, or zero, if the
 	// owning database could not be determined.
 	GetDatabaseID() descpb.ID

--- a/pkg/sql/opt/exec/explain/plan_gist_factory.go
+++ b/pkg/sql/opt/exec/explain/plan_gist_factory.go
@@ -646,6 +646,11 @@ func (u *unknownTable) HomeRegionColName() (colName string, ok bool) {
 	return "", false
 }
 
+// RegionalByRowUsingConstraint is part of the cat.Table interface.
+func (ot *unknownTable) RegionalByRowUsingConstraint() cat.ForeignKeyConstraint {
+	return nil
+}
+
 // GetDatabaseID is part of the cat.Table interface.
 func (u *unknownTable) GetDatabaseID() descpb.ID {
 	return 0

--- a/pkg/sql/opt/optbuilder/testdata/region_lookup
+++ b/pkg/sql/opt/optbuilder/testdata/region_lookup
@@ -1,0 +1,1677 @@
+# --------------------------------------------------
+# Test region column lookup feature for RBR tables.
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE parent (
+  a INT,
+  b INT,
+  c INT,
+  UNIQUE (a, b)
+) LOCALITY REGIONAL BY ROW;
+----
+
+exec-ddl
+CREATE TABLE child (
+  x INT,
+  y INT,
+  z INT,
+  UNIQUE (z),
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent (crdb_region, a, b)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+----
+
+exec-ddl
+CREATE TABLE child_computed (
+  x INT,
+  y INT AS (x + 1) VIRTUAL,
+  z INT,
+  UNIQUE (z),
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent (crdb_region, a, b)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+----
+
+exec-ddl
+CREATE TABLE child_trigger (
+  x INT,
+  y INT,
+  z INT,
+  UNIQUE (z),
+  CONSTRAINT foo FOREIGN KEY (crdb_region, x, y) REFERENCES parent (crdb_region, a, b)
+) WITH (infer_rbr_region_col_using_constraint = 'foo') LOCALITY REGIONAL BY ROW;
+----
+
+exec-ddl
+CREATE FUNCTION f() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RETURN COALESCE(NEW, OLD);
+  END
+$$;
+----
+
+exec-ddl
+CREATE TRIGGER tr_before BEFORE INSERT OR UPDATE ON child_trigger FOR EACH ROW EXECUTE FUNCTION f();
+----
+
+opt locality=(region=east) format=(hide-all,show-columns)
+INSERT INTO child VALUES (1, 2, 3);
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:20 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── check columns: check1:21
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:21 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 fk_lookup_crdb_region:20
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:20 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    ├── left-join (cross)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 a:13 b:14 parent.crdb_region:16
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    ├── locality-optimized-search
+ │    │    │    │    ├── columns: a:13 b:14 parent.crdb_region:16
+ │    │    │    │    ├── left columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    ├── right columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │    ├── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │    │    ├── columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    │    ├── constraint: /59/56/57: [/'east'/1/2 - /'east'/1/2]
+ │    │    │    │    │    └── flags: avoid-full-scan
+ │    │    │    │    └── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │         ├── columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │         ├── constraint: /66/63/64
+ │    │    │    │         │    ├── [/'central'/1/2 - /'central'/1/2]
+ │    │    │    │         │    └── [/'west'/1/2 - /'west'/1/2]
+ │    │    │    │         └── flags: avoid-full-scan
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:16 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:16 END [as=fk_lookup_crdb_region:20]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:20 IN ('central', 'east', 'west') [as=check1:21]
+ ├── unique-checks
+ │    ├── unique-checks-item: child(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:33
+ │    │         └── semi-join (lookup child)
+ │    │              ├── columns: crdb_region:32 rowid:33
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child.crdb_region:25 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:33 = child.rowid:26
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:32 rowid:33
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:20 => crdb_region:32
+ │    │              │         └──  rowid_default:12 => rowid:33
+ │    │              └── filters
+ │    │                   └── crdb_region:32 != child.crdb_region:25
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:43
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:43 crdb_region:44 rowid:45
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:37 IN ('central', 'east', 'west')
+ │                   │         └── z:43 = child.z:36
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:43 crdb_region:44 rowid:45
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:43
+ │                   │         ├──  fk_lookup_crdb_region:20 => crdb_region:44
+ │                   │         └──  rowid_default:12 => rowid:45
+ │                   └── filters
+ │                        └── (crdb_region:44 != child.crdb_region:37) OR (rowid:45 != child.rowid:38)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:46 x:47 y:48
+                ├── key columns: [46 47 48] = [52 49 50]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:46 x:47 y:48
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:20 => crdb_region:46
+                │         ├──  column1:8 => x:47
+                │         └──  column2:9 => y:48
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPSERT INTO child VALUES (1, 2, 3);
+----
+upsert child
+ ├── arbiter constraints: unique_rowid
+ ├── columns: <none>
+ ├── canary column: child.crdb_region:16
+ ├── fetch columns: child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:27 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── update-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    └── fk_lookup_crdb_region:27 => child.crdb_region:4
+ ├── check columns: check1:29
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:29 column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17 fk_lookup_crdb_region:27 upsert_rowid:28
+ │    ├── project
+ │    │    ├── columns: upsert_rowid:28 fk_lookup_crdb_region:27 column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17 a:20 b:21 parent.crdb_region:23
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:23 = 'east'
+ │    │    │    │         ├── column1:8 = a:20
+ │    │    │    │         └── column2:9 = b:21
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:23 IN ('central', 'west')
+ │    │    │    │         ├── column1:8 = a:20
+ │    │    │    │         └── column2:9 = b:21
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── left-join (lookup child)
+ │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    │    │    ├── lookup expression
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         ├── child.crdb_region:16 = 'east'
+ │    │    │    │    │         └── rowid_default:12 = child.rowid:17
+ │    │    │    │    ├── remote lookup expression
+ │    │    │    │    │    └── filters
+ │    │    │    │    │         ├── child.crdb_region:16 IN ('central', 'west')
+ │    │    │    │    │         └── rowid_default:12 = child.rowid:17
+ │    │    │    │    ├── lookup columns are key
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    │    └── filters (true)
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         ├── CASE WHEN child.crdb_region:16 IS NULL THEN rowid_default:12 ELSE child.rowid:17 END [as=upsert_rowid:28]
+ │    │         └── CASE WHEN parent.crdb_region:23 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:23 END [as=fk_lookup_crdb_region:27]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:27 IN ('central', 'east', 'west') [as=check1:29]
+ ├── unique-checks
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:39
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:39 crdb_region:40 rowid:41
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:33 IN ('central', 'east', 'west')
+ │                   │         └── z:39 = child.z:32
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:39 crdb_region:40 rowid:41
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:39
+ │                   │         ├──  fk_lookup_crdb_region:27 => crdb_region:40
+ │                   │         └──  upsert_rowid:28 => rowid:41
+ │                   └── filters
+ │                        └── (crdb_region:40 != child.crdb_region:33) OR (rowid:41 != child.rowid:34)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:42 x:43 y:44
+                ├── key columns: [42 43 44] = [48 45 46]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:42 x:43 y:44
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:27 => crdb_region:42
+                │         ├──  column1:8 => x:43
+                │         └──  column2:9 => y:44
+                └── filters (true)
+
+# Note that the lookup happens after the DO NOTHING anti-join.
+opt locality=(region=east) format=(hide-all,show-columns)
+INSERT INTO child VALUES (1, 2, 3) ON CONFLICT (z) DO NOTHING;
+----
+insert child
+ ├── arbiter constraints: unique_z
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:27 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── check columns: check1:28
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:28 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 fk_lookup_crdb_region:27
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:27 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 a:20 b:21 parent.crdb_region:23
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:23 = 'east'
+ │    │    │    │         ├── column1:8 = a:20
+ │    │    │    │         └── column2:9 = b:21
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:23 IN ('central', 'west')
+ │    │    │    │         ├── column1:8 = a:20
+ │    │    │    │         └── column2:9 = b:21
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── anti-join (cross)
+ │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    ├── values
+ │    │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    │    ├── locality-optimized-search
+ │    │    │    │    │    ├── columns: child.z:15
+ │    │    │    │    │    ├── left columns: child.z:53
+ │    │    │    │    │    ├── right columns: child.z:60
+ │    │    │    │    │    ├── scan child@child_crdb_region_z_key
+ │    │    │    │    │    │    ├── columns: child.z:53
+ │    │    │    │    │    │    ├── constraint: /54/53: [/'east'/3 - /'east'/3]
+ │    │    │    │    │    │    └── flags: avoid-full-scan
+ │    │    │    │    │    └── scan child@child_crdb_region_z_key
+ │    │    │    │    │         ├── columns: child.z:60
+ │    │    │    │    │         ├── constraint: /61/60
+ │    │    │    │    │         │    ├── [/'central'/3 - /'central'/3]
+ │    │    │    │    │         │    └── [/'west'/3 - /'west'/3]
+ │    │    │    │    │         └── flags: avoid-full-scan
+ │    │    │    │    └── filters (true)
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:23 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:23 END [as=fk_lookup_crdb_region:27]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:27 IN ('central', 'east', 'west') [as=check1:28]
+ ├── unique-checks
+ │    └── unique-checks-item: child(rowid)
+ │         └── project
+ │              ├── columns: rowid:40
+ │              └── semi-join (lookup child)
+ │                   ├── columns: crdb_region:39 rowid:40
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:32 IN ('central', 'east', 'west')
+ │                   │         └── rowid:40 = child.rowid:33
+ │                   ├── with-scan &1
+ │                   │    ├── columns: crdb_region:39 rowid:40
+ │                   │    └── mapping:
+ │                   │         ├──  fk_lookup_crdb_region:27 => crdb_region:39
+ │                   │         └──  rowid_default:12 => rowid:40
+ │                   └── filters
+ │                        └── crdb_region:39 != child.crdb_region:32
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:41 x:42 y:43
+                ├── key columns: [41 42 43] = [47 44 45]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:41 x:42 y:43
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:27 => crdb_region:41
+                │         ├──  column1:8 => x:42
+                │         └──  column2:9 => y:43
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+INSERT INTO child VALUES (1, 2, 3) ON CONFLICT (z) DO UPDATE SET z = 4, x = EXCLUDED.x + EXCLUDED.y, y = EXCLUDED.y + 1;
+----
+upsert child
+ ├── arbiter constraints: unique_z
+ ├── columns: <none>
+ ├── canary column: child.crdb_region:16
+ ├── fetch columns: child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:30 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── update-mapping:
+ │    ├── upsert_x:31 => child.x:1
+ │    ├── upsert_y:32 => child.y:2
+ │    ├── upsert_z:33 => child.z:3
+ │    └── fk_lookup_crdb_region:30 => child.crdb_region:4
+ ├── check columns: check1:35
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:35 column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17 fk_lookup_crdb_region:30 upsert_x:31 upsert_y:32 upsert_z:33 upsert_rowid:34
+ │    ├── project
+ │    │    ├── columns: upsert_x:31 upsert_y:32 upsert_z:33 upsert_rowid:34 fk_lookup_crdb_region:30 column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17 z_new:20 x_new:21 y_new:22 a:23 b:24 parent.crdb_region:26
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:26 = 'east'
+ │    │    │    │         ├── x_new:21 = a:23
+ │    │    │    │         └── y_new:22 = b:24
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:26 IN ('central', 'west')
+ │    │    │    │         ├── x_new:21 = a:23
+ │    │    │    │         └── y_new:22 = b:24
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: z_new:20 x_new:21 y_new:22 column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    │    │    ├── left-join (cross)
+ │    │    │    │    │    ├── columns: column1:8 column2:9 column3:10 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    │    │    │    ├── values
+ │    │    │    │    │    │    ├── columns: column1:8 column2:9 column3:10 rowid_default:12
+ │    │    │    │    │    │    └── (1, 2, 3, unique_rowid())
+ │    │    │    │    │    ├── index-join child
+ │    │    │    │    │    │    ├── columns: child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    │    │    │    │    └── locality-optimized-search
+ │    │    │    │    │    │         ├── columns: child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    │    │    │    │         ├── left columns: child.z:72 child.crdb_region:73 child.rowid:74
+ │    │    │    │    │    │         ├── right columns: child.z:79 child.crdb_region:80 child.rowid:81
+ │    │    │    │    │    │         ├── scan child@child_crdb_region_z_key
+ │    │    │    │    │    │         │    ├── columns: child.z:72 child.crdb_region:73 child.rowid:74
+ │    │    │    │    │    │         │    ├── constraint: /73/72: [/'east'/3 - /'east'/3]
+ │    │    │    │    │    │         │    └── flags: avoid-full-scan
+ │    │    │    │    │    │         └── scan child@child_crdb_region_z_key
+ │    │    │    │    │    │              ├── columns: child.z:79 child.crdb_region:80 child.rowid:81
+ │    │    │    │    │    │              ├── constraint: /80/79
+ │    │    │    │    │    │              │    ├── [/'central'/3 - /'central'/3]
+ │    │    │    │    │    │              │    └── [/'west'/3 - /'west'/3]
+ │    │    │    │    │    │              └── flags: avoid-full-scan
+ │    │    │    │    │    └── filters (true)
+ │    │    │    │    └── projections
+ │    │    │    │         ├── 4 [as=z_new:20]
+ │    │    │    │         ├── column1:8 + column2:9 [as=x_new:21]
+ │    │    │    │         └── column2:9 + 1 [as=y_new:22]
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         ├── CASE WHEN child.crdb_region:16 IS NULL THEN column1:8 ELSE x_new:21 END [as=upsert_x:31]
+ │    │         ├── CASE WHEN child.crdb_region:16 IS NULL THEN column2:9 ELSE y_new:22 END [as=upsert_y:32]
+ │    │         ├── CASE WHEN child.crdb_region:16 IS NULL THEN column3:10 ELSE z_new:20 END [as=upsert_z:33]
+ │    │         ├── CASE WHEN child.crdb_region:16 IS NULL THEN rowid_default:12 ELSE child.rowid:17 END [as=upsert_rowid:34]
+ │    │         └── CASE WHEN parent.crdb_region:26 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN child.crdb_region:16 ELSE parent.crdb_region:26 END [as=fk_lookup_crdb_region:30]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:30 IN ('central', 'east', 'west') [as=check1:35]
+ ├── unique-checks
+ │    ├── unique-checks-item: child(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:47
+ │    │         └── semi-join (lookup child)
+ │    │              ├── columns: crdb_region:46 rowid:47
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child.crdb_region:39 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:47 = child.rowid:40
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:46 rowid:47
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:30 => crdb_region:46
+ │    │              │         └──  upsert_rowid:34 => rowid:47
+ │    │              └── filters
+ │    │                   └── crdb_region:46 != child.crdb_region:39
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:57
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:57 crdb_region:58 rowid:59
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:51 IN ('central', 'east', 'west')
+ │                   │         └── z:57 = child.z:50
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:57 crdb_region:58 rowid:59
+ │                   │    └── mapping:
+ │                   │         ├──  upsert_z:33 => z:57
+ │                   │         ├──  fk_lookup_crdb_region:30 => crdb_region:58
+ │                   │         └──  upsert_rowid:34 => rowid:59
+ │                   └── filters
+ │                        └── (crdb_region:58 != child.crdb_region:51) OR (rowid:59 != child.rowid:52)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:60 x:61 y:62
+                ├── key columns: [60 61 62] = [66 63 64]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:60 x:61 y:62
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:30 => crdb_region:60
+                │         ├──  upsert_x:31 => x:61
+                │         └──  upsert_y:32 => y:62
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPDATE child SET z = 4, x = x + y, y = y + 1 WHERE x = 1 AND y = 2;
+----
+distribute
+ └── update child
+      ├── columns: <none>
+      ├── fetch columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      ├── update-mapping:
+      │    ├── x_new:16 => child.x:1
+      │    ├── y_new:17 => child.y:2
+      │    ├── z_new:15 => child.z:3
+      │    └── fk_lookup_crdb_region:25 => child.crdb_region:4
+      ├── check columns: check1:26
+      ├── input binding: &1
+      ├── project
+      │    ├── columns: check1:26 child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12 z_new:15 x_new:16 y_new:17 fk_lookup_crdb_region:25
+      │    ├── project
+      │    │    ├── columns: fk_lookup_crdb_region:25 child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12 z_new:15 x_new:16 y_new:17
+      │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+      │    │    │    ├── columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12 z_new:15 x_new:16 y_new:17 a:18 b:19 parent.crdb_region:21
+      │    │    │    ├── lookup expression
+      │    │    │    │    └── filters
+      │    │    │    │         ├── parent.crdb_region:21 = 'east'
+      │    │    │    │         ├── x_new:16 = a:18
+      │    │    │    │         └── y_new:17 = b:19
+      │    │    │    ├── remote lookup expression
+      │    │    │    │    └── filters
+      │    │    │    │         ├── parent.crdb_region:21 IN ('central', 'west')
+      │    │    │    │         ├── x_new:16 = a:18
+      │    │    │    │         └── y_new:17 = b:19
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: z_new:15 x_new:16 y_new:17 child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      │    │    │    │    ├── select
+      │    │    │    │    │    ├── columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      │    │    │    │    │    ├── scan child
+      │    │    │    │    │    │    ├── columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      │    │    │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    │    │    └── child.crdb_region:11 IN ('central', 'east', 'west')
+      │    │    │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    │    └── filters
+      │    │    │    │    │         ├── child.x:8 = 1
+      │    │    │    │    │         └── child.y:9 = 2
+      │    │    │    │    └── projections
+      │    │    │    │         ├── 4 [as=z_new:15]
+      │    │    │    │         ├── child.x:8 + child.y:9 [as=x_new:16]
+      │    │    │    │         └── child.y:9 + 1 [as=y_new:17]
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── CASE WHEN parent.crdb_region:21 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN child.crdb_region:11 ELSE parent.crdb_region:21 END [as=fk_lookup_crdb_region:25]
+      │    └── projections
+      │         └── fk_lookup_crdb_region:25 IN ('central', 'east', 'west') [as=check1:26]
+      ├── unique-checks
+      │    └── unique-checks-item: child(z)
+      │         └── project
+      │              ├── columns: z:36
+      │              └── semi-join (lookup child@child_crdb_region_z_key)
+      │                   ├── columns: z:36 crdb_region:37 rowid:38
+      │                   ├── lookup expression
+      │                   │    └── filters
+      │                   │         ├── child.crdb_region:30 IN ('central', 'east', 'west')
+      │                   │         └── z:36 = child.z:29
+      │                   ├── with-scan &1
+      │                   │    ├── columns: z:36 crdb_region:37 rowid:38
+      │                   │    └── mapping:
+      │                   │         ├──  z_new:15 => z:36
+      │                   │         ├──  fk_lookup_crdb_region:25 => crdb_region:37
+      │                   │         └──  child.rowid:12 => rowid:38
+      │                   └── filters
+      │                        └── (crdb_region:37 != child.crdb_region:30) OR (rowid:38 != child.rowid:31)
+      └── f-k-checks
+           └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+                └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                     ├── columns: crdb_region:39 x:40 y:41
+                     ├── key columns: [39 40 41] = [45 42 43]
+                     ├── lookup columns are key
+                     ├── with-scan &1
+                     │    ├── columns: crdb_region:39 x:40 y:41
+                     │    └── mapping:
+                     │         ├──  fk_lookup_crdb_region:25 => crdb_region:39
+                     │         ├──  x_new:16 => x:40
+                     │         └──  y_new:17 => y:41
+                     └── filters (true)
+
+# Case where the update does not mutate a FK column, in which case the lookup
+# is not needed.
+opt locality=(region=east) format=(hide-all,show-columns)
+UPDATE child SET z = 4 WHERE x = 1 AND y = 2;
+----
+distribute
+ └── update child
+      ├── columns: <none>
+      ├── fetch columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      ├── update-mapping:
+      │    └── z_new:15 => child.z:3
+      ├── input binding: &1
+      ├── project
+      │    ├── columns: z_new:15 child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      │    ├── select
+      │    │    ├── columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      │    │    ├── scan child
+      │    │    │    ├── columns: child.x:8 child.y:9 child.z:10 child.crdb_region:11 child.rowid:12
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    └── child.crdb_region:11 IN ('central', 'east', 'west')
+      │    │    │    └── flags: avoid-full-scan
+      │    │    └── filters
+      │    │         ├── child.x:8 = 1
+      │    │         └── child.y:9 = 2
+      │    └── projections
+      │         └── 4 [as=z_new:15]
+      └── unique-checks
+           └── unique-checks-item: child(z)
+                └── project
+                     ├── columns: z:26
+                     └── semi-join (lookup child@child_crdb_region_z_key)
+                          ├── columns: z:26 crdb_region:27 rowid:28
+                          ├── lookup expression
+                          │    └── filters
+                          │         ├── child.crdb_region:20 IN ('central', 'east', 'west')
+                          │         └── z:26 = child.z:19
+                          ├── with-scan &1
+                          │    ├── columns: z:26 crdb_region:27 rowid:28
+                          │    └── mapping:
+                          │         ├──  z_new:15 => z:26
+                          │         ├──  child.crdb_region:11 => crdb_region:27
+                          │         └──  child.rowid:12 => rowid:28
+                          └── filters
+                               └── (crdb_region:27 != child.crdb_region:20) OR (rowid:28 != child.rowid:21)
+
+# Case with a computed column in the FK.
+opt locality=(region=east) format=(hide-all,show-columns)
+INSERT INTO child_computed (x, z) VALUES (1, 200);
+----
+insert child_computed
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child_computed.x:1
+ │    ├── y_comp:12 => child_computed.y:2
+ │    ├── column2:9 => child_computed.z:3
+ │    ├── fk_lookup_crdb_region:20 => child_computed.crdb_region:4
+ │    └── rowid_default:11 => child_computed.rowid:5
+ ├── check columns: check1:21
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:21 column1:8 column2:9 crdb_region_default:10 rowid_default:11 y_comp:12 fk_lookup_crdb_region:20
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:20 column1:8 column2:9 crdb_region_default:10 rowid_default:11 y_comp:12
+ │    │    ├── left-join (cross)
+ │    │    │    ├── columns: column1:8 column2:9 crdb_region_default:10 rowid_default:11 y_comp:12 a:13 b:14 parent.crdb_region:16
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:8 column2:9 crdb_region_default:10 rowid_default:11 y_comp:12
+ │    │    │    │    └── (1, 200, default_to_database_primary_region('east'), unique_rowid(), 2)
+ │    │    │    ├── locality-optimized-search
+ │    │    │    │    ├── columns: a:13 b:14 parent.crdb_region:16
+ │    │    │    │    ├── left columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    ├── right columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │    ├── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │    │    ├── columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    │    ├── constraint: /59/56/57: [/'east'/1/2 - /'east'/1/2]
+ │    │    │    │    │    └── flags: avoid-full-scan
+ │    │    │    │    └── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │         ├── columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │         ├── constraint: /66/63/64
+ │    │    │    │         │    ├── [/'central'/1/2 - /'central'/1/2]
+ │    │    │    │         │    └── [/'west'/1/2 - /'west'/1/2]
+ │    │    │    │         └── flags: avoid-full-scan
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:16 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:10 ELSE parent.crdb_region:16 END [as=fk_lookup_crdb_region:20]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:20 IN ('central', 'east', 'west') [as=check1:21]
+ ├── unique-checks
+ │    ├── unique-checks-item: child_computed(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:33
+ │    │         └── semi-join (lookup child_computed)
+ │    │              ├── columns: crdb_region:32 rowid:33
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child_computed.crdb_region:25 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:33 = child_computed.rowid:26
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:32 rowid:33
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:20 => crdb_region:32
+ │    │              │         └──  rowid_default:11 => rowid:33
+ │    │              └── filters
+ │    │                   └── crdb_region:32 != child_computed.crdb_region:25
+ │    └── unique-checks-item: child_computed(z)
+ │         └── project
+ │              ├── columns: z:43
+ │              └── semi-join (lookup child_computed@child_computed_crdb_region_z_key)
+ │                   ├── columns: z:43 crdb_region:44 rowid:45
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child_computed.crdb_region:37 IN ('central', 'east', 'west')
+ │                   │         └── z:43 = child_computed.z:36
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:43 crdb_region:44 rowid:45
+ │                   │    └── mapping:
+ │                   │         ├──  column2:9 => z:43
+ │                   │         ├──  fk_lookup_crdb_region:20 => crdb_region:44
+ │                   │         └──  rowid_default:11 => rowid:45
+ │                   └── filters
+ │                        └── (crdb_region:44 != child_computed.crdb_region:37) OR (rowid:45 != child_computed.rowid:38)
+ └── f-k-checks
+      └── f-k-checks-item: child_computed(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:46 x:47 y:48
+                ├── key columns: [46 47 48] = [52 49 50]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:46 x:47 y:48
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:20 => crdb_region:46
+                │         ├──  column1:8 => x:47
+                │         └──  y_comp:12 => y:48
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPSERT INTO child_computed (x, z) VALUES (1, 200);
+----
+upsert child_computed
+ ├── arbiter constraints: unique_rowid
+ ├── columns: <none>
+ ├── canary column: child_computed.crdb_region:16
+ ├── fetch columns: child_computed.x:13 child_computed.y:14 child_computed.z:15 child_computed.crdb_region:16 child_computed.rowid:17
+ ├── insert-mapping:
+ │    ├── column1:8 => child_computed.x:1
+ │    ├── y_comp:12 => child_computed.y:2
+ │    ├── column2:9 => child_computed.z:3
+ │    ├── fk_lookup_crdb_region:27 => child_computed.crdb_region:4
+ │    └── rowid_default:11 => child_computed.rowid:5
+ ├── update-mapping:
+ │    ├── column1:8 => child_computed.x:1
+ │    ├── y_comp:12 => child_computed.y:2
+ │    ├── column2:9 => child_computed.z:3
+ │    └── fk_lookup_crdb_region:27 => child_computed.crdb_region:4
+ ├── check columns: check1:29
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:29 column1:8 column2:9 rowid_default:11 y_comp:12 child_computed.x:13 child_computed.y:14 child_computed.z:15 child_computed.crdb_region:16 child_computed.rowid:17 fk_lookup_crdb_region:27 upsert_rowid:28
+ │    ├── project
+ │    │    ├── columns: upsert_rowid:28 fk_lookup_crdb_region:27 column1:8 column2:9 rowid_default:11 y_comp:12 child_computed.x:13 child_computed.y:14 child_computed.z:15 child_computed.crdb_region:16 child_computed.rowid:17
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: column1:8 column2:9 rowid_default:11 y_comp:12 child_computed.x:13 child_computed.y:14 child_computed.z:15 child_computed.crdb_region:16 child_computed.rowid:17 a:20 b:21 parent.crdb_region:23
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:23 = 'east'
+ │    │    │    │         ├── column1:8 = a:20
+ │    │    │    │         └── y_comp:12 = b:21
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:23 IN ('central', 'west')
+ │    │    │    │         ├── column1:8 = a:20
+ │    │    │    │         └── y_comp:12 = b:21
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: child_computed.y:14 column1:8 column2:9 rowid_default:11 y_comp:12 child_computed.x:13 child_computed.z:15 child_computed.crdb_region:16 child_computed.rowid:17
+ │    │    │    │    ├── left-join (lookup child_computed)
+ │    │    │    │    │    ├── columns: column1:8 column2:9 rowid_default:11 y_comp:12 child_computed.x:13 child_computed.z:15 child_computed.crdb_region:16 child_computed.rowid:17
+ │    │    │    │    │    ├── lookup expression
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         ├── child_computed.crdb_region:16 = 'east'
+ │    │    │    │    │    │         └── rowid_default:11 = child_computed.rowid:17
+ │    │    │    │    │    ├── remote lookup expression
+ │    │    │    │    │    │    └── filters
+ │    │    │    │    │    │         ├── child_computed.crdb_region:16 IN ('central', 'west')
+ │    │    │    │    │    │         └── rowid_default:11 = child_computed.rowid:17
+ │    │    │    │    │    ├── lookup columns are key
+ │    │    │    │    │    ├── values
+ │    │    │    │    │    │    ├── columns: column1:8 column2:9 rowid_default:11 y_comp:12
+ │    │    │    │    │    │    └── (1, 200, unique_rowid(), 2)
+ │    │    │    │    │    └── filters (true)
+ │    │    │    │    └── projections
+ │    │    │    │         └── CASE child_computed.crdb_region:16 IS NULL WHEN true THEN CAST(NULL AS INT8) ELSE child_computed.x:13 + 1 END [as=child_computed.y:14]
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         ├── CASE WHEN child_computed.crdb_region:16 IS NULL THEN rowid_default:11 ELSE child_computed.rowid:17 END [as=upsert_rowid:28]
+ │    │         └── CASE WHEN parent.crdb_region:23 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN child_computed.crdb_region:16 ELSE parent.crdb_region:23 END [as=fk_lookup_crdb_region:27]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:27 IN ('central', 'east', 'west') [as=check1:29]
+ ├── unique-checks
+ │    └── unique-checks-item: child_computed(z)
+ │         └── project
+ │              ├── columns: z:39
+ │              └── semi-join (lookup child_computed@child_computed_crdb_region_z_key)
+ │                   ├── columns: z:39 crdb_region:40 rowid:41
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child_computed.crdb_region:33 IN ('central', 'east', 'west')
+ │                   │         └── z:39 = child_computed.z:32
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:39 crdb_region:40 rowid:41
+ │                   │    └── mapping:
+ │                   │         ├──  column2:9 => z:39
+ │                   │         ├──  fk_lookup_crdb_region:27 => crdb_region:40
+ │                   │         └──  upsert_rowid:28 => rowid:41
+ │                   └── filters
+ │                        └── (crdb_region:40 != child_computed.crdb_region:33) OR (rowid:41 != child_computed.rowid:34)
+ └── f-k-checks
+      └── f-k-checks-item: child_computed(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:42 x:43 y:44
+                ├── key columns: [42 43 44] = [48 45 46]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:42 x:43 y:44
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:27 => crdb_region:42
+                │         ├──  column1:8 => x:43
+                │         └──  y_comp:12 => y:44
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPDATE child_computed SET z = 4, x = x + y WHERE x = 1 AND y = 2;
+----
+distribute
+ └── update child_computed
+      ├── columns: <none>
+      ├── fetch columns: child_computed.x:8 child_computed.y:9 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12
+      ├── update-mapping:
+      │    ├── x_new:16 => child_computed.x:1
+      │    ├── y_comp:17 => child_computed.y:2
+      │    ├── z_new:15 => child_computed.z:3
+      │    └── fk_lookup_crdb_region:25 => child_computed.crdb_region:4
+      ├── check columns: check1:26
+      ├── input binding: &1
+      ├── project
+      │    ├── columns: check1:26 child_computed.x:8 child_computed.y:9 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12 z_new:15 x_new:16 y_comp:17 fk_lookup_crdb_region:25
+      │    ├── project
+      │    │    ├── columns: fk_lookup_crdb_region:25 child_computed.x:8 child_computed.y:9 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12 z_new:15 x_new:16 y_comp:17
+      │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+      │    │    │    ├── columns: child_computed.x:8 child_computed.y:9 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12 z_new:15 x_new:16 y_comp:17 a:18 b:19 parent.crdb_region:21
+      │    │    │    ├── lookup expression
+      │    │    │    │    └── filters
+      │    │    │    │         ├── parent.crdb_region:21 = 'east'
+      │    │    │    │         ├── x_new:16 = a:18
+      │    │    │    │         └── y_comp:17 = b:19
+      │    │    │    ├── remote lookup expression
+      │    │    │    │    └── filters
+      │    │    │    │         ├── parent.crdb_region:21 IN ('central', 'west')
+      │    │    │    │         ├── x_new:16 = a:18
+      │    │    │    │         └── y_comp:17 = b:19
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: y_comp:17 child_computed.x:8 child_computed.y:9 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12 z_new:15 x_new:16
+      │    │    │    │    ├── project
+      │    │    │    │    │    ├── columns: z_new:15 x_new:16 child_computed.x:8 child_computed.y:9 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: child_computed.y:9 child_computed.x:8 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12
+      │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    ├── columns: child_computed.x:8 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12
+      │    │    │    │    │    │    │    ├── scan child_computed
+      │    │    │    │    │    │    │    │    ├── columns: child_computed.x:8 child_computed.z:10 child_computed.crdb_region:11 child_computed.rowid:12
+      │    │    │    │    │    │    │    │    ├── check constraint expressions
+      │    │    │    │    │    │    │    │    │    └── child_computed.crdb_region:11 IN ('central', 'east', 'west')
+      │    │    │    │    │    │    │    │    ├── computed column expressions
+      │    │    │    │    │    │    │    │    │    └── child_computed.y:9
+      │    │    │    │    │    │    │    │    │         └── child_computed.x:8 + 1
+      │    │    │    │    │    │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │         └── child_computed.x:8 = 1
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── child_computed.x:8 + 1 [as=child_computed.y:9]
+      │    │    │    │    │    └── projections
+      │    │    │    │    │         ├── 4 [as=z_new:15]
+      │    │    │    │    │         └── child_computed.x:8 + child_computed.y:9 [as=x_new:16]
+      │    │    │    │    └── projections
+      │    │    │    │         └── x_new:16 + 1 [as=y_comp:17]
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── CASE WHEN parent.crdb_region:21 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN child_computed.crdb_region:11 ELSE parent.crdb_region:21 END [as=fk_lookup_crdb_region:25]
+      │    └── projections
+      │         └── fk_lookup_crdb_region:25 IN ('central', 'east', 'west') [as=check1:26]
+      ├── unique-checks
+      │    └── unique-checks-item: child_computed(z)
+      │         └── project
+      │              ├── columns: z:36
+      │              └── semi-join (lookup child_computed@child_computed_crdb_region_z_key)
+      │                   ├── columns: z:36 crdb_region:37 rowid:38
+      │                   ├── lookup expression
+      │                   │    └── filters
+      │                   │         ├── child_computed.crdb_region:30 IN ('central', 'east', 'west')
+      │                   │         └── z:36 = child_computed.z:29
+      │                   ├── with-scan &1
+      │                   │    ├── columns: z:36 crdb_region:37 rowid:38
+      │                   │    └── mapping:
+      │                   │         ├──  z_new:15 => z:36
+      │                   │         ├──  fk_lookup_crdb_region:25 => crdb_region:37
+      │                   │         └──  child_computed.rowid:12 => rowid:38
+      │                   └── filters
+      │                        └── (crdb_region:37 != child_computed.crdb_region:30) OR (rowid:38 != child_computed.rowid:31)
+      └── f-k-checks
+           └── f-k-checks-item: child_computed(crdb_region,x,y) -> parent(crdb_region,a,b)
+                └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                     ├── columns: crdb_region:39 x:40 y:41
+                     ├── key columns: [39 40 41] = [45 42 43]
+                     ├── lookup columns are key
+                     ├── with-scan &1
+                     │    ├── columns: crdb_region:39 x:40 y:41
+                     │    └── mapping:
+                     │         ├──  fk_lookup_crdb_region:25 => crdb_region:39
+                     │         ├──  x_new:16 => x:40
+                     │         └──  y_comp:17 => y:41
+                     └── filters (true)
+
+# Case with BEFORE trigger on the child table. The parent table lookup is
+# planned after any BEFORE triggers. 
+opt locality=(region=east) format=(hide-all,show-columns)
+INSERT INTO child_trigger VALUES (1, 2, 3);
+----
+insert child_trigger
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── x_new:28 => child_trigger.x:1
+ │    ├── y_new:29 => child_trigger.y:2
+ │    ├── z_new:30 => child_trigger.z:3
+ │    ├── fk_lookup_crdb_region:38 => child_trigger.crdb_region:4
+ │    └── rowid_default:12 => child_trigger.rowid:5
+ ├── check columns: check1:39
+ ├── before-triggers
+ │    └── tr_before
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:39 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13 f:27 x_new:28 y_new:29 z_new:30 fk_lookup_crdb_region:38
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:38 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13 f:27 x_new:28 y_new:29 z_new:30
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13 f:27 x_new:28 y_new:29 z_new:30 a:31 b:32 parent.crdb_region:34
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:34 = 'east'
+ │    │    │    │         ├── x_new:28 = a:31
+ │    │    │    │         └── y_new:29 = b:32
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:34 IN ('central', 'west')
+ │    │    │    │         ├── x_new:28 = a:31
+ │    │    │    │         └── y_new:29 = b:32
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: x_new:28 y_new:29 z_new:30 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13 f:27
+ │    │    │    │    ├── barrier
+ │    │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13 f:27
+ │    │    │    │    │    └── select
+ │    │    │    │    │         ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13 f:27
+ │    │    │    │    │         ├── project
+ │    │    │    │    │         │    ├── columns: f:27 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13
+ │    │    │    │    │         │    ├── barrier
+ │    │    │    │    │         │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13
+ │    │    │    │    │         │    │    └── values
+ │    │    │    │    │         │    │         ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 new:13
+ │    │    │    │    │         │    │         └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid(), ((1, 2, 3) AS x, y, z))
+ │    │    │    │    │         │    └── projections
+ │    │    │    │    │         │         └── f(new:13, NULL, 'tr_before', 'BEFORE', 'ROW', 'INSERT', 56, 'child_trigger', 'child_trigger', 'public', 0, ARRAY[]) [as=f:27]
+ │    │    │    │    │         └── filters
+ │    │    │    │    │              └── f:27 IS DISTINCT FROM NULL
+ │    │    │    │    └── projections
+ │    │    │    │         ├── (f:27).x [as=x_new:28]
+ │    │    │    │         ├── (f:27).y [as=y_new:29]
+ │    │    │    │         └── (f:27).z [as=z_new:30]
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:34 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:34 END [as=fk_lookup_crdb_region:38]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:38 IN ('central', 'east', 'west') [as=check1:39]
+ ├── unique-checks
+ │    ├── unique-checks-item: child_trigger(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:51
+ │    │         └── semi-join (lookup child_trigger)
+ │    │              ├── columns: crdb_region:50 rowid:51
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child_trigger.crdb_region:43 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:51 = child_trigger.rowid:44
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:50 rowid:51
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:38 => crdb_region:50
+ │    │              │         └──  rowid_default:12 => rowid:51
+ │    │              └── filters
+ │    │                   └── crdb_region:50 != child_trigger.crdb_region:43
+ │    └── unique-checks-item: child_trigger(z)
+ │         └── project
+ │              ├── columns: z:61
+ │              └── semi-join (lookup child_trigger@child_trigger_crdb_region_z_key)
+ │                   ├── columns: z:61 crdb_region:62 rowid:63
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child_trigger.crdb_region:55 IN ('central', 'east', 'west')
+ │                   │         └── z:61 = child_trigger.z:54
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:61 crdb_region:62 rowid:63
+ │                   │    └── mapping:
+ │                   │         ├──  z_new:30 => z:61
+ │                   │         ├──  fk_lookup_crdb_region:38 => crdb_region:62
+ │                   │         └──  rowid_default:12 => rowid:63
+ │                   └── filters
+ │                        └── (crdb_region:62 != child_trigger.crdb_region:55) OR (rowid:63 != child_trigger.rowid:56)
+ └── f-k-checks
+      └── f-k-checks-item: child_trigger(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:64 x:65 y:66
+                ├── key columns: [64 65 66] = [70 67 68]
+                ├── lookup columns are key
+                ├── select
+                │    ├── columns: crdb_region:64 x:65 y:66
+                │    ├── with-scan &1
+                │    │    ├── columns: crdb_region:64 x:65 y:66
+                │    │    └── mapping:
+                │    │         ├──  fk_lookup_crdb_region:38 => crdb_region:64
+                │    │         ├──  x_new:28 => x:65
+                │    │         └──  y_new:29 => y:66
+                │    └── filters
+                │         ├── x:65 IS NOT NULL
+                │         └── y:66 IS NOT NULL
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPSERT INTO child_trigger VALUES (1, 2, 3);
+----
+upsert child_trigger
+ ├── arbiter constraints: unique_rowid
+ ├── columns: <none>
+ ├── canary column: child_trigger.crdb_region:16
+ ├── fetch columns: child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17
+ ├── insert-mapping:
+ │    ├── x_new:35 => child_trigger.x:1
+ │    ├── y_new:36 => child_trigger.y:2
+ │    ├── z_new:37 => child_trigger.z:3
+ │    ├── fk_lookup_crdb_region:51 => child_trigger.crdb_region:4
+ │    └── rowid_default:12 => child_trigger.rowid:5
+ ├── update-mapping:
+ │    ├── upsert_x:52 => child_trigger.x:1
+ │    ├── upsert_y:53 => child_trigger.y:2
+ │    ├── upsert_z:54 => child_trigger.z:3
+ │    └── fk_lookup_crdb_region:51 => child_trigger.crdb_region:4
+ ├── check columns: check1:56
+ ├── before-triggers
+ │    └── tr_before
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:56 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 x_new:35 y_new:36 z_new:37 fk_lookup_crdb_region:51 upsert_x:52 upsert_y:53 upsert_z:54 upsert_rowid:55
+ │    ├── project
+ │    │    ├── columns: upsert_x:52 upsert_y:53 upsert_z:54 upsert_rowid:55 fk_lookup_crdb_region:51 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 x_new:35 y_new:36 z_new:37
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 x_new:35 y_new:36 z_new:37 x_new:41 y_new:42 z_new:43 a:44 b:45 parent.crdb_region:47
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:47 = 'east'
+ │    │    │    │         ├── x_new:41 = a:44
+ │    │    │    │         └── y_new:42 = b:45
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:47 IN ('central', 'west')
+ │    │    │    │         ├── x_new:41 = a:44
+ │    │    │    │         └── y_new:42 = b:45
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── project
+ │    │    │    │    ├── columns: x_new:41 y_new:42 z_new:43 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 x_new:35 y_new:36 z_new:37
+ │    │    │    │    ├── barrier
+ │    │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34 x_new:35 y_new:36 z_new:37 old:38 new:39 f:40
+ │    │    │    │    │    └── select
+ │    │    │    │    │         ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34 x_new:35 y_new:36 z_new:37 old:38 new:39 f:40
+ │    │    │    │    │         ├── project
+ │    │    │    │    │         │    ├── columns: f:40 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34 x_new:35 y_new:36 z_new:37 old:38 new:39
+ │    │    │    │    │         │    ├── barrier
+ │    │    │    │    │         │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34 x_new:35 y_new:36 z_new:37 old:38 new:39
+ │    │    │    │    │         │    │    └── project
+ │    │    │    │    │         │    │         ├── columns: new:39 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34 x_new:35 y_new:36 z_new:37 old:38
+ │    │    │    │    │         │    │         ├── project
+ │    │    │    │    │         │    │         │    ├── columns: old:38 x_new:35 y_new:36 z_new:37 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34
+ │    │    │    │    │         │    │         │    ├── barrier
+ │    │    │    │    │         │    │         │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34
+ │    │    │    │    │         │    │         │    │    └── select
+ │    │    │    │    │         │    │         │    │         ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20 f:34
+ │    │    │    │    │         │    │         │    │         ├── project
+ │    │    │    │    │         │    │         │    │         │    ├── columns: f:34 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20
+ │    │    │    │    │         │    │         │    │         │    ├── barrier
+ │    │    │    │    │         │    │         │    │         │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19 new:20
+ │    │    │    │    │         │    │         │    │         │    │    └── project
+ │    │    │    │    │         │    │         │    │         │    │         ├── columns: new:20 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19
+ │    │    │    │    │         │    │         │    │         │    │         ├── left-join (lookup child_trigger)
+ │    │    │    │    │         │    │         │    │         │    │         │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 child_trigger.x:13 child_trigger.y:14 child_trigger.z:15 child_trigger.crdb_region:16 child_trigger.rowid:17 child_trigger.crdb_internal_mvcc_timestamp:18 child_trigger.tableoid:19
+ │    │    │    │    │         │    │         │    │         │    │         │    ├── lookup expression
+ │    │    │    │    │         │    │         │    │         │    │         │    │    └── filters
+ │    │    │    │    │         │    │         │    │         │    │         │    │         ├── child_trigger.crdb_region:16 = 'east'
+ │    │    │    │    │         │    │         │    │         │    │         │    │         └── rowid_default:12 = child_trigger.rowid:17
+ │    │    │    │    │         │    │         │    │         │    │         │    ├── remote lookup expression
+ │    │    │    │    │         │    │         │    │         │    │         │    │    └── filters
+ │    │    │    │    │         │    │         │    │         │    │         │    │         ├── child_trigger.crdb_region:16 IN ('central', 'west')
+ │    │    │    │    │         │    │         │    │         │    │         │    │         └── rowid_default:12 = child_trigger.rowid:17
+ │    │    │    │    │         │    │         │    │         │    │         │    ├── lookup columns are key
+ │    │    │    │    │         │    │         │    │         │    │         │    ├── values
+ │    │    │    │    │         │    │         │    │         │    │         │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    │         │    │         │    │         │    │         │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    │    │         │    │         │    │         │    │         │    └── filters (true)
+ │    │    │    │    │         │    │         │    │         │    │         └── projections
+ │    │    │    │    │         │    │         │    │         │    │              └── ((column1:8, column2:9, column3:10) AS x, y, z) [as=new:20]
+ │    │    │    │    │         │    │         │    │         │    └── projections
+ │    │    │    │    │         │    │         │    │         │         └── f(new:20, NULL, 'tr_before', 'BEFORE', 'ROW', 'INSERT', 56, 'child_trigger', 'child_trigger', 'public', 0, ARRAY[]) [as=f:34]
+ │    │    │    │    │         │    │         │    │         └── filters
+ │    │    │    │    │         │    │         │    │              └── f:34 IS DISTINCT FROM NULL
+ │    │    │    │    │         │    │         │    └── projections
+ │    │    │    │    │         │    │         │         ├── ((child_trigger.x:13, child_trigger.y:14, child_trigger.z:15) AS x, y, z) [as=old:38]
+ │    │    │    │    │         │    │         │         ├── (f:34).x [as=x_new:35]
+ │    │    │    │    │         │    │         │         ├── (f:34).y [as=y_new:36]
+ │    │    │    │    │         │    │         │         └── (f:34).z [as=z_new:37]
+ │    │    │    │    │         │    │         └── projections
+ │    │    │    │    │         │    │              └── ((x_new:35, y_new:36, z_new:37) AS x, y, z) [as=new:39]
+ │    │    │    │    │         │    └── projections
+ │    │    │    │    │         │         └── CASE WHEN child_trigger.crdb_region:16 IS NOT NULL THEN f(new:39, old:38, 'tr_before', 'BEFORE', 'ROW', 'UPDATE', 56, 'child_trigger', 'child_trigger', 'public', 0, ARRAY[]) ELSE new:39 END [as=f:40]
+ │    │    │    │    │         └── filters
+ │    │    │    │    │              └── f:40 IS DISTINCT FROM NULL
+ │    │    │    │    └── projections
+ │    │    │    │         ├── (f:40).x [as=x_new:41]
+ │    │    │    │         ├── (f:40).y [as=y_new:42]
+ │    │    │    │         └── (f:40).z [as=z_new:43]
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         ├── CASE WHEN child_trigger.crdb_region:16 IS NULL THEN x_new:35 ELSE x_new:41 END [as=upsert_x:52]
+ │    │         ├── CASE WHEN child_trigger.crdb_region:16 IS NULL THEN y_new:36 ELSE y_new:42 END [as=upsert_y:53]
+ │    │         ├── CASE WHEN child_trigger.crdb_region:16 IS NULL THEN z_new:37 ELSE z_new:43 END [as=upsert_z:54]
+ │    │         ├── CASE WHEN child_trigger.crdb_region:16 IS NULL THEN rowid_default:12 ELSE child_trigger.rowid:17 END [as=upsert_rowid:55]
+ │    │         └── CASE WHEN parent.crdb_region:47 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:47 END [as=fk_lookup_crdb_region:51]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:51 IN ('central', 'east', 'west') [as=check1:56]
+ ├── unique-checks
+ │    └── unique-checks-item: child_trigger(z)
+ │         └── project
+ │              ├── columns: z:66
+ │              └── semi-join (lookup child_trigger@child_trigger_crdb_region_z_key)
+ │                   ├── columns: z:66 crdb_region:67 rowid:68
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child_trigger.crdb_region:60 IN ('central', 'east', 'west')
+ │                   │         └── z:66 = child_trigger.z:59
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:66 crdb_region:67 rowid:68
+ │                   │    └── mapping:
+ │                   │         ├──  upsert_z:54 => z:66
+ │                   │         ├──  fk_lookup_crdb_region:51 => crdb_region:67
+ │                   │         └──  upsert_rowid:55 => rowid:68
+ │                   └── filters
+ │                        └── (crdb_region:67 != child_trigger.crdb_region:60) OR (rowid:68 != child_trigger.rowid:61)
+ └── f-k-checks
+      └── f-k-checks-item: child_trigger(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:69 x:70 y:71
+                ├── key columns: [69 70 71] = [75 72 73]
+                ├── lookup columns are key
+                ├── select
+                │    ├── columns: crdb_region:69 x:70 y:71
+                │    ├── with-scan &1
+                │    │    ├── columns: crdb_region:69 x:70 y:71
+                │    │    └── mapping:
+                │    │         ├──  fk_lookup_crdb_region:51 => crdb_region:69
+                │    │         ├──  upsert_x:52 => x:70
+                │    │         └──  upsert_y:53 => y:71
+                │    └── filters
+                │         ├── x:70 IS NOT NULL
+                │         └── y:71 IS NOT NULL
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPDATE child_trigger SET z = 4, x = x + y, y = y + 1 WHERE x = 1 AND y = 2;
+----
+distribute
+ └── update child_trigger
+      ├── columns: <none>
+      ├── fetch columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12
+      ├── update-mapping:
+      │    ├── x_new:34 => child_trigger.x:1
+      │    ├── y_new:35 => child_trigger.y:2
+      │    ├── z_new:36 => child_trigger.z:3
+      │    └── fk_lookup_crdb_region:44 => child_trigger.crdb_region:4
+      ├── check columns: check1:45
+      ├── before-triggers
+      │    └── tr_before
+      ├── input binding: &1
+      ├── project
+      │    ├── columns: check1:45 child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 x_new:34 y_new:35 z_new:36 fk_lookup_crdb_region:44
+      │    ├── project
+      │    │    ├── columns: fk_lookup_crdb_region:44 child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 x_new:34 y_new:35 z_new:36
+      │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+      │    │    │    ├── columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 x_new:34 y_new:35 z_new:36 a:37 b:38 parent.crdb_region:40
+      │    │    │    ├── lookup expression
+      │    │    │    │    └── filters
+      │    │    │    │         ├── parent.crdb_region:40 = 'east'
+      │    │    │    │         ├── x_new:34 = a:37
+      │    │    │    │         └── y_new:35 = b:38
+      │    │    │    ├── remote lookup expression
+      │    │    │    │    └── filters
+      │    │    │    │         ├── parent.crdb_region:40 IN ('central', 'west')
+      │    │    │    │         ├── x_new:34 = a:37
+      │    │    │    │         └── y_new:35 = b:38
+      │    │    │    ├── lookup columns are key
+      │    │    │    ├── project
+      │    │    │    │    ├── columns: x_new:34 y_new:35 z_new:36 child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12
+      │    │    │    │    ├── barrier
+      │    │    │    │    │    ├── columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14 z_new:15 x_new:16 y_new:17 old:18 new:19 f:33
+      │    │    │    │    │    └── select
+      │    │    │    │    │         ├── columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14 z_new:15 x_new:16 y_new:17 old:18 new:19 f:33
+      │    │    │    │    │         ├── project
+      │    │    │    │    │         │    ├── columns: f:33 child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14 z_new:15 x_new:16 y_new:17 old:18 new:19
+      │    │    │    │    │         │    ├── barrier
+      │    │    │    │    │         │    │    ├── columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14 z_new:15 x_new:16 y_new:17 old:18 new:19
+      │    │    │    │    │         │    │    └── project
+      │    │    │    │    │         │    │         ├── columns: new:19 child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14 z_new:15 x_new:16 y_new:17 old:18
+      │    │    │    │    │         │    │         ├── project
+      │    │    │    │    │         │    │         │    ├── columns: old:18 z_new:15 x_new:16 y_new:17 child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14
+      │    │    │    │    │         │    │         │    ├── select
+      │    │    │    │    │         │    │         │    │    ├── columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14
+      │    │    │    │    │         │    │         │    │    ├── scan child_trigger
+      │    │    │    │    │         │    │         │    │    │    ├── columns: child_trigger.x:8 child_trigger.y:9 child_trigger.z:10 child_trigger.crdb_region:11 child_trigger.rowid:12 child_trigger.crdb_internal_mvcc_timestamp:13 child_trigger.tableoid:14
+      │    │    │    │    │         │    │         │    │    │    ├── check constraint expressions
+      │    │    │    │    │         │    │         │    │    │    │    └── child_trigger.crdb_region:11 IN ('central', 'east', 'west')
+      │    │    │    │    │         │    │         │    │    │    └── flags: avoid-full-scan
+      │    │    │    │    │         │    │         │    │    └── filters
+      │    │    │    │    │         │    │         │    │         ├── child_trigger.x:8 = 1
+      │    │    │    │    │         │    │         │    │         └── child_trigger.y:9 = 2
+      │    │    │    │    │         │    │         │    └── projections
+      │    │    │    │    │         │    │         │         ├── ((child_trigger.x:8, child_trigger.y:9, child_trigger.z:10) AS x, y, z) [as=old:18]
+      │    │    │    │    │         │    │         │         ├── 4 [as=z_new:15]
+      │    │    │    │    │         │    │         │         ├── child_trigger.x:8 + child_trigger.y:9 [as=x_new:16]
+      │    │    │    │    │         │    │         │         └── child_trigger.y:9 + 1 [as=y_new:17]
+      │    │    │    │    │         │    │         └── projections
+      │    │    │    │    │         │    │              └── ((x_new:16, y_new:17, 4) AS x, y, z) [as=new:19]
+      │    │    │    │    │         │    └── projections
+      │    │    │    │    │         │         └── f(new:19, old:18, 'tr_before', 'BEFORE', 'ROW', 'UPDATE', 56, 'child_trigger', 'child_trigger', 'public', 0, ARRAY[]) [as=f:33]
+      │    │    │    │    │         └── filters
+      │    │    │    │    │              └── f:33 IS DISTINCT FROM NULL
+      │    │    │    │    └── projections
+      │    │    │    │         ├── (f:33).x [as=x_new:34]
+      │    │    │    │         ├── (f:33).y [as=y_new:35]
+      │    │    │    │         └── (f:33).z [as=z_new:36]
+      │    │    │    └── filters (true)
+      │    │    └── projections
+      │    │         └── CASE WHEN parent.crdb_region:40 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN child_trigger.crdb_region:11 ELSE parent.crdb_region:40 END [as=fk_lookup_crdb_region:44]
+      │    └── projections
+      │         └── fk_lookup_crdb_region:44 IN ('central', 'east', 'west') [as=check1:45]
+      ├── unique-checks
+      │    └── unique-checks-item: child_trigger(z)
+      │         └── project
+      │              ├── columns: z:55
+      │              └── semi-join (lookup child_trigger@child_trigger_crdb_region_z_key)
+      │                   ├── columns: z:55 crdb_region:56 rowid:57
+      │                   ├── lookup expression
+      │                   │    └── filters
+      │                   │         ├── child_trigger.crdb_region:49 IN ('central', 'east', 'west')
+      │                   │         └── z:55 = child_trigger.z:48
+      │                   ├── with-scan &1
+      │                   │    ├── columns: z:55 crdb_region:56 rowid:57
+      │                   │    └── mapping:
+      │                   │         ├──  z_new:36 => z:55
+      │                   │         ├──  fk_lookup_crdb_region:44 => crdb_region:56
+      │                   │         └──  child_trigger.rowid:12 => rowid:57
+      │                   └── filters
+      │                        └── (crdb_region:56 != child_trigger.crdb_region:49) OR (rowid:57 != child_trigger.rowid:50)
+      └── f-k-checks
+           └── f-k-checks-item: child_trigger(crdb_region,x,y) -> parent(crdb_region,a,b)
+                └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                     ├── columns: crdb_region:58 x:59 y:60
+                     ├── key columns: [58 59 60] = [64 61 62]
+                     ├── lookup columns are key
+                     ├── select
+                     │    ├── columns: crdb_region:58 x:59 y:60
+                     │    ├── with-scan &1
+                     │    │    ├── columns: crdb_region:58 x:59 y:60
+                     │    │    └── mapping:
+                     │    │         ├──  fk_lookup_crdb_region:44 => crdb_region:58
+                     │    │         ├──  x_new:34 => x:59
+                     │    │         └──  y_new:35 => y:60
+                     │    └── filters
+                     │         ├── x:59 IS NOT NULL
+                     │         └── y:60 IS NOT NULL
+                     └── filters (true)
+
+# Setting prefer_lookup_joins_for_fks adds a lookup-join hint.
+opt locality=(region=east) set=prefer_lookup_joins_for_fks=true format=(hide-all,show-columns)
+INSERT INTO child VALUES (1, 2, 3);
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:20 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── check columns: check1:21
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:21 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 fk_lookup_crdb_region:20
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:20 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    ├── left-join (lookup parent@parent_crdb_region_a_b_key)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 a:13 b:14 parent.crdb_region:16
+ │    │    │    ├── flags: prefer lookup join (into right side)
+ │    │    │    ├── lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:16 = 'east'
+ │    │    │    │         ├── column1:8 = a:13
+ │    │    │    │         └── column2:9 = b:14
+ │    │    │    ├── remote lookup expression
+ │    │    │    │    └── filters
+ │    │    │    │         ├── parent.crdb_region:16 IN ('central', 'west')
+ │    │    │    │         ├── column1:8 = a:13
+ │    │    │    │         └── column2:9 = b:14
+ │    │    │    ├── lookup columns are key
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:16 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:16 END [as=fk_lookup_crdb_region:20]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:20 IN ('central', 'east', 'west') [as=check1:21]
+ ├── unique-checks
+ │    ├── unique-checks-item: child(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:33
+ │    │         └── semi-join (lookup child)
+ │    │              ├── columns: crdb_region:32 rowid:33
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child.crdb_region:25 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:33 = child.rowid:26
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:32 rowid:33
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:20 => crdb_region:32
+ │    │              │         └──  rowid_default:12 => rowid:33
+ │    │              └── filters
+ │    │                   └── crdb_region:32 != child.crdb_region:25
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:43
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:43 crdb_region:44 rowid:45
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:37 IN ('central', 'east', 'west')
+ │                   │         └── z:43 = child.z:36
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:43 crdb_region:44 rowid:45
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:43
+ │                   │         ├──  fk_lookup_crdb_region:20 => crdb_region:44
+ │                   │         └──  rowid_default:12 => rowid:45
+ │                   └── filters
+ │                        └── (crdb_region:44 != child.crdb_region:37) OR (rowid:45 != child.rowid:38)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:46 x:47 y:48
+                ├── flags: prefer lookup join (into right side)
+                ├── key columns: [46 47 48] = [52 49 50]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:46 x:47 y:48
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:20 => crdb_region:46
+                │         ├──  column1:8 => x:47
+                │         └──  column2:9 => y:48
+                └── filters (true)
+
+# Un-setting avoid_full_table_scans_in_mutations removes the flag from the scan.
+opt locality=(region=east) set=avoid_full_table_scans_in_mutations=false format=(hide-all,show-columns)
+INSERT INTO child (x, y, z) VALUES (1, 2, 3);
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:20 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── check columns: check1:21
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:21 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 fk_lookup_crdb_region:20
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:20 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    ├── left-join (cross)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 a:13 b:14 parent.crdb_region:16
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    ├── locality-optimized-search
+ │    │    │    │    ├── columns: a:13 b:14 parent.crdb_region:16
+ │    │    │    │    ├── left columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    ├── right columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │    ├── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │    │    ├── columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    │    └── constraint: /59/56/57: [/'east'/1/2 - /'east'/1/2]
+ │    │    │    │    └── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │         ├── columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │         └── constraint: /66/63/64
+ │    │    │    │              ├── [/'central'/1/2 - /'central'/1/2]
+ │    │    │    │              └── [/'west'/1/2 - /'west'/1/2]
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:16 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:16 END [as=fk_lookup_crdb_region:20]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:20 IN ('central', 'east', 'west') [as=check1:21]
+ ├── unique-checks
+ │    ├── unique-checks-item: child(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:33
+ │    │         └── semi-join (lookup child)
+ │    │              ├── columns: crdb_region:32 rowid:33
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child.crdb_region:25 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:33 = child.rowid:26
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:32 rowid:33
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:20 => crdb_region:32
+ │    │              │         └──  rowid_default:12 => rowid:33
+ │    │              └── filters
+ │    │                   └── crdb_region:32 != child.crdb_region:25
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:43
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:43 crdb_region:44 rowid:45
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:37 IN ('central', 'east', 'west')
+ │                   │         └── z:43 = child.z:36
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:43 crdb_region:44 rowid:45
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:43
+ │                   │         ├──  fk_lookup_crdb_region:20 => crdb_region:44
+ │                   │         └──  rowid_default:12 => rowid:45
+ │                   └── filters
+ │                        └── (crdb_region:44 != child.crdb_region:37) OR (rowid:45 != child.rowid:38)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:46 x:47 y:48
+                ├── key columns: [46 47 48] = [52 49 50]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:46 x:47 y:48
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:20 => crdb_region:46
+                │         ├──  column1:8 => x:47
+                │         └──  column2:9 => y:48
+                └── filters (true)
+
+# Setting enable_implicit_fk_locking_for_serializable causes the lookup to use
+# shared locking in serializable isolation.
+opt locality=(region=east) set=enable_implicit_fk_locking_for_serializable=true format=(hide-all,show-columns)
+INSERT INTO child (x, y, z) VALUES (1, 2, 3);
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── fk_lookup_crdb_region:20 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── check columns: check1:21
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:21 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 fk_lookup_crdb_region:20
+ │    ├── project
+ │    │    ├── columns: fk_lookup_crdb_region:20 column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    ├── left-join (cross)
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12 a:13 b:14 parent.crdb_region:16
+ │    │    │    ├── values
+ │    │    │    │    ├── columns: column1:8 column2:9 column3:10 crdb_region_default:11 rowid_default:12
+ │    │    │    │    └── (1, 2, 3, default_to_database_primary_region('east'), unique_rowid())
+ │    │    │    ├── locality-optimized-search
+ │    │    │    │    ├── columns: a:13 b:14 parent.crdb_region:16
+ │    │    │    │    ├── left columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    ├── right columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │    ├── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │    │    ├── columns: a:56 b:57 parent.crdb_region:59
+ │    │    │    │    │    ├── constraint: /59/56/57: [/'east'/1/2 - /'east'/1/2]
+ │    │    │    │    │    ├── flags: avoid-full-scan
+ │    │    │    │    │    └── locking: for-share
+ │    │    │    │    └── scan parent@parent_crdb_region_a_b_key
+ │    │    │    │         ├── columns: a:63 b:64 parent.crdb_region:66
+ │    │    │    │         ├── constraint: /66/63/64
+ │    │    │    │         │    ├── [/'central'/1/2 - /'central'/1/2]
+ │    │    │    │         │    └── [/'west'/1/2 - /'west'/1/2]
+ │    │    │    │         ├── flags: avoid-full-scan
+ │    │    │    │         └── locking: for-share
+ │    │    │    └── filters (true)
+ │    │    └── projections
+ │    │         └── CASE WHEN parent.crdb_region:16 IS NOT DISTINCT FROM CAST(NULL AS STRING) THEN crdb_region_default:11 ELSE parent.crdb_region:16 END [as=fk_lookup_crdb_region:20]
+ │    └── projections
+ │         └── fk_lookup_crdb_region:20 IN ('central', 'east', 'west') [as=check1:21]
+ ├── unique-checks
+ │    ├── unique-checks-item: child(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:33
+ │    │         └── semi-join (lookup child)
+ │    │              ├── columns: crdb_region:32 rowid:33
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child.crdb_region:25 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:33 = child.rowid:26
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:32 rowid:33
+ │    │              │    └── mapping:
+ │    │              │         ├──  fk_lookup_crdb_region:20 => crdb_region:32
+ │    │              │         └──  rowid_default:12 => rowid:33
+ │    │              └── filters
+ │    │                   └── crdb_region:32 != child.crdb_region:25
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:43
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:43 crdb_region:44 rowid:45
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:37 IN ('central', 'east', 'west')
+ │                   │         └── z:43 = child.z:36
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:43 crdb_region:44 rowid:45
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:43
+ │                   │         ├──  fk_lookup_crdb_region:20 => crdb_region:44
+ │                   │         └──  rowid_default:12 => rowid:45
+ │                   └── filters
+ │                        └── (crdb_region:44 != child.crdb_region:37) OR (rowid:45 != child.rowid:38)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:46 x:47 y:48
+                ├── key columns: [46 47 48] = [52 49 50]
+                ├── lookup columns are key
+                ├── locking: for-share
+                ├── with-scan &1
+                │    ├── columns: crdb_region:46 x:47 y:48
+                │    └── mapping:
+                │         ├──  fk_lookup_crdb_region:20 => crdb_region:46
+                │         ├──  column1:8 => x:47
+                │         └──  column2:9 => y:48
+                └── filters (true)
+
+# If the user explicitly specifies a value for the region column, no
+# parent-table lookup is performed.
+opt locality=(region=east) format=(hide-all,show-columns)
+INSERT INTO child (x, y, z, crdb_region) VALUES (1, 2, 3, 'central');
+----
+insert child
+ ├── columns: <none>
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── column4:11 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── check columns: check1:13
+ ├── input binding: &1
+ ├── values
+ │    ├── columns: column1:8 column2:9 column3:10 column4:11 rowid_default:12 check1:13
+ │    └── (1, 2, 3, 'central', unique_rowid(), true)
+ ├── unique-checks
+ │    ├── unique-checks-item: child(rowid)
+ │    │    └── project
+ │    │         ├── columns: rowid:25
+ │    │         └── semi-join (lookup child)
+ │    │              ├── columns: crdb_region:24 rowid:25
+ │    │              ├── lookup expression
+ │    │              │    └── filters
+ │    │              │         ├── child.crdb_region:17 IN ('central', 'east', 'west')
+ │    │              │         └── rowid:25 = child.rowid:18
+ │    │              ├── with-scan &1
+ │    │              │    ├── columns: crdb_region:24 rowid:25
+ │    │              │    └── mapping:
+ │    │              │         ├──  column4:11 => crdb_region:24
+ │    │              │         └──  rowid_default:12 => rowid:25
+ │    │              └── filters
+ │    │                   └── crdb_region:24 != child.crdb_region:17
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:35
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:35 crdb_region:36 rowid:37
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:29 IN ('central', 'east', 'west')
+ │                   │         └── z:35 = child.z:28
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:35 crdb_region:36 rowid:37
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:35
+ │                   │         ├──  column4:11 => crdb_region:36
+ │                   │         └──  rowid_default:12 => rowid:37
+ │                   └── filters
+ │                        └── (crdb_region:36 != child.crdb_region:29) OR (rowid:37 != child.rowid:30)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:38 x:39 y:40
+                ├── key columns: [38 39 40] = [44 41 42]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:38 x:39 y:40
+                │    └── mapping:
+                │         ├──  column4:11 => crdb_region:38
+                │         ├──  column1:8 => x:39
+                │         └──  column2:9 => y:40
+                └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPDATE child SET x = 4, crdb_region = 'central' WHERE x = 1 AND y = 2;
+----
+distribute
+ └── update child
+      ├── columns: <none>
+      ├── fetch columns: child.x:8 child.y:9 z:10 child.crdb_region:11 child.rowid:12
+      ├── update-mapping:
+      │    ├── x_new:15 => child.x:1
+      │    └── crdb_region_new:16 => child.crdb_region:4
+      ├── check columns: check1:17
+      ├── input binding: &1
+      ├── project
+      │    ├── columns: check1:17 x_new:15 crdb_region_new:16 child.x:8 child.y:9 z:10 child.crdb_region:11 child.rowid:12
+      │    ├── select
+      │    │    ├── columns: child.x:8 child.y:9 z:10 child.crdb_region:11 child.rowid:12
+      │    │    ├── scan child
+      │    │    │    ├── columns: child.x:8 child.y:9 z:10 child.crdb_region:11 child.rowid:12
+      │    │    │    ├── check constraint expressions
+      │    │    │    │    └── child.crdb_region:11 IN ('central', 'east', 'west')
+      │    │    │    └── flags: avoid-full-scan
+      │    │    └── filters
+      │    │         ├── child.x:8 = 1
+      │    │         └── child.y:9 = 2
+      │    └── projections
+      │         ├── true [as=check1:17]
+      │         ├── 4 [as=x_new:15]
+      │         └── 'central' [as=crdb_region_new:16]
+      └── f-k-checks
+           └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+                └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                     ├── columns: crdb_region:18 x:19 y:20
+                     ├── key columns: [18 19 20] = [24 21 22]
+                     ├── lookup columns are key
+                     ├── with-scan &1
+                     │    ├── columns: crdb_region:18 x:19 y:20
+                     │    └── mapping:
+                     │         ├──  crdb_region_new:16 => crdb_region:18
+                     │         ├──  x_new:15 => x:19
+                     │         └──  child.y:9 => y:20
+                     └── filters (true)
+
+opt locality=(region=east) format=(hide-all,show-columns)
+UPSERT INTO child (x, y, z, crdb_region) VALUES (1, 2, 3, 'central');
+----
+upsert child
+ ├── arbiter constraints: unique_rowid
+ ├── columns: <none>
+ ├── canary column: child.crdb_region:16
+ ├── fetch columns: child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ ├── insert-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    ├── column4:11 => child.crdb_region:4
+ │    └── rowid_default:12 => child.rowid:5
+ ├── update-mapping:
+ │    ├── column1:8 => child.x:1
+ │    ├── column2:9 => child.y:2
+ │    ├── column3:10 => child.z:3
+ │    └── column4:11 => child.crdb_region:4
+ ├── check columns: check1:21
+ ├── input binding: &1
+ ├── project
+ │    ├── columns: check1:21 upsert_rowid:20 column1:8 column2:9 column3:10 column4:11 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    ├── left-join (lookup child)
+ │    │    ├── columns: column1:8 column2:9 column3:10 column4:11 rowid_default:12 child.x:13 child.y:14 child.z:15 child.crdb_region:16 child.rowid:17
+ │    │    ├── lookup expression
+ │    │    │    └── filters
+ │    │    │         ├── child.crdb_region:16 = 'east'
+ │    │    │         └── rowid_default:12 = child.rowid:17
+ │    │    ├── remote lookup expression
+ │    │    │    └── filters
+ │    │    │         ├── child.crdb_region:16 IN ('central', 'west')
+ │    │    │         └── rowid_default:12 = child.rowid:17
+ │    │    ├── lookup columns are key
+ │    │    ├── values
+ │    │    │    ├── columns: column1:8 column2:9 column3:10 column4:11 rowid_default:12
+ │    │    │    └── (1, 2, 3, 'central', unique_rowid())
+ │    │    └── filters (true)
+ │    └── projections
+ │         ├── column4:11 IN ('central', 'east', 'west') [as=check1:21]
+ │         └── CASE WHEN child.crdb_region:16 IS NULL THEN rowid_default:12 ELSE child.rowid:17 END [as=upsert_rowid:20]
+ ├── unique-checks
+ │    └── unique-checks-item: child(z)
+ │         └── project
+ │              ├── columns: z:31
+ │              └── semi-join (lookup child@child_crdb_region_z_key)
+ │                   ├── columns: z:31 crdb_region:32 rowid:33
+ │                   ├── lookup expression
+ │                   │    └── filters
+ │                   │         ├── child.crdb_region:25 IN ('central', 'east', 'west')
+ │                   │         └── z:31 = child.z:24
+ │                   ├── with-scan &1
+ │                   │    ├── columns: z:31 crdb_region:32 rowid:33
+ │                   │    └── mapping:
+ │                   │         ├──  column3:10 => z:31
+ │                   │         ├──  column4:11 => crdb_region:32
+ │                   │         └──  upsert_rowid:20 => rowid:33
+ │                   └── filters
+ │                        └── (crdb_region:32 != child.crdb_region:25) OR (rowid:33 != child.rowid:26)
+ └── f-k-checks
+      └── f-k-checks-item: child(crdb_region,x,y) -> parent(crdb_region,a,b)
+           └── anti-join (lookup parent@parent_crdb_region_a_b_key)
+                ├── columns: crdb_region:34 x:35 y:36
+                ├── key columns: [34 35 36] = [40 37 38]
+                ├── lookup columns are key
+                ├── with-scan &1
+                │    ├── columns: crdb_region:34 x:35 y:36
+                │    └── mapping:
+                │         ├──  column4:11 => crdb_region:34
+                │         ├──  column1:8 => x:35
+                │         └──  column2:9 => y:36
+                └── filters (true)

--- a/pkg/sql/opt/optbuilder/update.go
+++ b/pkg/sql/opt/optbuilder/update.go
@@ -295,6 +295,10 @@ func (mb *mutationBuilder) addUpdateCols(exprs tree.UpdateExprs, colRefs *opt.Co
 	mb.b.constructProjectForScope(mb.outScope, projectionsScope)
 	mb.outScope = projectionsScope
 
+	// Track whether the region column is being explicitly updated. This is a
+	// no-op if the table isn't regional-by-row.
+	mb.setRegionColExplicitlyMutated(mb.updateColIDs)
+
 	// Add assignment casts for update columns.
 	mb.addAssignmentCasts(mb.updateColIDs)
 
@@ -348,6 +352,8 @@ func (mb *mutationBuilder) addSynthesizedColsForUpdate() {
 func (mb *mutationBuilder) buildUpdate(
 	returning *tree.ReturningExprs, policyScopeCmd cat.PolicyCommandScope, colRefs *opt.ColSet,
 ) {
+	mb.maybeAddRegionColLookup(opt.UpdateOp)
+
 	// Disambiguate names so that references in any expressions, such as a
 	// check constraint, refer to the correct columns.
 	mb.disambiguateColumns()

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -898,7 +898,8 @@ type Table struct {
 
 	multiRegion bool
 
-	implicitRBRIndexElem *tree.IndexElem
+	implicitRBRIndexElem         *tree.IndexElem
+	regionalByRowUsingConstraint cat.ForeignKeyConstraint
 
 	homeRegion string
 
@@ -1102,6 +1103,14 @@ func (tt *Table) HomeRegionColName() (colName string, ok bool) {
 		return "", false
 	}
 	return string(tree.RegionalByRowRegionDefaultColName), true
+}
+
+// RegionalByRowUsingConstraint is part of the cat.Table interface.
+func (tt *Table) RegionalByRowUsingConstraint() cat.ForeignKeyConstraint {
+	if !tt.IsRegionalByRow() {
+		return nil
+	}
+	return tt.regionalByRowUsingConstraint
 }
 
 // GetDatabaseID is part of the cat.Table interface.

--- a/pkg/sql/opt/testutils/testcat/types.go
+++ b/pkg/sql/opt/testutils/testcat/types.go
@@ -97,7 +97,12 @@ func (tc *Catalog) ResolveType(
 
 // ResolveTypeByOID is part of the cat.Catalog interface.
 func (tc *Catalog) ResolveTypeByOID(ctx context.Context, typID oid.Oid) (*types.T, error) {
-	// First look for a matching user-defined enum type.
+	// Look for a builtin type first.
+	if typ, ok := types.OidToType[typID]; ok {
+		return typ, nil
+	}
+
+	// Look for a matching user-defined enum type.
 	for _, typ := range tc.enumTypes {
 		if typ.Oid() == typID {
 			return typ, nil

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -7571,6 +7571,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 		},
 		stringOverload1(
 			func(ctx context.Context, evalCtx *eval.Context, s string) (tree.Datum, error) {
+				// Check for nil evalCtx.Regions, which can happen in tests.
+				if evalCtx.Regions == nil {
+					return nil, nilRegionsError
+				}
 				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(ctx)
 				if err != nil {
 					return nil, err
@@ -7604,6 +7608,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.String),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, arg tree.Datums) (tree.Datum, error) {
+				// Check for nil evalCtx.Regions, which can happen in tests.
+				if evalCtx.Regions == nil {
+					return nil, nilRegionsError
+				}
 				regionConfig, err := evalCtx.Regions.CurrentDatabaseRegionConfig(ctx)
 				if err != nil {
 					return nil, err
@@ -7643,6 +7651,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			Types:      tree.ParamTypes{},
 			ReturnType: tree.FixedReturnType(types.Bool),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
+				// Check for nil evalCtx.Regions, which can happen in tests.
+				if evalCtx.Regions == nil {
+					return nil, nilRegionsError
+				}
 				if err := evalCtx.Regions.ValidateAllMultiRegionZoneConfigsInCurrentDatabase(
 					ctx,
 				); err != nil {
@@ -7668,6 +7680,10 @@ the locality flag on node startup. Returns an error if no region is set.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := int64(*args[0].(*tree.DInt))
 
+				// Check for nil evalCtx.Regions, which can happen in tests.
+				if evalCtx.Regions == nil {
+					return nil, nilRegionsError
+				}
 				if err := evalCtx.Regions.ResetMultiRegionZoneConfigsForTable(
 					ctx,
 					id,
@@ -7694,6 +7710,10 @@ table.`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				id := int64(*args[0].(*tree.DInt))
 
+				// Check for nil evalCtx.Regions, which can happen in tests.
+				if evalCtx.Regions == nil {
+					return nil, nilRegionsError
+				}
 				if err := evalCtx.Regions.ResetMultiRegionZoneConfigsForDatabase(
 					ctx,
 					id,
@@ -12426,3 +12446,5 @@ func exprSliceToStrSlice(exprs []tree.Expr) []string {
 		return tree.AsStringWithFlags(expr, tree.FmtBareStrings)
 	})
 }
+
+var nilRegionsError = errors.AssertionFailedf("evalCtx.Regions is nil")


### PR DESCRIPTION
#### sql,builtins: add nil-check for functions that use evalCtx.Regions

The optimizer tests do not initialize the `evalCtx.Regions` field.
This could previously cause NPE when the optimizer attempted constant
folding for a function that uses the field. This commit hardens all
such builtin functions against NPE.

Epic: None

Release note: None

#### opt: add support for region column inference to catalog and test catalog

This commit adds support for the new storage param
`infer_rbr_region_col_using_constraint` to the optimizer and test catalogs.

Informs #148243

Release note: None

#### opt: implement region-column inference

This commit finishes the implementation for the new storage parameter
`infer_rbr_region_col_using_constraint`. If a foreign key constraint
is specified via that setting, the constraint will be used to plan
a lookup join into the parent table to retrieve the correct values for
the region column on INSERT, UPDATE, and UPSERT operations. This will
make it easier for customers to add the `crdb_region` column to their
foreign-key constraints, since they no longer have to guarantee that
an insert into the child table happens in the same region as the
matching parent row.

Fixes #148243

Release note (sql change): Added support for automatically determining
the region column for a REGIONAL BY ROW table using a foreign key constraint.
The foreign key is specified by setting a new table storage parameter
`infer_rbr_region_col_using_constraint`, and must contain the region
column. This can be useful for applications that are unable to guarantee
that a child row is inserted or updated from the same region as the
matching parent row.