### PR TITLE
release-25.2: roachtest: increase timeout for small backup fixtures

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_fixtures.go
+++ b/pkg/cmd/roachtest/tests/backup_fixtures.go
@@ -293,7 +293,7 @@ func registerBackupFixtures(r registry.Registry) {
 			hardware: makeHardwareSpecs(hardwareSpecs{
 				workloadNode: true,
 			}),
-			timeout: 2 * time.Hour,
+			timeout: 3 * time.Hour,
 			suites:  registry.Suites(registry.Nightly),
 			clouds:  []spec.Cloud{spec.AWS, spec.GCE}},
 		{


### PR DESCRIPTION
/cc @cockroachdb/release

---

After the switch to the new fixtures, we are seeing some timeouts on the 5000 warehouse TPCC fixture. This adjusts the timeouts accordingly to fix the test failures.

Epic: CRDB-51482

Fixes: #148498

---

Release justification: Test-only change