### PR TITLE
opt: normalize non-null x LIKE '%' to true

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1522,6 +1522,36 @@ func (c *CustomFuncs) IntConst(d *tree.DInt) opt.ScalarExpr {
 	return c.f.ConstructConst(d, types.Int)
 }
 
+// StrConst constructs a Const holding a DString.
+func (c *CustomFuncs) StrConst(d *tree.DString) opt.ScalarExpr {
+	return c.f.ConstructConst(d, types.String)
+}
+
+// StringFromConst extracts a string from a Const expression. It returns the
+// string and a boolean indicating whether the extraction was successful.
+func (c *CustomFuncs) StringFromConst(expr opt.ScalarExpr) (string, bool) {
+	if constExpr, ok := expr.(*memo.ConstExpr); ok {
+		datum := tree.UnwrapDOidWrapper(constExpr.Value)
+		switch d := datum.(type) {
+		case *tree.DString:
+			return string(*d), true
+		case *tree.DCollatedString:
+			return d.Contents, true
+		}
+	}
+	return "", false
+}
+
+// EqualConstString compares two Const expressions to see if they hold equal string values.
+func (c *CustomFuncs) EqualConstStrings(left, right opt.ScalarExpr) bool {
+	leftStr, okLeft := c.StringFromConst(left)
+	rightStr, okRight := c.StringFromConst(right)
+	if !okLeft || !okRight {
+		return false
+	}
+	return leftStr == rightStr
+}
+
 // IsGreaterThan returns true if the first datum compares as greater than the
 // second.
 func (c *CustomFuncs) IsGreaterThan(first, second tree.Datum) bool {

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -480,3 +480,23 @@ $input
     )
     $remainingFilters
 )
+
+# NormalizeLikeAny replaces non-Null x LIKE '%' with true.
+[NormalizeLikeAny, Normalize]
+(Select
+    $input:*
+    $filters:[
+        ...
+        $item:(FiltersItem
+            (Like | ILike
+                $left:* &
+                    (ExprIsNeverNull $left (NotNullCols $input))
+                $pattern:(Const) &
+                    (EqualConstStrings $pattern (StrConst "%"))
+            )
+        )
+        ...
+    ]
+)
+=>
+(Select $input (RemoveFiltersItem $filters $item))

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -2562,3 +2562,21 @@ barrier
       └── filters
            ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
            └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
+
+# --------------------------------------------------
+# NormalizeLikeAny
+# --------------------------------------------------
+
+exec-ddl
+CREATE TABLE strs_notnull (
+  s STRING NOT NULL,
+  cs STRING COLLATE en_US NOT NULL,
+  name NAME NOT NULL
+)
+----
+
+norm expect=NormalizeLikeAny
+SELECT * FROM strs_notnull WHERE s LIKE '%' AND cs LIKE '%' COLLATE en_US AND name LIKE '%'::NAME;
+----
+scan strs_notnull
+ └── columns: s:1!null cs:2!null name:3!null

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -302,40 +302,34 @@ sort
       │    │    │    │    │    │    │    ├── inner-join (hash)
       │    │    │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
       │    │    │    │    │    │    │    │    ├── fd: ()-->(3,60), (2)==(9), (9)==(2), (7)==(44), (44)==(7)
-      │    │    │    │    │    │    │    │    ├── inner-join (merge)
-      │    │    │    │    │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24!null attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
-      │    │    │    │    │    │    │    │    │    ├── left ordering: +44
-      │    │    │    │    │    │    │    │    │    ├── right ordering: +7
-      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(60), (7)==(44), (44)==(7)
-      │    │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    │    │    ├── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
-      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(60)
-      │    │    │    │    │    │    │    │    │    │    ├── ordering: +44 opt(60) [actual: +44]
-      │    │    │    │    │    │    │    │    │    │    ├── scan pg_attribute@pg_attribute_attrelid_idx [as=a]
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49 atttypmod:52 a.attnotnull:56 attisdropped:60
-      │    │    │    │    │    │    │    │    │    │    │    └── ordering: +44
-      │    │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │    │         ├── attnum:49 > 0 [outer=(49), constraints=(/49: [/1 - ]; tight)]
-      │    │    │    │    │    │    │    │    │    │         └── NOT attisdropped:60 [outer=(60), constraints=(/60: [/false - /false]; tight), fd=()-->(60)]
+      │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    │    ├── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49!null atttypmod:52 a.attnotnull:56 attisdropped:60!null
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(60)
+      │    │    │    │    │    │    │    │    │    ├── scan pg_attribute [as=a]
+      │    │    │    │    │    │    │    │    │    │    └── columns: attrelid:44!null attname:45 atttypid:46 attlen:48 attnum:49 atttypmod:52 a.attnotnull:56 attisdropped:60
+      │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │    │         ├── attnum:49 > 0 [outer=(49), constraints=(/49: [/1 - ]; tight)]
+      │    │    │    │    │    │    │    │    │         └── NOT attisdropped:60 [outer=(60), constraints=(/60: [/false - /false]; tight), fd=()-->(60)]
+      │    │    │    │    │    │    │    │    ├── inner-join (hash)
+      │    │    │    │    │    │    │    │    │    ├── columns: n.oid:2!null n.nspname:3!null c.oid:7!null c.relname:8!null c.relnamespace:9!null c.relkind:24!null
+      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(3), (2)==(9), (9)==(2)
       │    │    │    │    │    │    │    │    │    ├── select
       │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24!null
-      │    │    │    │    │    │    │    │    │    │    ├── ordering: +7
-      │    │    │    │    │    │    │    │    │    │    ├── scan pg_class@pg_class_oid_idx [as=c]
-      │    │    │    │    │    │    │    │    │    │    │    ├── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24
-      │    │    │    │    │    │    │    │    │    │    │    └── ordering: +7
+      │    │    │    │    │    │    │    │    │    │    ├── scan pg_class [as=c]
+      │    │    │    │    │    │    │    │    │    │    │    └── columns: c.oid:7!null c.relname:8!null c.relnamespace:9 c.relkind:24
       │    │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │    │         ├── c.relkind:24 IN ('f', 'm', 'p', 'r', 'v') [outer=(24), constraints=(/24: [/'f' - /'f'] [/'m' - /'m'] [/'p' - /'p'] [/'r' - /'r'] [/'v' - /'v']; tight)]
-      │    │    │    │    │    │    │    │    │    │         └── c.relname:8 LIKE '%' [outer=(8), constraints=(/8: (/NULL - ])]
-      │    │    │    │    │    │    │    │    │    └── filters (true)
-      │    │    │    │    │    │    │    │    ├── select
-      │    │    │    │    │    │    │    │    │    ├── columns: n.oid:2 n.nspname:3!null
-      │    │    │    │    │    │    │    │    │    ├── fd: ()-->(3)
-      │    │    │    │    │    │    │    │    │    ├── scan pg_namespace [as=n]
-      │    │    │    │    │    │    │    │    │    │    └── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │    │    │    │    │    │    │         └── c.relkind:24 IN ('f', 'm', 'p', 'r', 'v') [outer=(24), constraints=(/24: [/'f' - /'f'] [/'m' - /'m'] [/'p' - /'p'] [/'r' - /'r'] [/'v' - /'v']; tight)]
+      │    │    │    │    │    │    │    │    │    ├── select
+      │    │    │    │    │    │    │    │    │    │    ├── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │    │    │    │    │    │    │    ├── fd: ()-->(3)
+      │    │    │    │    │    │    │    │    │    │    ├── scan pg_namespace [as=n]
+      │    │    │    │    │    │    │    │    │    │    │    └── columns: n.oid:2 n.nspname:3!null
+      │    │    │    │    │    │    │    │    │    │    └── filters
+      │    │    │    │    │    │    │    │    │    │         └── n.nspname:3 LIKE 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]
       │    │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │    │         └── n.nspname:3 LIKE 'public' [outer=(3), constraints=(/3: [/'public' - /'public']; tight), fd=()-->(3)]
+      │    │    │    │    │    │    │    │    │         └── c.relnamespace:9 = n.oid:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
       │    │    │    │    │    │    │    │    └── filters
-      │    │    │    │    │    │    │    │         └── c.relnamespace:9 = n.oid:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+      │    │    │    │    │    │    │    │         └── attrelid:44 = c.oid:7 [outer=(7,44), constraints=(/7: (/NULL - ]; /44: (/NULL - ]), fd=(7)==(44), (44)==(7)]
       │    │    │    │    │    │    │    └── filters
       │    │    │    │    │    │    │         ├── c.oid:7 = crdb_internal.kv_catalog_comments.objoid:110 [outer=(7,110), constraints=(/7: (/NULL - ]; /110: (/NULL - ]), fd=(7)==(110), (110)==(7)]
       │    │    │    │    │    │    │         └── attnum:49 = objsubid:118 [outer=(49,118), constraints=(/49: (/NULL - ]; /118: (/NULL - ]), fd=(49)==(118), (118)==(49)]


### PR DESCRIPTION
#### opt: normalize non-null x LIKE '%' to true

This commit adds the NormalizeLikeAny normalization rule, which normalizes `x
LIKE '%'` to true when x is non-null.

Epic: None
Fixes: cockroachdb#144523

Release note (performance improvement): LIKE expressions of the form `x LIKE
'%'` are normalized to true if x is non-Null.
