### PR TITLE
roachtest: fix load in decommissionBench

### DIFF
--- a/pkg/cmd/roachtest/tests/decommissionbench.go
+++ b/pkg/cmd/roachtest/tests/decommissionbench.go
@@ -611,7 +611,7 @@ func runDecommissionBench(
 		benchSpec.warehouses,
 	)
 	workloadCmd := fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --max-rate=%d --duration=%s "+
-		"%s --ramp=%s --tolerate-errors {pgurl:1-%d}", maxRate, benchSpec.warehouses,
+		"%s --ramp=%s --tolerate-errors {pgurl:1-%d}", benchSpec.warehouses, maxRate,
 		testTimeout, roachtestutil.GetWorkloadHistogramString(t, c, nil, true), rampDuration, benchSpec.nodes)
 
 	// In the case that we want to simulate high read amplification, we use kv0
@@ -764,7 +764,7 @@ func runDecommissionBenchLong(
 		benchSpec.warehouses,
 	)
 	workloadCmd := fmt.Sprintf("./cockroach workload run tpcc --warehouses=%d --max-rate=%d --duration=%s "+
-		"%s --ramp=%s --tolerate-errors {pgurl:1-%d}", maxRate, benchSpec.warehouses,
+		"%s --ramp=%s --tolerate-errors {pgurl:1-%d}", benchSpec.warehouses, maxRate,
 		testTimeout, roachtestutil.GetWorkloadHistogramString(t, c, nil, true), rampDuration, benchSpec.nodes)
 
 	setupDecommissionBench(ctx, t, c, benchSpec, pinnedNode, importCmd)


### PR DESCRIPTION
The order of `--warehouses` and `--max-rate` is incorrect. For example, the 1000 warehouses test that is supposed to run at 245/s rate, instead, has been a 245 warehouses test with max rate 1000.

```
run_081257.105936427_n8_cockroach-workload-r: 08:12:57 cluster.go:2417: > ./cockroach workload run tpcc --warehouses=245 --max-rate=1000 --duration=2h0m0s --histograms=perf/stats.json --ramp=3m0s --tolerate-errors {pgurl:1-6}
```

The "bug" is introduced long ago in #83733

Related to #148884