### PR TITLE
sql: version-gate sql.txn.write_buffering_for_weak_isolation.enabled

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
+++ b/pkg/ccl/logictestccl/testdata/logic_test/buffered_writes_lock_loss
@@ -1,4 +1,4 @@
-# LogicTest: !3node-tenant
+# LogicTest: !3node-tenant !local-mixed-25.2
 # cluster-opt: disable-mvcc-range-tombstones-for-point-deletes
 
 statement ok

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 34,
+    shard_count = 33,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
@@ -75,13 +75,6 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
-func TestCCLLogic_buffered_writes_lock_loss(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runCCLLogicTest(t, "buffered_writes_lock_loss")
-}
-
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {

--- a/pkg/sql/txn_state.go
+++ b/pkg/sql/txn_state.go
@@ -241,9 +241,7 @@ func (ts *txnState) resetForNewSQLTxn(
 			if err := ts.setIsolationLevelLocked(isoLevel); err != nil {
 				panic(err)
 			}
-			if isoLevel != isolation.Serializable && !allowBufferedWritesForWeakIsolation.Get(&tranCtx.settings.SV) {
-				// TODO(#143497): we currently only support buffered writes
-				// under serializable isolation.
+			if !bufferedWritesIsAllowedForIsolationLevel(connCtx, tranCtx.settings, isoLevel) {
 				bufferedWritesEnabled = false
 			}
 			if bufferedWritesEnabled {


### PR DESCRIPTION
Buffering writes in weak isolation levels such as read committed requires lock loss detection to avoid intra-statement anomalies.

Lock loss detection is only available when all nodes are on 25.3 or greater.

Epic: none
Release note: None