### PR TITLE
sql: fix check external connection evaluation

### DIFF
--- a/pkg/sql/check_external_connection.go
+++ b/pkg/sql/check_external_connection.go
@@ -150,6 +150,7 @@ func (n *checkExternalConnectionNode) Close(_ context.Context) {
 }
 
 func (n *checkExternalConnectionNode) parseParams(params runParams) error {
+	params.p.SemaCtx().Properties.Require("check_external_connection", tree.RejectSubqueries)
 	exprEval := params.p.ExprEvaluator("CHECK EXTERNAL CONNECTION")
 	loc, err := exprEval.String(params.ctx, n.node.URI)
 	if err != nil {

--- a/pkg/sql/logictest/testdata/logic_test/show_external_connections
+++ b/pkg/sql/logictest/testdata/logic_test/show_external_connections
@@ -68,3 +68,7 @@ SHOW EXTERNAL CONNECTIONS
 connection_name connection_uri    connection_type
 foo_conn        nodelocal://1/foo STORAGE
 baz_conn        nodelocal://1/baz STORAGE
+
+# Regression test for #147877
+statement error subqueries are not allowed in check_external_connection
+CHECK EXTERNAL CONNECTION NULLIF WITH CONCURRENTLY = EXISTS ( ( TABLE error ) );


### PR DESCRIPTION
Previously, `CHECK EXTERNAL CONNECTION '' WITH CONCURRENCY = (SELECT 1)` would panic because its not able to evaluate an expression containing a sub query.

Now, passing a sub query will fail with a user error.

```
CHECK EXTERNAL CONNECTION NULLIF WITH CONCURRENTLY = EXISTS ( ( TABLE error ) );
ERROR: subqueries are not allowed in check_external_connection
SQLSTATE: 0A000
```

Release note: none
Informs: #147876
Informs: #147877