### PR TITLE
roachtest: increase zone config timeout in change-replicas/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -111,7 +111,7 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 		}
 
 		var rangeCount int
-		for i := 0; i < 60; i++ {
+		for i := 0; i < 80; i++ {
 			err := h.QueryRow(r, `SELECT count(*) FROM `+
 				`[SHOW RANGES FROM TABLE test] WHERE $1::int = ANY(replicas)`, node).Scan(&rangeCount)
 			if err != nil {


### PR DESCRIPTION
There were recently a couple of failures in the test change-replicas/mixed-version. I couldn't find anything that indicates an actual bug. I think that it might have been just a general slowness in the environment. Therefore, this commit increases the zone config timeout from 3m to 4m.

References: #148991
Release note: None