### PR TITLE
kvnemesis: first step towards a fuzzed KVNemesis

### DIFF
--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -1394,6 +1394,7 @@ func TestLint(t *testing.T) {
 			"--",
 			"*.go",
 			":!testutils/skip/skip.go",
+			":!util/randutil/rand.go",
 			":!cmd/roachtest/*.go",
 			":!acceptance/compose/*.go",
 			":!util/syncutil/*.go",


### PR DESCRIPTION
You can run this test with the go fuzzer with something like:

  go test ./pkg/kv/kvnemesis/ -test.fuzz=FuzzKVNemesisSingleNode \
  -test.fuzzcachedir=_fuzzcache -v -test.run=^$ \
  -tags crdb_test  -timeout=300m -parallel=4

It can also be run under bazel, but I have not yet sorted out all of the flags needed to get a coverage enabled build and to ensure that the failing test cases get written somewhere that can be referenced on subsequent runs.

The idea here is that the fuzzer provides a []byte that then determines the output of all random decisions in KVNemesis. This doesn't account for metamorphic decisions made outside of KVNemesis.

KVNemesis is a rather heavyweight test which seemed to be a problem for running it reliably under go-fuzz; however, go-fuzz's poor diagnostics when the test worker crash has made it hard to determine the exact cause so far.

Epic: none
Release note: None