### PR TITLE
roachtest: fix test monitor error

### DIFF
--- a/pkg/cmd/roachtest/BUILD.bazel
+++ b/pkg/cmd/roachtest/BUILD.bazel
@@ -98,6 +98,7 @@ go_test(
         "main_test.go",
         "test_filter_test.go",
         "test_impl_test.go",
+        "test_monitor_test.go",
         "test_registry_test.go",
         "test_test.go",
         "zip_util_test.go",

--- a/pkg/cmd/roachtest/test_monitor_test.go
+++ b/pkg/cmd/roachtest/test_monitor_test.go
@@ -1,0 +1,77 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package main
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/util/stop"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+type stubTestMonitorError struct{}
+
+func (s *stubTestMonitorError) ExpectProcessDead(
+	nodes option.NodeListOption, opts ...option.OptionFunc,
+) {
+}
+
+func (s *stubTestMonitorError) ExpectProcessAlive(
+	nodes option.NodeListOption, opts ...option.OptionFunc,
+) {
+}
+
+func (s *stubTestMonitorError) WaitForNodeDeath() error {
+	return errors.New("test error")
+}
+
+func TestGlobalMonitorError(t *testing.T) {
+	newTestMonitor = func(_ context.Context, t test.Test, c *clusterImpl) *testMonitorImpl {
+		return &testMonitorImpl{
+			monitor: &stubTestMonitorError{},
+			t:       t,
+		}
+	}
+
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cr := newClusterRegistry()
+	runner := newUnitTestRunner(cr, stopper)
+
+	var buf syncedBuffer
+	copt := defaultClusterOpt()
+	lopt := defaultLoggingOpt(&buf)
+
+	mockTest := registry.TestSpec{
+		Name:             `mock test`,
+		Owner:            OwnerUnitTest,
+		Cluster:          spec.MakeClusterSpec(0),
+		CompatibleClouds: registry.AllExceptAWS,
+		Suites:           registry.Suites(registry.Nightly),
+		CockroachBinary:  registry.StandardCockroach,
+		Monitor:          true,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			select {
+			case <-ctx.Done():
+				return
+			case <-time.After(5 * time.Minute):
+				return
+			}
+		},
+	}
+	err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
+		defaultParallelism, copt, testOpts{}, lopt)
+	require.Error(t, err)
+}

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1351,7 +1351,7 @@ func (r *testRunner) runTest(
 
 	t.taskManager = task.NewManager(runCtx, t.L())
 	testMonitor := newTestMonitor(runCtx, t, c)
-	t.monitor = testMonitor
+	t.monitor = testMonitor.monitor
 
 	t.mu.Lock()
 	// t.Fatal() will cancel this context.


### PR DESCRIPTION
Previously, the global test monitor would fatal on an error. This is similar to
how the original monitor worked. But the original monitor would fatal where a
panic could be recovered by the goroutine running the test. This would
immediately short circuit the test. However, the global monitor can not use
fatal since it's running in a separate goroutine which causes the panic to be
unrecoverable. This change makes the global monitor call `Errorf` instead of
`Fatalf`. The test context will now instead be cancelled.

Epic: None
Release note: None