### PR TITLE
sql: improve error message for schema_locked

### DIFF
--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -512,6 +512,13 @@ func TestTenantLogic_create_index(
 	runLogicTest(t, "create_index")
 }
 
+func TestTenantLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestTenantLogic_create_table(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/testdata/logic_test/create_statements
+++ b/pkg/sql/logictest/testdata/logic_test/create_statements
@@ -1,4 +1,4 @@
-# LogicTest: !weak-iso-level-configs schema-locked-disabled
+# LogicTest: !weak-iso-level-configs
 # This test is skipped under READ COMMITTED and REPEATABLE READ, since it
 # asserts on the NOTICE output, and weak isolation level schema changes always
 # send out extra notices.

--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -87,35 +87,35 @@ statement ok
 INSERT INTO t SELECT i, i+1 FROM generate_series(1,10) AS tmp(i);
 
 onlyif config local-mixed-25.1 local-legacy-schema-changer
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE t ADD COLUMN k INT DEFAULT 30;
 
 onlyif config local-mixed-25.1 local-legacy-schema-changer
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE t DROP COLUMN j;
 
 onlyif config local-mixed-25.1
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE t RENAME TO t2;
 
 onlyif config local-mixed-25.1
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE t RENAME COLUMN j TO j2;
 
 onlyif config local-mixed-25.1
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER INDEX idx RENAME TO idx2;
 
 onlyif config local-mixed-25.1
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER INDEX idx INVISIBLE;
 
 onlyif config local-mixed-25.1 local-legacy-schema-changer
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 DROP INDEX idx;
 
 onlyif config local-mixed-25.1 local-legacy-schema-changer
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 CREATE INDEX idx2 ON t(j);
 
 statement ok
@@ -123,7 +123,7 @@ CREATE TABLE ref (a INT PRIMARY KEY, b INT)
 
 # Locked tables cannot be referenced by foreign keys.
 onlyif config local-mixed-25.1 local-legacy-schema-changer
-statement error pgcode 57000 schema changes are disallowed on table "t" because it is locked
+statement error pgcode 57000 this schema change is disallowed because table "t" is locked and this operation cannot automatically unlock the table
 ALTER TABLE ref ADD CONSTRAINT fk FOREIGN KEY (b) REFERENCES t(j);
 
 # GRANT statements are allowed on the table, as they only affect the

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -486,6 +486,13 @@ func TestLogic_create_index(
 	runLogicTest(t, "create_index")
 }
 
+func TestLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestLogic_create_table(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -486,6 +486,13 @@ func TestLogic_create_index(
 	runLogicTest(t, "create_index")
 }
 
+func TestLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestLogic_create_table(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -486,6 +486,13 @@ func TestLogic_create_index(
 	runLogicTest(t, "create_index")
 }
 
+func TestLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestLogic_create_table(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/local-vec-off/generated_test.go
@@ -486,6 +486,13 @@ func TestLogic_create_index(
 	runLogicTest(t, "create_index")
 }
 
+func TestLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestLogic_create_table(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/local/generated_test.go
+++ b/pkg/sql/logictest/tests/local/generated_test.go
@@ -507,6 +507,13 @@ func TestLogic_create_index(
 	runLogicTest(t, "create_index")
 }
 
+func TestLogic_create_statements(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "create_statements")
+}
+
 func TestLogic_create_table(
 	t *testing.T,
 ) {


### PR DESCRIPTION
This also unskips a logictest that was accidentally skipped.

Epic: CRDB-41681
Release note: None