### PR TITLE
failureinjection: add disk stall cycle option

### DIFF
--- a/pkg/cmd/roachtest/operations/disk_stall.go
+++ b/pkg/cmd/roachtest/operations/disk_stall.go
@@ -24,7 +24,9 @@ type cleanupDiskStall struct {
 }
 
 func (cl *cleanupDiskStall) Cleanup(ctx context.Context, o operation.Operation, c cluster.Cluster) {
-	cl.staller.Unstall(ctx, cl.nodes)
+	if err := cl.staller.Unstall(ctx, cl.nodes); err != nil {
+		o.Fatalf("failed to unstall disk: %v", err)
+	}
 	o.Status("unstalled nodes; waiting 10 seconds before restarting")
 	time.Sleep(10 * time.Second)
 	// We might need to restart the node if it isn't live.

--- a/pkg/cmd/roachtest/roachtestutil/disk_stall.go
+++ b/pkg/cmd/roachtest/roachtestutil/disk_stall.go
@@ -14,6 +14,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
+	"github.com/cockroachdb/errors"
 )
 
 // TODO(darryl): Once the failure injection library is a first class citizen of roachtest,
@@ -25,7 +26,7 @@ type DiskStaller interface {
 	Stall(ctx context.Context, nodes option.NodeListOption)
 	StallCycle(ctx context.Context, nodes option.NodeListOption, stallDuration, unstallDuration time.Duration)
 	Slow(ctx context.Context, nodes option.NodeListOption, bytesPerSecond int)
-	Unstall(ctx context.Context, nodes option.NodeListOption)
+	Unstall(ctx context.Context, nodes option.NodeListOption) error
 	DataDir() string
 	LogDir() string
 }
@@ -34,16 +35,17 @@ type NoopDiskStaller struct{}
 
 var _ DiskStaller = NoopDiskStaller{}
 
-func (n NoopDiskStaller) Cleanup(ctx context.Context)                                               {}
-func (n NoopDiskStaller) DataDir() string                                                           { return "{store-dir}" }
-func (n NoopDiskStaller) LogDir() string                                                            { return "logs" }
-func (n NoopDiskStaller) Setup(ctx context.Context)                                                 {}
-func (n NoopDiskStaller) Slow(_ context.Context, _ option.NodeListOption, _ int)                    {}
-func (n NoopDiskStaller) Stall(_ context.Context, _ option.NodeListOption)                          {}
+func (n NoopDiskStaller) Cleanup(ctx context.Context)                            {}
+func (n NoopDiskStaller) DataDir() string                                        { return "{store-dir}" }
+func (n NoopDiskStaller) LogDir() string                                         { return "logs" }
+func (n NoopDiskStaller) Setup(ctx context.Context)                              {}
+func (n NoopDiskStaller) Slow(_ context.Context, _ option.NodeListOption, _ int) {}
+func (n NoopDiskStaller) Stall(_ context.Context, _ option.NodeListOption)       {}
 func (n NoopDiskStaller) StallCycle(
 	_ context.Context, _ option.NodeListOption, _, _ time.Duration,
-) {}
-func (n NoopDiskStaller) Unstall(_ context.Context, _ option.NodeListOption)                        {}
+) {
+}
+func (n NoopDiskStaller) Unstall(_ context.Context, _ option.NodeListOption) error { return nil }
 
 type Fataler interface {
 	Fatal(args ...interface{})
@@ -140,11 +142,12 @@ func (s *cgroupDiskStaller) Slow(
 	}
 }
 
-func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
+func (s *cgroupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) error {
 	l := newDiskStallLogger(s.f.L(), nodes, "Unstall")
-	if err := s.Failer.Recover(ctx, l); err != nil {
-		s.f.Fatalf("failed to unstall disk: %s", err)
-	}
+	// cgroup may fail when unstalling the disk, usually because the node already
+	// fataled and the cgroup is no longer available. Return the error and let
+	// the caller decide if a node fatal is expected or not.
+	return errors.Wrap(s.Failer.Recover(ctx, l), "failed to unstall disk")
 }
 
 type dmsetupDiskStaller struct {
@@ -211,11 +214,13 @@ func (s *dmsetupDiskStaller) Slow(
 	s.f.Fatal("Slow is not supported for dmsetupDiskStaller")
 }
 
-func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) {
+func (s *dmsetupDiskStaller) Unstall(ctx context.Context, nodes option.NodeListOption) error {
 	l := newDiskStallLogger(s.f.L(), nodes, "Unstall")
+	// Any unstall error for dmsetup is unexpected and should fail the test.
 	if err := s.Failer.Recover(ctx, l); err != nil {
 		s.f.Fatalf("failed to unstall disk: %s", err)
 	}
+	return nil
 }
 
 func (s *dmsetupDiskStaller) DataDir() string { return "{store-dir}" }

--- a/pkg/cmd/roachtest/tests/disk_stall.go
+++ b/pkg/cmd/roachtest/tests/disk_stall.go
@@ -462,7 +462,11 @@ func runDiskStalledWALFailoverWithProgress(ctx context.Context, t test.Test, c c
 	// Use CgroupDiskStaller with readsToo=false to only stall writes.
 	s := roachtestutil.MakeCgroupDiskStaller(t, c, false /* readsToo */, false /* logsToo */)
 	s.Setup(ctx)
-	defer s.Cleanup(ctx)
+	// NB: We use a background context in the defer'ed cleanup command,
+	// otherwise on test failure our c.Run calls will be ignored. Leaving
+	// the disk stalled will prevent artifact collection, making debugging
+	// difficult.
+	defer s.Cleanup(context.Background())
 
 	t.Status("starting cluster")
 	startOpts := option.DefaultStartOpts()
@@ -612,36 +616,15 @@ func runDiskStalledWALFailoverWithProgress(ctx context.Context, t test.Test, c c
 				case <-time.After(diskStallWaitDur):
 					t.Status("starting disk stall")
 				}
-				stallStart := timeutil.Now()
-				// Execute short 200ms stalls every 5s.
-				for timeutil.Since(stallStart) < operationDur {
-					select {
-					case <-ctx.Done():
-						t.Fatalf("context done while stall induced: %s", ctx.Err())
-					case <-time.After(stallInterval):
-						func() {
-							t.Status("short disk stall on n1")
-							s.Stall(ctx, c.Node(1))
-							defer func() {
-								// NB: We use a background context in the defer'ed unstall command,
-								// otherwise on test failure our Unstall calls will be ignored. Leaving
-								// the disk stalled will prevent artifact collection, making debugging
-								// difficult.
-								ctx, cancel := context.WithTimeout(context.Background(), time.Minute)
-								defer cancel()
-								s.Unstall(ctx, c.Node(1))
-								t.Status("unstalled disk on n1")
-							}()
-							select {
-							case <-ctx.Done():
-								t.Fatalf("context done while stall induced: %s", ctx.Err())
-							case <-time.After(shortStallDur):
-								return
-							}
-						}()
-					}
+				// Execute short 200ms stalls every 5s for 3 minutes.
+				s.StallCycle(ctx, c.Node(1), shortStallDur, stallInterval)
+				select {
+				case <-ctx.Done():
+					t.Fatalf("context done while stall induced: %s", ctx.Err())
+				case <-time.After(operationDur):
+					s.Unstall(ctx, c.Node(1))
+					t.Status("disk stalls stopped")
 				}
-
 				return nil
 			}, task.Name("disk-stall-phase"))
 		} else {

--- a/pkg/cmd/roachtest/tests/failover.go
+++ b/pkg/cmd/roachtest/tests/failover.go
@@ -1605,7 +1605,6 @@ func (f *diskStallFailer) Setup(ctx context.Context) {
 }
 
 func (f *diskStallFailer) Cleanup(ctx context.Context) {
-	f.staller.Unstall(ctx, f.c.All())
 	// We have to stop the cluster before cleaning up the staller.
 	f.m.ExpectDeaths(int32(f.c.Spec().NodeCount))
 	f.c.Stop(ctx, f.t.L(), option.DefaultStopOpts(), f.c.All())
@@ -1628,7 +1627,9 @@ func (f *diskStallFailer) Fail(ctx context.Context, nodeID int) {
 }
 
 func (f *diskStallFailer) Recover(ctx context.Context, nodeID int) {
-	f.staller.Unstall(ctx, f.c.Node(nodeID))
+	if err := f.staller.Unstall(ctx, f.c.Node(nodeID)); err != nil {
+		f.t.Fatalf("failed to unstall disk %v", err)
+	}
 	// Pebble's disk stall detector should have terminated the node, but in case
 	// it didn't, we explicitly stop it first.
 	f.c.Stop(ctx, f.t.L(), option.DefaultStopOpts(), f.c.Node(nodeID))

--- a/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
+++ b/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
@@ -80,7 +80,9 @@ func (s *slowDisk) startPerturbation(ctx context.Context, t test.Test, v variati
 
 // endPerturbation implements perturbation.
 func (s *slowDisk) endPerturbation(ctx context.Context, t test.Test, v variations) time.Duration {
-	s.staller.Unstall(ctx, v.targetNodes())
+	if err := s.staller.Unstall(ctx, v.targetNodes()); err != nil {
+		t.Fatal("failed to unstall disk:", err)
+	}
 	waitDuration(ctx, v.validationDuration)
 	return v.validationDuration
 }

--- a/pkg/roachprod/failureinjection/failures/disk_stall.go
+++ b/pkg/roachprod/failureinjection/failures/disk_stall.go
@@ -27,6 +27,10 @@ const CgroupsDiskStallName = "cgroup-disk-stall"
 
 type CGroupDiskStaller struct {
 	GenericFailure
+	// Used in conjunction with the `Cycle` option to manage the
+	// async script.
+	waitCh      <-chan error
+	cancelCycle func()
 }
 
 func MakeCgroupDiskStaller(
@@ -57,6 +61,16 @@ type DiskStallArgs struct {
 	// only supports fully stalling reads/writes.
 	Throughput int
 	Nodes      install.Nodes
+	// If true, the failure mode will repeatedly stall and unstall the disk
+	// until recovered. The duration of the stall and unstall cycles is 5 seconds
+	// by default but can be configured with the CycleStallDuration and
+	// CycleUnstallDuration args.
+	//
+	// N.B. Because this is run asynchronously, any script errors will only be
+	// logged instead of returned.
+	Cycle                bool
+	CycleStallDuration   time.Duration
+	CycleUnstallDuration time.Duration
 }
 
 func (s *CGroupDiskStaller) Description() string {
@@ -116,27 +130,20 @@ fi
 }
 func (s *CGroupDiskStaller) Cleanup(ctx context.Context, l *logger.Logger, args FailureArgs) error {
 	diskStallArgs := args.(DiskStallArgs)
-	stallType := []bandwidthType{readBandwidth, writeBandwidth}
 	nodes := diskStallArgs.Nodes
 
-	// Setting cgroup limits is idempotent so attempt to unlimit reads/writes in case
-	// something went wrong in Recover.
-	err := s.setThroughput(ctx, l, stallType, throughput{limited: false}, nodes, cockroachIOController)
-	if err != nil {
-		l.PrintfCtx(ctx, "error unstalling the disk; stumbling on: %v", err)
-	}
 	if args.(DiskStallArgs).StallLogs {
 		// Cleanup our symlinked logs. Similar to Setup(), we must first stop the cluster
 		// to stop the cockroach process from concurrently writing to the logs directory.
-		if err = s.Run(ctx, l, nodes, "unlink logs"); err != nil {
+		if err := s.Run(ctx, l, nodes, "unlink logs"); err != nil {
 			return err
 		}
 		if diskStallArgs.RestartNodes {
-			if err = s.StopCluster(ctx, l, roachprod.DefaultStopOpts()); err != nil {
+			if err := s.StopCluster(ctx, l, roachprod.DefaultStopOpts()); err != nil {
 				return err
 			}
 		}
-		if err = s.Run(ctx, l, nodes, "cp -r {store-dir}/logs logs"); err != nil {
+		if err := s.Run(ctx, l, nodes, "cp -r {store-dir}/logs logs"); err != nil {
 			return err
 		}
 		if diskStallArgs.RestartNodes {
@@ -207,12 +214,22 @@ func (s *CGroupDiskStaller) Inject(ctx context.Context, l *logger.Logger, args F
 		}
 	}()
 
-	l.Printf("stalling disk I/O on nodes %d", nodes)
-	if err := s.setThroughput(ctx, l, stallTypes, throughput{limited: true, bytesPerSecond: fmt.Sprintf("%d", bytesPerSecond)}, nodes, cockroachIOController); err != nil {
+	stallCmd, err := s.setThroughputCmd(ctx, l, stallTypes, throughput{limited: true, bytesPerSecond: fmt.Sprintf("%d", bytesPerSecond)}, cockroachIOController)
+	if err != nil {
 		return err
 	}
 
-	return nil
+	if diskStallArgs.Cycle {
+		unstallCmd, err := s.setThroughputCmd(ctx, l, stallTypes, throughput{limited: false}, cockroachIOController)
+		if err != nil {
+			return err
+		}
+		s.waitCh, s.cancelCycle = s.stallCycle(ctx, l, diskStallArgs, stallCmd, unstallCmd)
+		return nil
+	}
+
+	l.Printf("stalling disk I/O on nodes %d", nodes)
+	return s.Run(ctx, l, nodes, stallCmd)
 }
 
 func (s *CGroupDiskStaller) Recover(ctx context.Context, l *logger.Logger, args FailureArgs) error {
@@ -226,12 +243,41 @@ func (s *CGroupDiskStaller) Recover(ctx context.Context, l *logger.Logger, args 
 
 	cockroachIOController := filepath.Join("/sys/fs/cgroup/system.slice", install.VirtualClusterLabel(install.SystemInterfaceName, 0)+".service", "io.max")
 
+	// If we are running an async disk stall cycle script, cancel the script and
+	// block until it returns.
+	if diskStallArgs.Cycle {
+		l.Printf("stopping disk stall cycle on nodes %d", nodes)
+		s.cancelCycle()
+		select {
+		case err = <-s.waitCh:
+			// We expect this to finish with a context canceled error, but log
+			// it anyway in case the script exited early.
+			l.Printf("disk stall cycle script finished with error: %v", err)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	l.Printf("unstalling disk I/O on nodes %d", nodes)
 	// N.B. cgroups v2 relies on systemd running, however if our disk stall
 	// was injected for too long, the cockroach process will detect a disk stall
 	// and exit. This deletes the cockroach service and there is no need to
-	// unlimit anything. Instead, restart the node if RestartNodes is true.
-	err = s.setThroughput(ctx, l, stallTypes, throughput{limited: false}, nodes, cockroachIOController)
+	// unlimit anything.
+	cmd, err := s.setThroughputCmd(ctx, l, stallTypes, throughput{limited: false}, cockroachIOController)
+	if err != nil {
+		return err
+	}
+	err = s.Run(ctx, l, diskStallArgs.Nodes, cmd)
+
+	// If we aren't restarting nodes, then return the error we encountered attempting to
+	// unstall the disk.
+	if !diskStallArgs.RestartNodes {
+		return err
+	}
+
+	// If we are restarting nodes, then we assume the failure above is because
+	// the disk stall was injected too long, and it was an expected death. Restart
+	// any dead nodes.
 	return forEachNode(diskStallArgs.Nodes, func(n install.Nodes) error {
 		err = s.Run(ctx, l, n, "cat", cockroachIOController)
 		if err != nil && diskStallArgs.RestartNodes {
@@ -245,6 +291,11 @@ func (s *CGroupDiskStaller) Recover(ctx context.Context, l *logger.Logger, args 
 func (s *CGroupDiskStaller) WaitForFailureToPropagate(
 	ctx context.Context, l *logger.Logger, args FailureArgs,
 ) error {
+	if args.(DiskStallArgs).Cycle {
+		l.Printf("Stall cycle is enabled, skipping WaitForFailureToPropagate")
+		return nil
+	}
+
 	diskStallArgs := args.(DiskStallArgs)
 	if diskStallArgs.StallWrites {
 		// If writes are stalled, we expect the disk stall detection to kick in
@@ -288,17 +339,16 @@ func (rw bandwidthType) cgroupV2BandwidthProp() string {
 	}
 }
 
-func (s *CGroupDiskStaller) setThroughput(
+func (s *CGroupDiskStaller) setThroughputCmd(
 	ctx context.Context,
 	l *logger.Logger,
 	readOrWrite []bandwidthType,
 	bw throughput,
-	nodes install.Nodes,
 	cockroachIOController string,
-) error {
+) (string, error) {
 	maj, min, err := s.DiskDeviceMajorMinor(ctx, l)
 	if err != nil {
-		return err
+		return "", err
 	}
 
 	var limits []string
@@ -311,13 +361,12 @@ func (s *CGroupDiskStaller) setThroughput(
 	}
 	l.Printf("setting cgroup bandwith limits:\n%v", limits)
 
-	return s.Run(ctx, l, nodes, "sudo", "/bin/bash", "-c", fmt.Sprintf(
-		`'echo %d:%d %s > %s'`,
+	return fmt.Sprintf("sudo /bin/bash -c 'echo %d:%d %s > %s'",
 		maj,
 		min,
 		strings.Join(limits, " "),
 		cockroachIOController,
-	))
+	), nil
 }
 
 // GetReadWriteBytes parses the io.stat file to get the number of bytes read and written.
@@ -356,10 +405,18 @@ func (s *CGroupDiskStaller) GetReadWriteBytes(
 	return readBytes, writeBytes, nil
 }
 
-const DmsetupDiskStallName = "dmsetup-disk-stall"
+const (
+	DmsetupDiskStallName = "dmsetup-disk-stall"
+	dmsetupStallCmd      = "sudo dmsetup suspend --noflush --nolockfs data1"
+	dmsetupUnstallCmd    = "sudo dmsetup resume data1"
+)
 
 type DmsetupDiskStaller struct {
 	GenericFailure
+	// Used in conjunction with the `Cycle` option to manage the
+	// async script.
+	waitCh      <-chan error
+	cancelCycle func()
 }
 
 func MakeDmsetupDiskStaller(
@@ -442,7 +499,12 @@ func (s *DmsetupDiskStaller) Setup(ctx context.Context, l *logger.Logger, args F
 func (s *DmsetupDiskStaller) Inject(ctx context.Context, l *logger.Logger, args FailureArgs) error {
 	nodes := args.(DiskStallArgs).Nodes
 	l.Printf("stalling disk I/O on nodes %d", nodes)
-	return s.Run(ctx, l, nodes, `sudo dmsetup suspend --noflush --nolockfs data1`)
+	if args.(DiskStallArgs).Cycle {
+		s.waitCh, s.cancelCycle = s.stallCycle(ctx, l, args.(DiskStallArgs), dmsetupStallCmd, dmsetupUnstallCmd)
+		return nil
+	}
+
+	return s.Run(ctx, l, nodes, dmsetupStallCmd)
 }
 
 func (s *DmsetupDiskStaller) Recover(
@@ -450,19 +512,40 @@ func (s *DmsetupDiskStaller) Recover(
 ) error {
 	diskStallArgs := args.(DiskStallArgs)
 	nodes := diskStallArgs.Nodes
+
+	// If we are running an async disk stall cycle script, cancel the script and
+	// block until it returns.
+	if diskStallArgs.Cycle {
+		l.Printf("stopping disk stall cycle on nodes %d", nodes)
+		s.cancelCycle()
+		select {
+		case err := <-s.waitCh:
+			// We expect this to finish with a context canceled error, but log
+			// it anyway in case the script exited early.
+			l.Printf("disk stall cycle script finished with error: %v", err)
+		case <-ctx.Done():
+			return ctx.Err()
+		}
+	}
+
 	l.Printf("unstalling disk I/O on nodes %d", nodes)
 	if err := s.Run(ctx, l, nodes, `sudo dmsetup resume data1`); err != nil {
 		return err
 	}
-	// If the disk stall was injected for long enough that the cockroach process
-	// detected it and shut down the node, then restart it.
-	return forEachNode(nodes, func(n install.Nodes) error {
-		if err := s.PingNode(ctx, l, n); err != nil && diskStallArgs.RestartNodes {
-			l.Printf("failed to connect to n%d, assuming node exited and restarting: %v", n, err)
-			return s.StartNodes(ctx, l, n)
-		}
-		return nil
-	})
+
+	if diskStallArgs.RestartNodes {
+		// If the disk stall was injected for long enough that the cockroach process
+		// detected it and shut down the node, then restart it.
+		return forEachNode(nodes, func(n install.Nodes) error {
+			if err := s.PingNode(ctx, l, n); err != nil {
+				l.Printf("failed to connect to n%d, assuming node exited and restarting: %v", n, err)
+				return s.StartNodes(ctx, l, n)
+			}
+			return nil
+		})
+	}
+
+	return nil
 }
 
 func (s *DmsetupDiskStaller) Cleanup(
@@ -522,13 +605,15 @@ func (s *DmsetupDiskStaller) Cleanup(
 func (s *DmsetupDiskStaller) WaitForFailureToPropagate(
 	ctx context.Context, l *logger.Logger, args FailureArgs,
 ) error {
+	if args.(DiskStallArgs).Cycle {
+		l.Printf("Stall cycle is enabled, skipping WaitForFailureToPropagate")
+		return nil
+	}
 	nodes := args.(DiskStallArgs).Nodes
+	// Since writes are stalled for dmsetup, we expect the disk stall detection to kick in
+	// and eventually kill the node.
 	return forEachNode(nodes, func(n install.Nodes) error {
-		// If writes are stalled, we expect the disk stall detection to kick in
-		// and kill the node.
-		return forEachNode(nodes, func(n install.Nodes) error {
-			return s.WaitForSQLUnavailable(ctx, l, n, 3*time.Minute)
-		})
+		return s.WaitForSQLUnavailable(ctx, l, n, 3*time.Minute)
 	})
 }
 
@@ -538,5 +623,56 @@ func (s *DmsetupDiskStaller) WaitForFailureToRecover(
 	nodes := args.(DiskStallArgs).Nodes
 	return forEachNode(nodes, func(n install.Nodes) error {
 		return s.WaitForSQLReady(ctx, l, n, time.Minute)
+	})
+}
+
+// stallCycle asynchronously runs a script in the background that repeatedly stalls and
+// unstalls the disk. It returns an error channel that returns any errors encountered
+// while running the script, and a cancel function to stop the script.
+func (f *GenericFailure) stallCycle(
+	ctx context.Context, l *logger.Logger, args DiskStallArgs, stallCmd, unstallCmd string,
+) (<-chan error, func()) {
+	// By default, induce stalls in 5 second intervals.
+	stallSleep, unstallSleep := float64(5*time.Second.Milliseconds()), float64(5*time.Second.Milliseconds())
+	if args.CycleStallDuration > 0 {
+		stallSleep = float64(args.CycleStallDuration.Milliseconds())
+	}
+	if args.CycleUnstallDuration > 0 {
+		unstallSleep = float64(args.CycleUnstallDuration.Milliseconds())
+	}
+
+	// `time sleep` accepts fractional seconds, but not milliseconds.
+	stallSleep /= 1000
+	unstallSleep /= 1000
+
+	cycleCmd := fmt.Sprintf(
+		`
+stall() {
+  %[1]s
+  echo "$(date '+%%Y-%%m-%%d %%H:%%M:%%S.%%3N'): disk stalled for %[2]f seconds"
+}
+
+unstall() {
+  %[3]s
+  echo "$(date '+%%Y-%%m-%%d %%H:%%M:%%S.%%3N'): disk unstalled for %[4]f seconds"
+}
+
+# Always attempt to unstall on script exit. We don't rely on Recover()
+# as unstalling a disk stall is time sensitive and waiting too long
+# may cause the node to fatal.
+trap 'unstall' EXIT INT TERM HUP
+
+while true; do
+  stall
+	time sleep %[2]f
+  unstall
+	time sleep %[4]f
+done
+`, stallCmd, stallSleep, unstallCmd, unstallSleep)
+
+	l.Printf("starting disk stall cycle on nodes %d", args.Nodes)
+
+	return runAsync(ctx, l, func(ctx context.Context) error {
+		return f.Run(ctx, l, args.Nodes, cycleCmd)
 	})
 }

--- a/pkg/roachprod/failureinjection/failures/failure.go
+++ b/pkg/roachprod/failureinjection/failures/failure.go
@@ -285,14 +285,18 @@ func forEachNode(nodes install.Nodes, fn func(install.Nodes) error) error {
 	return nil
 }
 
-func runAsync(ctx context.Context, l *logger.Logger, f func(context.Context) error) <-chan error {
+func runAsync(
+	ctx context.Context, l *logger.Logger, f func(context.Context) error,
+) (<-chan error, func()) {
 	errCh := make(chan error, 1)
+	asyncCtx, cancel := context.WithCancel(ctx)
 	go func() {
-		err := roachprodutil.PanicAsError(ctx, l, func(context.Context) error {
-			return f(ctx)
+		defer cancel()
+		err := roachprodutil.PanicAsError(asyncCtx, l, func(context.Context) error {
+			return f(asyncCtx)
 		})
 		errCh <- err
 		close(errCh)
 	}()
-	return errCh
+	return errCh, cancel
 }

--- a/pkg/roachprod/failureinjection/failures/process_kill.go
+++ b/pkg/roachprod/failureinjection/failures/process_kill.go
@@ -87,7 +87,7 @@ func (f *ProcessKillFailure) Inject(ctx context.Context, l *logger.Logger, args 
 	// WaitForFailureToPropagate. We run Stop in a goroutine to achieve this, although it
 	// does mean we will ignore all errors unless the user also calls WaitForFailureToPropagate.
 	// We make this tradeoff in order to avoid maintaining two different Stop implementations.
-	f.waitCh = runAsync(ctx, l, func(ctx context.Context) error {
+	f.waitCh, _ = runAsync(ctx, l, func(ctx context.Context) error {
 		return f.c.WithNodes(nodes).Stop(ctx, l, int(signal), true, gracePeriod, label)
 	})
 	return nil


### PR DESCRIPTION
Some usages of disk stalls wish to repeatedly stall and unstall a disk in a short period of time. The current implementation requires an ssh connection per stall/unstall call, which can easily lead to flakes. e.g. the unstall call runs into an ssh flake and the node fatals before it can be recovered.

This change adds a disk stall cycle option which will do this in one single ssh connection until Recover is called.

Fixes: https://github.com/cockroachdb/cockroach/issues/148345
Release note: none