### PR TITLE
roachtest: mark cluster as expected to die in validate_system_schema_after_version_upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -134,7 +134,13 @@ func validateSystemSchemaAfterUpgradeTest(
 	mvt.Run()
 
 	// Start a cluster with the latest binary and get the system schema
-	// from the cluster.
+	// from the cluster. Mark all processes as expected to die before wiping.
+	t.Monitor().ExpectProcessDead(c.All())
+	// If we have a tenant, mark it as expected to die too.
+	if tenantComparison != nil {
+		t.Monitor().ExpectProcessDead(c.All(), option.VirtualClusterName(tenantComparison.name))
+	}
+
 	c.Wipe(ctx, c.All())
 	settings := install.MakeClusterSettings()
 

--- a/pkg/upgrade/upgrades/upgrades.go
+++ b/pkg/upgrade/upgrades/upgrades.go
@@ -96,13 +96,6 @@ var upgrades = []upgradebase.Upgrade{
 		eventLogTableMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore the new column or index"),
 	),
-	upgrade.NewTenantUpgrade(
-		"add new hot range logger job",
-		clusterversion.V25_3_AddHotRangeLoggerJob.Version(),
-		upgrade.NoPrecondition,
-		addHotRangeLoggerJob,
-		upgrade.RestoreActionNotRequired("cluster restore does not restore this job"),
-	),
 
 	upgrade.NewTenantUpgrade(
 		"add 'estimated_last_login_time' column to system.users table",
@@ -110,6 +103,14 @@ var upgrades = []upgradebase.Upgrade{
 		upgrade.NoPrecondition,
 		usersLastLoginTimeTableMigration,
 		upgrade.RestoreActionNotRequired("cluster restore does not restore the new column"),
+	),
+
+	upgrade.NewTenantUpgrade(
+		"add new hot range logger job",
+		clusterversion.V25_3_AddHotRangeLoggerJob.Version(),
+		upgrade.NoPrecondition,
+		addHotRangeLoggerJob,
+		upgrade.RestoreActionNotRequired("cluster restore does not restore this job"),
 	),
 
 	// Note: when starting a new release version, the first upgrade (for


### PR DESCRIPTION
Before wiping the cluster, we need to indicate to the test that the
cluster is going to go down. This is needed after
eae1e78.

fixes #148981
fixes #148998

Release note: None