### PR TITLE
builtins: fix decimal logarithm computation when base is infinite

### DIFF
--- a/pkg/sql/sem/builtins/math_builtins.go
+++ b/pkg/sql/sem/builtins/math_builtins.go
@@ -307,6 +307,9 @@ var mathBuiltins = map[string]builtinDefinition{
 			case 0:
 				return nil, errLogOfZero
 			}
+			if isInf(b) {
+				return &tree.DDecimal{Decimal: *decimalZero}, nil
+			}
 
 			top := new(apd.Decimal)
 			if _, err := tree.IntermediateCtx.Ln(top, x); err != nil {

--- a/pkg/sql/sem/eval/testdata/eval/infinity
+++ b/pkg/sql/sem/eval/testdata/eval/infinity
@@ -239,3 +239,8 @@ eval
 'Inf'::float::decimal
 ----
 Infinity
+
+eval
+log('Inf'::decimal, 1)
+----
+0


### PR DESCRIPTION
Previously, we would end up using `apd.Context.Quo` method with the infinity in the denominator, and it would result in a zero decimal that had `Clamped` flag set (with exponent being 2019). The result should just be regular zero, so we add a short-circuiting behavior (which matches PG).

Fixes: #148255.

Release note: None