### PR TITLE
roachtest: run sysbench weekly on postgres

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -423,14 +423,14 @@ func registerSysbench(r registry.Registry) {
 			}
 			r.Add(spec)
 
-			// Add a variant of each test that uses PostgreSQL instead of CockroachDB.
+			// Add a variant of the single-node tests that uses PostgreSQL instead of CockroachDB.
 			if d.n == 1 {
 				pgOpts := opts
 				pgOpts.usePostgres = true
 				pgSpec := spec
 				pgSpec.Name = fmt.Sprintf("sysbench/%s/postgres/cpu=%d/conc=%d", w, d.cpus, conc)
-				pgSpec.Suites = registry.ManualOnly
-				pgSpec.TestSelectionOptOutSuites = registry.ManualOnly
+				pgSpec.Suites = registry.Suites(registry.Weekly)
+				pgSpec.TestSelectionOptOutSuites = registry.Suites(registry.Weekly)
 				pgSpec.Run = func(ctx context.Context, t test.Test, c cluster.Cluster) {
 					runSysbench(ctx, t, c, pgOpts)
 				}

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -428,7 +428,7 @@ func registerSysbench(r registry.Registry) {
 				pgOpts := opts
 				pgOpts.usePostgres = true
 				pgSpec := spec
-				pgSpec.Name = fmt.Sprintf("sysbench/%s/postgres/cpu=%d/conc=%d", w, d.cpus, conc)
+				pgSpec.Name = fmt.Sprintf("%s/%s/postgres/cpu=%d/conc=%d", benchname, w, d.cpus, conc)
 				pgSpec.Suites = registry.Suites(registry.Weekly)
 				pgSpec.TestSelectionOptOutSuites = registry.Suites(registry.Weekly)
 				pgSpec.Run = func(ctx context.Context, t test.Test, c cluster.Cluster) {

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -364,10 +364,7 @@ func registerSysbench(r registry.Registry) {
 		{n: 3, cpus: 8,
 			transform: func(opts *sysbenchOptions) bool {
 				// Only run core three.
-				if !coreThree(opts.workload) {
-					return false
-				}
-				return true
+				return coreThree(opts.workload)
 			},
 		},
 		{n: 3, cpus: 8,

--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -264,6 +264,12 @@ func runSysbench(ctx context.Context, t test.Test, c cluster.Cluster, opts sysbe
 			return err
 		}
 
+		// The remainder of this method collects profiles and applies only to CRDB,
+		// so exit early if benchmarking postgres.
+		if opts.usePostgres {
+			return nil
+		}
+
 		t.Status("running 75 second workload to collect profiles")
 		{
 			// We store profiles in the perf directory. That way, they're not zipped

--- a/scripts/trigger-pr-roachtest.sh
+++ b/scripts/trigger-pr-roachtest.sh
@@ -54,6 +54,7 @@ json_payload=$(jq -n \
     property: [
       {name: "env.ARM_PROBABILITY", value: "0"},
       {name: "env.COCKROACH_EA_PROBABILITY", value: "0"},
+      {name: "env.SELECT_PROBABILITY", value: "1.0"},
       {name: "env.DEBUG", value: $envDebug},
       {name: "env.COUNT", value: $envCount},
       {name: "env.TESTS", value: $tests}


### PR DESCRIPTION
Run each sysbench flavor on single node postgres once a week.

Epic: CRDB-42584