### PR TITLE
pkg/cli: Implement redaction validation and user confirmation for debug zip uploads

### DIFF
--- a/pkg/cli/testdata/table_dumps/debug_zip_command_flags.txt
+++ b/pkg/cli/testdata/table_dumps/debug_zip_command_flags.txt
@@ -1,0 +1,1 @@
+ --concurrency=15 --cpu-profile-duration=5s --files-from=2025-06-15 08:45:34 --files-until=2025-06-18 08:45:34 --include-goroutine-stacks=true --include-range-info=true --include-running-job-traces=true --redact=true

--- a/pkg/cli/zip.go
+++ b/pkg/cli/zip.go
@@ -48,6 +48,10 @@ type zipRequest struct {
 	pathName string
 }
 
+const (
+	debugZipCommandFlagsFileName = "debug_zip_command_flags.txt"
+)
+
 type debugZipContext struct {
 	z              *zipper
 	clusterPrinter *zipReporter
@@ -415,7 +419,7 @@ done
 				return filter
 			})
 
-			if err := z.createRaw(s, zc.prefix+"/debug_zip_command_flags.txt", []byte(flags)); err != nil {
+			if err := z.createRaw(s, zc.prefix+"/"+debugZipCommandFlagsFileName, []byte(flags)); err != nil {
 				return err
 			}
 

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -1234,7 +1234,7 @@ func TestCommandFlags(t *testing.T) {
 	}
 
 	for _, f := range r.File {
-		if f.Name == "debug/debug_zip_command_flags.txt" {
+		if f.Name == "debug/"+debugZipCommandFlagsFileName {
 			rc, err := f.Open()
 			if err != nil {
 				t.Fatal(err)
@@ -1251,7 +1251,7 @@ func TestCommandFlags(t *testing.T) {
 			return
 		}
 	}
-	assert.Fail(t, "debug/debug_zip_command_flags.txt is not generated")
+	assert.Fail(t, "debug/"+debugZipCommandFlagsFileName+" is not generated")
 
 	if err = r.Close(); err != nil {
 		t.Fatal(err)

--- a/pkg/cli/zip_upload_test.go
+++ b/pkg/cli/zip_upload_test.go
@@ -164,6 +164,11 @@ func TestUploadZipEndToEnd(t *testing.T) {
 
 	defer testutils.TestingHook(&gcsLogUpload, writeLogsToGCSHook)()
 
+	// Mock the interactive prompt to always accept (return nil) for end-to-end tests
+	defer testutils.TestingHook(&promptUserForConfirmation, func(warningMsg string) error {
+		return nil // Always accept in end-to-end tests
+	})()
+
 	datadriven.Walk(t, "testdata/upload", func(t *testing.T, path string) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			c := NewCLITest(TestCLIParams{})
@@ -277,6 +282,127 @@ func TestAppendUserTags(t *testing.T) {
 	for _, tc := range tt {
 		t.Run(tc.name, func(t *testing.T) {
 			assert.Equal(t, tc.expected, appendUserTags(tc.systemTags, tc.userTags...))
+		})
+	}
+}
+
+func TestValidateRedactionStatus(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		name          string
+		flagsContent  string
+		fileExists    bool
+		dryRun        bool
+		expectError   bool
+		errorContains string
+		description   string
+	}{
+		{
+			name:         "redacted zip with other flags proceeds silently",
+			flagsContent: " --concurrency=15 --cpu-profile-duration=5s --files-from=2025-06-15 08:45:34 --redact=true --include-range-info=true",
+			fileExists:   true,
+			dryRun:       false,
+			expectError:  false,
+			description:  "When --redact=true is found, no warnings should be shown and upload proceeds",
+		},
+		{
+			name:          "missing file user declines",
+			flagsContent:  "",
+			fileExists:    false,
+			dryRun:        false,
+			expectError:   true,
+			errorContains: "upload aborted",
+			description:   "When file is missing and user declines, should return cancellation error",
+		},
+		{
+			name:          "missing file user accepts",
+			flagsContent:  "",
+			fileExists:    false,
+			dryRun:        false,
+			expectError:   false,
+			errorContains: "user accepts",
+			description:   "When file is missing and user accepts, should proceed without error",
+		},
+		{
+			name:          "unredacted zip user declines",
+			flagsContent:  " --concurrency=1 --redact=false --nodes=1",
+			fileExists:    true,
+			dryRun:        false,
+			expectError:   true,
+			errorContains: "upload aborted",
+			description:   "When --redact=false and user declines, should return cancellation error",
+		},
+		{
+			name:          "unredacted zip user accepts",
+			flagsContent:  " --concurrency=1 --redact=false --nodes=1",
+			fileExists:    true,
+			dryRun:        false,
+			expectError:   false,
+			errorContains: "user accepts",
+			description:   "When --redact=false and user accepts, should proceed without error",
+		},
+		{
+			name:          "unclear redaction status user declines",
+			flagsContent:  " --concurrency=1 --nodes=1",
+			fileExists:    true,
+			dryRun:        false,
+			expectError:   true,
+			errorContains: "upload aborted",
+			description:   "When no --redact flag and user declines, should return cancellation error",
+		},
+		{
+			name:          "unclear redaction status user accepts",
+			flagsContent:  " --concurrency=1 --nodes=1",
+			fileExists:    true,
+			dryRun:        false,
+			expectError:   false,
+			errorContains: "user accepts",
+			description:   "When no --redact flag and user accepts, should proceed without error",
+		},
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			tempDir := t.TempDir()
+
+			if test.fileExists {
+				flagsFile := path.Join(tempDir, debugZipCommandFlagsFileName)
+				if err := os.WriteFile(flagsFile, []byte(test.flagsContent), 0644); err != nil {
+					t.Fatal(err)
+				}
+			}
+
+			originalDryRun := debugZipUploadOpts.dryRun
+			debugZipUploadOpts.dryRun = test.dryRun
+			defer func() { debugZipUploadOpts.dryRun = originalDryRun }()
+
+			if test.errorContains == "upload aborted" || test.errorContains == "user accepts" {
+				originalPrompt := promptUserForConfirmation
+				switch test.errorContains {
+				case "upload aborted":
+					promptUserForConfirmation = func(warningMsg string) error {
+						require.Contains(t, warningMsg, "WARNING:")
+						return fmt.Errorf("upload aborted")
+					}
+				case "user accepts":
+					promptUserForConfirmation = func(warningMsg string) error {
+						require.Contains(t, warningMsg, "WARNING:")
+						return nil
+					}
+				}
+				defer func() { promptUserForConfirmation = originalPrompt }()
+			}
+
+			// Test validation
+			err := validateRedactionStatus(tempDir)
+
+			if test.expectError {
+				require.Error(t, err, fmt.Sprintf("Test case: %s", test.description))
+				require.Contains(t, err.Error(), test.errorContains, fmt.Sprintf("Test case: %s", test.description))
+			} else {
+				require.NoError(t, err, fmt.Sprintf("Test case: %s", test.description))
+			}
 		})
 	}
 }


### PR DESCRIPTION
This change improves the safety and user awareness regarding sensitive data in debug zip uploads to Datadog.
- Added `validateRedactionStatus` function to check the redaction status of debug zips based on the `debug_zip_command_flags.txt` file.
- Introduced user prompts for confirmation when redaction is unclear or not enabled.
- Updated `runDebugZipUpload` to validate redaction status before proceeding with uploads.

Part of: CRDB-49203
Epic: None
Release Notes: None