### PR TITLE
release-25.3: roachtest: use multiple SSDs in schemachange/bulkingest

### DIFF
--- a/pkg/cmd/roachtest/tests/schemachange.go
+++ b/pkg/cmd/roachtest/tests/schemachange.go
@@ -339,7 +339,7 @@ func makeSchemaChangeBulkIngestTest(
 	return registry.TestSpec{
 		Name:             "schemachange/bulkingest",
 		Owner:            registry.OwnerSQLFoundations,
-		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.VolumeSize(200)),
+		Cluster:          r.MakeClusterSpec(numNodes, spec.WorkloadNode(), spec.SSD(4)),
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly),
 		Leases:           registry.MetamorphicLeases,


### PR DESCRIPTION
Backport 1/1 commits from #149089 on behalf of @rafiss.

fixes https://github.com/cockroachdb/cockroach/issues/149110

----

This test does a large index backfill. We recently increased the disk capacity, but that causes spinning disks to be used. We are seeing evidence that this makes AddSSTable operations too slow -- failing test logs show:

```
slow range RPC: have been waiting 245.03s
[(n5,s5):1, (n1,s1):2, (n8,s8):3, next=4, gen=523]; resp: (err: <nil>), *kvpb.AddSSTableResponse
```

We switch to SSDs to avoid slow disks. Since we can't specify a larger SSD capacity, we use multiple stores instead.

fixes https://github.com/cockroachdb/cockroach/issues/148516
Release note: None

----

Release justification: test only change