### PR TITLE
roachtest/pg_regress: accept recent diffs

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/alter_table.diffs
@@ -3816,10 +3816,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
  create temp view v2 as select * from v1;
  create or replace temp view v1 with (security_barrier = true)
    as select * from t1;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +create or replace temp view v1 with (security_barrier = true)
-+                               ^
++                                     ^
 +HINT:  try \h CREATE
  create temp table log (q1 int8, q2 int8);
  create rule v1_upd_rule as on update to v1
@@ -4212,10 +4212,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +ERROR:  relation "my_locks" does not exist
  alter view my_locks set (autovacuum_enabled = false);
 -ERROR:  unrecognized parameter "autovacuum_enabled"
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "autovacuum_enabled": syntax error
 +DETAIL:  source SQL:
 +alter view my_locks set (autovacuum_enabled = false)
-+                        ^
++                         ^
 +HINT:  try \h ALTER VIEW
  alter table my_locks reset (autovacuum_enabled);
 +ERROR:  relation "my_locks" does not exist
@@ -4227,10 +4227,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/alter_table.out -
 +HINT:  try \h ALTER VIEW
  begin;
  alter view my_locks set (security_barrier=off);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +alter view my_locks set (security_barrier=off)
-+                        ^
++                         ^
 +HINT:  try \h ALTER VIEW
  select * from my_locks order by 1;
 - relname  |    max_lockmode     

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_procedure.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_procedure.diffs
@@ -16,7 +16,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  HINT:  To call a function, use SELECT.
  CREATE FUNCTION cp_testfunc1(a int) RETURNS int LANGUAGE SQL AS $$ SELECT a $$;
  CREATE TABLE cp_test (a int, b text);
-@@ -16,47 +12,86 @@
+@@ -16,47 +12,91 @@
  INSERT INTO cp_test VALUES (1, x);
  $$;
  \df ptest1
@@ -51,9 +51,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
 - INSERT INTO cp_test VALUES (1, x);                  +
 - $procedure$                                         +
 - 
-+               pg_get_functiondef               
-+------------------------------------------------
-+ INSERT INTO root.public.cp_test VALUES (1, x);
++                   pg_get_functiondef                   
++--------------------------------------------------------
++ CREATE PROCEDURE public.ptest1(x STRING)              +
++         LANGUAGE SQL                                  +
++         SECURITY INVOKER                              +
++         AS $$                                         +
++         INSERT INTO root.public.cp_test VALUES (1, x);+
++ $$
  (1 row)
  
  -- show only normal functions
@@ -132,7 +137,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  SELECT * FROM cp_test ORDER BY b COLLATE "C";
   a |   b   
  ---+-------
-@@ -71,34 +106,47 @@
+@@ -71,34 +111,47 @@
  BEGIN ATOMIC
    INSERT INTO cp_test VALUES (1, x);
  END;
@@ -199,7 +204,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  
  -- utility functions currently not supported here
  CREATE PROCEDURE ptestx()
-@@ -106,13 +154,27 @@
+@@ -106,13 +159,27 @@
  BEGIN ATOMIC
    CREATE TABLE x (a int);
  END;
@@ -228,7 +233,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  -- nested CALL
  TRUNCATE cp_test;
  CREATE PROCEDURE ptest3(y text)
-@@ -122,6 +184,9 @@
+@@ -122,6 +189,9 @@
  CALL ptest1($1);
  $$;
  CALL ptest3('b');
@@ -238,7 +243,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  SELECT * FROM cp_test;
   a | b 
  ---+---
-@@ -147,7 +212,6 @@
+@@ -147,7 +217,6 @@
  CALL ptest4a(a, b);  -- error, not supported
  $$;
  ERROR:  calling procedures with output arguments is not supported in SQL functions
@@ -246,7 +251,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  DROP PROCEDURE ptest4a;
  -- named and default parameters
  CREATE OR REPLACE PROCEDURE ptest5(a int, b text, c int default 100)
-@@ -158,9 +222,23 @@
+@@ -158,9 +227,23 @@
  $$;
  TRUNCATE cp_test;
  CALL ptest5(10, 'Hello', 20);
@@ -270,7 +275,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  SELECT * FROM cp_test;
    a  |   b   
  -----+-------
-@@ -168,11 +246,7 @@
+@@ -168,11 +251,7 @@
    20 | Hello
    10 | Hello
   100 | Hello
@@ -283,7 +288,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  
  -- polymorphic types
  CREATE PROCEDURE ptest6(a int, b anyelement)
-@@ -181,6 +255,9 @@
+@@ -181,6 +260,9 @@
  SELECT NULL::int;
  $$;
  CALL ptest6(1, 2);
@@ -293,7 +298,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  -- collation assignment
  CREATE PROCEDURE ptest7(a text, b text)
  LANGUAGE SQL
-@@ -188,28 +265,47 @@
+@@ -188,28 +270,47 @@
  SELECT a = b;
  $$;
  CALL ptest7(least('a', 'b'), 'a');
@@ -356,7 +361,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  -- OUT parameters
  CREATE PROCEDURE ptest9(OUT a int)
  LANGUAGE SQL
-@@ -226,17 +322,10 @@
+@@ -226,17 +327,10 @@
  
  -- you can write an expression, but it's not evaluated
  CALL ptest9(1/0);  -- no error
@@ -376,7 +381,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_procedure.
  -- check named-parameter matching
  CREATE PROCEDURE ptest10(OUT a int, IN b int, IN c int)
  LANGUAGE SQL AS $$ SELECT b - c $$;
-@@ -247,137 +336,222 @@
+@@ -247,137 +341,222 @@
  (1 row)
  
  CALL ptest10(a => null, b => 8, c => 2);

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_view.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_view.diffs
@@ -340,74 +340,65 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  
  CREATE SCHEMA testviewschm2;
  SET search_path TO testviewschm2, public;
-@@ -286,99 +364,132 @@
+@@ -286,99 +364,119 @@
         AS SELECT * FROM tbl1 WHERE a = 0;
  CREATE VIEW mysecview2 WITH (security_barrier=true)
         AS SELECT * FROM tbl1 WHERE a > 0;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview2 WITH (security_barrier=true)
-+                       ^
++                             ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW mysecview3 WITH (security_barrier=false)
         AS SELECT * FROM tbl1 WHERE a < 0;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview3 WITH (security_barrier=false)
-+                       ^
++                             ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW mysecview4 WITH (security_barrier)
         AS SELECT * FROM tbl1 WHERE a <> 0;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview4 WITH (security_barrier)
-+                       ^
++                             ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW mysecview5 WITH (security_barrier=100)	-- Error
         AS SELECT * FROM tbl1 WHERE a > 100;
 -ERROR:  invalid value for boolean option "security_barrier": 100
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview5 WITH (security_barrier=100)	
-+                       ^
++                             ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW mysecview6 WITH (invalid_option)		-- Error
         AS SELECT * FROM tbl1 WHERE a < 100;
 -ERROR:  unrecognized parameter "invalid_option"
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "invalid_option": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview6 WITH (invalid_option)		
-+                       ^
++                             ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW mysecview7 WITH (security_invoker=true)
         AS SELECT * FROM tbl1 WHERE a = 100;
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE VIEW mysecview7 WITH (security_invoker=true)
-+                       ^
-+HINT:  try \h CREATE VIEW
++ERROR:  security invoker views are not supported
  CREATE VIEW mysecview8 WITH (security_invoker=false, security_barrier=true)
         AS SELECT * FROM tbl1 WHERE a > 100;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near ",": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview8 WITH (security_invoker=false, security_barrier=true)
-+                       ^
++                                                   ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW mysecview9 WITH (security_invoker)
         AS SELECT * FROM tbl1 WHERE a < 100;
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE VIEW mysecview9 WITH (security_invoker)
-+                       ^
-+HINT:  try \h CREATE VIEW
++ERROR:  security invoker views are not supported
  CREATE VIEW mysecview10 WITH (security_invoker=100)	-- Error
         AS SELECT * FROM tbl1 WHERE a <> 100;
 -ERROR:  invalid value for boolean option "security_invoker": 100
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near ")": syntax error: security_invoker accepts only true/false or 1/0
 +DETAIL:  source SQL:
 +CREATE VIEW mysecview10 WITH (security_invoker=100)	
-+                        ^
-+HINT:  try \h CREATE VIEW
++                                                  ^
  SELECT relname, relkind, reloptions FROM pg_class
         WHERE oid in ('mysecview1'::regclass, 'mysecview2'::regclass,
                       'mysecview3'::regclass, 'mysecview4'::regclass,
@@ -432,33 +423,29 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
         AS SELECT * FROM tbl1 WHERE a > 256;
  CREATE OR REPLACE VIEW mysecview3 WITH (security_barrier=true)
         AS SELECT * FROM tbl1 WHERE a < 256;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE OR REPLACE VIEW mysecview3 WITH (security_barrier=true)
-+                                  ^
++                                        ^
 +HINT:  try \h CREATE
  CREATE OR REPLACE VIEW mysecview4 WITH (security_barrier=false)
         AS SELECT * FROM tbl1 WHERE a <> 256;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE OR REPLACE VIEW mysecview4 WITH (security_barrier=false)
-+                                  ^
++                                        ^
 +HINT:  try \h CREATE
  CREATE OR REPLACE VIEW mysecview7
         AS SELECT * FROM tbl1 WHERE a > 256;
  CREATE OR REPLACE VIEW mysecview8 WITH (security_invoker=true)
         AS SELECT * FROM tbl1 WHERE a < 256;
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE OR REPLACE VIEW mysecview8 WITH (security_invoker=true)
-+                                  ^
-+HINT:  try \h CREATE
++ERROR:  security invoker views are not supported
  CREATE OR REPLACE VIEW mysecview9 WITH (security_invoker=false, security_barrier=true)
         AS SELECT * FROM tbl1 WHERE a <> 256;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near ",": syntax error
 +DETAIL:  source SQL:
 +CREATE OR REPLACE VIEW mysecview9 WITH (security_invoker=false, security_barrier=true)
-+                                  ^
++                                                              ^
 +HINT:  try \h CREATE
  SELECT relname, relkind, reloptions FROM pg_class
         WHERE oid in ('mysecview1'::regclass, 'mysecview2'::regclass,
@@ -518,7 +505,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- This test checks that proper typmods are assigned in a multi-row VALUES
  CREATE VIEW tt1 AS
    SELECT * FROM (
-@@ -386,40 +497,29 @@
+@@ -386,40 +484,29 @@
         ('abc'::varchar(3), '0123456789', 42, 'abcd'::varchar(4)),
         ('0123456789', 'abc'::varchar(3), 42.12, 'abc'::varchar(4))
    ) vv(a,b,c,d);
@@ -574,7 +561,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  CREATE VIEW aliased_view_1 AS
    select * from tt1
      where exists (select 1 from tx1 where tt1.f1 = tx1.x1);
-@@ -432,478 +532,307 @@
+@@ -432,478 +519,307 @@
  CREATE VIEW aliased_view_4 AS
    select * from temp_view_test.tt1
      where exists (select 1 from tt1 where temp_view_test.tt1.y1 = tt1.f1);
@@ -1307,7 +1294,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- Test view decompilation in the face of column addition/deletion/renaming
  create table tt2 (a int, b int, c int);
  create table tt3 (ax int8, b int2, c numeric);
-@@ -914,404 +843,120 @@
+@@ -914,404 +830,120 @@
  create view v2a as select * from (tt2 join tt3 using (b,c) join tt4 using (b)) j;
  create view v3 as select * from tt2 join tt3 using (b,c) full join tt4 using (b);
  select pg_get_viewdef('v1', true);
@@ -1782,7 +1769,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- Unnamed FULL JOIN USING is lots of fun too
  create table tt7 (x int, xx int, y int);
  alter table tt7 drop column xx;
-@@ -1321,25 +966,8 @@
+@@ -1321,25 +953,8 @@
  union all
  select * from tt7 full join tt8 using (x), tt8 tt8x;
  select pg_get_viewdef('vv2', true);
@@ -1810,7 +1797,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  create view vv3 as
  select * from (values(1,2,3,4,5,6)) v(a,b,c,x,e,f)
  union all
-@@ -1347,28 +975,8 @@
+@@ -1347,28 +962,8 @@
    tt7 full join tt8 using (x),
    tt7 tt7x full join tt8 tt8x using (x);
  select pg_get_viewdef('vv3', true);
@@ -1841,7 +1828,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  create view vv4 as
  select * from (values(1,2,3,4,5,6,7)) v(a,b,c,x,e,f,g)
  union all
-@@ -1376,104 +984,21 @@
+@@ -1376,104 +971,21 @@
    tt7 full join tt8 using (x),
    tt7 tt7x full join tt8 tt8x using (x) full join tt8 tt8y using (x);
  select pg_get_viewdef('vv4', true);
@@ -1954,7 +1941,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- Implicit coercions in a JOIN USING create issues similar to FULL JOIN
  create table tt7a (x date, xx int, y int);
  alter table tt7a drop column xx;
-@@ -1482,26 +1007,10 @@
+@@ -1482,26 +994,10 @@
  select * from (values(now(),2,3,now(),5)) v(a,b,c,d,e)
  union all
  select * from tt7a left join tt8a using (x), tt8a tt8ax;
@@ -1984,7 +1971,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  --
  -- Also check dropping a column that existed when the view was made
  --
-@@ -1509,26 +1018,12 @@
+@@ -1509,26 +1005,12 @@
  create table tt10 (x int, z int);
  create view vv5 as select x,y,z from tt9 join tt10 using(x);
  select pg_get_viewdef('vv5', true);
@@ -2015,7 +2002,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  --
  -- Another corner case is that we might add a column to a table below a
  -- JOIN USING, and thereby make the USING column name ambiguous
-@@ -1539,30 +1034,12 @@
+@@ -1539,30 +1021,12 @@
  create view vv6 as select x,y,z,q from
    (tt11 join tt12 using(x)) join tt13 using(z);
  select pg_get_viewdef('vv6', true);
@@ -2050,7 +2037,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  --
  -- Check cases involving dropped/altered columns in a function's rowtype result
  --
-@@ -1581,26 +1058,33 @@
+@@ -1581,26 +1045,33 @@
  end;
  $$
  language plpgsql;
@@ -2100,7 +2087,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -1614,46 +1098,28 @@
+@@ -1614,46 +1085,28 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2157,7 +2144,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- ... but some bug might let it happen, so check defenses
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -1664,124 +1130,63 @@
+@@ -1664,124 +1117,63 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2314,7 +2301,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  select * from int8_tbl i, lateral(values(i.*::int8_tbl)) ss;
          q1        |        q2         |               column1                
  ------------------+-------------------+--------------------------------------
-@@ -1804,14 +1209,8 @@
+@@ -1804,14 +1196,8 @@
  (5 rows)
  
  select pg_get_viewdef('tt17v', true);
@@ -2331,7 +2318,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  select * from int8_tbl i where i.* in (values(i.*::int8_tbl));
          q1        |        q2         
  ------------------+-------------------
-@@ -1823,48 +1222,48 @@
+@@ -1823,48 +1209,48 @@
  (5 rows)
  
  create table tt15v_log(o tt15v, n tt15v, incr bool);
@@ -2355,7 +2342,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
 +create rule updlog as on update to tt15v do also
 +            ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
-+
+ 
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
@@ -2364,7 +2351,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +\d+ tt15v
 +ERROR:  at or near ".": syntax error
 +DETAIL:  source SQL:
@@ -2412,7 +2399,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- check display of ScalarArrayOp with a sub-select
  select 'foo'::text = any(array['abc','def','foo']::text[]);
   ?column? 
-@@ -1873,10 +1272,7 @@
+@@ -1873,10 +1259,7 @@
  (1 row)
  
  select 'foo'::text = any((select array['abc','def','foo']::text[]));  -- fail
@@ -2424,7 +2411,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  select 'foo'::text = any((select array['abc','def','foo']::text[])::text[]);
   ?column? 
  ----------
-@@ -1887,12 +1283,8 @@
+@@ -1887,12 +1270,8 @@
  select 'foo'::text = any(array['abc','def','foo']::text[]) c1,
         'foo'::text = any((select array['abc','def','foo']::text[])::text[]) c2;
  select pg_get_viewdef('tt19v', true);
@@ -2439,7 +2426,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- check display of assorted RTE_FUNCTION expressions
  create view tt20v as
  select * from
-@@ -1902,23 +1294,14 @@
+@@ -1902,23 +1281,14 @@
    localtimestamp(3) as t,
    cast(1+2 as int4) as i4,
    cast(1+2 as int8) as i8;
@@ -2470,7 +2457,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- reverse-listing of various special function syntaxes required by SQL
  create view tt201v as
  select
-@@ -1974,136 +1357,41 @@
+@@ -1974,136 +1344,41 @@
    (select * from SESSION_USER) as seu2,
    SYSTEM_USER as su,
    (select * from SYSTEM_USER) as su2;
@@ -2626,7 +2613,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- test extraction of FieldSelect field names (get_name_for_var_field)
  create view tt24v as
  with cte as materialized (select r from (values(1,2),(3,4)) r)
-@@ -2111,66 +1399,29 @@
+@@ -2111,66 +1386,29 @@
    cte join (select rr from (values(1,7),(3,8)) rr limit 2) ss
    on (r).column1 = (rr).column1;
  select pg_get_viewdef('tt24v', true);
@@ -2707,7 +2694,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_view.out -
  -- test pretty-print parenthesization rules, and SubLink deparsing
  create view tt26v as
  select x + y + z as c1,
-@@ -2186,128 +1437,9 @@
+@@ -2186,128 +1424,9 @@
         (x,y) <= ANY (values(1,2),(3,4)) as c11
  from (values(1,2,3)) v(x,y,z);
  select pg_get_viewdef('tt26v', true);

--- a/pkg/cmd/roachtest/testdata/pg_regress/identity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/identity.diffs
@@ -39,7 +39,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/identity.out --la
  
  SELECT pg_get_serial_sequence('itest1', 'a');
   pg_get_serial_sequence 
-@@ -33,41 +39,48 @@
+@@ -33,12 +39,15 @@
  (1 row)
  
  \d itest1_a_seq
@@ -61,11 +61,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/identity.out --la
  CREATE TABLE itest4 (a int, b text);
  ALTER TABLE itest4 ALTER COLUMN a ADD GENERATED ALWAYS AS IDENTITY;  -- error, requires NOT NULL
  ERROR:  column "a" of relation "itest4" must be declared NOT NULL before identity can be added
- ALTER TABLE itest4 ALTER COLUMN a SET NOT NULL;
- ALTER TABLE itest4 ALTER COLUMN a ADD GENERATED ALWAYS AS IDENTITY;  -- ok
- ALTER TABLE itest4 ALTER COLUMN a DROP NOT NULL;  -- error, disallowed
--ERROR:  column "a" of relation "itest4" is an identity column
-+ERROR:  relation "itest4": conflicting NULL/NOT NULL declarations for column "a"
+@@ -49,25 +58,29 @@
  ALTER TABLE itest4 ALTER COLUMN a ADD GENERATED ALWAYS AS IDENTITY;  -- error, already set
  ERROR:  column "a" of relation "itest4" is already an identity column
  ALTER TABLE itest4 ALTER COLUMN b ADD GENERATED ALWAYS AS IDENTITY;  -- error, wrong data type

--- a/pkg/cmd/roachtest/testdata/pg_regress/int8.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/int8.diffs
@@ -523,7 +523,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/int8.out --label=
 - 1259
 +    oid     
 +------------
-+ 4294967083
++ 4294967082
  (1 row)
  
  -- bit operations

--- a/pkg/cmd/roachtest/testdata/pg_regress/lock.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/lock.diffs
@@ -280,7 +280,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/lock.out --label=
  ROLLBACK;
  RESET ROLE;
  REVOKE UPDATE ON TABLE lock_tbl1 FROM regress_rol_lock1;
-@@ -163,79 +254,95 @@
+@@ -163,79 +254,91 @@
  -- fail without permissions on the view
  BEGIN;
  LOCK TABLE lock_view1;
@@ -318,11 +318,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/lock.out --label=
  -- Tables referred to by security invoker views require explicit permission to
  -- be locked.
  CREATE VIEW lock_view8 WITH (security_invoker) AS SELECT * FROM lock_tbl1;
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE VIEW lock_view8 WITH (security_invoker) AS SELECT * FROM lock_tbl1
-+                       ^
-+HINT:  try \h CREATE VIEW
++ERROR:  security invoker views are not supported
  SET ROLE regress_rol_lock1;
  -- fail without permissions on the view
  BEGIN;
@@ -396,7 +392,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/lock.out --label=
  DROP SCHEMA lock_schema1 CASCADE;
  DROP ROLE regress_rol_lock1;
  -- atomic ops tests
-@@ -244,9 +351,8 @@
+@@ -244,9 +347,8 @@
      RETURNS bool
      AS :'regresslib'
      LANGUAGE C;

--- a/pkg/cmd/roachtest/testdata/pg_regress/privileges.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/privileges.diffs
@@ -614,10 +614,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
 +HINT:  try \h CREATE VIEW
  CREATE VIEW atest12sbv WITH (security_barrier=true) AS
    SELECT * FROM atest12 WHERE b <<< 5;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW atest12sbv WITH (security_barrier=true) AS
-+                       ^
++                             ^
 +HINT:  try \h CREATE VIEW
  GRANT SELECT ON atest12v TO PUBLIC;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "atest12v" does not exist

--- a/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rangefuncs.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --label=/mnt/data1/postgres/src/test/regress/results/rangefuncs.out /mnt/data1/postgres/src/test/regress/expected/rangefuncs.out /mnt/data1/postgres/src/test/regress/results/rangefuncs.out
 --- /mnt/data1/postgres/src/test/regress/expected/rangefuncs.out
 +++ /mnt/data1/postgres/src/test/regress/results/rangefuncs.out
-@@ -52,34 +52,27 @@
+@@ -52,12 +52,12 @@
  (1 row)
  
  select row_to_json(s.*) from generate_series(11,14) with ordinality s;
@@ -20,16 +20,9 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (4 rows)
  
  -- ordinality vs. views
- create temporary view vw_ord as select * from (values (1)) v(n) join rngfunct(1) with ordinality as z(a,b,ord) on (n=ord);
-+ERROR:  unknown function: rngfunct()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- select * from vw_ord;
-- n | a | b  | ord 
-----+---+----+-----
-- 1 | 1 | 11 |   1
--(1 row)
--
-+ERROR:  relation "vw_ord" does not exist
+@@ -69,14 +69,9 @@
+ (1 row)
+ 
  select definition from pg_views where viewname='vw_ord';
 -                               definition                                
 --------------------------------------------------------------------------
@@ -39,29 +32,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 -     z.ord                                                              +
 -    FROM (( VALUES (1)) v(n)                                            +
 -      JOIN rngfunct(1) WITH ORDINALITY z(a, b, ord) ON ((v.n = z.ord)));
--(1 row)
-+ definition 
-+------------
-+(0 rows)
++                                                                   definition                                                                    
++-------------------------------------------------------------------------------------------------------------------------------------------------
++ SELECT v.n, z.a, z.b, z.ord FROM (VALUES (1)) AS v (n) JOIN ROWS FROM (public.rngfunct(1:::INT8)) WITH ORDINALITY AS z (a, b, ord) ON (n = ord)
+ (1 row)
  
  drop view vw_ord;
-+ERROR:  relation "vw_ord" does not exist
- -- multiple functions
- select * from rows from(rngfunct(1),rngfunct(2)) with ordinality as z(a,b,c,d,ord);
-  a |  b  | c | d  | ord 
-@@ -89,26 +82,17 @@
- (2 rows)
+@@ -96,16 +91,9 @@
+ (1 row)
  
- create temporary view vw_ord as select * from (values (1)) v(n) join rows from(rngfunct(1),rngfunct(2)) with ordinality as z(a,b,c,d,ord) on (n=ord);
-+ERROR:  unknown function: rngfunct()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- select * from vw_ord;
-- n | a | b  | c | d  | ord 
-----+---+----+---+----+-----
-- 1 | 1 | 11 | 2 | 22 |   1
--(1 row)
--
-+ERROR:  relation "vw_ord" does not exist
  select definition from pg_views where viewname='vw_ord';
 -                                              definition                                               
 --------------------------------------------------------------------------------------------------------
@@ -73,17 +52,13 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 -     z.ord                                                                                            +
 -    FROM (( VALUES (1)) v(n)                                                                          +
 -      JOIN ROWS FROM(rngfunct(1), rngfunct(2)) WITH ORDINALITY z(a, b, c, d, ord) ON ((v.n = z.ord)));
--(1 row)
-+ definition 
-+------------
-+(0 rows)
++                                                                                         definition                                                                                         
++--------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------
++ SELECT v.n, z.a, z.b, z.c, z.d, z.ord FROM (VALUES (1)) AS v (n) JOIN ROWS FROM (public.rngfunct(1:::INT8), public.rngfunct(2:::INT8)) WITH ORDINALITY AS z (a, b, c, d, ord) ON (n = ord)
+ (1 row)
  
  drop view vw_ord;
-+ERROR:  relation "vw_ord" does not exist
- -- expansions of unnest()
- select * from unnest(array[10,20],array['foo','bar'],array[1.0]);
-  unnest | unnest | unnest 
-@@ -147,12 +131,9 @@
+@@ -147,12 +135,9 @@
  (2 rows)
  
  select definition from pg_views where viewname='vw_ord';
@@ -99,7 +74,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (1 row)
  
  drop view vw_ord;
-@@ -165,12 +146,9 @@
+@@ -165,12 +150,9 @@
  (2 rows)
  
  select definition from pg_views where viewname='vw_ord';
@@ -115,7 +90,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (1 row)
  
  drop view vw_ord;
-@@ -183,106 +161,44 @@
+@@ -183,106 +165,44 @@
  (2 rows)
  
  select definition from pg_views where viewname='vw_ord';
@@ -241,7 +216,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  commit;
  -- function with implicit LATERAL
  select * from rngfunc2, rngfunct(rngfunc2.rngfuncid) z where rngfunc2.f2 = z.f2;
-@@ -329,12 +245,7 @@
+@@ -329,12 +249,7 @@
  
  -- nested functions
  select rngfunct.rngfuncid, rngfunct.f2 from rngfunct(sin(pi()/2)::int) ORDER BY 1,2;
@@ -255,163 +230,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  CREATE TABLE rngfunc (rngfuncid int, rngfuncsubid int, rngfuncname text, primary key(rngfuncid,rngfuncsubid));
  INSERT INTO rngfunc VALUES(1,1,'Joe');
  INSERT INTO rngfunc VALUES(1,2,'Ed');
-@@ -354,21 +265,19 @@
- (1 row)
- 
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc1(1);
-+ERROR:  unknown function: getrngfunc1()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- getrngfunc1 
---------------
--           1
--(1 row)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc1(1) WITH ORDINALITY as t1(v,o);
-+ERROR:  unknown function: getrngfunc1()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- v | o 
-----+---
-- 1 | 1
--(1 row)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- -- sql, proretset = t, prorettype = b
- CREATE FUNCTION getrngfunc2(int) RETURNS setof int AS 'SELECT rngfuncid FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
- SELECT * FROM getrngfunc2(1) AS t1;
-@@ -386,23 +295,19 @@
- (2 rows)
- 
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc2(1);
-+ERROR:  unknown function: getrngfunc2()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- getrngfunc2 
---------------
--           1
--           1
--(2 rows)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc2(1) WITH ORDINALITY AS t1(v,o);
-+ERROR:  unknown function: getrngfunc2()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- v | o 
-----+---
-- 1 | 1
-- 1 | 2
--(2 rows)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- -- sql, proretset = t, prorettype = b
- CREATE FUNCTION getrngfunc3(int) RETURNS setof text AS 'SELECT rngfuncname FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
- SELECT * FROM getrngfunc3(1) AS t1;
-@@ -420,23 +325,19 @@
- (2 rows)
- 
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc3(1);
-+ERROR:  unknown function: getrngfunc3()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- getrngfunc3 
---------------
-- Joe
-- Ed
--(2 rows)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc3(1) WITH ORDINALITY AS t1(v,o);
-+ERROR:  unknown function: getrngfunc3()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
--  v  | o 
-------+---
-- Joe | 1
-- Ed  | 2
--(2 rows)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- -- sql, proretset = f, prorettype = c
- CREATE FUNCTION getrngfunc4(int) RETURNS rngfunc AS 'SELECT * FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
- SELECT * FROM getrngfunc4(1) AS t1;
-@@ -452,21 +353,19 @@
- (1 row)
- 
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc4(1);
-+ERROR:  unknown function: getrngfunc4()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- rngfuncid | rngfuncsubid | rngfuncname 
-------------+--------------+-------------
--         1 |            1 | Joe
--(1 row)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc4(1) WITH ORDINALITY AS t1(a,b,c,o);
-+ERROR:  unknown function: getrngfunc4()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- a | b |  c  | o 
-----+---+-----+---
-- 1 | 1 | Joe | 1
--(1 row)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- -- sql, proretset = t, prorettype = c
- CREATE FUNCTION getrngfunc5(int) RETURNS setof rngfunc AS 'SELECT * FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
- SELECT * FROM getrngfunc5(1) AS t1;
-@@ -484,23 +383,19 @@
- (2 rows)
- 
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc5(1);
-+ERROR:  unknown function: getrngfunc5()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- rngfuncid | rngfuncsubid | rngfuncname 
-------------+--------------+-------------
--         1 |            1 | Joe
--         1 |            2 | Ed
--(2 rows)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc5(1) WITH ORDINALITY AS t1(a,b,c,o);
-+ERROR:  unknown function: getrngfunc5()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- SELECT * FROM vw_getrngfunc;
-- a | b |  c  | o 
-----+---+-----+---
-- 1 | 1 | Joe | 1
-- 1 | 2 | Ed  | 2
--(2 rows)
--
-+ERROR:  relation "vw_getrngfunc" does not exist
- DROP VIEW vw_getrngfunc;
-+ERROR:  relation "vw_getrngfunc" does not exist
- -- sql, proretset = f, prorettype = record
- CREATE FUNCTION getrngfunc6(int) RETURNS RECORD AS 'SELECT * FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
- SELECT * FROM getrngfunc6(1) AS t1(rngfuncid int, rngfuncsubid int, rngfuncname text);
-@@ -510,30 +405,24 @@
+@@ -510,30 +425,22 @@
  (1 row)
  
  SELECT * FROM ROWS FROM( getrngfunc6(1) AS (rngfuncid int, rngfuncsubid int, rngfuncname text) ) WITH ORDINALITY;
@@ -423,8 +242,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +ERROR:  a column definition list is required for functions returning "record"
  CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc6(1) AS
  (rngfuncid int, rngfuncsubid int, rngfuncname text);
-+ERROR:  unknown function: getrngfunc6()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
++ERROR:  a column definition list is required for functions returning "record"
  SELECT * FROM vw_getrngfunc;
 - rngfuncid | rngfuncsubid | rngfuncname 
 ------------+--------------+-------------
@@ -437,8 +255,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  CREATE VIEW vw_getrngfunc AS
    SELECT * FROM ROWS FROM( getrngfunc6(1) AS (rngfuncid int, rngfuncsubid int, rngfuncname text) )
                  WITH ORDINALITY;
-+ERROR:  unknown function: getrngfunc6()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
++ERROR:  a column definition list is required for functions returning "record"
  SELECT * FROM vw_getrngfunc;
 - rngfuncid | rngfuncsubid | rngfuncname | ordinality 
 ------------+--------------+-------------+------------
@@ -451,7 +268,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- sql, proretset = t, prorettype = record
  CREATE FUNCTION getrngfunc7(int) RETURNS setof record AS 'SELECT * FROM rngfunc WHERE rngfuncid = $1;' LANGUAGE SQL;
  SELECT * FROM getrngfunc7(1) AS t1(rngfuncid int, rngfuncsubid int, rngfuncname text);
-@@ -544,143 +433,92 @@
+@@ -544,143 +451,90 @@
  (2 rows)
  
  SELECT * FROM ROWS FROM( getrngfunc7(1) AS (rngfuncid int, rngfuncsubid int, rngfuncname text) ) WITH ORDINALITY;
@@ -464,8 +281,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
 +ERROR:  a column definition list is required for functions returning "record"
  CREATE VIEW vw_getrngfunc AS SELECT * FROM getrngfunc7(1) AS
  (rngfuncid int, rngfuncsubid int, rngfuncname text);
-+ERROR:  unknown function: getrngfunc7()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
++ERROR:  a column definition list is required for functions returning "record"
  SELECT * FROM vw_getrngfunc;
 - rngfuncid | rngfuncsubid | rngfuncname 
 ------------+--------------+-------------
@@ -479,8 +295,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  CREATE VIEW vw_getrngfunc AS
    SELECT * FROM ROWS FROM( getrngfunc7(1) AS (rngfuncid int, rngfuncsubid int, rngfuncname text) )
                  WITH ORDINALITY;
-+ERROR:  unknown function: getrngfunc7()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
++ERROR:  a column definition list is required for functions returning "record"
  SELECT * FROM vw_getrngfunc;
 - rngfuncid | rngfuncsubid | rngfuncname | ordinality 
 ------------+--------------+-------------+------------
@@ -634,7 +449,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP FUNCTION getrngfunc1(int);
  DROP FUNCTION getrngfunc2(int);
  DROP FUNCTION getrngfunc3(int);
-@@ -689,7 +527,9 @@
+@@ -689,7 +543,9 @@
  DROP FUNCTION getrngfunc6(int);
  DROP FUNCTION getrngfunc7(int);
  DROP FUNCTION getrngfunc8(int);
@@ -644,7 +459,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP FUNCTION rngfunct(int);
  DROP TABLE rngfunc2;
  DROP TABLE rngfunc;
-@@ -698,8 +538,10 @@
+@@ -698,8 +554,10 @@
  CREATE TEMPORARY SEQUENCE rngfunc_rescan_seq2;
  CREATE TYPE rngfunc_rescan_t AS (i integer, s bigint);
  CREATE FUNCTION rngfunc_sql(int,int) RETURNS setof rngfunc_rescan_t AS 'SELECT i, nextval(''rngfunc_rescan_seq1'') FROM generate_series($1,$2) i;' LANGUAGE SQL;
@@ -655,7 +470,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --invokes ExecReScanFunctionScan - all these cases should materialize the function only once
  -- LEFT JOIN on a condition that the planner can't prove to be true is used to ensure the function
  -- is on the inner path of a nestloop join
-@@ -710,19 +552,7 @@
+@@ -710,19 +568,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_sql(11,13) ON (r+i)<100;
@@ -676,7 +491,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -730,19 +560,7 @@
+@@ -730,19 +576,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_sql(11,13) WITH ORDINALITY AS f(i,s,o) ON (r+i)<100;
@@ -697,7 +512,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -750,19 +568,7 @@
+@@ -750,19 +584,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_mat(11,13) ON (r+i)<100;
@@ -718,7 +533,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -770,19 +576,7 @@
+@@ -770,19 +592,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN rngfunc_mat(11,13) WITH ORDINALITY AS f(i,s,o) ON (r+i)<100;
@@ -739,7 +554,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -790,30 +584,18 @@
+@@ -790,30 +600,18 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r) LEFT JOIN ROWS FROM( rngfunc_sql(11,13), rngfunc_mat(11,13) ) WITH ORDINALITY AS f(i1,s1,i2,s2,o) ON (r+i1+i2)<100;
@@ -775,7 +590,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
   3 | 13
  (9 rows)
  
-@@ -821,13 +603,13 @@
+@@ -821,13 +619,13 @@
   r | i  | o 
  ---+----+---
   1 | 11 | 1
@@ -793,7 +608,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
   3 | 13 | 3
  (9 rows)
  
-@@ -867,16 +649,7 @@
+@@ -867,16 +665,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(10+r,13);
@@ -811,7 +626,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -884,16 +657,7 @@
+@@ -884,16 +673,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(10+r,13) WITH ORDINALITY AS f(i,s,o);
@@ -829,7 +644,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -901,16 +665,7 @@
+@@ -901,16 +681,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(11,10+r);
@@ -847,7 +662,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -918,16 +673,7 @@
+@@ -918,16 +689,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_sql(11,10+r) WITH ORDINALITY AS f(i,s,o);
@@ -865,7 +680,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -935,20 +681,7 @@
+@@ -935,20 +697,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_sql(r1,r2);
@@ -887,7 +702,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -956,20 +689,7 @@
+@@ -956,20 +705,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_sql(r1,r2) WITH ORDINALITY AS f(i,s,o);
@@ -909,7 +724,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -977,16 +697,7 @@
+@@ -977,16 +713,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(10+r,13);
@@ -927,7 +742,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -994,16 +705,7 @@
+@@ -994,16 +721,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(10+r,13) WITH ORDINALITY AS f(i,s,o);
@@ -945,7 +760,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1011,16 +713,7 @@
+@@ -1011,16 +729,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(11,10+r);
@@ -963,7 +778,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1028,16 +721,7 @@
+@@ -1028,16 +737,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), rngfunc_mat(11,10+r) WITH ORDINALITY AS f(i,s,o);
@@ -981,7 +796,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1045,20 +729,7 @@
+@@ -1045,20 +745,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_mat(r1,r2);
@@ -1003,7 +818,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1066,20 +737,7 @@
+@@ -1066,20 +753,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (11,12),(13,15),(16,20)) v(r1,r2), rngfunc_mat(r1,r2) WITH ORDINALITY AS f(i,s,o);
@@ -1025,7 +840,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- selective rescan of multiple functions:
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
-@@ -1088,16 +746,7 @@
+@@ -1088,16 +762,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), ROWS FROM( rngfunc_sql(11,11), rngfunc_mat(10+r,13) );
@@ -1043,7 +858,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1105,16 +754,7 @@
+@@ -1105,16 +770,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), ROWS FROM( rngfunc_sql(10+r,13), rngfunc_mat(11,11) );
@@ -1061,7 +876,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1122,16 +762,7 @@
+@@ -1122,16 +778,7 @@
  (1 row)
  
  SELECT * FROM (VALUES (1),(2),(3)) v(r), ROWS FROM( rngfunc_sql(10+r,13), rngfunc_mat(10+r,13) );
@@ -1079,7 +894,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT setval('rngfunc_rescan_seq1',1,false),setval('rngfunc_rescan_seq2',1,false);
   setval | setval 
  --------+--------
-@@ -1139,23 +770,7 @@
+@@ -1139,23 +786,7 @@
  (1 row)
  
  SELECT * FROM generate_series(1,2) r1, generate_series(r1,3) r2, ROWS FROM( rngfunc_sql(10+r1,13), rngfunc_mat(10+r2,13) );
@@ -1104,7 +919,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT * FROM (VALUES (1),(2),(3)) v(r), generate_series(10+r,20-r) f(i);
   r | i  
  ---+----
-@@ -1243,31 +858,31 @@
+@@ -1243,31 +874,31 @@
   r1 | r1 | r2 | i  
  ----+----+----+----
    1 |  1 | 10 | 21
@@ -1154,7 +969,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
    3 |  3 | 30 | 23
  (27 rows)
  
-@@ -1302,95 +917,47 @@
+@@ -1302,95 +933,47 @@
   r1 | r1 | r2 | i  
  ----+----+----+----
    1 |  1 | 10 | 10
@@ -1273,7 +1088,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- check handling of FULL JOIN with multiple lateral references (bug #15741)
  SELECT *
  FROM (VALUES (1),(2)) v1(r1)
-@@ -1404,20 +971,11 @@
+@@ -1404,20 +987,11 @@
          ) AS ss1 ON TRUE
          FULL JOIN generate_series(1, v1.r1) AS gs4 ON FALSE
      ) AS ss0 ON TRUE;
@@ -1297,7 +1112,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP SEQUENCE rngfunc_rescan_seq1;
  DROP SEQUENCE rngfunc_rescan_seq2;
  --
-@@ -1449,7 +1007,7 @@
+@@ -1449,7 +1023,7 @@
  -- error, wrong result type
  CREATE OR REPLACE FUNCTION rngfunc(in f1 int, out f2 int) RETURNS float
  AS 'select $1+1' LANGUAGE sql;
@@ -1306,7 +1121,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- with multiple OUT params you must get a RECORD result
  CREATE OR REPLACE FUNCTION rngfunc(in f1 int, out f2 int, out f3 text) RETURNS int
  AS 'select $1+1' LANGUAGE sql;
-@@ -1457,8 +1015,8 @@
+@@ -1457,8 +1031,8 @@
  CREATE OR REPLACE FUNCTION rngfunc(in f1 int, out f2 int, out f3 text)
  RETURNS record
  AS 'select $1+1' LANGUAGE sql;
@@ -1317,7 +1132,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  CREATE OR REPLACE FUNCTION rngfuncr(in f1 int, out f2 int, out text)
  AS $$select $1-1, $1::text || 'z'$$ LANGUAGE sql;
  SELECT f1, rngfuncr(f1) FROM int4_tbl;
-@@ -1486,15 +1044,7 @@
+@@ -1486,15 +1060,7 @@
  CREATE OR REPLACE FUNCTION rngfuncb(in f1 int, inout f2 int, out text)
  AS $$select $2-1, $1::text || 'z'$$ LANGUAGE sql;
  SELECT f1, rngfuncb(f1, f1/2) FROM int4_tbl;
@@ -1334,7 +1149,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT * FROM rngfuncb(42, 99);
   f2 | column2 
  ----+---------
-@@ -1523,7 +1073,11 @@
+@@ -1523,7 +1089,11 @@
  (1 row)
  
  SELECT dup('xyz');	-- fails
@@ -1347,7 +1162,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  SELECT dup('xyz'::text);
          dup        
  -------------------
-@@ -1540,7 +1094,6 @@
+@@ -1540,7 +1110,6 @@
  CREATE OR REPLACE FUNCTION dup (inout f2 anyelement, out f3 anyarray)
  AS 'select $1, array[$1,$1]' LANGUAGE sql;
  ERROR:  cannot change name of input parameter "f1"
@@ -1355,7 +1170,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  DROP FUNCTION dup(anyelement);
  -- equivalent behavior, though different name exposed for input arg
  CREATE OR REPLACE FUNCTION dup (inout f2 anyelement, out f3 anyarray)
-@@ -1559,57 +1112,32 @@
+@@ -1559,57 +1128,32 @@
  DETAIL:  A result of type anyelement requires at least one input of type anyelement, anyarray, anynonarray, anyenum, anyrange, or anymultirange.
  CREATE FUNCTION dup (f1 anycompatible, f2 anycompatiblearray, f3 out anycompatible, f4 out anycompatiblearray)
  AS 'select $1, $2' LANGUAGE sql;
@@ -1425,7 +1240,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- table functions
  --
-@@ -1661,100 +1189,77 @@
+@@ -1661,100 +1205,77 @@
  --
  -- some tests on SQL functions with RETURNING
  --
@@ -1557,7 +1372,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  
  -- triggers will fire, too
  create function noticetrigger() returns trigger as $$
-@@ -1764,70 +1269,55 @@
+@@ -1764,70 +1285,55 @@
  end $$ language plpgsql;
  create trigger tnoticetrigger after insert on tt for each row
  execute procedure noticetrigger();
@@ -1664,7 +1479,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  
  -- test case for a whole-row-variable bug
  create function rngfunc1(n integer, out a text, out b text)
-@@ -1835,6 +1325,18 @@
+@@ -1835,6 +1341,18 @@
    language sql
    as $$ select 'foo ' || i, 'bar ' || i from generate_series(1,$1) i $$;
  set work_mem='64kB';
@@ -1683,7 +1498,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1842,6 +1344,18 @@
+@@ -1842,6 +1360,18 @@
  (1 row)
  
  reset work_mem;
@@ -1702,7 +1517,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select t.a, t, t.a from rngfunc1(10000) t limit 1;
     a   |         t         |   a   
  -------+-------------------+-------
-@@ -1871,8 +1385,6 @@
+@@ -1871,8 +1401,6 @@
  
  select * from array_to_set(array['one', 'two']); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1711,7 +1526,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- after-the-fact coercion of the columns is now possible, too
  select * from array_to_set(array['one', 'two']) as t(f1 numeric(4,2),f2 text);
    f1  | f2  
-@@ -1883,19 +1395,20 @@
+@@ -1883,19 +1411,20 @@
  
  -- and if it doesn't work, you get a compile-time not run-time error
  select * from array_to_set(array['one', 'two']) as t(f1 point,f2 text);
@@ -1742,7 +1557,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- but without, it can be:
  create or replace function array_to_set(anyarray) returns setof record as $$
    select i AS "index", $1[i] AS "value" from generate_subscripts($1, 1) i
-@@ -1922,18 +1435,19 @@
+@@ -1922,18 +1451,19 @@
  (2 rows)
  
  select * from array_to_set(array['one', 'two']) as t(f1 point,f2 text);
@@ -1772,7 +1587,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  create temp table rngfunc(f1 int8, f2 int8);
  create function testrngfunc() returns record as $$
    insert into rngfunc values (1,2) returning *;
-@@ -1952,8 +1466,6 @@
+@@ -1952,8 +1482,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1781,7 +1596,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  create function testrngfunc() returns setof record as $$
    insert into rngfunc values (1,2), (3,4) returning *;
-@@ -1974,8 +1486,6 @@
+@@ -1974,8 +1502,6 @@
  
  select * from testrngfunc(); -- fail
  ERROR:  a column definition list is required for functions returning "record"
@@ -1790,7 +1605,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function testrngfunc();
  -- Check that typmod imposed by a composite type is honored
  create type rngfunc_type as (f1 numeric(35,6), f2 numeric(35,2));
-@@ -1984,12 +1494,11 @@
+@@ -1984,12 +1510,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1808,7 +1623,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -1998,13 +1507,11 @@
+@@ -1998,13 +1523,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1827,7 +1642,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2016,12 +1523,11 @@
+@@ -2016,12 +1539,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1845,7 +1660,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2030,13 +1536,11 @@
+@@ -2030,13 +1552,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1864,7 +1679,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2049,13 +1553,11 @@
+@@ -2049,13 +1569,11 @@
  $$ language sql immutable;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1883,7 +1698,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2064,12 +1566,11 @@
+@@ -2064,12 +1582,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1901,7 +1716,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2081,13 +1582,11 @@
+@@ -2081,13 +1598,11 @@
  $$ language sql volatile;
  explain (verbose, costs off)
  select testrngfunc();
@@ -1920,7 +1735,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select testrngfunc();
     testrngfunc   
  -----------------
-@@ -2096,13 +1595,11 @@
+@@ -2096,13 +1611,11 @@
  
  explain (verbose, costs off)
  select * from testrngfunc();
@@ -1939,7 +1754,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  select * from testrngfunc();
      f1    |  f2  
  ----------+------
-@@ -2112,62 +1609,45 @@
+@@ -2112,62 +1625,45 @@
  create or replace function testrngfunc() returns setof rngfunc_type as $$
    select 1, 2 union select 3, 4 order by 1;
  $$ language sql immutable;
@@ -2023,7 +1838,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  --
  -- Check some cases involving added/dropped columns in a rowtype result
  --
-@@ -2178,79 +1658,37 @@
+@@ -2178,79 +1674,37 @@
  create or replace function get_first_user() returns users as
  $$ SELECT * FROM users ORDER BY userid LIMIT 1; $$
  language sql stable;
@@ -2116,7 +1931,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- We used to have a bug that would allow the above to succeed, posing
  -- hazards for later execution of the view.  Check that the internal
  -- defenses for those hazards haven't bit-rotted, in case some other
-@@ -2264,18 +1702,14 @@
+@@ -2264,18 +1718,14 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2139,7 +1954,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  -- likewise, check we don't crash if the dependency goes wrong
  begin;
  -- destroy the dependency entry that prevents the ALTER:
-@@ -2286,19 +1720,18 @@
+@@ -2286,19 +1736,18 @@
  returning pg_describe_object(classid, objid, objsubid) as obj,
            pg_describe_object(refclassid, refobjid, refobjsubid) as ref,
            deptype;
@@ -2165,7 +1980,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop table users;
  -- check behavior with type coercion required for a set-op
  create or replace function rngfuncbar() returns setof text as
-@@ -2320,17 +1753,11 @@
+@@ -2320,17 +1769,11 @@
  
  -- this function is now inlinable, too:
  explain (verbose, costs off) select * from rngfuncbar();
@@ -2188,7 +2003,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  drop function rngfuncbar();
  -- check handling of a SQL function with multiple OUT params (bug #5777)
  create or replace function rngfuncbar(out integer, out numeric) as
-@@ -2344,115 +1771,93 @@
+@@ -2344,115 +1787,93 @@
  create or replace function rngfuncbar(out integer, out numeric) as
  $$ select (1, 2) $$ language sql;
  select * from rngfuncbar();  -- fail
@@ -2355,7 +2170,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rangefuncs.out --
  (0 rows)
  
  drop type rngfunc2;
-@@ -2463,18 +1868,11 @@
+@@ -2463,18 +1884,11 @@
     from unnest(array['{"lectures": [{"id": "1"}]}'::jsonb])
          as unnested_modules(module)) as ss,
    jsonb_to_recordset(ss.lecture) as j (id text);

--- a/pkg/cmd/roachtest/testdata/pg_regress/roleattributes.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/roleattributes.diffs
@@ -130,7 +130,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/roleattributes.ou
           rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
  -------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
 - regress_test_createrole | f        | t          | f             | f           | f           | f              | f            |           -1 |             | 
-+ regress_test_createrole | f        | t          | t             | f           | f           | f              | f            |           -1 | ********    | 
++ regress_test_createrole | f        | t          | f             | f           | f           | f              | f            |           -1 | ********    | 
  (1 row)
  
  ALTER ROLE regress_test_createrole WITH CREATEROLE;
@@ -163,7 +163,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/roleattributes.ou
          rolname        | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
  -----------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
 - regress_test_createdb | f        | t          | f             | f           | f           | f              | f            |           -1 |             | 
-+ regress_test_createdb | f        | t          | f             | t           | f           | f              | f            |           -1 | ********    | 
++ regress_test_createdb | f        | t          | f             | f           | f           | f              | f            |           -1 | ********    | 
  (1 row)
  
  ALTER ROLE regress_test_createdb WITH CREATEDB;
@@ -295,7 +295,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/roleattributes.ou
          rolname         | rolsuper | rolinherit | rolcreaterole | rolcreatedb | rolcanlogin | rolreplication | rolbypassrls | rolconnlimit | rolpassword | rolvaliduntil 
  ------------------------+----------+------------+---------------+-------------+-------------+----------------+--------------+--------------+-------------+---------------
 - regress_test_bypassrls | f        | t          | f             | f           | f           | f              | f            |           -1 |             | 
-+ regress_test_bypassrls | f        | t          | f             | f           | f           | f              | t            |           -1 | ********    | 
++ regress_test_bypassrls | f        | t          | f             | f           | f           | f              | f            |           -1 | ********    | 
  (1 row)
  
  ALTER ROLE regress_test_bypassrls WITH BYPASSRLS;

--- a/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rowsecurity.diffs
@@ -1680,17 +1680,17 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -drop cascades to policy r2 on table rec2
 +ERROR:  relation "rec1v" does not exist
  CREATE VIEW rec1v WITH (security_barrier) AS SELECT * FROM rec1;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW rec1v WITH (security_barrier) AS SELECT * FROM rec1
-+                  ^
++                        ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW rec2v WITH (security_barrier) AS SELECT * FROM rec2;
 -SET SESSION AUTHORIZATION regress_rls_alice;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW rec2v WITH (security_barrier) AS SELECT * FROM rec2
-+                  ^
++                        ^
 +HINT:  try \h CREATE VIEW
 +SET ROLE regress_rls_alice;
  CREATE POLICY r1 ON rec1 USING (x = (SELECT a FROM rec2v WHERE b = y));
@@ -2359,10 +2359,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -SET SESSION AUTHORIZATION regress_rls_bob;
 +SET ROLE regress_rls_bob;
  CREATE VIEW bv1 WITH (security_barrier) AS SELECT * FROM b1 WHERE a > 0 WITH CHECK OPTION;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW bv1 WITH (security_barrier) AS SELECT * FROM b1 WHERE a > 0 WITH CHECK OPTION
-+                ^
++                      ^
 +HINT:  try \h CREATE VIEW
  GRANT ALL ON bv1 TO regress_rls_carol;
 -SET SESSION AUTHORIZATION regress_rls_carol;
@@ -3075,7 +3075,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET ROLE regress_rls_group2;
  SELECT * FROM z1 WHERE f_leak(b);
  NOTICE:  f_leak => aba
-@@ -2499,422 +1762,324 @@
+@@ -2499,74 +1762,55 @@
  (2 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM z1 WHERE f_leak(b);
@@ -3143,34 +3143,31 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -SET SESSION AUTHORIZATION regress_rls_alice;
 +SET ROLE regress_rls_alice;
  CREATE VIEW rls_view AS SELECT * FROM z1 WHERE f_leak(b);
-+ERROR:  unknown function: f_leak()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
  GRANT SELECT ON rls_view TO regress_rls_bob;
-+ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  -- Query as role that is not owner of view or table.  Should return all records.
 -SET SESSION AUTHORIZATION regress_rls_bob;
 +SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => aba
--NOTICE:  f_leak => bbb
+ NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => ccc
--NOTICE:  f_leak => dad
-- a |  b  
-----+-----
+ NOTICE:  f_leak => dad
+  a |  b  
+ ---+-----
 - 1 | aba
-- 2 | bbb
+  2 | bbb
 - 3 | ccc
-- 4 | dad
+  4 | dad
 -(4 rows)
 -
-+ERROR:  relation "rls_view" does not exist
- EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
+-EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -     QUERY PLAN      
 ----------------------
 - Seq Scan on z1
 -   Filter: f_leak(b)
--(2 rows)
--
+ (2 rows)
+ 
++EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 +ERROR:  at or near "off": syntax error
 +DETAIL:  source SQL:
 +EXPLAIN (COSTS OFF) SELECT * FROM rls_view
@@ -3180,19 +3177,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -SET SESSION AUTHORIZATION regress_rls_alice;
 +SET ROLE regress_rls_alice;
  SELECT * FROM rls_view;
--NOTICE:  f_leak => aba
--NOTICE:  f_leak => bbb
--NOTICE:  f_leak => ccc
--NOTICE:  f_leak => dad
-- a |  b  
-----+-----
-- 1 | aba
-- 2 | bbb
-- 3 | ccc
-- 4 | dad
--(4 rows)
--
-+ERROR:  relation "rls_view" does not exist
+ NOTICE:  f_leak => aba
+ NOTICE:  f_leak => bbb
+@@ -2581,39 +1825,41 @@
+ (4 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -     QUERY PLAN      
 ----------------------
@@ -3206,29 +3195,29 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +               ^
 +HINT:  try \h <SELECTCLAUSE>
  DROP VIEW rls_view;
-+ERROR:  relation "rls_view" does not exist
  -- View and Table owners are different.
 -SET SESSION AUTHORIZATION regress_rls_bob;
 +SET ROLE regress_rls_bob;
  CREATE VIEW rls_view AS SELECT * FROM z1 WHERE f_leak(b);
-+ERROR:  unknown function: f_leak()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
  GRANT SELECT ON rls_view TO regress_rls_alice;
-+ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  -- Query as role that is not owner of view but is owner of table.
  -- Should return records based on view owner policies.
 -SET SESSION AUTHORIZATION regress_rls_alice;
 +SET ROLE regress_rls_alice;
  SELECT * FROM rls_view;
--NOTICE:  f_leak => bbb
--NOTICE:  f_leak => dad
-- a |  b  
-----+-----
-- 2 | bbb
-- 4 | dad
++NOTICE:  f_leak => aba
+ NOTICE:  f_leak => bbb
++NOTICE:  f_leak => ccc
+ NOTICE:  f_leak => dad
+  a |  b  
+ ---+-----
++ 1 | aba
+  2 | bbb
++ 3 | ccc
+  4 | dad
 -(2 rows)
--
-+ERROR:  relation "rls_view" does not exist
++(4 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -               QUERY PLAN                
 ------------------------------------------
@@ -3246,15 +3235,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -SET SESSION AUTHORIZATION regress_rls_bob;
 +SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
--NOTICE:  f_leak => bbb
--NOTICE:  f_leak => dad
-- a |  b  
-----+-----
-- 2 | bbb
-- 4 | dad
--(2 rows)
--
-+ERROR:  relation "rls_view" does not exist
+ NOTICE:  f_leak => bbb
+ NOTICE:  f_leak => dad
+@@ -2624,297 +1870,270 @@
+ (2 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -               QUERY PLAN                
 ------------------------------------------
@@ -3272,7 +3257,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_carol;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for view rls_view
-+ERROR:  relation "rls_view" does not exist
++ERROR:  user regress_rls_carol does not have SELECT privilege on relation rls_view
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for view rls_view
 +ERROR:  at or near "off": syntax error
@@ -3285,18 +3270,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_bob;
  GRANT SELECT ON rls_view TO regress_rls_carol;
 -SET SESSION AUTHORIZATION regress_rls_carol;
-+ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
 +SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
 -NOTICE:  f_leak => dad
-- a |  b  
-----+-----
++NOTICE:  f_leak => aba
++NOTICE:  f_leak => ccc
+  a |  b  
+ ---+-----
 - 2 | bbb
 - 4 | dad
--(2 rows)
--
-+ERROR:  relation "rls_view" does not exist
++ 1 | aba
++ 3 | ccc
+ (2 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -               QUERY PLAN                
 ------------------------------------------
@@ -3321,7 +3308,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_bob;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
-+ERROR:  relation "rls_view" does not exist
++NOTICE:  f_leak => bbb
++NOTICE:  f_leak => dad
++ a |  b  
++---+-----
++ 2 | bbb
++ 4 | dad
++(2 rows)
++
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  at or near "off": syntax error
@@ -3334,7 +3328,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_carol;
  SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
-+ERROR:  relation "rls_view" does not exist
++NOTICE:  f_leak => aba
++NOTICE:  f_leak => ccc
++ a |  b  
++---+-----
++ 1 | aba
++ 3 | ccc
++(2 rows)
++
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view; --fail - permission denied.
 -ERROR:  permission denied for table z1_blacklist
 +ERROR:  at or near "off": syntax error
@@ -3349,13 +3350,15 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 -SET SESSION AUTHORIZATION regress_rls_bob;
 +SET ROLE regress_rls_bob;
  SELECT * FROM rls_view;
--NOTICE:  f_leak => bbb
-- a |  b  
-----+-----
-- 2 | bbb
+ NOTICE:  f_leak => bbb
++NOTICE:  f_leak => dad
+  a |  b  
+ ---+-----
+  2 | bbb
 -(1 row)
--
-+ERROR:  relation "rls_view" does not exist
++ 4 | dad
++(2 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -                              QUERY PLAN                              
 -----------------------------------------------------------------------
@@ -3375,12 +3378,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_carol;
  SELECT * FROM rls_view;
 -NOTICE:  f_leak => bbb
-- a |  b  
-----+-----
++NOTICE:  f_leak => aba
++NOTICE:  f_leak => ccc
+  a |  b  
+ ---+-----
 - 2 | bbb
 -(1 row)
--
-+ERROR:  relation "rls_view" does not exist
++ 1 | aba
++ 3 | ccc
++(2 rows)
+ 
  EXPLAIN (COSTS OFF) SELECT * FROM rls_view;
 -                              QUERY PLAN                              
 -----------------------------------------------------------------------
@@ -3403,7 +3410,6 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +ERROR:  policy "p3" for table "z1" does not exist
 +SET ROLE regress_rls_bob;
  DROP VIEW rls_view;
-+ERROR:  relation "rls_view" does not exist
  --
  -- Security invoker views should follow policy for current user.
  --
@@ -3412,11 +3418,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_alice;
  CREATE VIEW rls_view WITH (security_invoker) AS
      SELECT * FROM z1 WHERE f_leak(b);
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE VIEW rls_view WITH (security_invoker) AS
-+                     ^
-+HINT:  try \h CREATE VIEW
++ERROR:  security invoker views are not supported
  GRANT SELECT ON rls_view TO regress_rls_bob;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  GRANT SELECT ON rls_view TO regress_rls_carol;
@@ -3507,11 +3509,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_bob;
  CREATE VIEW rls_view WITH (security_invoker) AS
      SELECT * FROM z1 WHERE f_leak(b);
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE VIEW rls_view WITH (security_invoker) AS
-+                     ^
-+HINT:  try \h CREATE VIEW
++ERROR:  security invoker views are not supported
  GRANT SELECT ON rls_view TO regress_rls_alice;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "rls_view" does not exist
  GRANT SELECT ON rls_view TO regress_rls_carol;
@@ -3707,7 +3705,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE x1 (a int, b text, c text);
  GRANT ALL ON x1 TO PUBLIC;
  INSERT INTO x1 VALUES
-@@ -2932,7 +2097,7 @@
+@@ -2932,7 +2151,7 @@
  CREATE POLICY p3 ON x1 FOR UPDATE USING (a % 2 = 0);
  CREATE POLICY p4 ON x1 FOR DELETE USING (a < 8);
  ALTER TABLE x1 ENABLE ROW LEVEL SECURITY;
@@ -3716,7 +3714,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM x1 WHERE f_leak(b) ORDER BY a ASC;
  NOTICE:  f_leak => abc
  NOTICE:  f_leak => bcd
-@@ -2967,13 +2132,13 @@
+@@ -2967,13 +2186,13 @@
   8 | fgh_updt | regress_rls_carol
  (6 rows)
  
@@ -3733,7 +3731,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  NOTICE:  f_leak => fgh_updt
   a |    b     |         c         
  ---+----------+-------------------
-@@ -2986,50 +2151,50 @@
+@@ -2986,50 +2205,50 @@
  (6 rows)
  
  UPDATE x1 SET b = b || '_updt' WHERE f_leak(b) RETURNING *;
@@ -3794,7 +3792,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON y2 FOR ALL USING (a % 2 = 0);  --OK
  ALTER TABLE y1 ENABLE ROW LEVEL SECURITY;
  ALTER TABLE y2 ENABLE ROW LEVEL SECURITY;
-@@ -3037,189 +2202,105 @@
+@@ -3037,189 +2256,105 @@
  -- Expression structure with SBV
  --
  -- Create view as table owner.  RLS should NOT be applied.
@@ -3802,10 +3800,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_alice;
  CREATE VIEW rls_sbv WITH (security_barrier) AS
      SELECT * FROM y1 WHERE f_leak(b);
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW rls_sbv WITH (security_barrier) AS
-+                    ^
++                          ^
 +HINT:  try \h CREATE VIEW
  EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
 -            QUERY PLAN             
@@ -3826,10 +3824,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
 +SET ROLE regress_rls_bob;
  CREATE VIEW rls_sbv WITH (security_barrier) AS
      SELECT * FROM y1 WHERE f_leak(b);
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW rls_sbv WITH (security_barrier) AS
-+                    ^
++                          ^
 +HINT:  try \h CREATE VIEW
  EXPLAIN (COSTS OFF) SELECT * FROM rls_sbv WHERE (a = 1);
 -                            QUERY PLAN                            
@@ -4038,7 +4036,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE t1 (a integer);
  GRANT SELECT ON t1 TO regress_rls_bob, regress_rls_carol;
  CREATE POLICY p1 ON t1 TO regress_rls_bob USING ((a % 2) = 0);
-@@ -3230,97 +2311,62 @@
+@@ -3230,97 +2365,62 @@
  PREPARE role_inval AS SELECT * FROM t1;
  -- Check plan
  EXPLAIN (COSTS OFF) EXECUTE role_inval;
@@ -4169,7 +4167,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  WITH cte1 AS (INSERT INTO t1 VALUES (21, 'Fail') RETURNING *) SELECT * FROM cte1; --fail
  ERROR:  new row violates row-level security policy for table "t1"
-@@ -3333,9 +2379,8 @@
+@@ -3333,9 +2433,8 @@
  --
  -- Rename Policy
  --
@@ -4180,7 +4178,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT polname, relname
      FROM pg_policy pol
      JOIN pg_class pc ON (pc.oid = pol.polrelid)
-@@ -3358,80 +2403,46 @@
+@@ -3358,80 +2457,46 @@
  --
  -- Check INSERT SELECT
  --
@@ -4285,7 +4283,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE blog (id integer, author text, post text);
  CREATE TABLE comment (blog_id integer, message text);
  GRANT ALL ON blog, comment TO regress_rls_bob;
-@@ -3450,7 +2461,7 @@
+@@ -3450,7 +2515,7 @@
      (5, 'what?'),
      (4, 'insane!'),
      (2, 'who did it?');
@@ -4294,7 +4292,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Check RLS JOIN with Non-RLS.
  SELECT id, author, message FROM blog JOIN comment ON id = blog_id;
   id | author |   message   
-@@ -3467,10 +2478,10 @@
+@@ -3467,10 +2532,10 @@
    2 | bob    | who did it?
  (2 rows)
  
@@ -4307,7 +4305,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Check RLS JOIN RLS
  SELECT id, author, message FROM blog JOIN comment ON id = blog_id;
   id | author |   message   
-@@ -3484,86 +2495,44 @@
+@@ -3484,86 +2549,44 @@
    2 | bob    | who did it?
  (1 row)
  
@@ -4415,7 +4413,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security TO ON;
  SELECT * FROM t1;
   a | b 
-@@ -3571,221 +2540,158 @@
+@@ -3571,221 +2594,158 @@
  (0 rows)
  
  EXPLAIN (COSTS OFF) SELECT * FROM t1;
@@ -4687,7 +4685,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE current_check (currentid int, payload text, rlsuser text);
  GRANT ALL ON current_check TO PUBLIC;
  INSERT INTO current_check VALUES
-@@ -3797,7 +2703,7 @@
+@@ -3797,7 +2757,7 @@
  CREATE POLICY p2 ON current_check FOR DELETE USING (currentid = 4 AND rlsuser = current_user);
  CREATE POLICY p3 ON current_check FOR UPDATE USING (currentid = 4) WITH CHECK (rlsuser = current_user);
  ALTER TABLE current_check ENABLE ROW LEVEL SECURITY;
@@ -4696,7 +4694,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- Can SELECT even rows
  SELECT * FROM current_check;
   currentid | payload |     rlsuser     
-@@ -3814,112 +2720,74 @@
+@@ -3814,112 +2774,74 @@
  
  BEGIN;
  DECLARE current_check_cursor SCROLL CURSOR FOR SELECT * FROM current_check;
@@ -4846,7 +4844,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT attname, most_common_vals FROM pg_stats
    WHERE tablename = 'current_check'
    ORDER BY 1;
-@@ -3932,16 +2800,18 @@
+@@ -3932,16 +2854,18 @@
  --
  BEGIN;
  CREATE TABLE coll_t (c) AS VALUES ('bar'::text);
@@ -4869,7 +4867,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM coll_t;
    c  
  -----
-@@ -3949,14 +2819,17 @@
+@@ -3949,14 +2873,17 @@
  (1 row)
  
  ROLLBACK;
@@ -4888,7 +4886,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  GRANT SELECT ON TABLE tbl1 TO regress_rls_eve;
  CREATE POLICY P ON tbl1 TO regress_rls_eve, regress_rls_frank USING (true);
  SELECT refclassid::regclass, deptype
-@@ -3965,8 +2838,7 @@
+@@ -3965,8 +2892,7 @@
    AND refobjid = 'tbl1'::regclass;
   refclassid | deptype 
  ------------+---------
@@ -4898,7 +4896,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  
  SELECT refclassid::regclass, deptype
    FROM pg_shdepend
-@@ -3974,48 +2846,58 @@
+@@ -3974,48 +2900,58 @@
    AND refobjid IN ('regress_rls_eve'::regrole, 'regress_rls_frank'::regrole);
   refclassid | deptype 
  ------------+---------
@@ -4967,7 +4965,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE TABLE r1 (a int);
  CREATE TABLE r2 (a int);
  INSERT INTO r1 VALUES (10), (20);
-@@ -4028,7 +2910,7 @@
+@@ -4028,7 +2964,7 @@
  CREATE POLICY p3 ON r2 FOR UPDATE USING (false);
  CREATE POLICY p4 ON r2 FOR DELETE USING (false);
  ALTER TABLE r2 ENABLE ROW LEVEL SECURITY;
@@ -4976,7 +4974,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SELECT * FROM r1;
   a  
  ----
-@@ -4092,13 +2974,13 @@
+@@ -4092,13 +3028,13 @@
   20
  (2 rows)
  
@@ -4992,7 +4990,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int);
  INSERT INTO r1 VALUES (10), (20);
-@@ -4131,19 +3013,17 @@
+@@ -4131,19 +3067,17 @@
  SET row_security = off;
  -- these all fail, would be affected by RLS
  TABLE r1;
@@ -5017,7 +5015,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int PRIMARY KEY);
  CREATE TABLE r2 (a int REFERENCES r1);
-@@ -4157,7 +3037,7 @@
+@@ -4157,7 +3091,7 @@
  ALTER TABLE r2 FORCE ROW LEVEL SECURITY;
  -- Errors due to rows in r2
  DELETE FROM r1;
@@ -5026,7 +5024,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DETAIL:  Key (a)=(10) is still referenced from table "r2".
  -- Reset r2 to no-RLS
  DROP POLICY p1 ON r2;
-@@ -4233,7 +3113,7 @@
+@@ -4233,7 +3167,7 @@
  -- Test INSERT+RETURNING applies SELECT policies as
  -- WithCheckOptions (meaning an error is thrown)
  --
@@ -5035,7 +5033,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int);
  CREATE POLICY p1 ON r1 FOR SELECT USING (false);
-@@ -4251,8 +3131,10 @@
+@@ -4251,8 +3185,10 @@
  SET row_security = off;
  -- fail, would be affected by RLS
  TABLE r1;
@@ -5048,7 +5046,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  -- Error
  INSERT INTO r1 VALUES (10), (20) RETURNING *;
-@@ -4262,7 +3144,7 @@
+@@ -4262,7 +3198,7 @@
  -- Test UPDATE+RETURNING applies SELECT policies as
  -- WithCheckOptions (meaning an error is thrown)
  --
@@ -5057,7 +5055,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  SET row_security = on;
  CREATE TABLE r1 (a int PRIMARY KEY);
  CREATE POLICY p1 ON r1 FOR SELECT USING (a < 20);
-@@ -4308,28 +3190,31 @@
+@@ -4308,28 +3244,31 @@
  ERROR:  new row violates row-level security policy for table "r1"
  DROP TABLE r1;
  -- Check dependency handling
@@ -5092,7 +5090,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Should return one
-@@ -4338,7 +3223,7 @@
+@@ -4338,7 +3277,7 @@
  					 AND refobjid = (SELECT oid FROM pg_authid WHERE rolname = 'regress_rls_carol');
   ?column? 
  ----------
@@ -5101,7 +5099,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  (1 row)
  
  -- Should return zero
-@@ -4351,15 +3236,19 @@
+@@ -4351,15 +3290,19 @@
  (1 row)
  
  -- DROP OWNED BY testing
@@ -5123,7 +5121,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role2 USING (true);
  DROP OWNED BY regress_rls_dob_role1;
  DROP POLICY p1 ON dob_t1; -- should succeed
-@@ -4367,14 +3256,15 @@
+@@ -4367,14 +3310,15 @@
  CREATE POLICY p1 ON dob_t1 TO regress_rls_dob_role1,regress_rls_dob_role1 USING (true);
  DROP OWNED BY regress_rls_dob_role1;
  DROP POLICY p1 ON dob_t1; -- should fail, already gone
@@ -5140,7 +5138,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  DROP USER regress_rls_dob_role1;
  DROP USER regress_rls_dob_role2;
  -- Bug #15708: view + table with RLS should check policies as view owner
-@@ -4384,81 +3274,97 @@
+@@ -4384,81 +3328,97 @@
  INSERT INTO rls_tbl VALUES (10);
  ALTER TABLE rls_tbl ENABLE ROW LEVEL SECURITY;
  CREATE POLICY p1 ON rls_tbl USING (EXISTS (SELECT 1 FROM ref_tbl));
@@ -5272,7 +5270,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rowsecurity.out -
  -- CVE-2023-2455: inlining an SRF may introduce an RLS dependency
  create table rls_t (c text);
  insert into rls_t values ('invisible to bob');
-@@ -4489,39 +3395,8 @@
+@@ -4489,39 +3449,8 @@
  --
  -- Clean up objects
  --

--- a/pkg/cmd/roachtest/testdata/pg_regress/rules.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/rules.diffs
@@ -1204,54 +1204,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  create table rtest_view1 (a int4, b text, v bool);
  create table rtest_view2 (a int4);
  create table rtest_view3 (a int4, b text);
-@@ -767,6 +1041,8 @@
- 	language sql;
- create view rtest_vview5 as select a, b, rtest_viewfunc1(a) as refcount
- 	from rtest_view1;
-+ERROR:  unknown function: rtest_viewfunc1()
-+HINT:  There is probably a typo in function name. Or the intention was to use a user-defined function in the view query, which is currently not supported.
- insert into rtest_view1 values (1, 'item 1', 't');
- insert into rtest_view1 values (2, 'item 2', 't');
- insert into rtest_view1 values (3, 'item 3', 't');
-@@ -821,18 +1097,7 @@
- (4 rows)
- 
- select * from rtest_vview5;
-- a |   b    | refcount 
-----+--------+----------
-- 1 | item 1 |        0
-- 2 | item 2 |        2
-- 3 | item 3 |        0
-- 4 | item 4 |        1
-- 5 | item 5 |        1
-- 6 | item 6 |        0
-- 7 | item 7 |        4
-- 8 | item 8 |        0
--(8 rows)
--
-+ERROR:  relation "rtest_vview5" does not exist
- insert into rtest_view3 select * from rtest_vview1 where a < 7;
- select * from rtest_view3;
-  a |   b    
-@@ -875,13 +1140,11 @@
- 
- delete from rtest_view4;
- insert into rtest_view4 select * from rtest_vview5 where a > 2 and refcount = 0;
-+ERROR:  relation "rtest_vview5" does not exist
- select * from rtest_view4;
-- a |   b    | c 
-----+--------+---
-- 3 | item 3 | 0
-- 6 | item 6 | 0
-- 8 | item 8 | 0
--(3 rows)
-+ a | b | c 
-+---+---+---
-+(0 rows)
- 
- delete from rtest_view4;
- --
-@@ -921,15 +1184,10 @@
+@@ -921,15 +1195,10 @@
  (6 rows)
  
  select * from rtest_vcomp where size_in_cm > 10.0 order by size_in_cm using >;
@@ -1271,7 +1224,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- In addition run the (slightly modified) queries from the
  -- programmers manual section on the rule system.
-@@ -983,6 +1241,8 @@
+@@ -983,6 +1252,8 @@
  	 WHERE rsl.sl_color = rsh.slcolor
  	   AND rsl.sl_len_cm >= rsh.slminlen_cm
  	   AND rsl.sl_len_cm <= rsh.slmaxlen_cm;
@@ -1280,7 +1233,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  INSERT INTO unit VALUES ('cm', 1.0);
  INSERT INTO unit VALUES ('m', 100.0);
  INSERT INTO unit VALUES ('inch', 2.54);
-@@ -1013,12 +1273,7 @@
+@@ -1013,12 +1284,7 @@
  (8 rows)
  
  SELECT * FROM shoe_ready WHERE total_avail >= 2 ORDER BY 1;
@@ -1294,7 +1247,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
      CREATE TABLE shoelace_log (
          sl_name    char(10),      -- shoelace changed
          sl_avail   integer,       -- new available value
-@@ -1036,12 +1291,26 @@
+@@ -1036,12 +1302,26 @@
                                          'Al Bundy',
                                          'epoch'
                                      );
@@ -1325,7 +1278,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
      CREATE RULE shoelace_ins AS ON INSERT TO shoelace
          DO INSTEAD
-@@ -1051,6 +1320,21 @@
+@@ -1051,6 +1331,21 @@
                 NEW.sl_color,
                 NEW.sl_len,
                 NEW.sl_unit);
@@ -1347,7 +1300,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
      CREATE RULE shoelace_upd AS ON UPDATE TO shoelace
          DO INSTEAD
          UPDATE shoelace_data SET
-@@ -1060,10 +1344,40 @@
+@@ -1060,10 +1355,40 @@
                 sl_len = NEW.sl_len,
                 sl_unit = NEW.sl_unit
           WHERE sl_name = OLD.sl_name;
@@ -1388,7 +1341,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
      CREATE TABLE shoelace_arrive (
          arr_name    char(10),
          arr_quant   integer
-@@ -1077,6 +1391,21 @@
+@@ -1077,6 +1402,21 @@
          UPDATE shoelace SET
                 sl_avail = sl_avail + NEW.ok_quant
           WHERE sl_name = NEW.ok_name;
@@ -1410,7 +1363,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  INSERT INTO shoelace_arrive VALUES ('sl3', 10);
  INSERT INTO shoelace_arrive VALUES ('sl6', 20);
  INSERT INTO shoelace_arrive VALUES ('sl8', 20);
-@@ -1099,22 +1428,18 @@
+@@ -1099,22 +1439,18 @@
  ------------+----------+------------+--------+----------+-----------
   sl1        |        5 | black      |     80 | cm       |        80
   sl2        |        6 | black      |    100 | cm       |       100
@@ -1439,7 +1392,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
      CREATE VIEW shoelace_obsolete AS
  	SELECT * FROM shoelace WHERE NOT EXISTS
-@@ -1122,40 +1447,39 @@
+@@ -1122,40 +1458,39 @@
      CREATE VIEW shoelace_candelete AS
  	SELECT * FROM shoelace_obsolete WHERE sl_avail = 0;
  insert into shoelace values ('sl9', 0, 'pink', 35.0, 'inch', 0.0);
@@ -1494,7 +1447,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
  SELECT * FROM shoe ORDER BY shoename;
    shoename  | sh_avail |  slcolor   | slminlen | slminlen_cm | slmaxlen | slmaxlen_cm |  slunit  
-@@ -1179,42 +1503,114 @@
+@@ -1179,42 +1514,114 @@
  create table rules_foo2 (f1 int);
  create rule rules_foorule as on insert to rules_foo where f1 < 100
  do instead nothing;
@@ -1618,7 +1571,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  drop table rules_foo;
  drop table rules_foo2;
  --
-@@ -1236,6 +1632,21 @@
+@@ -1236,6 +1643,21 @@
      select old.pid, new.descrip where old.descrip isnull;
    update cchild set descrip = new.descrip where cchild.pid = old.pid;
  );
@@ -1640,7 +1593,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  select * from vview;
   pid |   txt   | descrip  
  -----+---------+----------
-@@ -1244,37 +1655,54 @@
+@@ -1244,37 +1666,54 @@
  (2 rows)
  
  update vview set descrip='test1' where pid=1;
@@ -1711,7 +1664,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  drop view vview;
  drop table pparent;
  drop table cchild;
-@@ -1286,1357 +1714,9 @@
+@@ -1286,1357 +1725,9 @@
  SELECT viewname, definition FROM pg_views
  WHERE schemaname = 'pg_catalog'
  ORDER BY viewname;
@@ -3069,7 +3022,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- restore normal output mode
  \a\t
  --
-@@ -2646,16 +1726,44 @@
+@@ -2646,16 +1737,44 @@
  CREATE TABLE ruletest_tbl2 (a int, b int);
  CREATE OR REPLACE RULE myrule AS ON INSERT TO ruletest_tbl
  	DO INSTEAD INSERT INTO ruletest_tbl2 VALUES (10, 10);
@@ -3119,7 +3072,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
  -- Check that rewrite rules splitting one INSERT into multiple
  -- conditional statements does not disable FK checking.
-@@ -2691,27 +1799,27 @@
+@@ -2691,27 +1810,27 @@
  insert into rule_and_refint_t3 values (1, 12, 11, 'row3');
  insert into rule_and_refint_t3 values (1, 12, 12, 'row4');
  insert into rule_and_refint_t3 values (1, 11, 13, 'row5');
@@ -3152,7 +3105,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  create rule rule_and_refint_t3_ins as on insert to rule_and_refint_t3
  	where (exists (select 1 from rule_and_refint_t3
  			where (((rule_and_refint_t3.id3a = new.id3a)
-@@ -2721,19 +1829,47 @@
+@@ -2721,19 +1840,47 @@
  	where (((rule_and_refint_t3.id3a = new.id3a)
  	and (rule_and_refint_t3.id3b = new.id3b))
  	and (rule_and_refint_t3.id3c = new.id3c));
@@ -3204,7 +3157,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  drop view rules_fooview;
  --
  -- We used to allow converting a table to a view by creating a "_RETURN"
-@@ -2742,116 +1878,263 @@
+@@ -2742,116 +1889,263 @@
  create table rules_fooview (x int, y text);
  create rule "_RETURN" as on select to rules_fooview do instead
    select 1 as x, 'aaa'::text as y;
@@ -3515,7 +3468,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
   10
   11
   12
-@@ -2862,83 +2145,98 @@
+@@ -2862,83 +2156,98 @@
   17
   18
   19
@@ -3558,10 +3511,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +update rules_base set f2 = f2 + 1;
@@ -3577,11 +3530,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
 +create or replace rule r1 as on update to rules_base do instead
 +                       ^
 +HINT:  You have attempted to use a feature that is not yet implemented.
- 
++
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
@@ -3669,7 +3622,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- check multi-row VALUES in rules
  --
-@@ -2947,6 +2245,21 @@
+@@ -2947,6 +2256,21 @@
  insert into rules_src values(1,2), (11,12);
  create rule r1 as on update to rules_src do also
    insert into rules_log values(old.*, 'old', default), (new.*, 'new', default);
@@ -3691,7 +3644,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  update rules_src set f2 = f2 + 1;
  update rules_src set f2 = f2 * 10;
  select * from rules_src;
-@@ -2957,68 +2270,112 @@
+@@ -2957,68 +2281,112 @@
  (2 rows)
  
  select * from rules_log;
@@ -3729,10 +3682,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
- 
++
 +If you would rather not post publicly, please contact us directly
 +using the support form.
-+
+ 
 +We appreciate your feedback.
 +
 +update rules_src set f2 = f2 / 10;
@@ -3848,7 +3801,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- Check deparse disambiguation of INSERT/UPDATE/DELETE targets.
  --
-@@ -3028,52 +2385,32 @@
+@@ -3028,52 +2396,32 @@
         wdel as (delete from int4_tbl trgt where f1 = 0 returning *)
    insert into rules_log AS trgt select old.* from wins, wupd, wdel
    returning trgt.f1, trgt.f2;
@@ -3925,7 +3878,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- Also check multiassignment deparsing.
  --
-@@ -3082,21 +2419,31 @@
+@@ -3082,21 +2430,31 @@
  create rule rr as on update to rule_t1 do instead UPDATE rule_dest trgt
    SET (f2[1], f1, tag) = (SELECT new.f2, new.f1, 'updated'::varchar)
    WHERE trgt.f1 = new.f1 RETURNING new.*;
@@ -3952,10 +3905,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
- 
++
 +We appreciate your feedback.
 +
 +\d+ rule_t1
@@ -3971,7 +3924,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  drop table rule_t1, rule_dest;
  --
  -- Test implicit LATERAL references to old/new in rules
-@@ -3106,23 +2453,50 @@
+@@ -3106,23 +2464,50 @@
  CREATE RULE v1_ins AS ON INSERT TO rule_v1
    DO ALSO INSERT INTO rule_t1
    SELECT * FROM (SELECT a + 10 FROM rule_t1 WHERE a = NEW.a) tt;
@@ -4030,7 +3983,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- check alter rename rule
  --
-@@ -3132,36 +2506,65 @@
+@@ -3132,36 +2517,65 @@
      ON INSERT TO rule_v1
      DO INSTEAD
          INSERT INTO rule_t1 VALUES(new.a);
@@ -4113,7 +4066,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  DROP VIEW rule_v1;
  DROP TABLE rule_t1;
  --
-@@ -3169,66 +2572,70 @@
+@@ -3169,66 +2583,70 @@
  --
  create view rule_v1 as values(1,2);
  \d+ rule_v1
@@ -4232,7 +4185,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- Check DO INSTEAD rules with ON CONFLICT
  --
-@@ -3242,6 +2649,12 @@
+@@ -3242,6 +2660,12 @@
  );
  create unique index hat_data_unique_idx
    on hat_data (hat_name COLLATE "C" bpchar_pattern_ops);
@@ -4245,7 +4198,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- DO NOTHING with ON CONFLICT
  CREATE RULE hat_nosert AS ON INSERT TO hats
      DO INSTEAD
-@@ -3251,16 +2664,25 @@
+@@ -3251,16 +2675,25 @@
          ON CONFLICT (hat_name COLLATE "C" bpchar_pattern_ops) WHERE hat_color = 'green'
          DO NOTHING
          RETURNING *;
@@ -4280,7 +4233,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
  -- Works (projects row)
  INSERT INTO hats VALUES ('h7', 'black') RETURNING *;
-@@ -3271,23 +2693,30 @@
+@@ -3271,23 +2704,30 @@
  
  -- Works (does nothing)
  INSERT INTO hats VALUES ('h7', 'black') RETURNING *;
@@ -4324,7 +4277,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- DO NOTHING without ON CONFLICT
  CREATE RULE hat_nosert_all AS ON INSERT TO hats
      DO INSTEAD
-@@ -3297,24 +2726,46 @@
+@@ -3297,24 +2737,46 @@
          ON CONFLICT
          DO NOTHING
          RETURNING *;
@@ -4384,7 +4337,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- DO UPDATE with a WHERE clause
  CREATE RULE hat_upsert AS ON INSERT TO hats
      DO INSTEAD
-@@ -3326,16 +2777,25 @@
+@@ -3326,16 +2788,25 @@
             SET hat_name = hat_data.hat_name, hat_color = excluded.hat_color
             WHERE excluded.hat_color <>  'forbidden' AND hat_data.* != excluded.*
          RETURNING *;
@@ -4419,7 +4372,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
  -- Works (does upsert)
  INSERT INTO hats VALUES ('h8', 'black') RETURNING *;
-@@ -3345,57 +2805,39 @@
+@@ -3345,57 +2816,39 @@
  (1 row)
  
  SELECT * FROM hat_data WHERE hat_name = 'h8';
@@ -4496,7 +4449,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- ensure upserting into a rule, with a CTE (different offsets!) works
  WITH data(hat_name, hat_color) AS MATERIALIZED (
      VALUES ('h8', 'green'),
-@@ -3405,12 +2847,8 @@
+@@ -3405,12 +2858,8 @@
  INSERT INTO hats
      SELECT * FROM data
  RETURNING *;
@@ -4511,7 +4464,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  EXPLAIN (costs off)
  WITH data(hat_name, hat_color) AS MATERIALIZED (
      VALUES ('h8', 'green'),
-@@ -3420,26 +2858,32 @@
+@@ -3420,26 +2869,32 @@
  INSERT INTO hats
      SELECT * FROM data
  RETURNING *;
@@ -4561,7 +4514,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  drop table hats;
  drop table hat_data;
  -- test for pg_get_functiondef properly regurgitating SET parameters
-@@ -3453,22 +2897,26 @@
+@@ -3453,22 +2908,26 @@
      SET datestyle to iso, mdy
      SET local_preload_libraries TO "Mixed/Case", 'c:/''a"/path', '', '0123456789012345678901234567890123456789012345678901234567890123456789012345678901234567890123456789'
      IMMUTABLE STRICT;
@@ -4592,18 +4545,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
 +Please check the public issue tracker to check whether this problem is
 +already tracked. If you cannot find it there, please report the error
 +with details by creating a new issue.
-+
+ 
 +If you would rather not post publicly, please contact us directly
 +using the support form.
 +
 +We appreciate your feedback.
- 
++
 +SELECT pg_get_functiondef('func_with_set_params()'::regprocedure);
 +ERROR:  unknown function: func_with_set_params()
  -- tests for pg_get_*def with invalid objects
  SELECT pg_get_constraintdef(0);
   pg_get_constraintdef 
-@@ -3489,23 +2937,11 @@
+@@ -3489,23 +2948,11 @@
  (1 row)
  
  SELECT pg_get_ruledef(0);
@@ -4630,7 +4583,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  SELECT pg_get_viewdef(0);
   pg_get_viewdef 
  ----------------
-@@ -3550,11 +2986,42 @@
+@@ -3550,11 +2997,42 @@
  
  -- test rename for a rule defined on a partitioned table
  CREATE TABLE rules_parted_table (a int) PARTITION BY LIST (a);
@@ -4673,7 +4626,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  --
  -- test MERGE
  --
-@@ -3562,11 +3029,56 @@
+@@ -3562,11 +3040,56 @@
  CREATE TABLE rule_merge2 (a int, b text);
  CREATE RULE rule1 AS ON INSERT TO rule_merge1
  	DO INSTEAD INSERT INTO rule_merge2 VALUES (NEW.*);
@@ -4730,7 +4683,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- MERGE not supported for table with rules
  MERGE INTO rule_merge1 t USING (SELECT 1 AS a) s
  	ON t.a = s.a
-@@ -3576,8 +3088,10 @@
+@@ -3576,8 +3099,10 @@
  		DELETE
  	WHEN NOT MATCHED THEN
  		INSERT VALUES (s.a, '');
@@ -4743,7 +4696,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- should be ok with the other table though
  MERGE INTO rule_merge2 t USING (SELECT 1 AS a) s
  	ON t.a = s.a
-@@ -3587,6 +3101,10 @@
+@@ -3587,6 +3112,10 @@
  		DELETE
  	WHEN NOT MATCHED THEN
  		INSERT VALUES (s.a, '');
@@ -4754,7 +4707,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  -- test deparsing
  CREATE TABLE sf_target(id int, data text, filling int[]);
  CREATE FUNCTION merge_sf_test()
-@@ -3629,48 +3147,19 @@
+@@ -3629,48 +3158,19 @@
     THEN INSERT (filling[1], id)
     VALUES (s.a, s.a);
  END;
@@ -4811,7 +4764,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  DROP TABLE sf_target;
  --
  -- Test enabling/disabling
-@@ -3679,30 +3168,84 @@
+@@ -3679,30 +3179,84 @@
  CREATE TABLE ruletest2 (b int);
  CREATE RULE rule1 AS ON INSERT TO ruletest1
      DO INSTEAD INSERT INTO ruletest2 VALUES (NEW.*);
@@ -4900,15 +4853,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  
  DROP TABLE ruletest1;
  DROP TABLE ruletest2;
-@@ -3715,24 +3258,82 @@
+@@ -3715,24 +3269,78 @@
  CREATE TABLE ruletest_t2 (x int);
  CREATE VIEW ruletest_v1 WITH (security_invoker=true) AS
      SELECT * FROM ruletest_t1;
-+ERROR:  at or near "with": syntax error
-+DETAIL:  source SQL:
-+CREATE VIEW ruletest_v1 WITH (security_invoker=true) AS
-+                        ^
-+HINT:  try \h CREATE VIEW
++ERROR:  security invoker views are not supported
  GRANT INSERT ON ruletest_v1 TO regress_rule_user1;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "ruletest_v1" does not exist
  CREATE RULE rule1 AS ON INSERT TO ruletest_v1
@@ -4984,7 +4933,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/rules.out --label
  SELECT * FROM ruletest_t1;
   x 
  ---
-@@ -3741,11 +3342,26 @@
+@@ -3741,11 +3349,26 @@
  SELECT * FROM ruletest_t2;
   x 
  ---

--- a/pkg/cmd/roachtest/testdata/pg_regress/select_views.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/select_views.diffs
@@ -1285,10 +1285,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/select_views.out 
         SELECT * FROM customer WHERE name = current_user;
  CREATE VIEW my_property_secure WITH (security_barrier) AS
         SELECT * FROM customer WHERE name = current_user;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW my_property_secure WITH (security_barrier) AS
-+                               ^
++                                     ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW my_credit_card_normal AS
         SELECT * FROM customer l NATURAL JOIN credit_card r
@@ -1296,20 +1296,20 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/select_views.out 
  CREATE VIEW my_credit_card_secure WITH (security_barrier) AS
         SELECT * FROM customer l NATURAL JOIN credit_card r
         WHERE l.name = current_user;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW my_credit_card_secure WITH (security_barrier) AS
-+                                  ^
++                                        ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW my_credit_card_usage_normal AS
         SELECT * FROM my_credit_card_secure l NATURAL JOIN credit_usage r;
 +ERROR:  relation "my_credit_card_secure" does not exist
  CREATE VIEW my_credit_card_usage_secure WITH (security_barrier) AS
         SELECT * FROM my_credit_card_secure l NATURAL JOIN credit_usage r;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW my_credit_card_usage_secure WITH (security_barrier) AS
-+                                        ^
++                                              ^
 +HINT:  try \h CREATE VIEW
  GRANT SELECT ON my_property_normal TO public;
  GRANT SELECT ON my_property_secure TO public;
@@ -1605,16 +1605,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/select_views.out 
 +              ^
 +HINT:  try \h RESET
  ALTER VIEW my_property_normal SET (security_barrier=true);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +ALTER VIEW my_property_normal SET (security_barrier=true)
-+                                  ^
++                                   ^
 +HINT:  try \h ALTER VIEW
  ALTER VIEW my_property_secure SET (security_barrier=false);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +ALTER VIEW my_property_secure SET (security_barrier=false)
-+                                  ^
++                                   ^
 +HINT:  try \h ALTER VIEW
  SET SESSION AUTHORIZATION regress_alice;
 +ERROR:  at or near "regress_alice": syntax error: unimplemented: this syntax

--- a/pkg/cmd/roachtest/testdata/pg_regress/sequence.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/sequence.diffs
@@ -1,7 +1,7 @@
 diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/sequence.out --label=/mnt/data1/postgres/src/test/regress/results/sequence.out /mnt/data1/postgres/src/test/regress/expected/sequence.out /mnt/data1/postgres/src/test/regress/results/sequence.out
 --- /mnt/data1/postgres/src/test/regress/expected/sequence.out
 +++ /mnt/data1/postgres/src/test/regress/results/sequence.out
-@@ -5,9 +5,9 @@
+@@ -5,27 +5,26 @@
  CREATE SEQUENCE sequence_testx INCREMENT BY 0;
  ERROR:  INCREMENT must not be zero
  CREATE SEQUENCE sequence_testx INCREMENT BY -1 MINVALUE 20;
@@ -13,7 +13,12 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/sequence.out --la
  CREATE SEQUENCE sequence_testx INCREMENT BY -1 START 10;
  ERROR:  START value (10) cannot be greater than MAXVALUE (-1)
  CREATE SEQUENCE sequence_testx INCREMENT BY 1 START -10;
-@@ -19,13 +19,12 @@
+ ERROR:  START value (-10) cannot be less than MINVALUE (1)
+ CREATE SEQUENCE sequence_testx CACHE 0;
+-ERROR:  CACHE (0) must be greater than zero
++ERROR:  PER NODE CACHE (0) must be greater than zero
+ -- OWNED BY errors
+ CREATE SEQUENCE sequence_testx OWNED BY nobody;  -- nonsense word
  ERROR:  invalid OWNED BY option
  HINT:  Specify OWNED BY table.column or OWNED BY NONE.
  CREATE SEQUENCE sequence_testx OWNED BY pg_class_oid_index.oid;  -- not a table

--- a/pkg/cmd/roachtest/testdata/pg_regress/stats_ext.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/stats_ext.diffs
@@ -4630,10 +4630,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/stats_ext.out --l
 +HINT:  try \h RESET
  CREATE VIEW tststats.priv_test_view WITH (security_barrier=true)
      AS SELECT * FROM tststats.priv_test_tbl WHERE false;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW tststats.priv_test_view WITH (security_barrier=true)
-+                                    ^
++                                          ^
 +HINT:  try \h CREATE VIEW
  GRANT SELECT, DELETE ON tststats.priv_test_view TO regress_stats_user1;
 +ERROR:  cannot get the privileges on the grant targets: cannot determine the target type of the GRANT statement: relation "tststats.priv_test_view" does not exist

--- a/pkg/cmd/roachtest/testdata/pg_regress/sysviews.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/sysviews.diffs
@@ -65,7 +65,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/sysviews.out --la
  -- We expect no walreceiver running in this test
  select count(*) = 0 as ok from pg_stat_wal_receiver;
   ok 
-@@ -109,30 +97,24 @@
+@@ -109,30 +97,25 @@
  -- This is to record the prevailing planner enable_foo settings during
  -- a regression test run.
  select name, setting from pg_settings where name like 'enable%';
@@ -106,15 +106,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/sysviews.out --la
 + enable_insert_fast_path                          | on
 + enable_multiple_modifications_of_table           | off
 + enable_multiregion_placement_policy              | off
++ enable_scrub_job                                 | off
 + enable_seqscan                                   | on
 + enable_shared_locking_for_serializable           | off
 + enable_super_regions                             | off
 + enable_zigzag_join                               | off
-+(15 rows)
++(16 rows)
  
  -- Test that the pg_timezone_names and pg_timezone_abbrevs views are
  -- more-or-less working.  We can't test their contents in any great detail
-@@ -149,21 +131,45 @@
+@@ -149,21 +132,45 @@
  select count(distinct utc_offset) >= 24 as ok from pg_timezone_abbrevs;
   ok 
  ----

--- a/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/type_sanity.diffs
@@ -45,7 +45,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Look for "toastable" types that aren't varlena.
  SELECT t1.oid, t1.typname
-@@ -67,15 +81,369 @@
+@@ -67,15 +81,370 @@
       WHERE t2.typname = ('_' || t1.typname)::name AND
             t2.typelem = t1.oid and t1.typarray = t2.oid)
  ORDER BY t1.oid;
@@ -91,308 +91,309 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 +     100198 | interval_tbl
 +     100213 | timestamp_tbl
 +     100214 | timestamptz_tbl
-+ 4294966962 | spatial_ref_sys
-+ 4294966963 | geometry_columns
-+ 4294966964 | geography_columns
-+ 4294966966 | pg_views
-+ 4294966967 | pg_user
-+ 4294966968 | pg_user_mappings
-+ 4294966969 | pg_user_mapping
-+ 4294966970 | pg_type
-+ 4294966971 | pg_ts_template
-+ 4294966972 | pg_ts_parser
-+ 4294966973 | pg_ts_dict
-+ 4294966974 | pg_ts_config
-+ 4294966975 | pg_ts_config_map
-+ 4294966976 | pg_trigger
-+ 4294966977 | pg_transform
-+ 4294966978 | pg_timezone_names
-+ 4294966979 | pg_timezone_abbrevs
-+ 4294966980 | pg_tablespace
-+ 4294966981 | pg_tables
-+ 4294966982 | pg_subscription
-+ 4294966983 | pg_subscription_rel
-+ 4294966984 | pg_stats
-+ 4294966985 | pg_stats_ext
-+ 4294966986 | pg_statistic
-+ 4294966987 | pg_statistic_ext
-+ 4294966988 | pg_statistic_ext_data
-+ 4294966989 | pg_statio_user_tables
-+ 4294966990 | pg_statio_user_sequences
-+ 4294966991 | pg_statio_user_indexes
-+ 4294966992 | pg_statio_sys_tables
-+ 4294966993 | pg_statio_sys_sequences
-+ 4294966994 | pg_statio_sys_indexes
-+ 4294966995 | pg_statio_all_tables
-+ 4294966996 | pg_statio_all_sequences
-+ 4294966997 | pg_statio_all_indexes
-+ 4294966998 | pg_stat_xact_user_tables
-+ 4294966999 | pg_stat_xact_user_functions
-+ 4294967000 | pg_stat_xact_sys_tables
-+ 4294967001 | pg_stat_xact_all_tables
-+ 4294967002 | pg_stat_wal_receiver
-+ 4294967003 | pg_stat_user_tables
-+ 4294967004 | pg_stat_user_indexes
-+ 4294967005 | pg_stat_user_functions
-+ 4294967006 | pg_stat_sys_tables
-+ 4294967007 | pg_stat_sys_indexes
-+ 4294967008 | pg_stat_subscription
-+ 4294967009 | pg_stat_ssl
-+ 4294967010 | pg_stat_slru
-+ 4294967011 | pg_stat_replication
-+ 4294967012 | pg_stat_progress_vacuum
-+ 4294967013 | pg_stat_progress_create_index
-+ 4294967014 | pg_stat_progress_cluster
-+ 4294967015 | pg_stat_progress_basebackup
-+ 4294967016 | pg_stat_progress_analyze
-+ 4294967017 | pg_stat_gssapi
-+ 4294967018 | pg_stat_database
-+ 4294967019 | pg_stat_database_conflicts
-+ 4294967020 | pg_stat_bgwriter
-+ 4294967021 | pg_stat_archiver
-+ 4294967022 | pg_stat_all_tables
-+ 4294967023 | pg_stat_all_indexes
-+ 4294967024 | pg_stat_activity
-+ 4294967025 | pg_shmem_allocations
-+ 4294967026 | pg_shdepend
-+ 4294967027 | pg_shseclabel
-+ 4294967028 | pg_shdescription
-+ 4294967029 | pg_shadow
-+ 4294967030 | pg_settings
-+ 4294967031 | pg_sequences
-+ 4294967032 | pg_sequence
-+ 4294967033 | pg_seclabel
-+ 4294967034 | pg_seclabels
-+ 4294967035 | pg_rules
-+ 4294967036 | pg_roles
-+ 4294967037 | pg_rewrite
-+ 4294967038 | pg_replication_slots
-+ 4294967039 | pg_replication_origin
-+ 4294967040 | pg_replication_origin_status
-+ 4294967041 | pg_range
-+ 4294967042 | pg_publication_tables
-+ 4294967043 | pg_publication
-+ 4294967044 | pg_publication_rel
-+ 4294967045 | pg_proc
-+ 4294967046 | pg_prepared_xacts
-+ 4294967047 | pg_prepared_statements
-+ 4294967048 | pg_policy
-+ 4294967049 | pg_policies
-+ 4294967050 | pg_partitioned_table
-+ 4294967051 | pg_opfamily
-+ 4294967052 | pg_operator
-+ 4294967053 | pg_opclass
-+ 4294967054 | pg_namespace
-+ 4294967055 | pg_matviews
-+ 4294967056 | pg_locks
-+ 4294967057 | pg_largeobject
-+ 4294967058 | pg_largeobject_metadata
-+ 4294967059 | pg_language
-+ 4294967060 | pg_init_privs
-+ 4294967061 | pg_inherits
-+ 4294967062 | pg_indexes
-+ 4294967063 | pg_index
-+ 4294967064 | pg_hba_file_rules
-+ 4294967065 | pg_group
-+ 4294967066 | pg_foreign_table
-+ 4294967067 | pg_foreign_server
-+ 4294967068 | pg_foreign_data_wrapper
-+ 4294967069 | pg_file_settings
-+ 4294967070 | pg_extension
-+ 4294967071 | pg_event_trigger
-+ 4294967072 | pg_enum
-+ 4294967073 | pg_description
-+ 4294967074 | pg_depend
-+ 4294967075 | pg_default_acl
-+ 4294967076 | pg_db_role_setting
-+ 4294967077 | pg_database
-+ 4294967078 | pg_cursors
-+ 4294967079 | pg_conversion
-+ 4294967080 | pg_constraint
-+ 4294967081 | pg_config
-+ 4294967082 | pg_collation
-+ 4294967083 | pg_class
-+ 4294967084 | pg_cast
-+ 4294967085 | pg_available_extensions
-+ 4294967086 | pg_available_extension_versions
-+ 4294967087 | pg_auth_members
-+ 4294967088 | pg_authid
-+ 4294967089 | pg_attribute
-+ 4294967090 | pg_attrdef
-+ 4294967091 | pg_amproc
-+ 4294967092 | pg_amop
-+ 4294967093 | pg_am
-+ 4294967094 | pg_aggregate
-+ 4294967096 | views
-+ 4294967097 | view_table_usage
-+ 4294967098 | view_routine_usage
-+ 4294967099 | view_column_usage
-+ 4294967100 | user_privileges
-+ 4294967101 | user_mappings
-+ 4294967102 | user_mapping_options
-+ 4294967103 | user_defined_types
-+ 4294967104 | user_attributes
-+ 4294967105 | usage_privileges
-+ 4294967106 | udt_privileges
-+ 4294967107 | type_privileges
-+ 4294967108 | triggers
-+ 4294967109 | triggered_update_columns
-+ 4294967110 | transforms
-+ 4294967111 | tablespaces
-+ 4294967112 | tablespaces_extensions
-+ 4294967113 | tables
-+ 4294967114 | tables_extensions
-+ 4294967115 | table_privileges
-+ 4294967116 | table_constraints_extensions
-+ 4294967117 | table_constraints
-+ 4294967118 | statistics
-+ 4294967119 | st_units_of_measure
-+ 4294967120 | st_spatial_reference_systems
-+ 4294967121 | st_geometry_columns
-+ 4294967122 | session_variables
-+ 4294967123 | sequences
-+ 4294967124 | schema_privileges
-+ 4294967125 | schemata
-+ 4294967126 | schemata_extensions
-+ 4294967127 | sql_sizing
-+ 4294967128 | sql_parts
-+ 4294967129 | sql_implementation_info
-+ 4294967130 | sql_features
-+ 4294967131 | routines
-+ 4294967132 | routine_privileges
-+ 4294967133 | role_usage_grants
-+ 4294967134 | role_udt_grants
-+ 4294967135 | role_table_grants
-+ 4294967136 | role_routine_grants
-+ 4294967137 | role_column_grants
-+ 4294967138 | resource_groups
-+ 4294967139 | referential_constraints
-+ 4294967140 | profiling
-+ 4294967141 | processlist
-+ 4294967142 | plugins
-+ 4294967143 | partitions
-+ 4294967144 | parameters
-+ 4294967145 | optimizer_trace
-+ 4294967146 | keywords
-+ 4294967147 | key_column_usage
-+ 4294967148 | information_schema_catalog_name
-+ 4294967149 | foreign_tables
-+ 4294967150 | foreign_table_options
-+ 4294967151 | foreign_servers
-+ 4294967152 | foreign_server_options
-+ 4294967153 | foreign_data_wrappers
-+ 4294967154 | foreign_data_wrapper_options
-+ 4294967155 | files
-+ 4294967156 | events
-+ 4294967157 | engines
-+ 4294967158 | enabled_roles
-+ 4294967159 | element_types
-+ 4294967160 | domains
-+ 4294967161 | domain_udt_usage
-+ 4294967162 | domain_constraints
-+ 4294967163 | data_type_privileges
-+ 4294967164 | constraint_table_usage
-+ 4294967165 | constraint_column_usage
-+ 4294967166 | columns
-+ 4294967167 | columns_extensions
-+ 4294967168 | column_udt_usage
-+ 4294967169 | column_statistics
-+ 4294967170 | column_privileges
-+ 4294967171 | column_options
-+ 4294967172 | column_domain_usage
-+ 4294967173 | column_column_usage
-+ 4294967174 | collations
-+ 4294967175 | collation_character_set_applicability
-+ 4294967176 | check_constraints
-+ 4294967177 | check_constraint_routine_usage
-+ 4294967178 | character_sets
-+ 4294967179 | attributes
-+ 4294967180 | applicable_roles
-+ 4294967181 | administrable_role_authorizations
-+ 4294967184 | store_liveness_support_for
-+ 4294967185 | store_liveness_support_from
-+ 4294967186 | fully_qualified_names
-+ 4294967187 | logical_replication_node_processors
-+ 4294967188 | cluster_replication_node_stream_checkpoints
-+ 4294967189 | cluster_replication_node_stream_spans
-+ 4294967190 | cluster_replication_node_streams
-+ 4294967191 | logical_replication_spans
-+ 4294967192 | cluster_replication_spans
-+ 4294967193 | kv_session_based_leases
-+ 4294967194 | kv_protected_ts_records
-+ 4294967195 | kv_repairable_catalog_corruptions
-+ 4294967196 | kv_flow_token_deductions_v2
-+ 4294967197 | kv_flow_token_deductions
-+ 4294967198 | kv_flow_control_handles_v2
-+ 4294967199 | kv_flow_control_handles
-+ 4294967200 | kv_flow_controller_v2
-+ 4294967201 | kv_flow_controller
-+ 4294967202 | kv_system_privileges
-+ 4294967203 | kv_inherited_role_members
-+ 4294967204 | node_tenant_capabilities_cache
-+ 4294967205 | kv_dropped_relations
-+ 4294967206 | super_regions
-+ 4294967207 | pg_catalog_table_is_implemented
-+ 4294967208 | tenant_usage_details
-+ 4294967209 | active_range_feeds
-+ 4294967210 | default_privileges
-+ 4294967211 | regions
-+ 4294967212 | cluster_inflight_traces
-+ 4294967213 | lost_descriptors_with_data
-+ 4294967214 | cross_db_references
-+ 4294967215 | cluster_database_privileges
-+ 4294967216 | invalid_objects
-+ 4294967217 | zones
-+ 4294967218 | transaction_statistics_persisted_v22_2
-+ 4294967219 | transaction_statistics_persisted
-+ 4294967220 | transaction_statistics
-+ 4294967221 | transaction_activity
-+ 4294967222 | node_transaction_statistics
-+ 4294967223 | table_row_statistics
-+ 4294967224 | tables
-+ 4294967225 | table_spans
-+ 4294967226 | table_indexes
-+ 4294967227 | table_columns
-+ 4294967228 | statement_statistics_persisted_v22_2
-+ 4294967229 | statement_statistics_persisted
-+ 4294967230 | statement_statistics
-+ 4294967231 | statement_activity
-+ 4294967232 | session_variables
-+ 4294967233 | session_trace
-+ 4294967234 | schema_changes
-+ 4294967235 | node_runtime_info
-+ 4294967236 | ranges
-+ 4294967237 | ranges_no_leases
-+ 4294967238 | partitions
-+ 4294967239 | node_txn_stats
-+ 4294967240 | node_statement_statistics
-+ 4294967241 | node_memory_monitors
-+ 4294967242 | node_metrics
-+ 4294967243 | node_sessions
-+ 4294967244 | node_transactions
-+ 4294967245 | node_queries
-+ 4294967246 | node_execution_insights
-+ 4294967247 | node_distsql_flows
-+ 4294967248 | node_contention_events
-+ 4294967249 | leases
-+ 4294967250 | kv_store_status
-+ 4294967251 | kv_node_status
-+ 4294967252 | system_jobs
-+ 4294967253 | jobs
-+ 4294967254 | node_inflight_trace_spans
-+ 4294967255 | index_usage_statistics
-+ 4294967256 | index_spans
-+ 4294967257 | index_columns
-+ 4294967258 | transaction_contention_events
-+ 4294967259 | gossip_network
-+ 4294967260 | gossip_liveness
-+ 4294967261 | gossip_alerts
-+ 4294967262 | gossip_nodes
-+ 4294967263 | kv_node_liveness
-+ 4294967264 | forward_dependencies
-+ 4294967265 | feature_usage
-+ 4294967266 | databases
-+ 4294967267 | create_type_statements
++ 4294966961 | spatial_ref_sys
++ 4294966962 | geometry_columns
++ 4294966963 | geography_columns
++ 4294966965 | pg_views
++ 4294966966 | pg_user
++ 4294966967 | pg_user_mappings
++ 4294966968 | pg_user_mapping
++ 4294966969 | pg_type
++ 4294966970 | pg_ts_template
++ 4294966971 | pg_ts_parser
++ 4294966972 | pg_ts_dict
++ 4294966973 | pg_ts_config
++ 4294966974 | pg_ts_config_map
++ 4294966975 | pg_trigger
++ 4294966976 | pg_transform
++ 4294966977 | pg_timezone_names
++ 4294966978 | pg_timezone_abbrevs
++ 4294966979 | pg_tablespace
++ 4294966980 | pg_tables
++ 4294966981 | pg_subscription
++ 4294966982 | pg_subscription_rel
++ 4294966983 | pg_stats
++ 4294966984 | pg_stats_ext
++ 4294966985 | pg_statistic
++ 4294966986 | pg_statistic_ext
++ 4294966987 | pg_statistic_ext_data
++ 4294966988 | pg_statio_user_tables
++ 4294966989 | pg_statio_user_sequences
++ 4294966990 | pg_statio_user_indexes
++ 4294966991 | pg_statio_sys_tables
++ 4294966992 | pg_statio_sys_sequences
++ 4294966993 | pg_statio_sys_indexes
++ 4294966994 | pg_statio_all_tables
++ 4294966995 | pg_statio_all_sequences
++ 4294966996 | pg_statio_all_indexes
++ 4294966997 | pg_stat_xact_user_tables
++ 4294966998 | pg_stat_xact_user_functions
++ 4294966999 | pg_stat_xact_sys_tables
++ 4294967000 | pg_stat_xact_all_tables
++ 4294967001 | pg_stat_wal_receiver
++ 4294967002 | pg_stat_user_tables
++ 4294967003 | pg_stat_user_indexes
++ 4294967004 | pg_stat_user_functions
++ 4294967005 | pg_stat_sys_tables
++ 4294967006 | pg_stat_sys_indexes
++ 4294967007 | pg_stat_subscription
++ 4294967008 | pg_stat_ssl
++ 4294967009 | pg_stat_slru
++ 4294967010 | pg_stat_replication
++ 4294967011 | pg_stat_progress_vacuum
++ 4294967012 | pg_stat_progress_create_index
++ 4294967013 | pg_stat_progress_cluster
++ 4294967014 | pg_stat_progress_basebackup
++ 4294967015 | pg_stat_progress_analyze
++ 4294967016 | pg_stat_gssapi
++ 4294967017 | pg_stat_database
++ 4294967018 | pg_stat_database_conflicts
++ 4294967019 | pg_stat_bgwriter
++ 4294967020 | pg_stat_archiver
++ 4294967021 | pg_stat_all_tables
++ 4294967022 | pg_stat_all_indexes
++ 4294967023 | pg_stat_activity
++ 4294967024 | pg_shmem_allocations
++ 4294967025 | pg_shdepend
++ 4294967026 | pg_shseclabel
++ 4294967027 | pg_shdescription
++ 4294967028 | pg_shadow
++ 4294967029 | pg_settings
++ 4294967030 | pg_sequences
++ 4294967031 | pg_sequence
++ 4294967032 | pg_seclabel
++ 4294967033 | pg_seclabels
++ 4294967034 | pg_rules
++ 4294967035 | pg_roles
++ 4294967036 | pg_rewrite
++ 4294967037 | pg_replication_slots
++ 4294967038 | pg_replication_origin
++ 4294967039 | pg_replication_origin_status
++ 4294967040 | pg_range
++ 4294967041 | pg_publication_tables
++ 4294967042 | pg_publication
++ 4294967043 | pg_publication_rel
++ 4294967044 | pg_proc
++ 4294967045 | pg_prepared_xacts
++ 4294967046 | pg_prepared_statements
++ 4294967047 | pg_policy
++ 4294967048 | pg_policies
++ 4294967049 | pg_partitioned_table
++ 4294967050 | pg_opfamily
++ 4294967051 | pg_operator
++ 4294967052 | pg_opclass
++ 4294967053 | pg_namespace
++ 4294967054 | pg_matviews
++ 4294967055 | pg_locks
++ 4294967056 | pg_largeobject
++ 4294967057 | pg_largeobject_metadata
++ 4294967058 | pg_language
++ 4294967059 | pg_init_privs
++ 4294967060 | pg_inherits
++ 4294967061 | pg_indexes
++ 4294967062 | pg_index
++ 4294967063 | pg_hba_file_rules
++ 4294967064 | pg_group
++ 4294967065 | pg_foreign_table
++ 4294967066 | pg_foreign_server
++ 4294967067 | pg_foreign_data_wrapper
++ 4294967068 | pg_file_settings
++ 4294967069 | pg_extension
++ 4294967070 | pg_event_trigger
++ 4294967071 | pg_enum
++ 4294967072 | pg_description
++ 4294967073 | pg_depend
++ 4294967074 | pg_default_acl
++ 4294967075 | pg_db_role_setting
++ 4294967076 | pg_database
++ 4294967077 | pg_cursors
++ 4294967078 | pg_conversion
++ 4294967079 | pg_constraint
++ 4294967080 | pg_config
++ 4294967081 | pg_collation
++ 4294967082 | pg_class
++ 4294967083 | pg_cast
++ 4294967084 | pg_available_extensions
++ 4294967085 | pg_available_extension_versions
++ 4294967086 | pg_auth_members
++ 4294967087 | pg_authid
++ 4294967088 | pg_attribute
++ 4294967089 | pg_attrdef
++ 4294967090 | pg_amproc
++ 4294967091 | pg_amop
++ 4294967092 | pg_am
++ 4294967093 | pg_aggregate
++ 4294967095 | views
++ 4294967096 | view_table_usage
++ 4294967097 | view_routine_usage
++ 4294967098 | view_column_usage
++ 4294967099 | user_privileges
++ 4294967100 | user_mappings
++ 4294967101 | user_mapping_options
++ 4294967102 | user_defined_types
++ 4294967103 | user_attributes
++ 4294967104 | usage_privileges
++ 4294967105 | udt_privileges
++ 4294967106 | type_privileges
++ 4294967107 | triggers
++ 4294967108 | triggered_update_columns
++ 4294967109 | transforms
++ 4294967110 | tablespaces
++ 4294967111 | tablespaces_extensions
++ 4294967112 | tables
++ 4294967113 | tables_extensions
++ 4294967114 | table_privileges
++ 4294967115 | table_constraints_extensions
++ 4294967116 | table_constraints
++ 4294967117 | statistics
++ 4294967118 | st_units_of_measure
++ 4294967119 | st_spatial_reference_systems
++ 4294967120 | st_geometry_columns
++ 4294967121 | session_variables
++ 4294967122 | sequences
++ 4294967123 | schema_privileges
++ 4294967124 | schemata
++ 4294967125 | schemata_extensions
++ 4294967126 | sql_sizing
++ 4294967127 | sql_parts
++ 4294967128 | sql_implementation_info
++ 4294967129 | sql_features
++ 4294967130 | routines
++ 4294967131 | routine_privileges
++ 4294967132 | role_usage_grants
++ 4294967133 | role_udt_grants
++ 4294967134 | role_table_grants
++ 4294967135 | role_routine_grants
++ 4294967136 | role_column_grants
++ 4294967137 | resource_groups
++ 4294967138 | referential_constraints
++ 4294967139 | profiling
++ 4294967140 | processlist
++ 4294967141 | plugins
++ 4294967142 | partitions
++ 4294967143 | parameters
++ 4294967144 | optimizer_trace
++ 4294967145 | keywords
++ 4294967146 | key_column_usage
++ 4294967147 | information_schema_catalog_name
++ 4294967148 | foreign_tables
++ 4294967149 | foreign_table_options
++ 4294967150 | foreign_servers
++ 4294967151 | foreign_server_options
++ 4294967152 | foreign_data_wrappers
++ 4294967153 | foreign_data_wrapper_options
++ 4294967154 | files
++ 4294967155 | events
++ 4294967156 | engines
++ 4294967157 | enabled_roles
++ 4294967158 | element_types
++ 4294967159 | domains
++ 4294967160 | domain_udt_usage
++ 4294967161 | domain_constraints
++ 4294967162 | data_type_privileges
++ 4294967163 | constraint_table_usage
++ 4294967164 | constraint_column_usage
++ 4294967165 | columns
++ 4294967166 | columns_extensions
++ 4294967167 | column_udt_usage
++ 4294967168 | column_statistics
++ 4294967169 | column_privileges
++ 4294967170 | column_options
++ 4294967171 | column_domain_usage
++ 4294967172 | column_column_usage
++ 4294967173 | collations
++ 4294967174 | collation_character_set_applicability
++ 4294967175 | check_constraints
++ 4294967176 | check_constraint_routine_usage
++ 4294967177 | character_sets
++ 4294967178 | attributes
++ 4294967179 | applicable_roles
++ 4294967180 | administrable_role_authorizations
++ 4294967183 | store_liveness_support_for
++ 4294967184 | store_liveness_support_from
++ 4294967185 | fully_qualified_names
++ 4294967186 | logical_replication_node_processors
++ 4294967187 | cluster_replication_node_stream_checkpoints
++ 4294967188 | cluster_replication_node_stream_spans
++ 4294967189 | cluster_replication_node_streams
++ 4294967190 | logical_replication_spans
++ 4294967191 | cluster_replication_spans
++ 4294967192 | kv_session_based_leases
++ 4294967193 | kv_protected_ts_records
++ 4294967194 | kv_repairable_catalog_corruptions
++ 4294967195 | kv_flow_token_deductions_v2
++ 4294967196 | kv_flow_token_deductions
++ 4294967197 | kv_flow_control_handles_v2
++ 4294967198 | kv_flow_control_handles
++ 4294967199 | kv_flow_controller_v2
++ 4294967200 | kv_flow_controller
++ 4294967201 | kv_system_privileges
++ 4294967202 | kv_inherited_role_members
++ 4294967203 | node_tenant_capabilities_cache
++ 4294967204 | kv_dropped_relations
++ 4294967205 | super_regions
++ 4294967206 | pg_catalog_table_is_implemented
++ 4294967207 | tenant_usage_details
++ 4294967208 | active_range_feeds
++ 4294967209 | default_privileges
++ 4294967210 | regions
++ 4294967211 | cluster_inflight_traces
++ 4294967212 | lost_descriptors_with_data
++ 4294967213 | cross_db_references
++ 4294967214 | cluster_database_privileges
++ 4294967215 | invalid_objects
++ 4294967216 | zones
++ 4294967217 | transaction_statistics_persisted_v22_2
++ 4294967218 | transaction_statistics_persisted
++ 4294967219 | transaction_statistics
++ 4294967220 | transaction_activity
++ 4294967221 | node_transaction_statistics
++ 4294967222 | table_row_statistics
++ 4294967223 | tables
++ 4294967224 | table_spans
++ 4294967225 | table_indexes
++ 4294967226 | table_columns
++ 4294967227 | statement_statistics_persisted_v22_2
++ 4294967228 | statement_statistics_persisted
++ 4294967229 | statement_statistics
++ 4294967230 | statement_activity
++ 4294967231 | session_variables
++ 4294967232 | session_trace
++ 4294967233 | schema_changes
++ 4294967234 | node_runtime_info
++ 4294967235 | ranges
++ 4294967236 | ranges_no_leases
++ 4294967237 | partitions
++ 4294967238 | node_txn_stats
++ 4294967239 | node_statement_statistics
++ 4294967240 | node_memory_monitors
++ 4294967241 | node_metrics
++ 4294967242 | node_sessions
++ 4294967243 | node_transactions
++ 4294967244 | node_queries
++ 4294967245 | node_execution_insights
++ 4294967246 | node_distsql_flows
++ 4294967247 | node_contention_events
++ 4294967248 | leases
++ 4294967249 | kv_store_status
++ 4294967250 | kv_node_status
++ 4294967251 | system_jobs
++ 4294967252 | jobs
++ 4294967253 | node_inflight_trace_spans
++ 4294967254 | index_usage_statistics
++ 4294967255 | index_spans
++ 4294967256 | index_columns
++ 4294967257 | transaction_contention_events
++ 4294967258 | gossip_network
++ 4294967259 | gossip_liveness
++ 4294967260 | gossip_alerts
++ 4294967261 | gossip_nodes
++ 4294967262 | kv_node_liveness
++ 4294967263 | forward_dependencies
++ 4294967264 | feature_usage
++ 4294967265 | databases
++ 4294967266 | create_type_statements
++ 4294967267 | create_trigger_statements
 + 4294967268 | create_statements
 + 4294967269 | create_schema_statements
 + 4294967270 | create_procedure_statements
@@ -420,11 +421,11 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 + 4294967292 | builtin_functions
 + 4294967293 | node_build_info
 + 4294967294 | backward_dependencies
-+(360 rows)
++(361 rows)
  
  -- Make sure typarray points to a "true" array type of our own base
  SELECT t1.oid, t1.typname as basetype, t2.typname as arraytype,
-@@ -84,10 +452,7 @@
+@@ -84,10 +453,7 @@
  WHERE  t1.typarray <> 0 AND
         (t2.oid IS NULL OR
          t2.typsubscript <> 'array_subscript_handler'::regproc);
@@ -436,7 +437,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- Look for range types that do not have a pg_range entry
  SELECT t1.oid, t1.typname
  FROM pg_type as t1
-@@ -113,10 +478,13 @@
+@@ -113,10 +479,13 @@
  -- Text conversion routines must be provided.
  SELECT t1.oid, t1.typname
  FROM pg_type as t1
@@ -454,7 +455,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Check for bogus typinput routines
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
-@@ -128,10 +496,7 @@
+@@ -128,10 +497,7 @@
       (p1.pronargs = 3 AND p1.proargtypes[0] = 'cstring'::regtype AND
        p1.proargtypes[1] = 'oid'::regtype AND
        p1.proargtypes[2] = 'int4'::regtype));
@@ -466,7 +467,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- As of 8.0, this check finds refcursor, which is borrowing
  -- other types' I/O routines
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
-@@ -140,10 +505,9 @@
+@@ -140,10 +506,9 @@
      (t1.typelem != 0 AND t1.typlen < 0) AND NOT
      (p1.prorettype = t1.oid AND NOT p1.proretset)
  ORDER BY 1;
@@ -480,7 +481,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Varlena array types will point to array_in
  -- Exception as of 8.1: int2vector and oidvector have their own I/O routines
-@@ -153,10 +517,10 @@
+@@ -153,10 +518,10 @@
      (t1.typelem != 0 AND t1.typlen < 0) AND NOT
      (p1.oid = 'array_in'::regproc)
  ORDER BY 1;
@@ -495,7 +496,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  (2 rows)
  
  -- typinput routines should not be volatile
-@@ -172,14 +536,11 @@
+@@ -172,14 +537,11 @@
  FROM pg_type AS t1
  WHERE t1.typtype not in ('b', 'p')
  ORDER BY 1;
@@ -513,7 +514,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Check for bogus typoutput routines
  -- As of 8.0, this check finds refcursor, which is borrowing
-@@ -192,19 +553,15 @@
+@@ -192,19 +554,15 @@
        (p1.oid = 'array_out'::regproc AND
         t1.typelem != 0 AND t1.typlen = -1)))
  ORDER BY 1;
@@ -537,7 +538,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- typoutput routines should not be volatile
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
  FROM pg_type AS t1, pg_proc AS p1
-@@ -218,13 +575,11 @@
+@@ -218,13 +576,11 @@
  FROM pg_type AS t1
  WHERE t1.typtype not in ('b', 'd', 'p')
  ORDER BY 1;
@@ -554,7 +555,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Domains should have same typoutput as their base types
  SELECT t1.oid, t1.typname, t2.oid, t2.typname
-@@ -244,10 +599,7 @@
+@@ -244,10 +600,7 @@
       (p1.pronargs = 3 AND p1.proargtypes[0] = 'internal'::regtype AND
        p1.proargtypes[1] = 'oid'::regtype AND
        p1.proargtypes[2] = 'int4'::regtype));
@@ -566,7 +567,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- As of 7.4, this check finds refcursor, which is borrowing
  -- other types' I/O routines
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
-@@ -256,10 +608,9 @@
+@@ -256,10 +609,9 @@
      (t1.typelem != 0 AND t1.typlen < 0) AND NOT
      (p1.prorettype = t1.oid AND NOT p1.proretset)
  ORDER BY 1;
@@ -580,7 +581,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Varlena array types will point to array_recv
  -- Exception as of 8.1: int2vector and oidvector have their own I/O routines
-@@ -271,8 +622,8 @@
+@@ -271,8 +623,8 @@
  ORDER BY 1;
   oid |  typname   | oid  |    proname     
  -----+------------+------+----------------
@@ -591,7 +592,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  (2 rows)
  
  -- Suspicious if typreceive doesn't take same number of args as typinput
-@@ -297,14 +648,11 @@
+@@ -297,14 +649,11 @@
  FROM pg_type AS t1
  WHERE t1.typtype not in ('b', 'p')
  ORDER BY 1;
@@ -609,7 +610,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Check for bogus typsend routines
  -- As of 7.4, this check finds refcursor, which is borrowing
-@@ -317,10 +665,9 @@
+@@ -317,10 +666,9 @@
        (p1.oid = 'array_send'::regproc AND
         t1.typelem != 0 AND t1.typlen = -1)))
  ORDER BY 1;
@@ -623,7 +624,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
  FROM pg_type AS t1, pg_proc AS p1
-@@ -343,13 +690,11 @@
+@@ -343,13 +691,11 @@
  FROM pg_type AS t1
  WHERE t1.typtype not in ('b', 'd', 'p')
  ORDER BY 1;
@@ -640,7 +641,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  
  -- Domains should have same typsend as their base types
  SELECT t1.oid, t1.typname, t2.oid, t2.typname
-@@ -366,10 +711,7 @@
+@@ -366,10 +712,7 @@
      (p1.pronargs = 1 AND
       p1.proargtypes[0] = 'cstring[]'::regtype AND
       p1.prorettype = 'int4'::regtype AND NOT p1.proretset);
@@ -652,7 +653,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- typmodin routines should not be volatile
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
  FROM pg_type AS t1, pg_proc AS p1
-@@ -385,10 +727,7 @@
+@@ -385,10 +728,7 @@
      (p1.pronargs = 1 AND
       p1.proargtypes[0] = 'int4'::regtype AND
       p1.prorettype = 'cstring'::regtype AND NOT p1.proretset);
@@ -664,7 +665,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- typmodout routines should not be volatile
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
  FROM pg_type AS t1, pg_proc AS p1
-@@ -409,7 +748,8 @@
+@@ -409,7 +749,8 @@
  -- Array types should have same typdelim as their element types
  SELECT t1.oid, t1.typname, t2.oid, t2.typname
  FROM pg_type AS t1, pg_type AS t2
@@ -674,7 +675,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
   oid | typname | oid | typname 
  -----+---------+-----+---------
  (0 rows)
-@@ -428,29 +768,20 @@
+@@ -428,29 +769,20 @@
  SELECT t1.oid, t1.typname, t1.typelem
  FROM pg_type AS t1
  WHERE t1.typelem != 0 AND t1.typsubscript = 0;
@@ -707,7 +708,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- Check for bogus typanalyze routines
  SELECT t1.oid, t1.typname, p1.oid, p1.proname
  FROM pg_type AS t1, pg_proc AS p1
-@@ -458,10 +789,7 @@
+@@ -458,10 +790,7 @@
      (p1.pronargs = 1 AND
       p1.proargtypes[0] = 'internal'::regtype AND
       p1.prorettype = 'bool'::regtype AND NOT p1.proretset);
@@ -719,7 +720,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- there does not seem to be a reason to care about volatility of typanalyze
  -- domains inherit their base type's typanalyze
  SELECT d.oid, d.typname, d.typanalyze, t.oid, t.typname, t.typanalyze
-@@ -477,10 +805,7 @@
+@@ -477,10 +806,7 @@
  FROM pg_type t LEFT JOIN pg_range r on t.oid = r.rngtypid
  WHERE t.typbasetype = 0 AND
      (t.typanalyze = 'range_typanalyze'::regproc) != (r.rngtypid IS NOT NULL);
@@ -731,7 +732,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- array_typanalyze should be used for all and only array types
  -- (but exclude domains, which we checked above)
  -- As of 9.2 this finds int2vector and oidvector, which are weird anyway
-@@ -490,12 +815,7 @@
+@@ -490,12 +816,7 @@
      (t.typanalyze = 'array_typanalyze'::regproc) !=
      (t.typsubscript = 'array_subscript_handler'::regproc)
  ORDER BY 1;
@@ -745,7 +746,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- **************** pg_class ****************
  -- Look for illegal values in pg_class fields
  SELECT c1.oid, c1.relname
-@@ -535,14 +855,10 @@
+@@ -535,14 +856,10 @@
  (0 rows)
  
  -- Tables, matviews etc should have AMs of type 't'
@@ -764,7 +765,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- **************** pg_attribute ****************
  -- Look for illegal values in pg_attribute fields
  SELECT a1.attrelid, a1.attname
-@@ -555,22 +871,49 @@
+@@ -555,22 +872,46 @@
  (0 rows)
  
  -- Cross-check attnum against parent relation
@@ -789,42 +790,39 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
 -(0 rows)
 +    oid     |                    relname                    
 +------------+-----------------------------------------------
-+ 2026476611 | cluster_database_privileges_database_name_idx
-+ 3371553616 | cluster_inflight_traces_trace_id_idx
++  681399602 | cluster_database_privileges_database_name_idx
++ 3111817351 | cluster_inflight_traces_trace_id_idx
 +  866982258 | cluster_locks_table_id_idx
 +  866982259 | cluster_locks_database_name_idx
 +  866982260 | cluster_locks_table_name_idx
 +  866982261 | cluster_locks_contended_idx
++   87773451 | create_function_statements_function_id_idx
++ 3037663738 | create_procedure_statements_procedure_id_idx
 + 1432850456 | create_statements_descriptor_id_idx
-+ 1173114191 | create_type_statements_descriptor_id_idx
-+  208322724 | index_spans_descriptor_id_idx
-+ 2638740473 | jobs_job_id_idx
-+ 2638740472 | jobs_status_idx
-+ 2638740479 | jobs_job_type_idx
-+ 1887289619 | kv_flow_control_handles_range_id_idx
-+  542212610 | kv_flow_control_handles_v2_range_id_idx
-+  282476337 | kv_flow_token_deductions_range_id_idx
-+ 3232366624 | kv_flow_token_deductions_v2_range_id_idx
-+ 1293663464 | system_jobs_id_idx
-+ 1293663465 | system_jobs_job_type_idx
-+ 1293663470 | system_jobs_status_idx
-+ 1460608405 | table_spans_descriptor_id_idx
-+  115531396 | tables_parent_id_idx
-+  115531397 | tables_database_name_idx
-+ 4262191470 | pg_attrdef_adrelid_idx
-+ 4002455197 | pg_attribute_attrelid_idx
-+ 3482982663 | pg_class_oid_idx
-+  533092372 | pg_constraint_conrelid_idx
-+  959773586 | pg_namespace_oid_idx
-+  440301044 | pg_policy_polrelid_idx
-+ 2870718793 | pg_proc_oid_idx
-+ 2748285217 | pg_timezone_names_name_idx
-+  299229753 | pg_type_oid_idx
-+(31 rows)
++ 1173114191 | create_trigger_statements_table_id_idx
++ 4123004478 | create_type_statements_descriptor_id_idx
++ 4243553755 | index_spans_descriptor_id_idx
++  542212610 | kv_flow_control_handles_range_id_idx
++  282476337 | kv_flow_control_handles_v2_range_id_idx
++ 3232366624 | kv_flow_token_deductions_range_id_idx
++ 2972630359 | kv_flow_token_deductions_v2_range_id_idx
++  115531396 | table_spans_descriptor_id_idx
++ 4150762427 | tables_parent_id_idx
++ 4150762426 | tables_database_name_idx
++ 4002455197 | pg_attrdef_adrelid_idx
++ 2657378188 | pg_attribute_attrelid_idx
++ 2137905654 | pg_class_oid_idx
++  273356107 | pg_constraint_conrelid_idx
++  700037313 | pg_namespace_oid_idx
++  180564779 | pg_policy_polrelid_idx
++ 1525641784 | pg_proc_oid_idx
++ 3008021490 | pg_timezone_names_name_idx
++  558966026 | pg_type_oid_idx
++(28 rows)
  
  -- Cross-check against pg_type entry
  -- NOTE: we allow attstorage to be 'plain' even when typstorage is not;
-@@ -613,10 +956,7 @@
+@@ -613,10 +954,7 @@
        EXISTS(select 1 from pg_catalog.pg_type where
               oid = r.rngsubtype and typelem != 0 and
               typsubscript = 'array_subscript_handler'::regproc)));
@@ -836,7 +834,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- canonical function, if any, had better match the range type
  SELECT r.rngtypid, r.rngsubtype, p.proname
  FROM pg_range r JOIN pg_proc p ON p.oid = r.rngcanonical
-@@ -639,10 +979,7 @@
+@@ -639,10 +977,7 @@
  SELECT r.rngtypid, r.rngsubtype, r.rngmultitypid
  FROM pg_range r
  WHERE r.rngmultitypid IS NULL OR r.rngmultitypid = 0;
@@ -848,7 +846,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- Create a table that holds all the known in-core data types and leave it
  -- around so as pg_upgrade is able to test their binary compatibility.
  CREATE TABLE tab_core_types AS SELECT
-@@ -709,6 +1046,13 @@
+@@ -709,6 +1044,13 @@
    '{(2020-01-02 03:04:05, 2021-02-03 06:07:08)}'::tsmultirange,
    '(2020-01-02 03:04:05, 2021-02-03 06:07:08)'::tstzrange,
    '{(2020-01-02 03:04:05, 2021-02-03 06:07:08)}'::tstzmultirange;
@@ -862,7 +860,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/type_sanity.out -
  -- Sanity check on the previous table, checking that all core types are
  -- included in this table.
  SELECT oid, typname, typtype, typelem, typarray
-@@ -736,7 +1080,4 @@
+@@ -736,7 +1078,4 @@
                      WHERE a.atttypid=t.oid AND
                            a.attnum > 0 AND
                            a.attrelid='tab_core_types'::regclass);

--- a/pkg/cmd/roachtest/testdata/pg_regress/updatable_views.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/updatable_views.diffs
@@ -1398,7 +1398,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view1;
   a |   b   | c 
  ---+-------+---
-@@ -1172,167 +1304,341 @@
+@@ -1172,167 +1304,361 @@
  (1 row)
  
  UPDATE rw_view1 SET b = 'foo' WHERE a = 1;
@@ -1545,11 +1545,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  INSERT INTO base_tbl VALUES (1, 'Row 1', 1.0);
  CREATE VIEW rw_view1 AS SELECT b AS bb, c AS cc, a AS aa FROM base_tbl;
  ALTER VIEW rw_view1 SET (security_invoker = true);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near ")": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +ALTER VIEW rw_view1 SET (security_invoker = true)
-+                        ^
-+HINT:  try \h ALTER VIEW
++                                                ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  INSERT INTO rw_view1 VALUES ('Row 2', 2.0, 2);
 +ERROR:  "rw_view1" is not a table
  GRANT SELECT ON rw_view1 TO regress_view_user2;
@@ -1739,11 +1749,21 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
 +See: https://go.crdb.dev/issue-v/40283/_version_
  CREATE VIEW rw_view1 AS SELECT b AS bb, c AS cc, a AS aa FROM base_tbl;
  ALTER VIEW rw_view1 SET (security_invoker = true);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near ")": syntax error: unimplemented: this syntax
 +DETAIL:  source SQL:
 +ALTER VIEW rw_view1 SET (security_invoker = true)
-+                        ^
-+HINT:  try \h ALTER VIEW
++                                                ^
++HINT:  You have attempted to use a feature that is not yet implemented.
++
++Please check the public issue tracker to check whether this problem is
++already tracked. If you cannot find it there, please report the error
++with details by creating a new issue.
++
++If you would rather not post publicly, please contact us directly
++using the support form.
++
++We appreciate your feedback.
++
  SELECT * FROM rw_view1;  -- not allowed
 -ERROR:  permission denied for table base_tbl
 +  bb   | cc | aa 
@@ -1796,7 +1816,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view1; -- ok
    bb   | cc | aa 
  -------+----+----
-@@ -1340,35 +1646,103 @@
+@@ -1340,35 +1666,103 @@
  (1 row)
  
  UPDATE rw_view1 SET aa=aa, bb=bb;  -- ok
@@ -1909,7 +1929,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view2;  -- ok
   ccc | aaa |  bbb  
  -----+-----+-------
-@@ -1376,23 +1750,50 @@
+@@ -1376,23 +1770,50 @@
  (1 row)
  
  UPDATE rw_view2 SET aaa=aaa;  -- not allowed
@@ -1966,7 +1986,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view2;  -- ok
   ccc | aaa |  bbb  
  -----+-----+-------
-@@ -1400,18 +1801,40 @@
+@@ -1400,18 +1821,40 @@
  (1 row)
  
  UPDATE rw_view2 SET aaa=aaa;  -- not allowed
@@ -2011,7 +2031,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view2;  -- ok
   ccc | aaa |  bbb  
  -----+-----+-------
-@@ -1419,11 +1842,18 @@
+@@ -1419,11 +1862,18 @@
  (1 row)
  
  UPDATE rw_view2 SET aaa=aaa;  -- not allowed
@@ -2032,7 +2052,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view2;  -- ok
   ccc | aaa |  bbb  
  -----+-----+-------
-@@ -1431,22 +1861,44 @@
+@@ -1431,22 +1881,44 @@
  (1 row)
  
  UPDATE rw_view2 SET aaa=aaa;  -- not allowed
@@ -2083,7 +2103,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM rw_view2;  -- ok
   ccc | aaa |  bbb  
  -----+-----+-------
-@@ -1454,39 +1906,47 @@
+@@ -1454,39 +1926,47 @@
  (1 row)
  
  UPDATE rw_view2 SET aaa=aaa;  -- not allowed
@@ -2146,7 +2166,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- Table having triggers
  CREATE TABLE base_tbl (a int PRIMARY KEY, b text DEFAULT 'Unspecified');
  INSERT INTO base_tbl VALUES (1, 'Row 1');
-@@ -1505,18 +1965,23 @@
+@@ -1505,18 +1985,23 @@
  LANGUAGE plpgsql;
  CREATE TRIGGER rw_view1_ins_trig AFTER INSERT ON base_tbl
    FOR EACH ROW EXECUTE PROCEDURE rw_view1_trig_fn();
@@ -2173,7 +2193,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  DROP FUNCTION rw_view1_trig_fn();
  DROP TABLE base_tbl;
  -- view with ORDER BY
-@@ -1526,148 +1991,112 @@
+@@ -1526,148 +2011,112 @@
  SELECT * FROM rw_view1;
   a | b  
  ---+----
@@ -2368,7 +2388,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT table_name, is_insertable_into
    FROM information_schema.tables
-@@ -1675,10 +2104,7 @@
+@@ -1675,10 +2124,7 @@
   ORDER BY table_name;
   table_name | is_insertable_into 
  ------------+--------------------
@@ -2380,7 +2400,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT table_name, is_updatable, is_insertable_into
    FROM information_schema.views
-@@ -1686,10 +2112,7 @@
+@@ -1686,10 +2132,7 @@
   ORDER BY table_name;
   table_name | is_updatable | is_insertable_into 
  ------------+--------------+--------------------
@@ -2392,7 +2412,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT table_name, column_name, is_updatable
    FROM information_schema.columns
-@@ -1697,75 +2120,56 @@
+@@ -1697,75 +2140,56 @@
   ORDER BY table_name, ordinal_position;
   table_name | column_name | is_updatable 
  ------------+-------------+--------------
@@ -2488,7 +2508,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  CREATE VIEW rw_view1 AS SELECT * FROM base_tbl_parent;
  CREATE VIEW rw_view2 AS SELECT * FROM ONLY base_tbl_parent;
  SELECT * FROM rw_view1 ORDER BY a;
-@@ -1779,15 +2183,7 @@
+@@ -1779,15 +2203,7 @@
   -3
   -2
   -1
@@ -2505,7 +2525,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT * FROM ONLY rw_view1 ORDER BY a;
   a  
-@@ -1800,15 +2196,7 @@
+@@ -1800,15 +2216,7 @@
   -3
   -2
   -1
@@ -2522,7 +2542,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT * FROM rw_view2 ORDER BY a;
   a  
-@@ -1824,316 +2212,315 @@
+@@ -1824,316 +2232,315 @@
  (8 rows)
  
  INSERT INTO rw_view1 VALUES (-100), (100);
@@ -2864,16 +2884,16 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  ALTER VIEW rw_view1 SET (check_option=here); -- invalid
 -ERROR:  invalid value for enum option "check_option": here
 -DETAIL:  Valid values are "local" and "cascaded".
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "check_option": syntax error
 +DETAIL:  source SQL:
 +ALTER VIEW rw_view1 SET (check_option=here)
-+                        ^
++                         ^
 +HINT:  try \h ALTER VIEW
  ALTER VIEW rw_view1 SET (check_option=local);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "check_option": syntax error
 +DETAIL:  source SQL:
 +ALTER VIEW rw_view1 SET (check_option=local)
-+                        ^
++                         ^
 +HINT:  try \h ALTER VIEW
  INSERT INTO rw_view2 VALUES (-20); -- should fail
 -ERROR:  new row violates check option for view "rw_view1"
@@ -3030,7 +3050,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- WITH CHECK OPTION with subquery
  CREATE TABLE base_tbl (a int);
  CREATE TABLE ref_tbl (a int PRIMARY KEY);
-@@ -2142,40 +2529,34 @@
+@@ -2142,40 +2549,34 @@
    SELECT * FROM base_tbl b
    WHERE EXISTS(SELECT 1 FROM ref_tbl r WHERE r.a = b.a)
    WITH CHECK OPTION;
@@ -3092,7 +3112,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- WITH CHECK OPTION with BEFORE trigger on base table
  CREATE TABLE base_tbl (a int, b int);
  CREATE FUNCTION base_tbl_trig_fn()
-@@ -2190,19 +2571,22 @@
+@@ -2190,19 +2591,22 @@
  CREATE TRIGGER base_tbl_trig BEFORE INSERT OR UPDATE ON base_tbl
    FOR EACH ROW EXECUTE PROCEDURE base_tbl_trig_fn();
  CREATE VIEW rw_view1 AS SELECT * FROM base_tbl WHERE a < b WITH CHECK OPTION;
@@ -3120,7 +3140,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  CREATE FUNCTION rw_view1_trig_fn()
  RETURNS trigger AS
  $$
-@@ -2223,75 +2607,131 @@
+@@ -2223,75 +2627,131 @@
  CREATE TRIGGER rw_view1_trig
    INSTEAD OF INSERT OR UPDATE OR DELETE ON rw_view1
    FOR EACH ROW EXECUTE PROCEDURE rw_view1_trig_fn();
@@ -3158,10 +3178,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  -- Check option won't cascade down to base view with INSTEAD OF triggers
  ALTER VIEW rw_view2 SET (check_option=cascaded);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "check_option": syntax error
 +DETAIL:  source SQL:
 +ALTER VIEW rw_view2 SET (check_option=cascaded)
-+                        ^
++                         ^
 +HINT:  try \h ALTER VIEW
  INSERT INTO rw_view2 VALUES (100); -- ok, but not in view (doesn't fail rw_view1's check)
 +ERROR:  "rw_view2" is not a table
@@ -3283,7 +3303,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- security barrier view
  CREATE TABLE base_tbl (person text, visibility text);
  INSERT INTO base_tbl VALUES ('Tom', 'public'),
-@@ -2299,6 +2739,7 @@
+@@ -2299,6 +2759,7 @@
                              ('Harry', 'public');
  CREATE VIEW rw_view1 AS
    SELECT person FROM base_tbl WHERE visibility = 'public';
@@ -3291,7 +3311,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  CREATE FUNCTION snoop(anyelement)
  RETURNS boolean AS
  $$
-@@ -2308,6 +2749,29 @@
+@@ -2308,6 +2769,29 @@
  END;
  $$
  LANGUAGE plpgsql COST 0.000001;
@@ -3321,7 +3341,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  CREATE OR REPLACE FUNCTION leakproof(anyelement)
  RETURNS boolean AS
  $$
-@@ -2317,30 +2781,23 @@
+@@ -2317,30 +2801,23 @@
  $$
  LANGUAGE plpgsql STRICT IMMUTABLE LEAKPROOF;
  SELECT * FROM rw_view1 WHERE snoop(person);
@@ -3346,10 +3366,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
 -NOTICE:  snooped value: Harry
 +ERROR:  "rw_view1" is not a table
  ALTER VIEW rw_view1 SET (security_barrier = true);
-+ERROR:  at or near "(": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +ALTER VIEW rw_view1 SET (security_barrier = true)
-+                        ^
++                         ^
 +HINT:  try \h ALTER VIEW
  SELECT table_name, is_insertable_into
    FROM information_schema.tables
@@ -3361,7 +3381,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  (1 row)
  
  SELECT table_name, is_updatable, is_insertable_into
-@@ -2348,7 +2805,7 @@
+@@ -2348,7 +2825,7 @@
   WHERE table_name = 'rw_view1';
   table_name | is_updatable | is_insertable_into 
  ------------+--------------+--------------------
@@ -3370,7 +3390,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  (1 row)
  
  SELECT table_name, column_name, is_updatable
-@@ -2357,58 +2814,47 @@
+@@ -2357,58 +2834,47 @@
   ORDER BY ordinal_position;
   table_name | column_name | is_updatable 
  ------------+-------------+--------------
@@ -3439,10 +3459,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- security barrier view on top of security barrier view
  CREATE VIEW rw_view2 WITH (security_barrier = true) AS
    SELECT * FROM rw_view1 WHERE snoop(person);
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW rw_view2 WITH (security_barrier = true) AS
-+                     ^
++                           ^
 +HINT:  try \h CREATE VIEW
  SELECT table_name, is_insertable_into
    FROM information_schema.tables
@@ -3454,7 +3474,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  (1 row)
  
  SELECT table_name, is_updatable, is_insertable_into
-@@ -2416,7 +2862,7 @@
+@@ -2416,7 +2882,7 @@
   WHERE table_name = 'rw_view2';
   table_name | is_updatable | is_insertable_into 
  ------------+--------------+--------------------
@@ -3463,7 +3483,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  (1 row)
  
  SELECT table_name, column_name, is_updatable
-@@ -2425,61 +2871,34 @@
+@@ -2425,61 +2891,34 @@
   ORDER BY ordinal_position;
   table_name | column_name | is_updatable 
  ------------+-------------+--------------
@@ -3544,7 +3564,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- security barrier view on top of table with rules
  CREATE TABLE base_tbl(id int PRIMARY KEY, data text, deleted boolean);
  INSERT INTO base_tbl VALUES (1, 'Row 1', false), (2, 'Row 2', true);
-@@ -2487,61 +2906,83 @@
+@@ -2487,61 +2926,83 @@
    WHERE EXISTS (SELECT 1 FROM base_tbl t WHERE t.id = new.id)
    DO INSTEAD
      UPDATE base_tbl SET data = new.data, deleted = false WHERE id = new.id;
@@ -3583,10 +3603,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
 +
  CREATE VIEW rw_view1 WITH (security_barrier=true) AS
    SELECT id, data FROM base_tbl WHERE NOT deleted;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW rw_view1 WITH (security_barrier=true) AS
-+                     ^
++                           ^
 +HINT:  try \h CREATE VIEW
  SELECT * FROM rw_view1;
 - id | data  
@@ -3668,7 +3688,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- security barrier view based on inheritance set
  CREATE TABLE t1 (a int, b float, c text);
  CREATE INDEX t1_a_idx ON t1(a);
-@@ -2549,83 +2990,71 @@
+@@ -2549,83 +3010,71 @@
  SELECT i,i,'t1' FROM generate_series(1,10) g(i);
  ANALYZE t1;
  CREATE TABLE t11 (d text) INHERITS (t1);
@@ -3720,10 +3740,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT *, (SELECT d FROM t11 WHERE t11.a = t1.a LIMIT 1) AS d
  FROM t1
  WHERE a > 5 AND EXISTS(SELECT 1 FROM t12 WHERE t12.a = t1.a);
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW v1 WITH (security_barrier=true) AS
-+               ^
++                     ^
 +HINT:  try \h CREATE VIEW
  SELECT * FROM v1 WHERE a=3; -- should not see anything
 - a | b | c | d 
@@ -3793,7 +3813,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  SELECT * FROM t1 WHERE a=100; -- Nothing should have been changed to 100
   a | b | c 
  ---+---+---
-@@ -2633,114 +3062,47 @@
+@@ -2633,114 +3082,47 @@
  
  EXPLAIN (VERBOSE, COSTS OFF)
  UPDATE v1 SET a=a+1 WHERE snoop(a) AND leakproof(a) AND a = 8;
@@ -3933,7 +3953,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT * FROM vx1;
   a 
-@@ -2756,13 +3118,13 @@
+@@ -2756,13 +3138,13 @@
  CREATE TABLE tx3 (c integer);
  CREATE VIEW vx1 AS SELECT a FROM tx1 WHERE EXISTS(SELECT 1 FROM tx2 JOIN tx3 ON b=c);
  INSERT INTO vx1 VALUES (1);
@@ -3950,7 +3970,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT * FROM vx1;
   a 
-@@ -2781,13 +3143,13 @@
+@@ -2781,13 +3163,13 @@
  ALTER TABLE tx3 DROP COLUMN d;
  CREATE VIEW vx1 AS SELECT a FROM tx1 WHERE EXISTS(SELECT 1 FROM tx2 JOIN tx3 ON b=c);
  INSERT INTO vx1 VALUES (1);
@@ -3967,7 +3987,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  SELECT * FROM vx1;
   a 
-@@ -2803,38 +3165,47 @@
+@@ -2803,38 +3185,47 @@
  -- security barrier views, per bug #13988
  --
  CREATE TABLE t1 (a int, b text, c int);
@@ -3979,18 +3999,18 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  CREATE VIEW v1 WITH (security_barrier = true) AS
    SELECT * FROM t1 WHERE (a > 0)
    WITH CHECK OPTION;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW v1 WITH (security_barrier = true) AS
-+               ^
++                     ^
 +HINT:  try \h CREATE VIEW
  CREATE VIEW v2 WITH (security_barrier = true) AS
    SELECT * FROM v1 WHERE EXISTS (SELECT 1 FROM t2 WHERE t2.cc = v1.c)
    WITH CHECK OPTION;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW v2 WITH (security_barrier = true) AS
-+               ^
++                     ^
 +HINT:  try \h CREATE VIEW
  INSERT INTO v2 VALUES (2, 'two', 20); -- ok
 +ERROR:  relation "v2" does not exist
@@ -4028,14 +4048,14 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  DROP TABLE t2;
  DROP TABLE t1;
  --
-@@ -2843,31 +3214,45 @@
+@@ -2843,31 +3234,45 @@
  CREATE TABLE t1 (a int);
  CREATE VIEW v1 WITH (security_barrier = true) AS
    SELECT * FROM t1;
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW v1 WITH (security_barrier = true) AS
-+               ^
++                     ^
 +HINT:  try \h CREATE VIEW
  CREATE RULE v1_upd_rule AS ON UPDATE TO v1 DO INSTEAD
    UPDATE t1 SET a = NEW.a WHERE a = OLD.a;
@@ -4056,10 +4076,10 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
 +
  CREATE VIEW v2 WITH (security_barrier = true) AS
    SELECT * FROM v1 WHERE EXISTS (SELECT 1);
-+ERROR:  at or near "with": syntax error
++ERROR:  at or near "security_barrier": syntax error
 +DETAIL:  source SQL:
 +CREATE VIEW v2 WITH (security_barrier = true) AS
-+               ^
++                     ^
 +HINT:  try \h CREATE VIEW
  EXPLAIN (COSTS OFF) UPDATE v2 SET a = 1;
 -                    QUERY PLAN                     
@@ -4092,7 +4112,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  DROP TABLE t1;
  --
  -- Test CREATE OR REPLACE VIEW turning a non-updatable view into an
-@@ -2876,85 +3261,120 @@
+@@ -2876,85 +3281,120 @@
  CREATE TABLE t1 (a int, b text);
  CREATE VIEW v1 AS SELECT null::int AS a;
  CREATE OR REPLACE VIEW v1 AS SELECT * FROM t1 WHERE a > 0 WITH CHECK OPTION;
@@ -4245,7 +4265,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  create table sometable (a int, b text);
  insert into sometable values (1, 'a'), (2, 'b');
  create view wcowrtest_v2 as
-@@ -2962,13 +3382,22 @@
+@@ -2962,13 +3402,22 @@
        from wcowrtest r
        where r in (select s from sometable s where r.a = s.a)
  with check option;
@@ -4270,7 +4290,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  -- Check INSERT .. ON CONFLICT DO UPDATE works correctly when the view's
  -- columns are named and ordered differently than the underlying table's.
  create table uv_iocu_tab (a text unique, b float);
-@@ -2977,6 +3406,7 @@
+@@ -2977,6 +3426,7 @@
     select b, b+1 as c, a, '2.0'::text as two from uv_iocu_tab;
  insert into uv_iocu_view (a, b) values ('xyxyxy', 1)
     on conflict (a) do update set b = uv_iocu_view.b;
@@ -4278,7 +4298,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  select * from uv_iocu_tab;
     a    | b 
  --------+---
-@@ -2985,40 +3415,39 @@
+@@ -2985,40 +3435,39 @@
  
  insert into uv_iocu_view (a, b) values ('xyxyxy', 1)
     on conflict (a) do update set b = excluded.b;
@@ -4330,7 +4350,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  (1 row)
  
  drop view uv_iocu_view;
-@@ -3028,112 +3457,179 @@
+@@ -3028,112 +3477,179 @@
  create view uv_iocu_view as
      select b as bb, a as aa, uv_iocu_tab::text as cc from uv_iocu_tab;
  insert into uv_iocu_view (aa,bb) values (1,'x');
@@ -4544,7 +4564,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  select * from base_tbl;
   a |  b  | c 
  ---+-----+---
-@@ -3141,22 +3637,38 @@
+@@ -3141,22 +3657,38 @@
  (1 row)
  
  set session authorization regress_view_user2;
@@ -4585,7 +4605,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  drop view rw_view3;
  drop view rw_view2;
  drop view rw_view1;
-@@ -3169,36 +3681,43 @@
+@@ -3169,36 +3701,43 @@
                             c text default 'Table default', d text, e text);
  create view base_tab_def_view as select * from base_tab_def;
  alter view base_tab_def_view alter b set default 'View default';
@@ -4646,7 +4666,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  -- Adding an INSTEAD OF trigger should cause NULLs to be inserted instead of
  -- table defaults, where there are no view defaults.
-@@ -3213,6 +3732,9 @@
+@@ -3213,6 +3752,9 @@
  language plpgsql;
  create trigger base_tab_def_view_instrig instead of insert on base_tab_def_view
    for each row execute function base_tab_def_view_instrig_func();
@@ -4656,7 +4676,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  truncate base_tab_def;
  insert into base_tab_def values (1);
  insert into base_tab_def values (2), (3);
-@@ -3220,36 +3742,49 @@
+@@ -3220,36 +3762,49 @@
  insert into base_tab_def values (5, default, default, default, default),
                                  (6, default, default, default, default);
  insert into base_tab_def_view values (11);
@@ -4723,7 +4743,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  truncate base_tab_def;
  insert into base_tab_def values (1);
  insert into base_tab_def values (2), (3);
-@@ -3257,29 +3792,26 @@
+@@ -3257,29 +3812,26 @@
  insert into base_tab_def values (5, default, default, default, default),
                                  (6, default, default, default, default);
  insert into base_tab_def_view values (11);
@@ -4767,7 +4787,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  -- A DO ALSO rule should cause each row to be inserted twice. The first
  -- insert should behave the same as an auto-updatable view (using table
-@@ -3287,8 +3819,38 @@
+@@ -3287,8 +3839,38 @@
  -- behave the same as a rule-updatable view (inserting NULLs where there are
  -- no view defaults).
  drop rule base_tab_def_view_ins_rule on base_tab_def_view;
@@ -4806,7 +4826,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  truncate base_tab_def;
  insert into base_tab_def values (1);
  insert into base_tab_def values (2), (3);
-@@ -3296,56 +3858,71 @@
+@@ -3296,56 +3878,71 @@
  insert into base_tab_def values (5, default, default, default, default),
                                  (6, default, default, default, default);
  insert into base_tab_def_view values (11);
@@ -4912,7 +4932,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/updatable_views.o
  
  drop view base_tab_def_view;
  drop table base_tab_def;
-@@ -3353,14 +3930,22 @@
+@@ -3353,14 +3950,22 @@
  create table base_tab (a serial, b int[], c text, d text default 'Table default');
  create view base_tab_view as select c, a, b from base_tab;
  alter view base_tab_view alter column c set default 'View default';

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -100,6 +100,8 @@ func initPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 	for _, cmd := range []string{
 		`CREATE DATABASE root;`,
 		`SET CLUSTER SETTING sql.defaults.experimental_temporary_tables.enabled=true`,
+		`SET create_table_with_schema_locked=false`,
+		`ALTER ROLE ALL SET create_table_with_schema_locked=false`,
 		`CREATE USER test_admin`,
 		`GRANT admin TO test_admin`,
 	} {


### PR DESCRIPTION
We now disable `create_table_with_schema_locked` (the default has recently changed to `true`).

Fixes: #148331.
Release note: None