### PR TITLE
sql/colfetcher: remove `catalog.TableColMap` from `cFetcherTableArgs`

### DIFF
--- a/pkg/sql/colfetcher/BUILD.bazel
+++ b/pkg/sql/colfetcher/BUILD.bazel
@@ -26,7 +26,6 @@ go_library(
         "//pkg/roachpb",
         "//pkg/settings",
         "//pkg/settings/cluster",
-        "//pkg/sql/catalog",
         "//pkg/sql/catalog/catenumpb",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",

--- a/pkg/sql/colfetcher/cfetcher_setup.go
+++ b/pkg/sql/colfetcher/cfetcher_setup.go
@@ -9,7 +9,6 @@ import (
 	"context"
 	"sync"
 
-	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/fetchpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
@@ -22,9 +21,6 @@ import (
 // caller) are included in the internal state.
 type cFetcherTableArgs struct {
 	spec fetchpb.IndexFetchSpec
-	// ColIdxMap is a mapping from ColumnID to the ordinal of the corresponding
-	// column within spec.FetchedColumns.
-	ColIdxMap catalog.TableColMap
 	// typs are the types from spec.FetchedColumns.
 	typs []*types.T
 }
@@ -98,9 +94,6 @@ func populateTableArgs(
 		}
 	}
 	args.populateTypes(args.spec.FetchedColumns)
-	for i := range args.spec.FetchedColumns {
-		args.ColIdxMap.Set(args.spec.FetchedColumns[i].ColumnID, i)
-	}
 
 	return args, nil
 }

--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -522,6 +522,17 @@ var queries = [...]benchQuery{
 		`,
 		args: []interface{}{1, 2},
 	},
+
+	// Similar to many-columns-and-indexes-a, but fetches all columns.
+	{
+		name: "many-columns-and-indexes-e",
+		query: `
+			SELECT * FROM k
+			WHERE x = $1
+		`,
+		args: []interface{}{1},
+	},
+
 	{
 		name:  "comp-pk",
 		query: "SELECT * FROM comp WHERE a = $1 AND b = $2 AND c = $3 AND d = $4 AND e = $5",


### PR DESCRIPTION
The `catalog.TableColMap` in `cFetcherTableArgs` has been removed.
Information in `IndexFetchSpec` and `cTableInfo` is used instead.

Release note: None
