### PR TITLE
allocator: hoist some calls to Locality

### DIFF
--- a/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
+++ b/pkg/kv/kvserver/allocator/allocatorimpl/allocator_scorer.go
@@ -1159,7 +1159,7 @@ func rankedCandidateListForAllocation(
 			continue
 		}
 
-		diversityScore := diversityAllocateScore(s, existingStoreLocalities)
+		diversityScore := diversityAllocateScore(s.Locality(), existingStoreLocalities)
 		balanceScore := options.balanceScore(validStoreList, s.Capacity)
 		var hasNonVoter bool
 		if targetType == VoterTarget {
@@ -1656,9 +1656,10 @@ func rankedCandidateListForRebalancing(
 			// this stage, in additon to hard checks and validation.
 			// TODO(kvoli,ayushshah15): Refactor this to make it harder to
 			// inadvertently break the invariant above,
+			locality := store.Locality()
 			constraintsOK, necessary, voterNecessary := rebalanceConstraintsChecker(store, existing.store)
 			diversityScore := diversityRebalanceFromScore(
-				store, existing.store.StoreID, existingStoreLocalities)
+				locality, existing.store.StoreID, existingStoreLocalities)
 			cand := candidate{
 				store:          store,
 				valid:          constraintsOK,
@@ -1676,7 +1677,7 @@ func rankedCandidateListForRebalancing(
 						"s%d: should-rebalance(necessary/diversity=s%d): oldNecessary:%t, newNecessary:%t, "+
 							"oldDiversity:%f, newDiversity:%f, locality:%q",
 						existing.store.StoreID, store.StoreID, existing.necessary, cand.necessary,
-						existing.diversityScore, cand.diversityScore, store.Locality())
+						existing.diversityScore, cand.diversityScore, locality)
 				}
 			}
 		}
@@ -2236,7 +2237,7 @@ func RangeDiversityScore(existingStoreLocalities map[roachpb.StoreID]roachpb.Loc
 // desirable it would be to add a replica to store. A higher score means the
 // store is a better fit.
 func diversityAllocateScore(
-	store roachpb.StoreDescriptor, existingStoreLocalities map[roachpb.StoreID]roachpb.Locality,
+	storeLocality roachpb.Locality, existingStoreLocalities map[roachpb.StoreID]roachpb.Locality,
 ) float64 {
 	var sumScore float64
 	var numSamples int
@@ -2245,7 +2246,7 @@ func diversityAllocateScore(
 	// consider adding the pairwise average diversity of the existing replicas
 	// is the same.
 	for _, locality := range existingStoreLocalities {
-		newScore := store.Locality().DiversityScore(locality)
+		newScore := storeLocality.DiversityScore(locality)
 		sumScore += newScore
 		numSamples++
 	}
@@ -2296,8 +2297,9 @@ func diversityRebalanceScore(
 	var maxScore float64
 	// For every existing node, calculate what the diversity score would be if we
 	// remove that node's replica to replace it with one on the provided store.
+	storeLocality := store.Locality()
 	for removedStoreID := range existingStoreLocalities {
-		score := diversityRebalanceFromScore(store, removedStoreID, existingStoreLocalities)
+		score := diversityRebalanceFromScore(storeLocality, removedStoreID, existingStoreLocalities)
 		if score > maxScore {
 			maxScore = score
 		}
@@ -2312,7 +2314,7 @@ func diversityRebalanceScore(
 // A higher score indicates that the provided store is a better fit for the
 // range.
 func diversityRebalanceFromScore(
-	store roachpb.StoreDescriptor,
+	storeLocality roachpb.Locality,
 	fromStoreID roachpb.StoreID,
 	existingStoreLocalities map[roachpb.StoreID]roachpb.Locality,
 ) float64 {
@@ -2324,7 +2326,7 @@ func diversityRebalanceFromScore(
 		if storeID == fromStoreID {
 			continue
 		}
-		newScore := store.Locality().DiversityScore(locality)
+		newScore := storeLocality.DiversityScore(locality)
 		sumScore += newScore
 		numSamples++
 		for otherStoreID, otherLocality := range existingStoreLocalities {


### PR DESCRIPTION
store.Locality() allocates. Previously we were calling this inside an double-nested loop in diversityRebalanceScore which itself is called in a loop.

This is probably just a drop in the bucket given how much is going on in the callers of this function, but perhaps it helps a bit:

    BenchmarkRebalanceToDiversityScore        427075              2734 ns/op            1920 B/op         12 allocs/op
    BenchmarkRebalanceToDiversityScore        904476              1443 ns/op             160 B/op          1 allocs/op

Informs #147800

Release note: None