### PR TITLE
release-25.1: pkg/kv/kvpb: Add SafeFormat method to BatchResponse struct

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4769,26 +4769,26 @@ func TestDistSenderSlowLogMessage(t *testing.T) {
 	br.Error = kvpb.NewError(errors.New("boom"))
 	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x"), EndKey: roachpb.RKey("z")}
 	{
-		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) ["a"] to` +
-			` r9:{x-z} [<no replicas>, next=0, gen=0]; resp: (err: boom)`
+		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) [‹"a"›] to` +
+			` r9:{‹x›-‹z›} [<no replicas>, next=0, gen=0]; resp: (err: boom)`
 		var s redact.StringBuilder
 		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, nil /* err */, br)
-		act := s.RedactableString().StripMarkers()
+		act := s.RedactableString()
 		require.EqualValues(t, exp, act)
 	}
 	{
 		exp := `slow RPC finished after 8.16s (120 attempts)`
 		var s redact.StringBuilder
 		slowRangeRPCReturnWarningStr(&s, dur, attempts)
-		act := s.RedactableString().StripMarkers()
+		act := s.RedactableString()
 		require.EqualValues(t, exp, act)
 	}
 	{
-		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) ["a"] to` +
+		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) [‹"a"›] to` +
 			` replica (n2,s3):1; resp: (err: boom)`
 		var s redact.StringBuilder
 		slowReplicaRPCWarningStr(&s, ba, dur, attempts, nil /* err */, br)
-		act := s.RedactableString().StripMarkers()
+		act := s.RedactableString()
 		require.EqualValues(t, exp, act)
 	}
 }

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4770,7 +4770,7 @@ func TestDistSenderSlowLogMessage(t *testing.T) {
 	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x"), EndKey: roachpb.RKey("z")}
 	{
 		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) [‹"a"›] to` +
-			` r9:{‹x›-‹z›} [<no replicas>, next=0, gen=0]; resp: (err: boom)`
+			` r9:‹{x-z}› [<no replicas>, next=0, gen=0]; resp: (err: boom)`
 		var s redact.StringBuilder
 		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, nil /* err */, br)
 		act := s.RedactableString()

--- a/pkg/kv/kvclient/kvcoord/dist_sender_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_test.go
@@ -4769,26 +4769,26 @@ func TestDistSenderSlowLogMessage(t *testing.T) {
 	br.Error = kvpb.NewError(errors.New("boom"))
 	desc := &roachpb.RangeDescriptor{RangeID: 9, StartKey: roachpb.RKey("x"), EndKey: roachpb.RKey("z")}
 	{
-		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) [‹"a"›] to` +
-			` r9:‹{x-z}› [<no replicas>, next=0, gen=0]; resp: ‹(err: boom)›`
+		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) ["a"] to` +
+			` r9:{x-z} [<no replicas>, next=0, gen=0]; resp: (err: boom)`
 		var s redact.StringBuilder
 		slowRangeRPCWarningStr(&s, ba, dur, attempts, desc, nil /* err */, br)
-		act := s.RedactableString()
+		act := s.RedactableString().StripMarkers()
 		require.EqualValues(t, exp, act)
 	}
 	{
 		exp := `slow RPC finished after 8.16s (120 attempts)`
 		var s redact.StringBuilder
 		slowRangeRPCReturnWarningStr(&s, dur, attempts)
-		act := s.RedactableString()
+		act := s.RedactableString().StripMarkers()
 		require.EqualValues(t, exp, act)
 	}
 	{
-		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) [‹"a"›] to` +
-			` replica (n2,s3):1; resp: ‹(err: boom)›`
+		exp := `have been waiting 8.16s (120 attempts) for RPC Get(Shared,Unreplicated) ["a"] to` +
+			` replica (n2,s3):1; resp: (err: boom)`
 		var s redact.StringBuilder
 		slowReplicaRPCWarningStr(&s, ba, dur, attempts, nil /* err */, br)
-		act := s.RedactableString()
+		act := s.RedactableString().StripMarkers()
 		require.EqualValues(t, exp, act)
 	}
 }

--- a/pkg/kv/kvpb/batch.go
+++ b/pkg/kv/kvpb/batch.go
@@ -460,7 +460,7 @@ func (br *BatchResponse) String() string {
 func (br *BatchResponse) SafeFormat(s redact.SafePrinter, verb rune) {
 	// Marking Error of BatchResponse as safe as Outside of the RPC boundaries,
 	// this field is nil and must neither be checked nor populated
-	s.Printf("(err: %s)", redact.Safe(br.Error.String()))
+	s.Printf("(err: %v)", br.Error)
 
 	for count, union := range br.Responses {
 		// Limit the strings to provide just a summary. Without this limit a log


### PR DESCRIPTION
Backport:
  * 1/1 commits from "pkg/kv/kvpb: Add SafeFormat method to BatchResponse struct" (#147609)
  * 1/1 commits from "kvclient: update error formatting in BatchResponse and improve test expectations in dist_sender_test" (#148570)

Please see individual PRs for details.

/cc @cockroachdb/release

----
This patch helps to fix the overly redacted log line on instances where BatchResponse is logged. Implemented a SafeFormat function on BatchResponse struct which overrides the String() method when its object is logged.

Epic: CRDB-37533
Part of: CRDB-44885
Release note: None

----

Release justification: Resolves high priority overly redacted log line.
