### PR TITLE
release-25.3: sql: fix cancel leak in happy case in fingerprint_span

### DIFF
--- a/pkg/sql/fingerprint_span.go
+++ b/pkg/sql/fingerprint_span.go
@@ -139,6 +139,7 @@ func (p *planner) fingerprintSpanFanout(
 			// the coordinator encounters an error.
 			workCh := make(chan roachpb.Span)
 			ctx, cancel := context.WithCancel(ctx)
+			defer cancel()
 
 			grp := ctxgroup.WithContext(ctx)
 			for range maxWorkerCount {


### PR DESCRIPTION
Backport 1/1 commits from #149053 on behalf of @yuzefovich.

----

The recent fix introduced a possible leak of the cancel function (namely, in the happy case when the coordinator doesn't hit an early error, we would never call the cancellation function). We should just defer it unconditionally and might call it earlier on a shutdown due to an error.

Epic: None
Release note: None

----

Release justification: low-risk bug fix.