### PR TITLE
logictest: skip upsert_non_metamorphic under race

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
+++ b/pkg/sql/logictest/testdata/logic_test/upsert_non_metamorphic
@@ -1,5 +1,7 @@
 # LogicTest: !metamorphic-batch-sizes
 
+skip under race
+
 # Regression test for UPSERT batching logic not respecting footprint-based
 # limiting (#102472).
 statement ok


### PR DESCRIPTION
This test runs a large mutation (6MB in size), and we've seen a couple overload-related failures under race, so let's skip it in that config.

Fixes: #148648.

Release note: None