### PR TITLE
roachtest: add mutator to inject a network partition

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/BUILD.bazel
@@ -25,6 +25,7 @@ go_library(
         "//pkg/cmd/roachtest/spec",
         "//pkg/cmd/roachtest/test",
         "//pkg/roachpb",
+        "//pkg/roachprod/failureinjection/failures",
         "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/roachprod/vm",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/context.go
@@ -34,6 +34,9 @@ type (
 		// upgraded to a certain version, and the migrations are being
 		// executed).
 		Finalizing bool
+		// hasUnavailableNodes indicates whether this step has any nodes
+		// that are currently marked as unavailable.
+		hasUnavailableNodes bool
 
 		// nodesByVersion maps released versions to which nodes are
 		// currently running that version.

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -934,9 +934,14 @@ func (t *Test) plan() (plan *TestPlan, retErr error) {
 			hooks:          t.hooks,
 			prng:           t.prng,
 			bgChans:        t.bgChans,
+			logger:         t.logger,
+			cluster:        t.cluster,
 		}
 		// Let's generate a plan.
-		plan = planner.Plan()
+		plan, err = planner.Plan()
+		if err != nil {
+			return nil, errors.Wrapf(err, "error generating test plan")
+		}
 		if plan.length <= t.options.maxNumPlanSteps {
 			break
 		}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators_test.go
@@ -29,7 +29,8 @@ func TestPreserveDowngradeOptionRandomizerMutator(t *testing.T) {
 	require.NoError(t, err)
 
 	var mut preserveDowngradeOptionRandomizerMutator
-	mutations := mut.Generate(newRand(), plan, nil)
+	mutations, err := mut.Generate(newRand(), plan, nil)
+	require.NoError(t, err)
 	require.NotEmpty(t, mutations)
 	require.True(t, len(mutations)%2 == 0, "should produce even number of mutations") // one removal and one insertion per upgrade
 
@@ -97,7 +98,8 @@ func TestClusterSettingMutator(t *testing.T) {
 
 		const settingName = "test_cluster_setting"
 		mut := newClusterSettingMutator(settingName, possibleValues, options...)
-		mutations := mut.Generate(newRand(), plan, nil)
+		mutations, err := mut.Generate(newRand(), plan, nil)
+		require.NoError(t, err)
 
 		// Number of mutations should be 1 <= n <= maxChanges
 		require.GreaterOrEqual(t, len(mutations), 1, "plan:\n%s", plan.PrettyPrint())

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -12,10 +12,12 @@ import (
 	"strings"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 )
 
@@ -93,6 +95,8 @@ type (
 		hooks          *testHooks
 		prng           *rand.Rand
 		bgChans        []shouldStop
+		logger         *logger.Logger
+		cluster        cluster.Cluster
 
 		// State variables updated as the test plan is generated.
 		usingFixtures bool
@@ -131,7 +135,7 @@ type (
 		// mutations that should be applied to the plan. The test plan is the intended output
 		// after applying the mutations. The testPlanner is used to access specific attributes
 		// of the test plan, such as the current context or the services.
-		Generate(*rand.Rand, *TestPlan, *testPlanner) []mutation
+		Generate(*rand.Rand, *TestPlan, *testPlanner) ([]mutation, error)
 	}
 
 	// mutationOp encodes the type of mutation and controls how the
@@ -217,6 +221,7 @@ const (
 // failure injection mutators.
 var failureInjectionMutators = []mutator{
 	panicNodeMutator{},
+	networkPartitionMutator{},
 }
 
 // clusterSettingMutators includes a list of all
@@ -291,7 +296,7 @@ var planMutators = func() []mutator {
 //     allowing the cluster version to advance. Mixed-version hooks may be
 //     executed while this is happening.
 //     - AfterUpgradeFinalizedStage: run after-upgrade hooks.
-func (p *testPlanner) Plan() *TestPlan {
+func (p *testPlanner) Plan() (*TestPlan, error) {
 	setup, testUpgrades := p.setupTest()
 
 	upgradeStepsForService := func(
@@ -434,23 +439,34 @@ func (p *testPlanner) Plan() *TestPlan {
 	}
 
 	// Probabilistically enable some of the mutators on the base test
-	// plan generated above. We disable any failure injections that
-	// would occur on clusters with less than three nodes as this
-	// can lead to uninteresting failures (e.g. a single node
-	// panic failure).
+	// plan generated above.
 	for _, mut := range planMutators {
 		if p.mutatorEnabled(mut) {
-			if _, found := failureInjections[mut.Name()]; found && len(p.currentContext.Nodes()) < 3 {
-				continue
+			if _, found := failureInjections[mut.Name()]; found {
+				// We disable any failure injections that would occur on clusters with
+				// less than three nodes as this can lead to uninteresting failures
+				// (e.g. a single node panic failure).
+				if len(p.currentContext.Nodes()) < 3 {
+					continue
+				}
+				// We disable failure injections for local runs as some failure
+				// injections are not supported in that mode and can
+				// cause unintended behaviors (partitions using iptables).
+				if p.isLocal {
+					continue
+				}
 			}
-			mutations := mut.Generate(p.prng, testPlan, p)
+			mutations, err := mut.Generate(p.prng, testPlan, p)
+			if err != nil {
+				return nil, err
+			}
 			testPlan.applyMutations(p.prng, mutations)
 			testPlan.enabledMutators = append(testPlan.enabledMutators, mut)
 		}
 	}
 
 	testPlan.assignIDs()
-	return testPlan
+	return testPlan, nil
 }
 
 // nonUpgradeContext builds a mixed-version context to be used during
@@ -1394,6 +1410,20 @@ func (ss stepSelector) CutBefore(predicate func(*singleStep) bool) (stepSelector
 	return append(before, cut...), after
 }
 
+// MarkNodesUnavailable marks all steps in the given step selector
+// as having unavailable nodes for the given tenant(s). This is used to
+// act as a filter for steps that requires all nodes to be available.
+func (ss stepSelector) MarkNodesUnavailable(systemUnavailable bool, tenantUnavailable bool) {
+	for _, s := range ss {
+		if systemUnavailable {
+			s.context.System.hasUnavailableNodes = true
+		}
+		if tenantUnavailable && s.context.Tenant != nil {
+			s.context.Tenant.hasUnavailableNodes = true
+		}
+	}
+}
+
 // RandomStep returns a new selector that selects a single step,
 // randomly chosen from the list of selected steps in the original
 // selector.
@@ -1490,7 +1520,6 @@ func (plan *TestPlan) applyMutations(rng *rand.Rand, mutations []mutation) {
 	for _, mut := range mutationApplicationOrder(mutations) {
 		plan.mapSingleSteps(func(ss *singleStep, isConcurrent bool) []testStep {
 			index := newStepIndex(plan)
-
 			// If the mutation is not relative to this step, move on.
 			if ss != mut.reference {
 				return []testStep{ss}

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -389,6 +389,7 @@ func newTest(options ...CustomOption) *Test {
 	defaultTestOverrides := []CustomOption{
 		EnabledDeploymentModes(SystemOnlyDeployment),
 		DisableSkipVersionUpgrades,
+		DisableAllFailureInjectionMutators(),
 	}
 
 	for _, fn := range defaultTestOverrides {
@@ -863,7 +864,7 @@ func (concurrentUserHooksMutator) Probability() float64 { return 0.5 }
 
 func (concurrentUserHooksMutator) Generate(
 	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
-) []mutation {
+) ([]mutation, error) {
 	// Insert our `testSingleStep` implementation concurrently with every
 	// user-provided function.
 	return plan.
@@ -872,7 +873,7 @@ func (concurrentUserHooksMutator) Generate(
 			_, ok := s.impl.(runHookStep)
 			return ok
 		}).
-		InsertConcurrent(&testSingleStep{})
+		InsertConcurrent(&testSingleStep{}), nil
 }
 
 // removeUserHooksMutator is a test mutator that removes every
@@ -884,14 +885,14 @@ func (removeUserHooksMutator) Probability() float64 { return 0.5 }
 
 func (removeUserHooksMutator) Generate(
 	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
-) []mutation {
+) ([]mutation, error) {
 	return plan.
 		newStepSelector().
 		Filter(func(s *singleStep) bool {
 			_, ok := s.impl.(runHookStep)
 			return ok
 		}).
-		Remove()
+		Remove(), nil
 }
 
 func dummyHook(context.Context, *logger.Logger, *rand.Rand, *Helper) error {
@@ -935,6 +936,7 @@ func Test_SeparateProcessUsesLatestPred(t *testing.T) {
 	testOverrides := []CustomOption{
 		EnabledDeploymentModes(SeparateProcessDeployment),
 		DisableSkipVersionUpgrades,
+		DisableAllFailureInjectionMutators(),
 		MinUpgrades(5),
 		MaxUpgrades(5),
 	}
@@ -956,7 +958,6 @@ func Test_SeparateProcessUsesLatestPred(t *testing.T) {
 
 	plan, err := mvt.plan()
 	require.NoError(t, err)
-	//
 	upgradePath := plan.Versions()
 	// Remove the last element as it's the current version which is a special case.
 	// The unit test framework hardcodes the current version which should have no

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -16,6 +16,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/failureinjection/failures"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
@@ -584,7 +585,6 @@ func (s resetClusterSettingStep) Run(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper,
 ) error {
 	stmt := fmt.Sprintf("RESET CLUSTER SETTING %s", s.name)
-
 	return serviceByName(h, s.virtualClusterName).ExecWithGateway(
 		rng, nodesRunningAtLeast(s.virtualClusterName, s.minVersion, h), stmt,
 	)
@@ -876,4 +876,96 @@ func (s restartNodeStep) Run(ctx context.Context, l *logger.Logger, _ *rand.Rand
 
 func (s restartNodeStep) ConcurrencyDisabled() bool {
 	return true
+}
+
+type networkPartitionInjectStep struct {
+	f          *failures.Failer
+	partition  failures.NetworkPartition
+	targetNode option.NodeListOption
+}
+
+func (s networkPartitionInjectStep) Background() shouldStop { return nil }
+
+func (s networkPartitionInjectStep) Description() string {
+	var desc string
+	switch s.partition.Type {
+	case failures.Bidirectional:
+		desc = fmt.Sprintf("setting up bidirectional network partition: dropping connections between nodes %d and %v", s.partition.Source, s.partition.Destination)
+	case failures.Incoming:
+		desc = fmt.Sprintf("setting up incoming network partition: dropping connections from nodes %v to %d", s.partition.Destination, s.partition.Source)
+	case failures.Outgoing:
+		desc = fmt.Sprintf("setting up outgoing network partition: dropping connections from nodes %d to %v", s.partition.Source, s.partition.Destination)
+	}
+	return desc
+}
+
+func (s networkPartitionInjectStep) Run(
+	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
+) error {
+	h.runner.monitor.ExpectProcessDead(s.targetNode)
+	if h.Tenant != nil {
+		opt := option.VirtualClusterName(h.Tenant.Descriptor.Name)
+		h.runner.monitor.ExpectProcessDead(s.targetNode, opt)
+	}
+
+	args := failures.NetworkPartitionArgs{Partitions: []failures.NetworkPartition{s.partition}}
+
+	if err := s.f.Setup(ctx, l, args); err != nil {
+		return errors.Wrapf(err, "failed to setup failure %s", failures.IPTablesNetworkPartitionName)
+	}
+
+	if err := s.f.Inject(ctx, l, args); err != nil {
+		return errors.Wrapf(err, "failed to inject failure %s", failures.IPTablesNetworkPartitionName)
+	}
+
+	return s.f.WaitForFailureToPropagate(ctx, l)
+}
+
+func (s networkPartitionInjectStep) ConcurrencyDisabled() bool {
+	return true
+}
+
+type networkPartitionRecoveryStep struct {
+	f          *failures.Failer
+	partition  failures.NetworkPartition
+	targetNode option.NodeListOption
+}
+
+func (s networkPartitionRecoveryStep) Background() shouldStop { return nil }
+
+func (s networkPartitionRecoveryStep) Description() string {
+	var desc string
+	switch s.partition.Type {
+	case failures.Bidirectional:
+		desc = fmt.Sprintf("recovering from bidirectional network partition: allowing connections between nodes %d and %v", s.partition.Source, s.partition.Destination)
+	case failures.Incoming:
+		desc = fmt.Sprintf("recovering from incoming network partition: allowing connections from nodes %v to %d", s.partition.Destination, s.partition.Source)
+	case failures.Outgoing:
+		desc = fmt.Sprintf("recovering from outgoing network partition: allowing connections from nodes %d to %v", s.partition.Source, s.partition.Destination)
+	}
+	return desc
+}
+
+func (s networkPartitionRecoveryStep) Run(
+	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
+) error {
+	if err := s.f.Recover(ctx, l); err != nil {
+		return errors.Wrapf(err, "failed to recover failure %s", failures.IPTablesNetworkPartitionName)
+	}
+
+	if err := s.f.WaitForFailureToRecover(ctx, l); err != nil {
+		return errors.Wrapf(err, "failed to wait for recovery of failure %s", failures.IPTablesNetworkPartitionName)
+	}
+
+	h.runner.monitor.ExpectProcessAlive(s.targetNode)
+	if h.Tenant != nil {
+		opt := option.VirtualClusterName(h.Tenant.Descriptor.Name)
+		h.runner.monitor.ExpectProcessAlive(s.targetNode, opt)
+	}
+	return s.f.Cleanup(ctx, l)
+
+}
+
+func (s networkPartitionRecoveryStep) ConcurrencyDisabled() bool {
+	return false
 }

--- a/pkg/roachprod/failureinjection/failures/network_partition.go
+++ b/pkg/roachprod/failureinjection/failures/network_partition.go
@@ -15,6 +15,19 @@ import (
 
 type PartitionType int
 
+func (p PartitionType) String() string {
+	switch p {
+	case Bidirectional:
+		return "Bidirectional"
+	case Incoming:
+		return "Incoming"
+	case Outgoing:
+		return "Outgoing"
+	default:
+		panic(fmt.Sprintf("unknown PartitionType: %d", p))
+	}
+}
+
 const (
 	// Bidirectional drops traffic in both directions.
 	Bidirectional PartitionType = iota
@@ -23,6 +36,12 @@ const (
 	// Outgoing drops outgoing traffic from the source to the destination
 	Outgoing
 )
+
+var AllPartitionTypes = []PartitionType{
+	Bidirectional,
+	Incoming,
+	Outgoing,
+}
 
 type NetworkPartition struct {
 	// Source is a list of nodes that will have the network partition created as


### PR DESCRIPTION
This change adds a new mutator that will enable the ability to randomly inject a network partition between one node and a random subset of other nodes. The network partition is safely recovered a random number of steps later, restricted by any steps that are incompatible with a network partition.

Epic: None
Release note: None
Fixes: None
