### PR TITLE
roachprod-microbench: c4 machine type support

### DIFF
--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -83,8 +83,8 @@ done
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
 
-# Update gcloud SDK to the latest version, specifically the core module
-gcloud components update core --quiet
+# Update gcloud SDK to the latest version
+sudo apt-get update && sudo apt-get install --only-upgrade google-cloud-cli -y
 
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -84,7 +84,7 @@ google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
 
 # Update gcloud SDK to the latest version
-sudo apt-get update && sudo apt-get install --only-upgrade google-cloud-cli -y
+apt-get update && apt-get install --only-upgrade google-cloud-cli -y
 
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -82,6 +82,10 @@ done
 # Set up credentials
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
+
+# Update gcloud SDK to the latest version, specifically the compute module
+gcloud components update --quiet
+
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity
 export ROACHPROD_CLUSTER=teamcity-microbench-${TC_BUILD_ID}

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -83,9 +83,6 @@ done
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
 
-# Update gcloud SDK to the latest version
-apt-get update && apt-get install --only-upgrade google-cloud-cli -y
-
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity
 export ROACHPROD_CLUSTER=teamcity-microbench-${TC_BUILD_ID}

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -83,8 +83,8 @@ done
 google_credentials="$GOOGLE_EPHEMERAL_CREDENTIALS"
 log_into_gcloud
 
-# Update gcloud SDK to the latest version, specifically the compute module
-gcloud components update --quiet
+# Update gcloud SDK to the latest version, specifically the core module
+gcloud components update core --quiet
 
 export GOOGLE_APPLICATION_CREDENTIALS="$PWD/.google-credentials.json"
 export ROACHPROD_USER=teamcity

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -132,8 +132,8 @@ log_into_gcloud
 # For this machine type we need to specify additional flags
 additional_roachprod_args=""
 if [[ "$GCE_MACHINE_TYPE" == c4* ]]; then
-  additional_roachprod_args="--gce-boot-disk-type=\"hyperdisk-balanced\" \
-    --gce-pd-volume-type=\"hyperdisk-balanced\" \
+  additional_roachprod_args="--gce-boot-disk-type=hyperdisk-balanced \
+    --gce-pd-volume-type=hyperdisk-balanced \
     --gce-turbo-mode=ALL_CORE_MAX \
     --gce-threads-per-core=1"
 fi

--- a/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_weekly.sh
@@ -127,8 +127,19 @@ BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e GOOGLE_EPHEMERAL_CREDENTIALS -e SANITIZED_BE
 # Log into gcloud again (credentials are removed by teamcity-support in the build script)
 log_into_gcloud
 
+# Check if machine type starts with c4
+# For this machine type we need to specify additional flags
+additional_roachprod_args=""
+if [[ "$GCE_MACHINE_TYPE" == c4* ]]; then
+  additional_roachprod_args="--gce-boot-disk-type=\"hyperdisk-balanced\" \
+    --gce-pd-volume-type=\"hyperdisk-balanced\" \
+    --gce-turbo-mode=ALL_CORE_MAX \
+    --gce-threads-per-core=1"
+fi
+
 # Create roachprod cluster
 ./bin/roachprod create "$ROACHPROD_CLUSTER" -n "$GCE_NODE_COUNT" \
+  ${additional_roachprod_args:+$additional_roachprod_args} \
   --lifetime "$CLUSTER_LIFETIME" \
   --clouds gce \
   --gce-machine-type "$GCE_MACHINE_TYPE" \

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -1436,6 +1436,9 @@ func (p *ProviderOpts) minCPUPlatform() string {
 	case "best":
 		// By default, we choose the latest CPU platform available for the machine
 		// type. This ensures run-to-run consistency.
+		if !supportsMinCPUPlatform(p.MachineType) {
+			return ""
+		}
 		info, err := gcedb.GetMachineInfo(p.MachineType)
 		if err != nil || len(info.CPUPlatforms) < 2 {
 			return ""
@@ -1444,6 +1447,25 @@ func (p *ProviderOpts) minCPUPlatform() string {
 
 	default:
 		return p.MinCPUPlatform
+	}
+}
+
+// supportsMinCPUPlatform returns whether the given machine type supports the
+// --min-cpu-platform flag. C4 family VMs reject this flag with the error
+// "C4 VM does not support minCpuPlatform" when instances are created via
+// managed instance groups. This is not documented in the GCE docs but is
+// enforced by the API.
+func supportsMinCPUPlatform(machineType string) bool {
+	parts := strings.Split(machineType, "-")
+	if len(parts) < 2 {
+		return false
+	}
+	family := parts[0]
+	switch family {
+	case "c4", "c4a", "c4d":
+		return false
+	default:
+		return true
 	}
 }
 


### PR DESCRIPTION
When the c4 machine type is specified, we need to specify additional flags to roachprod `create`. These additional flags yield better results when running microbenchmarks.

Epic: None
Release note: None