### PR TITLE
release-25.3: optbuilder: prohibit some operations on REFCURSOR

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/refcursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/refcursor
@@ -470,6 +470,12 @@ SELECT NULLIF('foo'::REFCURSOR, 'bar'::REFCURSOR);
 statement error pgcode 42883 pq: unsupported comparison operator
 SELECT NULLIF('foo'::REFCURSOR, NULL);
 
+statement error pgcode 42883 pq: could not identify an ordering operator for type refcursor
+SELECT * FROM t ORDER BY x;
+
+statement error pgcode 42883 pq: operator does not exist: refcursor = refcursor
+SELECT * FROM t INNER JOIN t t2 USING (x);
+
 # Regression test for #112010 - REFCURSOR should allow IS NULL and
 # IS NOT NULL comparisons.
 subtest is_null
@@ -685,22 +691,33 @@ baz   NULL  baz  foo
 statement error pgcode 42883 pq: unknown signature
 SELECT lag(y) OVER w, lead(y) OVER w, first_value(y) OVER w, last_value(y) OVER w FROM t WINDOW w AS ();
 
-# Array functions are allowed.
-query TT
-SELECT array_agg(x ORDER BY x, y), array_cat_agg(y ORDER BY x, y) FROM t;
-----
-{baz,foo}  {bar}
+# Array functions are allowed (but ordering on REFCURSOR and REFCURSOR[] columns
+# is not).
+statement ok
+SELECT array_agg(x), array_cat_agg(y) FROM t;
 
-query TT
-SELECT array_append(y, x), array_prepend(x, y) FROM t ORDER BY x, y;
+query TT rowsort
+SELECT array_append(y, x), array_prepend(x, y) FROM t;
 ----
 {baz}      {baz}
 {bar,foo}  {foo,bar}
 
-query TT
-SELECT array_remove(y, 'baz'), array_replace(y, 'baz', 'foo') FROM t ORDER BY x, y;
+query TT rowsort
+SELECT array_remove(y, 'baz'), array_replace(y, 'baz', 'foo') FROM t;
 ----
 {}     {}
 {bar}  {bar}
+
+statement error pgcode 42883 pq: could not identify an ordering operator for type refcursor
+SELECT array_agg(x ORDER BY x) FROM t;
+
+statement error pgcode 42883 pq: could not identify an ordering operator for type refcursor\[\]
+SELECT array_agg(y ORDER BY y) FROM t;
+
+statement error pgcode 42883 pq: could not identify an ordering operator for type refcursor
+SELECT array_append(y, x), array_prepend(x, y) FROM t ORDER BY x;
+
+statement error pgcode 42883 pq: could not identify an ordering operator for type refcursor\[\]
+SELECT array_append(y, x), array_prepend(x, y) FROM t ORDER BY y;
 
 subtest end

--- a/pkg/sql/opt/optbuilder/groupby.go
+++ b/pkg/sql/opt/optbuilder/groupby.go
@@ -730,6 +730,7 @@ func (b *Builder) buildAggregateFunction(
 					expr := tree.NewTypedIsNullExpr(e)
 					b.buildAggArg(expr, &info, tempScope, fromScope)
 				}
+				ensureColumnOrderable(e)
 				b.buildAggArg(e, &info, tempScope, fromScope)
 			}
 		}

--- a/pkg/sql/opt/optbuilder/join.go
+++ b/pkg/sql/opt/optbuilder/join.go
@@ -482,6 +482,11 @@ func (jb *usingJoinBuilder) addEqualityCondition(leftCol, rightCol *scopeColumn)
 				"JOIN/USING types %s for left and %s for right cannot be matched for column %q",
 				leftCol.typ, rightCol.typ, tree.ErrString(&name)))
 		}
+	} else if !tree.EqCmpAllowedForEquivalentTypes(leftCol.typ, rightCol.typ) {
+		panic(pgerror.Newf(pgcode.UndefinedFunction,
+			"operator does not exist: %s = %s",
+			leftCol.typ.SQLStandardName(), rightCol.typ.SQLStandardName(),
+		))
 	}
 
 	// We will create a new "merged" column and hide the original columns.

--- a/pkg/sql/opt/optbuilder/orderby.go
+++ b/pkg/sql/opt/optbuilder/orderby.go
@@ -325,14 +325,15 @@ func (b *Builder) hasDefaultNullsOrder(order *tree.Order) bool {
 
 func ensureColumnOrderable(e tree.TypedExpr) {
 	typ := e.ResolvedType()
+	var arraySuffix string
 	if typ.Family() == types.ArrayFamily {
 		typ = typ.ArrayContents()
+		arraySuffix = "[]"
 	}
 	switch typ.Family() {
 	case types.TSQueryFamily, types.TSVectorFamily, types.PGVectorFamily:
 		panic(unimplementedWithIssueDetailf(92165, "", "can't order by column type %s", typ.SQLString()))
-	case types.JsonpathFamily:
-		panic(pgerror.Newf(pgcode.UndefinedFunction, "could not identify an ordering operator for type jsonpath"))
-
+	case types.RefCursorFamily, types.JsonpathFamily:
+		panic(pgerror.Newf(pgcode.UndefinedFunction, "could not identify an ordering operator for type %s%s", typ.SQLStandardName(), arraySuffix))
 	}
 }

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -3782,6 +3782,8 @@ var CannotAcceptTriggerErr = pgerror.New(pgcode.FeatureNotSupported,
 // given family, which is invalid for comparison. We don't simply remove
 // the relevant comparison overloads because we rely on their existence in
 // various locations throughout the codebase.
+// TODO(yuzefovich): audit callers of this method to see whether Jsonpath family
+// should be handled in the same way as RefCursor family is.
 func checkComparison(
 	op treecmp.ComparisonOperatorSymbol, left, right *types.T, family types.Family,
 ) error {


### PR DESCRIPTION
Backport 1/1 commits from #148863 on behalf of @yuzefovich.

----

Postgres doesn't allow ordering by and equality comparison on refcursor columns, so this commit adds checks to match that behavior.

Fixes: #145477.

Release note (bug fix): CockroachDB now prohibits ORDER BY and join equality operations on REFCURSOR type, matching behavior of Postgres.

----

Release justification: low-risk bug fix.