### PR TITLE
backup: increase pool size for backup sink tests

### DIFF
--- a/pkg/backup/backupsink/BUILD.bazel
+++ b/pkg/backup/backupsink/BUILD.bazel
@@ -37,6 +37,7 @@ go_test(
         "sst_sink_key_writer_test.go",
     ],
     embed = [":backupsink"],
+    exec_properties = {"test.Pool": "large"},
     deps = [
         "//pkg/backup/backuppb",
         "//pkg/ccl/storageccl",


### PR DESCRIPTION
A test failure was discovered that was likely caused by an OOM. This commit increases the pool size for the test.

Epic: CRDB-51482

Fixes: #148630