### PR TITLE
eval: adjust a couple trig eval tests for s390x

### DIFF
--- a/pkg/sql/sem/eval/testdata/eval/trig
+++ b/pkg/sql/sem/eval/testdata/eval/trig
@@ -1,7 +1,12 @@
 # Trig functions
+#
 # In some cases x64 and arm64 may yeild slightly different results due to float
 # operation ordering/fusing differences, as allowed by spec, so some results are
 # checks using round(expr, 10) to ignore any minute float differences.
+#
+# Similarly, s390x can produce slightly different results (e.g. since it has
+# architectural support for some trig functions like atan), so we check rounded
+# results too.
 
 eval
 cos(0)
@@ -34,14 +39,14 @@ asin(1.0)
 1.5707963267948966
 
 eval
-atan(1.0)
+round(atan(1.0), 15)
 ----
-0.7853981633974483
+0.785398163397448
 
 eval
-atan2(1.0, 1.0)
+round(atan2(1.0, 1.0), 15)
 ----
-0.7853981633974483
+0.785398163397448
 
 eval
 cosd(0)
@@ -74,12 +79,12 @@ asind(1.0)
 90.0
 
 eval
-atand(1.0)
+round(atand(1.0), 10)
 ----
 45.0
 
 eval
-atan2d(1.0, 1.0)
+round(atan2d(1.0, 1.0), 10)
 ----
 45.0
 


### PR DESCRIPTION
This commit is similar in spirit to ba3639d02b2db73d39b76ddd156d98db7f9fb5fc. It turns out that s390x produces slightly different results when evaluating some trig functions like `atan` (possibly because it has architecture support, meaning it's implemented in assembly). This commit adjusts a few tests to use rounding to hide those differences.

Fixes: #145992.
Fixes: #146009.

Release note: None