### PR TITLE
roachprod: add stop option to reset VM failure

### DIFF
--- a/pkg/cmd/roachtest/tests/failure_injection.go
+++ b/pkg/cmd/roachtest/tests/failure_injection.go
@@ -789,46 +789,51 @@ var processKillTests = func(c cluster.Cluster) []failureSmokeTest {
 	return tests
 }
 
-var resetVMTests = func(c cluster.Cluster) failureSmokeTest {
+var resetVMTests = func(c cluster.Cluster) []failureSmokeTest {
 	rng, _ := randutil.NewPseudoRand()
 	rebootedNode := c.CRDBNodes().SeededRandNode(rng)
-	return failureSmokeTest{
-		testName:    failures.ResetVMFailureName,
-		failureName: failures.ResetVMFailureName,
-		args: failures.ResetVMArgs{
-			Nodes: rebootedNode.InstallNodes(),
-		},
-		validateFailure: func(ctx context.Context, l *logger.Logger, c cluster.Cluster, f *failures.Failer) error {
-			// Check that we aren't able to establish a SQL connection to the rebooted node.
-			// waitForFailureToPropagate already does a similar check, but we do it here
-			// to satisfy the smoke test framework since this is a fairly simple failure
-			// mode with less to validate.
-			return testutils.SucceedsSoonError(func() error {
-				if ctx.Err() != nil {
-					return ctx.Err()
-				}
-
-				killedDB, err := c.ConnE(ctx, l, rebootedNode[0])
-				if err == nil {
-					defer killedDB.Close()
-					if err := killedDB.Ping(); err == nil {
-						return errors.Errorf("expected node %d to be dead, but it is alive", rebootedNode)
-					} else {
-						l.Printf("failed to connect to node %d: %v", rebootedNode, err)
+	var tests []failureSmokeTest
+	for _, stopCluster := range []bool{true, false} {
+		tests = append(tests, failureSmokeTest{
+			testName:    fmt.Sprintf("%s/StopCluster=%t", failures.ResetVMFailureName, stopCluster),
+			failureName: failures.ResetVMFailureName,
+			args: failures.ResetVMArgs{
+				Nodes:         rebootedNode.InstallNodes(),
+				StopProcesses: stopCluster,
+			},
+			validateFailure: func(ctx context.Context, l *logger.Logger, c cluster.Cluster, f *failures.Failer) error {
+				// Check that we aren't able to establish a SQL connection to the rebooted node.
+				// waitForFailureToPropagate already does a similar check, but we do it here
+				// to satisfy the smoke test framework since this is a fairly simple failure
+				// mode with less to validate.
+				return testutils.SucceedsSoonError(func() error {
+					if ctx.Err() != nil {
+						return ctx.Err()
 					}
-				} else {
-					l.Printf("unable to establish SQL connection to node %d", rebootedNode)
-				}
+
+					killedDB, err := c.ConnE(ctx, l, rebootedNode[0])
+					if err == nil {
+						defer killedDB.Close()
+						if err := killedDB.Ping(); err == nil {
+							return errors.Errorf("expected node %d to be dead, but it is alive", rebootedNode)
+						} else {
+							l.Printf("failed to connect to node %d: %v", rebootedNode, err)
+						}
+					} else {
+						l.Printf("unable to establish SQL connection to node %d", rebootedNode)
+					}
+					return nil
+				})
+			},
+			validateRecover: func(ctx context.Context, l *logger.Logger, c cluster.Cluster, f *failures.Failer) error {
 				return nil
-			})
-		},
-		validateRecover: func(ctx context.Context, l *logger.Logger, c cluster.Cluster, f *failures.Failer) error {
-			return nil
-		},
-		workload: func(ctx context.Context, c cluster.Cluster, args ...string) error {
-			return defaultFailureSmokeTestWorkload(ctx, c, "--tolerate-errors")
-		},
+			},
+			workload: func(ctx context.Context, c cluster.Cluster, args ...string) error {
+				return defaultFailureSmokeTestWorkload(ctx, c, "--tolerate-errors")
+			},
+		})
 	}
+	return tests
 }
 
 func defaultFailureSmokeTestWorkload(ctx context.Context, c cluster.Cluster, args ...string) error {
@@ -873,11 +878,11 @@ func runFailureSmokeTest(ctx context.Context, t test.Test, c cluster.Cluster, no
 		asymmetricOutgoingNetworkPartitionTest(c),
 		latencyTest(c),
 		dmsetupDiskStallTest(c),
-		resetVMTests(c),
 		cgroupStallLogsTest(c),
 	}
 	failureSmokeTests = append(failureSmokeTests, cgroupsDiskStallTests(c)...)
 	failureSmokeTests = append(failureSmokeTests, processKillTests(c)...)
+	failureSmokeTests = append(failureSmokeTests, resetVMTests(c)...)
 
 	// Randomize the order of the tests in case any of the failures have unexpected side
 	// effects that may mask failures, e.g. a cgroups disk stall isn't properly recovered

--- a/pkg/roachprod/failureinjection/failures/reset.go
+++ b/pkg/roachprod/failureinjection/failures/reset.go
@@ -7,6 +7,7 @@ package failures
 
 import (
 	"context"
+	"slices"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
@@ -16,12 +17,22 @@ import (
 
 type (
 	ResetVMArgs struct {
-		Nodes install.Nodes
+		Nodes         install.Nodes
+		StopProcesses bool
 	}
 	resetVMFailure struct {
 		GenericFailure
-		Processes map[install.Node][]install.MonitorProcessRunning
+		processes processMap
 	}
+	// nodeSet is a set of nodes.
+	nodeSet map[install.Node]struct{}
+	// instanceMap is a map of SQL instances to a map of nodes that are running
+	// that instance.
+	instanceMap map[int]nodeSet
+	// processMap is a map of virtual cluster names to instance maps. It's a
+	// convenience type that allows grouping the processes that should be
+	// started and stopped together.
+	processMap map[string]instanceMap
 )
 
 var _ FailureMode = &resetVMFailure{}
@@ -47,6 +58,43 @@ func MakeResetVMFailure(
 	}, nil
 }
 
+func (m *processMap) add(virtualClusterName string, instance int, node install.Node) {
+	if virtualClusterName == "" {
+		virtualClusterName = install.SystemInterfaceName
+	}
+	if _, ok := (*m)[virtualClusterName]; !ok {
+		(*m)[virtualClusterName] = make(map[int]nodeSet, 0)
+	}
+	if _, ok := (*m)[virtualClusterName][instance]; !ok {
+		(*m)[virtualClusterName][instance] = make(nodeSet, 0)
+	}
+	(*m)[virtualClusterName][instance][node] = struct{}{}
+}
+
+// getStartOrder returns the order in which the processes should be started. It
+// ensures that the System interface is started first.
+func (m *processMap) getStartOrder() []string {
+	var order []string
+	// If the System interface is present, it should be the first to start.
+	if _, ok := (*m)[install.SystemInterfaceName]; ok {
+		order = append(order, install.SystemInterfaceName)
+	}
+	for virtualClusterName := range *m {
+		if virtualClusterName != install.SystemInterfaceName {
+			order = append(order, virtualClusterName)
+		}
+	}
+	return order
+}
+
+// getStopOrder returns the order in which the processes should be stopped. It
+// is the reverse of the start order.
+func (m *processMap) getStopOrder() []string {
+	order := m.getStartOrder()
+	slices.Reverse(order)
+	return order
+}
+
 // Description implements FailureMode.
 func (r *resetVMFailure) Description() string {
 	return ResetVMFailureName
@@ -62,10 +110,29 @@ func (r *resetVMFailure) Inject(ctx context.Context, l *logger.Logger, args Fail
 	// Capture the processes running on the nodes.
 	nodes := args.(ResetVMArgs).Nodes
 	monitorChan := r.c.WithNodes(nodes).Monitor(l, ctx, install.MonitorOpts{OneShot: true})
-	r.Processes = make(map[install.Node][]install.MonitorProcessRunning, 0)
+	r.processes = make(processMap, 0)
 	for e := range monitorChan {
 		if p, ok := e.Event.(install.MonitorProcessRunning); ok {
-			r.Processes[e.Node] = append(r.Processes[e.Node], p)
+			r.processes.add(p.VirtualClusterName, p.SQLInstance, e.Node)
+		}
+	}
+
+	// Optionally stop the processes.
+	if args.(ResetVMArgs).StopProcesses {
+		for _, virtualClusterName := range r.processes.getStopOrder() {
+			instanceMap := r.processes[virtualClusterName]
+			for _, nodeMap := range instanceMap {
+				var stopNodes install.Nodes
+				for node := range nodeMap {
+					stopNodes = append(nodes, node)
+				}
+				l.Printf("Stopping process %s on nodes %v", virtualClusterName, stopNodes)
+				stopOpts := roachprod.DefaultStopOpts()
+				err := r.c.WithNodes(stopNodes).Stop(ctx, l, stopOpts.Sig, stopOpts.Wait, stopOpts.GracePeriod, virtualClusterName)
+				if err != nil {
+					return err
+				}
+			}
 		}
 	}
 
@@ -80,12 +147,17 @@ func (r *resetVMFailure) Cleanup(ctx context.Context, l *logger.Logger, args Fai
 // Recover implements FailureMode.
 func (r *resetVMFailure) Recover(ctx context.Context, l *logger.Logger, args FailureArgs) error {
 	// Restart the processes.
-	for node, processes := range r.Processes {
-		for _, p := range processes {
-			l.Printf("Starting process %s on node %s", p.PID, p.VirtualClusterName)
-			err := r.c.WithNodes([]install.Node{node}).Start(ctx, l, install.StartOpts{
-				VirtualClusterName: p.VirtualClusterName,
-				SQLInstance:        p.SQLInstance,
+	for _, virtualClusterName := range r.processes.getStartOrder() {
+		instanceMap := r.processes[virtualClusterName]
+		for instance, nodeMap := range instanceMap {
+			var nodes install.Nodes
+			for node := range nodeMap {
+				nodes = append(nodes, node)
+			}
+			l.Printf("Starting process %s on nodes %v", virtualClusterName, nodes)
+			err := r.c.WithNodes(nodes).Start(ctx, l, install.StartOpts{
+				VirtualClusterName: virtualClusterName,
+				SQLInstance:        instance,
 				IsRestart:          true,
 			})
 			if err != nil {

--- a/pkg/roachprod/failureinjection/failures/reset.go
+++ b/pkg/roachprod/failureinjection/failures/reset.go
@@ -7,7 +7,7 @@ package failures
 
 import (
 	"context"
-	"slices"
+	"math/rand"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
@@ -87,11 +87,12 @@ func (m *processMap) getStartOrder() []string {
 	return order
 }
 
-// getStopOrder returns the order in which the processes should be stopped. It
-// is the reverse of the start order.
+// getStopOrder returns the order in which the processes should be stopped.
 func (m *processMap) getStopOrder() []string {
 	order := m.getStartOrder()
-	slices.Reverse(order)
+	rand.Shuffle(len(order), func(i, j int) {
+		order[i], order[j] = order[j], order[i]
+	})
 	return order
 }
 


### PR DESCRIPTION
When the reset VM failure is injected, we now have the option to stop the
processes before restarting the cluster.

This change also improves process management by starting the processes in the
correct order (System interface first, then tenants).

Epic: None
Release note: None