### PR TITLE
kvserver: introduce TestStoreRangeSplitRaftSnapshotAfterRHSRebalanced 

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -576,6 +576,7 @@ go_test(
         "@com_github_stretchr_testify//require",
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",
+        "@org_golang_x_exp//maps",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//syncmap",
     ],


### PR DESCRIPTION
This patch adds a new test,
TestStoreRangeSplitRaftSnapshotAfterRHSRebalanced, to show the hazard
described in https://github.com/cockroachdb/cockroach/issues/73462 is legit. In particular, when a replica learns about
a split through a snapshot after the post-split RHS has been rebalanced
away, we leak the RHS's on-disk data.

References https://github.com/cockroachdb/cockroach/issues/73462

Release note: None