### PR TITLE
release-25.2: schemachanger: attempt to deflake schemachanger integration tests

### DIFF
--- a/pkg/ccl/schemachangerccl/BUILD.bazel
+++ b/pkg/ccl/schemachangerccl/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/sql",
         "//pkg/sql/schemachanger/scexec",
         "//pkg/sql/schemachanger/sctest",
+        "//pkg/sql/sem/eval",
         "//pkg/testutils/serverutils",
     ],
 )

--- a/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
+++ b/pkg/ccl/schemachangerccl/multiregion_testcluster_factory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/sctest"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 )
 
@@ -52,6 +53,9 @@ func (f MultiRegionTestClusterFactory) Run(
 ) {
 	const numServers = 3
 	knobs := base.TestingKnobs{
+		SQLEvalContext: &eval.TestingKnobs{
+			ForceProductionValues: true,
+		},
 		JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		SQLExecutor: &sql.ExecutorTestingKnobs{
 			UseTransactionalDescIDGenerator: true,

--- a/pkg/sql/schemachanger/sctest/BUILD.bazel
+++ b/pkg/sql/schemachanger/sctest/BUILD.bazel
@@ -42,6 +42,7 @@ go_library(
         "//pkg/sql/schemachanger/scplan/scviz",
         "//pkg/sql/schemachanger/screl",
         "//pkg/sql/schemachanger/scrun",
+        "//pkg/sql/sem/eval",
         "//pkg/sql/sem/tree",
         "//pkg/sql/sessiondata",
         "//pkg/sql/sessiondatapb",

--- a/pkg/sql/schemachanger/sctest/cumulative.go
+++ b/pkg/sql/schemachanger/sctest/cumulative.go
@@ -36,6 +36,7 @@ func Rollback(t *testing.T, relPath string, factory TestServerFactory) {
 	// These tests are expensive.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	testRollbackCase := func(t *testing.T, cs CumulativeTestCaseSpec) {
 		if cs.Phase != scop.PostCommitPhase {
@@ -268,6 +269,7 @@ func GenerateSchemaChangeCorpus(t *testing.T, path string, factory TestServerFac
 	// These tests are expensive.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	if corpusPath == "" {
 		skip.IgnoreLintf(t, "requires declarative-corpus path parameter")
@@ -308,6 +310,7 @@ func Pause(t *testing.T, path string, factory TestServerFactory) {
 	// These tests are expensive.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {
 		pause(t, factory, cs)
@@ -320,6 +323,7 @@ func PauseMixedVersion(t *testing.T, path string, factory TestServerFactory) {
 	// These tests are expensive.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	factory.WithMixedVersion()
 	cumulativeTestForEachPostCommitStage(t, path, factory, func(t *testing.T, cs CumulativeTestCaseSpec) {

--- a/pkg/sql/schemachanger/sctest/decomp.go
+++ b/pkg/sql/schemachanger/sctest/decomp.go
@@ -36,6 +36,7 @@ func DecomposeToElements(t *testing.T, dir string, factory TestServerFactory) {
 	// These tests are expensive.
 	skip.UnderRace(t)
 	skip.UnderStress(t)
+	skip.UnderDeadlock(t)
 
 	ctx := context.Background()
 	datadriven.Walk(t, dir, func(t *testing.T, path string) {

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -58,6 +58,7 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 	// These tests are expensive.
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.UnderDeadlock(t)
 
 	ctx := context.Background()
 	testCaseDir := datapathutils.RewritableDataPath(t, relTestCaseDir)

--- a/pkg/sql/schemachanger/sctest/test_server_factory.go
+++ b/pkg/sql/schemachanger/sctest/test_server_factory.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/server"
 	"github.com/cockroachdb/cockroach/pkg/sql"
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/scexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/eval"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -76,6 +77,9 @@ func (f SingleNodeTestClusterFactory) Run(
 ) {
 	args := base.TestServerArgs{
 		Knobs: base.TestingKnobs{
+			SQLEvalContext: &eval.TestingKnobs{
+				ForceProductionValues: true,
+			},
 			JobsTestingKnobs: newJobsKnobs(),
 			SQLExecutor: &sql.ExecutorTestingKnobs{
 				UseTransactionalDescIDGenerator: true,


### PR DESCRIPTION
Backport 1/1 commits from #149099 on behalf of @rafiss.\

fixes https://github.com/cockroachdb/cockroach/issues/149006

----

We are seeing more timeouts in the tests. This patch attempts to deflake the test by forcing production values for constants and settings, rather than using metamorphic settings.

It also skips more tests under deadlock, which were already skipped under race.

informs https://github.com/cockroachdb/cockroach/issues/148902
informs https://github.com/cockroachdb/cockroach/issues/148901
informs https://github.com/cockroachdb/cockroach/issues/148901
Release note: None

----

Release justification: test only change