### PR TITLE
vecstorepb: remove unused proto import

### DIFF
--- a/pkg/sql/vecindex/vecstore/vecstorepb/BUILD.bazel
+++ b/pkg/sql/vecindex/vecstore/vecstorepb/BUILD.bazel
@@ -8,7 +8,6 @@ proto_library(
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/sql/catalog/descpb:descpb_proto",
         "//pkg/sql/catalog/fetchpb:fetchpb_proto",
         "@com_github_gogo_protobuf//gogoproto:gogo_proto",
     ],
@@ -21,7 +20,6 @@ go_proto_library(
     proto = ":vecstorepb_proto",
     visibility = ["//visibility:public"],
     deps = [
-        "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/fetchpb",
         "@com_github_gogo_protobuf//gogoproto",
     ],
@@ -29,7 +27,9 @@ go_proto_library(
 
 go_library(
     name = "vecstorepb",
+    srcs = ["fullvecfetchspec.go"],
     embed = [":vecstorepb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore/vecstorepb",
     visibility = ["//visibility:public"],
+    deps = ["//pkg/sql/catalog/descpb"],
 )

--- a/pkg/sql/vecindex/vecstore/vecstorepb/fullvecfetchspec.go
+++ b/pkg/sql/vecindex/vecstore/vecstorepb/fullvecfetchspec.go
@@ -1,0 +1,11 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package vecstorepb
+
+import "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
+
+// Import descpb package for the cast in the generated protobuf code.
+var _ descpb.FamilyID

--- a/pkg/sql/vecindex/vecstore/vecstorepb/fullvecfetchspec.proto
+++ b/pkg/sql/vecindex/vecstore/vecstorepb/fullvecfetchspec.proto
@@ -9,7 +9,6 @@ option go_package = "github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore/
 
 import "gogoproto/gogo.proto";
 import "sql/catalog/fetchpb/index_fetch.proto";
-import "sql/catalog/descpb/structured.proto";
 
 option (gogoproto.goproto_getters_all) = false;
 


### PR DESCRIPTION
This commit moves the import of `descpb` package from the proto file to the regular Go file (the proto linter was complaining). We need this package for the cast in the generated protobuf code.

Epic: None
Release note: None