### PR TITLE
roachtest: add `s390x-test-failure` GH label when arch == "s390x"

### DIFF
--- a/pkg/cmd/roachtest/github.go
+++ b/pkg/cmd/roachtest/github.go
@@ -217,6 +217,7 @@ func (g *githubIssues) createPostRequest(
 	const infraFlakeLabel = "X-infra-flake"
 	const runtimeAssertionsLabel = "B-runtime-assertions-enabled"
 	const coverageLabel = "B-coverage-enabled"
+	const s390xTestFailureLabel = "s390x-test-failure"
 	labels := []string{"O-roachtest"}
 	if infraFlake {
 		labels = append(labels, infraFlakeLabel)
@@ -234,6 +235,11 @@ func (g *githubIssues) createPostRequest(
 		if coverageBuild {
 			labels = append(labels, coverageLabel)
 		}
+	}
+	// N.B. To simplify tracking failures on s390x, we add the designated s390x-test-failure label. This could be removed
+	// in the future, i.e., after several major releases, when we expect s390x to be sufficiently stable.
+	if arch := params["arch"]; vm.CPUArch(arch) == vm.ArchS390x {
+		labels = append(labels, s390xTestFailureLabel)
 	}
 	labels = append(labels, spec.ExtraLabels...)
 


### PR DESCRIPTION
To simplify tracking roachtest failures on s390x, we add `s390x-test-failure` Github label.

Epic: none
Release note: None