### PR TITLE
release-25.2: roachtest: mark psycopg test as flaky

### DIFF
--- a/pkg/cmd/roachtest/tests/psycopg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/psycopg_blocklist.go
@@ -24,6 +24,7 @@ var psycopgIgnoreList = blocklist{
 	`tests.pool.test_pool.test_reconnect_after_grow_failed`:                                          "requires insecure mode",
 	`tests.pool.test_pool.test_reconnect_failure[False]`:                                             "requires insecure mode",
 	`tests.pool.test_pool.test_refill_on_check`:                                                      "requires insecure mode",
+	`tests.pool.test_pool.test_shrink`:                                                               "flaky; see #146895",
 	`tests.pool.test_pool.test_stats_connect`:                                                        "requires insecure mode",
 	`tests.pool.test_pool_async.test_connect_check_timeout[asyncio]`:                                 "requires insecure mode",
 	`tests.pool.test_pool_async.test_reconnect[asyncio]`:                                             "requires insecure mode",


### PR DESCRIPTION
Backport 1/1 commits from #148695 on behalf of @rafiss.

----

fixes https://github.com/cockroachdb/cockroach/issues/148343
fixes https://github.com/cockroachdb/cockroach/issues/146895

Release note: None

----

Release justification: test only change