### PR TITLE
*: add DRPC dial methods to nodedialer

### DIFF
--- a/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/sidetransport/BUILD.bazel
@@ -30,6 +30,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )
@@ -59,6 +60,7 @@ go_test(
         "//pkg/util/syncutil",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -36,6 +36,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 // Sender represents the sending-side of the closed timestamps "side-transport".
@@ -705,6 +706,7 @@ func (f *rpcConnFactory) new(s *Sender, nodeID roachpb.NodeID) conn {
 // nodeDialer abstracts *nodedialer.Dialer.
 type nodeDialer interface {
 	Dial(ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (_ *grpc.ClientConn, err error)
+	DRPCDial(ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (_ drpc.Conn, err error)
 }
 
 // On sending errors, we sleep a bit as to not spin on a tripped

--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -31,6 +31,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 // mockReplica is a mock implementation of the Replica interface.
@@ -661,6 +662,12 @@ func (m *mockDialer) Dial(
 	return c, err
 }
 
+func (m *mockDialer) DRPCDial(
+	ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (_ drpc.Conn, _ error) {
+	return nil, errors.New("DRPCDial unimplemented")
+}
+
 func (m *mockDialer) Close() {
 	m.mu.Lock()
 	defer m.mu.Unlock()
@@ -825,6 +832,12 @@ func (f *failingDialer) Dial(
 ) (_ *grpc.ClientConn, err error) {
 	atomic.AddInt32(&f.dialCount, 1)
 	return nil, errors.New("failingDialer")
+}
+
+func (f *failingDialer) DRPCDial(
+	ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
+) (_ drpc.Conn, err error) {
+	return nil, errors.New("DRPCDial unimplemented")
 }
 
 func (f *failingDialer) callCount() int32 {

--- a/pkg/rpc/rpcbase/BUILD.bazel
+++ b/pkg/rpc/rpcbase/BUILD.bazel
@@ -26,6 +26,7 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc/rpcpb",
         "//pkg/util/envutil",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/rpc/rpcbase/nodedialer.go
+++ b/pkg/rpc/rpcbase/nodedialer.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 // TODODRPC is a marker to identify each RPC client creation site that needs to
@@ -20,6 +21,7 @@ const TODODRPC = false
 // node IDs.
 type NodeDialer interface {
 	Dial(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
+	DRPCDial(context.Context, roachpb.NodeID, ConnectionClass) (_ drpc.Conn, err error)
 }
 
 // NodeDialerNoBreaker interface defines methods for dialing peer nodes using their
@@ -27,4 +29,5 @@ type NodeDialer interface {
 // breaker before dialing.
 type NodeDialerNoBreaker interface {
 	DialNoBreaker(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
+	DRPCDialNoBreaker(context.Context, roachpb.NodeID, ConnectionClass) (_ drpc.Conn, err error)
 }

--- a/pkg/upgrade/upgradecluster/BUILD.bazel
+++ b/pkg/upgrade/upgradecluster/BUILD.bazel
@@ -53,6 +53,7 @@ go_test(
         "//pkg/util/leaktest",
         "//pkg/util/retry",
         "//pkg/util/syncutil",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/upgrade/upgradecluster/helper_test.go
+++ b/pkg/upgrade/upgradecluster/helper_test.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 type NoopDialer struct{}
@@ -26,6 +27,12 @@ type NoopDialer struct{}
 func (n NoopDialer) Dial(
 	ctx context.Context, id roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (*grpc.ClientConn, error) {
+	return nil, nil
+}
+
+func (n NoopDialer) DRPCDial(
+	ctx context.Context, id roachpb.NodeID, class rpcbase.ConnectionClass,
+) (drpc.Conn, error) {
 	return nil, nil
 }
 


### PR DESCRIPTION
This change enables nodedialer to dial either a gRPC or a DRPC connection, depending on `rpc.experimental_drpc.enabled` setting.

Epic: CRDB-48923
Fixes: none
Release note: none