### PR TITLE
changefeedccl: add geo case to skipped random expressions test

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1367,6 +1367,7 @@ func TestChangefeedRandomExpressions(t *testing.T) {
 					"invalid regular expression",
 					"invalid escape string",
 					"error parsing GeoJSON",
+					"error parsing EWKB",
 					"error parsing EWKT",
 					"geometry type is unsupported",
 					"should be of length",


### PR DESCRIPTION
Adds the "error parsing EWKB" case to the skipped error cases in TestChangefeedRandomExpressions.

Epic: none
Fixes: #147247

Release note: None