### PR TITLE
release-24.3: roachtest: more CPU profiling in rebalancing tests

### DIFF
--- a/pkg/cmd/roachtest/tests/rebalance_load.go
+++ b/pkg/cmd/roachtest/tests/rebalance_load.go
@@ -97,6 +97,12 @@ func registerRebalanceLoad(r registry.Registry) {
 		settings.ClusterSettings["kv.allocator.load_based_rebalancing"] = rebalanceMode
 		settings.ClusterSettings["kv.range_split.by_load_enabled"] = "false"
 
+		// Take a 10s profile every minute.
+		settings.ClusterSettings["server.cpu_profile.duration"] = "10s"
+		settings.ClusterSettings["server.cpu_profile.interval"] = "1m"
+		settings.ClusterSettings["server.cpu_profile.cpu_usage_combined_threshold"] = "1" // basically always true
+		settings.ClusterSettings["server.cpu_profile.total_dump_size_limit"] = "256 MiB"
+
 		if mixedVersion {
 			mvt := mixedversion.NewTest(ctx, t, t.L(), c, roachNodes, mixedversion.NeverUseFixtures,
 				mixedversion.ClusterSettingOption(
@@ -126,8 +132,6 @@ func registerRebalanceLoad(r registry.Registry) {
 				})
 			mvt.Run()
 		} else {
-			// Note that CPU profiling is already enabled by default, should there be
-			// a failure it will be available in the artifacts.
 			c.Start(ctx, t.L(), startOpts, settings, roachNodes)
 			require.NoError(t, rebalanceByLoad(
 				ctx, t, t.L(), c, rebalanceMode, maxDuration,


### PR DESCRIPTION
Backport 1/1 commits from #148658 on behalf of @tbg.

----

Closes #147487.

----

Release justification: