### PR TITLE
release-24.1: roachtest: deflake splits/largerange/size=32GiB

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -616,7 +616,12 @@ func runLargeRangeSplits(ctx context.Context, t test.Test, c cluster.Cluster, si
 			if err := disableLoadBasedSplitting(ctx, db); err != nil {
 				return err
 			}
-			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='512MiB'`); err != nil {
+
+			// Setting the max snapshot rebalance rate to a very high value like
+			// 512MiB could cause the snapshot-copy operation to timeout if the actual
+			// copy rate is significantly lower than  that. See #148982 for more
+			// details.
+			if _, err := db.ExecContext(ctx, `SET CLUSTER SETTING kv.snapshot_rebalance.max_rate='192MiB'`); err != nil {
 				return err
 			}
 			// This test splits an exceptionally large range. Disable MVCC stats


### PR DESCRIPTION
Backport 1/1 commits from #149283.

/cc @cockroachdb/release

---

This commit reduces the snapshot_rebalance.max_rate from 512 to 192. The reasons are: (1) Even on Azure and GCE, I saw that we get about 192 Mbps of an actual snapshot send rate. (2) On IBM, the rate is much lower. (3) This rate goes into calculating the snapshot sending timeout, and it should generally be lower or slightly higher than the actual snapshot sending rate. If it's 10 times lower than the actual rate, the snapshot will most likely timeout.

See this comment for the exact analysis:
https://github.com/cockroachdb/cockroach/issues/148982#issuecomment-3020552145

Fixes: #148982

Release note: None

Release justification: test deflake