### PR TITLE
release-25.2: Make uuid parsing errors as safe string

### DIFF
--- a/pkg/util/uuid/codec.go
+++ b/pkg/util/uuid/codec.go
@@ -165,7 +165,10 @@ func (u UUID) MarshalBinary() ([]byte, error) {
 // It will return an error if the slice isn't 16 bytes long.
 func (u *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != Size {
-		return fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return errors.Newf(
+			"uuid: UUID must be exactly 16 bytes long, got %d bytes",
+			len(data),
+		)
 	}
 	copy(u[:], data)
 


### PR DESCRIPTION
Backport:
  * 1/1 commits from "pkg/util/uuid: simplify error message in UUID UnmarshalBinary method" (#149190)
  * 1/1 commits from "pkg/util/uuid: Make uuid parsing errors as safe string" (#147762)

Please see individual PRs for details.

/cc @cockroachdb/release

----
This patch helps to make the uuid parsing errors as safe so that when the roachpb.Key is
logged, the error message is not redacted.

The prior implementation of uuid errors followed the fmt.Errorf strings which are
categorised as unsafe by default when logged using %v verb of string formatting.
This patch convert those error objects to use redact.Safe implementation.

----

Release justification: Fixing the high priority error log line that was over redacted.
