### PR TITLE
release-25.3: logictest: deflake drop_database

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/drop_database
+++ b/pkg/sql/logictest/testdata/logic_test/drop_database
@@ -226,16 +226,21 @@ query TT
 WITH cte AS (
   SELECT job_type, description
   FROM crdb_internal.jobs
-  WHERE (job_type = 'SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC')
+  WHERE (job_type = 'NEW SCHEMA CHANGE' OR job_type = 'SCHEMA CHANGE GC')
   AND (status = 'succeeded' OR status = 'running')
+  AND (description LIKE '%DROP%')
   ORDER BY created DESC
-  LIMIT 4
 ) SELECT * FROM cte ORDER BY job_type, description
 ----
-SCHEMA CHANGE     CREATE TABLE constraint_db.public.t2 (t1_id INT8, CONSTRAINT fk FOREIGN KEY (t1_id) REFERENCES constraint_db.public.t1 (a), INDEX (t1_id))
-SCHEMA CHANGE     updating referenced FK table t1(125) for table t2(126)
-SCHEMA CHANGE GC  GC for DROP DATABASE constraint_db CASCADE
-SCHEMA CHANGE GC  GC for DROP DATABASE d2 CASCADE
+NEW SCHEMA CHANGE  DROP DATABASE "foo bar" CASCADE
+NEW SCHEMA CHANGE  DROP DATABASE "foo-bar" CASCADE
+NEW SCHEMA CHANGE  DROP DATABASE constraint_db CASCADE
+NEW SCHEMA CHANGE  DROP DATABASE d1 CASCADE
+NEW SCHEMA CHANGE  DROP DATABASE d2 CASCADE
+SCHEMA CHANGE GC   GC for DROP DATABASE "foo-bar" CASCADE
+SCHEMA CHANGE GC   GC for DROP DATABASE constraint_db CASCADE
+SCHEMA CHANGE GC   GC for DROP DATABASE d1 CASCADE
+SCHEMA CHANGE GC   GC for DROP DATABASE d2 CASCADE
 
 query TTTTTT rowsort
 SHOW DATABASES


### PR DESCRIPTION
Backport 1/1 commits from #148824 on behalf of @fqazi.

----

Previously, the drop_database logic test would list SCHEMA CHANGE GC and SCHEMA CHANGE jobs without filtering the job description and a limit clause, which would be non-deterministic. To address this, this patch adds filtering on job description and removes the limit clause for a more deterministic result.

Fixes: #148009
Release note: None

----

Release justification: test only change