### PR TITLE
batcheval: latch writes at MinTimestamp

### DIFF
--- a/pkg/kv/kvserver/batcheval/declare.go
+++ b/pkg/kv/kvserver/batcheval/declare.go
@@ -137,6 +137,13 @@ func DefaultDeclareIsolatedKeys(
 			default:
 				return errors.AssertionFailedf("unexpected lock strength %s", str)
 			}
+		} else {
+			if header.Txn != nil {
+				// TODO(ssd): This is an experiment. By latching at the commit
+				// timestamp, we ensure that if that if we are on an Epoch > 0, then we
+				// don't overlap with readers who might be reading our old intents.
+				timestamp.Backward(header.Txn.MinTimestamp)
+			}
 		}
 	}
 	latchSpans.AddMVCC(access, req.Header().Span(), timestamp)


### PR DESCRIPTION
Retrying writers currently latch at their WriteTimestamp, allowing them to overlap with readers who might be reading intents from their previous Epoch. This is fine, but does lead to some interesting situations like the one described in #147065. In some cases, such readers will end up unnecessarily waiting on the old intent and will only be unblocked when a subsequent reader discovers the updated intent or when the writer completes its transaction.

Latching at the MinTimestamp would disallow the overlapping reader and writer. The reader would wait until the writer had updated its intent and then would proceed with its read.

Release note: None