### PR TITLE
release-25.1: storage_api: don't check raft status in test

### DIFF
--- a/pkg/server/storage_api/ranges_test.go
+++ b/pkg/server/storage_api/ranges_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/srvtestutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
@@ -56,9 +55,6 @@ func TestRangesResponse(t *testing.T) {
 		for _, ri := range response.Ranges {
 			// Do some simple validation based on the fact that this is a
 			// single-node cluster.
-			if ri.RaftState.State != "StateLeader" && ri.RaftState.State != server.RaftStateDormant {
-				t.Errorf("expected to be Raft leader or dormant, but was '%s'", ri.RaftState.State)
-			}
 			expReplica := roachpb.ReplicaDescriptor{
 				NodeID:    1,
 				StoreID:   1,


### PR DESCRIPTION
Backport 1/1 commits from #148593 on behalf of @tbg.

----

This seems unrelated to the test. We don't actually guarantee that a single node raft group can't transition through StateCandidate; clearly it's possible.

Via backports:
Closes https://github.com/cockroachdb/cockroach/issues/148564.

Epic: none

----

Release justification: