### PR TITLE
rpc: remove DRPC dependency from `Peer` and `Connection` generics

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3755,6 +3755,11 @@ service Cluster {
   rpc Join (JoinNodeRequest) returns (JoinNodeResponse) {}
 }
 
+// RangeFeed service implemented by nodes for KV API requests.
+service RangeFeed {
+  rpc MuxRangeFeed (stream RangeFeedRequest) returns (stream MuxRangeFeedEvent) {}
+}
+
 // Batch and RangeFeed service implemented by nodes for KV API requests.
 service Internal {
   rpc Batch (BatchRequest) returns (BatchResponse) {}
@@ -3883,8 +3888,3 @@ message ScanStats {
 // UsedFollowerRead indicates whether at least some reads were served by the
 // follower replicas.
 message UsedFollowerRead {}
-
-// RangeFeed service implemented by nodes for KV API requests.
-service RangeFeed {
-  rpc MuxRangeFeed       (stream RangeFeedRequest)   returns (stream MuxRangeFeedEvent)       {}
-}

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3883,3 +3883,8 @@ message ScanStats {
 // UsedFollowerRead indicates whether at least some reads were served by the
 // follower replicas.
 message UsedFollowerRead {}
+
+// RangeFeed service implemented by nodes for KV API requests.
+service RangeFeed {
+  rpc MuxRangeFeed       (stream RangeFeedRequest)   returns (stream MuxRangeFeedEvent)       {}
+}

--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -41,7 +41,7 @@ func (d *drpcCloseNotifier) CloseNotify(ctx context.Context) <-chan struct{} {
 	return d.conn.Closed()
 }
 
-// TODO DB Server: unexport this once dial methods are added in rpccontext.
+// TODO(server): unexport this once dial methods are added in rpccontext.
 func DialDRPC(
 	rpcCtx *Context,
 ) func(ctx context.Context, target string, _ rpcbase.ConnectionClass) (drpc.Conn, error) {
@@ -211,64 +211,12 @@ func newDRPCPeerOptions(
 		locality: locality,
 		peers:    &rpcCtx.drpcPeers,
 		connOptions: &ConnectionOptions[drpc.Conn]{
-			dial: func(ctx context.Context, target string, _ rpcbase.ConnectionClass) (drpc.Conn, error) {
-				// TODO(server): could use connection class instead of empty key here.
-				pool := drpcpool.New[struct{}, drpcpool.Conn](drpcpool.Options{
-					Expiration: defaultDRPCConnIdleTimeout,
-				})
-				pooledConn := pool.Get(ctx /* unused */, struct{}{}, func(ctx context.Context,
-					_ struct{}) (drpcpool.Conn, error) {
-
-					netConn, err := drpcmigrate.DialWithHeader(ctx, "tcp", target, drpcmigrate.DRPCHeader)
-					if err != nil {
-						return nil, err
-					}
-
-					opts := drpcconn.Options{
-						Manager: drpcmanager.Options{
-							Reader: drpcwire.ReaderOptions{
-								MaximumBufferSize: math.MaxInt,
-							},
-							Stream: drpcstream.Options{
-								MaximumBufferSize: 0, // unlimited
-							},
-							SoftCancel: true, // don't close the transport when stream context is canceled
-						},
-					}
-					var conn *drpcconn.Conn
-					if rpcCtx.ContextOptions.Insecure {
-						conn = drpcconn.NewWithOptions(netConn, opts)
-					} else {
-						tlsConfig, err := rpcCtx.GetClientTLSConfig()
-						if err != nil {
-							return nil, err
-						}
-						// Clone TLS config to avoid modifying a cached TLS config.
-						tlsConfig = tlsConfig.Clone()
-						// TODO(server): remove this hack which is necessary at least in
-						// testing to get TestDRPCSelectQuery to pass.
-						tlsConfig.InsecureSkipVerify = true
-						tlsConn := tls.Client(netConn, tlsConfig)
-						conn = drpcconn.NewWithOptions(tlsConn, opts)
-					}
-
-					return conn, nil
-				})
-				// `pooledConn.Close` doesn't tear down any of the underlying TCP
-				// connections but simply marks the pooledConn handle as returning
-				// errors. When we "close" this conn, we want to tear down all of
-				// the connections in the pool (in effect mirroring the behavior of
-				// gRPC where a single conn is shared).
-				return &closeEntirePoolConn{
-					Conn: pooledConn,
-					pool: pool,
-				}, nil
-			},
+			dial: DialDRPC(rpcCtx),
 			connEquals: func(a, b drpc.Conn) bool {
 				return a == b
 			},
 			newBatchStreamClient: func(ctx context.Context, cc drpc.Conn) (BatchStreamClient, error) {
-				return kvpb.NewDRPCInternalClientAdapter(cc).BatchStream(ctx)
+				return kvpb.NewDRPCKVBatchClientAdapter(cc).BatchStream(ctx)
 			},
 			newCloseNotifier: func(_ *stop.Stopper, cc drpc.Conn) closeNotifier {
 				return &drpcCloseNotifier{conn: cc}

--- a/pkg/rpc/stream_pool.go
+++ b/pkg/rpc/stream_pool.go
@@ -344,8 +344,3 @@ type BatchStreamClient = streamClient[*kvpb.BatchRequest, *kvpb.BatchResponse]
 type DRPCBatchStreamPool = streamPool[*kvpb.BatchRequest, *kvpb.BatchResponse, drpc.Conn]
 
 type DRPCBatchStreamClient = streamClient[*kvpb.BatchRequest, *kvpb.BatchResponse]
-
-// newDRPCBatchStream constructs a BatchStreamClient from a drpc.Conn.
-func newDRPCBatchStream(ctx context.Context, dc drpc.Conn) (DRPCBatchStreamClient, error) {
-	return kvpb.NewDRPCKVBatchClient(dc).BatchStream(ctx)
-}

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -2201,7 +2201,6 @@ func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
 	return n.muxRangeFeed(muxStream)
 }
 
-// MuxRangeFeed implements the roachpb.InternalServer interface.
 func (n *Node) muxRangeFeed(muxStream kvpb.RPCInternal_MuxRangeFeedStream) error {
 	lockedMuxStream := &lockedMuxStream{
 		wrapped: muxStream,

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -1918,6 +1918,16 @@ func (n *kvBatchServer) BatchStream(stream kvpb.DRPCKVBatch_BatchStreamStream) e
 	return (*Node)(n).batchStreamImpl(stream)
 }
 
+type kvRangeFeedServer Node
+
+func (n *Node) AsDRPCRangeFeedServer() kvpb.DRPCRangeFeedServer {
+	return (*kvRangeFeedServer)(n)
+}
+
+func (n *kvRangeFeedServer) MuxRangeFeed(stream kvpb.DRPCRangeFeed_MuxRangeFeedStream) error {
+	return (*Node)(n).muxRangeFeed(stream)
+}
+
 // spanForRequest is the retval of setupSpanForIncomingRPC. It groups together a
 // few variables needed when finishing an RPC's span.
 //
@@ -2092,7 +2102,7 @@ func (n *Node) RangeLookup(
 // MuxRangeFeedServer (default grpc.Stream) is not safe for concurrent calls to
 // Send.
 type lockedMuxStream struct {
-	wrapped kvpb.Internal_MuxRangeFeedServer
+	wrapped kvpb.RPCInternal_MuxRangeFeedStream
 	sendMu  syncutil.Mutex
 	metrics *rangefeed.LockedMuxStreamMetrics
 }
@@ -2188,6 +2198,11 @@ func (n *Node) defaultRangefeedConsumerID() int64 {
 
 // MuxRangeFeed implements the roachpb.InternalServer interface.
 func (n *Node) MuxRangeFeed(muxStream kvpb.Internal_MuxRangeFeedServer) error {
+	return n.muxRangeFeed(muxStream)
+}
+
+// MuxRangeFeed implements the roachpb.InternalServer interface.
+func (n *Node) muxRangeFeed(muxStream kvpb.RPCInternal_MuxRangeFeedStream) error {
 	lockedMuxStream := &lockedMuxStream{
 		wrapped: muxStream,
 		metrics: n.metrics.LockedMuxStreamMetrics,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -986,6 +986,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	if err := kvpb.DRPCRegisterKVBatch(drpcServer, node.AsDRPCKVBatchServer()); err != nil {
 		return nil, err
 	}
+	if err := kvpb.DRPCRegisterRangeFeed(drpcServer, node.AsDRPCRangeFeedServer()); err != nil {
+		return nil, err
+	}
 	if err := kvpb.DRPCRegisterTenantService(drpcServer, node.AsDRPCTenantServiceServer()); err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Although `Peer` and `Connection` are generic and intended to support both gRPC and DRPC connections, the current implementation has a hardcoded dependency on DRPC. As a result, a DRPC connection is always dialed, regardless of the intended type. This PR removes the direct dependency on DRPC, allowing the appropriate connection type (gRPC or DRPC) to be used based on the generic parameter.

Epic: CRDB-48923
Fixes: none
Release note: none