### PR TITLE
release-25.3: roachtest: deflake c2c/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_c2c.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_c2c.go
@@ -50,7 +50,7 @@ func registerC2CMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
 		Name:             "c2c/mixed-version",
 		Owner:            registry.OwnerDisasterRecovery,
-		Cluster:          r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, spec.WorkloadNode()),
+		Cluster:          r.MakeClusterSpec(sp.dstNodes+sp.srcNodes+1, spec.WorkloadNode(), spec.CPU(8)),
 		CompatibleClouds: sp.clouds,
 		Suites:           registry.Suites(registry.MixedVersion, registry.Nightly),
 		Monitor:          true,


### PR DESCRIPTION
Backport 1/1 commits from #148912 on behalf of @fqazi.

----

Previously, this test flakes because of CPU overload, which can cause different failure modes. To address this, this patch gives more CPU cores to nodes in the cluster.

Fixes: #146500
Fixes: #148580
Release note: None

----

Release justification: test only