### PR TITLE
release-25.3: roachtest: mark cluster as expected to die in validate_system_schema_after_version_upgrade

### DIFF
--- a/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
+++ b/pkg/cmd/roachtest/tests/validate_system_schema_after_version_upgrade.go
@@ -134,7 +134,13 @@ func validateSystemSchemaAfterUpgradeTest(
 	mvt.Run()
 
 	// Start a cluster with the latest binary and get the system schema
-	// from the cluster.
+	// from the cluster. Mark all processes as expected to die before wiping.
+	t.Monitor().ExpectProcessDead(c.All())
+	// If we have a tenant, mark it as expected to die too.
+	if tenantComparison != nil {
+		t.Monitor().ExpectProcessDead(c.All(), option.VirtualClusterName(tenantComparison.name))
+	}
+
 	c.Wipe(ctx, c.All())
 	settings := install.MakeClusterSettings()
 


### PR DESCRIPTION
Backport 2/2 commits from #149353 on behalf of @rafiss.

----

Before wiping the cluster, we need to indicate to the test that the
cluster is going to go down. This is needed after
eae1e78.

fixes #148981
fixes #148998

Release note: None

----

Release justification: test only change