### PR TITLE
roachtest: disable create_table_with_schema_locked for certain tests

### DIFF
--- a/pkg/ccl/changefeedccl/nemeses_test.go
+++ b/pkg/ccl/changefeedccl/nemeses_test.go
@@ -38,8 +38,11 @@ func TestChangefeedNemeses(t *testing.T) {
 			withLegacySchemaChanger := nop.EnableSQLSmith || rng.Float32() < 0.1
 			if withLegacySchemaChanger {
 				t.Log("using legacy schema changer")
+				sqlDB.Exec(t, "SET create_table_with_schema_locked=false")
 				sqlDB.Exec(t, "SET use_declarative_schema_changer='off'")
-				sqlDB.Exec(t, "SET CLUSTER SETTING  sql.defaults.use_declarative_schema_changer='off'")
+				sqlDB.Exec(t, "SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer='off'")
+				sqlDB.Exec(t, "SET CLUSTER SETTING sql.defaults.create_table_with_schema_locked='false'")
+
 			}
 			v, err := cdctest.RunNemesis(f, s.DB, t.Name(), withLegacySchemaChanger, rng, nop)
 			if err != nil {

--- a/pkg/cmd/roachtest/tests/follower_reads.go
+++ b/pkg/cmd/roachtest/tests/follower_reads.go
@@ -527,6 +527,13 @@ func initFollowerReadsDB(
 		}
 	}
 
+	// Disable schema_locked within this since it will modify locality on
+	// tables.
+	_, err = db.ExecContext(ctx, "SET create_table_with_schema_locked=false")
+	require.NoError(t, err)
+	_, err = db.ExecContext(ctx, "ALTER ROLE ALL SET create_table_with_schema_locked=false")
+	require.NoError(t, err)
+
 	// Create a multi-region database and table.
 	_, err = db.ExecContext(ctx, `CREATE DATABASE mr_db`)
 	require.NoError(t, err)

--- a/pkg/cmd/roachtest/tests/sqlsmith.go
+++ b/pkg/cmd/roachtest/tests/sqlsmith.go
@@ -420,12 +420,15 @@ func setupMultiRegionDatabase(t test.Test, conn *gosql.DB, rnd *rand.Rand, logSt
 	}
 
 	for _, table := range tables {
+		// Locality changes can only be made if schema_locked is toggled.
+		execStmt(fmt.Sprintf(`ALTER TABLE %s SET (schema_locked=false);`, table.String()))
 		// Maybe change the locality of the table.
 		if val := rnd.Intn(3); val == 0 {
 			execStmt(fmt.Sprintf(`ALTER TABLE %s SET LOCALITY REGIONAL BY ROW;`, table.String()))
 		} else if val == 1 {
 			execStmt(fmt.Sprintf(`ALTER TABLE %s SET LOCALITY GLOBAL;`, table.String()))
 		}
+		execStmt(fmt.Sprintf(`ALTER TABLE %s SET (schema_locked=true);`, table.String()))
 		// Else keep the locality as REGIONAL BY TABLE.
 	}
 }


### PR DESCRIPTION
This series of commits addresses several test failures across different roachtest suites (`costfuzz`, `unoptimized-query-oracle`, `follower-reads`, and `sqlsmith`) that were caused by the `schema_locked` table setting. The multi-region version of these tests preform `ALTER TABLE ... SET LOCALITY`, so these have been modified either to toggle schema_locked or disable it for newly created tables.

This patch also fixes a flake inside TestChangefeedNemeses by disabling create_table_with_schema_locked when the legacy schema changer is in use.

Fixes: #148927
Fixes: #148940
Fixes: #149007
Fixes: #148976
Fixes: #148975
Fixes: #149002
Fixes: #148994
Fixes: #148995
Fixes: #149005
Fixes: #149000
Fixes: #148999
Fixes: #148996
Fixes: #149018
Fixes: #149015
Fixes: #149013
Fixes: #148997
Fixes: #149047
Fixes: #149045
Fixes: #149017
Fixes: #149014
Fixes: #149019
Fixes: #149016
Fixes: #149012

Release note: None