### PR TITLE
release-25.2: storeliveness: skip TestStoreLivenessRestart under duress

### DIFF
--- a/pkg/kv/kvserver/storeliveness/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/BUILD.bazel
@@ -72,6 +72,7 @@ go_test(
         "//pkg/testutils/datapathutils",
         "//pkg/testutils/listenerutil",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/hlc",

--- a/pkg/kv/kvserver/storeliveness/multi_store_test.go
+++ b/pkg/kv/kvserver/storeliveness/multi_store_test.go
@@ -20,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/fs"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/listenerutil"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
@@ -179,6 +180,7 @@ func TestStoreLivenessAllToAllSupport(t *testing.T) {
 func TestStoreLivenessRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuressWithIssue(t, 148566)
 
 	ctx := context.Background()
 	lisReg := listenerutil.NewListenerRegistry()


### PR DESCRIPTION
Backport 1/1 commits from #148595 on behalf of @tbg.

----

Fixes https://github.com/cockroachdb/cockroach/issues/148566.

Epic: none

----

Release justification: test deflake