### PR TITLE
server/profiler: bump heap profiler size limit from 256MiB to 512MiB

### DIFF
--- a/pkg/server/profiler/heapprofiler.go
+++ b/pkg/server/profiler/heapprofiler.go
@@ -39,15 +39,17 @@ var maxCombinedFileSize = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"server.mem_profile.total_dump_size_limit",
 	"maximum combined disk size of preserved memory profiles",
-	256<<20, // 256MiB
+	512<<20, // 512MiB
 )
 
 func init() {
+	// This setting definition still exists so as to not break deployment
+	// scripts that set it unconditionally.
 	_ = settings.RegisterByteSizeSetting(
 		settings.ApplicationLevel,
 		"server.heap_profile.total_dump_size_limit",
 		"use server.mem_profile.total_dump_size_limit instead",
-		256<<20, // 256MiB
+		512<<20, // 512MiB
 		settings.Retired,
 	)
 }


### PR DESCRIPTION
I've seen a couple of cases where the heap profiles I was interested in were just rotated, so let's bump the limit by 2x.

Epic: None

Release note (ops change): The default value of `server.mem_profile.total_dump_size_limit` (which controls how much space can be used by automatically collected heap profiles) has been increased from 256MiB to 512MiB.