### PR TITLE
roachtest: fix pertubation disk stall

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -297,6 +297,10 @@ func RegisterTests(r registry.Registry) {
 
 func (v variations) makeClusterSpec() spec.ClusterSpec {
 	opts := append(v.specOptions, spec.CPU(v.vcpu), spec.SSD(v.disks), spec.Mem(v.mem), spec.TerminateOnMigration())
+	// Disable cluster reuse to avoid potential cgroup side effects.
+	if v.perturbationName() == "slowDisk" {
+		opts = append(opts, spec.ReuseNone())
+	}
 	return spec.MakeClusterSpec(v.numNodes+v.numWorkloadNodes, opts...)
 }
 

--- a/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
+++ b/pkg/cmd/roachtest/tests/perturbation/slow_disk.go
@@ -67,6 +67,7 @@ func (s *slowDisk) startTargetNode(ctx context.Context, t test.Test, v variation
 		s.staller = roachtestutil.NoopDiskStaller{}
 	} else {
 		s.staller = roachtestutil.MakeCgroupDiskStaller(t, v, false /* readsToo */, false /* logsToo */)
+		s.staller.Setup(ctx)
 	}
 }
 


### PR DESCRIPTION
These tests were not calling disk stall setup. While setup is currently a noop under the configuration it uses, the FI framework asserts that failers are setup first.

Fixes: https://github.com/cockroachdb/cockroach/issues/149004
Fixes: https://github.com/cockroachdb/cockroach/issues/149097
Release note: none