### PR TITLE
roachtest: avoid running timing-related psycopg tests

### DIFF
--- a/pkg/cmd/roachtest/tests/psycopg.go
+++ b/pkg/cmd/roachtest/tests/psycopg.go
@@ -155,7 +155,7 @@ func registerPsycopg(r registry.Registry) {
 			cd /mnt/data1/psycopg/ &&
 			export PSYCOPG_TEST_DSN="host=localhost port={pgport:1} user=%[1]s password=%[2]s dbname=defaultdb" &&
 			export PGPASSWORD=%[2]s
-			pytest -vv --junit-xml=%[3]s`,
+			pytest -vv -m "not timing" --junit-xml=%[3]s`,
 			install.DefaultUser, install.DefaultPassword, testResultsXML))
 
 		// Fatal for a roachprod or transient error. A roachprod error is when result.Err==nil.


### PR DESCRIPTION
The timing tests are all rather flaky, so we skip running them in nightlies.

fixes https://github.com/cockroachdb/cockroach/issues/149165
fixes https://github.com/cockroachdb/cockroach/issues/148732

Release note: None