### PR TITLE
release-25.1: sql: ignore some session variables in RESET ALL

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/read_committed
@@ -577,3 +577,24 @@ statement ok
 COMMIT
 
 subtest end
+
+# Verify that RESET ALL does not change transaction_isolation.
+
+statement ok
+BEGIN ISOLATION LEVEL READ COMMITTED
+
+query T
+SHOW transaction_isolation
+----
+read committed
+
+statement ok
+RESET ALL
+
+query T
+SHOW transaction_isolation
+----
+read committed
+
+statement ok
+COMMIT

--- a/pkg/sql/discard.go
+++ b/pkg/sql/discard.go
@@ -44,7 +44,6 @@ func (n *discardNode) startExec(params runParams) error {
 
 		// RESET ALL
 		if err := params.p.resetAllSessionVars(params.ctx); err != nil {
-
 			return err
 		}
 

--- a/pkg/sql/logictest/testdata/logic_test/discard
+++ b/pkg/sql/logictest/testdata/logic_test/discard
@@ -223,3 +223,72 @@ SELECT currval('discard_seq')
 query T rowsort
 SELECT table_name FROM [SHOW TABLES FROM pg_temp]
 ----
+
+# Check that DISCARD still works with follower reads.
+
+query T
+SET search_path = bar, public; SHOW search_path
+----
+bar, public
+
+query T
+SET timezone = 'Europe/Amsterdam'; SHOW timezone
+----
+Europe/Amsterdam
+
+statement ok
+PREPARE a AS SELECT 1
+
+statement ok
+CREATE SEQUENCE discard_seq2 START WITH 10
+
+statement ok
+SET experimental_enable_temp_tables = on
+
+statement ok
+CREATE TEMP TABLE tempy (a int)
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
+----
+tempy
+
+# Sleep longer than the follower_reads duration so that the DISCARD ALL sees
+# everything we just created.
+query B
+SELECT pg_sleep(5)
+----
+true
+
+statement ok
+SET default_transaction_use_follower_reads = on
+
+# DISCARD should be allowed, even with AOST set.
+statement ok
+DISCARD ALL
+
+# The DISCARD ALL should have reset default_transaction_use_follower_reads.
+query T
+SHOW default_transaction_use_follower_reads
+----
+off
+
+query T
+SHOW search_path
+----
+"$user", public
+
+query T
+SHOW timezone
+----
+UTC
+
+statement error prepared statement \"a\" does not exist
+DEALLOCATE a
+
+statement error pgcode 55000 pq: currval\(\): currval of sequence "test.public.discard_seq2" is not yet defined in this session
+SELECT currval('discard_seq2')
+
+query T rowsort
+SELECT table_name FROM [SHOW TABLES FROM pg_temp]
+----

--- a/pkg/sql/logictest/testdata/logic_test/reset
+++ b/pkg/sql/logictest/testdata/logic_test/reset
@@ -63,3 +63,42 @@ query T
 RESET time zone; SHOW TIME ZONE
 ----
 UTC
+
+# Verify that RESET ALL does not change transaction_read_only.
+
+statement ok
+BEGIN TRANSACTION READ ONLY
+
+query T
+SHOW transaction_read_only
+----
+on
+
+statement ok
+RESET ALL
+
+query T
+SHOW transaction_read_only
+----
+on
+
+statement ok
+COMMIT
+
+# Verify that RESET ALL works with follower reads.
+
+statement ok
+SET default_transaction_use_follower_reads = on
+
+query T
+SHOW default_transaction_use_follower_reads
+----
+on
+
+statement ok
+RESET ALL
+
+query T
+SHOW default_transaction_use_follower_reads
+----
+off

--- a/pkg/sql/logictest/testdata/logic_test/set_role
+++ b/pkg/sql/logictest/testdata/logic_test/set_role
@@ -134,6 +134,16 @@ SHOW is_superuser
 ----
 on
 
+# Verify that RESET ALL does not change is_superuser.
+
+statement ok
+RESET ALL
+
+query T
+SHOW is_superuser
+----
+on
+
 # Check testuser cannot transition to other users as it has no privileges.
 user testuser
 

--- a/pkg/sql/set_var.go
+++ b/pkg/sql/set_var.go
@@ -204,8 +204,8 @@ func (p *planner) resetAllSessionVars(ctx context.Context) error {
 		if v.Set == nil && v.RuntimeSet == nil && v.SetWithPlanner == nil {
 			continue
 		}
-		// For Postgres compatibility, Don't reset `role` here.
-		if varName == "role" {
+		// For Postgres compatibility, don't reset some settings here.
+		if v.NoResetAll {
 			continue
 		}
 		hasDefault, defVal := getSessionVarDefaultString(


### PR DESCRIPTION
Backport 1/1 commits from #148770.

/cc @cockroachdb/release

---

Looking at `src/backend/utils/misc/guc_tables.c` in PG source code, there are a few session variables flagged with `GUC_NO_RESET_ALL` that should not be affected by RESET ALL. This commit adds a `NoResetAll` flag to the following session variables that overlap with PG:

- `is_superuser`
- `role`
- `session_authorization`
- `transaction_isolation`
- `transaction_read_only`

This commit also adds the flag to a couple CRDB-only session variables that seem similar:

- `transaction_priority`
- `transaction_status`

Most of these variables are read-only, and so were not affected by RESET ALL, but the new flag makes the intended behavior clear in case any of them do become writable in the future.

By fixing RESET ALL, this change also makes DISCARD ALL work correctly when `default_transaction_use_follower_reads` is enabled.

Fixes: #124150

Release note (bug fix): The RESET ALL statement is fixed to no longer affect the following session variables:

- `is_superuser`
- `role`
- `session_authorization`
- `transaction_isolation`
- `transaction_priority`
- `transaction_status`
- `transaction_read_only`

This better matches PostgreSQL behavior for RESET ALL.

By fixing RESET ALL, the DISCARD ALL statement is also fixed to work correctly when `default_transaction_use_follower_reads` is enabled.

---

Release justification: customer-requested bug fix.