### PR TITLE
sql: support referencing a routine from a view query

### DIFF
--- a/pkg/sql/catalog/descpb/structured.proto
+++ b/pkg/sql/catalog/descpb/structured.proto
@@ -1838,6 +1838,9 @@ message FunctionDescriptor {
       (gogoproto.casttype) = "TriggerID"];
     repeated uint32 policy_ids = 6 [(gogoproto.customname) = "PolicyIDs",
       (gogoproto.casttype) = "PolicyID"];
+    // ViewQuery indicates that this function is referenced in the query of a
+    // view.
+    optional bool view_query = 7 [(gogoproto.nullable) = false];
   }
 
   optional string name = 1 [(gogoproto.nullable) = false];

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -1580,6 +1580,7 @@ func (e *distSQLSpecExecFactory) ConstructCreateView(
 	columns colinfo.ResultColumns,
 	deps opt.SchemaDeps,
 	typeDeps opt.SchemaTypeDeps,
+	funcDeps opt.SchemaFunctionDeps,
 ) (exec.Node, error) {
 	return nil, unimplemented.NewWithIssue(47473, "experimental opt-driven distsql planning: create view")
 }

--- a/pkg/sql/drop_view.go
+++ b/pkg/sql/drop_view.go
@@ -323,6 +323,12 @@ func (p *planner) dropViewImpl(
 		return cascadeDroppedViews, err
 	}
 
+	// Remove back-references from the routines this view depends on.
+	routinesDependedOn := append([]descpb.ID(nil), viewDesc.DependsOnFunctions...)
+	if err := p.removeRoutineViewBackReferences(ctx, routinesDependedOn, viewDesc.ID); err != nil {
+		return cascadeDroppedViews, err
+	}
+
 	if behavior == tree.DropCascade {
 		dependedOnBy := append([]descpb.TableDescriptor_Reference(nil), viewDesc.DependedOnBy...)
 		for _, ref := range dependedOnBy {

--- a/pkg/sql/logictest/testdata/logic_test/drop_function
+++ b/pkg/sql/logictest/testdata/logic_test/drop_function
@@ -301,7 +301,7 @@ CREATE SCHEMA altSchema;
 CREATE FUNCTION altSchema.f_called_by_b() RETURNS INT LANGUAGE SQL AS $$ SELECT 1 $$;
 CREATE TABLE t1_with_b_2_ref(j int default altSchema.f_called_by_b() CHECK (altSchema.f_called_by_b() > 0));
 
-statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions \(\[test.public.f_called_by_b2\]\) still depend on it
+statement error pgcode 0A000 cannot set schema for function \"f_called_by_b\" because other functions or views \(\[test.public.f_called_by_b2\]\) still depend on it
 ALTER FUNCTION f_called_by_b SET SCHEMA altSchema;
 
 skipif config local-legacy-schema-changer

--- a/pkg/sql/logictest/testdata/logic_test/udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf
@@ -1046,3 +1046,148 @@ select * from pg_catalog.pg_attrdef;
 3466299041  175  2  unique_rowid()                                         unique_rowid()
 
 subtest end
+
+subtest view
+
+statement ok
+CREATE TABLE xy (x INT, y INT);
+INSERT INTO xy VALUES (1, 2), (3, 4), (5, 6);
+
+statement ok
+CREATE FUNCTION f_scalar() RETURNS INT LANGUAGE SQL AS $$ SELECT count(*) FROM xy $$;
+
+statement ok
+CREATE FUNCTION f_setof() RETURNS SETOF xy LANGUAGE SQL AS $$ SELECT * FROM xy $$;
+
+statement ok
+CREATE VIEW v AS SELECT x, y, f_scalar() FROM f_setof();
+
+statement ok
+CREATE MATERIALIZED VIEW mv AS SELECT x, y, f_scalar() FROM f_setof();
+
+query III
+SELECT * FROM v ORDER BY x, y;
+----
+1  2  3
+3  4  3
+5  6  3
+
+query III
+SELECT * FROM mv ORDER BY x, y;
+----
+1  2  3
+3  4  3
+5  6  3
+
+statement ok
+REFRESH MATERIALIZED VIEW mv;
+
+query III
+SELECT * FROM mv ORDER BY x, y;
+----
+1  2  3
+3  4  3
+5  6  3
+
+statement ok
+INSERT INTO xy VALUES (7, 8);
+
+query III
+SELECT * FROM v ORDER BY x, y;
+----
+1  2  4
+3  4  4
+5  6  4
+7  8  4
+
+query III
+SELECT * FROM mv ORDER BY x, y;
+----
+1  2  3
+3  4  3
+5  6  3
+
+statement ok
+REFRESH MATERIALIZED VIEW mv;
+
+query III
+SELECT * FROM mv ORDER BY x, y;
+----
+1  2  4
+3  4  4
+5  6  4
+7  8  4
+
+statement ok
+CREATE ROLE bob;
+
+statement ok
+GRANT ALL ON SCHEMA public TO bob;
+
+statement ok
+GRANT ALL ON v TO bob;
+
+statement ok
+GRANT ALL ON mv TO bob;
+
+statement ok
+REVOKE EXECUTE ON FUNCTION f_scalar() FROM PUBLIC;
+
+statement ok
+REVOKE EXECUTE ON FUNCTION f_scalar() FROM bob;
+
+statement ok
+SET ROLE bob;
+
+statement error pgcode 42501 pq: user bob does not have EXECUTE privilege on function f_scalar
+SELECT f_scalar();
+
+statement error pgcode 42501 pq: user bob does not have EXECUTE privilege on function f_scalar
+SELECT * FROM v;
+
+statement ok
+SELECT * FROM mv;
+
+statement ok
+SET ROLE root;
+
+statement error pgcode 0A000 cannot rename function "f_scalar" because other functions or views \(\[test.public.v, test.public.mv\]\) still depend on it
+ALTER FUNCTION f_scalar RENAME TO f_scalar_renamed;
+
+statement error pgcode 0A000 cannot rename function "f_setof" because other functions or views \(\[test.public.v, test.public.mv\]\) still depend on it
+ALTER FUNCTION f_setof RENAME TO f_setof_renamed;
+
+statement error pgcode 2BP01 pq: cannot drop function "f_scalar" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
+DROP FUNCTION f_scalar;
+
+statement error pgcode 2BP01 pq: cannot drop function "f_setof" because other objects \(\[test.public.v, test.public.mv\]\) still depend on it
+DROP FUNCTION f_setof;
+
+statement ok
+DROP VIEW v;
+
+statement ok
+DROP MATERIALIZED VIEW mv;
+
+statement ok
+DROP FUNCTION f_scalar;
+
+statement ok
+DROP FUNCTION f_setof;
+
+# Test a view referencing a builtin function.
+statement ok
+CREATE VIEW v_builtin AS SELECT * FROM generate_series(1, 4);
+
+query I
+SELECT * FROM v_builtin ORDER BY 1;
+----
+1
+2
+3
+4
+
+statement ok
+DROP VIEW v_builtin;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
+++ b/pkg/sql/logictest/testdata/logic_test/udf_calling_udf
@@ -55,16 +55,15 @@ statement error pgcode 42883 unknown function: recursion_check\(\)
 CREATE FUNCTION recursion_check() RETURNS STRING  LANGUAGE SQL AS $$ SELECT recursion_check() $$;
 
 # Validate that function renaming is blocked.
-statement error pgcode 0A000 cannot rename function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+statement error pgcode 0A000 cannot rename function \"lower_hello\" because other functions or views \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
 ALTER FUNCTION lower_hello rename to lower_hello_new
 
 statement ok
 CREATE SCHEMA sc2;
 
 # Validate that function schema changes are blocked.
-statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other functions \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
+statement error pgcode 0A000 cannot set schema for function \"lower_hello\" because other functions or views \(\[test.public.upper_hello, test.public.concat_hello\]\) still depend on it
 ALTER FUNCTION lower_hello SET SCHEMA sc2;
-
 
 statement ok
 CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$

--- a/pkg/sql/logictest/testdata/logic_test/udf_unsupported
+++ b/pkg/sql/logictest/testdata/logic_test/udf_unsupported
@@ -69,35 +69,6 @@ CREATE INDEX idx_b ON test_tbl_t (test_tbl_f());
 subtest end
 
 
-subtest disallow_udf_in_views
-
-statement ok
-CREATE FUNCTION test_vf_f() RETURNS STRING LANGUAGE SQL AS $$ SELECT lower('hello') $$;
-
-
-statement error pgcode 42883 pq: unknown function: test_vf_f\(\)\nHINT:.*intention was to use a user-defined function in the view query, which is currently not supported.
-CREATE VIEW v AS SELECT test_vf_f();
-
-statement ok
-CREATE VIEW v AS SELECT lower('hello');
-
-query T
-SELECT create_statement FROM [SHOW CREATE FUNCTION test_vf_f];
-----
-CREATE FUNCTION public.test_vf_f()
-  RETURNS STRING
-  VOLATILE
-  NOT LEAKPROOF
-  CALLED ON NULL INPUT
-  LANGUAGE SQL
-  SECURITY INVOKER
-  AS $$
-  SELECT lower('hello':::STRING);
-$$
-
-subtest end
-
-
 subtest cross_db
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/statement.go
+++ b/pkg/sql/opt/exec/execbuilder/statement.go
@@ -65,6 +65,7 @@ func (b *Builder) buildCreateView(
 		cols,
 		cv.Deps,
 		cv.TypeDeps,
+		cv.FuncDeps,
 	)
 	return execPlan{root: root}, colOrdMap{}, err
 }

--- a/pkg/sql/opt/exec/factory.opt
+++ b/pkg/sql/opt/exec/factory.opt
@@ -692,6 +692,7 @@ define CreateView {
     Columns colinfo.ResultColumns
     deps opt.SchemaDeps
     typeDeps opt.SchemaTypeDeps
+    functionDeps opt.SchemaFunctionDeps
 }
 
 # SequenceSelect implements a scan of a sequence as a data source.

--- a/pkg/sql/opt/ops/statement.opt
+++ b/pkg/sql/opt/ops/statement.opt
@@ -55,6 +55,9 @@ define CreateViewPrivate {
     # TypeDeps contains the type dependencies of the view.
     TypeDeps SchemaTypeDeps
 
+    # FuncDeps contains the function dependencies of the function.
+    FuncDeps SchemaFunctionDeps
+
     # WithData indicates if the materialized view is populated
     # with data upon creation.
     WithData bool

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/colinfo",
         "//pkg/sql/catalog/descpb",
+        "//pkg/sql/catalog/funcdesc",
         "//pkg/sql/catalog/funcinfo",
         "//pkg/sql/catalog/schemaexpr",
         "//pkg/sql/catalog/seqexpr",

--- a/pkg/sql/opt/optbuilder/create_trigger.go
+++ b/pkg/sql/opt/optbuilder/create_trigger.go
@@ -7,6 +7,7 @@ package optbuilder
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/typedesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/cat"
@@ -175,7 +176,7 @@ func (b *Builder) buildFunctionForTrigger(
 		panic(errors.AssertionFailedf("SQL language not supported for triggers"))
 	}
 	// The trigger always references the trigger function.
-	b.schemaFunctionDeps.Add(int(o.Oid))
+	b.schemaFunctionDeps.Add(int(funcdesc.UserDefinedFunctionOIDToID(o.Oid)))
 
 	// The trigger function can reference the NEW and OLD transition relations,
 	// aliased in the trigger definition.

--- a/pkg/sql/opt/optbuilder/create_view.go
+++ b/pkg/sql/opt/optbuilder/create_view.go
@@ -16,8 +16,6 @@ import (
 
 func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope *scope) {
 	b.DisableMemoReuse = true
-	preFuncResolver := b.semaCtx.FunctionResolver
-	b.semaCtx.FunctionResolver = nil
 
 	isTemp := resolveTemporaryStatus(cv.Name.ObjectNamePrefix, cv.Persistence)
 	if isTemp {
@@ -62,7 +60,6 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 		b.qualifyDataSourceNamesInAST = false
 		delete(b.sourceViews, viewFQString)
 
-		b.semaCtx.FunctionResolver = preFuncResolver
 		switch recErr := recover().(type) {
 		case nil:
 			// No error.
@@ -134,6 +131,7 @@ func (b *Builder) buildCreateView(cv *tree.CreateView, inScope *scope) (outScope
 			Columns:   p,
 			Deps:      b.schemaDeps,
 			TypeDeps:  b.schemaTypeDeps,
+			FuncDeps:  b.schemaFunctionDeps,
 		},
 	)
 	return outScope

--- a/pkg/sql/opt/optbuilder/routine.go
+++ b/pkg/sql/opt/optbuilder/routine.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/funcdesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
@@ -98,8 +99,8 @@ func (b *Builder) buildUDF(
 		}
 	}
 
-	if b.trackSchemaDeps {
-		b.schemaFunctionDeps.Add(int(o.Oid))
+	if b.trackSchemaDeps && o.Type != tree.BuiltinRoutine {
+		b.schemaFunctionDeps.Add(int(funcdesc.UserDefinedFunctionOIDToID(o.Oid)))
 	}
 
 	return b.finishBuildScalar(f, routine, outScope, outCol)
@@ -338,8 +339,8 @@ func (b *Builder) buildRoutine(
 		}
 	}
 
-	if b.trackSchemaDeps {
-		b.schemaFunctionDeps.Add(int(o.Oid))
+	if b.trackSchemaDeps && o.Type != tree.BuiltinRoutine {
+		b.schemaFunctionDeps.Add(int(funcdesc.UserDefinedFunctionOIDToID(o.Oid)))
 	}
 	// Do not track any other routine invocations inside this routine, since
 	// for the schema changer we only need depth 1. Also keep track of when

--- a/pkg/sql/opt/optbuilder/testdata/create_trigger
+++ b/pkg/sql/opt/optbuilder/testdata/create_trigger
@@ -20,7 +20,8 @@ CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f_
 ----
 create-trigger
  ├── CREATE TRIGGER tr BEFORE INSERT OR UPDATE ON xy FOR EACH ROW EXECUTE FUNCTION f_basic()
- └── no dependencies
+ └── dependencies
+      └── [FUNCTION 100057]
 
 # TODO(#126362, #135655): implement this case.
 build
@@ -33,7 +34,8 @@ CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f_basic();
 ----
 create-trigger
  ├── CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f_basic()
- └── no dependencies
+ └── dependencies
+      └── [FUNCTION 100057]
 
 exec-ddl
 CREATE FUNCTION f_typ() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
@@ -51,7 +53,8 @@ CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f_typ();
 create-trigger
  ├── CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f_typ()
  └── dependencies
-      └── typ
+      ├── typ
+      └── [FUNCTION 100058]
 
 exec-ddl
 CREATE FUNCTION f_relation() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
@@ -68,4 +71,5 @@ CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f_relation()
 create-trigger
  ├── CREATE TRIGGER foo AFTER INSERT ON xy FOR EACH ROW EXECUTE FUNCTION f_relation()
  └── dependencies
-      └── ab [columns: a b]
+      ├── ab [columns: a b]
+      └── [FUNCTION 100059]

--- a/pkg/sql/opt/optbuilder/testdata/create_view
+++ b/pkg/sql/opt/optbuilder/testdata/create_view
@@ -19,6 +19,29 @@ exec-ddl
 CREATE TABLE foobars (fb foobar)
 ----
 
+exec-ddl
+CREATE FUNCTION foo() RETURNS INT LANGUAGE SQL AS $$ SELECT 100 $$;
+----
+
+exec-ddl
+CREATE FUNCTION bar(x INT, y INT) RETURNS INT LANGUAGE SQL AS $$ SELECT x + y $$;
+----
+
+exec-ddl
+CREATE VIEW ab_view AS SELECT a, b FROM ab
+----
+
+exec-ddl
+CREATE FUNCTION baz() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', 'foo'::foobar;
+    RAISE NOTICE '%', nextval('s');
+    RAISE NOTICE '%', (SELECT count(*) FROM ab_view);
+    RETURN (SELECT count(*) FROM cd);
+  END
+$$;
+----
+
 build
 CREATE VIEW v1 AS VALUES (1)
 ----
@@ -391,3 +414,64 @@ create-view t.public.v26
  ├── columns: fb:1
  └── dependencies
       └── foobars [columns: fb]
+
+# Test UDFs called from a view.
+build
+CREATE VIEW v27 AS SELECT foo();
+----
+create-view t.public.v27
+ ├── SELECT public.foo()
+ ├── columns: foo:2
+ └── dependencies
+      └── [FUNCTION 100059]
+
+build
+CREATE VIEW v28 AS SELECT bar(1, 2);
+----
+create-view t.public.v28
+ ├── SELECT public.bar(1:::INT8, 2:::INT8)
+ ├── columns: bar:4
+ └── dependencies
+      └── [FUNCTION 100060]
+
+# The routine's dependencies are not added to the view's dependencies.
+build
+CREATE VIEW v29 AS SELECT baz();
+----
+create-view t.public.v29
+ ├── SELECT public.baz()
+ ├── columns: baz:18
+ └── dependencies
+      └── [FUNCTION 100062]
+
+build
+CREATE VIEW v30 AS SELECT foo() AS x, bar(1, 2) AS y, baz() AS z
+----
+create-view t.public.v30
+ ├── SELECT public.foo() AS x, public.bar(1:::INT8, 2:::INT8) AS y, public.baz() AS z
+ ├── columns: x:2 y:6 z:24
+ └── dependencies
+      ├── [FUNCTION 100059]
+      ├── [FUNCTION 100060]
+      └── [FUNCTION 100062]
+
+build
+CREATE VIEW v31 AS SELECT bar(a, b) FROM ab
+----
+create-view t.public.v31
+ ├── SELECT public.bar(a, b) FROM t.public.ab
+ ├── columns: bar:8
+ └── dependencies
+      ├── ab [columns: a b]
+      └── [FUNCTION 100060]
+
+build
+CREATE VIEW v31 AS SELECT * FROM ab INNER JOIN cd ON bar(a, b) = c
+----
+create-view t.public.v31
+ ├── SELECT ab.a, ab.b, cd.c, cd.d FROM t.public.ab INNER JOIN t.public.cd ON public.bar(a, b) = c
+ ├── columns: a:1 b:2 c:5 d:6
+ └── dependencies
+      ├── ab [columns: a b]
+      ├── cd [columns: c d]
+      └── [FUNCTION 100060]

--- a/pkg/sql/opt/optbuilder/testdata/view
+++ b/pkg/sql/opt/optbuilder/testdata/view
@@ -3,7 +3,41 @@ CREATE TABLE a (k INT PRIMARY KEY, i INT, f FLOAT, s STRING, j JSON)
 ----
 
 exec-ddl
+CREATE TABLE cd (c INT PRIMARY KEY, d INT)
+----
+
+exec-ddl
 CREATE VIEW av AS SELECT k, i, s FROM a
+----
+
+exec-ddl
+CREATE SEQUENCE s
+----
+
+exec-ddl
+CREATE TYPE foobar AS ENUM ('foo', 'bar')
+----
+
+exec-ddl
+CREATE FUNCTION foo() RETURNS INT LANGUAGE SQL AS $$ SELECT 100 $$;
+----
+
+exec-ddl
+CREATE FUNCTION bar(x INT, y INT) RETURNS INT LANGUAGE SQL AS $$ SELECT x + y $$;
+----
+
+exec-ddl
+CREATE FUNCTION baz() RETURNS INT LANGUAGE PLpgSQL AS $$
+  BEGIN
+    RAISE NOTICE '%', 'foo'::foobar;
+    RAISE NOTICE '%', nextval('s');
+    RETURN (SELECT count(*) FROM cd);
+  END
+$$;
+----
+
+exec-ddl
+CREATE FUNCTION f_view() RETURNS INT LANGUAGE SQL AS $$ SELECT count(*) FROM av $$;
 ----
 
 build
@@ -117,3 +151,108 @@ project
                      │    └── (2,)
                      └── filters
                           └── column1:2 = column1:1
+
+# Test UDFs called from a view.
+exec-ddl
+CREATE VIEW v1 AS SELECT foo();
+----
+
+build
+SELECT * FROM v1
+----
+project
+ ├── columns: foo:2
+ ├── values
+ │    └── ()
+ └── projections
+      └── foo() [as=foo:2]
+
+exec-ddl
+CREATE VIEW v2 AS SELECT bar(1, 2);
+----
+
+build
+SELECT * FROM v2
+----
+project
+ ├── columns: bar:4
+ ├── values
+ │    └── ()
+ └── projections
+      └── bar(1, 2) [as=bar:4]
+
+exec-ddl
+CREATE VIEW v3 AS SELECT baz();
+----
+
+build
+SELECT * FROM v3
+----
+project
+ ├── columns: baz:11
+ ├── values
+ │    └── ()
+ └── projections
+      └── baz() [as=baz:11]
+
+exec-ddl
+CREATE VIEW v4 AS SELECT foo() AS x, bar(1, 2) AS y, baz() AS z
+----
+
+build
+SELECT * FROM v4
+----
+project
+ ├── columns: x:2 y:6 z:17
+ ├── values
+ │    └── ()
+ └── projections
+      ├── foo() [as=x:2]
+      ├── bar(1, 2) [as=y:6]
+      └── baz() [as=z:17]
+
+exec-ddl
+CREATE VIEW v5 AS SELECT bar(k, i) FROM a
+----
+
+build
+SELECT * FROM v5
+----
+project
+ ├── columns: bar:11
+ ├── scan a
+ │    └── columns: k:1!null i:2 f:3 s:4 j:5 crdb_internal_mvcc_timestamp:6 tableoid:7
+ └── projections
+      └── bar(k:1, i:2) [as=bar:11]
+
+exec-ddl
+CREATE VIEW v6 AS SELECT * FROM a INNER JOIN cd ON bar(k, i) = c
+----
+
+build
+SELECT * FROM v6
+----
+project
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 c:8!null d:9
+ └── inner-join (cross)
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 a.crdb_internal_mvcc_timestamp:6 a.tableoid:7 c:8!null d:9 cd.crdb_internal_mvcc_timestamp:10 cd.tableoid:11
+      ├── scan a
+      │    └── columns: k:1!null i:2 f:3 s:4 j:5 a.crdb_internal_mvcc_timestamp:6 a.tableoid:7
+      ├── scan cd
+      │    └── columns: c:8!null d:9 cd.crdb_internal_mvcc_timestamp:10 cd.tableoid:11
+      └── filters
+           └── bar(k:1, i:2) = c:8
+
+exec-ddl
+CREATE VIEW v7 AS SELECT f_view();
+----
+
+build
+SELECT * FROM v7
+----
+project
+ ├── columns: f_view:9
+ ├── values
+ │    └── ()
+ └── projections
+      └── f_view() [as=f_view:9]

--- a/pkg/sql/opt/schema_dependencies.go
+++ b/pkg/sql/opt/schema_dependencies.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 )
 
+// SchemaFunctionDeps contains a set of depended-on routine desc IDs.
 type SchemaFunctionDeps = intsets.Fast
 
 type SchemaFunctionDep struct {

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -302,6 +302,7 @@ func (w *walkCtx) walkRelation(tbl catalog.TableDescriptor) {
 			ViewID:          tbl.GetID(),
 			UsesTypeIDs:     catalog.MakeDescriptorIDSet(tbl.GetDependsOnTypes()...).Ordered(),
 			UsesRelationIDs: catalog.MakeDescriptorIDSet(tbl.GetDependsOn()...).Ordered(),
+			UsesRoutineIDs:  catalog.MakeDescriptorIDSet(tbl.GetDependsOnFunctions()...).Ordered(),
 			IsTemporary:     tbl.IsTemporary(),
 			IsMaterialized:  tbl.MaterializedView(),
 			ForwardReferences: func(tbl catalog.TableDescriptor) []*scpb.View_Reference {

--- a/pkg/sql/schemachanger/scdecomp/testdata/other
+++ b/pkg/sql/schemachanger/scdecomp/testdata/other
@@ -495,6 +495,7 @@ ElementState:
     isTemporary: false
     usesRelationIds:
     - 109
+    usesRoutineIds: []
     usesTypeIds: []
     viewId: 112
   Status: PUBLIC
@@ -810,6 +811,7 @@ ElementState:
     isTemporary: false
     usesRelationIds:
     - 112
+    usesRoutineIds: []
     usesTypeIds:
     - 110
     - 111

--- a/pkg/sql/schemachanger/scpb/elements.proto
+++ b/pkg/sql/schemachanger/scpb/elements.proto
@@ -475,6 +475,7 @@ message View {
   uint32 view_id = 1 [(gogoproto.customname) = "ViewID", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   repeated uint32 uses_type_ids = 2 [(gogoproto.customname) = "UsesTypeIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
   repeated uint32 uses_relation_ids = 3 [(gogoproto.customname) = "UsesRelationIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
+  repeated uint32 uses_routine_ids = 12 [(gogoproto.customname) = "UsesRoutineIDs", (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/sem/catid.DescID"];
 
   // a reference from this view to another relation, tracked down to index/column level.
   message Reference {

--- a/pkg/sql/schemachanger/scpb/uml/table.puml
+++ b/pkg/sql/schemachanger/scpb/uml/table.puml
@@ -550,6 +550,7 @@ object View
 View :  ViewID
 View : []UsesTypeIDs
 View : []UsesRelationIDs
+View : []UsesRoutineIDs
 View : []ForwardReferences
 View :  IsTemporary
 View :  IsMaterialized

--- a/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
+++ b/pkg/sql/schemachanger/scplan/internal/opgen/opgen_view.go
@@ -45,6 +45,15 @@ func init() {
 						TypeIDs:                    this.UsesTypeIDs,
 					}
 				}),
+				emit(func(this *scpb.View) *scop.RemoveBackReferenceInFunctions {
+					if len(this.UsesRoutineIDs) == 0 {
+						return nil
+					}
+					return &scop.RemoveBackReferenceInFunctions{
+						BackReferencedDescriptorID: this.ViewID,
+						FunctionIDs:                this.UsesRoutineIDs,
+					}
+				}),
 				emit(func(this *scpb.View) *scop.RemoveBackReferencesInRelations {
 					if len(this.UsesRelationIDs) == 0 {
 						return nil


### PR DESCRIPTION
#### sql,schemachanger: add remaining handling for routine references in views

This commit adds the remaining logic needed to keep track of references
to routines from a view query in the schema changer. The following commit
will resolve these references upon planning the `CREATE VIEW` statement
and pass them to the schema changer.

Informs #146123

Release note: None

#### sql: support referencing a routine from a view query

This commit adds support for invoking a UDF from a view (materialized or
otherwise). This requires resolving routine references while planning the
`CREATE VIEW` statement and passing them to the schema changer.

Fixes #146123

Release note (sql change): Added support for invoking a UDF from a view
query. Renaming or setting the schema on the routine is currently not
allowed if it is referenced by a view.