### PR TITLE
logictest: fix up recent change

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/refcursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/refcursor
@@ -693,10 +693,8 @@ SELECT lag(y) OVER w, lead(y) OVER w, first_value(y) OVER w, last_value(y) OVER 
 
 # Array functions are allowed (but ordering on REFCURSOR and REFCURSOR[] columns
 # is not).
-query TT
+statement ok
 SELECT array_agg(x), array_cat_agg(y) FROM t;
-----
-{foo,baz}  {bar}
 
 query TT rowsort
 SELECT array_append(y, x), array_prepend(x, y) FROM t;


### PR DESCRIPTION
Just merged 55108a1e713f75d6a79cfc3d0e2acd2963900b20 made one query flaky: namely, we removed ORDER BY from `array_agg` so now the order of two items can be arbitrary. This commit changes the test to assert that the query succeeds (which this test is really about) without hitting an error.

Epic: None
Release note: None