### PR TITLE
workflow: check PR base branch

### DIFF
--- a/.github/bors.toml
+++ b/.github/bors.toml
@@ -19,7 +19,11 @@ status = [
 # r+-ed. If it's still in progress (for e.g. if CI is still running), bors will
 # construct the merge commit in parallel and simply wait for success right
 # before merging.
-pr_status = ["license/cla", "blathers/release-justification-check"]
+pr_status = [
+        "license/cla",
+        "blathers/release-justification-check",
+        "check_base_branch",
+]
 
 # List of PR labels that may not be attached to a PR when it is r+-ed.
 block_labels = ["do-not-merge", "backport"]

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,19 @@
+name: Bors
+
+on:
+  pull_request:
+    types: [opened, synchronize, reopened, edited]
+    branches: [master]
+
+jobs:
+  check_base_branch:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check if PR targets master branch
+        run: |
+          if [ "${{ github.base_ref }}" != "master" ]; then
+            echo "::error::Bors cannot be used for this pull request. Pull request must target the 'master' branch. Current target: ${{ github.base_ref }}. You can ignore this check if the pull request is not a backport."
+            exit 1
+          else
+            echo "✅ Pull request correctly targets 'master' branch"
+          fi


### PR DESCRIPTION
Bors should not be used for pull requests that do not target the master branch. Previously, bors didn't allow PRs with the `backport` label to be merged, but this was not restrictive enough - one can remove the label and use bors. Now, we check the base branch of the pull request to ensure it is targeting the master branch.

Release note: none
Epic: none