### PR TITLE
server: register `DistSQL`, `Tracing` service with DRPC server

### DIFF
--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -375,6 +375,7 @@ go_library(
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@in_gopkg_yaml_v2//:yaml_v2",
+        "@io_storj_drpc//:drpc",
         "@io_storj_drpc//drpcerr",
         "@io_storj_drpc//drpcmigrate",
         "@org_golang_google_grpc//:grpc",

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1152,6 +1152,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 			nodeLiveness:             optionalnodeliveness.MakeContainer(nodeLiveness),
 			gossip:                   gossip.MakeOptionalGossip(g),
 			grpcServer:               grpcServer.Server,
+			drpcMux:                  drpcServer.DRPCServer,
 			nodeIDContainer:          idContainer,
 			externalStorage:          externalStorage,
 			externalStorageFromURI:   externalStorageFromURI,

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -1335,6 +1335,7 @@ func makeTenantSQLServerArgs(
 			nodeLiveness:      optionalnodeliveness.MakeContainer(nil),
 			gossip:            gossip.MakeOptionalGossip(nil),
 			grpcServer:        grpcServer.Server,
+			drpcMux:           drpcServer.DRPCServer,
 			isMeta1Leaseholder: func(_ context.Context, _ hlc.ClockTimestamp) (bool, error) {
 				return false, errors.New("isMeta1Leaseholder is not available to secondary tenants")
 			},


### PR DESCRIPTION
Enable `DistSQL` and `Tracing` services on the DRPC server in addition to gRPC. This is controlled by `rpc.experimental_drpc.enabled` (off by default).

This change is part of a series and is similar to: #146926

Note: This only registers the service; the client is not updated to use the DRPC client, so this service will not have any functional effect.

Epic: CRDB-48925
Release note: None