### PR TITLE
kv: remove improper use of `retry.NextCh` in tests

### DIFF
--- a/pkg/kv/kvserver/closed_timestamp_test.go
+++ b/pkg/kv/kvserver/closed_timestamp_test.go
@@ -1353,7 +1353,7 @@ func verifyCanReadFromAllRepls(
 		repl := repls[i]
 		g.Go(func() (err error) {
 			var shouldRetry bool
-			for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); <-r.NextCh() {
+			for r := retry.StartWithCtx(ctx, retryOptions); r.Next(); {
 				if shouldRetry, err = f(repl.Send(ctx, baRead)); !shouldRetry {
 					return err
 				}


### PR DESCRIPTION
This commit removes an improperly used `r.NextCh` call in the kvserver tests. The old use of `r.NextCh` would result in waiting for two retry intervals before each attempt.

Epic: None

Release note: None