### PR TITLE
cli: fix printing of the store spec

### DIFF
--- a/pkg/cli/start.go
+++ b/pkg/cli/start.go
@@ -1240,7 +1240,7 @@ func reportServerInfo(
 		buf.Printf("external I/O path: \t<disabled>\n")
 	}
 	for i, spec := range serverCfg.Stores.Specs {
-		buf.Printf("store[%d]:\t%s\n", i, log.SafeManaged(spec))
+		buf.Printf("store[%d]:\t%s\n", i, log.SafeManaged(base.StoreSpecCmdLineString(spec)))
 	}
 
 	// Print the commong server identifiers.


### PR DESCRIPTION
This was recently broken in 4744a801bd624a96f2572a09b6af7d6c10879ade.

Epic: None
Release note: None