### PR TITLE
release-25.3: geomfn: adjust two tests to work on s390x

### DIFF
--- a/pkg/geo/geomfn/BUILD.bazel
+++ b/pkg/geo/geomfn/BUILD.bazel
@@ -111,6 +111,7 @@ go_test(
         "//pkg/geo/geopb",
         "//pkg/geo/geos",
         "//pkg/geo/geotest",
+        "//pkg/testutils/floatcmp",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",


### PR DESCRIPTION
Backport 1/1 commits from #148778 on behalf of @yuzefovich.

----

`angleFromCoords` function uses `atan` to compute some geometry functions. s390x system has architecture support for that trigonometric function which can produce slightly different result than when computing via math operations, which resulted in a false positive failure in a couple of tests. This commit teaches those tests to use our custom float comparison function that only checks 15 significant decimal digits.

Fixes: #145985.

Release note: None

----

Release justification: test-only change.