### PR TITLE
*: use ExperimentalDRPCEnabled to pick DRPC or gRPC client

### DIFF
--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -478,7 +478,7 @@ func (n *Node) StatusClient(ctx context.Context) serverpb.RPCStatusClient {
 		return existingClient
 	}
 
-	if !rpcbase.TODODRPC && !rpc.UseDRPC(n.rpcCtx.Settings) {
+	if !rpcbase.TODODRPC && !rpc.DRPCEnabled(n.rpcCtx.Settings) {
 		conn, err := n.rpcCtx.GRPCUnvalidatedDial(n.RPCAddr(), roachpb.Locality{}).Connect(ctx)
 		if err != nil {
 			log.Fatalf(context.Background(), "failed to initialize status client: %s", err)

--- a/pkg/acceptance/localcluster/cluster.go
+++ b/pkg/acceptance/localcluster/cluster.go
@@ -478,7 +478,7 @@ func (n *Node) StatusClient(ctx context.Context) serverpb.RPCStatusClient {
 		return existingClient
 	}
 
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !rpc.UseDRPC(n.rpcCtx.Settings) {
 		conn, err := n.rpcCtx.GRPCUnvalidatedDial(n.RPCAddr(), roachpb.Locality{}).Connect(ctx)
 		if err != nil {
 			log.Fatalf(context.Background(), "failed to initialize status client: %s", err)

--- a/pkg/blobs/blobspb/BUILD.bazel
+++ b/pkg/blobs/blobspb/BUILD.bazel
@@ -29,5 +29,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/blobs/blobspb/rpc_clients.go
+++ b/pkg/blobs/blobspb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialBlobClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCBlobClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -437,7 +437,7 @@ func (c *client) drpcDial(ctx context.Context, rpcCtx *rpc.Context) (drpc.Conn, 
 func (c *client) dialGossipClient(
 	ctx context.Context, rpcCtx *rpc.Context,
 ) (RPCGossipClient, error) {
-	if !rpcbase.TODODRPC && !rpc.UseDRPC(rpcCtx.Settings) {
+	if !rpcbase.TODODRPC && !rpc.DRPCEnabled(rpcCtx.Settings) {
 		conn, err := c.dial(ctx, rpcCtx)
 		if err != nil {
 			return nil, err

--- a/pkg/gossip/client.go
+++ b/pkg/gossip/client.go
@@ -437,7 +437,7 @@ func (c *client) drpcDial(ctx context.Context, rpcCtx *rpc.Context) (drpc.Conn, 
 func (c *client) dialGossipClient(
 	ctx context.Context, rpcCtx *rpc.Context,
 ) (RPCGossipClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !rpc.UseDRPC(rpcCtx.Settings) {
 		conn, err := c.dial(ctx, rpcCtx)
 		if err != nil {
 			return nil, err

--- a/pkg/keyvisualizer/keyvispb/BUILD.bazel
+++ b/pkg/keyvisualizer/keyvispb/BUILD.bazel
@@ -38,5 +38,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/keyvisualizer/keyvispb/rpc_clients.go
+++ b/pkg/keyvisualizer/keyvispb/rpc_clients.go
@@ -10,6 +10,8 @@ import (
 
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 // DialKeyVisualizerClient establishes a DRPC connection if enabled; otherwise,
@@ -18,16 +20,10 @@ import (
 func DialKeyVisualizerClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCKeyVisualizerClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCKeyVisualizerClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCKeyVisualizerClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, class,
+		func(conn *grpc.ClientConn) RPCKeyVisualizerClient {
+			return NewGRPCKeyVisualizerClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCKeyVisualizerClient {
+			return NewDRPCKeyVisualizerClientAdapter(conn)
+		})
 }

--- a/pkg/keyvisualizer/keyvispb/rpc_clients.go
+++ b/pkg/keyvisualizer/keyvispb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialKeyVisualizerClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCKeyVisualizerClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -979,7 +979,7 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 		// Try each address on each retry iteration (in random order).
 		for _, i := range rand.Perm(len(c.addrs)) {
 			addr := c.addrs[i]
-			if !rpcbase.TODODRPC {
+			if !rpcbase.TODODRPC && !rpc.UseDRPC(c.rpcContext.Settings) {
 				conn, err := c.dialAddr(ctx, addr)
 				if err != nil {
 					log.Warningf(ctx, "error dialing tenant KV address %s: %v", addr, err)

--- a/pkg/kv/kvclient/kvtenant/connector.go
+++ b/pkg/kv/kvclient/kvtenant/connector.go
@@ -979,7 +979,7 @@ func (c *connector) dialAddrs(ctx context.Context) (*client, error) {
 		// Try each address on each retry iteration (in random order).
 		for _, i := range rand.Perm(len(c.addrs)) {
 			addr := c.addrs[i]
-			if !rpcbase.TODODRPC && !rpc.UseDRPC(c.rpcContext.Settings) {
+			if !rpcbase.TODODRPC && !rpc.DRPCEnabled(c.rpcContext.Settings) {
 				conn, err := c.dialAddr(ctx, addr)
 				if err != nil {
 					log.Warningf(ctx, "error dialing tenant KV address %s: %v", addr, err)

--- a/pkg/kv/kvserver/closedts/ctpb/BUILD.bazel
+++ b/pkg/kv/kvserver/closedts/ctpb/BUILD.bazel
@@ -16,6 +16,8 @@ go_library(
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
         "//pkg/util/timeutil",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
+++ b/pkg/kv/kvserver/closedts/ctpb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialSideTransportClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCSideTransportClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -707,6 +707,7 @@ func (f *rpcConnFactory) new(s *Sender, nodeID roachpb.NodeID) conn {
 type nodeDialer interface {
 	Dial(ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (_ *grpc.ClientConn, err error)
 	DRPCDial(ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (_ drpc.Conn, err error)
+	UseDRPC() bool
 }
 
 // On sending errors, we sleep a bit as to not spin on a tripped

--- a/pkg/kv/kvserver/closedts/sidetransport/sender.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender.go
@@ -707,7 +707,7 @@ func (f *rpcConnFactory) new(s *Sender, nodeID roachpb.NodeID) conn {
 type nodeDialer interface {
 	Dial(ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (_ *grpc.ClientConn, err error)
 	DRPCDial(ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass) (_ drpc.Conn, err error)
-	UseDRPC() bool
+	DRPCEnabled() bool
 }
 
 // On sending errors, we sleep a bit as to not spin on a tripped

--- a/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
+++ b/pkg/kv/kvserver/closedts/sidetransport/sender_test.go
@@ -644,6 +644,10 @@ func (m *mockDialer) addOrUpdateNode(nid roachpb.NodeID, addr string) {
 	m.mu.addrs[nid] = addr
 }
 
+func (m *mockDialer) UseDRPC() bool {
+	return false
+}
+
 func (m *mockDialer) Dial(
 	ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (_ *grpc.ClientConn, _ error) {
@@ -826,6 +830,10 @@ type failingDialer struct {
 }
 
 var _ nodeDialer = &failingDialer{}
+
+func (m *failingDialer) UseDRPC() bool {
+	return false
+}
 
 func (f *failingDialer) Dial(
 	ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialMultiRaftClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCMultiRaftClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
@@ -38,7 +38,7 @@ func DialMultiRaftClient(
 func DialPerReplicaClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCPerReplicaClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
@@ -58,7 +58,7 @@ func DialPerReplicaClient(
 func DialPerStoreClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCPerStoreClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err

--- a/pkg/kv/kvserver/rpc_clients.go
+++ b/pkg/kv/kvserver/rpc_clients.go
@@ -10,6 +10,8 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"google.golang.org/grpc"
+	drpc "storj.io/drpc"
 )
 
 // DialMultiRaftClient establishes a DRPC connection if enabled; otherwise,
@@ -18,18 +20,12 @@ import (
 func DialMultiRaftClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCMultiRaftClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCMultiRaftClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCMultiRaftClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, class,
+		func(conn *grpc.ClientConn) RPCMultiRaftClient {
+			return NewGRPCMultiRaftClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCMultiRaftClient {
+			return NewDRPCMultiRaftClientAdapter(conn)
+		})
 }
 
 // DialPerReplicaClient establishes a DRPC connection if enabled; otherwise,
@@ -38,18 +34,12 @@ func DialMultiRaftClient(
 func DialPerReplicaClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCPerReplicaClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCPerReplicaClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCPerReplicaClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, class,
+		func(conn *grpc.ClientConn) RPCPerReplicaClient {
+			return NewGRPCPerReplicaClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCPerReplicaClient {
+			return NewDRPCPerReplicaClientAdapter(conn)
+		})
 }
 
 // DialPerStoreClient establishes a DRPC connection if enabled; otherwise,
@@ -58,16 +48,10 @@ func DialPerReplicaClient(
 func DialPerStoreClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCPerStoreClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCPerStoreClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCPerStoreClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, class,
+		func(conn *grpc.ClientConn) RPCPerStoreClient {
+			return NewGRPCPerStoreClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCPerStoreClient {
+			return NewDRPCPerStoreClientAdapter(conn)
+		})
 }

--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/BUILD.bazel
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/BUILD.bazel
@@ -41,5 +41,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
+++ b/pkg/kv/kvserver/storeliveness/storelivenesspb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialStoreLivenessClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCStoreLivenessClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -117,6 +117,12 @@ func (n *Dialer) DRPCDial(
 	return dc, err
 }
 
+// UseDRPC determines whether to prefer DRPC over gRPC based on the
+// `rpc.experimental_drpc.enabled` cluster setting.
+func (n *Dialer) UseDRPC() bool {
+	return rpc.UseDRPC(n.rpcContext.Settings)
+}
+
 // DialNoBreaker is like Dial, but will not check the circuit breaker before
 // trying to connect. This function should only be used when there is good
 // reason to believe that the node is reachable.

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -119,8 +119,8 @@ func (n *Dialer) DRPCDial(
 
 // UseDRPC determines whether to prefer DRPC over gRPC based on the
 // `rpc.experimental_drpc.enabled` cluster setting.
-func (n *Dialer) UseDRPC() bool {
-	return rpc.UseDRPC(n.rpcContext.Settings)
+func (n *Dialer) DRPCEnabled() bool {
+	return rpc.DRPCEnabled(n.rpcContext.Settings)
 }
 
 // DialNoBreaker is like Dial, but will not check the circuit breaker before

--- a/pkg/rpc/peer_drpc.go
+++ b/pkg/rpc/peer_drpc.go
@@ -34,8 +34,8 @@ var ExperimentalDRPCEnabled = settings.RegisterBoolSetting(
 		return nil
 	}))
 
-// UseDRPC determines whether to prefer DRPC over gRPC based on the
+// DRPCEnabled returns whether to prefer DRPC over gRPC based on the
 // `rpc.experimental_drpc.enabled` cluster setting.
-func UseDRPC(st *cluster.Settings) bool {
+func DRPCEnabled(st *cluster.Settings) bool {
 	return ExperimentalDRPCEnabled.Get(&st.SV)
 }

--- a/pkg/rpc/peer_drpc.go
+++ b/pkg/rpc/peer_drpc.go
@@ -7,6 +7,7 @@ package rpc
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/errors"
@@ -32,3 +33,9 @@ var ExperimentalDRPCEnabled = settings.RegisterBoolSetting(
 		}
 		return nil
 	}))
+
+// UseDRPC determines whether to prefer DRPC over gRPC based on the
+// `rpc.experimental_drpc.enabled` cluster setting.
+func UseDRPC(st *cluster.Settings) bool {
+	return ExperimentalDRPCEnabled.Get(&st.SV)
+}

--- a/pkg/rpc/rpcbase/nodedialer.go
+++ b/pkg/rpc/rpcbase/nodedialer.go
@@ -22,6 +22,7 @@ const TODODRPC = false
 type NodeDialer interface {
 	Dial(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
 	DRPCDial(context.Context, roachpb.NodeID, ConnectionClass) (_ drpc.Conn, err error)
+	UseDRPC() bool
 }
 
 // NodeDialerNoBreaker interface defines methods for dialing peer nodes using their
@@ -30,4 +31,5 @@ type NodeDialer interface {
 type NodeDialerNoBreaker interface {
 	DialNoBreaker(context.Context, roachpb.NodeID, ConnectionClass) (_ *grpc.ClientConn, err error)
 	DRPCDialNoBreaker(context.Context, roachpb.NodeID, ConnectionClass) (_ drpc.Conn, err error)
+	UseDRPC() bool
 }

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -221,7 +221,7 @@ func newAdminServer(
 		),
 		st:             cs,
 		serverIterator: serverIterator,
-		nd:             &nodeDialer{si: serverIterator},
+		nd:             &nodeDialer{si: serverIterator, useDRPC: rpc.UseDRPC(cs)},
 		distSender:     distSender,
 		rpcContext:     rpcCtx,
 		clock:          clock,

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -221,7 +221,7 @@ func newAdminServer(
 		),
 		st:             cs,
 		serverIterator: serverIterator,
-		nd:             &nodeDialer{si: serverIterator, useDRPC: rpc.UseDRPC(cs)},
+		nd:             &nodeDialer{si: serverIterator, drpcEnabled: rpc.DRPCEnabled(cs)},
 		distSender:     distSender,
 		rpcContext:     rpcCtx,
 		clock:          clock,

--- a/pkg/server/fanout_clients.go
+++ b/pkg/server/fanout_clients.go
@@ -86,7 +86,12 @@ type ServerIterator interface {
 // implementation that can be use to create RPC clients. nodeDialer allows
 // reusing utity function in serverpb package to create RPC clients.
 type nodeDialer struct {
-	si ServerIterator
+	si      ServerIterator
+	useDRPC bool
+}
+
+func (d *nodeDialer) UseDRPC() bool {
+	return d.useDRPC
 }
 
 func (d *nodeDialer) Dial(

--- a/pkg/server/fanout_clients.go
+++ b/pkg/server/fanout_clients.go
@@ -86,12 +86,12 @@ type ServerIterator interface {
 // implementation that can be use to create RPC clients. nodeDialer allows
 // reusing utity function in serverpb package to create RPC clients.
 type nodeDialer struct {
-	si      ServerIterator
-	useDRPC bool
+	si          ServerIterator
+	drpcEnabled bool
 }
 
-func (d *nodeDialer) UseDRPC() bool {
-	return d.useDRPC
+func (d *nodeDialer) DRPCEnabled() bool {
+	return d.drpcEnabled
 }
 
 func (d *nodeDialer) Dial(

--- a/pkg/server/serverpb/BUILD.bazel
+++ b/pkg/server/serverpb/BUILD.bazel
@@ -116,6 +116,8 @@ go_library(
         "//pkg/util/errorutil",
         "//pkg/util/metric",
         "@com_github_prometheus_client_model//go",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialMigrationClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCMigrationClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
@@ -42,7 +42,7 @@ func DialStatusClientNoBreaker(
 	nodeID roachpb.NodeID,
 	class rpcbase.ConnectionClass,
 ) (RPCStatusClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.DialNoBreaker(ctx, nodeID, class)
 		if err != nil {
 			return nil, err
@@ -62,7 +62,7 @@ func DialStatusClientNoBreaker(
 func DialStatusClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID,
 ) (RPCStatusClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, err
@@ -82,7 +82,7 @@ func DialStatusClient(
 func DialAdminClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID,
 ) (RPCAdminClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, err
@@ -103,7 +103,7 @@ func DialAdminClient(
 func DialAdminClientNoBreaker(
 	nd rpcbase.NodeDialerNoBreaker, ctx context.Context, nodeID roachpb.NodeID,
 ) (RPCAdminClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.DialNoBreaker(ctx, nodeID, rpcbase.DefaultClass)
 		if err != nil {
 			return nil, err

--- a/pkg/server/serverpb/rpc_clients.go
+++ b/pkg/server/serverpb/rpc_clients.go
@@ -10,6 +10,8 @@ import (
 
 	roachpb "github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"google.golang.org/grpc"
+	"storj.io/drpc"
 )
 
 // DialMigrationClient establishes a DRPC connection if enabled; otherwise,
@@ -18,18 +20,12 @@ import (
 func DialMigrationClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCMigrationClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCMigrationClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCMigrationClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, class,
+		func(conn *grpc.ClientConn) RPCMigrationClient {
+			return NewGRPCMigrationClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCMigrationClient {
+			return NewDRPCMigrationClientAdapter(conn)
+		})
 }
 
 // DialStatusClientNoBreaker establishes a DRPC connection if enabled;
@@ -42,18 +38,12 @@ func DialStatusClientNoBreaker(
 	nodeID roachpb.NodeID,
 	class rpcbase.ConnectionClass,
 ) (RPCStatusClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.DialNoBreaker(ctx, nodeID, class)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCStatusClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDialNoBreaker(ctx, nodeID, class)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCStatusClientAdapter(conn), nil
+	return rpcbase.DialRPCClientNoBreaker(nd, ctx, nodeID, class,
+		func(conn *grpc.ClientConn) RPCStatusClient {
+			return NewGRPCStatusClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCStatusClient {
+			return NewDRPCStatusClientAdapter(conn)
+		})
 }
 
 // DialStatusClient establishes a DRPC connection if enabled; otherwise, it
@@ -62,18 +52,12 @@ func DialStatusClientNoBreaker(
 func DialStatusClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID,
 ) (RPCStatusClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, rpcbase.DefaultClass)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCStatusClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, rpcbase.DefaultClass)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCStatusClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, rpcbase.DefaultClass,
+		func(conn *grpc.ClientConn) RPCStatusClient {
+			return NewGRPCStatusClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCStatusClient {
+			return NewDRPCStatusClientAdapter(conn)
+		})
 }
 
 // DialAdminClient establishes a DRPC connection if enabled; otherwise, it
@@ -82,18 +66,12 @@ func DialStatusClient(
 func DialAdminClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID,
 ) (RPCAdminClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.Dial(ctx, nodeID, rpcbase.DefaultClass)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCAdminClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDial(ctx, nodeID, rpcbase.DefaultClass)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCAdminClientAdapter(conn), nil
+	return rpcbase.DialRPCClient(nd, ctx, nodeID, rpcbase.DefaultClass,
+		func(conn *grpc.ClientConn) RPCAdminClient {
+			return NewGRPCAdminClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCAdminClient {
+			return NewDRPCAdminClientAdapter(conn)
+		})
 }
 
 // DialAdminClientNoBreaker establishes a DRPC connection if enabled;
@@ -103,16 +81,10 @@ func DialAdminClient(
 func DialAdminClientNoBreaker(
 	nd rpcbase.NodeDialerNoBreaker, ctx context.Context, nodeID roachpb.NodeID,
 ) (RPCAdminClient, error) {
-	if !rpcbase.TODODRPC && !nd.UseDRPC() {
-		conn, err := nd.DialNoBreaker(ctx, nodeID, rpcbase.DefaultClass)
-		if err != nil {
-			return nil, err
-		}
-		return NewGRPCAdminClientAdapter(conn), nil
-	}
-	conn, err := nd.DRPCDialNoBreaker(ctx, nodeID, rpcbase.DefaultClass)
-	if err != nil {
-		return nil, err
-	}
-	return NewDRPCAdminClientAdapter(conn), nil
+	return rpcbase.DialRPCClientNoBreaker(nd, ctx, nodeID, rpcbase.DefaultClass,
+		func(conn *grpc.ClientConn) RPCAdminClient {
+			return NewGRPCAdminClientAdapter(conn)
+		}, func(conn drpc.Conn) RPCAdminClient {
+			return NewDRPCAdminClientAdapter(conn)
+		})
 }

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2677,7 +2677,7 @@ func (t *testTenant) RPCClientConn(
 func (t *testTenant) RPCClientConnE(user username.SQLUsername) (serverutils.RPCConn, error) {
 	ctx := context.Background()
 	rpcCtx := t.NewClientRPCContext(ctx, user)
-	if !rpcbase.TODODRPC && !rpc.UseDRPC(rpcCtx.Settings) {
+	if !rpcbase.TODODRPC && !rpc.DRPCEnabled(rpcCtx.Settings) {
 		conn, err := rpcCtx.GRPCDialPod(t.AdvRPCAddr(), t.SQLInstanceID(), t.Locality(), rpcbase.DefaultClass).Connect(ctx)
 		if err != nil {
 			return nil, err

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -2677,7 +2677,7 @@ func (t *testTenant) RPCClientConn(
 func (t *testTenant) RPCClientConnE(user username.SQLUsername) (serverutils.RPCConn, error) {
 	ctx := context.Background()
 	rpcCtx := t.NewClientRPCContext(ctx, user)
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !rpc.UseDRPC(rpcCtx.Settings) {
 		conn, err := rpcCtx.GRPCDialPod(t.AdvRPCAddr(), t.SQLInstanceID(), t.Locality(), rpcbase.DefaultClass).Connect(ctx)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -45,6 +45,8 @@ go_library(
         "@com_github_cockroachdb_redact//:redact",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_gogo_protobuf//types",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )
 

--- a/pkg/sql/execinfrapb/rpc_clients.go
+++ b/pkg/sql/execinfrapb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialDistSQLClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCDistSQLClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err

--- a/pkg/upgrade/upgradecluster/helper_test.go
+++ b/pkg/upgrade/upgradecluster/helper_test.go
@@ -24,6 +24,10 @@ import (
 
 type NoopDialer struct{}
 
+func (n NoopDialer) UseDRPC() bool {
+	return false
+}
+
 func (n NoopDialer) Dial(
 	ctx context.Context, id roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (*grpc.ClientConn, error) {

--- a/pkg/util/tracing/tracingservicepb/BUILD.bazel
+++ b/pkg/util/tracing/tracingservicepb/BUILD.bazel
@@ -37,5 +37,7 @@ go_library(
     deps = [
         "//pkg/roachpb",
         "//pkg/rpc/rpcbase",
+        "@io_storj_drpc//:drpc",
+        "@org_golang_google_grpc//:grpc",
     ],
 )

--- a/pkg/util/tracing/tracingservicepb/rpc_clients.go
+++ b/pkg/util/tracing/tracingservicepb/rpc_clients.go
@@ -18,7 +18,7 @@ import (
 func DialTracingClient(
 	nd rpcbase.NodeDialer, ctx context.Context, nodeID roachpb.NodeID, class rpcbase.ConnectionClass,
 ) (RPCTracingClient, error) {
-	if !rpcbase.TODODRPC {
+	if !rpcbase.TODODRPC && !nd.UseDRPC() {
 		conn, err := nd.Dial(ctx, nodeID, class)
 		if err != nil {
 			return nil, err


### PR DESCRIPTION
This change enables us to use the `rpc.experimental_drpc.enabled` setting to select between creating a DRPC or a gRPC client. We're leveraging the `nodedialer` by adding a `UseDRPC` method to it. This approach is beneficial because the node dialer is accessible in most locations where RPC clients are created, thus avoiding the need to introduce additional arguments to `Dial...Client` methods or plumb settings objects through numerous call paths.

This PR also introduces a small convenience method, `UseDRPC(st)`, as a shorthand for `ExperimentalDRPCEnabled.Get(&st.SV)`.

Epic: CRDB-48923
Release note: none