### PR TITLE
sql/pgwire: decode multi-byte "char" datums correctly

### DIFF
--- a/pkg/sql/pgwire/testdata/encodings.json
+++ b/pkg/sql/pgwire/testdata/encodings.json
@@ -105,6 +105,13 @@
 		"Binary": [0]
 	},
 	{
+		"SQL": "'☃'::\"char\"",
+		"Oid": 18,
+		"Text": "☃",
+		"TextAsBinary": [226, 152, 131],
+		"Binary": [226, 152, 131]
+	},
+	{
 		"SQL": "''::text",
 		"Oid": 25,
 		"Text": "",

--- a/pkg/sql/pgwire/testdata/pgtest/char
+++ b/pkg/sql/pgwire/testdata/pgtest/char
@@ -208,3 +208,70 @@ ReadyForQuery
 {"Type":"DataRow","Values":[{"binary":"00"}]}
 {"Type":"CommandComplete","CommandTag":"SELECT 1"}
 {"Type":"ReadyForQuery","TxStatus":"I"}
+
+# Regression test for #149427. "char" datums should be truncated to 1 UTF-8
+# character.
+send
+Query {"String": "CREATE TABLE t149427 (c \"char\" PRIMARY KEY)"}
+----
+
+until
+ReadyForQuery
+----
+{"Type":"CommandComplete","CommandTag":"CREATE TABLE"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "INSERT INTO t149427 VALUES ($1)", "Name": "i149427"}
+Describe {"Name": "i149427", "ObjectType": "S"}
+Bind {"ParameterFormatCodes": [0], "PreparedStatement": "i149427", "Parameters": [{"text":"☃"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[18]}
+{"Type":"NoData"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"INSERT 0 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "SELECT * FROM t149427", "Name": "s149427"}
+Describe {"Name": "s149427", "ObjectType": "S"}
+Bind {"PreparedStatement": "s149427", "ResultFormatCodes": [0]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":null}
+{"Type":"RowDescription","Fields":[{"Name":"c","TableOID":105,"TableAttributeNumber":1,"DataTypeOID":18,"DataTypeSize":1,"TypeModifier":-1,"Format":0}]}
+{"Type":"BindComplete"}
+{"Type":"DataRow","Values":[{"text":"☃"}]}
+{"Type":"CommandComplete","CommandTag":"SELECT 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}
+
+send
+Parse {"Query": "DELETE FROM t149427 WHERE c = $1", "Name": "d149427"}
+Describe {"Name": "d149427", "ObjectType": "S"}
+Bind {"ParameterFormatCodes": [0], "PreparedStatement": "d149427", "Parameters": [{"text":"☃"}]}
+Execute
+Sync
+----
+
+until
+ReadyForQuery
+----
+{"Type":"ParseComplete"}
+{"Type":"ParameterDescription","ParameterOIDs":[25]}
+{"Type":"NoData"}
+{"Type":"BindComplete"}
+{"Type":"CommandComplete","CommandTag":"DELETE 1"}
+{"Type":"ReadyForQuery","TxStatus":"I"}


### PR DESCRIPTION
Historically, our `"char"` type has differed from Postgres. We allow
multi-byte UTF-8 characters, while in Postgres `"char"` values are
always a single byte. This inconsistency is difficult to change at this
point.

In #70942 we began truncating `"char"` values to a single byte when
decoding them in pgwire. This caused odd behavior with these values
because the rest of the system truncates `"char"` values to a single
UTF-8 character instead. This commit updates the pgwire decoding to make
it consistent with other SQL logic.

Fixes #149427

Release note (bug fix): Fixes a minor bug that caused inconsistent
behavior with the very rarely used `"char"` type (not to be confused
with `CHAR`).
