### PR TITLE
kvcoord: remove elision of buffered revisions on mid txn flush

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -189,9 +189,16 @@ type txnWriteBuffer struct {
 	flushOnNextBatch bool
 
 	// firstExplicitSavepointSeq tracks the lowest explicit savepoint that hasn't
-	// been released or rolled back. If this savepoint is non-zero, then a
-	// mid-transaction flush must flush all revisions required to roll back this
-	// (or a later) savepoint.
+	// been released or rolled back.
+	//
+	// NOTE(ssd): Our original intent was to use this to elide old revisions
+	// during a mid-transaction flush. However, we may still need old revisions if
+	// we are flushed in the middle of a statement where some reads should not be
+	// able to see modifications from other parts of the statement.
+	//
+	// I _think_ we could bring this optimization back, but it would require some
+	// cooperation with the conn executor to inform us when such statements had
+	// started and stopped execution.
 	firstExplicitSavepointSeq enginepb.TxnSeq
 
 	buffer        btree
@@ -688,10 +695,6 @@ func (twb *txnWriteBuffer) epochBumpedLocked() {
 func (twb *txnWriteBuffer) resetBuffer() {
 	twb.buffer.Reset()
 	twb.bufferSize = 0
-}
-
-func (twb *txnWriteBuffer) hasActiveSavepoint() bool {
-	return twb.firstExplicitSavepointSeq != enginepb.TxnSeq(0)
 }
 
 // createSavepointLocked is part of the txnInterceptor interface.
@@ -1687,7 +1690,7 @@ func (twb *txnWriteBuffer) flushBufferAndSendBatch(
 		twb.txnMetrics.TxnWriteBufferDisabledAfterBuffering.Inc(1)
 	}
 
-	midTxnFlushWithExplicitSavepoint := !hasEndTxn && twb.hasActiveSavepoint()
+	midTxnFlush := !hasEndTxn
 
 	// Flush all buffered writes by pre-pending them to the requests being sent
 	// in the batch.
@@ -1698,8 +1701,8 @@ func (twb *txnWriteBuffer) flushBufferAndSendBatch(
 	it := twb.buffer.MakeIter()
 	numRevisionsBuffered := 0
 	for it.First(); it.Valid(); it.Next() {
-		if midTxnFlushWithExplicitSavepoint {
-			revs := it.Cur().toAllRevisionRequests(twb.firstExplicitSavepointSeq)
+		if midTxnFlush {
+			revs := it.Cur().toAllRevisionRequests()
 			numRevisionsBuffered += len(revs)
 			reqs = append(reqs, revs...)
 		} else {
@@ -1951,33 +1954,28 @@ func (bw *bufferedWrite) toRequest() kvpb.RequestUnion {
 //
 // A write below the the minimum sequence number can be elided if there is a
 // subsequent write also below the minimum sequence number.
-func (bw *bufferedWrite) toAllRevisionRequests(minSeq enginepb.TxnSeq) []kvpb.RequestUnion {
+func (bw *bufferedWrite) toAllRevisionRequests() []kvpb.RequestUnion {
 	likelyLockRequestCount := len(unreplicatedHolderStrengths)
 	if bw.lki == nil {
 		likelyLockRequestCount = 0
 	}
 
 	rus := make([]kvpb.RequestUnion, 0, len(bw.vals)+likelyLockRequestCount)
-	maxIdx := len(bw.vals) - 1
 
 	// We track the smallest sequence of an intent write to potentially elide
 	// locking requests. See the comment on (*lockedKeyInfo).toAllRequestUnions
 	// for details.
 	minIntentWriteSeq := enginepb.TxnSeq(math.MaxInt32)
 
-	for i, val := range bw.vals {
-		nextWriteLessThanSeq := (i+1 < maxIdx) && (bw.vals[i+1].seq < minSeq)
-		canElideRevision := val.seq < minSeq && nextWriteLessThanSeq
-		if !canElideRevision {
-			if val.seq < minIntentWriteSeq {
-				minIntentWriteSeq = val.seq
-			}
-			rus = append(rus, val.toRequestUnion(bw.key, bw.exclusionExpectedSinceTimestamp()))
+	for _, val := range bw.vals {
+		if val.seq < minIntentWriteSeq {
+			minIntentWriteSeq = val.seq
 		}
+		rus = append(rus, val.toRequestUnion(bw.key, bw.exclusionExpectedSinceTimestamp()))
 	}
 
 	if bw.lki != nil {
-		rus = bw.lki.toAllRequestUnions(rus, bw.key, bw.exclusionExpectedSinceTimestamp(), minSeq, minIntentWriteSeq)
+		rus = bw.lki.toAllRequestUnions(rus, bw.key, bw.exclusionExpectedSinceTimestamp(), minIntentWriteSeq)
 	}
 	return rus
 }
@@ -2098,40 +2096,19 @@ func (li *lockedKeyInfo) toRequestUnion(key roachpb.Key, ts hlc.Timestamp) kvpb.
 }
 
 // toAllRequestUnions appends all of the requests that need to be sent for the
-// given minimum known savepoint to the dst slice.
+// given minIntentSequence to the dst slice.
 //
 // minIntentSequence is assumed to be the smallest sequence number of any intent
-// write and is used to elide requests. We assume that
-//
-// - A locking request can be elided if a stronger lock is held at a lower sequence number;
-// - If all locks are below the minKnownSavepoint, only the strongest needs to be sent.
+// write and is used to elide requests. We assume that a locking request can be
+// elided if a stronger lock is held at a lower sequence number.
 func (li *lockedKeyInfo) toAllRequestUnions(
-	dst []kvpb.RequestUnion,
-	key roachpb.Key,
-	ts hlc.Timestamp,
-	minKnownSavepoint enginepb.TxnSeq,
-	minIntentSequence enginepb.TxnSeq,
+	dst []kvpb.RequestUnion, key roachpb.Key, ts hlc.Timestamp, minIntentSequence enginepb.TxnSeq,
 ) []kvpb.RequestUnion {
-	if minIntentSequence < minKnownSavepoint {
-		// We have an intent write that can't be rolled back, no reason to return
-		// anything at all.
-		return dst
-	}
-
-	allBelowMinSavepoint := false
-	for _, str := range unreplicatedHolderStrengths {
-		heldSeq := li.heldStrengths[heldStrengthToIndexMap[str]]
-		if heldSeq != notHeldSentinel && heldSeq < minKnownSavepoint {
-			allBelowMinSavepoint = true
-			break
-		}
-	}
-
 	lastSeq := minIntentSequence
 	for _, str := range unreplicatedHolderStrengths {
 		heldSeq := li.heldStrengths[heldStrengthToIndexMap[str]]
 		if heldSeq != notHeldSentinel {
-			if heldSeq > lastSeq {
+			if heldSeq >= lastSeq {
 				// This lock is above a stronger lock and can be elided.
 				continue
 			}
@@ -2147,11 +2124,6 @@ func (li *lockedKeyInfo) toAllRequestUnions(
 			getAlloc.union.Get = &getAlloc.get
 			ru.Value = &getAlloc.union
 			dst = append(dst, ru)
-
-			// If everyone was below the min savepoint, we only need to send the strongest lock.
-			if allBelowMinSavepoint {
-				break
-			}
 		}
 	}
 	return dst

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -2024,133 +2024,6 @@ func TestRollbackNeverHeldLock(t *testing.T) {
 	require.NotNil(t, br)
 }
 
-// TestTxnWriteBufferRollbackToSavepointMidTxn tests the savepoint rollback
-// logic in the presence of explicit savepoints.
-func TestTxnWriteBufferRollbackToSavepointMidTxn(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-	ctx := context.Background()
-
-	sendPut := func(t *testing.T, twb *txnWriteBuffer, mockSender *mockLockedSender, txn *roachpb.Transaction) {
-		txn.Sequence++
-		keyA := roachpb.Key("a")
-		valA := fmt.Sprintf("valA@%d", txn.Sequence)
-		putA := putArgs(keyA, valA, txn.Sequence)
-
-		ba := &kvpb.BatchRequest{}
-		ba.Header = kvpb.Header{Txn: txn}
-		ba.Add(putA)
-
-		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-			br := ba.CreateReply()
-			br.Txn = ba.Txn
-			return br, nil
-		})
-
-		numCalled := mockSender.NumCalled()
-		br, pErr := twb.SendLocked(ctx, ba)
-		require.Nil(t, pErr)
-		require.NotNil(t, br)
-		require.Equal(t, numCalled, mockSender.NumCalled())
-	}
-
-	delRangeBatch := func(txn *roachpb.Transaction) *kvpb.BatchRequest {
-		txn.Sequence++
-		keyB := roachpb.Key("b")
-		keyC := roachpb.Key("c")
-		delRangeReq := delRangeArgs(keyB, keyC, txn.Sequence)
-
-		ba := &kvpb.BatchRequest{}
-		ba.Header = kvpb.Header{Txn: txn}
-		ba.Add(delRangeReq)
-		return ba
-	}
-
-	savepoint := func(twb *txnWriteBuffer, txn *roachpb.Transaction) *savepoint {
-		txn.Sequence++
-		savepoint := &savepoint{seqNum: txn.Sequence}
-		twb.createSavepointLocked(ctx, savepoint)
-		return savepoint
-	}
-
-	t.Run("flush with no savepoint sends latest", func(t *testing.T) {
-		twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
-		txn := makeTxnProto()
-		// Send 4 requests to the buffer
-		sendPut(t, &twb, mockSender, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		ba := delRangeBatch(&txn)
-
-		// Expect 1 Put and 1 DelRange.
-		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-			require.Len(t, ba.Requests, 2)
-			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-			require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[1].GetInner())
-
-			br := ba.CreateReply()
-			br.Txn = ba.Txn
-			return br, nil
-		})
-		br, pErr := twb.SendLocked(ctx, ba)
-		require.Nil(t, pErr)
-		require.NotNil(t, br)
-	})
-
-	t.Run("flush with savepoint still elides unnecessary writes under savepoint", func(t *testing.T) {
-		twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
-		txn := makeTxnProto()
-		sendPut(t, &twb, mockSender, &txn) // should be elided
-		sendPut(t, &twb, mockSender, &txn)
-		_ = savepoint(&twb, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		ba := delRangeBatch(&txn)
-
-		// Expect 3 Put and 1 DelRange.
-		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-			require.Len(t, ba.Requests, 4)
-			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[1].GetInner())
-			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[2].GetInner())
-			require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[3].GetInner())
-
-			br := ba.CreateReply()
-			br.Txn = ba.Txn
-			return br, nil
-		})
-		br, pErr := twb.SendLocked(ctx, ba)
-		require.Nil(t, pErr)
-		require.NotNil(t, br)
-	})
-
-	t.Run("flush after release of earliest savepoint only sends latest", func(t *testing.T) {
-		twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
-		txn := makeTxnProto()
-		sendPut(t, &twb, mockSender, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		sp := savepoint(&twb, &txn)
-		sendPut(t, &twb, mockSender, &txn)
-		twb.releaseSavepointLocked(ctx, sp)
-
-		ba := delRangeBatch(&txn)
-		mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
-			require.Len(t, ba.Requests, 2)
-			require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-			require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[1].GetInner())
-
-			br := ba.CreateReply()
-			br.Txn = ba.Txn
-			return br, nil
-		})
-		br, pErr := twb.SendLocked(ctx, ba)
-		require.Nil(t, pErr)
-		require.NotNil(t, br)
-	})
-}
-
 // TestTxnWriteBufferFlushesAfterDisabling verifies that the txnWriteBuffer
 // flushes on the next batch after it is disabled if it buffered any writes.
 func TestTxnWriteBufferFlushesAfterDisabling(t *testing.T) {
@@ -3645,22 +3518,23 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 		validateFinalBatch func(t *testing.T, ba *kvpb.BatchRequest)
 	}
 
-	expectSingleWrite := func(t *testing.T, ba *kvpb.BatchRequest) {
-		require.Len(t, ba.Requests, 2) // Second request is whatever flushed us.
-		require.IsType(t, &kvpb.PutRequest{}, ba.Requests[0].GetInner())
-	}
-
-	expectSingleLock := func(str lock.Strength) func(t *testing.T, ba *kvpb.BatchRequest) {
-		return func(t *testing.T, ba *kvpb.BatchRequest) {
-			require.Len(t, ba.Requests, 2) // Second request is whatever flushed us.
-			require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
-			getReq := ba.Requests[0].GetGet()
-			require.Equal(t, str, getReq.KeyLockingStrength)
-		}
-	}
 	expectEndTxnOnly := func(t *testing.T, ba *kvpb.BatchRequest) {
 		require.Len(t, ba.Requests, 1)
 		require.IsType(t, &kvpb.EndTxnRequest{}, ba.Requests[0].GetInner())
+	}
+	expectRequests := func(strs ...lock.Strength) func(t *testing.T, ba *kvpb.BatchRequest) {
+		return func(t *testing.T, ba *kvpb.BatchRequest) {
+			require.Len(t, ba.Requests, len(strs)+1) // The +1 is whatever flushed us.
+			for i, str := range strs {
+				if str == lock.Intent {
+					require.IsType(t, &kvpb.PutRequest{}, ba.Requests[i].GetInner())
+				} else {
+					require.IsType(t, &kvpb.GetRequest{}, ba.Requests[i].GetInner())
+					getReq := ba.Requests[i].GetGet()
+					require.Equal(t, str, getReq.KeyLockingStrength)
+				}
+			}
+		}
 	}
 
 	testCases := []testCase{
@@ -3670,7 +3544,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				replicatedSharedLockingGet,
 				replicatedExclusiveLockingGet,
 			},
-			validateFinalBatch: expectSingleLock(lock.Exclusive),
+			validateFinalBatch: expectRequests(lock.Exclusive),
 		},
 		{
 			ops: []string{
@@ -3678,7 +3552,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				replicatedExclusiveLockingGet,
 				put,
 			},
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Intent),
 		},
 		{
 			ops: []string{
@@ -3687,36 +3561,38 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				replicatedExclusiveLockingGet,
 				put,
 			},
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Intent),
 		},
 		// Mid-transaction flush cases
+		//
+		// Regardless of savepoints, we still flush these locks.
 		{
 			ops: []string{
-				replicatedSharedLockingGet,    // This is elided because a write exists and no savepoint requires it.
-				replicatedExclusiveLockingGet, // This is elided because a write exists and no savepoint requires it.
+				replicatedSharedLockingGet,
+				replicatedExclusiveLockingGet,
 				put,
 			},
 			midTxn:             true,
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Shared, lock.Exclusive, lock.Intent),
 		},
 		{
 			ops: []string{
-				replicatedSharedLockingGet,    // This is elided because a write is also below savepoint.
-				replicatedExclusiveLockingGet, // This is elided because a write is also below savepoint.
+				replicatedSharedLockingGet,
+				replicatedExclusiveLockingGet,
 				put,
 				createSavepoint,
 			},
 			midTxn:             true,
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Shared, lock.Exclusive, lock.Intent),
 		},
 		{
 			ops: []string{
-				replicatedSharedLockingGet, // This is elided because a stronger lock is also below the savepoint.
+				replicatedSharedLockingGet,
 				replicatedExclusiveLockingGet,
 				createSavepoint,
 			},
 			midTxn:             true,
-			validateFinalBatch: expectSingleLock(lock.Exclusive),
+			validateFinalBatch: expectRequests(lock.Shared, lock.Exclusive),
 		},
 		{
 			ops: []string{
@@ -3725,20 +3601,8 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				replicatedExclusiveLockingGet,
 				put,
 			},
-			midTxn: true,
-			validateFinalBatch: func(t *testing.T, ba *kvpb.BatchRequest) {
-				require.Len(t, ba.Requests, 4)
-				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[0].GetInner())
-				getReq := ba.Requests[0].GetGet()
-				require.Equal(t, lock.Shared, getReq.KeyLockingStrength)
-
-				require.IsType(t, &kvpb.GetRequest{}, ba.Requests[1].GetInner())
-				getReq = ba.Requests[1].GetGet()
-				require.Equal(t, lock.Exclusive, getReq.KeyLockingStrength)
-
-				require.IsType(t, &kvpb.PutRequest{}, ba.Requests[2].GetInner())
-				require.IsType(t, &kvpb.DeleteRangeRequest{}, ba.Requests[3].GetInner())
-			},
+			midTxn:             true,
+			validateFinalBatch: expectRequests(lock.Shared, lock.Exclusive, lock.Intent),
 		},
 		{
 			ops: []string{
@@ -3747,7 +3611,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				replicatedSharedLockingGet, // This is elided because write is at a lower sequence.
 			},
 			midTxn:             true,
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Intent),
 		},
 		{
 			ops: []string{
@@ -3756,7 +3620,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				replicatedSharedLockingGet, // This is elided because write is at a lower sequence.
 			},
 			midTxn:             true,
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Intent),
 		},
 
 		// Rollback special cases
@@ -3795,7 +3659,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 				unreplicatedExclusiveLockingGet,
 				put,
 			},
-			validateFinalBatch: expectSingleWrite,
+			validateFinalBatch: expectRequests(lock.Intent),
 		},
 	}
 

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -509,101 +509,10 @@ SET TRACING = "off"
 statement ok
 COMMIT
 
-subtest rollback_after_mid_txn_flush_released_savepoint
+subtest rollback_of_nested_savepoint_after_flush
 
 statement ok
 CREATE TABLE t7 (pk int primary key, v int, FAMILY (pk, v))
-
-statement ok
-BEGIN
-
-statement ok
-INSERT INTO t7 VALUES (1,1);
-
-statement ok
-SAVEPOINT rollback_target
-
-statement ok
-UPDATE t7 SET v = 2 WHERE pk = 1
-
-statement ok
-RELEASE SAVEPOINT rollback_target
-
-statement ok
-SET TRACING = "on"
-
-# Force a flush before commit with DeleteRange
-statement ok
-DELETE FROM t7 WHERE pk > 5
-
-# This assertion depends on write buffering not being disabled because
-# of the version or transaction isolation level. Skip configurations
-# that result in buffered writes being disabled.
-skipif config local-read-committed local-repeatable-read
-query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'node received request:%'
-----
-node received request: 1 Put, 1 DelRng
-
-statement ok
-SET TRACING = "off"
-
-statement ok
-COMMIT;
-
-query II
-SELECT pk,v FROM t7 WHERE pk = 1
-----
-1  2
-
-subtest rollback_after_mid_txn_flush_multiple_writes_below_savepoint
-
-statement ok
-BEGIN
-
-statement ok
-INSERT INTO t7 VALUES (2,1);
-
-statement ok
-UPDATE t7 SET v = 2 WHERE pk = 2
-
-statement ok
-SAVEPOINT rollback_target
-
-statement ok
-UPDATE t7 SET v = 3 WHERE pk = 2
-
-statement ok
-SET TRACING = "on"
-
-# Force a flush before commit with DeleteRange
-statement ok
-DELETE FROM t7 WHERE pk > 5
-
-# This assertion depends on write buffering not being disabled because
-# of the version or transaction isolation level. Skip configurations
-# that result in buffered writes being disabled.
-skipif config local-read-committed local-repeatable-read
-query T
-SELECT message FROM [SHOW TRACE FOR SESSION] WHERE message LIKE 'node received request:%'
-----
-node received request: 2 Put, 1 DelRng
-
-statement ok
-SET TRACING = "off"
-
-statement ok
-ROLLBACK TO rollback_target
-
-statement ok
-COMMIT;
-
-query II
-SELECT pk,v FROM t7 WHERE pk = 2
-----
-2  2
-
-subtest rollback_of_nested_savepoint_after_flush
 
 statement ok
 BEGIN


### PR DESCRIPTION
In #147888 we attempted to claw back the ability to elide flushing buffered revisions for mid-transaction flushes. But, this optimization didn't account for mid-transaction flushes that happen in the middle of a query that may require reading previous values.

Here, we simply remove this optimization again.

Fixes #149459

Release note: None