### PR TITLE
release-25.2: kvcoord: fix memory leak on rollbacks in txnWriteBuffer in some cases

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -588,6 +588,12 @@ func (twb *txnWriteBuffer) rollbackToSavepointLocked(ctx context.Context, s save
 		// Update size bookkeeping for the values we're rolling back.
 		for i := idx; i < len(bufferedVals); i++ {
 			twb.bufferSize -= bufferedVals[i].size()
+			// Lose reference to the value since we're no longer tracking its
+			// memory footprint.
+			// TODO(yuzefovich): we also decremented the buffer size by the
+			// struct overhead, yet we keep reusing the same slice, so we have
+			// some slop in accounting.
+			bufferedVals[i] = bufferedValue{}
 		}
 		// Rollback writes by truncating the buffered values.
 		it.Cur().vals = bufferedVals[:idx]


### PR DESCRIPTION
Backport 1/1 commits from #148708 on behalf of @yuzefovich.

----

Whenever we perform a rollback of the txnWriteBuffer, we need to remove buffered values that are at or above the given sequence number. If the whole buffered write is being rolled back, we delete it proper, but if only some buffered values are rolled back, then we only remove them but keep the `bufferedWrite`. Previously, we would decrement the buffer size accordingly but forgot to also unset the `bufferedValue`s that could be of non-trivial size. This is now fixed.

Epic: None
Release note: None

----

Release justification: low-risk bug fix.