### PR TITLE
catalog/lease: handle range feed recovery for dropped descriptors

### DIFF
--- a/pkg/sql/catalog/lease/lease.go
+++ b/pkg/sql/catalog/lease/lease.go
@@ -2052,7 +2052,7 @@ func (m *Manager) refreshSomeLeases(ctx context.Context, refreshAndPurgeAllDescr
 				if _, err := acquireNodeLease(ctx, m, id, AcquireBackground); err != nil {
 					log.Errorf(ctx, "refreshing descriptor: %d lease failed: %s", id, err)
 
-					if errors.Is(err, catalog.ErrDescriptorNotFound) {
+					if errors.Is(err, catalog.ErrDescriptorNotFound) || errors.Is(err, catalog.ErrDescriptorDropped) {
 						// Lease renewal failed due to removed descriptor; Remove this descriptor from cache.
 						if err := purgeOldVersions(
 							ctx, m.storage.db.KV(), id, true /* dropped */, 0 /* minVersion */, m,


### PR DESCRIPTION
Previously, when range feed recovery was executed by the lease manager, the operation would handle missing descriptors by removing them. However, it also needs to gracefully handle dropped descriptors in the same way, since dropped descriptors cannot be leased. This patch updates the recovery process and adds a test to confirm that dropped descriptors are correctly released by the lease manager.

Fixes: #148598
Fixes: #148273
Fixes: #146536
Fixes: https://github.com/cockroachdb/cockroach/issues/146741

Release note: None