### PR TITLE
builtins: add has_system_privilege builtin function

### DIFF
--- a/docs/generated/sql/functions.md
+++ b/docs/generated/sql/functions.md
@@ -3502,6 +3502,12 @@ may increase either contention or retry errors, or both.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="has_server_privilege"></a><code>has_server_privilege(user: oid, server: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for foreign server.</p>
 </span></td><td>Stable</td></tr>
+<tr><td><a name="has_system_privilege"></a><code>has_system_privilege(privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for system.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="has_system_privilege"></a><code>has_system_privilege(user: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for system.</p>
+</span></td><td>Stable</td></tr>
+<tr><td><a name="has_system_privilege"></a><code>has_system_privilege(user: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the user has privileges for system.</p>
+</span></td><td>Stable</td></tr>
 <tr><td><a name="has_table_privilege"></a><code>has_table_privilege(table: <a href="string.html">string</a>, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for table.</p>
 </span></td><td>Stable</td></tr>
 <tr><td><a name="has_table_privilege"></a><code>has_table_privilege(table: oid, privilege: <a href="string.html">string</a>) &rarr; <a href="bool.html">bool</a></code></td><td><span class="funcdesc"><p>Returns whether or not the current user has privileges for table.</p>

--- a/pkg/sql/logictest/testdata/logic_test/privilege_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/privilege_builtins
@@ -1380,3 +1380,178 @@ SELECT has_schema_privilege('testuser', 'owned_schema', 'create'),
        has_schema_privilege('testuser2', 'owned_schema', 'usage')
 ----
 true true false false
+
+## has_system_privilege
+subtest has_system_privilege
+
+# Test as non-admin user (should not have system privileges).
+user testuser
+
+query BBBB
+SELECT has_system_privilege('BACKUP'),
+       has_system_privilege('RESTORE'),
+       has_system_privilege('VIEWSYSTEMTABLE'),
+       has_system_privilege('MODIFYCLUSTERSETTING')
+----
+false false false false
+
+query BBB
+SELECT has_system_privilege('VIEWACTIVITY'),
+       has_system_privilege('VIEWCLUSTERMETADATA'),
+       has_system_privilege('CANCELQUERY')
+----
+false false false
+
+# Test with specific user.
+query BBB
+SELECT has_system_privilege('testuser', 'BACKUP'),
+       has_system_privilege('testuser', 'RESTORE'),
+       has_system_privilege('testuser', 'VIEWSYSTEMTABLE')
+----
+false false false
+
+# Test invalid privilege.
+query error pgcode 22023 unrecognized privilege type: "INVALID"
+SELECT has_system_privilege('INVALID')
+
+# Test WITH GRANT OPTION.
+query BB
+SELECT has_system_privilege('BACKUP WITH GRANT OPTION'),
+       has_system_privilege('RESTORE WITH GRANT OPTION')
+----
+false false
+
+# Test as admin user (should have all system privileges).
+user root
+
+query BBBB
+SELECT has_system_privilege('BACKUP'),
+       has_system_privilege('RESTORE'),
+       has_system_privilege('VIEWSYSTEMTABLE'),
+       has_system_privilege('MODIFYCLUSTERSETTING')
+----
+true true true true
+
+query BBB
+SELECT has_system_privilege('VIEWACTIVITY'),
+       has_system_privilege('VIEWCLUSTERMETADATA'),
+       has_system_privilege('CANCELQUERY')
+----
+true true true
+
+query BB
+SELECT has_system_privilege('CREATEDB'),
+       has_system_privilege('CREATEROLE')
+----
+true true
+
+# Test WITH GRANT OPTION as admin
+query BB
+SELECT has_system_privilege('BACKUP WITH GRANT OPTION'),
+       has_system_privilege('RESTORE WITH GRANT OPTION')
+----
+true true
+
+# Test with specific user (admin checking testuser).
+query BBB
+SELECT has_system_privilege('testuser', 'BACKUP'),
+       has_system_privilege('testuser', 'RESTORE'),
+       has_system_privilege('testuser', 'VIEWSYSTEMTABLE')
+----
+false false false
+
+# Test with specific user (admin checking root).
+query BBB
+SELECT has_system_privilege('root', 'BACKUP'),
+       has_system_privilege('root', 'RESTORE'),
+       has_system_privilege('root', 'VIEWSYSTEMTABLE')
+----
+true true true
+
+# Grant some system privileges to testuser.
+statement ok
+GRANT SYSTEM VIEWACTIVITY TO testuser
+
+statement ok
+GRANT SYSTEM BACKUP TO testuser WITH GRANT OPTION
+
+user testuser
+
+# Test granted privileges
+query BBBB
+SELECT has_system_privilege('BACKUP'),
+       has_system_privilege('RESTORE'),
+       has_system_privilege('VIEWACTIVITY'),
+       has_system_privilege('VIEWSYSTEMTABLE')
+----
+true false true false
+
+# Test case insensitivity.
+query B
+SELECT has_system_privilege('backup')
+----
+true
+
+# Test multiple privileges (comma-separated).
+query B
+SELECT has_system_privilege('BACKUP, RESTORE')
+----
+true
+
+user root
+
+query BBB
+SELECT has_system_privilege('testuser', 'BACKUP'),
+       has_system_privilege('testuser', 'RESTORE'),
+       has_system_privilege('testuser', 'VIEWSYSTEMTABLE')
+----
+true  false  false
+
+# Test with OID.
+query BBB
+SELECT has_system_privilege((SELECT oid FROM pg_roles WHERE rolname = 'testuser'), 'BACKUP'),
+       has_system_privilege((SELECT oid FROM pg_roles WHERE rolname = 'testuser'), 'RESTORE'),
+       has_system_privilege((SELECT oid FROM pg_roles WHERE rolname = 'testuser'), 'VIEWSYSTEMTABLE')
+----
+true  false  false
+
+# Test WITH GRANT OPTION for granted privilege (should be false unless granted with grant option).
+query B
+SELECT has_system_privilege('testuser', 'BACKUP WITH GRANT OPTION')
+----
+true
+
+query B
+SELECT has_system_privilege('testuser', 'VIEWACTIVITY WITH GRANT OPTION')
+----
+false
+
+# Revoke privileges and check again.
+statement ok
+REVOKE SYSTEM VIEWACTIVITY FROM testuser
+
+statement ok
+REVOKE SYSTEM BACKUP FROM testuser
+
+query B
+SELECT has_system_privilege('testuser', 'BACKUP WITH GRANT OPTION')
+----
+false
+
+query B
+SELECT has_system_privilege('testuser', 'VIEWACTIVITY WITH GRANT OPTION')
+----
+false
+
+# Test with non-existent user.
+query error pgcode 42704 role 'non_existent_user' does not exist
+SELECT has_system_privilege('non_existent_user', 'BACKUP')
+
+# Test with non-existent user OID; note that the Postgres behavior is to return
+# false for non-existent OIDs.
+query B
+SELECT has_system_privilege(99999::OID, 'BACKUP')
+----
+false
+
+subtest end

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2667,6 +2667,9 @@ var builtinOidsArray = []string{
 	2704: `crdb_internal.show_create_all_triggers(database_name: string) -> string`,
 	2705: `crdb_internal.session_pending_jobs() -> tuple{int AS job_id, string AS job_type, string AS description, string AS user_name}`,
 	2706: `crdb_internal.can_view_job(owner: string) -> bool`,
+	2707: `has_system_privilege(privilege: string) -> bool`,
+	2708: `has_system_privilege(user: string, privilege: string) -> bool`,
+	2709: `has_system_privilege(user: oid, privilege: string) -> bool`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -167,6 +167,10 @@ type HasPrivilegeSpecifier struct {
 	// This needs to be a user-defined function OID. Builtin function OIDs won't
 	// work since they're not descriptors based.
 	FunctionOID *oid.Oid
+
+	// Global privilege
+	// When true, this specifier is for checking global/system privileges.
+	IsGlobalPrivilege bool
 }
 
 // TypeResolver is an interface for resolving types and type OIDs.


### PR DESCRIPTION
This builtin function can be used to check for a system privilege using a SQL interface.

Epic: None
Release note (sql change): Added the has_system_privilege builtin function, which can be used to check if a user has the given system privilege.