### PR TITLE
sql: avoid internal error when type-checking routine in edge case

### DIFF
--- a/pkg/sql/catalog/funcdesc/func_desc.go
+++ b/pkg/sql/catalog/funcdesc/func_desc.go
@@ -608,11 +608,6 @@ func (desc *Mutable) SetDeclarativeSchemaChangerState(state *scpb.DescriptorStat
 	desc.DeclarativeSchemaChangerState = state
 }
 
-// AddParams adds function parameters to the parameter list.
-func (desc *Mutable) AddParams(params ...descpb.FunctionDescriptor_Parameter) {
-	desc.Params = append(desc.Params, params...)
-}
-
 // SetVolatility sets the volatility attribute.
 func (desc *Mutable) SetVolatility(v catpb.Function_Volatility) {
 	desc.Volatility = v

--- a/pkg/sql/sem/builtins/builtinsregistry/builtins_registry.go
+++ b/pkg/sql/sem/builtins/builtinsregistry/builtins_registry.go
@@ -26,6 +26,11 @@ func Register(name string, props *tree.FunctionProperties, overloads []tree.Over
 	if _, exists := registry[name]; exists {
 		panic("duplicate builtin: " + name)
 	}
+	for _, overload := range overloads {
+		if overload.Types == nil || overload.Types == tree.TypeList(nil) {
+			panic("nil Types field for builtin: " + name)
+		}
+	}
 	registry[name] = definition{
 		props:     props,
 		overloads: overloads,


### PR DESCRIPTION
We just saw a sentry issue where `tree.Overload.Types` was `nil`. This is unexpected, and it resulted in a interface conversion panic during type-checking because we assumed that this field is castable to `tree.ParamTypes`. This usage was introduced in 92240f8bae8f67bb0de74209691fd0ad97605b13 and is now fixed in this commit.

I've audited the code and couldn't find a way for us to produce such a routine, so there is no reproduction test case added. I did add a defensive mechanism to ensure that all builtin overloads (i.e. non-user-defined) have non-nil `Types` set. This commit also removes an unused (but somewhat related) method from the catalog.

Fixes: #148045.

Release note: None