### PR TITLE
server,cli: extract `QuorumRecovery` and register with DRPC server

### DIFF
--- a/pkg/cli/debug_reset_quorum.go
+++ b/pkg/cli/debug_reset_quorum.go
@@ -53,7 +53,7 @@ func runDebugResetQuorum(cmd *cobra.Command, args []string) error {
 	defer finish()
 
 	// Call ResetQuorum to reset quorum for given range on target node.
-	_, err = conn.NewInternalClient().ResetQuorum(ctx, &kvpb.ResetQuorumRequest{
+	_, err = conn.NewQuorumRecoveryClient().ResetQuorum(ctx, &kvpb.ResetQuorumRequest{
 		RangeID: int32(rangeID),
 	})
 	if err != nil {

--- a/pkg/cli/rpc_clients.go
+++ b/pkg/cli/rpc_clients.go
@@ -27,7 +27,7 @@ type rpcConn interface {
 	NewAdminClient() serverpb.RPCAdminClient
 	NewInitClient() serverpb.RPCInitClient
 	NewTimeSeriesClient() tspb.RPCTimeSeriesClient
-	NewInternalClient() kvpb.RPCInternalClient
+	NewQuorumRecoveryClient() kvpb.RPCQuorumRecoveryClient
 }
 
 // grpcConn is an implementation of rpcConn that provides methods to create
@@ -53,7 +53,7 @@ func (c *grpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {
 	return tspb.NewGRPCTimeSeriesClientAdapter(c.conn)
 }
 
-func (c *grpcConn) NewInternalClient() kvpb.RPCInternalClient {
+func (c *grpcConn) NewQuorumRecoveryClient() kvpb.RPCQuorumRecoveryClient {
 	return kvpb.NewGRPCInternalClientAdapter(c.conn)
 }
 
@@ -80,8 +80,8 @@ func (c *drpcConn) NewTimeSeriesClient() tspb.RPCTimeSeriesClient {
 	return tspb.NewDRPCTimeSeriesClientAdapter(c.conn)
 }
 
-func (c *drpcConn) NewInternalClient() kvpb.RPCInternalClient {
-	return kvpb.NewDRPCInternalClientAdapter(c.conn)
+func (c *drpcConn) NewQuorumRecoveryClient() kvpb.RPCQuorumRecoveryClient {
+	return kvpb.NewDRPCQuorumRecoveryClientAdapter(c.conn)
 }
 
 func makeRPCClientConfig(cfg server.Config) rpc.ClientConnConfig {

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3760,6 +3760,12 @@ service RangeFeed {
   rpc MuxRangeFeed (stream RangeFeedRequest) returns (stream MuxRangeFeedEvent) {}
 }
 
+// QuorumRecovery offers RPC to reset the quorum for the given range on the target
+// node.
+service QuorumRecovery {
+  rpc ResetQuorum (ResetQuorumRequest) returns (ResetQuorumResponse) {}
+}
+
 // Batch and RangeFeed service implemented by nodes for KV API requests.
 service Internal {
   rpc Batch (BatchRequest) returns (BatchResponse) {}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1001,6 +1001,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	if err := kvpb.DRPCRegisterCluster(drpcServer, node); err != nil {
 		return nil, err
 	}
+	if err := kvpb.DRPCRegisterQuorumRecovery(drpcServer, node); err != nil {
+		return nil, err
+	}
 	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)
 	if err := kvserver.DRPCRegisterPerReplica(drpcServer, node.perReplicaServer); err != nil {
 		return nil, err


### PR DESCRIPTION
This is a follow-up to #145195, where we extracted `KVBatch` from the `Internal` service. Here, we do the same with `QuorumRecovery`. The TL;DR is that smaller services are easier to maintain and can be more smoothly migrated to DRPC.

We also enable this service on the DRPC server. This is controlled by `rpc.experimental_drpc.enabled` (off by default).

This change is part of a series and is similar to: #146926

Note: This only registers the service; the client is not updated to use the DRPC client, so this service will not have any functional effect.

Fixes: #148726
Epic: CRDB-48925
Release note: None