### PR TITLE
release-25.3: sql: reset schema_locked correctly in a mixed version state

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -1,3 +1,10 @@
+# Intentionally set this to true in 25.2, this setting
+# should be ignored.
+onlyif config local-mixed-25.2
+statement ok
+SET create_table_with_schema_locked=true
+
+skipif config local-mixed-25.2
 statement ok
 SET create_table_with_schema_locked=false
 

--- a/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
+++ b/pkg/sql/storageparam/tablestorageparam/BUILD.bazel
@@ -6,6 +6,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/storageparam/tablestorageparam",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/clusterversion",
         "//pkg/sql/catalog/catpb",
         "//pkg/sql/catalog/tabledesc",
         "//pkg/sql/paramparse",


### PR DESCRIPTION
Backport 1/1 commits from #149271 on behalf of @fqazi.

----

Previously, when schema_locked was reset it would always adopt the value from create_table_with_schema_locked. This was incorrect, since this setting should only adopted if the cluster is running on 25.3. This patch adds a version gate in the reset logic.

Fixes: #149266

Release note: None

----

Release justification: low risk change for incorrect behavior in a mixed version state