### PR TITLE
upgrades: fix order of AddHotRangeLoggerJob migration

### DIFF
--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -96,13 +96,6 @@ var upgrades = []upgradebase.Upgrade{
 		eventLogTableMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore the new column or index"),
 	),
-	upgrade.NewTenantUpgrade(
-		"add new hot range logger job",
-		clusterversion.V25_3_AddHotRangeLoggerJob.Version(),
-		upgrade.NoPrecondition,
-		addHotRangeLoggerJob,
-		upgrade.RestoreActionNotRequired("cluster restore does not restore this job"),
-	),
 
 	upgrade.NewTenantUpgrade(
 		"add 'estimated_last_login_time' column to system.users table",
@@ -110,6 +103,14 @@ var upgrades = []upgradebase.Upgrade{
 		upgrade.NoPrecondition,
 		usersLastLoginTimeTableMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore the new column"),
+	),
+
+	upgrade.NewTenantUpgrade(
+		"add new hot range logger job",
+		clusterversion.V25_3_AddHotRangeLoggerJob.Version(),
+		upgrade.NoPrecondition,
+		addHotRangeLoggerJob,
+		upgrade.RestoreActionNotRequired("cluster restore does not restore this job"),
 	),
 
 	// Note: when starting a new release version, the first upgrade (for


### PR DESCRIPTION
The V25_3_AddHotRangeLoggerJob cluster version comes _after_ the V25_3_AddEstimatedLastLoginTime version. Yet, the corresponding upgrade for adding the hot ranges logger was incorrectly being done _before_ the last login time column.

informs: https://github.com/cockroachdb/cockroach/issues/148981
informs: https://github.com/cockroachdb/cockroach/issues/148998

Release note: None