### PR TITLE
logictest: fix user logictest for provisioning gating validation

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -227,14 +227,13 @@ user root
 statement ok
 set cluster setting security.provisioning.ldap.enabled = true;
 
-skipif config local 3node-tenant
+onlyif config local-mixed-25.2
 statement ok
 DROP user testuser
 
-skipif config local 3node-tenant
+onlyif config local-mixed-25.2
 user testuser nodeidx=0 newsession
 
-skipif config local 3node-tenant
 statement error pq: password authentication failed for user testuser
 SHOW session_user
 
@@ -254,6 +253,11 @@ DROP user testuser
 skipif config local-mixed-25.2
 user testuser nodeidx=0 newsession
 
+# The logictest suite currently doesn't work for external authentication methods
+# as the register auth method for "ldap" is invoked outside of the sql package.
+# For the purpose of validating the release flags for provisioning, test only
+# auth method "cert-password" has been enabled which hasn't been provided with a
+# provisioner(handler for provisioning) which is the obtained error here.
 skipif config local-mixed-25.2
 statement error pq: user identity unknown for identity provider
 SHOW session_user


### PR DESCRIPTION
The current logictest validates the version gating logic for provisioning but checks for skipif version instead of onlyif version config which was pointed out in the discussion
https://github.com/cockroachdb/cockroach/pull/149405#discussion_r2180234390 and needs to change. Additionally, we need to add a comment for version gating logic as both are failure scenarios owing to "cert-password" currently being a non support provisioning auth method as in the discussion https://github.com/cockroachdb/cockroach/pull/149405#discussion_r2180199392.

fixes #147599
Epic CRDB-21590

Release note: None