### PR TITLE
schemachanger: implement ALTER TABLE .. RENAME

### DIFF
--- a/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
+++ b/pkg/ccl/schemachangerccl/sctestbackupccl/backup_base_generated_test.go
@@ -414,6 +414,13 @@ func TestBackupRollbacks_base_alter_table_no_force_row_level_security(t *testing
 	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupRollbacks_base_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
+	sctest.BackupRollbacks(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupRollbacks_base_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1111,6 +1118,13 @@ func TestBackupRollbacksMixedVersion_base_alter_table_no_force_row_level_securit
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupRollbacksMixedVersion_base_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
 	sctest.BackupRollbacksMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1814,6 +1828,13 @@ func TestBackupSuccess_base_alter_table_no_force_row_level_security(t *testing.T
 	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestBackupSuccess_base_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
+	sctest.BackupSuccess(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestBackupSuccess_base_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2511,6 +2532,13 @@ func TestBackupSuccessMixedVersion_base_alter_table_no_force_row_level_security(
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestBackupSuccessMixedVersion_base_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
 	sctest.BackupSuccessMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schema_change_plan_node.go
+++ b/pkg/sql/schema_change_plan_node.go
@@ -7,6 +7,7 @@ package sql
 
 import (
 	"context"
+	"fmt"
 	"reflect"
 	"time"
 
@@ -81,6 +82,7 @@ func (p *planner) SchemaChange(ctx context.Context, stmt tree.Statement) (planNo
 	state, logSchemaChangesFn, err := scbuild.Build(ctx, deps, scs.state, stmt, &scs.memAcc)
 	if scerrors.HasNotImplemented(err) &&
 		mode != sessiondatapb.UseNewSchemaChangerUnsafeAlways {
+		fmt.Printf("err %+v\n", err)
 		return nil, nil
 	}
 	if err != nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -44,6 +44,7 @@ go_library(
         "partition_helpers.go",
         "partition_zone_config.go",
         "process.go",
+        "rename_table.go",
         "statement_control.go",
         "table_zone_config.go",
         "zone_config_helpers.go",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/process.go
@@ -70,6 +70,7 @@ var supportedStatements = map[reflect.Type]supportedStatement{
 	reflect.TypeOf((*tree.DropTrigger)(nil)):         {fn: DropTrigger, statementTags: []string{tree.DropTriggerTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.DropType)(nil)):            {fn: DropType, statementTags: []string{tree.DropTypeTag}, on: true, checks: nil},
 	reflect.TypeOf((*tree.DropView)(nil)):            {fn: DropView, statementTags: []string{tree.DropViewTag}, on: true, checks: nil},
+	reflect.TypeOf((*tree.RenameTable)(nil)):         {fn: RenameTable, statementTags: []string{tree.AlterTableTag}, on: true, checks: isV253Active},
 	reflect.TypeOf((*tree.SetZoneConfig)(nil)):       {fn: SetZoneConfig, statementTags: []string{tree.ConfigureZoneTag}, on: true, checks: isV251Active},
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/rename_table.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/rename_table.go
@@ -1,0 +1,65 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package scbuildstmt
+
+import (
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
+	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
+	"github.com/cockroachdb/cockroach/pkg/sql/privilege"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scerrors"
+	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+)
+
+// RenameTable implements ALTER TABLE ... RENAME TO.
+func RenameTable(b BuildCtx, n *tree.RenameTable) {
+	// Only handle table renames, not views or sequences
+	if n.IsView || n.IsSequence {
+		panic(scerrors.NotImplementedError(n))
+	}
+
+	// 1. Resolve the existing table
+	elts := b.ResolveTable(n.Name, ResolveParams{
+		IsExistenceOptional: n.IfExists,
+		RequiredPrivilege:   privilege.CREATE,
+	})
+	_, target, tbl := scpb.FindTable(elts)
+
+	// 2. Handle IF EXISTS case
+	if tbl == nil {
+		if n.IfExists {
+			return
+		}
+		panic(pgerror.Newf(pgcode.UndefinedTable, "relation %q does not exist", n.Name))
+	}
+
+	// Ensure the table is not being dropped
+	if target != scpb.ToPublic {
+		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState,
+			"table %q is being dropped, try again later", n.Name.Object()))
+	}
+
+	// 3. Get current namespace element
+	_, _, currentNS := scpb.FindNamespace(elts)
+	if currentNS == nil {
+		panic(pgerror.Newf(pgcode.ObjectNotInPrerequisiteState, "namespace element not found for table %q", n.Name))
+	}
+
+	// 4. Validate new name doesn't conflict
+	// TODO: Implement name collision checking
+	// b.CheckObjectNameCollision(n.NewName, currentNS.DatabaseID, currentNS.SchemaID)
+
+	// 5. Mark old namespace as ABSENT
+	b.Drop(currentNS)
+
+	// 6. Add new namespace element targeting PUBLIC
+	b.Add(&scpb.Namespace{
+		DatabaseID:   currentNS.DatabaseID,
+		SchemaID:     currentNS.SchemaID,
+		DescriptorID: currentNS.DescriptorID,
+		Name:         n.NewName.Object(),
+	})
+}

--- a/pkg/sql/schemachanger/sctest_generated_test.go
+++ b/pkg/sql/schemachanger/sctest_generated_test.go
@@ -414,6 +414,13 @@ func TestEndToEndSideEffects_alter_table_no_force_row_level_security(t *testing.
 	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestEndToEndSideEffects_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
+	sctest.EndToEndSideEffects(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestEndToEndSideEffects_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -1111,6 +1118,13 @@ func TestExecuteWithDMLInjection_alter_table_no_force_row_level_security(t *test
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestExecuteWithDMLInjection_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
 	sctest.ExecuteWithDMLInjection(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -1814,6 +1828,13 @@ func TestGenerateSchemaChangeCorpus_alter_table_no_force_row_level_security(t *t
 	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestGenerateSchemaChangeCorpus_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
+	sctest.GenerateSchemaChangeCorpus(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestGenerateSchemaChangeCorpus_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -2511,6 +2532,13 @@ func TestPause_alter_table_no_force_row_level_security(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestPause_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
 	sctest.Pause(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
@@ -3214,6 +3242,13 @@ func TestPauseMixedVersion_alter_table_no_force_row_level_security(t *testing.T)
 	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 
+func TestPauseMixedVersion_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
+	sctest.PauseMixedVersion(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
 func TestPauseMixedVersion_alter_table_validate_constraint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
@@ -3911,6 +3946,13 @@ func TestRollback_alter_table_no_force_row_level_security(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_no_force_row_level_security"
+	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
+}
+
+func TestRollback_alter_table_rename(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	const path = "pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename"
 	sctest.Rollback(t, path, sctest.SingleNodeTestClusterFactory{})
 }
 

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.definition
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.definition
@@ -1,0 +1,10 @@
+setup
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (id INT PRIMARY KEY, name STRING);
+INSERT INTO t1 VALUES (1, 'foo');
+----
+
+test
+ALTER TABLE t1 RENAME TO t2;
+----

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain
@@ -1,0 +1,37 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (id INT PRIMARY KEY, name STRING);
+INSERT INTO t1 VALUES (1, 'foo');
+
+/* test */
+EXPLAIN (DDL) ALTER TABLE t1 RENAME TO t2;
+----
+Schema change plan for ALTER TABLE ‹t1› RENAME TO ‹t2›;
+ ├── StatementPhase
+ │    └── Stage 1 of 1 in StatementPhase
+ │         ├── 1 element transitioning toward PUBLIC
+ │         │    └── ABSENT → PUBLIC Namespace:{DescID: 106 (t1-t2+), Name: "t2", ReferencedDescID: 104 (db)}
+ │         ├── 1 element transitioning toward ABSENT
+ │         │    └── PUBLIC → ABSENT Namespace:{DescID: 106 (t1-t2+), Name: "t1", ReferencedDescID: 104 (db)}
+ │         └── 3 Mutation operations
+ │              ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t1","SchemaID":105}}
+ │              ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t2"}
+ │              └── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t2","SchemaID":105}}
+ └── PreCommitPhase
+      ├── Stage 1 of 2 in PreCommitPhase
+      │    ├── 1 element transitioning toward PUBLIC
+      │    │    └── PUBLIC → ABSENT Namespace:{DescID: 106 (t1-t2+), Name: "t2", ReferencedDescID: 104 (db)}
+      │    ├── 1 element transitioning toward ABSENT
+      │    │    └── ABSENT → PUBLIC Namespace:{DescID: 106 (t1-t2+), Name: "t1", ReferencedDescID: 104 (db)}
+      │    └── 1 Mutation operation
+      │         └── UndoAllInTxnImmediateMutationOpSideEffects
+      └── Stage 2 of 2 in PreCommitPhase
+           ├── 1 element transitioning toward PUBLIC
+           │    └── ABSENT → PUBLIC Namespace:{DescID: 106 (t1-t2+), Name: "t2", ReferencedDescID: 104 (db)}
+           ├── 1 element transitioning toward ABSENT
+           │    └── PUBLIC → ABSENT Namespace:{DescID: 106 (t1-t2+), Name: "t1", ReferencedDescID: 104 (db)}
+           └── 3 Mutation operations
+                ├── DrainDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t1","SchemaID":105}}
+                ├── SetNameInDescriptor {"DescriptorID":106,"Name":"t2"}
+                └── AddDescriptorName {"Namespace":{"DatabaseID":104,"DescriptorID":106,"Name":"t2","SchemaID":105}}

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain_shape
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.explain_shape
@@ -1,0 +1,11 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (id INT PRIMARY KEY, name STRING);
+INSERT INTO t1 VALUES (1, 'foo');
+
+/* test */
+EXPLAIN (DDL, SHAPE) ALTER TABLE t1 RENAME TO t2;
+----
+Schema change plan for ALTER TABLE ‹t1› RENAME TO ‹t2›;
+ └── execute 1 system table mutations transaction

--- a/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.side_effects
+++ b/pkg/sql/schemachanger/testdata/end_to_end/alter_table_rename/alter_table_rename.side_effects
@@ -1,0 +1,57 @@
+/* setup */
+CREATE DATABASE db;
+USE db;
+CREATE TABLE t1 (id INT PRIMARY KEY, name STRING);
+INSERT INTO t1 VALUES (1, 'foo');
+----
+...
++database {0 0 db} -> 104
++schema {104 0 public} -> 105
++object {104 105 t1} -> 106
+
+/* test */
+ALTER TABLE t1 RENAME TO t2;
+----
+begin transaction #1
+# begin StatementPhase
+checking for feature: ALTER TABLE
+## StatementPhase stage 1 of 1 with 3 MutationType ops
+delete object namespace entry {104 105 t1} -> 106
+add object namespace entry {104 105 t2} -> 106
+upsert descriptor #106
+  ...
+     id: 106
+     modificationTime: {}
+  -  name: t1
+  +  name: t2
+     nextColumnId: 3
+     nextConstraintId: 2
+  ...
+     schemaLocked: true
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+# end StatementPhase
+# begin PreCommitPhase
+## PreCommitPhase stage 1 of 2 with 1 MutationType op
+undo all catalog changes within txn #1
+persist all catalog changes to storage
+## PreCommitPhase stage 2 of 2 with 3 MutationType ops
+delete object namespace entry {104 105 t1} -> 106
+add object namespace entry {104 105 t2} -> 106
+upsert descriptor #106
+  ...
+     id: 106
+     modificationTime: {}
+  -  name: t1
+  +  name: t2
+     nextColumnId: 3
+     nextConstraintId: 2
+  ...
+     schemaLocked: true
+     unexposedParentSchemaId: 105
+  -  version: "1"
+  +  version: "2"
+persist all catalog changes to storage
+# end PreCommitPhase
+commit transaction #1


### PR DESCRIPTION
This patch adds support for ALTER TABLE .. RENAME in the declarative schema chagner. All the necessary infrastructure was in place already.

fixes #148339
Release note: None