### PR TITLE
changefeedccl: add test-only assertion for checkpoint fields invariant

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_dist.go
+++ b/pkg/ccl/changefeedccl/changefeed_dist.go
@@ -277,11 +277,15 @@ func startDistChangefeed(
 			return errors.AssertionFailedf("both legacy and current checkpoint set on " +
 				"changefeed job progress and legacy checkpoint has later timestamp")
 		}
-		// This should be an assertion failure but unfortunately due to a bug
+		// This should always be an assertion failure but unfortunately due to a bug
 		// that was included in earlier versions of 25.2 (#148620), we may fail
 		// to clear the legacy checkpoint when we start writing the new one.
 		// We instead discard the legacy checkpoint here and it will eventually be
 		// cleared once the cluster is running a newer patch release with the fix.
+		if buildutil.CrdbTestBuild {
+			return errors.AssertionFailedf("both legacy and current checkpoint set on " +
+				"changefeed job progress")
+		}
 		log.Warningf(ctx, "both legacy and current checkpoint set on changefeed job progress; "+
 			"discarding legacy checkpoint")
 		legacyCheckpoint = nil

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -11874,13 +11874,9 @@ func TestChangefeedResumeWithBothLegacyAndCurrentCheckpoint(t *testing.T) {
 		require.NoError(t, err)
 
 		sqlDB.Exec(t, `RESUME JOB $1`, jobFeed.JobID())
-		waitForJobState(sqlDB, t, jobFeed.JobID(), jobs.StateRunning)
-
-		// Wait for highwater to advance past the current time.
-		var tsStr string
-		sqlDB.QueryRow(t, `SELECT cluster_logical_timestamp()`).Scan(&tsStr)
-		ts := parseTimeToHLC(t, tsStr)
-		require.NoError(t, jobFeed.WaitForHighWaterMark(ts))
+		waitForJobState(sqlDB, t, jobFeed.JobID(), jobs.StateFailed)
+		require.ErrorContains(t, jobFeed.FetchTerminalJobErr(),
+			"both legacy and current checkpoint set on changefeed job progress")
 	}
 
 	cdcTest(t, testFn, feedTestEnterpriseSinks)

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -672,5 +672,40 @@ func runCDCMixedVersionCheckpointing(ctx context.Context, t test.Test, c cluster
 	mvt.InMixedVersion("wait and validate", tester.waitAndValidate)
 	mvt.AfterUpgradeFinalized("wait and validate", tester.waitAndValidate)
 
-	mvt.Run()
+	// Run the test.
+	plan, err := mvt.RunE()
+	if err != nil {
+		isAffectedBy148620 := func(plan *mixedversion.TestPlan) bool {
+			if plan == nil {
+				return false
+			}
+			for _, v := range []string{"v25.2.0", "v25.2.1", "v25.2.2"} {
+				version := clusterupgrade.MustParseVersion(v)
+				for _, planVersion := range plan.Versions() {
+					if planVersion.Equal(version) {
+						return true
+					}
+				}
+			}
+			return false
+		}
+
+		isExpectedErrorDueTo148620 := func(err error) bool {
+			for _, s := range []string{
+				"both legacy and current checkpoint set on change aggregator spec",
+				"both legacy and current checkpoint set on changefeed job progress",
+			} {
+				if strings.Contains(err.Error(), s) {
+					return true
+				}
+			}
+			return false
+		}
+
+		if isAffectedBy148620(plan) && isExpectedErrorDueTo148620(err) {
+			t.Skipf("expected error due to #148620: %s", err)
+		}
+
+		t.Fatal(err)
+	}
 }

--- a/pkg/cmd/roachtest/tests/mixed_version_cdc.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_cdc.go
@@ -140,6 +140,8 @@ type cdcMixedVersionTester struct {
 
 	validator *cdctest.CountValidator
 	fprintV   *cdctest.FingerprintValidator
+
+	jobID int
 }
 
 func newCDCMixedVersionTester(ctx context.Context, c cluster.Cluster) cdcMixedVersionTester {
@@ -186,6 +188,25 @@ func (cmvt *cdcMixedVersionTester) StartKafka(t test.Test, c cluster.Cluster) (c
 func (cmvt *cdcMixedVersionTester) waitAndValidate(
 	ctx context.Context, l *logger.Logger, r *rand.Rand, h *mixedversion.Helper,
 ) error {
+	cancel := h.GoWithCancel(func(ctx context.Context, l *logger.Logger) error {
+		for {
+			select {
+			case <-time.After(5 * time.Second):
+				_, db := h.RandomDB(r)
+				info, err := getChangefeedInfo(db, cmvt.jobID)
+				if err != nil {
+					return err
+				}
+				if info.GetStatus() == "failed" {
+					return errors.Newf("changefeed failed: %s", info.GetError())
+				}
+			case <-ctx.Done():
+				return ctx.Err()
+			}
+		}
+	})
+	defer cancel()
+
 	l.Printf("waiting for %d resolved timestamps", resolvedTimestampsPerState)
 	// create a new channel for the resolved timestamps, allowing any
 	// new resolved timestamps to be captured and account for in the
@@ -403,6 +424,7 @@ func (cmvt *cdcMixedVersionTester) createChangeFeed(
 		return err
 	}
 	l.Printf("created changefeed job %d", jobID)
+	cmvt.jobID = jobID
 	return nil
 }
 


### PR DESCRIPTION
Fixes #149100

---

**roachtest: surface changefeed failures in mixed-version CDC tests** 

Previously, if the changefeed failed in a mixed-version CDC test,
the test wouldn't fail until it hit the timeout. We now periodically
check for changefeed failures and fail the test if one is found.

Release note: None

---

**mixedversion: add RunE method to Test** 

This patch adds a `RunE` method to `Test`. Unlike the existing `Run` function,
it will not immediately fatal the test if an error is encountered and will
instead return the error along with the test plan so that callers may decide
how to handle the error.

Release note: None

---

**changefeedccl: add test-only assertion for checkpoint fields invariant** 

This patch adds a test-only assertion that we won't ever see both
checkpoint fields set on a changefeed job progress struct. It is
test-only because a bug that existed on earlier versions of 25.2
could cause both checkpoint fields to be set and so the production
code continues to discard the legacy checkpoint when that happens.

Release note: None