### PR TITLE
roachtest: create backup fixtures for azure

### DIFF
--- a/pkg/cmd/roachtest/tests/BUILD.bazel
+++ b/pkg/cmd/roachtest/tests/BUILD.bazel
@@ -350,6 +350,7 @@ go_library(
         "@com_github_prometheus_common//model",
         "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
+        "@in_gopkg_yaml_v3//:yaml_v3",
         "@org_golang_google_protobuf//proto",
         "@org_golang_x_exp//maps",
         "@org_golang_x_oauth2//clientcredentials",

--- a/pkg/cmd/roachtest/tests/backup.go
+++ b/pkg/cmd/roachtest/tests/backup.go
@@ -65,6 +65,10 @@ const (
 	AssumeRoleGCSCredentials    = "GOOGLE_CREDENTIALS_ASSUME_ROLE"
 	AssumeRoleGCSServiceAccount = "GOOGLE_SERVICE_ACCOUNT"
 
+	AzureClientIDEnvVar     = "AZURE_CLIENT_ID"
+	AzureClientSecretEnvVar = "AZURE_CLIENT_SECRET"
+	AzureTenantIDEnvVar     = "AZURE_TENANT_ID"
+
 	// rows2TiB is the number of rows to import to load 2TB of data (when
 	// replicated).
 	rows2TiB   = 65_104_166

--- a/pkg/roachprod/blobfixture/registry.go
+++ b/pkg/roachprod/blobfixture/registry.go
@@ -57,7 +57,7 @@ type Registry struct {
 // for all fixture data and metadata. See the comment on the uri field for the
 // structure of a fixture directory.
 func NewRegistry(ctx context.Context, uri url.URL) (*Registry, error) {
-	supportedSchemes := map[string]bool{"gs": true, "s3": true, "azure": true}
+	supportedSchemes := map[string]bool{"gs": true, "s3": true, "azure-blob": true}
 	if !supportedSchemes[uri.Scheme] {
 		return nil, errors.Errorf("unsupported scheme %q", uri.Scheme)
 	}


### PR DESCRIPTION
This commit adds support for backup fixtures on Azure blob storage buckets.

Epic: CRDB-52076

Fixes: #149370