### PR TITLE
roachtest: disable expensive checks for tpcc literal

### DIFF
--- a/pkg/cmd/roachtest/tests/tpcc.go
+++ b/pkg/cmd/roachtest/tests/tpcc.go
@@ -778,7 +778,6 @@ func registerTPCC(r registry.Registry) {
 				Duration:                      10 * time.Minute,
 				ExtraRunArgs:                  "--wait=false --tolerate-errors --workers=200 --literal-implementation",
 				SetupType:                     usingImport,
-				ExpensiveChecks:               true, // Run expensive checks here to catch any issues with the literal implementation
 				DisableDefaultScheduledBackup: true,
 			})
 		},


### PR DESCRIPTION
The expensive TPC-C checks are now disabled in the tpcc literal
roachtest. This significantly reduces the time to run the test by ~30
minutes.

Release note: None
