### PR TITLE
server: rename `Cluster` service to `Node` service

### DIFF
--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3747,9 +3747,9 @@ service TenantSpanConfig {
   rpc SpanConfigConformance(SpanConfigConformanceRequest) returns (SpanConfigConformanceResponse) {}
 }
 
-// Cluster service offers RPCs for inter-node communication essential for
+// Node service offers RPCs for inter-node communication essential for
 // cluster bootstrapping and operation.
-service Cluster {
+service Node {
   // Join a bootstrapped cluster. If the target node is itself not part of a
   // bootstrapped cluster, an appropriate error is returned.
   rpc Join (JoinNodeRequest) returns (JoinNodeResponse) {}

--- a/pkg/server/init.go
+++ b/pkg/server/init.go
@@ -466,7 +466,7 @@ func (s *initServer) attemptJoinTo(
 		BinaryVersion: &latestVersion,
 	}
 
-	var initClient kvpb.RPCClusterClient
+	var initClient kvpb.RPCNodeClient
 	if !rpcbase.TODODRPC {
 		initClient = kvpb.NewGRPCInternalClientAdapter(conn)
 	}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -998,7 +998,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 	if err := kvpb.DRPCRegisterTenantSpanConfig(drpcServer, node); err != nil {
 		return nil, err
 	}
-	if err := kvpb.DRPCRegisterCluster(drpcServer, node); err != nil {
+	if err := kvpb.DRPCRegisterNode(drpcServer, node); err != nil {
 		return nil, err
 	}
 	kvserver.RegisterPerReplicaServer(grpcServer.Server, node.perReplicaServer)


### PR DESCRIPTION
Renaming the `Cluster` service to `Node`. This new name is more appropriate because the service's functionality is provided by an individual node, rather than by the cluster as a whole. This is not a breaking change, as these services are currently used for DRPC only.

Epic: none
Release note: none