### PR TITLE
kvcoord: fix bug in bufferSize accounting in txnWriteBuffer

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -655,7 +655,8 @@ func (twb *txnWriteBuffer) rollbackToSavepointLocked(ctx context.Context, s save
 	toDelete := make([]*bufferedWrite, 0)
 	it := twb.buffer.MakeIter()
 	for it.First(); it.Valid(); it.Next() {
-		if held := it.Cur().rollbackLockInfo(s.seqNum); !held {
+		hadLockInfo := it.Cur().lki != nil
+		if held := it.Cur().rollbackLockInfo(s.seqNum); hadLockInfo && !held {
 			// If we aren't still held, update our buffer size.
 			twb.bufferSize -= lockKeyInfoSize
 		}


### PR DESCRIPTION
For a lock that was never held, we were over-decrementing the buffer size on savepoint rollback. I've added a regression test, but this bug was also caught by KVNemesis.

Epic: none
Release note: None