### PR TITLE
*: initialize roachpb.Values appropriately in tests

### DIFF
--- a/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
+++ b/pkg/ccl/changefeedccl/kvevent/blocking_buffer_test.go
@@ -50,18 +50,18 @@ func makeRangeFeedEvent(rnd *rand.Rand, valSize int, prevValSize int) *kvpb.Rang
 	e := kvpb.RangeFeedEvent{
 		Val: &kvpb.RangeFeedValue{
 			Key: key,
-			Value: roachpb.Value{
-				RawBytes:  randutil.RandBytes(rnd, valSize),
-				Timestamp: hlc.Timestamp{WallTime: 1},
-			},
+			Value: roachpb.MakeValueFromBytesAndTimestamp(
+				randutil.RandBytes(rnd, valSize),
+				 hlc.Timestamp{WallTime: 1},
+			),
 		},
 	}
 
 	if prevValSize > 0 {
-		e.Val.PrevValue = roachpb.Value{
-			RawBytes:  randutil.RandBytes(rnd, prevValSize),
-			Timestamp: hlc.Timestamp{WallTime: 1},
-		}
+		e.Val.PrevValue = roachpb.MakeValueFromBytesAndTimestamp(
+			randutil.RandBytes(rnd, prevValSize),
+			hlc.Timestamp{WallTime: 1},
+		)
 	}
 	return &e
 }

--- a/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
+++ b/pkg/ccl/changefeedccl/kvfeed/kv_feed_test.go
@@ -66,10 +66,7 @@ func TestKVFeed(t *testing.T) {
 	kv := func(codec keys.SQLCodec, tableID uint32, k, v string, ts hlc.Timestamp) roachpb.KeyValue {
 		return roachpb.KeyValue{
 			Key: mkKey(codec, tableID, k),
-			Value: roachpb.Value{
-				RawBytes:  []byte(v),
-				Timestamp: ts,
-			},
+			Value: roachpb.MakeValueFromBytesAndTimestamp([]byte(v), ts),
 		}
 	}
 

--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side_test.go
@@ -957,7 +957,8 @@ func makeTestBatch(
 			byteCount += bi.WriteBytes % bi.WriteCount
 		}
 
-		putReq := &kvpb.PutRequest{Value: roachpb.Value{RawBytes: make([]byte, byteCount)}}
+		value := roachpb.MakeValueFromBytes(make([]byte, byteCount))
+		putReq := &kvpb.PutRequest{Value: value}
 		req.Requests = append(req.Requests,
 			kvpb.RequestUnion{Value: &kvpb.RequestUnion_Put{Put: putReq}})
 

--- a/pkg/crosscluster/logical/lww_row_processor_test.go
+++ b/pkg/crosscluster/logical/lww_row_processor_test.go
@@ -207,7 +207,7 @@ func BenchmarkLWWInsertBatch(b *testing.B) {
 		return keyValue
 	}
 	// The contents of prevValue don't matter as long as RawBytes is non-nil.
-	prevValue := roachpb.Value{RawBytes: make([]byte, 1)}
+	prevValue := roachpb.MakeValueFromBytes(make([]byte, 1))
 	for _, tc := range []struct {
 		name        string
 		implicitTxn bool

--- a/pkg/crosscluster/streamclient/client_test.go
+++ b/pkg/crosscluster/streamclient/client_test.go
@@ -106,10 +106,10 @@ func (sc testStreamClient) Subscribe(
 ) (Subscription, error) {
 	sampleKV := roachpb.KeyValue{
 		Key: []byte("key_1"),
-		Value: roachpb.Value{
-			RawBytes:  []byte("value_1"),
-			Timestamp: hlc.Timestamp{WallTime: 1},
-		},
+		Value: roachpb.MakeValueFromBytesAndTimestamp(
+			[]byte("value_1"),
+			hlc.Timestamp{WallTime: 1},
+		),
 	}
 
 	sampleResolvedSpan := jobspb.ResolvedSpan{

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -2483,11 +2483,12 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 			resp := kvpb.ResponseUnion{}
 			// All requests get responses. Gets also have a return value.
 			for _, req := range ba.Requests {
+				value := roachpb.MakeValueFromBytes([]byte(makeValue(kvSize)))
 				switch req.GetInner().(type) {
 				case *kvpb.GetRequest:
 					resp.Value = &kvpb.ResponseUnion_Get{
 						Get: &kvpb.GetResponse{
-							Value: &roachpb.Value{RawBytes: []byte(makeValue(kvSize))},
+							Value: &value,
 						},
 					}
 				}

--- a/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
+++ b/pkg/kv/kvclient/kvstreamer/results_buffer_test.go
@@ -173,13 +173,11 @@ func makeResultWithGetResp(rng *rand.Rand, empty bool) Result {
 	if !empty {
 		rawBytes := make([]byte, rng.Intn(20)+1)
 		rng.Read(rawBytes)
-		r.GetResp.Value = &roachpb.Value{
-			RawBytes: rawBytes,
-			Timestamp: hlc.Timestamp{
-				WallTime: rng.Int63(),
-				Logical:  rng.Int31(),
-			},
-		}
+		value := roachpb.MakeValueFromBytesAndTimestamp(rawBytes, hlc.Timestamp{
+			WallTime: rng.Int63(),
+			Logical:  rng.Int31(),
+		})
+		r.GetResp.Value = &value
 	}
 	return r
 }

--- a/pkg/kv/kvpb/api_test.go
+++ b/pkg/kv/kvpb/api_test.go
@@ -55,12 +55,10 @@ func TestCombineResponses(t *testing.T) {
 	})
 
 	t.Run("neither combinable", func(t *testing.T) {
-		left := &GetResponse{
-			Value: &roachpb.Value{RawBytes: []byte("V")},
-		}
-		right := &GetResponse{
-			Value: &roachpb.Value{RawBytes: []byte("W")},
-		}
+		leftValue := roachpb.MakeValueFromBytes([]byte("V"))
+		left := &GetResponse{Value: &leftValue}
+		rightValue := roachpb.MakeValueFromBytes([]byte("W"))
+		right := &GetResponse{Value: &rightValue}
 		expCombined := &GetResponse{
 			Value: left.Value.ShallowClone(),
 		}
@@ -79,9 +77,8 @@ func TestCombineResponses(t *testing.T) {
 				{Key: roachpb.Key("Ai"), Value: roachpb.MakeValueFromString("X")},
 			},
 		}
-		right := &GetResponse{
-			Value: &roachpb.Value{RawBytes: []byte("W")},
-		}
+		rightValue := roachpb.MakeValueFromBytes([]byte("W"))
+		right := &GetResponse{Value: &rightValue}
 
 		err := CombineResponses(context.Background(), left, right, &BatchRequest{})
 		require.Error(t, err)
@@ -89,9 +86,8 @@ func TestCombineResponses(t *testing.T) {
 	})
 
 	t.Run("right combinable", func(t *testing.T) {
-		left := &GetResponse{
-			Value: &roachpb.Value{RawBytes: []byte("V")},
-		}
+		leftValue := roachpb.MakeValueFromBytes([]byte("V"))
+		left := &GetResponse{Value: &leftValue}
 		right := &ScanResponse{
 			Rows: []roachpb.KeyValue{
 				{Key: roachpb.Key("B"), Value: roachpb.MakeValueFromString("W")},

--- a/pkg/kv/kvserver/gc/gc_test.go
+++ b/pkg/kv/kvserver/gc/gc_test.go
@@ -134,7 +134,7 @@ func TestLockAgeThresholdSetting(t *testing.T) {
 		}
 		return strKey
 	}
-	value := roachpb.Value{RawBytes: []byte("0123456789")}
+	value := roachpb.MakeValueFromBytes([]byte("0123456789"))
 	intentHlc := hlc.Timestamp{
 		WallTime: lockTs.Nanoseconds(),
 	}
@@ -205,7 +205,7 @@ func TestIntentCleanupBatching(t *testing.T) {
 	// Prepare test locks using various transactions, keys, and lock strengths.
 	txnPrefixes := []byte{'a', 'b', 'c'}
 	objectKeys := []byte{'a', 'b', 'c', 'd', 'e'}
-	value := roachpb.Value{RawBytes: []byte("0123456789")}
+	value := roachpb.MakeValueFromBytes([]byte("0123456789"))
 	intentHlc := hlc.Timestamp{
 		WallTime: lockTs.Nanoseconds(),
 	}

--- a/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/buffered_sender_test.go
@@ -156,7 +156,7 @@ func TestBufferedSenderChaosWithStop(t *testing.T) {
 
 	t.Run("stream manager after stop", func(t *testing.T) {
 		// No events should be buffered after stopped.
-		val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		val1 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
 		ev1 := new(kvpb.RangeFeedEvent)
 		ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})
 		muxEv := &kvpb.MuxRangeFeedEvent{RangeFeedEvent: *ev1, RangeID: 0, StreamID: 1}

--- a/pkg/kv/kvserver/rangefeed/processor_test.go
+++ b/pkg/kv/kvserver/rangefeed/processor_test.go
@@ -114,10 +114,7 @@ func TestProcessorBasic(t *testing.T) {
 			[]*kvpb.RangeFeedEvent{
 				rangeFeedValue(
 					roachpb.Key("c"),
-					roachpb.Value{
-						RawBytes:  []byte("val"),
-						Timestamp: hlc.Timestamp{WallTime: 6},
-					},
+					roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 6}),
 				),
 			},
 			r1Stream.GetAndClearEvents(),
@@ -180,10 +177,7 @@ func TestProcessorBasic(t *testing.T) {
 			[]*kvpb.RangeFeedEvent{
 				rangeFeedValue(
 					roachpb.Key("e"),
-					roachpb.Value{
-						RawBytes:  []byte("ival"),
-						Timestamp: hlc.Timestamp{WallTime: 13},
-					},
+					roachpb.MakeValueFromBytesAndTimestamp([]byte("ival"), hlc.Timestamp{WallTime: 13}),
 				),
 				rangeFeedCheckpoint(
 					roachpb.Span{Key: roachpb.Key("a"), EndKey: roachpb.Key("m")},
@@ -255,10 +249,7 @@ func TestProcessorBasic(t *testing.T) {
 		valEvent := []*kvpb.RangeFeedEvent{
 			rangeFeedValue(
 				roachpb.Key("k"),
-				roachpb.Value{
-					RawBytes:  []byte("val2"),
-					Timestamp: hlc.Timestamp{WallTime: 22},
-				},
+				roachpb.MakeValueFromBytesAndTimestamp([]byte("val2"), hlc.Timestamp{WallTime: 22}),
 			),
 		}
 		require.Equal(t, valEvent, r1Stream.GetAndClearEvents())
@@ -271,10 +262,7 @@ func TestProcessorBasic(t *testing.T) {
 		valEvent2 := []*kvpb.RangeFeedEvent{
 			rangeFeedValue(
 				roachpb.Key("v"),
-				roachpb.Value{
-					RawBytes:  []byte("val3"),
-					Timestamp: hlc.Timestamp{WallTime: 23},
-				},
+				roachpb.MakeValueFromBytesAndTimestamp([]byte("val3"), hlc.Timestamp{WallTime: 23}),
 			),
 		}
 		require.Equal(t, []*kvpb.RangeFeedEvent(nil), r1Stream.GetAndClearEvents())
@@ -289,10 +277,7 @@ func TestProcessorBasic(t *testing.T) {
 		valEvent3 := []*kvpb.RangeFeedEvent{
 			rangeFeedValue(
 				roachpb.Key("k"),
-				roachpb.Value{
-					RawBytes:  []byte("val3"),
-					Timestamp: hlc.Timestamp{WallTime: 22},
-				},
+				roachpb.MakeValueFromBytesAndTimestamp([]byte("val3"), hlc.Timestamp{WallTime: 22}),
 			),
 		}
 		require.Equal(t, valEvent3, r1Stream.GetAndClearEvents())
@@ -410,10 +395,7 @@ func TestProcessorOmitRemote(t *testing.T) {
 		valEvent3 := []*kvpb.RangeFeedEvent{
 			rangeFeedValue(
 				roachpb.Key("k"),
-				roachpb.Value{
-					RawBytes:  []byte("val3"),
-					Timestamp: hlc.Timestamp{WallTime: 22},
-				},
+				roachpb.MakeValueFromBytesAndTimestamp([]byte("val3"), hlc.Timestamp{WallTime: 22}),
 			),
 		}
 

--- a/pkg/kv/kvserver/rangefeed/registry_test.go
+++ b/pkg/kv/kvserver/rangefeed/registry_test.go
@@ -24,7 +24,7 @@ func TestRegistrationBasic(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	val := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
 	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val})
 	ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val})
@@ -197,7 +197,7 @@ func TestRegistryWithOmitOrigin(t *testing.T) {
 			return ev
 		}
 
-		val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		val := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
 		ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
 		ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
 		ev2.MustSetValue(&kvpb.RangeFeedValue{Key: keyB, Value: val, PrevValue: val})
@@ -236,7 +236,7 @@ func TestRegistryBasic(t *testing.T) {
 	ctx := context.Background()
 
 	testutils.RunValues(t, "registration type=", registrationTestTypes, func(t *testing.T, rt registrationType) {
-		val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+		val := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
 		ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
 		ev3, ev4, ev5 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
 		ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
@@ -510,8 +510,8 @@ func TestPublishStrippedEvents(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
-	prevVal := roachpb.Value{RawBytes: []byte("prevVal"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	val := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
+	prevVal := roachpb.MakeValueFromBytesAndTimestamp([]byte("prevVal"), hlc.Timestamp{WallTime: 1})
 	ev1 := new(kvpb.RangeFeedEvent)
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: prevVal})
 	expectedEv := new(kvpb.RangeFeedEvent)

--- a/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_registration_test.go
@@ -118,8 +118,8 @@ func TestUnbufferedRegCorrectnessOnDisconnect(t *testing.T) {
 	const s1 = 1
 
 	key := roachpb.Key("d")
-	val1 := roachpb.Value{RawBytes: []byte("val1"), Timestamp: hlc.Timestamp{WallTime: 5}}
-	val2 := roachpb.Value{RawBytes: []byte("val2"), Timestamp: hlc.Timestamp{WallTime: 6}}
+	val1 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val1"), hlc.Timestamp{WallTime: 5})
+	val2 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val2"), hlc.Timestamp{WallTime: 6})
 	op1 := writeValueOpWithKV(key, val1.Timestamp, val1.RawBytes)
 	op2 := writeValueOpWithKV(key, val2.Timestamp, val2.RawBytes)
 	ev1, ev2 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
@@ -181,7 +181,7 @@ func TestUnbufferedRegWithCatchUpBufCleanUpAfterRunOutputLoop(t *testing.T) {
 
 	rng, _ := randutil.NewTestRand()
 	ev1 := new(kvpb.RangeFeedEvent)
-	val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+	val := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val})
 	numReg := rng.Intn(1000)
 	regs := make([]*unbufferedRegistration, numReg)
@@ -225,8 +225,8 @@ func TestUnbufferedRegOnCatchUpSwitchOver(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	ctx := context.Background()
 
-	val1 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
-	val2 := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 5}}
+	val1 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
+	val2 := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 5})
 	ev1, ev2, ev3, ev4, ev5 := new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent),
 		new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent), new(kvpb.RangeFeedEvent)
 	ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val1})

--- a/pkg/kv/kvserver/rangefeed/unbuffered_sender_test.go
+++ b/pkg/kv/kvserver/rangefeed/unbuffered_sender_test.go
@@ -227,7 +227,7 @@ func TestUnbufferedSenderWithConcurrentSend(t *testing.T) {
 		wg.Add(1)
 		go func() {
 			defer wg.Done()
-			val := roachpb.Value{RawBytes: []byte("val"), Timestamp: hlc.Timestamp{WallTime: 1}}
+			val := roachpb.MakeValueFromBytesAndTimestamp([]byte("val"), hlc.Timestamp{WallTime: 1})
 			ev1 := new(kvpb.RangeFeedEvent)
 			ev1.MustSetValue(&kvpb.RangeFeedValue{Key: keyA, Value: val, PrevValue: val})
 			require.NoError(t, sm.sender.sendUnbuffered(&kvpb.MuxRangeFeedEvent{

--- a/pkg/multitenant/tenantcostmodel/ecpu_model_test.go
+++ b/pkg/multitenant/tenantcostmodel/ecpu_model_test.go
@@ -68,12 +68,12 @@ func TestEstimatedCPUBatchInfo(t *testing.T) {
 					{Value: &kvpb.RequestUnion_Put{
 						Put: &kvpb.PutRequest{
 							RequestHeader: kvpb.RequestHeader{Key: make([]byte, 10)},
-							Value:         roachpb.Value{RawBytes: make([]byte, 100)}},
+							Value:         roachpb.MakeValueFromBytes(make([]byte, 100))},
 					}},
 					{Value: &kvpb.RequestUnion_Put{
 						Put: &kvpb.PutRequest{
 							RequestHeader: kvpb.RequestHeader{Key: make([]byte, 20)},
-							Value:         roachpb.Value{RawBytes: make([]byte, 200)}},
+							Value:         roachpb.MakeValueFromBytes(make([]byte, 200))},
 					}},
 					{Value: &kvpb.RequestUnion_EndTxn{
 						EndTxn: &kvpb.EndTxnRequest{
@@ -100,7 +100,7 @@ func TestEstimatedCPUBatchInfo(t *testing.T) {
 					{Value: &kvpb.RequestUnion_Put{
 						Put: &kvpb.PutRequest{
 							RequestHeader: kvpb.RequestHeader{Key: make([]byte, 10)},
-							Value:         roachpb.Value{RawBytes: make([]byte, 100)}},
+							Value:         roachpb.MakeValueFromBytes(make([]byte, 100))},
 					}},
 					{Value: &kvpb.RequestUnion_Get{
 						Get: &kvpb.GetRequest{

--- a/pkg/multitenant/tenantcostmodel/ru_model_test.go
+++ b/pkg/multitenant/tenantcostmodel/ru_model_test.go
@@ -67,12 +67,12 @@ func TestRequestUnitBatchInfo(t *testing.T) {
 					{Value: &kvpb.RequestUnion_Put{
 						Put: &kvpb.PutRequest{
 							RequestHeader: kvpb.RequestHeader{Key: make([]byte, 10)},
-							Value:         roachpb.Value{RawBytes: make([]byte, 100)}},
+							Value:         roachpb.MakeValueFromBytes(make([]byte, 100))},
 					}},
 					{Value: &kvpb.RequestUnion_Put{
 						Put: &kvpb.PutRequest{
 							RequestHeader: kvpb.RequestHeader{Key: make([]byte, 20)},
-							Value:         roachpb.Value{RawBytes: make([]byte, 200)}},
+							Value:         roachpb.MakeValueFromBytes(make([]byte, 200))},
 					}},
 					{Value: &kvpb.RequestUnion_EndTxn{
 						EndTxn: &kvpb.EndTxnRequest{
@@ -99,7 +99,7 @@ func TestRequestUnitBatchInfo(t *testing.T) {
 					{Value: &kvpb.RequestUnion_Put{
 						Put: &kvpb.PutRequest{
 							RequestHeader: kvpb.RequestHeader{Key: make([]byte, 10)},
-							Value:         roachpb.Value{RawBytes: make([]byte, 100)}},
+							Value:         roachpb.MakeValueFromBytes(make([]byte, 100))},
 					}},
 					{Value: &kvpb.RequestUnion_Get{
 						Get: &kvpb.GetRequest{

--- a/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer_test.go
+++ b/pkg/sql/rowcontainer/kvstreamer_result_disk_buffer_test.go
@@ -67,13 +67,11 @@ func makeResultWithGetResp(rng *rand.Rand, empty bool) kvstreamer.Result {
 	if !empty {
 		rawBytes := make([]byte, rng.Intn(20)+1)
 		rng.Read(rawBytes)
-		r.GetResp.Value = &roachpb.Value{
-			RawBytes: rawBytes,
-			Timestamp: hlc.Timestamp{
-				WallTime: rng.Int63(),
-				Logical:  rng.Int31(),
-			},
-		}
+		value := roachpb.MakeValueFromBytesAndTimestamp(rawBytes, hlc.Timestamp{
+			WallTime: rng.Int63(),
+			Logical:  rng.Int31(),
+		})
+		r.GetResp.Value = &value
 	}
 	return r
 }

--- a/pkg/storage/batch_test.go
+++ b/pkg/storage/batch_test.go
@@ -95,7 +95,7 @@ func testBatchBasics(t *testing.T, writeOnly bool, commit func(e Engine, b Write
 	// Write a MVCC value to be deleted with a known value size.
 	keyF := mvccKey("f")
 	keyF.Timestamp.WallTime = 1
-	valueF := MVCCValue{Value: roachpb.Value{RawBytes: []byte("fvalue")}}
+	valueF := MVCCValue{Value: roachpb.MakeValueFromString("fvalue")}
 	encodedValueF, err := EncodeMVCCValue(valueF)
 	require.NoError(t, err)
 	require.NoError(t, e.PutMVCC(keyF, valueF))
@@ -313,7 +313,7 @@ func TestBatchRepr(t *testing.T) {
 			"merge(c\x00)",
 			"put(e\x00,)",
 			"single_delete(d\x00)",
-			"delete-sized(f\x00\x00\x00\x00\x00\x00\x00\x00\x01\t,17)",
+			"delete-sized(f\x00\x00\x00\x00\x00\x00\x00\x00\x01\t,22)",
 		}
 		require.Equal(t, expOps, ops)
 

--- a/pkg/storage/engine_key_test.go
+++ b/pkg/storage/engine_key_test.go
@@ -414,7 +414,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 					Key:       roachpb.Key("foobar"),
 					Timestamp: hlc.Timestamp{WallTime: 1711383740550067000, Logical: 2},
 				},
-				MVCCValue{Value: roachpb.Value{RawBytes: []byte("hello world")}},
+				MVCCValue{Value: roachpb.MakeValueFromString("hello world")},
 			),
 		},
 		{
@@ -429,7 +429,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 						LocalTimestamp:   hlc.ClockTimestamp{WallTime: 1711383740550069000},
 						OmitInRangefeeds: true,
 					},
-					Value: roachpb.Value{RawBytes: []byte("hello world")},
+					Value: roachpb.MakeValueFromString("hello world"),
 				},
 			),
 		},
@@ -446,7 +446,7 @@ func BenchmarkEngineKeyVerify(b *testing.B) {
 					ValBytes: 100,
 				},
 				MVCCValue{
-					Value: roachpb.Value{RawBytes: []byte("hello world")},
+					Value: roachpb.MakeValueFromString("hello world"),
 				},
 			),
 		},

--- a/pkg/storage/engine_test.go
+++ b/pkg/storage/engine_test.go
@@ -1105,7 +1105,7 @@ func TestCreateCheckpoint_SpanConstrained(t *testing.T) {
 	for i := 1; i <= maxTableID; i++ {
 		require.NoError(t, b.PutMVCC(
 			MVCCKey{Key: key(i), Timestamp: hlc.Timestamp{WallTime: int64(i)}},
-			MVCCValue{Value: roachpb.Value{RawBytes: randutil.RandBytes(rng, 100)}},
+			MVCCValue{Value: roachpb.MakeValueFromBytes(randutil.RandBytes(rng, 100))},
 		))
 	}
 	require.NoError(t, b.Commit(true /* sync */))
@@ -1640,7 +1640,8 @@ func TestScanLocks(t *testing.T) {
 	for k, str := range locks {
 		var err error
 		if str == lock.Intent {
-			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp, roachpb.Value{RawBytes: roachpb.Key(k)}, MVCCWriteOptions{Txn: txn1})
+			_, err = MVCCPut(ctx, eng, roachpb.Key(k), txn1.ReadTimestamp,
+				roachpb.MakeValueFromBytes(roachpb.Key(k)), MVCCWriteOptions{Txn: txn1})
 		} else {
 			err = MVCCAcquireLock(ctx, eng, &txn1.TxnMeta, txn1.IgnoredSeqNums, str, roachpb.Key(k), nil, 0, 0)
 		}
@@ -2135,7 +2136,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarly(t *testing.T) {
 	keyB := roachpb.Key("b")
 	keyC := roachpb.Key("c")
 	keyD := roachpb.Key("d")
-	val := roachpb.Value{RawBytes: []byte{'v'}}
+	val := roachpb.MakeValueFromBytes([]byte{'v'})
 
 	testCases := []struct {
 		name                  string
@@ -2356,7 +2357,7 @@ func TestScanConflictingIntentsForDroppingLatchesEarlyReadYourOwnWrites(t *testi
 	aboveReadSeqNumber := enginepb.TxnSeq(3)
 
 	keyA := roachpb.Key("a")
-	val := roachpb.Value{RawBytes: []byte{'v'}}
+	val := roachpb.MakeValueFromBytes([]byte{'v'})
 
 	testCases := []struct {
 		name                  string

--- a/pkg/storage/pebble_mvcc_scanner_test.go
+++ b/pkg/storage/pebble_mvcc_scanner_test.go
@@ -219,7 +219,7 @@ func TestMVCCScanWithMemoryAccounting(t *testing.T) {
 		GlobalUncertaintyLimit: ts1,
 	}
 	ui1 := uncertainty.Interval{GlobalLimit: txn1.GlobalUncertaintyLimit}
-	val := roachpb.Value{RawBytes: bytes.Repeat([]byte("v"), 1000)}
+	val := roachpb.MakeValueFromBytes(bytes.Repeat([]byte("v"), 1000))
 	func() {
 		batch := eng.NewBatch()
 		defer batch.Close()


### PR DESCRIPTION
Fix many instances across the codebase's tests where a roachpb.Value's RawBytes was manually set. The roachpb.Value type has a subtle interface. When constructing a new Value, callers are expected to call one of the Value's Set(Type) methods. These methods handle initializing a header within the Value.RawBytes field appropriately. This header is necessary for decoding the roachpb.Value appropriately.

With the introduction of value separation (cockroachdb/pebble#112), we may attempt to parse these values during a memtable flush.

Epic: none
Release note: none