### PR TITLE
kvcoord: transform replicated, locking Get requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -9,6 +9,7 @@ import (
 	"context"
 	"encoding/binary"
 	"fmt"
+	"math"
 	"slices"
 	"sort"
 	"strings"
@@ -132,6 +133,8 @@ var bufferedWritesMaxBufferSize = settings.RegisterByteSizeSetting(
 //
 // TODO(arul): In various places below, there's potential to optimize things by
 // batch allocating misc objects and pre-allocating some slices.
+//
+// TODO(ssd): Review the use of logging/tracing in this interceptor.
 type txnWriteBuffer struct {
 	st *cluster.Settings
 	// enabled indicates whether write buffering is currently enabled for the
@@ -444,6 +447,12 @@ func (twb *txnWriteBuffer) estimateSize(ba *kvpb.BatchRequest) int64 {
 			}
 			estimate += scratch.size()
 			estimate += lockKeyInfoSize
+		case *kvpb.GetRequest:
+			if t.KeyLockingDurability == lock.Replicated {
+				scratch.key = t.Key
+				estimate += scratch.size()
+				estimate += lockKeyInfoSize
+			}
 		case *kvpb.PutRequest:
 			// NB: when estimating, we're being conservative by assuming the Put is to
 			// a key that isn't already present in the buffer. If it were, we could
@@ -660,9 +669,17 @@ func (twb *txnWriteBuffer) rollbackToSavepointLocked(ctx context.Context, s save
 			// If we aren't still held, update our buffer size.
 			twb.bufferSize -= lockKeyInfoSize
 		}
-		bufferedVals := it.Cur().vals
+
+		// Simplify the code below a bit by handling the case where the only entry
+		// for this key was a buffered locking read.
+		if it.Cur().empty() {
+			toDelete = append(toDelete, it.Cur())
+			continue
+		}
+
 		// NB: the savepoint is being rolled back to s.seqNum (inclusive). So,
 		// idx is the index of the first value that is considered rolled back.
+		bufferedVals := it.Cur().vals
 		idx := sort.Search(len(bufferedVals), func(i int) bool {
 			return bufferedVals[i].seq >= s.seqNum
 		})
@@ -676,9 +693,9 @@ func (twb *txnWriteBuffer) rollbackToSavepointLocked(ctx context.Context, s save
 		}
 		// Rollback writes by truncating the buffered values.
 		it.Cur().vals = bufferedVals[:idx]
-		if len(it.Cur().vals) == 0 {
-			// All writes have been rolled back; we should remove this key from
-			// the buffer entirely.
+		if it.Cur().empty() {
+			// All writes have been rolled back and we hold no locks; we should remove
+			// this key from the buffer entirely.
 			toDelete = append(toDelete, it.Cur())
 		}
 	}
@@ -698,23 +715,36 @@ func (twb *txnWriteBuffer) closeLocked() {}
 // along with a list of requestRecords is returned. The caller must handle the
 // transformations on the response path.
 //
-// Some examples of transformations include:
+// The transformations include:
 //
 // 1. Blind writes (Put/Delete requests) are buffered locally. When the original
 // request has MustAcquireExclusiveLock set, a locking Get is used to acquire
-// the lock.
-// 2. Point reads (Get requests) are served from the buffer and stripped from
-// the batch iff the key has seen a buffered write.
-// 3. Scans are always sent to the KV layer, but if the key span being scanned
+// the lock unless an exclusive lock has already been acquired for the relevant
+// key.
+//
+// 2. Non-locking GetRequests are served from the buffer and stripped from the
+// batch iff the key has seen a buffered write.
+//
+// 3. Locking GetRequests are served from the buffer and stripped from the batch
+// iff the key has seen a buffered write and a lock of sufficient strength has
+// already been acquired. If the request has a KeyLockingDurability of
+// replicated, it is transformed to an unreplicated locking request and
+// information about the locking request is added to the buffer.
+//
+// 4. Scans are always sent to the KV layer, but if the key span being scanned
 // overlaps with any buffered writes, then the response from the KV layer needs
 // to be merged with buffered writes. These are collected as requestRecords.
-// 4. ReverseScans, similar to scans, are also always sent to the KV layer and
+//
+// 5. ReverseScans, similar to scans, are also always sent to the KV layer and
 // their response needs to be merged with any buffered writes. The only
 // difference is the direction in which the buffer is iterated when doing the
 // merge. As a result, they're also collected as requestRecords.
-// 5. Conditional Puts are decomposed into a locking Get followed by a Put. The
+//
+// 6. Conditional Puts are decomposed into a locking Get followed by a Put. The
 // Put is buffered locally if the condition evaluates successfully using the
-// Get's response. Otherwise, a ConditionFailedError is returned.
+// Get's response. Otherwise, a ConditionFailedError is returned. We elide the
+// locking Get request if it can be served from the buffer (i.e if a lock of
+// sufficient strength has been acquired and a value has been buffered).
 //
 // TODO(arul): Augment this comment as these expand.
 func (twb *txnWriteBuffer) applyTransformations(
@@ -819,33 +849,25 @@ func (twb *txnWriteBuffer) applyTransformations(
 		case *kvpb.GetRequest:
 			// If the key is in the buffer, we must serve the read from the buffer.
 			// The actual serving of the read will happen on the response path though.
-			stripped := false
 			_, lockStr, served := twb.maybeServeRead(t.Key, t.Sequence)
-			if served {
-				if t.KeyLockingStrength > lockStr {
-					// Even though the Get request must be served from the buffer, as the
-					// transaction performed a previous write to the key, we still need to
-					// acquire a lock at the leaseholder because we don't have a known
-					// lock of a sufficient strength on this key. As a result, we can't
-					// strip the request from the remote batch.
-					log.VEventf(ctx, 2, "%s(Locking=%s) on key %s must be sent to the server",
-						t.Method(), t.KeyLockingStrength, t.Key)
-					baRemote.Requests = append(baRemote.Requests, ru)
-				} else {
-					// We'll synthesize the response from the buffer on the response path;
-					// eschew sending the request to the KV layer since we already have a
-					// lock of a sufficient strength on this key.
-					stripped = true
-					log.VEventf(
-						ctx, 2, "%s(Locking=%s) on key %s can be fully served by the client; not sending to KV",
-						t.Method(), t.KeyLockingStrength, t.Key,
-					)
-				}
+
+			requiresAdditionalLocking := t.KeyLockingStrength > lockStr
+			requiresLockTransform := t.KeyLockingStrength != lock.None && t.KeyLockingDurability == lock.Replicated
+			requestRequired := requiresAdditionalLocking || !served
+
+			if requestRequired && requiresLockTransform {
+				var getReqU kvpb.RequestUnion
+				getReq := t.ShallowCopy().(*kvpb.GetRequest)
+				getReq.KeyLockingDurability = lock.Unreplicated
+				getReqU.MustSetInner(getReq)
+
+				record.transformed = true
+				baRemote.Requests = append(baRemote.Requests, getReqU)
+			} else if !requestRequired {
+				record.stripped = true
 			} else {
-				// Wasn't served locally; send the request to the KV layer.
 				baRemote.Requests = append(baRemote.Requests, ru)
 			}
-			record.stripped = stripped
 
 		case *kvpb.ScanRequest, *kvpb.ReverseScanRequest:
 			// Regardless of whether the scan overlaps with any writes in the buffer
@@ -1167,9 +1189,9 @@ func (rr requestRecord) toResp(
 			return kvpb.ResponseUnion{}, pErr
 		}
 
-		var lei *lockAcquisition
+		var dla *bufferedDurableLockAcquisition
 		if rr.transformed && exclusionTimestampRequired {
-			lei = &lockAcquisition{
+			dla = &bufferedDurableLockAcquisition{
 				str: lock.Exclusive,
 				seq: req.Sequence,
 				ts:  txn.ReadTimestamp,
@@ -1179,19 +1201,19 @@ func (rr requestRecord) toResp(
 		// The condition was satisfied; buffer the write and return a
 		// synthesized response.
 		ru.MustSetInner(&kvpb.ConditionalPutResponse{})
-		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq, lei)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq, dla)
 
 	case *kvpb.PutRequest:
-		var lei *lockAcquisition
+		var dla *bufferedDurableLockAcquisition
 		if rr.transformed && exclusionTimestampRequired {
-			lei = &lockAcquisition{
+			dla = &bufferedDurableLockAcquisition{
 				str: lock.Exclusive,
 				seq: req.Sequence,
 				ts:  txn.ReadTimestamp,
 			}
 		}
 		ru.MustSetInner(&kvpb.PutResponse{})
-		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq, lei)
+		twb.addToBuffer(req.Key, req.Value, req.Sequence, req.KVNemesisSeq, dla)
 
 	case *kvpb.DeleteRequest:
 		// To correctly populate FoundKey in the response, we must prefer any
@@ -1223,9 +1245,9 @@ func (rr requestRecord) toResp(
 			foundKey = false
 		}
 
-		var lei *lockAcquisition
+		var dla *bufferedDurableLockAcquisition
 		if rr.transformed && exclusionTimestampRequired {
-			lei = &lockAcquisition{
+			dla = &bufferedDurableLockAcquisition{
 				str: lock.Exclusive,
 				seq: req.Sequence,
 				ts:  txn.ReadTimestamp,
@@ -1235,7 +1257,7 @@ func (rr requestRecord) toResp(
 		ru.MustSetInner(&kvpb.DeleteResponse{
 			FoundKey: foundKey,
 		})
-		twb.addToBuffer(req.Key, roachpb.Value{}, req.Sequence, req.KVNemesisSeq, lei)
+		twb.addToBuffer(req.Key, roachpb.Value{}, req.Sequence, req.KVNemesisSeq, dla)
 
 	case *kvpb.GetRequest:
 		val, _, served := twb.maybeServeRead(req.Key, req.Sequence)
@@ -1251,6 +1273,25 @@ func (rr requestRecord) toResp(
 			// KV layer.
 			assertTrue(!rr.stripped, "we shouldn't be stripping requests that aren't served from the buffer")
 			ru = br
+		}
+		// If rr.transformed is true, this is a replicated locking request that was
+		// transformed into an unreplicated locking request. If the request acquired
+		// a lock, we add it to the buffer since we may need to flush it as
+		// replicated lock.
+		if rr.transformed {
+
+			transformedGetResponse := br.GetInner().(*kvpb.GetResponse)
+			valueWasPresent := transformedGetResponse.Value.IsPresent()
+			lockShouldHaveBeenAcquired := valueWasPresent || req.LockNonExisting
+
+			if lockShouldHaveBeenAcquired {
+				dla := &bufferedDurableLockAcquisition{
+					str: req.KeyLockingStrength,
+					seq: req.Sequence,
+					ts:  txn.ReadTimestamp,
+				}
+				twb.addDurableLockedReadToBuffer(req.Key, dla)
+			}
 		}
 
 	case *kvpb.ScanRequest:
@@ -1330,8 +1371,10 @@ func (rr requestRecords) Summary() string {
 	return b.String()
 }
 
-// lockAcquisition represents a request that acquired a lock.
-type lockAcquisition struct {
+// bufferedDurableLockAcquisition represents a durable locking request that was
+// transformed to an unreplicated lock. Such locks may need to be flushed as
+// durable locks if there is no write (or stronger lock) on the related key.
+type bufferedDurableLockAcquisition struct {
 	str lock.Strength
 	seq enginepb.TxnSeq
 
@@ -1345,7 +1388,7 @@ func (twb *txnWriteBuffer) addToBuffer(
 	val roachpb.Value,
 	seq enginepb.TxnSeq,
 	kvNemSeq kvnemesisutil.Container,
-	lockInfo *lockAcquisition,
+	lockInfo *bufferedDurableLockAcquisition,
 ) {
 	it := twb.buffer.MakeIter()
 	seek := twb.seekItemForSpan(key, nil)
@@ -1372,6 +1415,34 @@ func (twb *txnWriteBuffer) addToBuffer(
 		if lockInfo != nil {
 			bw.acquireLock(lockInfo)
 		}
+		twb.buffer.Set(bw)
+		twb.bufferSize += bw.size()
+	}
+}
+
+// addDurableLockedReadToBuffer adds a locking read to the given buffer.
+//
+// TODO(ssd): Determine if we need to track the kvnemesis sequence number for
+// these reads.
+func (twb *txnWriteBuffer) addDurableLockedReadToBuffer(
+	key roachpb.Key, lockInfo *bufferedDurableLockAcquisition,
+) {
+	assertTrue(lockInfo != nil, "expect non-nil bufferedDurableLockAcquisition")
+	it := twb.buffer.MakeIter()
+	seek := twb.seekItemForSpan(key, nil)
+
+	it.FirstOverlap(seek)
+	if it.Valid() {
+		if firstAcquisition := it.Cur().acquireLock(lockInfo); firstAcquisition {
+			twb.bufferSize += lockKeyInfoSize
+		}
+	} else {
+		twb.bufferIDAlloc++
+		bw := &bufferedWrite{
+			id:  twb.bufferIDAlloc,
+			key: key,
+		}
+		bw.acquireLock(lockInfo)
 		twb.buffer.Set(bw)
 		twb.bufferSize += bw.size()
 	}
@@ -1530,9 +1601,15 @@ func (bw *bufferedWrite) size() int64 {
 	return size
 }
 
+// empty returns true if the bufferedWrite has no values and no lock information
+// that would require a request to be sent upon flush.
+func (bw *bufferedWrite) empty() bool {
+	return len(bw.vals) == 0 && bw.lki == nil
+}
+
 // acquireLock updates the lock information for this buffered write. It returns
 // true if this is the first lock acquisition.
-func (bw *bufferedWrite) acquireLock(li *lockAcquisition) bool {
+func (bw *bufferedWrite) acquireLock(li *bufferedDurableLockAcquisition) bool {
 	if bw.lki == nil {
 		bw.lki = newLockedKeyInfo(li.str, li.seq, li.ts)
 		return true
@@ -1651,6 +1728,14 @@ func (bw *bufferedWrite) SetEndKey(v []byte)  { bw.endKey = v }
 // we only need to flush the most recent write (read: the one with the highest
 // sequence number).
 func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
+	// If we don't have any values, we may still have a lock that needs to be
+	// sent. Since toRequest() is only called when we know no savepoint rollback
+	// can occur, we only need to send the strongest lock we have.
+	if len(bw.vals) == 0 {
+		assertTrue(bw.lki != nil, "empty vals and no lock info")
+		return bw.lki.toRequestUnion(bw.key, bw.exclusionExpectedSinceTimestamp())
+	}
+
 	// As we store values in increasing sequence number order, the most recent
 	// write should be the last value in the slice.
 	return bw.vals[len(bw.vals)-1].toRequestUnion(bw.key, bw.exclusionExpectedSinceTimestamp())
@@ -1669,14 +1754,32 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 // A write below the the minimum sequence number can be elided if there is a
 // subsequent write also below the minimum sequence number.
 func (bw *bufferedWrite) toAllRevisionRequests(minSeq enginepb.TxnSeq) []kvpb.RequestUnion {
-	rus := make([]kvpb.RequestUnion, 0, len(bw.vals))
+	likelyLockRequestCount := len(unreplicatedHolderStrengths)
+	if bw.lki == nil {
+		likelyLockRequestCount = 0
+	}
+
+	rus := make([]kvpb.RequestUnion, 0, len(bw.vals)+likelyLockRequestCount)
 	maxIdx := len(bw.vals) - 1
+
+	// We track the smallest sequence of an intent write to potentially elide
+	// locking requests. See the comment on (*lockedKeyInfo).toAllRequestUnions
+	// for details.
+	minIntentWriteSeq := enginepb.TxnSeq(math.MaxInt32)
+
 	for i, val := range bw.vals {
 		nextWriteLessThanSeq := (i+1 < maxIdx) && (bw.vals[i+1].seq < minSeq)
 		canElideRevision := val.seq < minSeq && nextWriteLessThanSeq
 		if !canElideRevision {
+			if val.seq < minIntentWriteSeq {
+				minIntentWriteSeq = val.seq
+			}
 			rus = append(rus, val.toRequestUnion(bw.key, bw.exclusionExpectedSinceTimestamp()))
 		}
+	}
+
+	if bw.lki != nil {
+		rus = bw.lki.toAllRequestUnions(rus, bw.key, bw.exclusionExpectedSinceTimestamp(), minSeq, minIntentWriteSeq)
 	}
 	return rus
 }
@@ -1773,6 +1876,107 @@ func (li *lockedKeyInfo) acquireLock(str lock.Strength, seq enginepb.TxnSeq, ts 
 	} else {
 		assertTrue(minSeq <= seq, "new acquisition at lower sequence number")
 	}
+}
+
+// toRequestUnion returns a kvpb.RequestUnion containing a replicated, locking
+// Get request for the strongest held lock.
+func (li *lockedKeyInfo) toRequestUnion(key roachpb.Key, ts hlc.Timestamp) kvpb.RequestUnion {
+	var ru kvpb.RequestUnion
+	for _, str := range unreplicatedHolderStrengths {
+		heldSeq := li.heldStrengths[heldStrengthToIndexMap[str]]
+		if heldSeq != notHeldSentinel {
+			getAlloc := new(struct {
+				get   kvpb.GetRequest
+				union kvpb.RequestUnion_Get
+			})
+			populateGetReq(&getAlloc.get, key, heldSeq, str, ts)
+			getAlloc.union.Get = &getAlloc.get
+			ru.Value = &getAlloc.union
+			return ru
+		}
+	}
+	assertTrue(false, "toRequestUnion called on unheld lock info")
+	return ru
+}
+
+// toAllRequestUnions appends all of the requests that need to be sent for the
+// given minimum known savepoint to the dst slice.
+//
+// minIntentSequence is assumed to be the smallest sequence number of any intent
+// write and is used to elide requests. We assume that
+//
+// - A locking request can be elided if a stronger lock is held at a lower sequence number;
+// - If all locks are below the minKnownSavepoint, only the strongest needs to be sent.
+func (li *lockedKeyInfo) toAllRequestUnions(
+	dst []kvpb.RequestUnion,
+	key roachpb.Key,
+	ts hlc.Timestamp,
+	minKnownSavepoint enginepb.TxnSeq,
+	minIntentSequence enginepb.TxnSeq,
+) []kvpb.RequestUnion {
+	if minIntentSequence < minKnownSavepoint {
+		// We have an intent write that can't be rolled back, no reason to return
+		// anything at all.
+		return dst
+	}
+
+	allBelowMinSavepoint := false
+	for _, str := range unreplicatedHolderStrengths {
+		heldSeq := li.heldStrengths[heldStrengthToIndexMap[str]]
+		if heldSeq != notHeldSentinel && heldSeq < minKnownSavepoint {
+			allBelowMinSavepoint = true
+			break
+		}
+	}
+
+	lastSeq := minIntentSequence
+	for _, str := range unreplicatedHolderStrengths {
+		heldSeq := li.heldStrengths[heldStrengthToIndexMap[str]]
+		if heldSeq != notHeldSentinel {
+			if heldSeq > lastSeq {
+				// This lock is above a stronger lock and can be elided.
+				continue
+			}
+			// We are iterating the lock strengths from strongest to weakest, so any
+			// future lock greater than this lock can be elided.
+			lastSeq = heldSeq
+			var ru kvpb.RequestUnion
+			getAlloc := new(struct {
+				get   kvpb.GetRequest
+				union kvpb.RequestUnion_Get
+			})
+			populateGetReq(&getAlloc.get, key, heldSeq, str, ts)
+			getAlloc.union.Get = &getAlloc.get
+			ru.Value = &getAlloc.union
+			dst = append(dst, ru)
+
+			// If everyone was below the min savepoint, we only need to send the strongest lock.
+			if allBelowMinSavepoint {
+				break
+			}
+		}
+	}
+	return dst
+}
+
+func populateGetReq(
+	get *kvpb.GetRequest,
+	key roachpb.Key,
+	heldSeq enginepb.TxnSeq,
+	str lock.Strength,
+	exclusionTS hlc.Timestamp,
+) {
+	get.Key = key
+	get.Sequence = heldSeq
+	get.KeyLockingStrength = str
+	get.KeyLockingDurability = lock.Replicated
+	// If we have a lock in our buffer it was either the result of a
+	// successful locking request on a present key or a locking request with
+	// LockNonExisting set to true. In the former case, setting this to true
+	// should have no effect, in the latter case we need it set to true to
+	// ensure a lock is acquired.
+	get.LockNonExisting = true
+	get.ExpectExclusionSince = exclusionTS
 }
 
 // held returns true if a lock has been acquired at the given strength.

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -2943,7 +2943,7 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 
 	// A number of the requests expect a single locking get to be produced. This
 	// validator function is shared across them.
-	validateLockingGetOfStr := func(str lock.Strength) func(t *testing.T, ba *kvpb.BatchRequest) *kvpb.BatchResponse {
+	validateLockingGetOfStr := func(str lock.Strength, keyExists bool) func(t *testing.T, ba *kvpb.BatchRequest) *kvpb.BatchResponse {
 		return func(t *testing.T, ba *kvpb.BatchRequest) *kvpb.BatchResponse {
 			getReq := ba.Requests[0].GetGet()
 			require.NotNil(t, getReq)
@@ -2951,6 +2951,9 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 			require.Equal(t, lock.Unreplicated, getReq.KeyLockingDurability) // NB: always Unreplicated
 			resp := ba.CreateReply()
 			resp.Txn = ba.Txn
+			if keyExists {
+				resp.Responses[0].MustSetInner(&kvpb.GetResponse{Value: &valueA})
+			}
 			return resp
 		}
 	}
@@ -3041,7 +3044,8 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 		},
 		{
 			name:                         "ReplicatedLockingGet(Strength=Exclusive)",
-			buffersLock:                  false,
+			buffersLock:                  true,
+			bufferedLockStr:              lock.Exclusive,
 			buffersValue:                 false,
 			requiresValue:                true,
 			isFullyCoveredByLockStrength: lock.Exclusive,
@@ -3053,7 +3057,7 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				getReq.KeyLockingStrength = lock.Exclusive
 				ba.Add(getReq)
 			},
-			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive),
+			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive, true),
 		},
 		{
 			name:                         "UnReplicatedLockingGet(Strength=Exclusive)",
@@ -3069,11 +3073,12 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				getReq.KeyLockingStrength = lock.Exclusive
 				ba.Add(getReq)
 			},
-			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive),
+			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive, true),
 		},
 		{
 			name:                         "ReplicatedLockingGet(Strength=Shared)",
-			buffersLock:                  false,
+			buffersLock:                  true,
+			bufferedLockStr:              lock.Shared,
 			buffersValue:                 false,
 			requiresValue:                true,
 			isFullyCoveredByLockStrength: lock.Shared,
@@ -3085,7 +3090,7 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				getReq.KeyLockingStrength = lock.Shared
 				ba.Add(getReq)
 			},
-			validateAndGenerateResponse: validateLockingGetOfStr(lock.Shared),
+			validateAndGenerateResponse: validateLockingGetOfStr(lock.Shared, true),
 		},
 		{
 			name:                         "PutMustAcquireExclusive",
@@ -3099,7 +3104,7 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				putReq.MustAcquireExclusiveLock = true
 				ba.Add(putReq)
 			},
-			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive),
+			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive, false),
 		},
 		{
 			name:            "DeleteMustAcquireExclusive",
@@ -3114,7 +3119,7 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				delReq.MustAcquireExclusiveLock = true
 				ba.Add(delReq)
 			},
-			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive),
+			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive, false),
 		},
 		{
 			name:            "ConditionalPut",
@@ -3134,13 +3139,21 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				cput.AllowIfDoesNotExist = true
 				ba.Add(cput)
 			},
-			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive),
+			validateAndGenerateResponse: validateLockingGetOfStr(lock.Exclusive, false),
 		},
+	}
+
+	lockConfigIsValid := func(t *testing.T, l lockingRequests) {
+		if l.buffersLock {
+			require.True(t, l.bufferedLockStr > lock.None, "bufferedLockStr must be set if buffersLock is true")
+		}
 	}
 
 	for _, firstReq := range reqs {
 		for _, secondReq := range reqs {
 			t.Run(fmt.Sprintf("%s followed by %s", firstReq.name, secondReq.name), func(t *testing.T) {
+				lockConfigIsValid(t, firstReq)
+				lockConfigIsValid(t, secondReq)
 				if !firstReq.buffersLock {
 					skip.WithIssue(t, 142977, "%s does not buffer its lock", firstReq.name)
 				}
@@ -3199,8 +3212,448 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 				require.Nil(t, pErr)
 				require.NotNil(t, br)
 				require.Len(t, br.Responses, 1)
-				require.Equal(t, numCalled+expectedCalls, mockSender.NumCalled())
+				require.Equal(t, expectedCalls, mockSender.NumCalled()-numCalled)
 			})
 		}
+	}
+}
+
+// TestTxnWriteBufferLockingGetTransformations tests the basic locking
+// transformations that we do for GetRequest, assuming an empty buffer.
+func TestTxnWriteBufferLockingGetTransformations(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	type testCase struct {
+		name string
+		// originalRequest generates the inbound request to the buffer.
+		originalRequest func(ba *kvpb.BatchRequest)
+		// validateTransformedRequestAndGenerateResponse validates the request that
+		// we send immediately in response to the originalRequest.
+		validateTransformedRequestAndGenerateResponse func(t *testing.T, ba *kvpb.BatchRequest) *kvpb.BatchResponse
+		// validateFlushedRequest validates the request that we prepend to the batch
+		// containing the final EndTxn.
+		validateFlushedRequest func(t *testing.T, ba *kvpb.BatchRequest)
+	}
+
+	keyA := roachpb.Key("a")
+	valueA := roachpb.MakeValueFromString("valueA")
+
+	lockingGet := func(str lock.Strength, dur lock.Durability, lockNonExisting bool) func(ba *kvpb.BatchRequest) {
+		return func(ba *kvpb.BatchRequest) {
+			ba.Add(&kvpb.GetRequest{
+				KeyLockingStrength:   str,
+				KeyLockingDurability: dur,
+				LockNonExisting:      lockNonExisting,
+				RequestHeader: kvpb.RequestHeader{
+					Key: keyA,
+				},
+			})
+		}
+	}
+
+	validateGet := func(str lock.Strength, dur lock.Durability, lockNonExisting bool, value *roachpb.Value) func(t *testing.T, ba *kvpb.BatchRequest) *kvpb.BatchResponse {
+		return func(t *testing.T, ba *kvpb.BatchRequest) *kvpb.BatchResponse {
+			require.Len(t, ba.Requests, 1)
+			getReq := ba.Requests[0].GetGet()
+			require.NotNil(t, getReq)
+			require.Equal(t, str, getReq.KeyLockingStrength)
+			require.Equal(t, dur, getReq.KeyLockingDurability)
+			require.Equal(t, lockNonExisting, getReq.LockNonExisting)
+
+			resp := ba.CreateReply()
+			resp.Txn = ba.Txn
+			resp.Responses[0].MustSetInner(&kvpb.GetResponse{
+				Value: value,
+			})
+			return resp
+		}
+	}
+
+	expectEndTxnOnly := func(t *testing.T, ba *kvpb.BatchRequest) {
+		require.Len(t, ba.Requests, 1)
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+	}
+
+	expectGetWithEndTxn := func(str lock.Strength, dur lock.Durability) func(t *testing.T, ba *kvpb.BatchRequest) {
+		return func(t *testing.T, ba *kvpb.BatchRequest) {
+			require.Len(t, ba.Requests, 2)
+			getReq := ba.Requests[0].GetGet()
+			require.NotNil(t, getReq)
+			require.Equal(t, str, getReq.KeyLockingStrength)
+			require.Equal(t, dur, getReq.KeyLockingDurability)
+			require.Equal(t, true, getReq.LockNonExisting)
+			require.True(t, getReq.ExpectExclusionSince.IsSet(), "ExpectExclusionSince should be set")
+			require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[1].GetInner())
+		}
+	}
+
+	testCases := []testCase{
+		{
+			name:            "GetReplicatedExclusiveLock(key=exists) is transformed to GetUnreplicatedExclusiveLock",
+			originalRequest: lockingGet(lock.Exclusive, lock.Replicated, false),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Exclusive, lock.Unreplicated, false, &valueA),
+			validateFlushedRequest:                        expectGetWithEndTxn(lock.Exclusive, lock.Replicated),
+		},
+		{
+			name:            "GetReplicatedExclusiveLock(key=missing) is transformed to GetUnreplicatedExclusiveLock",
+			originalRequest: lockingGet(lock.Exclusive, lock.Replicated, false),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Exclusive, lock.Unreplicated, false, nil),
+			validateFlushedRequest:                        expectEndTxnOnly,
+		},
+		{
+			name:            "GetReplicatedExclusiveLock(key=missing, lock-non-existing) is transformed to GetUnreplicatedExclusiveLock",
+			originalRequest: lockingGet(lock.Exclusive, lock.Replicated, true),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Exclusive, lock.Unreplicated, true, nil),
+			validateFlushedRequest:                        expectGetWithEndTxn(lock.Exclusive, lock.Replicated),
+		},
+		{
+			name:            "GetReplicatedSharedLock(key=exists) is transformed to GetUnreplicatedSharedLock",
+			originalRequest: lockingGet(lock.Shared, lock.Replicated, false),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Shared, lock.Unreplicated, false, &valueA),
+			validateFlushedRequest:                        expectGetWithEndTxn(lock.Shared, lock.Replicated),
+		},
+		{
+			name:            "GetReplicatedSharedLock(key=missing) is transformed to GetUnreplicatedSharedLock",
+			originalRequest: lockingGet(lock.Shared, lock.Replicated, false),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Shared, lock.Unreplicated, false, nil),
+			validateFlushedRequest:                        expectEndTxnOnly,
+		},
+		{
+			name:            "GetReplicatedSharedLock(key=missing, lock-non-existing) is transformed to GetUnreplicatedSharedLock",
+			originalRequest: lockingGet(lock.Shared, lock.Replicated, true),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Shared, lock.Unreplicated, true, nil),
+			validateFlushedRequest:                        expectGetWithEndTxn(lock.Shared, lock.Replicated),
+		},
+		{
+			name:            "GetUnreplicatedExclusiveLock is not transformed",
+			originalRequest: lockingGet(lock.Exclusive, lock.Unreplicated, false),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Exclusive, lock.Unreplicated, false, &valueA),
+			validateFlushedRequest:                        expectEndTxnOnly,
+		},
+		{
+			name:            "GetUnreplicatedSharedLock is not transformed",
+			originalRequest: lockingGet(lock.Shared, lock.Unreplicated, false),
+			validateTransformedRequestAndGenerateResponse: validateGet(lock.Shared, lock.Unreplicated, false, &valueA),
+			validateFlushedRequest:                        expectEndTxnOnly,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+			txn := makeTxnProto()
+			txn.Sequence = 10
+
+			// Send first request and run validation
+			ba := &kvpb.BatchRequest{}
+			ba.Header = kvpb.Header{Txn: &txn}
+			tc.originalRequest(ba)
+
+			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+				resp := tc.validateTransformedRequestAndGenerateResponse(t, ba)
+				return resp, nil
+			})
+			br, pErr := twb.SendLocked(ctx, ba)
+			require.NotNil(t, br)
+			require.Nil(t, pErr)
+
+			// Flush the buffer and run validation
+			ba = &kvpb.BatchRequest{}
+			ba.Header = kvpb.Header{Txn: &txn}
+			ba.Add(&kvpb.EndTxnRequest{Commit: true})
+			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+				tc.validateFlushedRequest(t, ba)
+				resp := ba.CreateReply()
+				resp.Txn = ba.Txn
+				return resp, nil
+			})
+			br, pErr = twb.SendLocked(ctx, ba)
+			require.NotNil(t, br)
+			require.Nil(t, pErr)
+		})
+	}
+}
+
+// TestTxnWriteBufferLockingGetFlushing tests the how we flush locking Get's in
+// response to different buffer and rollback states.
+//
+// TODO(ssd): This and the other table-driven tests would be nice to convert to
+// data driven tests.
+func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	keyA := roachpb.Key("a")
+	valueAStr := "valueA"
+	valueA := roachpb.MakeValueFromString(valueAStr)
+
+	const (
+		replicatedSharedLockingGet      = "replicated-shared-lock"
+		replicatedExclusiveLockingGet   = "replicated-exclusive-lock"
+		unreplicatedSharedLockingGet    = "unreplicated-shared-lock"
+		unreplicatedExclusiveLockingGet = "unreplicated-exclusive-lock"
+		put                             = "put"
+		createSavepoint                 = "savepoint"
+		rollbackSavepoint               = "rollback"
+	)
+	type testCase struct {
+		ops                []string
+		midTxn             bool
+		validateFinalBatch func(t *testing.T, ba *kvpb.BatchRequest)
+	}
+
+	expectSingleWrite := func(t *testing.T, ba *kvpb.BatchRequest) {
+		require.Len(t, ba.Requests, 2) // Second request is whatever flushed us.
+		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
+	}
+
+	expectSingleLock := func(str lock.Strength) func(t *testing.T, ba *kvpb.BatchRequest) {
+		return func(t *testing.T, ba *kvpb.BatchRequest) {
+			require.Len(t, ba.Requests, 2) // Second request is whatever flushed us.
+			require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+			getReq := ba.Requests[0].GetGet()
+			require.Equal(t, str, getReq.KeyLockingStrength)
+		}
+	}
+	expectEndTxnOnly := func(t *testing.T, ba *kvpb.BatchRequest) {
+		require.Len(t, ba.Requests, 1)
+		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+	}
+
+	testCases := []testCase{
+		// EndTxn flush cases
+		{
+			ops: []string{
+				replicatedSharedLockingGet,
+				replicatedExclusiveLockingGet,
+			},
+			validateFinalBatch: expectSingleLock(lock.Exclusive),
+		},
+		{
+			ops: []string{
+				replicatedSharedLockingGet,
+				replicatedExclusiveLockingGet,
+				put,
+			},
+			validateFinalBatch: expectSingleWrite,
+		},
+		{
+			ops: []string{
+				createSavepoint,
+				replicatedSharedLockingGet,
+				replicatedExclusiveLockingGet,
+				put,
+			},
+			validateFinalBatch: expectSingleWrite,
+		},
+		// Mid-transaction flush cases
+		{
+			ops: []string{
+				replicatedSharedLockingGet,    // This is elided because a write exists and no savepoint requires it.
+				replicatedExclusiveLockingGet, // This is elided because a write exists and no savepoint requires it.
+				put,
+			},
+			midTxn:             true,
+			validateFinalBatch: expectSingleWrite,
+		},
+		{
+			ops: []string{
+				replicatedSharedLockingGet,    // This is elided because a write is also below savepoint.
+				replicatedExclusiveLockingGet, // This is elided because a write is also below savepoint.
+				put,
+				createSavepoint,
+			},
+			midTxn:             true,
+			validateFinalBatch: expectSingleWrite,
+		},
+		{
+			ops: []string{
+				replicatedSharedLockingGet, // This is elided because a stronger lock is also below the savepoint.
+				replicatedExclusiveLockingGet,
+				createSavepoint,
+			},
+			midTxn:             true,
+			validateFinalBatch: expectSingleLock(lock.Exclusive),
+		},
+		{
+			ops: []string{
+				createSavepoint,
+				replicatedSharedLockingGet,
+				replicatedExclusiveLockingGet,
+				put,
+			},
+			midTxn: true,
+			validateFinalBatch: func(t *testing.T, ba *kvpb.BatchRequest) {
+				require.Len(t, ba.Requests, 4)
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
+				getReq := ba.Requests[0].GetGet()
+				require.Equal(t, lock.Shared, getReq.KeyLockingStrength)
+
+				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[1].GetInner())
+				getReq = ba.Requests[1].GetGet()
+				require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
+
+				require.IsType(t, &kvpb.PutRequest{}, ba.Requests[2].GetInner())
+				require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[3].GetInner())
+			},
+		},
+		{
+			ops: []string{
+				createSavepoint,
+				put,
+				replicatedSharedLockingGet, // This is elided because write is at a lower sequence.
+			},
+			midTxn:             true,
+			validateFinalBatch: expectSingleWrite,
+		},
+		{
+			ops: []string{
+				put,
+				createSavepoint,
+				replicatedSharedLockingGet, // This is elided because write is at a lower sequence.
+			},
+			midTxn:             true,
+			validateFinalBatch: expectSingleWrite,
+		},
+
+		// Rollback special cases
+		{
+			ops: []string{
+				createSavepoint,
+				replicatedSharedLockingGet, // This should be rolled back.
+				rollbackSavepoint,
+			},
+			validateFinalBatch: expectEndTxnOnly,
+		},
+		// Unreplicated lock cases. We never expect unreplicated locks to result in
+		// a flushed request.
+		{
+			ops: []string{
+				unreplicatedSharedLockingGet,
+			},
+			validateFinalBatch: expectEndTxnOnly,
+		},
+		{
+			ops: []string{
+				unreplicatedExclusiveLockingGet,
+			},
+			validateFinalBatch: expectEndTxnOnly,
+		},
+		{
+			ops: []string{
+				unreplicatedSharedLockingGet,
+				unreplicatedExclusiveLockingGet,
+			},
+			validateFinalBatch: expectEndTxnOnly,
+		},
+		{
+			ops: []string{
+				unreplicatedSharedLockingGet,
+				unreplicatedExclusiveLockingGet,
+				put,
+			},
+			validateFinalBatch: expectSingleWrite,
+		},
+	}
+
+	addGet := func(ba *kvpb.BatchRequest, str lock.Strength, dur lock.Durability, seq enginepb.TxnSeq) {
+		ba.Add(&kvpb.GetRequest{
+			KeyLockingStrength:   str,
+			KeyLockingDurability: dur,
+			RequestHeader: kvpb.RequestHeader{
+				Sequence: seq,
+				Key:      keyA,
+			},
+		})
+	}
+	for _, tc := range testCases {
+		name := strings.Join(tc.ops, "_")
+		t.Run(name, func(t *testing.T) {
+			twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+			txn := makeTxnProto()
+			txn.Sequence = 10
+			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+				require.Len(t, ba.Requests, 1)
+				resp := ba.CreateReply()
+				resp.Txn = ba.Txn
+				if req := ba.Requests[0].GetGet(); req != nil {
+					resp.Responses[0].MustSetInner(&kvpb.GetResponse{Value: &valueA})
+				}
+				return resp, nil
+			})
+
+			var sp *savepoint
+			for _, op := range tc.ops {
+				txn.Sequence++
+				t.Logf("%d: %s", txn.Sequence, op)
+				switch op {
+				case replicatedSharedLockingGet:
+					ba := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}
+					addGet(ba, lock.Shared, lock.Replicated, txn.Sequence)
+					br, pErr := twb.SendLocked(ctx, ba)
+					require.NotNil(t, br)
+					require.Nil(t, pErr)
+				case replicatedExclusiveLockingGet:
+					ba := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}
+					addGet(ba, lock.Exclusive, lock.Replicated, txn.Sequence)
+					br, pErr := twb.SendLocked(ctx, ba)
+					require.NotNil(t, br)
+					require.Nil(t, pErr)
+				case unreplicatedSharedLockingGet:
+					ba := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}
+					addGet(ba, lock.Shared, lock.Unreplicated, txn.Sequence)
+					br, pErr := twb.SendLocked(ctx, ba)
+					require.NotNil(t, br)
+					require.Nil(t, pErr)
+				case unreplicatedExclusiveLockingGet:
+					ba := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}
+					addGet(ba, lock.Exclusive, lock.Unreplicated, txn.Sequence)
+					br, pErr := twb.SendLocked(ctx, ba)
+					require.NotNil(t, br)
+					require.Nil(t, pErr)
+				case put:
+					ba := &kvpb.BatchRequest{Header: kvpb.Header{Txn: &txn}}
+					ba.Add(putArgs(keyA, valueAStr, txn.Sequence))
+					br, pErr := twb.SendLocked(ctx, ba)
+					require.NotNil(t, br)
+					require.Nil(t, pErr)
+				case createSavepoint:
+					if sp != nil {
+						t.Fatal("implemented: multiple active savepoints")
+					}
+					sp = &savepoint{seqNum: txn.Sequence}
+					twb.createSavepointLocked(ctx, sp)
+				case rollbackSavepoint:
+					if sp == nil {
+						t.Fatal("rollback without active savepoint")
+					}
+					twb.rollbackToSavepointLocked(ctx, *sp)
+					sp = nil
+				}
+			}
+
+			ba := &kvpb.BatchRequest{}
+			ba.Header = kvpb.Header{Txn: &txn}
+			txn.Sequence++
+			if tc.midTxn {
+				ba.Add(delRangeArgs(keyA, keyA.Next(), txn.Sequence))
+			} else {
+				ba.Add(&kvpb.EndTxnRequest{Commit: true})
+			}
+			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
+				tc.validateFinalBatch(t, ba)
+				resp := ba.CreateReply()
+				resp.Txn = ba.Txn
+				return resp, nil
+			})
+			br, pErr := twb.SendLocked(ctx, ba)
+			require.NotNil(t, br)
+			require.Nil(t, pErr)
+		})
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/select_for_update
+++ b/pkg/sql/logictest/testdata/logic_test/select_for_update
@@ -668,6 +668,10 @@ user testuser
 statement ok
 SET enable_durable_locking_for_serializable = true;
 
+# Turn off buffered writes since we want to ensure a durable lock is actually acquired.
+statement ok
+SET kv_transaction_buffered_writes_enabled=false;
+
 query I
 BEGIN;
 SELECT * FROM t WHERE a = 1 FOR UPDATE;


### PR DESCRIPTION
A replicated locking Get request is a write that we would like to defer until commit time. We do this by transforming it to an unreplicated locking Get. At flush time, if no other write has been performed on that key, we send a replicated locking Get to ensure we have exclusion on the key all the way until the commit timestamp.

Epic: none
Release note: None