### PR TITLE
release-25.3: colserde,rowcontainer: prohibit writing very large keys

### DIFF
--- a/pkg/col/colserde/BUILD.bazel
+++ b/pkg/col/colserde/BUILD.bazel
@@ -23,6 +23,7 @@ go_library(
         "@com_github_apache_arrow_go_arrow//array",
         "@com_github_apache_arrow_go_arrow//memory",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_edsrzf_mmap_go//:mmap-go",
         "@com_github_google_flatbuffers//go",
     ],


### PR DESCRIPTION
Backport 1/1 commits from #148958 on behalf of @yuzefovich.

----

We just saw a node crash in a test when we wrote 2.5 GiB key to the temporary storage used by the row container. Such large keys aren't well supported by pebble and can lead to undefined behavior, so we add an explicit check that the key doesn't exceed 1.5 GiB. We also now will lose scratch slices once they exceed 1 MiB in size (we already have memory accounting in place for them).

Similarly, the vectorized disk spilling could suffer from the same problem since in the arrow format offsets are int32, so we if were to serialize a vector of more than 2 GiB in size, we'd encounter undefined behavior (which we've seen a couple of times in sentry issues). This commit adds an explicit check there as well returning an error if the serialized size exceeds max int32. Additionally, we now will lose references to the large scratch slice that we keep across the calls once it exceeds 32 MiB. Note that I initially added a simple unit test that allocated a vector of 3 GiB size and ensured that an error is returned, but it hits an OOM on EngFlow environment, and it doesn't seem worth upgrading it to the heavy pool, so I removed it.

In the test failure such a large value was produced via `st_collect` geo builtin. Another example I can think of would be an array created via `array_agg` argument.

Fixes: #147601.

Release note: None

----

Release justification: low-risk stability improvement.