### PR TITLE
release-25.2: execbuilder: fix locked indexes info in an edge case

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/delete
+++ b/pkg/sql/opt/exec/execbuilder/testdata/delete
@@ -971,3 +971,94 @@ RESET optimizer_use_lock_elision_multiple_families;
 RESET buffered_writes_use_locking_on_non_unique_indexes;
 
 subtest end
+
+# Regression test for incorrectly treating a locked index in one table as being
+# locked in another. Furthermore, we shouldn't be locking an index in a
+# different table altogether.
+subtest locking_other_table
+
+statement ok
+CREATE TABLE legal_entity (
+   id TEXT PRIMARY KEY
+);
+INSERT INTO legal_entity VALUES ('foo');
+
+statement ok
+CREATE TABLE entity_address (
+   id TEXT PRIMARY KEY
+);
+INSERT INTO entity_address VALUES ('bar');
+
+# Retry to ensure that referenced tables are visible.
+retry
+statement ok
+CREATE TABLE legal_entity_address (
+    id INT PRIMARY KEY,
+    legal_entity_id text NOT NULL REFERENCES legal_entity(id) ON DELETE CASCADE,
+    entity_address_id text NOT NULL REFERENCES entity_address(id) ON DELETE CASCADE,
+    UNIQUE (legal_entity_id, entity_address_id),
+    FAMILY (legal_entity_id, entity_address_id)
+);
+
+statement ok
+INSERT INTO legal_entity_address VALUES (1, 'foo', 'bar');
+
+query T
+EXPLAIN
+DELETE FROM entity_address WHERE id IN (
+    SELECT entity_address_id FROM legal_entity_address WHERE legal_entity_id = 'foo'
+);
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • delete
+│   │ from: entity_address
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • scan
+│                 missing stats
+│                 table: legal_entity_address@legal_entity_address_legal_entity_id_entity_address_id_key
+│                 spans: [/'foo' - /'foo']
+│
+└── • fk-cascade
+    │ fk: legal_entity_address_entity_address_id_fkey
+    │
+    └── • delete
+        │ from: legal_entity_address
+        │
+        └── • hash join
+            │ equality: (entity_address_id) = (id)
+            │ right cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: legal_entity_address@legal_entity_address_pkey
+            │     spans: FULL SCAN
+            │
+            └── • distinct
+                │ estimated row count: 10
+                │ distinct on: id
+                │
+                └── • scan buffer
+                      estimated row count: 100
+                      label: buffer 1000000
+
+query T kvtrace
+DELETE FROM entity_address WHERE id IN (
+    SELECT entity_address_id FROM legal_entity_address WHERE legal_entity_id = 'foo'
+);
+----
+Scan /Table/120/2/"foo"{-/PrefixEnd}
+Del (locking) /Table/119/1/"bar"/0
+Scan /Table/120/{1-2}
+Del (locking) /Table/120/2/"foo"/"bar"/0
+Del (locking) /Table/120/1/1/0
+
+subtest end

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1829,3 +1829,91 @@ RESET optimizer_use_lock_elision_multiple_families;
 RESET use_cputs_on_non_unique_indexes;
 
 subtest end
+
+# Regression test for incorrectly treating a locked index in one table as being
+# locked in another. Furthermore, we shouldn't be locking an index in a
+# different table altogether.
+subtest locking_other_table
+
+statement ok
+CREATE TABLE legal_entity (
+   id TEXT PRIMARY KEY
+);
+INSERT INTO legal_entity VALUES ('foo');
+
+statement ok
+CREATE TABLE entity_address (
+   id TEXT PRIMARY KEY
+);
+INSERT INTO entity_address VALUES ('bar');
+
+# Retry to ensure that referenced tables are visible.
+retry
+statement ok
+CREATE TABLE legal_entity_address (
+    legal_entity_id text NOT NULL REFERENCES legal_entity(id),
+    entity_address_id text NOT NULL REFERENCES entity_address(id),
+    UNIQUE (legal_entity_id, entity_address_id),
+    FAMILY (legal_entity_id, entity_address_id)
+);
+
+statement ok
+INSERT INTO legal_entity_address VALUES ('foo', 'bar');
+
+query T
+EXPLAIN
+UPDATE entity_address SET id = 'bar' WHERE id IN (
+    SELECT entity_address_id FROM legal_entity_address WHERE legal_entity_id = 'foo'
+);
+----
+distribution: local
+vectorized: true
+·
+• root
+│
+├── • update
+│   │ table: entity_address
+│   │ set: id
+│   │
+│   └── • buffer
+│       │ label: buffer 1
+│       │
+│       └── • render
+│           │
+│           └── • render
+│               │
+│               └── • scan
+│                     missing stats
+│                     table: legal_entity_address@legal_entity_address_legal_entity_id_entity_address_id_key
+│                     spans: [/'foo' - /'foo']
+│
+└── • constraint-check
+    │
+    └── • error if rows
+        │
+        └── • hash join (right semi)
+            │ equality: (entity_address_id) = (id)
+            │ right cols are key
+            │
+            ├── • scan
+            │     missing stats
+            │     table: legal_entity_address@legal_entity_address_pkey
+            │     spans: FULL SCAN
+            │
+            └── • except all
+                │
+                ├── • scan buffer
+                │     label: buffer 1
+                │
+                └── • scan buffer
+                      label: buffer 1
+
+query T kvtrace
+UPDATE entity_address SET id = 'bar' WHERE id IN (
+    SELECT entity_address_id FROM legal_entity_address WHERE legal_entity_id = 'foo'
+);
+----
+Scan /Table/123/2/"foo"{-/PrefixEnd}
+Put (locking) /Table/122/1/"bar"/0 -> /TUPLE/
+
+subtest end


### PR DESCRIPTION
Backport 1/1 commits from #149093 on behalf of @yuzefovich.

----

For buffered writes project, in 5e968e66791f54b71af2abccaa7d0a76a5ef82c6 we started propagating information about which indexes have been locked which allows us to use non-locking Puts and Dels when mutating those indexes. That change had an incorrect assumption that any indexes we lock belong to the same table as the one being mutated. However, we just saw a user report where this wasn't the case - in some cases we might perform the initial scan on a different table (in the example, it was a FK referencing us), so we could incorrectly treat some indexes as having been locked when they haven't. With buffered writes enabled, this could lead to difference in blocking behavior (but no corruption or correctness issues since we still would find the concurrent write on COMMIT); with buffered writes disabled, the locked indexes info doesn't have any impact, so we could only hit an internal error when a given index ordinal doesn't exist in the target table.

Furthermore, there is no point in locking an index of a different table since we might not actually modify it (this will depend on whether there exists a CASCADE action and which action it is).

Fixes: #148650.

Release note (bug fix): CockroachDB previously could hit an internal error when performing a DELETE, an UPDATE, or an UPSERT statement where the initial scan of the mutation is locking and is on a table different from the one being mutated. As a workaround, one could do `SET enable_implicit_select_for_update = false`, but note that it might increase contention, so use with caution. The bug was introduced in 25.2 version and is now fixed.

----

Release justification: low-risk bug fix that can be disabled via existing `enable_implicit_select_for_update` session variable. Disabling the fix by default doesn't make sense.