### PR TITLE
*: create DRPC RPC clients conditionally

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -485,7 +485,11 @@ func (n *Node) StatusClient(ctx context.Context) serverpb.RPCStatusClient {
 		}
 		return serverpb.NewGRPCStatusClientAdapter(conn)
 	}
-	return nil // This should never happen
+	conn, err := n.rpcCtx.DRPCUnvalidatedDial(n.RPCAddr(), roachpb.Locality{}).Connect(ctx)
+	if err != nil {
+		log.Fatalf(context.Background(), "failed to initialize status client: %s", err)
+	}
+	return serverpb.NewDRPCStatusClientAdapter(conn)
 }
 
 func (n *Node) logDir() string {

--- a/pkg/blobs/blobspb/rpc_clients.go
+++ b/pkg/blobs/blobspb/rpc_clients.go
@@ -25,5 +25,9 @@ func DialBlobClient(
 		}
 		return NewGRPCBlobClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCBlobClientAdapter(conn), nil
 }

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -107,13 +107,12 @@ func newClientConn(ctx context.Context, cfg server.Config) (rpcConn, func(), err
 			return nil, nil, errors.Wrap(err, "failed to connect to the node")
 		}
 		return &grpcConn{conn: cc}, finish, nil
-	} else {
-		dc, finish, err := rpc.NewDRPCClientConn(ctx, ccfg)
-		if err != nil {
-			return nil, nil, errors.Wrap(err, "failed to connect to the node")
-		}
-		return &drpcConn{conn: dc}, finish, nil
 	}
+	dc, finish, err := rpc.NewDRPCClientConn(ctx, ccfg)
+	if err != nil {
+		return nil, nil, errors.Wrap(err, "failed to connect to the node")
+	}
+	return &drpcConn{conn: dc}, finish, nil
 }
 
 // dialAdminClient dials a client connection and returns an AdminClient and a

--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"google.golang.org/grpc"
+	drpc "storj.io/drpc"
 )
 
 // client is a client-side RPC connection to a gossip peer node.
@@ -415,6 +416,21 @@ func (c *client) dial(ctx context.Context, rpcCtx *rpc.Context) (*grpc.ClientCon
 	return conn.Connect(ctx)
 }
 
+// dials the peer node and returns a DRPC connection to the peer node.
+func (c *client) drpcDial(ctx context.Context, rpcCtx *rpc.Context) (drpc.Conn, error) {
+	var conn *rpc.DRPCConnection
+	if c.peerID != 0 {
+		conn = rpcCtx.DRPCDialNode(c.addr.String(), c.peerID, c.locality, rpcbase.SystemClass)
+	} else {
+		// TODO(baptist): Use this as a temporary connection for getting
+		// onto gossip and then replace with a validated connection.
+		log.Infof(ctx, "unvalidated bootstrap gossip dial to %s", c.addr)
+		conn = rpcCtx.DRPCUnvalidatedDial(c.addr.String(), c.locality)
+	}
+
+	return conn.Connect(ctx)
+}
+
 // dialGossipClient establishes a DRPC connection if enabled; otherwise,
 // it falls back to gRPC. The established connection is used to create a
 // RPCGossipClient.
@@ -428,5 +444,9 @@ func (c *client) dialGossipClient(
 		}
 		return NewGRPCGossipClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := c.drpcDial(ctx, rpcCtx)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCGossipClientAdapter(conn), nil
 }

--- a/pkg/keyvisualizer/keyvispb/rpc_clients.go
+++ b/pkg/keyvisualizer/keyvispb/rpc_clients.go
@@ -25,5 +25,9 @@ func DialKeyVisualizerClient(
 		}
 		return NewGRPCKeyVisualizerClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCKeyVisualizerClientAdapter(conn), nil
 }

--- a/pkg/kv/kvclient/kvtenant/BUILD.bazel
+++ b/pkg/kv/kvclient/kvtenant/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_errors//errorspb",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -51,6 +51,7 @@ import (
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/codes"
 	"google.golang.org/grpc/status"
+	"storj.io/drpc"
 )
 
 func init() {
@@ -993,6 +994,19 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 					RPCTimeSeriesClient:       tspb.NewGRPCTimeSeriesClientAdapter(conn),
 				}, nil
 			}
+			conn, err := c.drpcDialAddr(ctx, addr)
+			if err != nil {
+				log.Warningf(ctx, "error dialing tenant KV address %s: %v", addr, err)
+				continue
+			}
+			return &client{
+				RPCTenantServiceClient:    kvpb.NewDRPCTenantServiceClientAdapter(conn),
+				RPCTenantSpanConfigClient: kvpb.NewDRPCTenantSpanConfigClientAdapter(conn),
+				RPCTenantUsageClient:      kvpb.NewDRPCTenantUsageClientAdapter(conn),
+				RPCStatusClient:           serverpb.NewDRPCStatusClientAdapter(conn),
+				RPCAdminClient:            serverpb.NewDRPCAdminClientAdapter(conn),
+				RPCTimeSeriesClient:       tspb.NewDRPCTimeSeriesClientAdapter(conn),
+			}, nil
 		}
 	}
 	return nil, errors.Wrap(ctx.Err(), "dial addrs")
@@ -1004,6 +1018,17 @@ func (c *connector) dialAddr(ctx context.Context, addr string) (conn *grpc.Clien
 	}
 	err = timeutil.RunWithTimeout(ctx, "dial addr", c.rpcDialTimeout, func(ctx context.Context) error {
 		conn, err = c.rpcContext.GRPCUnvalidatedDial(addr, roachpb.Locality{}).Connect(ctx)
+		return err
+	})
+	return conn, err
+}
+
+func (c *connector) drpcDialAddr(ctx context.Context, addr string) (conn drpc.Conn, err error) {
+	if c.rpcDialTimeout == 0 {
+		return c.rpcContext.DRPCUnvalidatedDial(addr, roachpb.Locality{}).Connect(ctx)
+	}
+	err = timeutil.RunWithTimeout(ctx, "dial addr", c.rpcDialTimeout, func(ctx context.Context) error {
+		conn, err = c.rpcContext.DRPCUnvalidatedDial(addr, roachpb.Locality{}).Connect(ctx)
 		return err
 	})
 	return conn, err

--- a/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
+++ b/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
@@ -25,5 +25,9 @@ func DialSideTransportClient(
 		}
 		return NewGRPCSideTransportClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCSideTransportClientAdapter(conn), nil
 }

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -25,7 +25,11 @@ func DialMultiRaftClient(
 		}
 		return NewGRPCMultiRaftClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCMultiRaftClientAdapter(conn), nil
 }
 
 // DialPerReplicaClient establishes a DRPC connection if enabled; otherwise,
@@ -41,7 +45,11 @@ func DialPerReplicaClient(
 		}
 		return NewGRPCPerReplicaClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCPerReplicaClientAdapter(conn), nil
 }
 
 // DialPerStoreClient establishes a DRPC connection if enabled; otherwise,
@@ -57,5 +65,9 @@ func DialPerStoreClient(
 		}
 		return NewGRPCPerStoreClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCPerStoreClientAdapter(conn), nil
 }

--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
@@ -25,5 +25,9 @@ func DialStoreLivenessClient(
 		}
 		return NewGRPCStoreLivenessClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCStoreLivenessClientAdapter(conn), nil
 }

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -69,7 +69,7 @@ func newGRPCPeerOptions(
 				return a == b
 			},
 			newBatchStreamClient: func(ctx context.Context, cc *grpc.ClientConn) (BatchStreamClient, error) {
-				return kvpb.NewInternalClient(cc).BatchStream(ctx)
+				return kvpb.NewGRPCInternalClientAdapter(cc).BatchStream(ctx)
 			},
 			newCloseNotifier: func(stopper *stop.Stopper, cc *grpc.ClientConn) closeNotifier {
 				return &grpcCloseNotifier{stopper: stopper, conn: cc}

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -351,14 +351,14 @@ func (c *baseInternalClient) asConn() *grpc.ClientConn {
 func (c *baseInternalClient) Batch(
 	ctx context.Context, ba *kvpb.BatchRequest,
 ) (*kvpb.BatchResponse, error) {
-	return kvpb.NewInternalClient(c.asConn()).Batch(ctx, ba)
+	return kvpb.NewGRPCInternalClientAdapter(c.asConn()).Batch(ctx, ba)
 }
 
 // MuxRangeFeed implements the RestrictedInternalClient interface.
 func (c *baseInternalClient) MuxRangeFeed(
 	ctx context.Context,
 ) (kvpb.RPCInternal_MuxRangeFeedClient, error) {
-	return kvpb.NewInternalClient(c.asConn()).MuxRangeFeed(ctx)
+	return kvpb.NewGRPCInternalClientAdapter(c.asConn()).MuxRangeFeed(ctx)
 }
 
 var batchStreamPoolingEnabled = settings.RegisterBoolSetting(
@@ -407,7 +407,7 @@ func (c *batchStreamPoolClient) Batch(
 func (c *batchStreamPoolClient) MuxRangeFeed(
 	ctx context.Context,
 ) (kvpb.RPCInternal_MuxRangeFeedClient, error) {
-	return kvpb.NewInternalClient(c.asPool().Conn()).MuxRangeFeed(ctx)
+	return kvpb.NewGRPCInternalClientAdapter(c.asPool().Conn()).MuxRangeFeed(ctx)
 }
 
 // tracingInternalClient wraps a RestrictedInternalClient and fills in trace

--- a/pkg/server/authserver/authentication_test.go
+++ b/pkg/server/authserver/authentication_test.go
@@ -842,7 +842,7 @@ func TestGRPCAuthentication(t *testing.T) {
 			return err
 		}, true},
 		{"internal", func(ctx context.Context, conn *grpc.ClientConn) error {
-			_, err := kvpb.NewInternalClient(conn).Batch(ctx, &kvpb.BatchRequest{})
+			_, err := kvpb.NewGRPCInternalClientAdapter(conn).Batch(ctx, &kvpb.BatchRequest{})
 			return err
 		}, true},
 		{"perReplica", func(ctx context.Context, conn *grpc.ClientConn) error {

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -25,7 +25,11 @@ func DialMigrationClient(
 		}
 		return NewGRPCMigrationClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCMigrationClientAdapter(conn), nil
 }
 
 // DialStatusClientNoBreaker establishes a DRPC connection if enabled;
@@ -45,7 +49,11 @@ func DialStatusClientNoBreaker(
 		}
 		return NewGRPCStatusClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDialNoBreaker(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCStatusClientAdapter(conn), nil
 }
 
 // DialStatusClient establishes a DRPC connection if enabled; otherwise, it
@@ -61,7 +69,11 @@ func DialStatusClient(
 		}
 		return NewGRPCStatusClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, rpcbase.DefaultClass)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCStatusClientAdapter(conn), nil
 }
 
 // DialAdminClient establishes a DRPC connection if enabled; otherwise, it
@@ -77,7 +89,11 @@ func DialAdminClient(
 		}
 		return NewGRPCAdminClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, rpcbase.DefaultClass)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCAdminClientAdapter(conn), nil
 }
 
 // DialAdminClientNoBreaker establishes a DRPC connection if enabled;
@@ -94,5 +110,9 @@ func DialAdminClientNoBreaker(
 		}
 		return NewGRPCAdminClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDialNoBreaker(ctx, nodeID, rpcbase.DefaultClass)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCAdminClientAdapter(conn), nil
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2684,7 +2684,11 @@ func (t *testTenant) RPCClientConnE(user username.SQLUsername) (serverutils.RPCC
 		}
 		return serverutils.FromGRPCConn(conn), nil
 	}
-	return nil, nil
+	conn, err := rpcCtx.DRPCDialPod(t.AdvRPCAddr(), t.SQLInstanceID(), t.Locality(), rpcbase.DefaultClass).Connect(ctx)
+	if err != nil {
+		return nil, err
+	}
+	return serverutils.FromDRPCConn(conn), nil
 }
 
 // GetAdminClient is part of the serverutils.ApplicationLayerInterface.

--- a/pkg/sql/colflow/colrpc/BUILD.bazel
+++ b/pkg/sql/colflow/colrpc/BUILD.bazel
@@ -12,6 +12,7 @@ go_library(
         "//pkg/base",
         "//pkg/col/coldata",
         "//pkg/col/colserde",
+        "//pkg/rpc/rpcbase",
         "//pkg/sql/colexec/colexecargs",
         "//pkg/sql/colexec/colexecutils",
         "//pkg/sql/colexecerror",

--- a/pkg/sql/colflow/colrpc/outbox.go
+++ b/pkg/sql/colflow/colrpc/outbox.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/col/colserde"
+	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecargs"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexec/colexecutils"
 	"github.com/cockroachdb/cockroach/pkg/sql/colexecerror"
@@ -150,7 +151,7 @@ func (o *Outbox) close(ctx context.Context) {
 //     Outbox goes through the same steps as 1).
 func (o *Outbox) Run(
 	ctx context.Context,
-	dialer execinfra.Dialer,
+	dialer rpcbase.NodeDialerNoBreaker,
 	sqlInstanceID base.SQLInstanceID,
 	streamID execinfrapb.StreamID,
 	flowCtxCancel context.CancelFunc,
@@ -179,13 +180,12 @@ func (o *Outbox) Run(
 
 	var stream execinfrapb.RPCDistSQL_FlowStreamClient
 	if err := func() error {
-		conn, err := execinfra.GetConnForOutbox(ctx, dialer, sqlInstanceID, connectionTimeout)
+		client, err := execinfra.GetDistSQLClientForOutbox(ctx, dialer, sqlInstanceID, connectionTimeout)
 		if err != nil {
 			log.VWarningf(ctx, 1, "Outbox Dial connection error, distributed query will fail: %+v", err)
 			return err
 		}
 
-		client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 		// We use the flow context for the RPC so that when outbox context is
 		// canceled in case of a graceful shutdown, the gRPC stream keeps on
 		// running. If, however, the flow context is canceled, then the

--- a/pkg/sql/execinfra/BUILD.bazel
+++ b/pkg/sql/execinfra/BUILD.bazel
@@ -83,7 +83,6 @@ go_library(
         "@com_github_cockroachdb_redact//interfaces",
         "@com_github_marusama_semaphore//:semaphore",
         "@io_opentelemetry_go_otel//attribute",
-        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/pkg/sql/execinfra/outboxbase.go
+++ b/pkg/sql/execinfra/outboxbase.go
@@ -12,34 +12,30 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
-	"google.golang.org/grpc"
 )
 
-// Dialer is used for dialing based on node IDs. It extracts out the single
-// method that outboxes need from nodedialer.Dialer so that we can mock it
-// in tests outside of this package.
-type Dialer interface {
-	DialNoBreaker(context.Context, roachpb.NodeID, rpcbase.ConnectionClass) (*grpc.ClientConn, error)
-}
-
-// GetConnForOutbox is a shared function between the rowexec and colexec
-// outboxes. It attempts to dial the destination ignoring the breaker, up to the
-// given timeout and returns the connection or an error.
-// This connection attempt is retried since failure results in a query error. In
-// the past, we have seen cases where a gateway node, n1, would send a flow
+// GetDistSQLClientForOutbox is a shared function between the rowexec and
+// colexec outboxes. It attempts to dial the destination ignoring the breaker,
+// up to the given timeout and returns the connection or an error.
+// This connection attempt is retried since failure results in a query error.
+// In the past, we have seen cases where a gateway node, n1, would send a flow
 // request to n2, but n2 would be unable to connect back to n1 due to this
 // connection attempt failing.
 // Retrying here alleviates these flakes and causes no impact to the end
 // user, since the receiver at the other end will hang for
 // SettingFlowStreamTimeout waiting for a successful connection attempt.
-func GetConnForOutbox(
-	ctx context.Context, dialer Dialer, sqlInstanceID base.SQLInstanceID, timeout time.Duration,
-) (conn *grpc.ClientConn, err error) {
+func GetDistSQLClientForOutbox(
+	ctx context.Context,
+	dialer rpcbase.NodeDialerNoBreaker,
+	sqlInstanceID base.SQLInstanceID,
+	timeout time.Duration,
+) (client execinfrapb.RPCDistSQLClient, err error) {
 	firstConnectionAttempt := timeutil.Now()
 	for r := retry.StartWithCtx(ctx, base.DefaultRetryOptions()); r.Next(); {
-		conn, err = dialer.DialNoBreaker(ctx, roachpb.NodeID(sqlInstanceID), rpcbase.DefaultClass)
+		client, err = execinfrapb.DialDistSQLClientNoBreaker(dialer, ctx, roachpb.NodeID(sqlInstanceID), rpcbase.DefaultClass)
 		if err == nil || timeutil.Since(firstConnectionAttempt) > timeout {
 			break
 		}

--- a/pkg/sql/execinfrapb/rpc_clients.go
+++ b/pkg/sql/execinfrapb/rpc_clients.go
@@ -25,5 +25,33 @@ func DialDistSQLClient(
 		}
 		return NewGRPCDistSQLClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCDistSQLClientAdapter(conn), nil
+}
+
+// DialDistSQLClientNoBreaker establishes a DRPC connection if enabled;
+// otherwise, it falls back to gRPC. The established connection is used
+// to create a RPCDistSQLClient.  This method is same as DialDistSQLClient,
+// but it does not check the breaker before dialing the connection.
+func DialDistSQLClientNoBreaker(
+	nd rpcbase.NodeDialerNoBreaker,
+	ctx context.Context,
+	nodeID roachpb.NodeID,
+	class rpcbase.ConnectionClass,
+) (RPCDistSQLClient, error) {
+	if !rpcbase.TODODRPC {
+		conn, err := nd.DialNoBreaker(ctx, nodeID, class)
+		if err != nil {
+			return nil, err
+		}
+		return NewGRPCDistSQLClientAdapter(conn), nil
+	}
+	conn, err := nd.DRPCDialNoBreaker(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCDistSQLClientAdapter(conn), nil
 }

--- a/pkg/sql/flowinfra/BUILD.bazel
+++ b/pkg/sql/flowinfra/BUILD.bazel
@@ -58,6 +58,7 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_gogo_protobuf//proto",
         "@io_opentelemetry_go_otel//attribute",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/sql/flowinfra/outbox.go
+++ b/pkg/sql/flowinfra/outbox.go
@@ -231,14 +231,13 @@ func (m *Outbox) mainLoop(ctx context.Context, wg *sync.WaitGroup) (retErr error
 	}
 
 	if err := func() error {
-		conn, err := execinfra.GetConnForOutbox(
+		client, err := execinfra.GetDistSQLClientForOutbox(
 			ctx, m.flowCtx.Cfg.SQLInstanceDialer, m.sqlInstanceID, SettingFlowStreamTimeout.Get(&m.flowCtx.Cfg.Settings.SV),
 		)
 		if err != nil {
 			log.VWarningf(ctx, 1, "Outbox Dial connection error, distributed query will fail: %+v", err)
 			return err
 		}
-		client := execinfrapb.NewGRPCDistSQLClientAdapter(conn)
 		if log.V(2) {
 			log.Infof(ctx, "outbox: calling FlowStream")
 		}

--- a/pkg/sql/flowinfra/testutils.go
+++ b/pkg/sql/flowinfra/testutils.go
@@ -21,8 +21,10 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 func newInsecureRPCContext(ctx context.Context, stopper *stop.Stopper) *rpc.Context {
@@ -125,6 +127,13 @@ func (d *MockDialer) DialNoBreaker(
 	//lint:ignore SA1019 grpc.WithInsecure is deprecated
 	d.mu.conn, err = grpc.Dial(d.Addr.String(), grpc.WithInsecure(), grpc.WithBlock())
 	return d.mu.conn, err
+}
+
+// DRPCDialNoBreaker establishes a grpc connection once.
+func (d *MockDialer) DRPCDialNoBreaker(
+	context.Context, roachpb.NodeID, rpcbase.ConnectionClass,
+) (drpc.Conn, error) {
+	return nil, errors.New("DRPC unimplemented")
 }
 
 // Close must be called after the test is done.

--- a/pkg/testutils/serverutils/BUILD.bazel
+++ b/pkg/testutils/serverutils/BUILD.bazel
@@ -55,6 +55,7 @@ go_library(
         "//pkg/util/tracing",
         "//pkg/util/uuid",
         "@com_github_cockroachdb_errors//:errors",
+        "@io_storj_drpc//:drpc",
         "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/testutils/serverutils/rpc_conn.go
+++ b/pkg/testutils/serverutils/rpc_conn.go
@@ -11,6 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/ts/tspb"
 	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 // grpcConn implements server.RPCConn that provides methods to create various
@@ -46,4 +47,39 @@ func (c *grpcConn) NewInternalClient() kvpb.RPCInternalClient {
 
 func (c *grpcConn) NewDistSQLClient() execinfrapb.RPCDistSQLClient {
 	return execinfrapb.NewGRPCDistSQLClientAdapter(c.conn)
+}
+
+// drpcConn implements server.RPCConn that provides methods to create various
+// RPC clients. This allows the CLI to interact with the server using DRPC
+// without exposing the underlying connection details.
+type drpcConn struct {
+	conn drpc.Conn
+}
+
+func FromDRPCConn(conn drpc.Conn) RPCConn {
+	return &drpcConn{conn: conn}
+}
+
+func (c *drpcConn) NewStatusClient() serverpb.RPCStatusClient {
+	return serverpb.NewDRPCStatusClientAdapter(c.conn)
+}
+
+func (c *drpcConn) NewAdminClient() serverpb.RPCAdminClient {
+	return serverpb.NewDRPCAdminClientAdapter(c.conn)
+}
+
+func (c *drpcConn) NewInitClient() serverpb.RPCInitClient {
+	return serverpb.NewDRPCInitClientAdapter(c.conn)
+}
+
+func (c *drpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {
+	return tspb.NewDRPCTimeSeriesClientAdapter(c.conn)
+}
+
+func (c *drpcConn) NewInternalClient() kvpb.RPCInternalClient {
+	return kvpb.NewDRPCInternalClientAdapter(c.conn)
+}
+
+func (c *drpcConn) NewDistSQLClient() execinfrapb.RPCDistSQLClient {
+	return execinfrapb.NewDRPCDistSQLClientAdapter(c.conn)
 }

--- a/pkg/util/tracing/tracingservicepb/rpc_clients.go
+++ b/pkg/util/tracing/tracingservicepb/rpc_clients.go
@@ -25,5 +25,9 @@ func DialTracingClient(
 		}
 		return NewGRPCTracingClientAdapter(conn), nil
 	}
-	return nil, nil
+	conn, err := nd.DRPCDial(ctx, nodeID, class)
+	if err != nil {
+		return nil, err
+	}
+	return NewDRPCTracingClientAdapter(conn), nil
 }


### PR DESCRIPTION
Create DRPC RPC clients when DRPC is enabled. Although DRPC is currently disabled by default, it will be eventually controlled via `rpc.experimental_drpc.enabled` cluster setting.

Epic: CRDB-48923
Fixes: none
Release note: none