### PR TITLE
pkg/util/uuid: simplify error message in UUID UnmarshalBinary method

### DIFF
--- a/pkg/util/uuid/codec.go
+++ b/pkg/util/uuid/codec.go
@@ -169,7 +169,7 @@ func (u *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != Size {
 		return errors.Newf(
 			"uuid: UUID must be exactly 16 bytes long, got %d bytes",
-			redact.SafeInt(len(data)),
+			len(data),
 		)
 	}
 	copy(u[:], data)


### PR DESCRIPTION
Updated the error message in the UnmarshalBinary method of the UUID struct to directly use the length of the data instead of a redaction function.

Epic: CRDB-37533
Part of: CRDB-44885
Release note: None