### PR TITLE
release-24.3: Make uuid parsing errors as safe string

### DIFF
--- a/pkg/util/uuid/BUILD.bazel
+++ b/pkg/util/uuid/BUILD.bazel
@@ -16,6 +16,7 @@ go_library(
         "//pkg/util/timeutil",
         "//pkg/util/uint128",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_cockroachdb_redact//:redact",
     ],
 )
 

--- a/pkg/util/uuid/codec.go
+++ b/pkg/util/uuid/codec.go
@@ -14,7 +14,9 @@ package uuid
 import (
 	"bytes"
 	"encoding/hex"
-	"fmt"
+
+	"github.com/cockroachdb/errors"
+	"github.com/cockroachdb/redact"
 )
 
 // FromBytes returns a UUID generated from the raw byte slice input.
@@ -101,7 +103,7 @@ func (u *UUID) UnmarshalText(text []byte) error {
 	stringifiedText := string(text)
 
 	if l < 32 || l > 48 {
-		return fmt.Errorf("uuid: incorrect UUID length: %s", text)
+		return errors.Newf("uuid: incorrect UUID length: %s", redact.SafeString(stringifiedText))
 	} else if stringifiedText[0] == '{' && stringifiedText[l-1] == '}' {
 		return u.decodeHyphenated(text[1 : l-1])
 	} else if bytes.Equal(text[:9], urnPrefix) {
@@ -129,7 +131,7 @@ func (u *UUID) decodeHashLike(t []byte) error {
 func (u *UUID) decodeHyphenated(t []byte) error {
 	l := len(t)
 	if l < 32 || l > 40 {
-		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+		return errors.Newf("uuid: incorrect UUID format: %s", redact.SafeString(string(t)))
 	}
 
 	hashLike := make([]byte, 32)
@@ -137,11 +139,11 @@ func (u *UUID) decodeHyphenated(t []byte) error {
 	i := 0
 	for _, c := range t {
 		if i >= len(hashLike) {
-			return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+			return errors.Newf("uuid: incorrect UUID format: %s", redact.SafeString(string(t)))
 		}
 		if c == '-' {
 			if countSinceHyphen == 0 || countSinceHyphen%4 != 0 {
-				return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+				return errors.Newf("uuid: incorrect UUID format: %s", redact.SafeString(string(t)))
 			}
 			countSinceHyphen = 0
 			continue
@@ -151,7 +153,7 @@ func (u *UUID) decodeHyphenated(t []byte) error {
 		countSinceHyphen++
 	}
 	if i != len(hashLike) {
-		return fmt.Errorf("uuid: incorrect UUID format: %s", t)
+		return errors.Newf("uuid: incorrect UUID format: %s", redact.SafeString(string(t)))
 	}
 	return u.decodeHashLike(hashLike)
 }
@@ -165,7 +167,10 @@ func (u UUID) MarshalBinary() ([]byte, error) {
 // It will return an error if the slice isn't 16 bytes long.
 func (u *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != Size {
-		return fmt.Errorf("uuid: UUID must be exactly 16 bytes long, got %d bytes", len(data))
+		return errors.Newf(
+			"uuid: UUID must be exactly 16 bytes long, got %d bytes",
+			redact.SafeInt(len(data)),
+		)
 	}
 	copy(u[:], data)
 

--- a/pkg/util/uuid/codec.go
+++ b/pkg/util/uuid/codec.go
@@ -169,7 +169,7 @@ func (u *UUID) UnmarshalBinary(data []byte) error {
 	if len(data) != Size {
 		return errors.Newf(
 			"uuid: UUID must be exactly 16 bytes long, got %d bytes",
-			redact.SafeInt(len(data)),
+			len(data),
 		)
 	}
 	copy(u[:], data)


### PR DESCRIPTION
Backport:
  * 1/1 commits from "pkg/util/uuid: Make uuid parsing errors as safe string" (#147762)
  * 1/1 commits from "pkg/util/uuid: simplify error message in UUID UnmarshalBinary method" (#149190)

Please see individual PRs for details.

/cc @cockroachdb/release

----
This patch helps to make the uuid parsing errors as safe so that when the roachpb.Key is
logged, the error message is not redacted.

The prior implementation of uuid errors followed the fmt.Errorf strings which are
categorised as unsafe by default when logged using %v verb of string formatting.
This patch convert those error objects to use redact.Safe implementation.

----

Release justification: Fixing the high priority error log line that was over redacted.
