### PR TITLE
release-25.2: roachtest: increase fixture timeout to account for fingerprinting

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -293,7 +293,9 @@ func registerBackupFixtures(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{
 				workloadNode: true,
 			}),
-			timeout: 2 * time.Hour,
+			// Fingerprinting is measured to take about 40 minutes on a 350 GB
+			// fixture on top of the allocated 2 hours for the test.
+			timeout: 3 * time.Hour,
 			suites:  registry.Suites(registry.Nightly),
 			clouds:  []spec.Cloud{spec.AWS, spec.GCE}},
 		{


### PR DESCRIPTION
Backport 1/1 commits from #148156.

/cc @cockroachdb/release

---

Fixes: #148498

Release note: None

Release justification: Test-only change
