### PR TITLE
storage: disable short attribute extractor in temp engine

### DIFF
--- a/pkg/storage/disk_map_test.go
+++ b/pkg/storage/disk_map_test.go
@@ -40,7 +40,7 @@ func runTestForEngine(ctx context.Context, t *testing.T, filename string, engine
 			// creation and usage code involves too much test-specific code, so use
 			// a type switch with implementation-specific code instead.
 			switch e := engine.(type) {
-			case *pebbleTempEngine:
+			case *tempEngine:
 				iter, err := e.db.NewIter(&pebble.IterOptions{UpperBound: roachpb.KeyMax})
 				if err != nil {
 					t.Fatal(err)
@@ -167,14 +167,14 @@ func runTestForEngine(ctx context.Context, t *testing.T, filename string, engine
 	})
 }
 
-func TestPebbleMap(t *testing.T) {
+func TestTempEngineMap(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 
-	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+	e, _, err := NewTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
 	}, base.StoreSpec{}, disk.NewWriteStatsManager(vfs.Default))
@@ -193,7 +193,7 @@ func TestPebbleMultiMap(t *testing.T) {
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
 
-	e, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+	e, _, err := NewTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
 	}, base.StoreSpec{}, disk.NewWriteStatsManager(vfs.Default))
@@ -212,7 +212,7 @@ func TestPebbleMapClose(t *testing.T) {
 	ctx := context.Background()
 	dir, cleanup := testutils.TempDir(t)
 	defer cleanup()
-	e, _, err := newPebbleTempEngine(ctx, base.TempStorageConfig{
+	e, _, err := newTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
 	}, base.StoreSpec{}, disk.NewWriteStatsManager(vfs.Default))
@@ -319,7 +319,7 @@ func TestPebbleMapClose(t *testing.T) {
 func BenchmarkPebbleMapWrite(b *testing.B) {
 	dir := b.TempDir()
 	ctx := context.Background()
-	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+	tempEngine, _, err := NewTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
 	}, base.DefaultTestStoreSpec, disk.NewWriteStatsManager(vfs.Default))
@@ -360,7 +360,7 @@ func BenchmarkPebbleMapIteration(b *testing.B) {
 	skip.UnderShort(b)
 	dir := b.TempDir()
 	ctx := context.Background()
-	tempEngine, _, err := NewPebbleTempEngine(ctx, base.TempStorageConfig{
+	tempEngine, _, err := NewTempEngine(ctx, base.TempStorageConfig{
 		Path:     dir,
 		Settings: cluster.MakeClusterSettings(),
 	}, base.DefaultTestStoreSpec, disk.NewWriteStatsManager(vfs.Default))

--- a/pkg/storage/temp_engine_test.go
+++ b/pkg/storage/temp_engine_test.go
@@ -19,7 +19,7 @@ import (
 	"github.com/cockroachdb/pebble/vfs"
 )
 
-func TestNewPebbleTempEngine(t *testing.T) {
+func TestNewTempEngine(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
@@ -28,12 +28,12 @@ func TestNewPebbleTempEngine(t *testing.T) {
 	defer tempDirCleanup()
 
 	diskWriteStats := disk.NewWriteStatsManager(vfs.Default)
-	db, filesystem, err := NewPebbleTempEngine(context.Background(), base.TempStorageConfig{
+	db, filesystem, err := NewTempEngine(context.Background(), base.TempStorageConfig{
 		Path:     tempDir,
 		Settings: cluster.MakeTestingClusterSettings(),
 	}, base.StoreSpec{Path: tempDir}, diskWriteStats)
 	if err != nil {
-		t.Fatalf("error encountered when invoking NewRocksDBTempEngine: %+v", err)
+		t.Fatalf("error encountered when invoking NewTempEngine: %+v", err)
 	}
 	defer db.Close()
 


### PR DESCRIPTION
Disable the short attribute extractor in temporary engines. The short attribute extractor is only capable of parsing Cockroach MVCC keys. Additionally, rename some temp engine identifiers that needlessly were prefixed with 'Pebble'. These were vestiges from when Pebble and RocksDB implementations co-existed.

Epic: none
Release note: none