### PR TITLE
jobs: make GC of old jobs txn'l

### DIFF
--- a/pkg/jobs/adopt.go
+++ b/pkg/jobs/adopt.go
@@ -37,6 +37,10 @@ const (
 		`'` + string(StatePauseRequested) + `', ` +
 		`'` + string(StateReverting) + `'`
 
+	terminalStateList = `'` + string(StateFailed) + `', ` +
+		`'` + string(StateCanceled) + `', ` +
+		`'` + string(StateSucceeded) + `'`
+
 	claimableStateTupleString = `(` + claimableStateList + `)`
 
 	nonTerminalStateList = claimableStateList + `, ` +


### PR DESCRIPTION
A single logical job is now made up of many rows stored in many different tables, meaning

that deletion of a job from the system should imply complete deletion of all of its rows in all of these tables. Previously we were not using a single txn to delete from all of the tables, meaning a job could have its row deleted from e.g. system.jobs but not from job_status, orphaning the status row. These orphan rows were not particularly problematic but are cruft which could build up over time as nothing would remove them once the main record in system.jobs was removed.

Instead, we now identify all expired jobs in system jobs which we will delete using one txn, then delete each job in a txn that deletes all rows for that job in all tables.

Release note: none.
Epic: CRDB-51121.
Fixes: #147552.