### PR TITLE
storage: add value separation cluster settings [do not merge]

### DIFF
--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -95,7 +95,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Write
 	// Write a MVCC value to be deleted with a known value size.
 	keyF := mvccKey("f")
 	keyF.Timestamp.WallTime = 1
-	valueF := MVCCValue{Value: roachpb.Value{RawBytes: []byte("fvalue")}}
+	valueF := MVCCValue{Value: roachpb.MakeValueFromString("fvalue")}
 	encodedValueF, err := EncodeMVCCValue(valueF)
 	require.NoError(t, err)
 	require.NoError(t, e.PutMVCC(keyF, valueF))
@@ -313,7 +313,7 @@ func TestBatchRepr(t *testing.T) {
 			"merge(c\x00)",
 			"put(e\x00,)",
 			"single_delete(d\x00)",
-			"delete-sized(f\x00\x00\x00\x00\x00\x00\x00\x00\x01\t,17)",
+			"delete-sized(f\x00\x00\x00\x00\x00\x00\x00\x00\x01\t,22)",
 		}
 		require.Equal(t, expOps, ops)
 

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -414,7 +414,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 					Key:       roachpb.Key("foobar"),
 					Timestamp: hlc.Timestamp{WallTime: 1711383740550067000, Logical: 2},
 				},
-				MVCCValue{Value: roachpb.Value{RawBytes: []byte("hello world")}},
+				MVCCValue{Value: roachpb.MakeValueFromBytes([]byte("hello world"))},
 			),
 		},
 		{
@@ -429,7 +429,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 						LocalTimestamp:   hlc.ClockTimestamp{WallTime: 1711383740550069000},
 						OmitInRangefeeds: true,
 					},
-					Value: roachpb.Value{RawBytes: []byte("hello world")},
+					Value: roachpb.MakeValueFromString("hello world"),
 				},
 			),
 		},
@@ -446,7 +446,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 					ValBytes: 100,
 				},
 				MVCCValue{
-					Value: roachpb.Value{RawBytes: []byte("hello world")},
+					Value: roachpb.MakeValueFromString("hello world"),
 				},
 			),
 		},

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1105,7 +1105,7 @@ func TestCreateCheckpoint_SpanConstrained(t *testing.T) {
 	for i := 1; i <= maxTableID; i++ {
 		require.NoError(t, b.PutMVCC(
 			MVCCKey{Key: key(i), Timestamp: hlc.Timestamp{WallTime: int64(i)}},
-			MVCCValue{Value: roachpb.Value{RawBytes: randutil.RandBytes(rng, 100)}},
+			MVCCValue{Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, 100))},
 		))
 	}
 	require.NoError(t, b.Commit(true /* sync */))
@@ -1640,7 +1640,7 @@ func TestScanLocks(t *testing.T) {
 	for k, str := range locks {
 		var err error
 		if str == lock.Intent {
-			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.Value{RawBytes: roachpb.Key(k)}, MVCCWriteOptions{Txn: txn1})
+			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.MakeValueFromBytes(roachpb.Key(k)), MVCCWriteOptions{Txn: txn1})
 		} else {
 			err = MVCCAcquireLock(ctx, eng, &txn1.TxnMeta, txn1.IgnoredSeqNums, str, roachpb.Key(k), nil, 0, 0)
 		}
@@ -2135,7 +2135,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 	keyB := roachpb.Key("b")
 	keyC := roachpb.Key("c")
 	keyD := roachpb.Key("d")
-	val := roachpb.Value{RawBytes: []byte{'v'}}
+	val := roachpb.MakeValueFromString("v")
 
 	testCases := []struct {
 		name                  string
@@ -2356,7 +2356,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 	aboveReadSeqNumber := enginepb.TxnSeq(3)
 
 	keyA := roachpb.Key("a")
-	val := roachpb.Value{RawBytes: []byte{'v'}}
+	val := roachpb.MakeValueFromString("v")
 
 	testCases := []struct {
 		name                  string

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -219,7 +219,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		GlobalUncertaintyLimit: ts1,
 	}
 	ui1 := uncertainty.Interval{GlobalLimit: txn1.GlobalUncertaintyLimit}
-	val := roachpb.Value{RawBytes: bytes.Repeat([]byte("v"), 1000)}
+	val := roachpb.MakeValueFromBytes(bytes.Repeat([]byte{'v'}, 1000))
 	func() {
 		batch := eng.NewBatch()
 		defer batch.Close()


### PR DESCRIPTION
Add new cluster settings for enabling and configuring value separation.

Close #147709.
Epic: CRDB-20379
Release note (ops change): Introduces new cluster settings for enabling the preview feature of value separation.