### PR TITLE
rpc: remove `InsecureSkipVerify` from DRPC TLS client config

### DIFF
--- a/pkg/rpc/drpc.go
+++ b/pkg/rpc/drpc.go
@@ -79,9 +79,11 @@ func DialDRPC(
 				}
 				// Clone TLS config to avoid modifying a cached TLS config.
 				tlsConfig = tlsConfig.Clone()
-				// TODO(server): remove this hack which is necessary at least in
-				// testing to get TestDRPCSelectQuery to pass.
-				tlsConfig.InsecureSkipVerify = true
+				sn, _, err := net.SplitHostPort(target)
+				if err != nil {
+					return nil, err
+				}
+				tlsConfig.ServerName = sn
 				tlsConn := tls.Client(netConn, tlsConfig)
 				conn = drpcconn.NewWithOptions(tlsConn, opts)
 			}


### PR DESCRIPTION
`InsecureSkipVerify` disables certificate verification and introduces significant security risks. This commit removes the `InsecureSkipVerify` option from the DRPC TLS client configuration. ServerName in TLS config is used to ensure the server's certificate matches the expected hostname the client is connecting to.

gRPC does it [here](https://github.com/grpc/grpc-go/blob/62071420ce2be9eaa916159c1d7609adf3c3aaaa/credentials/tls.go#L110-L120).

Epic: CRDB-51459
Fixes: #147921
Release note: none