### PR TITLE
pkg/keys: replace fmt.Fprintf with buf.Printf

### DIFF
--- a/pkg/keys/printer.go
+++ b/pkg/keys/printer.go
@@ -424,7 +424,7 @@ func localRangeIDKeyPrint(
 		return
 	}
 
-	fmt.Fprintf(buf, "/%d", i)
+	buf.Printf("/%d", i)
 
 	// Print and remove the rangeID infix specifier.
 	if len(key) != 0 {


### PR DESCRIPTION
To maintain redactability, strings must be constructed using helper functions from the redact package. This change replaces an instance of `fmt.Fprintf` with `buf.Printf` to prevent marking the `rangeID` as unsafe.

Epic: none
Release note: None