### PR TITLE
release-25.2: tpcc: use explicit decimals when initializing items

### DIFF
--- a/pkg/ccl/workloadccl/allccl/all_test.go
+++ b/pkg/ccl/workloadccl/allccl/all_test.go
@@ -247,6 +247,11 @@ func hashTableInitialData(
 					binary.LittleEndian.PutUint64(scratch[:8], uint64(colTime[i].UnixNano()))
 					_, _ = h.Write(scratch[:8])
 				}
+			case types.DecimalFamily:
+				colDecimal := col.Decimal()
+				for i := 0; i < b.Length(); i++ {
+					_, _ = h.Write([]byte(colDecimal[i].String()))
+				}
 			default:
 				return errors.Errorf(`unhandled type %s`, col.Type())
 			}
@@ -282,7 +287,7 @@ func TestDeterministicInitialData(t *testing.T) {
 		`roachmart`:  0xda5e73423dbdb2d9,
 		`sqlsmith`:   0xcbf29ce484222325,
 		`startrek`:   0xa0249fbdf612734c,
-		`tpcc`:       0xcccced25deea244e,
+		`tpcc`:       0xccfecd06eed59975,
 		`tpch`:       0xcd2abbd021ed895d,
 		`ycsb`:       0x0e6012ee6491a0fb,
 	}

--- a/pkg/cmd/roachtest/tests/mixed_version_import.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_import.go
@@ -20,6 +20,11 @@ import (
 
 func registerImportMixedVersions(r registry.Registry) {
 	r.Add(registry.TestSpec{
+		// TODO(jeffswenson): re-enable mixed version import once #144818 is
+		// backported. This test is fragile because it expects the special
+		// 'workload://' fixtures to be deterministic across versions. A better
+		// version of this test would use actual CSV fixtures.
+		Skip:             "Issue #143870",
 		Name:             "import/mixed-versions",
 		Owner:            registry.OwnerSQLQueries,
 		Cluster:          r.MakeClusterSpec(4),

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -132,6 +132,8 @@ func makeDatumFromColOffset(
 			// MakeDTimestamp here and just directly construct it.
 			return alloc.NewDTimestampTZ(tree.DTimestampTZ{Time: col.Timestamp()[rowIdx]}), nil
 		}
+	case types.DecimalFamily:
+		return alloc.NewDDecimal(tree.DDecimal{Decimal: col.Decimal()[rowIdx]}), nil
 	}
 	return nil, errors.Errorf(
 		`don't know how to interpret %s column as %s`, col.Type(), hint)

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2089,8 +2089,6 @@ func TestLint(t *testing.T) {
 			stream.GrepNot(`pkg/cmd/mirror/go/mirror.go`),
 			// As above, the bazel build tag has an impact here.
 			stream.GrepNot(`pkg/testutils/docker/single_node_docker_test.go`),
-			// TODO(#143870): remove uses of this package.
-			stream.GrepNot(`"golang.org/x/exp/rand" is deprecated`),
 		}
 		for analyzerName, config := range nogoConfig {
 			if !staticcheckCheckNameRe.MatchString(analyzerName) {

--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -28,6 +28,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/workload/histogram",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_datadog_datadog_api_client_go_v2//api/datadog",
         "@com_github_datadog_datadog_api_client_go_v2//api/datadogV1",

--- a/pkg/workload/BUILD.bazel
+++ b/pkg/workload/BUILD.bazel
@@ -72,5 +72,6 @@ go_test(
         "//pkg/workload/bank",
         "//pkg/workload/tpcc",
         "//pkg/workload/tpch",
+        "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/workload/bench_test.go
+++ b/pkg/workload/bench_test.go
@@ -38,6 +38,8 @@ func columnByteSize(col *coldata.Vec) int64 {
 		return col.Bytes().Size() - coldata.FlatBytesOverhead
 	case types.TimestampTZFamily:
 		return int64(col.Timestamp().Len()) * memsize.Time
+	case types.DecimalFamily:
+		return int64(col.Decimal().Len()) * memsize.Decimal
 	default:
 		panic(fmt.Sprintf(`unhandled type %s`, t))
 	}

--- a/pkg/workload/csv.go
+++ b/pkg/workload/csv.go
@@ -86,6 +86,8 @@ func colDatumToCSVString(col *coldata.Vec, rowIdx int) string {
 		return *(*string)(unsafe.Pointer(&bytes))
 	case types.TimestampTZFamily:
 		return col.Timestamp()[rowIdx].Format(timestampOutputFormat)
+	case types.DecimalFamily:
+		return col.Decimal()[rowIdx].String()
 	}
 	panic(fmt.Sprintf(`unhandled type %s`, col.Type()))
 }

--- a/pkg/workload/csv_test.go
+++ b/pkg/workload/csv_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/cockroach/pkg/workload/bank"
 	"github.com/cockroachdb/cockroach/pkg/workload/tpcc"
+	"github.com/stretchr/testify/require"
 )
 
 func TestHandleCSV(t *testing.T) {
@@ -65,6 +66,45 @@ func TestHandleCSV(t *testing.T) {
 			if d, e := strings.TrimSpace(string(data)), strings.TrimSpace(test.expected); d != e {
 				t.Errorf("got [\n%s\n] expected [\n%s\n]", d, e)
 			}
+		})
+	}
+}
+
+func TestHandleCSVTpcc(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	tests := []struct {
+		params, expected string
+	}{
+		{
+			`?rows=1`, `
+0,9,10,17,16,RG,955311111,0.1622,300000.00`,
+		},
+		{
+			`?rows=5&row-start=1&row-end=3`, `
+1,10,20,13,20,RG,327711111,0.1625,300000.00
+2,9,18,12,10,QN,533211111,0.1000,300000.00`,
+		},
+	}
+
+	// assertions depend on this seed
+	tpcc.RandomSeed.Set(1)
+	meta := tpcc.FromWarehouses(1).Meta()
+	for _, test := range tests {
+		t.Run(test.params, func(t *testing.T) {
+			ts := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				require.NoError(t, workload.HandleCSV(w, r, `/tpcc/`, meta))
+			}))
+			defer ts.Close()
+
+			res, err := httputil.Get(context.Background(), ts.URL+`/tpcc/warehouse`+test.params)
+			require.NoError(t, err)
+
+			data, err := io.ReadAll(res.Body)
+			res.Body.Close()
+			require.NoError(t, err)
+
+			require.Equal(t, strings.TrimSpace(test.expected), strings.TrimSpace(string(data)))
 		})
 	}
 }

--- a/pkg/workload/tpcc/BUILD.bazel
+++ b/pkg/workload/tpcc/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/workload/histogram",
         "//pkg/workload/histogram/exporter",
         "//pkg/workload/workloadimpl",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_cockroach_go_v2//crdb/crdbpgxv5",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_codahale_hdrhistogram//:hdrhistogram",
@@ -50,7 +51,6 @@ go_library(
         "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_golang//prometheus/promauto",
         "@com_github_spf13_pflag//:pflag",
-        "@org_golang_x_exp//rand",
         "@org_golang_x_sync//errgroup",
     ],
 )

--- a/pkg/workload/tpcc/tpcc.go
+++ b/pkg/workload/tpcc/tpcc.go
@@ -31,7 +31,6 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/jackc/pgx/v5"
 	"github.com/spf13/pflag"
-	randold "golang.org/x/exp/rand"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -662,9 +661,6 @@ func (w *tpcc) Tables() []workload.Table {
 	aCharsInit := workloadimpl.PrecomputedRandInit(rand.NewPCG(seed, 0), precomputedLength, aCharsAlphabet)
 	lettersInit := workloadimpl.PrecomputedRandInit(rand.NewPCG(seed, 0), precomputedLength, lettersAlphabet)
 	numbersInit := workloadimpl.PrecomputedRandInit(rand.NewPCG(seed, 0), precomputedLength, numbersAlphabet)
-	aCharsInitOld := workloadimpl.PrecomputedRandInit(randold.New(randold.NewSource(seed)), precomputedLength, aCharsAlphabet)
-	lettersInitOld := workloadimpl.PrecomputedRandInit(randold.New(randold.NewSource(seed)), precomputedLength, lettersAlphabet)
-	numbersInitOld := workloadimpl.PrecomputedRandInit(randold.New(randold.NewSource(seed)), precomputedLength, numbersAlphabet)
 	if w.localsPool == nil {
 		w.localsPool = &sync.Pool{
 			New: func() interface{} {
@@ -677,15 +673,6 @@ func (w *tpcc) Tables() []workload.Table {
 						aChars:  aCharsInit(),
 						letters: lettersInit(),
 						numbers: numbersInit(),
-					},
-					rngOld: tpccRandOld{
-						Rand: randold.New(randold.NewSource(uint64(timeutil.Now().UnixNano()))),
-						// Intentionally wait until here to initialize the precomputed rands
-						// so a caller of Tables that only wants schema doesn't compute
-						// them.
-						aChars:  aCharsInitOld(),
-						letters: lettersInitOld(),
-						numbers: numbersInitOld(),
 					},
 				}
 			},


### PR DESCRIPTION
Backport:
  * 1/1 commits from "tpcc: use explicit decimal when initializing items" (#144818)
  * 1/1 commits from "workload: add support to csv generation for decimal" (#145287)

Please see individual PRs for details.

/cc @cockroachdb/release

Release Justification: test only change. This slightly speeds up tpcc imports and fixes a minor corruption bug that causes issues for LDR fingerprinting.
