### PR TITLE
all: reduce usage of `tenant 2` as an application tenant from tests

### DIFF
--- a/pkg/backup/schedule_exec_test.go
+++ b/pkg/backup/schedule_exec_test.go
@@ -42,7 +42,7 @@ func TestBackupSucceededUpdatesMetrics(t *testing.T) {
 
 	t.Run("updates RPO tenant metric", func(t *testing.T) {
 		schedule := createSchedule(t, true)
-		tenantIDs := mustMakeTenantIDs(t, 1, 2)
+		tenantIDs := mustMakeTenantIDs(t, 1, 3)
 		endTime := hlc.Timestamp{WallTime: hlc.UnixNano()}
 		details := jobspb.BackupDetails{
 			EndTime:           endTime,
@@ -52,7 +52,7 @@ func TestBackupSucceededUpdatesMetrics(t *testing.T) {
 		err := executor.backupSucceeded(ctx, nil, schedule, details, nil)
 		require.NoError(t, err)
 
-		expectedTenantIDs := []string{"system", "2"}
+		expectedTenantIDs := []string{"system", "3"}
 		verifyRPOTenantMetricLabels(t, executor.metrics.RpoTenantMetric, expectedTenantIDs)
 		verifyRPOTenantMetricGaugeValue(t, executor.metrics.RpoTenantMetric, details.EndTime)
 	})

--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -541,23 +541,23 @@ func TestShowBackupTenantView(t *testing.T) {
 
 	_ = securitytest.EmbeddedTenantIDs()
 
-	_, conn2 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(2)})
-	defer conn2.Close()
+	_, conn3 := serverutils.StartTenant(t, srv, base.TestTenantArgs{TenantID: roachpb.MustMakeTenantID(3)})
+	defer conn3.Close()
 
-	tenant2 := sqlutils.MakeSQLRunner(conn2)
+	tenant3 := sqlutils.MakeSQLRunner(conn3)
 	dataQuery := `CREATE DATABASE foo; CREATE TABLE foo.bar(i int primary key); INSERT INTO foo.bar VALUES (110), (210)`
 	backupQuery := `BACKUP TABLE foo.bar INTO $1`
 	showBackupQuery := "SELECT object_name, object_type, rows FROM [SHOW BACKUP FROM LATEST IN $1]"
-	tenant2.Exec(t, dataQuery)
+	tenant3.Exec(t, dataQuery)
 
 	// First, assert that SHOW BACKUPS on a tenant backup returns the same results if
-	// either the system tenant or tenant2 calls it.
+	// either the system tenant or tenant3 calls it.
 	tenantAddr, httpServerCleanup := makeInsecureHTTPServer(t)
 	defer httpServerCleanup()
 
-	tenant2.Exec(t, backupQuery, tenantAddr)
+	tenant3.Exec(t, backupQuery, tenantAddr)
 	systemTenantShowRes := systemDB.QueryStr(t, showBackupQuery, tenantAddr)
-	require.Equal(t, systemTenantShowRes, tenant2.QueryStr(t, showBackupQuery, tenantAddr))
+	require.Equal(t, systemTenantShowRes, tenant3.QueryStr(t, showBackupQuery, tenantAddr))
 
 	// If the system tenant created the same data, and conducted the same backup,
 	// the row counts should look the same.

--- a/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
+++ b/pkg/ccl/spanconfigccl/spanconfigsqlwatcherccl/sqlwatcher_test.go
@@ -229,11 +229,11 @@ func TestSQLWatcherReactsToUpdates(t *testing.T) {
 		},
 		{
 			stmts: []string{
-				"SELECT crdb_internal.create_tenant(2);",
-				"BACKUP TENANT 2 INTO 'nodelocal://1/foo'",
+				"SELECT crdb_internal.create_tenant(3);",
+				"BACKUP TENANT 3 INTO 'nodelocal://1/foo'",
 			},
 			expectedPTSUpdates: []spanconfig.ProtectedTimestampUpdate{{ClusterTarget: false,
-				TenantTarget: roachpb.MustMakeTenantID(2)}},
+				TenantTarget: roachpb.MustMakeTenantID(3)}},
 		},
 	}
 

--- a/pkg/crosscluster/producer/stream_event_batcher_test.go
+++ b/pkg/crosscluster/producer/stream_event_batcher_test.go
@@ -70,7 +70,7 @@ func TestBatchSpanConfigs(t *testing.T) {
 	t.Logf("Replication helper seed %d", seed)
 
 	seb := makeStreamEventBatcher(true)
-	codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(2))
+	codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(3))
 	bufferedEvents := make([]streampb.StreamedSpanConfigEntry, 0)
 
 	tableSpan := func(tableID uint32) roachpb.Span {

--- a/pkg/keys/keys_test.go
+++ b/pkg/keys/keys_test.go
@@ -702,7 +702,7 @@ func TestEnsureSafeSplitKey(t *testing.T) {
 func TestDecodeTenantPrefix(t *testing.T) {
 	tIDs := []roachpb.TenantID{
 		roachpb.SystemTenantID,
-		roachpb.MustMakeTenantID(2),
+		roachpb.MustMakeTenantID(3),
 		roachpb.MustMakeTenantID(999),
 		roachpb.MustMakeTenantID(math.MaxUint64),
 	}

--- a/pkg/kv/kvclient/kvtenant/tenant_range_lookup_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_range_lookup_test.go
@@ -28,7 +28,7 @@ func TestRangeLookupPrefetchFiltering(t *testing.T) {
 
 	ctx := context.Background()
 	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
-		// Avovid additional splits (outside those below) by disabling the split
+		// Avoid additional splits (outside those below) by disabling the split
 		// queue via the replication manual mode.
 		ReplicationMode: base.ReplicationManual,
 		ServerArgs: base.TestServerArgs{
@@ -37,33 +37,33 @@ func TestRangeLookupPrefetchFiltering(t *testing.T) {
 	})
 	defer tc.Stopper().Stop(ctx)
 
-	ten2ID := roachpb.MustMakeTenantID(2)
-	tenant2, err := tc.Server(0).TenantController().StartTenant(ctx, base.TestTenantArgs{
-		TenantID: ten2ID,
+	ten3ID := roachpb.MustMakeTenantID(3)
+	tenant3, err := tc.Server(0).TenantController().StartTenant(ctx, base.TestTenantArgs{
+		TenantID: ten3ID,
 	})
 	require.NoError(t, err)
 
-	// Split some ranges within tenant2 that we'll want to see in prefetch.
-	ten2Codec := keys.MakeSQLCodec(ten2ID)
-	ten2Split1 := append(ten2Codec.TenantPrefix(), 'a')
-	ten2Split2 := append(ten2Codec.TenantPrefix(), 'b')
+	// Split some ranges within tenant3 that we'll want to see in prefetch.
+	ten3Codec := keys.MakeSQLCodec(ten3ID)
+	ten3Split1 := append(ten3Codec.TenantPrefix(), 'a')
+	ten3Split2 := append(ten3Codec.TenantPrefix(), 'b')
 	{
-		tc.SplitRangeOrFatal(t, ten2Split1)
-		tc.SplitRangeOrFatal(t, ten2Split2)
+		tc.SplitRangeOrFatal(t, ten3Split1)
+		tc.SplitRangeOrFatal(t, ten3Split2)
 	}
 
-	// Split some ranges for the tenant which comes after tenant2.
+	// Split some ranges for the tenant which comes after tenant3.
 	{
-		ten3Codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(3))
-		tc.SplitRangeOrFatal(t, ten3Codec.TenantPrefix())
-		tc.SplitRangeOrFatal(t, append(ten3Codec.TenantPrefix(), 'b'))
-		tc.SplitRangeOrFatal(t, append(ten3Codec.TenantPrefix(), 'c'))
+		ten4Codec := keys.MakeSQLCodec(roachpb.MustMakeTenantID(4))
+		tc.SplitRangeOrFatal(t, ten4Codec.TenantPrefix())
+		tc.SplitRangeOrFatal(t, append(ten4Codec.TenantPrefix(), 'b'))
+		tc.SplitRangeOrFatal(t, append(ten4Codec.TenantPrefix(), 'c'))
 	}
 
 	// Do the fetch and make sure we prefetch all the ranges we should see,
 	// and none of the ranges we should not.
-	db := tenant2.DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache().DB()
-	prefixRKey := keys.MustAddr(ten2Codec.TenantPrefix())
+	db := tenant3.DistSenderI().(*kvcoord.DistSender).RangeDescriptorCache().DB()
+	prefixRKey := keys.MustAddr(ten3Codec.TenantPrefix())
 	res, prefetch, err := db.RangeLookup(
 		ctx, prefixRKey,
 		rangecache.ReadFromLeaseholder, false, /* useReverseScan */
@@ -72,6 +72,6 @@ func TestRangeLookupPrefetchFiltering(t *testing.T) {
 	require.Len(t, res, 1)
 	require.Equal(t, prefixRKey, res[0].StartKey)
 	require.Len(t, prefetch, 2)
-	require.Equal(t, keys.MustAddr(ten2Split1), prefetch[0].StartKey)
-	require.Equal(t, keys.MustAddr(ten2Split2), prefetch[1].StartKey)
+	require.Equal(t, keys.MustAddr(ten3Split1), prefetch[0].StartKey)
+	require.Equal(t, keys.MustAddr(ten3Split2), prefetch[1].StartKey)
 }

--- a/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
+++ b/pkg/kv/kvclient/kvtenant/tenant_scan_range_descriptors_test.go
@@ -31,12 +31,12 @@ func setup(
 		},
 	})
 
-	ten2ID := roachpb.MustMakeTenantID(2)
-	tenant2, err := tc.Server(0).TenantController().StartTenant(ctx, base.TestTenantArgs{
-		TenantID: ten2ID,
+	ten3ID := roachpb.MustMakeTenantID(3)
+	tenant3, err := tc.Server(0).TenantController().StartTenant(ctx, base.TestTenantArgs{
+		TenantID: ten3ID,
 	})
 	require.NoError(t, err)
-	return tc, tenant2, tenant2.RangeDescIteratorFactory().(rangedesc.IteratorFactory)
+	return tc, tenant3, tenant3.RangeDescIteratorFactory().(rangedesc.IteratorFactory)
 }
 
 // TestScanRangeDescriptors is an integration test to ensure that tenants can
@@ -46,20 +46,20 @@ func TestScanRangeDescriptors(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	tc, tenant2, iteratorFactory := setup(t, ctx)
+	tc, tenant3, iteratorFactory := setup(t, ctx)
 	defer tc.Stopper().Stop(ctx)
 
 	// Split some ranges within tenant2 that we'll scan over.
-	ten2Codec := tenant2.Codec()
-	ten2Split1 := append(ten2Codec.TenantPrefix(), 'a')
-	ten2Split2 := append(ten2Codec.TenantPrefix(), 'b')
+	ten3Codec := tenant3.Codec()
+	ten3Split1 := append(ten3Codec.TenantPrefix(), 'a')
+	ten3Split2 := append(ten3Codec.TenantPrefix(), 'b')
 	{
-		tc.SplitRangeOrFatal(t, ten2Split1)
-		tc.SplitRangeOrFatal(t, ten2Split2)
-		tc.SplitRangeOrFatal(t, ten2Codec.TenantEndKey()) // Last range
+		tc.SplitRangeOrFatal(t, ten3Split1)
+		tc.SplitRangeOrFatal(t, ten3Split2)
+		tc.SplitRangeOrFatal(t, ten3Codec.TenantEndKey()) // Last range
 	}
 
-	iter, err := iteratorFactory.NewIterator(ctx, ten2Codec.TenantSpan())
+	iter, err := iteratorFactory.NewIterator(ctx, ten3Codec.TenantSpan())
 	require.NoError(t, err)
 
 	var rangeDescs []roachpb.RangeDescriptor
@@ -71,17 +71,17 @@ func TestScanRangeDescriptors(t *testing.T) {
 	require.Len(t, rangeDescs, 3)
 	require.Equal(
 		t,
-		keys.MustAddr(ten2Codec.TenantPrefix()),
+		keys.MustAddr(ten3Codec.TenantPrefix()),
 		rangeDescs[0].StartKey,
 	)
 	require.Equal(
 		t,
-		keys.MustAddr(ten2Split1),
+		keys.MustAddr(ten3Split1),
 		rangeDescs[1].StartKey,
 	)
 	require.Equal(
 		t,
-		keys.MustAddr(ten2Split2),
+		keys.MustAddr(ten3Split2),
 		rangeDescs[2].StartKey,
 	)
 
@@ -110,7 +110,7 @@ func TestScanRangeDescriptors(t *testing.T) {
 	// Last range we created above.
 	require.Equal(
 		t,
-		keys.MustAddr(ten2Codec.TenantEndKey()),
+		keys.MustAddr(ten3Codec.TenantEndKey()),
 		rangeDescs[numRanges-1].StartKey,
 	)
 }
@@ -124,5 +124,5 @@ func TestScanRangeDescriptorsOutsideTenantKeyspace(t *testing.T) {
 	defer tc.Stopper().Stop(ctx)
 
 	_, err := iteratorFactory.NewIterator(ctx, keys.EverythingSpan)
-	require.ErrorContains(t, err, "requested key span /M{in-ax} not fully contained in tenant keyspace /Tenant/{2-3}")
+	require.ErrorContains(t, err, "requested key span /M{in-ax} not fully contained in tenant keyspace /Tenant/{3-4}")
 }

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -2663,7 +2663,7 @@ func TestStore_HottestReplicasByTenant(t *testing.T) {
 	}
 
 	td := []testData{{1, 2}, {1, 3}, {1, 4}, {1, 5},
-		{2, 1}, {2, 2}, {2, 3}, {2, 4}}
+		{3, 1}, {3, 2}, {3, 3}, {3, 4}}
 
 	acc := NewTenantReplicaAccumulator(aload.Queries)
 
@@ -2689,7 +2689,7 @@ func TestStore_HottestReplicasByTenant(t *testing.T) {
 	for i := 0; i < iterationsNum; i++ {
 		go func() {
 			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(1)))
-			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(2)))
+			require.NotNil(t, store.HottestReplicasByTenant(roachpb.MustMakeTenantID(3)))
 			wg.Done()
 		}()
 	}

--- a/pkg/kv/kvserver/tenantrate/limiter_test.go
+++ b/pkg/kv/kvserver/tenantrate/limiter_test.go
@@ -50,7 +50,7 @@ func TestCloser(t *testing.T) {
 	factory := tenantrate.NewLimiterFactory(&st.SV, &tenantrate.TestingKnobs{
 		QuotaPoolOptions: []quotapool.Option{quotapool.WithTimeSource(timeSource)},
 	}, fakeAuthorizer{})
-	tenant := roachpb.MustMakeTenantID(2)
+	tenant := roachpb.MustMakeTenantID(3)
 	closer := make(chan struct{})
 	limiter := factory.GetTenant(ctx, tenant, closer)
 	// First Wait call will not block.

--- a/pkg/roachpb/tenant_test.go
+++ b/pkg/roachpb/tenant_test.go
@@ -16,7 +16,7 @@ func TestTenantIDString(t *testing.T) {
 	for tID, expStr := range map[TenantID]string{
 		{}:                               "invalid",
 		SystemTenantID:                   "system",
-		MustMakeTenantID(2):              "2",
+		MustMakeTenantID(3):              "3",
 		MustMakeTenantID(999):            "999",
 		MustMakeTenantID(math.MaxUint64): "18446744073709551615",
 	} {

--- a/pkg/rpc/auth_test.go
+++ b/pkg/rpc/auth_test.go
@@ -436,7 +436,7 @@ func TestTenantAuthRequest(t *testing.T) {
 		}
 	}
 
-	tenantTwo := roachpb.MustMakeTenantID(2)
+	tenantThree := roachpb.MustMakeTenantID(3)
 	makeTimeseriesQueryReq := func(tenantID *roachpb.TenantID) *tspb.TimeSeriesQueryRequest {
 		req := &tspb.TimeSeriesQueryRequest{
 			Queries: []tspb.Query{{}},
@@ -998,7 +998,7 @@ func TestTenantAuthRequest(t *testing.T) {
 				expErr: noError,
 			},
 			{
-				req:    makeTimeseriesQueryReq(&tenantTwo),
+				req:    makeTimeseriesQueryReq(&tenantThree),
 				expErr: `tsdb query with invalid tenant not permitted`,
 			},
 		},

--- a/pkg/rpc/heartbeat_test.go
+++ b/pkg/rpc/heartbeat_test.go
@@ -285,7 +285,7 @@ func TestTenantVersionCheck(t *testing.T) {
 	})
 	// Ensure that the same ping succeeds with a secondary tenant context.
 	t.Run("old, secondary tenant", func(t *testing.T) {
-		tenantCtx := roachpb.ContextWithClientTenant(context.Background(), roachpb.MustMakeTenantID(2))
+		tenantCtx := roachpb.ContextWithClientTenant(context.Background(), roachpb.MustMakeTenantID(3))
 		_, err := heartbeat.Ping(tenantCtx, request)
 		require.NoError(t, err)
 	})

--- a/pkg/spanconfig/protectedts_state_reader_test.go
+++ b/pkg/spanconfig/protectedts_state_reader_test.go
@@ -57,8 +57,8 @@ func TestProtectedTimestampStateReader(t *testing.T) {
 	protectSchemaObject(state, ts(2), []descpb.ID{56, 57})
 	protectCluster(state, ts(3))
 	protectTenants(state, ts(4), []roachpb.TenantID{roachpb.MustMakeTenantID(1)})
-	protectTenants(state, ts(5), []roachpb.TenantID{roachpb.MustMakeTenantID(2)})
-	protectTenants(state, ts(6), []roachpb.TenantID{roachpb.MustMakeTenantID(2)})
+	protectTenants(state, ts(5), []roachpb.TenantID{roachpb.MustMakeTenantID(3)})
+	protectTenants(state, ts(6), []roachpb.TenantID{roachpb.MustMakeTenantID(3)})
 
 	ptsStateReader := spanconfig.NewProtectedTimestampStateReader(context.Background(), *state)
 	clusterTimestamps := ptsStateReader.GetProtectionPoliciesForCluster()
@@ -76,7 +76,7 @@ func TestProtectedTimestampStateReader(t *testing.T) {
 			Protections: []roachpb.ProtectionPolicy{{ProtectedTimestamp: ts(4)}},
 		},
 		{
-			TenantID: roachpb.MustMakeTenantID(2),
+			TenantID: roachpb.MustMakeTenantID(3),
 			Protections: []roachpb.ProtectionPolicy{{ProtectedTimestamp: ts(5)},
 				{ProtectedTimestamp: ts(6)}},
 		},

--- a/pkg/spanconfig/record_test.go
+++ b/pkg/spanconfig/record_test.go
@@ -107,8 +107,8 @@ func TestRecordSystemTargetValidation(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			emptyScfg := roachpb.SpanConfig{}
-			systemTarget := TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(2),
-				roachpb.MustMakeTenantID(2))
+			systemTarget := TestingMakeTenantKeyspaceTargetOrFatal(t, roachpb.MustMakeTenantID(3),
+				roachpb.MustMakeTenantID(3))
 			target := MakeTargetFromSystemTarget(systemTarget)
 			_, err := MakeRecord(target, emptyScfg)
 			testutils.IsError(err, tc.expectedErr)

--- a/pkg/spanconfig/spanconfigsqlwatcher/buffer_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/buffer_test.go
@@ -318,9 +318,9 @@ func TestBufferedEventsSort(t *testing.T) {
 	evs = append(evs, makePTSEvent(true, roachpb.TenantID{}, ts(2)))
 
 	// Insert a few tenant updates that should sort before the cluster updates.
-	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(3)))
+	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(3), ts(3)))
 	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(1), ts(7)))
-	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(2)))
+	evs = append(evs, makePTSEvent(false, roachpb.MustMakeTenantID(3), ts(2)))
 
 	// Insert a few more descriptor updates to interleave the updates.
 	evs = append(evs, makeDescriptorEvent(4, ts(12)))
@@ -340,8 +340,8 @@ func TestBufferedEventsSort(t *testing.T) {
 		makeDescriptorEvent(4, ts(12)),
 		makeDescriptorEvent(5, ts(11)),
 		makePTSEvent(false, roachpb.MustMakeTenantID(1), ts(7)),
-		makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(2)),
-		makePTSEvent(false, roachpb.MustMakeTenantID(2), ts(3)),
+		makePTSEvent(false, roachpb.MustMakeTenantID(3), ts(2)),
+		makePTSEvent(false, roachpb.MustMakeTenantID(3), ts(3)),
 		makePTSEvent(true, roachpb.TenantID{}, ts(2)),
 		makePTSEvent(true, roachpb.TenantID{}, ts(3)),
 	}, evs)

--- a/pkg/spanconfig/spanconfigsqlwatcher/protectedtsdecoder_test.go
+++ b/pkg/spanconfig/spanconfigsqlwatcher/protectedtsdecoder_test.go
@@ -53,7 +53,7 @@ func TestProtectedTimestampDecoder(t *testing.T) {
 		{
 			name: "tenant",
 			target: ptpb.MakeTenantsTarget([]roachpb.TenantID{roachpb.MustMakeTenantID(1),
-				roachpb.MustMakeTenantID(2)}),
+				roachpb.MustMakeTenantID(3)}),
 		},
 		{
 			name:   "schema-object",


### PR DESCRIPTION
Currently, we use tenant ID 2 as an application tenant in various tests. 
However, in normal operational scenarios, the creation of tenant ID 2 is 
explicitly disabled to avoid conflicts with its role in UA, as detailed here:

https://github.com/cockroachdb/cockroach/blob/9919801f067f26c951f43cbedfa093c37cdda20e/pkg/sql/tenant_creation.go#L604-L609

With the ongoing migration towards UA, tenant ID 2 will begin functioning
as a system tenant.

Consequently, we are shifting the application tenant role from tenant ID 2 to 
tenant ID 3 to clearly separate the roles and responsibilities of system and 
application tenants. This patch specifically addresses and reduces the usage
of tenant ID 2 within tests, ensuring tests align with this architectural adjustment 
and maintaining consistency across the codebase.

Part of: https://github.com/cockroachdb/cockroach/issues/138801
Epic : CRDB-45181
Release note: none