### PR TITLE
restore: add secondary retry policy to restore

### DIFF
--- a/pkg/backup/restore_data_processor.go
+++ b/pkg/backup/restore_data_processor.go
@@ -119,8 +119,6 @@ var defaultNumWorkers = metamorphic.ConstantWithTestRange(
 	1, /* metamorphic min */
 	8, /* metamorphic max */
 )
-var retryableRestoreProcError = errors.New("restore processor error after forward progress")
-var restoreProcError = errors.New("restore processor error without forward progress")
 
 // TODO(pbardea): It may be worthwhile to combine this setting with the one that
 // controls the number of concurrent AddSSTable requests if each restore worker
@@ -647,11 +645,6 @@ func (rd *restoreDataProcessor) Next() (rowenc.EncDatumRow, *execinfrapb.Produce
 		if !ok {
 			// Done. Check if any phase exited early with an error.
 			err := rd.phaseGroup.Wait()
-			if rd.progressMade {
-				err = errors.Mark(err, retryableRestoreProcError)
-			} else {
-				err = errors.Mark(err, restoreProcError)
-			}
 			rd.MoveToDraining(err)
 			return nil, rd.DrainHelper()
 		}

--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -7,16 +7,25 @@ package backup
 
 import (
 	"context"
+	"syscall"
 	"testing"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/backup/backuptestutils"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/jobutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
 
@@ -84,4 +93,116 @@ func TestFailAfterCleanupSystemTables(t *testing.T) {
 
 	sqlDB.Exec(t, "CANCEL JOB $1", jobID)
 	jobutils.WaitForJobToCancel(t, sqlDB, jobID)
+}
+
+func TestRestoreRetryFastFails(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	skip.UnderRace(t, "test is flaky without extending duration of retry policy, takes too long")
+	skip.UnderDeadlock(t, "test is flaky under deadlock detector, takes too long")
+
+	// Max duration needs to be long enough such that the restore job
+	// runtime does not exceed the max duration of the retry policy, or
+	// else very few attempts will be made.
+	maxDuration := 100 * time.Millisecond
+	if skip.Stress() {
+		// Under stress, the restore will take longer to complete, so we need to
+		// increase max duration accordingly.
+		maxDuration = time.Second
+	}
+	const numAccounts = 10
+
+	// This will run a restore job and fail it repeatedly at the start of the
+	// restore until we've exhausted the maximum attempts before fast failing. It
+	// will allow progress to be made, and then start failing the restore at the
+	// end of the job to until it either fast fails or exhausts the retry policy.
+	// It tracks the number of attempts made by the restore job and returns it.
+	runRestoreAndTrackAttempts := func(
+		t *testing.T, progThreshold float32, endStatus jobs.State,
+	) int {
+		mu := struct {
+			syncutil.Mutex
+			attemptCount int
+		}{}
+		// waitForProgress is a channel that will be closed whenever we detect that
+		// the restore job has made progress.
+		waitForProgress := make(chan struct{})
+
+		testKnobs := &sql.BackupRestoreTestingKnobs{
+			RestoreDistSQLRetryPolicy: &retry.Options{
+				InitialBackoff: time.Microsecond,
+				Multiplier:     2,
+				MaxBackoff:     100 * time.Millisecond,
+				MaxDuration:    maxDuration,
+			},
+			RestoreRetryProgressThreshold: progThreshold,
+			RunBeforeRestoreFlow: func() error {
+				mu.Lock()
+				defer mu.Unlock()
+				mu.attemptCount++
+
+				if mu.attemptCount <= maxRestoreRetryFastFail {
+					// Have not consumed all retries before a fast fail.
+					return syscall.ECONNRESET
+				}
+
+				return nil
+			},
+			RunAfterRestoreFlow: func() error {
+				// Wait for progress to persist, then continue sending retryable errors
+				<-waitForProgress
+				return syscall.ECONNRESET
+			},
+		}
+		var params base.TestClusterArgs
+		params.ServerArgs.Knobs.BackupRestore = testKnobs
+
+		_, sqlDB, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
+			t, singleNode, backuptestutils.WithParams(params), backuptestutils.WithBank(numAccounts),
+		)
+		defer cleanupFn()
+
+		sqlDB.Exec(t, "BACKUP DATABASE data INTO 'nodelocal://1/backup'")
+		var restoreJobID jobspb.JobID
+		sqlDB.QueryRow(
+			t,
+			`RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/backup'
+			WITH detached, new_db_name = 'restored_data'`,
+		).Scan(&restoreJobID)
+
+		testutils.SucceedsSoon(t, func() error {
+			jobProgress := jobutils.GetJobProgress(t, sqlDB, restoreJobID)
+			if len(jobProgress.GetRestore().Checkpoint) == 0 {
+				return errors.Newf("frontier has not advanced yet")
+			}
+			return nil
+		})
+		close(waitForProgress)
+		jobutils.WaitForJobToHaveStatus(t, sqlDB, restoreJobID, endStatus)
+		mu.Lock()
+		defer mu.Unlock()
+		return mu.attemptCount
+	}
+
+	// This is the total number of attempts that should occur assuming we fast
+	// fail, accounting for the fact that the above flow will reset the retry loop
+	// once time.
+	var expFastFailAttempts = maxRestoreRetryFastFail*2 + 2
+
+	t.Run("retry policy times out when enough progress is made", func(t *testing.T) {
+		attempts := runRestoreAndTrackAttempts(t, 0 /* progThreshold */, jobs.StatePaused)
+		// If progress is made, then the restore job should make more attempts than
+		// the fast fail path.
+		require.Greater(t, attempts, expFastFailAttempts)
+	})
+
+	t.Run("retry policy fast fails if insufficient progress is made", func(t *testing.T) {
+		// Set an impossibly high threshold so that the restore job never
+		// sufficiently makes enough progress to avoid fast failing.
+		attempts := runRestoreAndTrackAttempts(t, 1.5 /* progThreshold */, jobs.StateFailed)
+		// Since we do allow progress to be made, we expect the restore job to reset
+		// the retry loop and then fast fail.
+		require.Equal(t, expFastFailAttempts, attempts)
+	})
 }

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -54,6 +54,10 @@ type BackupRestoreTestingKnobs struct {
 
 	RestoreDistSQLRetryPolicy *retry.Options
 
+	// RestoreRetryProgressThreshold allows configuring the threshold at which
+	// the restore will no longer fast fail after a certain number of retries.
+	RestoreRetryProgressThreshold float32
+
 	RunBeforeRestoreFlow func() error
 
 	RunAfterRestoreFlow func() error

--- a/pkg/testutils/jobutils/jobs_verification.go
+++ b/pkg/testutils/jobutils/jobs_verification.go
@@ -26,37 +26,37 @@ import (
 // WaitForJobToSucceed waits for the specified job ID to succeed.
 func WaitForJobToSucceed(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
 	t.Helper()
-	waitForJobToHaveStatus(t, db, jobID, jobs.StateSucceeded)
+	WaitForJobToHaveStatus(t, db, jobID, jobs.StateSucceeded)
 }
 
 // WaitForJobToPause waits for the specified job ID to be paused.
 func WaitForJobToPause(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
 	t.Helper()
-	waitForJobToHaveStatus(t, db, jobID, jobs.StatePaused)
+	WaitForJobToHaveStatus(t, db, jobID, jobs.StatePaused)
 }
 
 // WaitForJobToCancel waits for the specified job ID to be in a cancelled state.
 func WaitForJobToCancel(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
 	t.Helper()
-	waitForJobToHaveStatus(t, db, jobID, jobs.StateCanceled)
+	WaitForJobToHaveStatus(t, db, jobID, jobs.StateCanceled)
 }
 
 // WaitForJobToRun waits for the specified job ID to be in a running state.
 func WaitForJobToRun(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
 	t.Helper()
-	waitForJobToHaveStatus(t, db, jobID, jobs.StateRunning)
+	WaitForJobToHaveStatus(t, db, jobID, jobs.StateRunning)
 }
 
 // WaitForJobToFail waits for the specified job ID to be in a failed state.
 func WaitForJobToFail(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
 	t.Helper()
-	waitForJobToHaveStatus(t, db, jobID, jobs.StateFailed)
+	WaitForJobToHaveStatus(t, db, jobID, jobs.StateFailed)
 }
 
 // WaitForJobReverting waits for the specified job ID to be in a reverting state.
 func WaitForJobReverting(t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID) {
 	t.Helper()
-	waitForJobToHaveStatus(t, db, jobID, jobs.StateReverting)
+	WaitForJobToHaveStatus(t, db, jobID, jobs.StateReverting)
 }
 
 const (
@@ -75,7 +75,7 @@ const (
 	JobPayloadByIDQuery         = "SELECT value FROM system.job_info WHERE job_id = $1 AND info_key::string = 'legacy_payload' ORDER BY written DESC LIMIT 1"
 )
 
-func waitForJobToHaveStatus(
+func WaitForJobToHaveStatus(
 	t testing.TB, db *sqlutils.SQLRunner, jobID jobspb.JobID, expectedStatus jobs.State,
 ) {
 	t.Helper()


### PR DESCRIPTION
This commit teaches restore to use a more dynamic retry policy that depends on the progress of the restore. Previously, restore would attempt a retry a set amount of times before failing with some minimal max backoff. This approach works relatively well in cases where a restore is failing early into a job and presumably there exists some issue blocking restore and we want to fail early.

However, for restores that have been running to near completion, it becomes increasingly more likely that the error is a transient and due to some temporary cluster unhealthiness. In these cases, it is beneficial to retry with a longer backup and for a longer period of time before reporting a failure.

We now update restore such that if the restore progress has exceeded some predefined threshold, we switch from an attempt-limited retry mechanism to a duration-limited mechanism with larger backoffs.

Epic: CRDB-51362

Fixes: #148028

Release note: None