### PR TITLE
logcrash: skip reporting forced panics to Sentry

### DIFF
--- a/pkg/sql/sqltelemetry/report.go
+++ b/pkg/sql/sqltelemetry/report.go
@@ -51,7 +51,7 @@ func RecordError(ctx context.Context, err error, sv *settings.Values) {
 		// report is sent to sentry below.
 		log.Errorf(ctx, "encountered internal error:\n%+v", err)
 
-		if logcrash.ShouldSendReport(sv) {
+		if logcrash.ShouldSendReport(sv, err) {
 			event, extraDetails := errors.BuildSentryReport(err)
 			logcrash.SendReport(ctx, logcrash.ReportTypeError, event, extraDetails)
 		}

--- a/pkg/util/sentryutil/sentry.go
+++ b/pkg/util/sentryutil/sentry.go
@@ -17,7 +17,7 @@ import (
 // The format string will be reproduced ad litteram in the report; the arguments
 // will be sanitized.
 func SendReport(ctx context.Context, sv *settings.Values, err error) {
-	if !logcrash.ShouldSendReport(sv) {
+	if !logcrash.ShouldSendReport(sv, err) {
 		return
 	}
 	event, extraDetails := errors.BuildSentryReport(err)


### PR DESCRIPTION
Release note: None