### PR TITLE
roachprod: scrape workload metrics via promhelperservice

### DIFF
--- a/pkg/roachprod/vm/startup.go
+++ b/pkg/roachprod/vm/startup.go
@@ -35,6 +35,13 @@ const (
 	// EbpfExporterMetricsPath is the path that EbpfExporter serves metrics on.
 	EbpfExporterMetricsPath = "/metrics"
 
+	// WorkloadMetricsPortMin and WorkloadMetricsPortMax are the range of ports
+	// used by workload to expose metrics.
+	WorkloadMetricsPortMin = 2112
+	WorkloadMetricsPortMax = 2120
+	// WorkloadMetricsPath is the path that workload serves metrics on.
+	WorkloadMetricsPath = "/metrics"
+
 	// DefaultSharedUser is the default user that is shared across all VMs.
 	DefaultSharedUser = "ubuntu"
 	// InitializedFile is the base name of the initialization paths defined below.


### PR DESCRIPTION
This patch adds the workload metrics ports range (2112-2120) to the scrape targets handled by promhelperservice to allow scraping of workload metrics in all Cloud providers.

For releases prior to 25.3 (this patch will be backported to 25.3), workload metrics will only be scraped in GCE by the gce_sd_config Prometheus discovery mechanism.

Epic: none
Release note: None