### PR TITLE
kvcoord: optimize the initial allocation of bufferedWrite.vals

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -26,8 +26,15 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeMockTxnWriteBuffer(st *cluster.Settings) (txnWriteBuffer, *mockLockedSender) {
-	metrics := MakeTxnMetrics(time.Hour)
+func makeMockTxnWriteBuffer(
+	st *cluster.Settings, optionalMetrics ...TxnMetrics,
+) (txnWriteBuffer, *mockLockedSender) {
+	var metrics TxnMetrics
+	if len(optionalMetrics) > 0 {
+		metrics = optionalMetrics[0]
+	} else {
+		metrics = MakeTxnMetrics(time.Hour)
+	}
 	mockSender := &mockLockedSender{}
 	return txnWriteBuffer{
 		enabled:    true,
@@ -2626,19 +2633,47 @@ func TestTxnWriteBufferHasBufferedAllPrecedingWrites(t *testing.T) {
 func BenchmarkTxnWriteBuffer(b *testing.B) {
 	defer leaktest.AfterTest(b)()
 	ctx := context.Background()
+	ct := cluster.MakeClusterSettings()
+	metrics := MakeTxnMetrics(time.Hour)
 
+	// Map from kvSize to a slice of keys where the i-th element corresponds to
+	// the key for the 'i' parameter. The function assumes that for a given
+	// kvSize it'll be called with consecutive values of 'i' ("going back" is
+	// allowed but "jumping forward with gaps" is not).
+	cachedKeys := make(map[int][]roachpb.Key)
 	makeKey := func(i int, kvSize int) roachpb.Key {
+		if _, ok := cachedKeys[kvSize]; !ok {
+			cachedKeys[kvSize] = make([]roachpb.Key, 0, 8)
+		}
+		cached := cachedKeys[kvSize]
+		if len(cached) > i {
+			return cached[i]
+		}
+		if len(cached) < i {
+			b.Fatal("a gap in values of i")
+		}
 		// The keys are kvSize bytes.
 		keyPrefix := strings.Repeat("a", kvSize-1)
-		return roachpb.Key(fmt.Sprintf("%s%d", keyPrefix, i))
+		cached = append(cached, roachpb.Key(fmt.Sprintf("%s%d", keyPrefix, i)))
+		cachedKeys[kvSize] = cached
+		return cached[i]
 	}
-	makeValue := func(kvSize int) string {
-		// The values are kvSize KiB.
-		return strings.Repeat("a", kvSize*1024)
+	cachedValues := make(map[int]roachpb.Value)
+	makeValue := func(kvSize int) roachpb.Value {
+		if _, ok := cachedValues[kvSize]; !ok {
+			// The values are kvSize KiB.
+			cachedValues[kvSize] = roachpb.MakeValueFromString(strings.Repeat("a", kvSize*1024))
+		}
+		return cachedValues[kvSize]
+	}
+	putArgs := func(key roachpb.Key, valueSize int, seq enginepb.TxnSeq) *kvpb.PutRequest {
+		return &kvpb.PutRequest{
+			RequestHeader: kvpb.RequestHeader{Key: key, Sequence: seq},
+			Value:         makeValue(valueSize),
+		}
 	}
 	makeBuffer := func(kvSize int, txn *roachpb.Transaction, numWrites int) txnWriteBuffer {
-		twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
-		twb.setEnabled(true)
+		twb, mockSender := makeMockTxnWriteBuffer(ct, metrics)
 		sendFunc := func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 			br := ba.CreateReply()
 			br.Txn = ba.Txn
@@ -2648,9 +2683,10 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 			for _, req := range ba.Requests {
 				switch req.GetInner().(type) {
 				case *kvpb.GetRequest:
+					v := makeValue(kvSize)
 					resp.Value = &kvpb.ResponseUnion_Get{
 						Get: &kvpb.GetResponse{
-							Value: &roachpb.Value{RawBytes: []byte(makeValue(kvSize))},
+							Value: &v,
 						},
 					}
 				}
@@ -2666,7 +2702,7 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 		// Write to the keys that will later be served from the buffer but
 		// not from the benchmarked batch.
 		for i := 0; i < numWrites; i++ {
-			ba.Add(putArgs(makeKey(i, kvSize), makeValue(kvSize), enginepb.TxnSeq(i)))
+			ba.Add(putArgs(makeKey(i, kvSize), kvSize, enginepb.TxnSeq(i)))
 		}
 		_, pErr := twb.SendLocked(ctx, ba)
 		if pErr != nil {
@@ -2724,7 +2760,7 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 							// and are in the benchmarked batch.
 							for i := readsFromPrevBatch; i < readsFromPrevBatch+readsFromBufferSameBatch; i++ {
 								// Half of these puts acquire exclusive locks.
-								args := putArgs(makeKey(i, kvSize), makeValue(kvSize), enginepb.TxnSeq(i))
+								args := putArgs(makeKey(i, kvSize), kvSize, enginepb.TxnSeq(i))
 								if i%2 == 0 {
 									args.MustAcquireExclusiveLock = true
 								}
@@ -2738,7 +2774,7 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 							// Add any remaining writes, not observed by any reads.
 							for i := readsFromPrevBatch + readsFromBufferSameBatch; i < numWrites; i++ {
 								// Half of these puts acquire exclusive locks.
-								args := putArgs(makeKey(i, kvSize), makeValue(kvSize), enginepb.TxnSeq(i))
+								args := putArgs(makeKey(i, kvSize), kvSize, enginepb.TxnSeq(i))
 								if i%2 == 0 {
 									args.MustAcquireExclusiveLock = true
 								}


### PR DESCRIPTION
**kvcoord: optimize allocations in BenchmarkTxnWriteBuffer**

When looking at the mem profile from a run of `BenchmarkTxnWriteBuffer`,
the allocations that happen outside of the benchmark loop dominate. This
commit attempts to reduce them by aggresively caching and reusing
different `roachpb.Key` and `roachpb.Value` objects that we need. This
should be fine since we don't expect the txnWriteBuffer to modify those
and will allow us to focus on the txnWriteBuffer allocations more
easily.

**kvcoord: optimize the initial allocation of bufferedWrite.vals**

We now embed `[1]bufferedValue` into `bufferedWrite` struct which gives
us the initial capacity of the first buffered value on a key. This
increases the size of `bufferedWrite` struct from 96B to 144B, but on
the main path `addToBuffer` we'd allocate the `bufferedValue` anyway,
and other paths that allocate `bufferedWrite`s
(`addDurableLockedReadToBuffer` and `initializeLeaf`) seem not as
important to optimize (in those spots we now redundantly increase the
memory usage of the struct).

Informs: #140672.
Epic: None

Release note: None