### PR TITLE
jsonpath: allow case insensitivity for keyword ident

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
+++ b/pkg/sql/logictest/testdata/logic_test/jsonb_path_query
@@ -629,6 +629,12 @@ SELECT jsonb_path_query('{"a": [1,2,3]}', 'strict $.a ? (1 == 1)');
 ----
 [1, 2, 3]
 
+# Ensure keyword ("strict") is parsed case-insensitively.
+query T
+SELECT jsonb_path_query('{"a": [1,2,3]}', 'StriCt $.a ? (1 == 1)');
+----
+[1, 2, 3]
+
 query empty
 SELECT jsonb_path_query('{"a": [1,2,3]}', 'strict $.a ? (1 != 1)');
 
@@ -913,6 +919,13 @@ SELECT jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\
 "abc"
 "abdacb"
 
+# Ensure keywords ("lax", "like_regex") are parsed case-insensitively.
+query T rowsort
+SELECT jsonb_path_query('[null, 1, "abc", "abd", "aBdC", "abdacb", "babc", "adc\nabc", "ab\nadc"]', 'LaX $[*] ? (@ like_rEgeX "^ab.*c")');
+----
+"abc"
+"abdacb"
+
 query T
 SELECT jsonb_path_query('"He said \"Hello\\World!\""', '$ ? (@ like_regex ".*\"H.*\\\\.*!.*\".*")');
 ----
@@ -1059,6 +1072,12 @@ SELECT jsonb_path_query('[1, 2, 3, 4]', '$[last]');
 ----
 4
 
+# Ensure keyword ("last") is parsed case-insensitively.
+query T
+SELECT jsonb_path_query('[1, 2, 3, 4]', '$[LaSt]');
+----
+4
+
 query T
 SELECT jsonb_path_query('"hello"', '$[last]');
 ----
@@ -1104,6 +1123,12 @@ true
 
 query T
 SELECT jsonb_path_query('{}', '(null like_regex "^he.*$") is unknown');
+----
+true
+
+# Ensure keyword ("like_regex") is parsed case-insensitively.
+query T
+SELECT jsonb_path_query('{}', '(null like_RegEx "^he.*$") is unknown');
 ----
 true
 
@@ -1898,3 +1923,63 @@ query T
 SELECT jsonb_path_query('"Line1\nLine2"', '$ like_regex "^Line1\nLine2$" flag "mq"');
 ----
 false
+
+
+# If a key is accidentally a keyword, it won't be normalized.
+query T
+SELECT jsonb_path_query('{"STRICT": 1}'::JSONB, 'strIct $.STRICT'::JSONPATH);
+----
+1
+
+query T
+SELECT jsonb_path_query('{"STRICT": 1}'::JSONB, 'lax $.STRICT'::JSONPATH);
+----
+1
+
+query T
+SELECT jsonb_path_query('{"STRICT": 1}'::JSONB, 'lax $.strict'::JSONPATH);
+----
+
+query T
+SELECT jsonb_path_query('{"STRICt": 1}'::JSONB, '$.STRICt'::JSONPATH);
+----
+1
+
+query T
+SELECT jsonb_path_query('{"STRICt": 1}'::JSONB, '$.STRICT'::JSONPATH);
+----
+
+query T
+SELECT jsonb_path_query('{"strict": 1}'::JSONB, '$.STRICT'::JSONPATH);
+----
+
+query T
+SELECT jsonb_path_query('{"strict": 1}'::JSONB, 'lax $.STRICT'::JSONPATH);
+----
+
+query T
+SELECT jsonb_path_query('{"strict": 1}'::JSONB, '$.STRICt'::JSONPATH);
+----
+
+query T
+SELECT jsonb_path_query('{"strict": 1}'::JSONB, 'lax $.STRICt'::JSONPATH);
+----
+
+query T
+SELECT jsonb_path_query('{"strict": 1}'::JSONB, '$.strict'::JSONPATH);
+----
+1
+
+query T
+SELECT jsonb_path_query('{"LIKE_REGEX": 1}'::JSONB, '$.LIKE_REGEX'::JSONPATH);
+----
+1
+
+query T
+SELECT jsonb_path_query('{"LIKE_REGEx": 1}'::JSONB, '$.LIKE_REGEx'::JSONPATH);
+----
+1
+
+query T
+SELECT jsonb_path_query('{"LIKE_REGEx": 1}'::JSONB, '$.LIKE_REGEX'::JSONPATH);
+----

--- a/pkg/sql/logictest/testdata/logic_test/jsonpath
+++ b/pkg/sql/logictest/testdata/logic_test/jsonpath
@@ -27,8 +27,20 @@ SELECT 'strict $'::JSONPATH
 ----
 strict $
 
+# Ensure keyword ("strict") is parsed case-insensitively.
+query T
+SELECT 'sTrict $'::JSONPATH
+----
+strict $
+
 query T
 SELECT 'lax $'::JSONPATH
+----
+$
+
+# Ensure keyword ("lax") is parsed case-insensitively.
+query T
+SELECT 'LaX $'::JSONPATH
 ----
 $
 
@@ -209,6 +221,13 @@ query T
 SELECT '$.*'::JSONPATH
 ----
 $.*
+
+# keyword "strict" is case-insensitive, but a key ("STRIcT") will never be normalized
+# even if it matches the same spelling of a keyword.
+query T
+SELECT 'strIct $.STRIcT'::JSONPATH
+----
+strict $."STRIcT"
 
 ## When we allow table creation
 

--- a/pkg/sql/scanner/jsonpath_scan.go
+++ b/pkg/sql/scanner/jsonpath_scan.go
@@ -6,6 +6,8 @@
 package scanner
 
 import (
+	"strings"
+
 	sqllexbase "github.com/cockroachdb/cockroach/pkg/sql/lexbase"
 	"github.com/cockroachdb/cockroach/pkg/util/jsonpath/parser/lexbase"
 )
@@ -136,9 +138,10 @@ func isIdentMiddle(ch int) bool {
 
 // scanIdent is similar to Scanner.scanIdent, but uses Jsonpath tokens.
 func (s *JSONPathScanner) scanIdent(lval ScanSymType) {
-	// TODO(#144255): Allow any case for specific identifiers (strict, lax, to)
 	s.normalizeIdent(lval, isIdentMiddle, false /* toLower */)
-	lval.SetID(lexbase.GetKeywordID(lval.Str()))
+	// Postgres is case-insensitive for keywords, see
+	// https://github.com/cockroachdb/cockroach/issues/144255.
+	lval.SetID(lexbase.GetKeywordID(strings.ToLower(lval.Str())))
 }
 
 // scanNumber is similar to Scanner.scanNumber, but uses Jsonpath tokens.

--- a/pkg/util/jsonpath/parser/testdata/jsonpath
+++ b/pkg/util/jsonpath/parser/testdata/jsonpath
@@ -741,6 +741,104 @@ parse
 ----
 ("a" like_regex ".*" flag "ismq") -- normalized!
 
+# Subtests with casing for idents.
+parse
+sTrict $
+----
+strict $ -- normalized!
+
+parse
+Lax $
+----
+$ -- normalized!
+
+parse
+$ ? (exiSts(1))
+----
+$?(exists (1)) -- normalized!
+
+parse
+"a" like_Regex ".*" flAg "i"
+----
+("a" like_regex ".*" flag "i") -- normalized!
+
+parse
+(1 == 1) Is unKnown
+----
+(1 == 1) is unknown -- normalized!
+
+parse
+$[1 tO 5, lAst]
+----
+$[1 to 5,last] -- normalized!
+
+parse
+"" sTarts With ""
+----
+("" starts with "") -- normalized!
+
+parse
+$.active == false
+----
+($."active" == false) -- normalized!
+
+# This will not work for PG as it is case-sensitive for "false" ident.
+# But for crdb we're case-insensitive for all idents.
+parse
+$.active == FaLse
+----
+($."active" == false) -- normalized!
+
+parse
+$.active == true
+----
+($."active" == true) -- normalized!
+
+# This will not work for PG as it is case-sensitive for "true" ident.
+# But for crdb we're case-insensitive for all idents.
+parse
+$.active == True
+----
+($."active" == true) -- normalized!
+
+parse
+$.active == TrUe
+----
+($."active" == true) -- normalized!
+
+# This will not work for PG as it is case-sensitive for "null" ident.
+# But for crdb we're case-insensitive for all idents.
+parse
+$.active == Null
+----
+($."active" == null) -- normalized!
+
+parse
+$.active == null
+----
+($."active" == null) -- normalized!
+
+# If an ident is accidentally a keyword, it will not be normalized.
+parse
+$.STRICT == null
+----
+($."STRICT" == null) -- normalized!
+
+parse
+strIcT $.STRICT == null
+----
+strict ($."STRICT" == null) -- normalized!
+
+parse
+$.STRiCt == null
+----
+($."STRiCt" == null) -- normalized!
+
+parse
+strIcT $.STRiCt == null
+----
+strict ($."STRiCt" == null) -- normalized!
+
 # parse
 # $.1a
 # ----


### PR DESCRIPTION
Epic: None
Fix: https://github.com/cockroachdb/cockroach/issues/144255

Previously, if the keyword is not all capital letter, it will cause syntax error. For example, `strIcT $.STRiCt == null` will failed the parsing with `at or near "strIcT": syntax error`. This is because the lexer sees `strIcT $.STRiCt == null` as `IDENT $.IDENT == NULL`, which is a rule that is not found in `jsonpath.y`. 

Note that the lexer recognizes `strIcT` and `STRiCt` as `IDENT` by [the id](https://github.com/cockroachdb/cockroach/blob/ac3b2b749ca61a781566557faf29daa08ae2f9b5/pkg/util/jsonpath/parser/lexer.go#L69-L79), not by the string. So this commit is to set the ID for all string whose lowercased form matches a keyword. More specifically, we now do `lval.SetID(lexbase.GetKeywordID(strings.ToLower(lval.Str())))` in the scanning logic.

So with the same example, `strIcT $.STRiCt == null` is now recognized as `STRICT $.STRICT == NULL` by the parser, for which a rule exists in the yacc and it will pass the **Lexical Analysis**. Then, at the **Syntactic Analysis** step, the keyword `STRICT` will be normalized, while the property accessing part, `$.STRiCt`, will remain the same, as the original str `STRiCt` is still reserved.

Release note (bug fix): Support any casing for keyword identifiers in a jsonpath query. Note that for 3 special
identifiers "TRUE", "FALSE", "NULL", crdb parses them with case insensitivity, but PG parses them case sensitively, e.g. `select '$.active == TrUe'::jsonpath;` will work in crdb but not in pg.