### PR TITLE
telemtryccl: wait for schema changes to finish in test

### DIFF
--- a/pkg/sql/sqltestutils/BUILD.bazel
+++ b/pkg/sql/sqltestutils/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/base",
         "//pkg/config/zonepb",
+        "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
         "//pkg/roachpb",


### PR DESCRIPTION
TestTelemetry timeouts appear to be related to schema changes in the datadriven test files. We observed that in other tests, there's a process to wait for schema change jobs to complete before proceeding. It's possible that these tests should do the same since we trigger many schema changes in rapid succession.

The wait step is added to the `exec` command since that's where we process statements like `ALTER TABLE t5 SET LOCALITY REGIONAL BY ROW AS "cr"`.

Resolves: #148387
Release note: None