### PR TITLE
dbworkload: add DDL and YAML generators

### DIFF
--- a/pkg/workload/dbWorkload_go/ddl_generator.go
+++ b/pkg/workload/dbWorkload_go/ddl_generator.go
@@ -1,0 +1,450 @@
+package dbworkloadgo
+
+import (
+	"bufio"
+	"encoding/csv"
+	"fmt"
+	"github.com/cockroachdb/errors"
+	"log"
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+)
+
+// Column stores column level schema information based on input ddl.
+type Column struct {
+	Name         string
+	ColType      string
+	IsNullable   bool
+	IsPrimaryKey bool
+	Default      string
+	IsUnique     bool
+	FKTable      string
+	FKColumn     string
+	InlineCheck  string
+}
+
+// TableSchema stores table level schema information based on input ddl.
+type TableSchema struct {
+	rowCount          int
+	TableName         string
+	Columns           map[string]*Column
+	PrimaryKeys       []string
+	UniqueConstraints [][]string
+	ForeignKeys       [][3]interface{} // (local cols []string, table string, foreign cols []string)
+	CheckConstraints  []string
+	OriginalTable     string
+}
+
+func NewTableSchema(name string, original string) *TableSchema {
+	return &TableSchema{
+		TableName:     name,
+		Columns:       make(map[string]*Column),
+		OriginalTable: original,
+	}
+}
+
+// String function converts the Column schema details into a parsable placeholder.
+func (c *Column) String() string {
+	parts := []string{c.Name, c.ColType}
+	if c.IsNullable {
+		parts = append(parts, "NULL")
+	} else {
+		parts = append(parts, "NOT NULL")
+	}
+	if c.IsPrimaryKey {
+		parts = append(parts, "PRIMARY KEY")
+	}
+	if c.Default != "" {
+		parts = append(parts, "DEFAULT "+c.Default)
+	}
+	if c.IsUnique {
+		parts = append(parts, "UNIQUE")
+	}
+	if c.FKTable != "" && c.FKColumn != "" {
+		parts = append(parts, fmt.Sprintf("FK→%s.%s", c.FKTable, c.FKColumn))
+	}
+	if c.InlineCheck != "" {
+		parts = append(parts, fmt.Sprintf("CHECK(%s)", c.InlineCheck))
+	}
+	return strings.Join(parts, " ")
+}
+
+// String function converts the TableSchema object into a readable format - mostly for symmetry and testing.
+func (ts *TableSchema) String() string {
+	out := []string{fmt.Sprintf("Table: %s", ts.TableName), " Columns:"}
+	for _, col := range ts.Columns {
+		out = append(out, "  "+col.String())
+	}
+	if len(ts.PrimaryKeys) > 0 {
+		out = append(out, " PKs: "+strings.Join(ts.PrimaryKeys, ", "))
+	}
+	if len(ts.UniqueConstraints) > 0 {
+		tmp := []string{}
+		for _, u := range ts.UniqueConstraints {
+			tmp = append(tmp, "("+strings.Join(u, ",")+")")
+		}
+		out = append(out, " UNIQUE: "+strings.Join(tmp, "; "))
+	}
+	if len(ts.ForeignKeys) > 0 {
+		tmp := []string{}
+		for _, fk := range ts.ForeignKeys {
+			l := fk[0].([]string)
+			t := fk[1].(string)
+			f := fk[2].([]string)
+			tmp = append(tmp, fmt.Sprintf("(%s)→%s(%s)", strings.Join(l, ","), t, strings.Join(f, ",")))
+		}
+		out = append(out, " FKs: "+strings.Join(tmp, "; "))
+	}
+	if len(ts.CheckConstraints) > 0 {
+		out = append(out, " CHECKs: "+strings.Join(ts.CheckConstraints, "; "))
+	}
+	return strings.Join(out, "\n") + "\n"
+}
+
+// AddColumn adds a Column to the TableSchema
+func (ts *TableSchema) AddColumn(c *Column) {
+	ts.Columns[c.Name] = c
+}
+
+// SetPrimaryKeys store primary key infirmation at table level
+func (ts *TableSchema) SetPrimaryKeys(pks []string) {
+	ts.PrimaryKeys = pks
+	single := len(pks) == 1
+	//Columns labeled as primary key are all labelled not nullable. Primary key columns are only labeled unique if they are not part of a composite Primary Key
+	for _, pk := range pks {
+		if col, ok := ts.Columns[pk]; ok {
+			col.IsPrimaryKey = true
+			col.IsNullable = false
+			if single {
+				col.IsUnique = true
+			}
+		}
+	}
+}
+
+// ParseDDL converts a "CREATE TABLE ..." DDL statement into a TableSchema.
+func ParseDDL(ddl string) (*TableSchema, error) {
+	ident := `(?:"[^"]+"|[A-Za-z_][\w]*)`
+	fullIdent := fmt.Sprintf(`(%s(?:\.%s){0,2})`, ident, ident)
+	tablePattern := regexp.MustCompile(`(?i)CREATE\s+TABLE(?:\s+IF\s+NOT\s+EXISTS)?\s+` + fullIdent)
+	m := tablePattern.FindStringSubmatch(ddl)
+	if m == nil {
+		return nil, errors.New("no table name")
+	}
+	tableName := m[1]
+	parts := strings.Split(tableName, ".")
+	for i := range parts {
+		parts[i] = strings.Trim(parts[i], `"`)
+	}
+	rawName := tableName
+	tableName = strings.Join(parts, ".")
+	ts := NewTableSchema(tableName, rawName)
+
+	bodyRe := regexp.MustCompile(`(?s)\((.*)\)\s*([^)]*)$`)
+	bodyMatch := bodyRe.FindStringSubmatch(ddl)
+	if bodyMatch == nil {
+		return nil, errors.New("no column block")
+	}
+	body := bodyMatch[1]
+
+	var partsList []string
+	buf := ""
+	depth := 0
+	for _, ch := range body {
+		switch ch {
+		case '(':
+			depth++
+			buf += string(ch)
+		case ')':
+			depth--
+			buf += string(ch)
+		case ',':
+			if depth == 0 {
+				partsList = append(partsList, strings.TrimSpace(buf))
+				buf = ""
+			} else {
+				buf += string(ch)
+			}
+		default:
+			buf += string(ch)
+		}
+	}
+	if strings.TrimSpace(buf) != "" {
+		partsList = append(partsList, strings.TrimSpace(buf))
+	}
+
+	var colDefs, tableConstraints []string
+	for _, p := range partsList {
+		up := strings.ToUpper(strings.TrimSpace(p))
+		if strings.HasPrefix(up, "CONSTRAINT") || strings.HasPrefix(up, "PRIMARY KEY") || strings.HasPrefix(up, "UNIQUE") || strings.HasPrefix(up, "FOREIGN KEY") || strings.HasPrefix(up, "CHECK") || strings.HasPrefix(up, "INDEX") {
+			tableConstraints = append(tableConstraints, p)
+		} else {
+			colDefs = append(colDefs, p)
+		}
+	}
+
+	colPattern := regexp.MustCompile(`(?i)^\s*("?[^"]+"|[\w-]+)"?\s+([^\s]+)(?:\s+(NOT\s+NULL|NULL))?(?:\s+DEFAULT\s+((?:\([^\)]*\)|[^\s,]+)))?(?:\s+PRIMARY\s+KEY)?(?:\s+UNIQUE)?(?:\s+REFERENCES\s+([\w\.]+)\s*\(\s*([\w]+)\s*\))?(?:\s+CHECK\s*\(\s*(.*?)\s*\))?`)
+	inlinePKCols := []string{}
+	for _, cd := range colDefs {
+		m := colPattern.FindStringSubmatch(cd)
+		if m == nil {
+			continue
+		}
+		name := m[1]
+		ctype := m[2]
+		nullSpec := m[3]
+		defVal := m[4]
+		fkTable := m[5]
+		fkCol := m[6]
+
+		inlineCheck := ""
+		checkIdx := regexp.MustCompile(`(?i)\bCHECK\s*\(`).FindStringIndex(cd)
+		if checkIdx != nil {
+			start := checkIdx[1]
+			depth := 1
+			i := start
+			for i < len(cd) && depth > 0 {
+				switch cd[i] {
+				case '(':
+					depth++
+				case ')':
+					depth--
+				}
+				i++
+			}
+			inlineCheck = strings.TrimSpace(cd[start : i-1])
+		}
+
+		isNullable := nullSpec == "" || strings.ToUpper(nullSpec) == "NULL"
+		isUnique := regexp.MustCompile(`(?i)\bUNIQUE\b`).MatchString(cd)
+		isPK := regexp.MustCompile(`(?i)\bPRIMARY\s+KEY\b`).MatchString(cd)
+
+		if isPK {
+			inlinePKCols = append(inlinePKCols, strings.Trim(name, `"`))
+			isNullable = false
+			isUnique = true
+		}
+
+		col := &Column{
+			Name:         strings.Trim(name, `"`),
+			ColType:      ctype,
+			IsNullable:   isNullable,
+			IsPrimaryKey: isPK,
+			Default:      strings.TrimSpace(defVal),
+			IsUnique:     isUnique,
+		}
+		if fkTable != "" {
+			col.FKTable = fkTable
+			col.FKColumn = fkCol
+		}
+		if inlineCheck != "" {
+			col.InlineCheck = inlineCheck
+			ts.CheckConstraints = append(ts.CheckConstraints, inlineCheck)
+		}
+		ts.AddColumn(col)
+	}
+
+	if len(inlinePKCols) > 0 {
+		ts.SetPrimaryKeys(inlinePKCols)
+	}
+
+	for _, tc := range tableConstraints {
+		up := strings.ToUpper(tc)
+		if strings.Contains(up, "PRIMARY KEY") {
+			raw := regexp.MustCompile(`\((.*?)\)`).FindStringSubmatch(tc)
+			if raw != nil {
+				cols := []string{}
+				for _, col := range strings.Split(raw[1], ",") {
+					cols = append(cols, strings.Split(strings.TrimSpace(strings.Trim(col, `"`)), " ")[0])
+				}
+				ts.SetPrimaryKeys(cols)
+			}
+			continue
+		}
+		if strings.Contains(up, "UNIQUE") {
+			raw := regexp.MustCompile(`\((.*?)\)`).FindStringSubmatch(tc)
+			if raw != nil {
+				cols := []string{}
+				for _, col := range strings.Split(raw[1], ",") {
+					cols = append(cols, strings.Split(strings.TrimSpace(strings.Trim(col, `"`)), " ")[0])
+				}
+				ts.UniqueConstraints = append(ts.UniqueConstraints, cols)
+				isComposite := len(cols) > 1
+				for _, c := range cols {
+					if !isComposite {
+						if col, ok := ts.Columns[c]; ok {
+							col.IsUnique = true
+						}
+					}
+				}
+			}
+			continue
+		}
+		if strings.Contains(up, "FOREIGN KEY") {
+			fkRe := regexp.MustCompile(`(?i)FOREIGN\s+KEY\s*\(([^\)]*)\)\s+REFERENCES\s+((?:"[^"]+"|[\w]+)(?:\.(?:"[^"]+"|[\w]+))*)\s*\(([^\)]*)\)`)
+			m2 := fkRe.FindStringSubmatch(tc)
+			if m2 != nil {
+				local := []string{}
+				for _, c := range strings.Split(m2[1], ",") {
+					local = append(local, strings.TrimSpace(c))
+				}
+				tbl := strings.TrimSpace(m2[2])
+				tblRaw := strings.ReplaceAll(tbl, "\"", "")
+				foreign := []string{}
+				for _, c := range strings.Split(m2[3], ",") {
+					foreign = append(foreign, strings.TrimSpace(c))
+				}
+				ts.ForeignKeys = append(ts.ForeignKeys, [3]interface{}{local, tblRaw, foreign})
+			}
+			continue
+		}
+		if strings.Contains(up, "CHECK") {
+			m2 := regexp.MustCompile(`CHECK\s*\((.*)\)`).FindStringSubmatch(tc)
+			if m2 != nil {
+				ts.CheckConstraints = append(ts.CheckConstraints, strings.TrimSpace(m2[1]))
+			}
+			continue
+		}
+		if strings.HasPrefix(up, "INDEX") {
+			continue
+		}
+	}
+
+	return ts, nil
+}
+
+// GenerateDDLs takes the location of the debug zip and the dbName and makes a dictionary for all tables' TableSchema.
+// The "anonymize" parameter is unused for now: on TODO list
+func GenerateDDLs(
+	zipDir, dbName, outputDir, outputFileName string, anonymize bool,
+) (allSchemas map[string]*TableSchema, retErr error) {
+	filePath := filepath.Join(zipDir, "crdb_internal.create_statements.txt")
+	if _, err := os.Stat(filePath); err != nil {
+		return nil, errors.Wrap(err, "could not find TSV file")
+	}
+
+	f, err := os.Open(filePath)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to open TSV file")
+	}
+	// Defer closes (input and output) propagate errors if no prior error occurred.
+	defer func() {
+		if cerr := f.Close(); cerr != nil && retErr == nil {
+			retErr = errors.Wrap(cerr, "failed to close input TSV file")
+		}
+	}()
+
+	reader := csv.NewReader(bufio.NewReader(f))
+	reader.Comma = '\t'
+	reader.LazyQuotes = true
+
+	header, err := reader.Read()
+	if err != nil {
+		return nil, errors.Wrap(err, "failed reading TSV header")
+	}
+	colIndex := map[string]int{}
+	for i, col := range header {
+		colIndex[col] = i
+	}
+	req := []string{"database_name", "create_statement", "schema_name", "descriptor_type", "descriptor_name"}
+	for _, c := range req {
+		if _, ok := colIndex[c]; !ok {
+			// Not wrapping an error, so fmt.Errorf is acceptable here.
+			return nil, fmt.Errorf("missing column %s", c)
+		}
+	}
+
+	tableStatements := make(map[string]string)
+	order := []string{}
+	seen := map[string]bool{}
+	schemaReCache := map[string]*regexp.Regexp{}
+
+	for {
+		rec, err := reader.Read()
+		if err != nil {
+			if errors.Is(err, os.ErrClosed) {
+				break
+			}
+			if err.Error() == "EOF" {
+				break
+			}
+			// Only break if line is empty AND error, not if just error (to protect partial final line)
+			if len(rec) == 0 {
+				break
+			}
+			// Any other error (besides EOF) is fatal for TSV import and should be reported
+			return nil, errors.Wrap(err, "failed while reading TSV rows")
+		}
+		if len(rec) == 0 {
+			break
+		}
+		if rec[colIndex["database_name"]] == dbName && rec[colIndex["descriptor_type"]] == "table" && rec[colIndex["schema_name"]] == "public" {
+			schemaName := rec[colIndex["schema_name"]]
+			stmt := rec[colIndex["create_statement"]]
+			tableName := rec[colIndex["descriptor_name"]]
+			fullTable := fmt.Sprintf("%s.%s.%s", dbName, schemaName, tableName)
+			pattern, ok := schemaReCache[schemaName]
+			if !ok {
+				pattern = regexp.MustCompile(`\b` + regexp.QuoteMeta(schemaName) + `\.`)
+				schemaReCache[schemaName] = pattern
+			}
+			stmt = pattern.ReplaceAllString(stmt, dbName+"."+schemaName+".")
+			if !regexp.MustCompile(`(?i)IF\s+NOT\s+EXISTS`).MatchString(stmt) {
+				stmt = regexp.MustCompile(`(?i)^(CREATE\s+TABLE\s+)`).ReplaceAllString(stmt, "${1}IF NOT EXISTS ")
+			}
+			if !seen[fullTable] {
+				order = append(order, fullTable)
+				seen[fullTable] = true
+			}
+			tableStatements[fullTable] = stmt
+		}
+	}
+
+	statements := make([]string, 0, len(order))
+	for _, t := range order {
+		statements = append(statements, tableStatements[t])
+	}
+
+	if outputDir == "" {
+		outputDir = "."
+	}
+	outputPath := filepath.Join(outputDir, outputFileName)
+	out, err := os.Create(outputPath)
+	if err != nil {
+		return nil, errors.Wrapf(err, "failed to create output file at %s", outputPath)
+	}
+	defer func() {
+		if cerr := out.Close(); cerr != nil && retErr == nil {
+			retErr = errors.Wrap(cerr, "failed to close output file")
+		}
+	}()
+
+	_, err = fmt.Fprintf(out, "create database if not exists %s;\n\n", dbName)
+	if err != nil {
+		return nil, errors.Wrap(err, "failed to write database create statement")
+	}
+	allSchemas = map[string]*TableSchema{}
+
+	for _, stmt := range statements {
+		_, err1 := fmt.Fprintln(out, stmt+";")
+		if err1 != nil {
+			return nil, errors.Wrap(err1, "failed to write table statement to output file")
+		}
+		_, err2 := fmt.Fprintln(out)
+		if err2 != nil {
+			return nil, errors.Wrap(err2, "failed to write newline to output file")
+		}
+		schema, err := ParseDDL(stmt)
+		if err != nil {
+			// Not fatal: log and continue (CockroachDB best practice for non-critical parse errors)
+			log.Printf("warning: failed to parse DDL (%v): %v", err, stmt)
+			continue
+		}
+		tableName := schema.TableName[strings.LastIndex(schema.TableName, ".")+1:]
+		allSchemas[tableName] = schema
+	}
+
+	return allSchemas, nil
+}

--- a/pkg/workload/dbWorkload_go/ddl_generator_test.go
+++ b/pkg/workload/dbWorkload_go/ddl_generator_test.go
@@ -1,0 +1,208 @@
+package dbworkloadgo
+
+import (
+	"fmt"
+	"os"
+	"testing"
+)
+
+// tweak these paths as needed
+var (
+	testZipDir     = "/Users/pradyumagarwal/workloads/git-dbworkload/dbworkload_intProj/debug-zips/debug_2"
+	testDBName     = "tpcc"
+	testOutputFile = "test_schema.ddl"
+)
+
+// examples can be customized to stress ParseDDL
+var examples = []string{
+	// warehouse table
+	`CREATE TABLE public.warehouse (
+        w_id INT8 NOT NULL,
+        w_name VARCHAR(10) NOT NULL,
+        w_street_1 VARCHAR(20) NOT NULL,
+        w_street_2 VARCHAR(20) NOT NULL,
+        w_city VARCHAR(20) NOT NULL,
+        w_state CHAR(2) NOT NULL,
+        w_zip CHAR(9) NOT NULL,
+        w_tax DECIMAL(4,4) NOT NULL,
+        w_ytd DECIMAL(12,2) NOT NULL,
+        CONSTRAINT warehouse_pkey PRIMARY KEY (w_id ASC)
+    )`,
+
+	// district table
+	`CREATE TABLE public.district (
+        d_id INT8 NOT NULL,
+        d_w_id INT8 NOT NULL,
+        d_name VARCHAR(10) NOT NULL,
+        d_street_1 VARCHAR(20) NOT NULL,
+        d_street_2 VARCHAR(20) NOT NULL,
+        d_city VARCHAR(20) NOT NULL,
+        d_state CHAR(2) NOT NULL,
+        d_zip CHAR(9) NOT NULL,
+        d_tax DECIMAL(4,4) NOT NULL,
+        d_ytd DECIMAL(12,2) NOT NULL,
+        d_next_o_id INT8 NOT NULL,
+        CONSTRAINT district_pkey PRIMARY KEY (d_w_id ASC, d_id ASC),
+        CONSTRAINT district_d_w_id_fkey FOREIGN KEY (d_w_id) REFERENCES public.warehouse(w_id) NOT VALID
+    )`,
+
+	// customer table
+	`CREATE TABLE public.customer (
+        c_id INT8 NOT NULL,
+        c_d_id INT8 NOT NULL,
+        c_w_id INT8 NOT NULL,
+        c_first VARCHAR(16) NOT NULL,
+        c_middle CHAR(2) NOT NULL,
+        c_last VARCHAR(16) NOT NULL,
+        c_street_1 VARCHAR(20) NOT NULL,
+        c_street_2 VARCHAR(20) NOT NULL,
+        c_city VARCHAR(20) NOT NULL,
+        c_state CHAR(2) NOT NULL,
+        c_zip CHAR(9) NOT NULL,
+        c_phone CHAR(16) NOT NULL,
+        c_since TIMESTAMP NOT NULL,
+        c_credit CHAR(2) NOT NULL,
+        c_credit_lim DECIMAL(12,2) NOT NULL,
+        c_discount DECIMAL(4,4) NOT NULL,
+        c_balance DECIMAL(12,2) NOT NULL,
+        c_ytd_payment DECIMAL(12,2) NOT NULL,
+        c_payment_cnt INT8 NOT NULL,
+        c_delivery_cnt INT8 NOT NULL,
+        c_data VARCHAR(500) NOT NULL,
+        CONSTRAINT customer_pkey PRIMARY KEY (c_w_id ASC, c_d_id ASC, c_id ASC),
+        CONSTRAINT customer_c_w_id_c_d_id_fkey FOREIGN KEY (c_w_id, c_d_id)
+            REFERENCES public.district(d_w_id, d_id) NOT VALID,
+        INDEX customer_idx (c_w_id ASC, c_d_id ASC, c_last ASC, c_first ASC)
+    )`,
+
+	// history table
+	`CREATE TABLE public.history (
+        rowid UUID NOT NULL DEFAULT gen_random_uuid(),
+        h_c_id INT8 NOT NULL,
+        h_c_d_id INT8 NOT NULL,
+        h_c_w_id INT8 NOT NULL,
+        h_d_id INT8 NOT NULL,
+        h_w_id INT8 NOT NULL,
+        h_date TIMESTAMP NULL,
+        h_amount DECIMAL(6,2) NULL,
+        h_data VARCHAR(24) NULL,
+        CONSTRAINT history_pkey PRIMARY KEY (h_w_id ASC, rowid ASC),
+        CONSTRAINT history_h_c_w_id_h_c_d_id_h_c_id_fkey FOREIGN KEY (h_c_w_id, h_c_d_id, h_c_id)
+            REFERENCES public.customer(c_w_id, c_d_id, c_id) NOT VALID,
+        CONSTRAINT history_h_w_id_h_d_id_fkey FOREIGN KEY (h_w_id, h_d_id)
+            REFERENCES public.district(d_w_id, d_id) NOT VALID
+    )`,
+
+	// "order" table
+	`CREATE TABLE public."order" (
+        o_id INT8 NOT NULL,
+        o_d_id INT8 NOT NULL,
+        o_w_id INT8 NOT NULL,
+        o_c_id INT8 NULL,
+        o_entry_d TIMESTAMP NULL,
+        o_carrier_id INT8 NULL,
+        o_ol_cnt INT8 NULL,
+        o_all_local INT8 NULL,
+        CONSTRAINT order_pkey PRIMARY KEY (o_w_id ASC, o_d_id ASC, o_id DESC),
+        CONSTRAINT order_o_w_id_o_d_id_o_c_id_fkey FOREIGN KEY (o_w_id, o_d_id, o_c_id)
+            REFERENCES public.customer(c_w_id, c_d_id, c_id) NOT VALID,
+        UNIQUE INDEX order_idx (o_w_id ASC, o_d_id ASC, o_c_id ASC, o_id DESC)
+            STORING (o_entry_d, o_carrier_id)
+    )`,
+
+	// new_order table
+	`CREATE TABLE public.new_order (
+        no_o_id INT8 NOT NULL,
+        no_d_id INT8 NOT NULL,
+        no_w_id INT8 NOT NULL,
+        CONSTRAINT new_order_pkey PRIMARY KEY (no_w_id ASC, no_d_id ASC, no_o_id ASC),
+        CONSTRAINT new_order_no_w_id_no_d_id_no_o_id_fkey FOREIGN KEY (no_w_id, no_d_id, no_o_id)
+            REFERENCES public."order"(o_w_id, o_d_id, o_id) NOT VALID
+    )`,
+
+	// item table
+	`CREATE TABLE public.item (
+        i_id INT8 NOT NULL,
+        i_im_id INT8 NULL,
+        i_name VARCHAR(24) NULL,
+        i_price DECIMAL(5,2) NULL,
+        i_data VARCHAR(50) NULL,
+        CONSTRAINT item_pkey PRIMARY KEY (i_id ASC)
+    )`,
+
+	// stock table
+	`CREATE TABLE public.stock (
+        s_i_id INT8 NOT NULL,
+        s_w_id INT8 NOT NULL,
+        s_quantity INT8 NULL,
+        s_dist_01 CHAR(24) NULL,
+        s_dist_02 CHAR(24) NULL,
+        s_dist_03 CHAR(24) NULL,
+        s_dist_04 CHAR(24) NULL,
+        s_dist_05 CHAR(24) NULL,
+        s_dist_06 CHAR(24) NULL,
+        s_dist_07 CHAR(24) NULL,
+        s_dist_08 CHAR(24) NULL,
+        s_dist_09 CHAR(24) NULL,
+        s_dist_10 CHAR(24) NULL,
+        s_ytd INT8 NULL,
+        s_order_cnt INT8 NULL,
+        s_remote_cnt INT8 NULL,
+        s_data VARCHAR(50) NULL,
+        CONSTRAINT stock_pkey PRIMARY KEY (s_w_id ASC, s_i_id ASC),
+        CONSTRAINT stock_s_w_id_fkey FOREIGN KEY (s_w_id) REFERENCES public.warehouse(w_id) NOT VALID,
+        CONSTRAINT stock_s_i_id_fkey FOREIGN KEY (s_i_id) REFERENCES public.item(i_id) NOT VALID
+    )`,
+
+	// order_line table
+	`CREATE TABLE public.order_line (
+        ol_o_id INT8 NOT NULL,
+        ol_d_id INT8 NOT NULL,
+        ol_w_id INT8 NOT NULL,
+        ol_number INT8 NOT NULL,
+        ol_i_id INT8 NOT NULL,
+        ol_supply_w_id INT8 NULL,
+        ol_delivery_d TIMESTAMP NULL,
+        ol_quantity INT8 NULL,
+        ol_amount DECIMAL(6,2) NULL,
+        ol_dist_info CHAR(24) NULL,
+        CONSTRAINT order_line_pkey PRIMARY KEY (ol_w_id ASC, ol_d_id ASC, ol_o_id DESC, ol_number ASC),
+        CONSTRAINT order_line_ol_w_id_ol_d_id_ol_o_id_fkey FOREIGN KEY (ol_w_id, ol_d_id, ol_o_id)
+            REFERENCES public."order"(o_w_id, o_d_id, o_id) NOT VALID,
+        CONSTRAINT order_line_ol_supply_w_id_ol_i_id_fkey FOREIGN KEY (ol_supply_w_id, ol_i_id)
+            REFERENCES public.stock(s_w_id, s_i_id) NOT VALID
+    )`,
+}
+
+func TestGenerateDDLs(t *testing.T) {
+	schemas, err := GenerateDDLs(testZipDir, testDBName, testZipDir, testOutputFile, false)
+	if err != nil {
+		t.Fatalf("GenerateDDLs failed: %v", err)
+	}
+	f, err := os.Create("generate_ddls_output.txt")
+	if err != nil {
+		t.Fatalf("could not create output file: %v", err)
+	}
+	defer f.Close()
+	for name, s := range schemas {
+		fmt.Fprintf(f, "--- %s ---\n%s\n", name, s.String())
+	}
+}
+
+func TestParseDDL(t *testing.T) {
+	out, err := os.Create("parse_ddl_output.txt")
+	if err != nil {
+		t.Fatalf("could not create output file: %v", err)
+	}
+	defer out.Close()
+	for _, ddl := range examples {
+		fmt.Fprintf(out, "IN : %s\n", ddl)
+		sch, err := ParseDDL(ddl)
+		if err != nil {
+			fmt.Fprintf(out, "[ERROR] %v\n\n", err)
+			continue
+		}
+		fmt.Fprintln(out, sch.String())
+		fmt.Fprintln(out, "----")
+	}
+}

--- a/pkg/workload/dbWorkload_go/yaml_generator.go
+++ b/pkg/workload/dbWorkload_go/yaml_generator.go
@@ -1,0 +1,316 @@
+package dbworkloadgo
+
+import (
+	"fmt"
+	"math/rand"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+
+	"gopkg.in/yaml.v3"
+)
+
+// canonical replaces "." with "__" to match the legacy YAML format.
+func canonical(name string) string { return strings.ReplaceAll(name, ".", "__") }
+
+// decanonical undoes canonical() for at most two components.
+func decanonical(name string) string { return strings.Replace(name, "__", ".", 2) }
+
+var (
+	decimalRe = regexp.MustCompile(`(?i)^(?:decimal|numeric)\s*(?:\(\s*(\d+)\s*,\s*(\d+)\s*\))?$`)
+	numericRe = regexp.MustCompile(`(?i)^(decimal|numeric|float|double|real)`)
+	varcharRe = regexp.MustCompile(`(?i)^(varchar|character varying)\((\d+)\)`)
+	charRe    = regexp.MustCompile(`(?i)^char\((\d+)\)$`)
+	bitRe     = regexp.MustCompile(`(?i)^(bit|varbit)(?:\((\d+)\))?`)
+	byteRe    = regexp.MustCompile(`(?i)^(bytea|blob|bytes)$`)
+)
+
+// mapSqlType converts teh data types mentioned in the DDL into data types understood by the generators, along with setting proper arguments.
+func mapSQLType(sql string, col *Column, rng *rand.Rand) (string, map[string]any) {
+	sql = strings.ToLower(sql)
+	args := map[string]any{"seed": rng.Intn(100)}
+
+	switch {
+	case strings.HasPrefix(sql, "int") ||
+		sql == "integer" || sql == "bigint" || sql == "smallint" || sql == "serial":
+		if col.IsPrimaryKey || col.IsUnique {
+			return "sequence", map[string]any{"start": 1, "seed": args["seed"]}
+		}
+		args["min"] = -(1 << 31)
+		args["max"] = (1 << 31) - 1
+		return "integer", args
+
+	case sql == "uuid":
+		return "uuid", args
+
+	case bitRe.MatchString(sql):
+		m := bitRe.FindStringSubmatch(sql)
+		size := 1
+		if m[2] != "" {
+			size = atoi(m[2])
+		}
+		args["size"] = size
+		return "bit", args
+
+	case byteRe.MatchString(sql):
+		m := byteRe.FindStringSubmatch(sql)
+		size := 1
+		if m[2] != "" {
+			size = atoi(m[2])
+		}
+		args["size"] = size
+		return "bytes", args
+
+	case varcharRe.MatchString(sql):
+		m := varcharRe.FindStringSubmatch(sql)
+		length := atoi(m[2])
+		args["min"] = 1
+		args["max"] = length
+		return "string", args
+
+	case charRe.MatchString(sql):
+		n := atoi(charRe.FindStringSubmatch(sql)[1])
+		args["min"], args["max"] = n, n
+		return "string", args
+
+	case sql == "text" || sql == "clob" || sql == "string":
+		args["min"] = 5
+		args["max"] = 30
+		return "string", args
+
+	case decimalRe.MatchString(sql):
+		m := decimalRe.FindStringSubmatch(sql)
+		if m[1] != "" {
+			precision := atoi(m[1])
+			scale := atoi(m[2])
+			intDigits := precision - scale
+			var minVal, maxVal int
+			if intDigits == 0 {
+				maxVal = 1
+				minVal = -1
+			} else {
+				maxVal = pow10(intDigits) - 1
+				minVal = -maxVal - 1
+			}
+			args["min"] = minVal
+			args["max"] = maxVal
+			args["round"] = scale
+		} else {
+			args["min"] = 0
+			args["max"] = 1
+			args["round"] = 2
+		}
+		return "float", args
+
+	case numericRe.MatchString(sql):
+		args["min"] = 0
+		args["max"] = 1
+		args["round"] = 2
+		return "float", args
+
+	case sql == "date":
+		args["start"] = "2000-01-01"
+		args["end"] = "2025-01-01"
+		args["format"] = "%Y-%m-%d"
+		return "date", args
+
+	case sql == "timestamp" || sql == "timestamptz":
+		args["start"] = "2000-01-01"
+		args["end"] = "2025-01-01"
+		args["format"] = "%Y-%m-%d %H:%M:%S.%f"
+		return "timestamp", args
+
+	case sql == "bool" || sql == "boolean":
+		return "bool", args
+	}
+	args["min"] = 5
+	args["max"] = 30
+	return "string", args
+}
+
+// Helper numeric functions
+func atoi(s string) int {
+	n, _ := strconv.Atoi(s)
+	return n
+}
+func pow10(n int) int {
+	v := 1
+	for i := 0; i < n; i++ {
+		v *= 10
+	}
+	return v
+}
+
+// columnYAML reads the TableSchema information and returns per column dictionaries for the yaml
+func columnYAML(col *Column, rng *rand.Rand, defaultProb float64) map[string]any {
+	d := map[string]any{}
+	typ, args := mapSQLType(col.ColType, col, rng)
+	d["type"] = typ
+	d["args"] = args
+
+	if col.IsNullable && !col.IsPrimaryKey {
+		args["null_pct"] = 0.1
+	} else {
+		args["null_pct"] = 0.0
+	}
+
+	if col.FKTable != "" {
+		parentTbl := col.FKTable
+		if !strings.Contains(parentTbl, ".") {
+			parentTbl = "public." + parentTbl
+		}
+		d["fk"] = fmt.Sprintf("%s.%s", canonical(parentTbl), col.FKColumn)
+		d["hasForeignKey"] = true
+	} else {
+		d["hasForeignKey"] = false
+	}
+
+	if col.IsPrimaryKey {
+		d["isPrimaryKey"] = true
+		d["isUnique"] = true
+	} else {
+		d["isPrimaryKey"] = false
+		d["isUnique"] = col.IsUnique
+	}
+
+	if col.Default != "" && isLiteralDefault(col.Default) {
+		d["default_prob"] = defaultProb
+		d["default"] = strings.TrimSpace(col.Default)
+	}
+	return d
+}
+
+var (
+	simpleNum = regexp.MustCompile(`^[+-]?\d+(?:\.\d+)?$`)
+	quotedStr = regexp.MustCompile(`^'.*'$`)
+	boolLit   = regexp.MustCompile(`^(?i:true|false)$`)
+)
+
+// isLiteralDefault helps find defaults from the schema information which are feasible for use by the generators. Remaining defaults are ignored for now.
+func isLiteralDefault(expr string) bool {
+	txt := strings.TrimSpace(strings.TrimRight(strings.TrimLeft(expr, "("), ")"))
+	return simpleNum.MatchString(txt) ||
+		quotedStr.MatchString(txt) ||
+		boolLit.MatchString(txt)
+}
+
+// ddlToYamlCa converts table_name: TableSchema map into a yaml for the database
+func ddlToYamlCA(allSchemas map[string]*TableSchema, dbName string) (string, error) {
+	fanout := 10
+	yamlDoc := map[string][]map[string]any{}
+	colSeedMap := map[[2]string]int{}
+	rng := rand.New(rand.NewSource(time.Now().UnixNano()))
+
+	for tblName, schema := range allSchemas {
+		block := map[string]any{
+			"count":          100,
+			"sort-by":        []string{},
+			"pk":             schema.PrimaryKeys,
+			"columns":        map[string]map[string]any{},
+			"original_table": schema.OriginalTable,
+		}
+		if len(schema.UniqueConstraints) > 0 {
+			block["unique"] = schema.UniqueConstraints
+		}
+		cols := block["columns"].(map[string]map[string]any)
+
+		for _, c := range schema.Columns {
+			colInfo := columnYAML(c, rng, 0.2)
+			cols[c.Name] = colInfo
+			seed, _ := colInfo["args"].(map[string]any)["seed"].(int)
+			colSeedMap[[2]string{tblName, c.Name}] = seed
+			two := "public__" + canonical(tblName)
+			three := dbName + "__" + canonical(two)
+			colSeedMap[[2]string{two, c.Name}] = seed
+			colSeedMap[[2]string{three, c.Name}] = seed
+		}
+
+		if len(schema.ForeignKeys) > 0 {
+			fkIDs := map[string]int{}
+			nextID := 1
+			for _, fk := range schema.ForeignKeys {
+				local := fk[0].([]string)
+				parent := fk[1].(string)
+				foreign := fk[2].([]string)
+				if !strings.Contains(parent, ".") {
+					parent = "public." + parent
+				}
+				parentCanon := canonical(parent)
+				key := parentCanon + "|" + strings.Join(foreign, ",")
+				cid, ok := fkIDs[key]
+				if !ok {
+					cid = nextID
+					fkIDs[key] = cid
+					nextID++
+				}
+				for i, lc := range local {
+					pc := foreign[i]
+					colMeta := cols[lc]
+					if _, ok := colMeta["fk"]; !ok {
+						colMeta["fk"] = fmt.Sprintf("%s.%s", parentCanon, pc)
+						colMeta["hasForeignKey"] = true
+					}
+					if len(local) > 1 {
+						colMeta["composite_id"] = cid
+					}
+				}
+			}
+		}
+		yamlDoc[canonical(tblName)] = []map[string]any{block}
+	}
+
+	// second pass: set fk_mode/fanout/parent_seed
+	for _, tbl := range yamlDoc {
+		block := tbl[0]
+		cols := block["columns"].(map[string]map[string]any)
+		for name, meta := range cols {
+			fkInfo, ok := meta["fk"].(string)
+			if !ok {
+				continue
+			}
+			parts := strings.SplitN(fkInfo, ".", 2)
+			if len(parts) != 2 {
+				continue
+			}
+			seed, ok := colSeedMap[[2]string{parts[0], parts[1]}]
+			if ok {
+				if _, ok := meta["fk_mode"]; !ok {
+					meta["fk_mode"] = "block"
+				}
+				if _, ok := meta["fanout"]; !ok {
+					meta["fanout"] = fanout
+				}
+				if _, ok := meta["parent_seed"]; !ok {
+					meta["parent_seed"] = seed
+				}
+			}
+			cols[name] = meta
+		}
+	}
+
+	for _, tbl := range yamlDoc {
+		block := tbl[0]
+		cols := block["columns"].(map[string]map[string]any)
+		allPkFK := true
+		for _, pk := range block["pk"].([]string) {
+			if val, ok := cols[pk]["hasForeignKey"].(bool); !ok || !val {
+				allPkFK = false
+				break
+			}
+		}
+		if allPkFK {
+			for _, meta := range cols {
+				if val, ok := meta["hasForeignKey"].(bool); ok && val {
+					meta["fanout"] = 1
+				}
+			}
+		}
+	}
+
+	out, err := yaml.Marshal(yamlDoc)
+	if err != nil {
+		return "", err
+	}
+	return string(out), nil
+}

--- a/pkg/workload/dbWorkload_go/yaml_generator_test.go
+++ b/pkg/workload/dbWorkload_go/yaml_generator_test.go
@@ -1,0 +1,46 @@
+package dbworkloadgo
+
+import (
+	"os"
+	"testing"
+)
+
+func TestDdlToYamlGeneration(t *testing.T) {
+	//tweak as needed
+	zipDir := "/Users/pradyumagarwal/workloads/git-dbworkload/dbworkload_intProj/debug-zips/debug_2" // make sure this path exists
+	dbName := "tpcc"                                                                                 // use your actual test DB name
+	outputFile := "test_output.yaml"                                                                 // generated YAML file
+
+	// ---- STEP 1: Generate schema from DDL ----
+	schemas, err := GenerateDDLs(
+		zipDir,
+		dbName,
+		"",               // no DDL output directory 		// no cluster URL
+		"ddl_output.sql", // will still dump DDLs here
+		false,
+	)
+	if err != nil {
+		t.Fatalf("GenerateDDLs failed: %v", err)
+	}
+
+	t.Logf("✅ Parsed %d tables", len(schemas))
+	for name, schema := range schemas {
+		t.Logf("Table: %s\n%s", name, schema.String())
+	}
+
+	// ---- STEP 2: Convert schema to YAML ----
+	yamlOut, err := ddlToYamlCA(schemas, dbName)
+	if err != nil {
+		t.Fatalf("YAML generation failed: %v", err)
+	}
+
+	t.Log("✅ YAML generation succeeded")
+	t.Logf("YAML Output:\n%s", yamlOut)
+
+	// ---- STEP 3: Write YAML to file ----
+	if err := os.WriteFile(outputFile, []byte(yamlOut), 0644); err != nil {
+		t.Fatalf("Error writing YAML output to file: %v", err)
+	}
+
+	t.Logf("✅ YAML written to %s", outputFile)
+}


### PR DESCRIPTION
Previously, the db_workload generator did not parse SQL CREATE TABLE DDL or produce YAML schemas. This was inadequate because users could not automatically convert debug zip exports into table definitions and corresponding synthetic data. To address this, this patch introduces ddl_generator.go and yaml_generator.go with tests, parsing create_statements.tsv into TableSchema and emitting YAML maps; it also adds data_generator.go and updates db_workload.go to wire up the new generators. Fixes: CRDB-51752
Release note: db_workload generator now supports DDL parsing and YAML schema generation for synthetic data workloads.