### PR TITLE
roachtest: deflake c2c/mixed-version failed

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -79,7 +79,7 @@ var (
 	// for an internal query (i.e., performed by the framework) to
 	// complete. These queries are typically associated with gathering
 	// upgrade state data to be displayed during execution.
-	internalQueryTimeout = 30 * time.Second
+	internalQueryTimeout = time.Minute
 )
 
 func newServiceRuntime(desc *ServiceDescriptor) *serviceRuntime {


### PR DESCRIPTION
Previously, this test waited up to 30 seconds to retrieve version information from the cluster. If the KV layer wasn't happy for any reason, this operation could take longer than the internal timeout. Specifically, we saw database_role_settings was not accessible because of slow RPCs. To address this, this patch adds a more lenient timeout for this operation.

Fixes: #148580
Release note: None