### PR TITLE
sql: restrict ALTER user password for provisioned users

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/provisioning
+++ b/pkg/ccl/logictestccl/testdata/logic_test/provisioning
@@ -21,24 +21,24 @@ AND option = 'PROVISIONSRC'
 ldap:ldap.bar.com
 
 statement ok
-ALTER ROLE role_with_provisioning PROVISIONSRC 'ldap:ldap.example.com'
+CREATE ROLE role_with_provisioning_2 PROVISIONSRC 'ldap:ldap.example.com'
 
 query T
 SELECT value FROM system.role_options
-WHERE username = 'role_with_provisioning'
+WHERE username = 'role_with_provisioning_2'
 AND option = 'PROVISIONSRC'
 ----
 ldap:ldap.example.com
 
 statement error pq: provided IDP "\[\]!@#%#\^\$&\*" in PROVISIONSRC is non parseable: parse "\[\]!@#%#\^\$&\*": invalid URL escape "%#\^"
-ALTER ROLE role_with_provisioning PROVISIONSRC 'ldap:[]!@#%#^$&*'
+CREATE ROLE role_with_provisioning_3 PROVISIONSRC 'ldap:[]!@#%#^$&*'
 
 statement ok
-ALTER ROLE role_with_provisioning PROVISIONSRC 'ldap:foo.bar'
+CREATE ROLE role_with_provisioning_3 PROVISIONSRC 'ldap:foo.bar'
 
 query T
 SELECT value FROM system.role_options
-WHERE username = 'role_with_provisioning'
+WHERE username = 'role_with_provisioning_3'
 AND option = 'PROVISIONSRC'
 ----
 ldap:foo.bar

--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -647,17 +647,20 @@ func (p *planner) UserHasRoleOption(
 		return false, errors.AssertionFailedf("cannot use HasRoleOption without a txn")
 	}
 
-	if user.IsRootUser() || user.IsNodeUser() {
-		return true, nil
-	}
+	// Skip non-admin inherited role options for validation.
+	if !slices.Contains(roleoption.NonAdminInheritedOptions, roleOption) {
+		if user.IsRootUser() || user.IsNodeUser() {
+			return true, nil
+		}
 
-	hasAdmin, err := p.UserHasAdminRole(ctx, user)
-	if err != nil {
-		return false, err
-	}
-	if hasAdmin {
-		// Superusers have all role privileges.
-		return true, nil
+		hasAdmin, err := p.UserHasAdminRole(ctx, user)
+		if err != nil {
+			return false, err
+		}
+		if hasAdmin {
+			// Superusers have all role privileges.
+			return true, nil
+		}
 	}
 
 	hasRolePrivilege, err := p.InternalSQLTxn().QueryRowEx(

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1530,6 +1530,66 @@ RESET ROLE
 
 subtest end
 
+subtest validate_alter_provisioned_user_restrictions
+
+# Changing PROVISIONSRC privilege for provisioned users is disallowed even for
+# ADMIN users, they can only be dropped.
+statement ok
+DROP ROLE testuser
+
+statement ok
+CREATE USER testuser with PROVISIONSRC 'ldap:example.com'
+
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER ROLE testuser WITH PROVISIONSRC 'ldap:example.com'
+
+statement ok
+SET ROLE testuser
+
+# Changing users with SET ROLE should now disallow self-password/provisionsrc
+# change as role has a PROVISIONSRC privilege.
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER testuser PASSWORD 'cat'
+
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER testuser PROVISIONSRC 'ldap:example2.com'
+
+statement ok
+RESET ROLE
+
+user testuser
+
+# Verify that now provisioned testuser can't change its own password or provisionsrc.
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER testuser PASSWORD 'xyz'
+
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER CURRENT_USER PASSWORD '123'
+
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER testuser PROVISIONSRC 'ldap:example2.com'
+
+# Verify that provisioned testuser still cannot *remove* its own password.
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER testuser PASSWORD NULL
+
+# testuser still cannot change another user's password.
+statement error pq: user testuser does not have CREATEROLE privilege
+ALTER USER testuser2 WITH PASSWORD 'abc'
+
+# Verify that testuser still cannot modify other role options of itself.
+statement error pq: cannot alter PASSWORD/PROVISIONSRC option for provisioned user testuser
+ALTER USER testuser PASSWORD 'abc' VALID UNTIL '4044-10-31'
+
+user root
+
+
+statement ok
+DROP user testuser;
+CREATE user testuser CREATEROLE;
+
+subtest end
+
 subtest replication
 
 statement ok

--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -81,6 +81,10 @@ const (
 	PROVISIONSRC
 )
 
+var NonAdminInheritedOptions = []Option{
+	PROVISIONSRC,
+}
+
 // ControlChangefeedDeprecationNoticeMsg is a user friendly notice which should be shown when CONTROLCHANGEFEED is used
 //
 // TODO(#94757): remove CONTROLCHANGEFEED entirely


### PR DESCRIPTION
We need to restrict the `ALTER USER password` command for provisioned users to
disallow password set/password change for self as login access for these users
is strictly managed through IDP based authentication method.

fixes #146061
Epic CRDB-21590

Release note (sql): Post the change the users with the role option
`PROVISIONSRC` assigned to them will be unable to change their own password
overriding any config set for sql.auth.change_own_password.enabled cluster
setting. Changing other role options still has the same privilege requirements
as before (either CREATEROLE or CREATELOGIN, depending on the option).