### PR TITLE
structlogging: clean up hot ranges logger startup procedure

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2361,12 +2361,11 @@ func (s *topLevelServer) AcceptClients(ctx context.Context) error {
 		return err
 	}
 
-	if err := structlogging.StartHotRangesLoggingScheduler(
+	if err := structlogging.StartSystemHotRangesLogger(
 		ctx,
 		s.stopper,
 		s.status,
 		s.ClusterSettings(),
-		nil,
 	); err != nil {
 		return err
 	}

--- a/pkg/server/structlogging/BUILD.bazel
+++ b/pkg/server/structlogging/BUILD.bazel
@@ -11,7 +11,6 @@ go_library(
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
-        "//pkg/multitenant/tenantcapabilities",
         "//pkg/server/serverpb",
         "//pkg/settings",
         "//pkg/settings/cluster",

--- a/pkg/server/structlogging/hot_ranges_log_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_test.go
@@ -257,7 +257,7 @@ func setupTestServer(
 	structlogging.TelemetryHotRangesStatsInterval.Override(ctx, &settings.SV, time.Millisecond)
 	structlogging.TelemetryHotRangesStatsLoggingDelay.Override(ctx, &settings.SV, 0*time.Millisecond)
 
-	err := structlogging.StartHotRangesLoggingScheduler(ctx, stopper, testHotRangeGetter{}, settings, nil)
+	err := structlogging.StartSystemHotRangesLogger(ctx, stopper, testHotRangeGetter{}, settings)
 	require.NoError(t, err)
 
 	return settings, spy, teardown

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -49,7 +49,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server/serverctl"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
 	"github.com/cockroachdb/cockroach/pkg/server/status"
-	"github.com/cockroachdb/cockroach/pkg/server/structlogging"
 	"github.com/cockroachdb/cockroach/pkg/server/systemconfigwatcher"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/spanconfig"
@@ -997,17 +996,6 @@ func (s *SQLServerWrapper) AcceptClients(ctx context.Context) error {
 		); err != nil {
 			return err
 		}
-	}
-
-	ti, _ := s.sqlServer.tenantConnect.TenantInfo()
-	if err := structlogging.StartHotRangesLoggingScheduler(
-		ctx,
-		s.stopper,
-		s.sqlServer.tenantConnect,
-		s.ClusterSettings(),
-		&ti,
-	); err != nil {
-		return err
 	}
 
 	s.sqlServer.isReady.Store(true)


### PR DESCRIPTION
structlogging: clean up hot ranges logger startup procedure

A recent fix in #149111 updated the hot ranges logger startup procedure to have the entrypoint for app tenants to be only from the job system. This change neglected to clean up the startup call in the app tenants startup sequence, so this PR removes a lot of that logic (which could be seen as confusing).

Additionally, it changes the job startup sequence so that the job does
not run in single tenant instances, which would be duplicative.

Fixes: none
Epic: none
Release note: none