### PR TITLE
storage: enable value separation by default

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -353,10 +353,10 @@ var (
 	valueSeparationEnabled = settings.RegisterBoolSetting(
 		settings.SystemVisible,
 		"storage.value_separation.enabled",
-		"(experimental) whether or not values may be separated into blob files; "+
+		"whether or not values may be separated into blob files; "+
 			"requires columnar blocks to be enabled",
 		metamorphic.ConstantWithTestBool(
-			"storage.value_separation.enabled", false), /* defaultValue */
+			"storage.value_separation.enabled", true /* defaultValue */),
 	)
 	valueSeparationMinimumSize = settings.RegisterIntSetting(
 		settings.SystemVisible,
@@ -378,7 +378,7 @@ var (
 		settings.SystemVisible,
 		"storage.value_separation.rewrite_minimum_age",
 		"the minimum age of a blob file before it is eligible for a rewrite compaction",
-		5*time.Minute, // 5 minutes
+		5*time.Minute,
 		settings.DurationWithMinimum(0),
 	)
 	valueSeparationCompactionGarbageThreshold = settings.RegisterIntSetting(


### PR DESCRIPTION
Epic: none
Release note (ops change): The `storage.value_separation.enabled` cluster setting is now true by default. This enables value separation for sstables, where values exceeding a certain size threshold are stored in separate blob files rather than inline in the sstable. This helps improve write performance (write-amp) by avoiding rewriting such values during compactions.