### PR TITLE
roachtest: exit with failure on github post errors

### DIFF
--- a/pkg/cmd/roachtest/github_test.go
+++ b/pkg/cmd/roachtest/github_test.go
@@ -2,7 +2,6 @@
 //
 // Use of this software is governed by the CockroachDB Software License
 // included in the /LICENSE file.
-
 package main
 
 import (
@@ -33,12 +32,12 @@ import (
 
 var (
 	teamsYaml = `cockroachdb/unowned:
-  aliases:
-    cockroachdb/rfc-prs: other
+ aliases:
+   cockroachdb/rfc-prs: other
 cockroachdb/test-eng:
-  label: T-testeng
+ label: T-testeng
 cockroachdb/dev-inf:
-  label: T-dev-inf`
+ label: T-dev-inf`
 
 	validTeamsFn   = func() (team.Map, error) { return loadYamlTeams(teamsYaml) }
 	invalidTeamsFn = func() (team.Map, error) { return loadYamlTeams("invalid yaml") }
@@ -154,10 +153,9 @@ func TestCreatePostRequest(t *testing.T) {
 		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
 			if d.Cmd == "post" {
 				github := &githubIssues{
-					vmCreateOpts: vmOpts,
-					cluster:      testClusterImpl,
-					teamLoader:   teamLoadFn,
+					teamLoader: teamLoadFn,
 				}
+				issueInfo := newGithubIssueInfo(testClusterImpl, vmOpts)
 
 				// See: `formatFailure` which formats failures for roachtests. Try to
 				// follow it here.
@@ -173,10 +171,11 @@ func TestCreatePostRequest(t *testing.T) {
 				}
 				message := b.String()
 
-				params := getTestParameters(ti, github.cluster, github.vmCreateOpts)
+				params := getTestParameters(ti, issueInfo.cluster, issueInfo.vmCreateOpts)
 				req, err := github.createPostRequest(
 					testName, ti.start, ti.end, testSpec, testCase.failures,
 					message, roachtestutil.UsingRuntimeAssertions(ti), ti.goCoverEnabled, params,
+					issueInfo,
 				)
 				if testCase.loadTeamsFailed {
 					// Assert that if TEAMS.yaml cannot be loaded then function errors.

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -47,6 +47,12 @@ const (
 	// created due to errors during cloud hardware allocation.
 	ExitCodeClusterProvisioningFailed = 11
 
+	// ExitCodeGithubPostFailed is the exit code indicating a failure in posting
+	// results to GitHub successfully.
+	// Note: This error masks the actual roachtest status i.e. this error can
+	// occur with any of the other exit codes.
+	ExitCodeGithubPostFailed = 12
+
 	// runnerLogsDir is the dir under the artifacts root where the test runner log
 	// and other runner-related logs (i.e. cluster creation logs) will be written.
 	runnerLogsDir = "_runner-logs"
@@ -241,11 +247,12 @@ Check --parallelism, --run-forever and --wait-before-next-execution flags`,
 
 	if err := rootCmd.Execute(); err != nil {
 		code := 1
-		if errors.Is(err, errTestsFailed) {
-			code = ExitCodeTestsFailed
-		}
-		if errors.Is(err, errSomeClusterProvisioningFailed) {
+		if errors.Is(err, errGithubPostFailed) {
+			code = ExitCodeGithubPostFailed
+		} else if errors.Is(err, errSomeClusterProvisioningFailed) {
 			code = ExitCodeClusterProvisioningFailed
+		} else if errors.Is(err, errTestsFailed) {
+			code = ExitCodeTestsFailed
 		}
 		// Cobra has already printed the error message.
 		os.Exit(code)

--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadog"
 	"github.com/DataDog/datadog-api-client-go/v2/api/datadogV1"
+	"github.com/cockroachdb/cockroach/pkg/cmd/bazci/githubpost/issues"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
@@ -138,6 +139,12 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 		literalArtifactsDir: literalArtifactsDir,
 		runnerLogPath:       runnerLogPath,
 	}
+
+	github := &githubIssues{
+		disable:     runner.config.disableIssue,
+		issuePoster: issues.Post,
+	}
+
 	l.Printf("global random seed: %d", roachtestflags.GlobalSeed)
 	go func() {
 		if err := http.ListenAndServe(
@@ -183,7 +190,8 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 			goCoverEnabled:         roachtestflags.GoCoverEnabled,
 			exportOpenMetrics:      roachtestflags.ExportOpenmetrics,
 		},
-		lopt)
+		lopt,
+		github)
 
 	// Make sure we attempt to clean up. We run with a non-canceled ctx; the
 	// ctx above might be canceled in case a signal was received. If that's

--- a/pkg/cmd/roachtest/test_monitor_test.go
+++ b/pkg/cmd/roachtest/test_monitor_test.go
@@ -49,6 +49,7 @@ func TestGlobalMonitorError(t *testing.T) {
 	defer stopper.Stop(ctx)
 	cr := newClusterRegistry()
 	runner := newUnitTestRunner(cr, stopper)
+	github := defaultGithub(runner.config.disableIssue)
 
 	var buf syncedBuffer
 	copt := defaultClusterOpt()
@@ -72,6 +73,6 @@ func TestGlobalMonitorError(t *testing.T) {
 		},
 	}
 	err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-		defaultParallelism, copt, testOpts{}, lopt)
+		defaultParallelism, copt, testOpts{}, lopt, github)
 	require.Error(t, err)
 }

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -62,8 +62,14 @@ func init() {
 var (
 	errTestsFailed = fmt.Errorf("some tests failed")
 
-	// reference error used by main.go at the end of a run of tests
+	// errSomeClusterProvisioningFailed error sent after a run in
+	// [testRunner.Run] if any worker encountered a cluster provisioning error.
+	// Used in main.go to determine the run exit code.
 	errSomeClusterProvisioningFailed = fmt.Errorf("some clusters could not be created")
+
+	// errGithubPostFailed error sent after a run in [testRunner.Run] if any
+	// worker encountered an error when trying to POST to GitHub
+	errGithubPostFailed = fmt.Errorf("failed to POST to GitHub")
 
 	prometheusNameSpace = "roachtest"
 	// prometheusScrapeInterval should be consistent with the scrape interval defined in
@@ -174,8 +180,11 @@ type testRunner struct {
 		completed []completedTestInfo
 	}
 
-	// Counts cluster creation errors across all workers.
+	// numClusterErrs Counts cluster creation errors across all workers.
 	numClusterErrs int32
+
+	// numGithubPostErrs Counts GitHub post errors across all workers
+	numGithubPostErrs int32
 }
 
 type perfMetricsCollector struct {
@@ -308,6 +317,7 @@ func (r *testRunner) Run(
 	clustersOpt clustersOpt,
 	topt testOpts,
 	lopt loggingOpt,
+	github GithubPoster,
 ) error {
 	// Validate options.
 	if len(tests) == 0 {
@@ -411,6 +421,7 @@ func (r *testRunner) Run(
 				topt,
 				childLogger,
 				n*count,
+				github,
 			)
 
 			if err != nil {
@@ -448,14 +459,25 @@ func (r *testRunner) Run(
 	passFailLine := r.generateReport()
 	shout(ctx, l, lopt.stdout, passFailLine)
 
+	// For the errors that don't short-circuit the pipeline run, return a joined
+	// error and leave case handling to the caller
+	var err error
+	if r.numGithubPostErrs > 0 {
+		shout(ctx, l, lopt.stdout, "%d errors occurred while posting to github", r.numGithubPostErrs)
+		err = errors.Join(err, errGithubPostFailed)
+	}
 	if r.numClusterErrs > 0 {
 		shout(ctx, l, lopt.stdout, "%d clusters could not be created", r.numClusterErrs)
-		return errSomeClusterProvisioningFailed
+		err = errors.Join(err, errSomeClusterProvisioningFailed)
+	}
+	if len(r.status.fail) > 0 {
+		shout(ctx, l, lopt.stdout, "%d tests failed", r.status.fail)
+		err = errors.Join(err, errTestsFailed)
+	}
+	if err != nil {
+		return err
 	}
 
-	if len(r.status.fail) > 0 {
-		return errTestsFailed
-	}
 	// To ensure all prometheus metrics have been scraped, ensure shutdown takes
 	// at least one scrapeInterval, unless the roachtest fails or gets cancelled.
 	requiredShutDownTime := prometheusScrapeInterval
@@ -596,6 +618,7 @@ func (r *testRunner) runWorker(
 	topt testOpts,
 	l *logger.Logger,
 	maxTotalFailures int,
+	github GithubPoster,
 ) error {
 	stdout := lopt.stdout
 
@@ -841,18 +864,22 @@ func (r *testRunner) runWorker(
 			runID:                  generateRunID(clustersOpt),
 		}
 		t.ReplaceL(testL)
-		github := newGithubIssues(r.config.disableIssue, c, vmCreateOpts)
-
+		issueInfo := newGithubIssueInfo(c, vmCreateOpts)
 		// handleClusterCreationFailure can be called when the `err` given
 		// occurred for reasons related to creating or setting up a
 		// cluster for a test.
-		handleClusterCreationFailure := func(err error) {
-			t.Error(errClusterProvisioningFailed(err))
+		handleClusterCreationFailure := func(clusterCreateErr error) {
+			t.Error(errClusterProvisioningFailed(clusterCreateErr))
 
-			params := getTestParameters(t, github.cluster, github.vmCreateOpts)
+			// Technically don't need the issueInfo struct here because we have access
+			// to the clusterImpl and vm.CreateOpts in runWorker()
+			// but not in runTests() so keeping the invocation of getTestParameters()
+			// the same in both spots
+			params := getTestParameters(t, issueInfo.cluster, issueInfo.vmCreateOpts)
 			logTestParameters(l, params)
-			if _, err := github.MaybePost(t, l, t.failureMsg(), params); err != nil {
-				shout(ctx, l, stdout, "failed to post issue: %s", err)
+			if _, githubErr := github.MaybePost(t, issueInfo, l, t.failureMsg(), params); githubErr != nil {
+				atomic.AddInt32(&r.numGithubPostErrs, 1)
+				shout(ctx, l, stdout, "failed to post issue: %s", githubErr)
 			}
 		}
 
@@ -978,7 +1005,8 @@ func (r *testRunner) runWorker(
 				wStatus.SetTest(t, testToRun)
 				wStatus.SetStatus("running test")
 
-				r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL, github)
+				r.runTest(ctx, t, testToRun.runNum, testToRun.runCount, c, stdout, testL,
+					github, issueInfo)
 			}
 		}
 
@@ -1135,7 +1163,8 @@ func (r *testRunner) runTest(
 	c *clusterImpl,
 	stdout io.Writer,
 	l *logger.Logger,
-	github *githubIssues,
+	github GithubPoster,
+	issueInfo *githubIssueInfo,
 ) {
 	testRunID := t.Name()
 	if runCount > 1 {
@@ -1238,11 +1267,12 @@ func (r *testRunner) runTest(
 				}
 
 				output := fmt.Sprintf("%s\ntest artifacts and logs in: %s", failureMsg, t.ArtifactsDir())
-				params := getTestParameters(t, github.cluster, github.vmCreateOpts)
+				params := getTestParameters(t, issueInfo.cluster, issueInfo.vmCreateOpts)
 				logTestParameters(l, params)
-				issue, err := github.MaybePost(t, l, output, params)
+				issue, err := github.MaybePost(t, issueInfo, l, output, params)
 				if err != nil {
 					shout(ctx, l, stdout, "failed to post issue: %s", err)
+					atomic.AddInt32(&r.numGithubPostErrs, 1)
 				}
 
 				// If an issue was created (or comment added) on GitHub,

--- a/pkg/cmd/roachtest/test_test.go
+++ b/pkg/cmd/roachtest/test_test.go
@@ -21,6 +21,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/cmd/bazci/githubpost/issues"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
@@ -72,6 +73,23 @@ func defaultClusterOpt() clustersOpt {
 	}
 }
 
+// clusterOptWithProvisioningError returns a clusterOpt with
+// preAllocateClusterFn set to a function that always returns nil to mock a
+// cluster provisioning error.
+func clusterOptWithProvisioningError() clustersOpt {
+	return clustersOpt{
+		typ:       roachprodCluster,
+		user:      "test_user",
+		cpuQuota:  1000,
+		debugMode: NoDebug,
+		preAllocateClusterFn: func(ctx context.Context,
+			t registry.TestSpec,
+			arch vm.CPUArch) error {
+			return errors.New("Provision error")
+		},
+	}
+}
+
 func defaultLoggingOpt(buf *syncedBuffer) loggingOpt {
 	return loggingOpt{
 		l:            nilLogger(),
@@ -80,6 +98,37 @@ func defaultLoggingOpt(buf *syncedBuffer) loggingOpt {
 		stderr:       buf,
 		artifactsDir: "",
 	}
+}
+
+func defaultGithub(disable bool) GithubPoster {
+	return &githubIssues{
+		disable: disable,
+		// issuePoster isn't mocked because an env var check exits MaybePost when
+		// the GitHub API isn't present, so technically setting it here doesn't
+		// matter
+		issuePoster: func(context.Context, issues.Logger, issues.IssueFormatter, issues.PostRequest,
+			*issues.Options) (*issues.TestFailureIssue, error) {
+			return nil, errors.New("unit test should never post to github")
+		},
+	}
+}
+
+// mockGithubIssues is a mock implementation of GithubPoster to test GitHub
+// failure scenarios
+type mockGithubIssues struct{}
+
+func (m *mockGithubIssues) MaybePost(
+	t *testImpl,
+	issueInfo *githubIssueInfo,
+	l *logger.Logger,
+	message string,
+	params map[string]string,
+) (*issues.TestFailureIssue, error) {
+	return nil, errors.New("mocked MaybePost error")
+}
+
+func brokenGithub(disable bool) GithubPoster {
+	return &mockGithubIssues{}
 }
 
 func TestRunnerRun(t *testing.T) {
@@ -181,9 +230,10 @@ func TestRunnerRun(t *testing.T) {
 	for _, c := range testCases {
 		t.Run("", func(t *testing.T) {
 			rt := setupRunnerTest(t, r, c.filters)
+			github := defaultGithub(rt.runner.config.disableIssue)
 
 			const count = 1
-			err := rt.runner.Run(ctx, rt.tests, count, defaultParallelism, rt.copt, testOpts{}, rt.lopt)
+			err := rt.runner.Run(ctx, rt.tests, count, defaultParallelism, rt.copt, testOpts{}, rt.lopt, github)
 			assertTestCompletion(t, rt.tests, c.filters, rt.runner.getCompletedTests(), err, c.expErr)
 			// Write test reports & verify their contents.
 			testSummaryPath := filepath.Join(rt.lopt.artifactsDir, "test_summary.tsv")
@@ -202,7 +252,8 @@ func TestRunnerRun(t *testing.T) {
 				copt.preAllocateClusterFn = func(ctx context.Context, t registry.TestSpec, arch vm.CPUArch) error {
 					return errors.New("cluster creation failed")
 				}
-				err = rt.runner.Run(ctx, rt.tests, count, defaultParallelism, copt, testOpts{}, rt.lopt)
+				err = rt.runner.Run(ctx, rt.tests, count, defaultParallelism, copt, testOpts{}, rt.lopt,
+					github)
 
 				assertTestCompletion(t,
 					rt.tests, c.filters, rt.runner.getCompletedTests(),
@@ -247,11 +298,12 @@ func TestRunnerEncryptionAtRest(t *testing.T) {
 	})
 
 	rt := setupRunnerTest(t, r, nil)
+	github := defaultGithub(rt.runner.config.disableIssue)
 
 	for i := 0; i < 10000; i++ {
 		require.NoError(t, rt.runner.Run(
 			context.Background(), rt.tests, 1 /* count */, 1, /* parallelism */
-			rt.copt, testOpts{}, rt.lopt,
+			rt.copt, testOpts{}, rt.lopt, github,
 		))
 		if atomic.LoadInt32(&sawEncrypted) == 0 {
 			// NB: since it's a 50% chance, the probability of *not* hitting
@@ -474,8 +526,9 @@ func TestRunnerTestTimeout(t *testing.T) {
 			<-ctx.Done()
 		},
 	}
+	github := defaultGithub(runner.config.disableIssue)
 	err := runner.Run(ctx, []registry.TestSpec{test}, 1, /* count */
-		defaultParallelism, copt, testOpts{}, lopt)
+		defaultParallelism, copt, testOpts{}, lopt, github)
 	if !testutils.IsError(err, "some tests failed") {
 		t.Fatalf("expected error \"some tests failed\", got: %v", err)
 	}
@@ -571,7 +624,8 @@ func runExitCodeTest(t *testing.T, injectedError error) error {
 	tests, _ := testsToRun(r, tf, false, 1.0, true)
 	var buf syncedBuffer
 	lopt := defaultLoggingOpt(&buf)
-	return runner.Run(ctx, tests, 1, 1, clustersOpt{}, testOpts{}, lopt)
+	github := defaultGithub(runner.config.disableIssue)
+	return runner.Run(ctx, tests, 1, 1, clustersOpt{}, testOpts{}, lopt, github)
 }
 
 func TestExitCode(t *testing.T) {
@@ -685,6 +739,7 @@ func TestTransientErrorFallback(t *testing.T) {
 	var buf syncedBuffer
 	copt := defaultClusterOpt()
 	lopt := defaultLoggingOpt(&buf)
+	github := defaultGithub(runner.config.disableIssue)
 
 	// Test that if a test fails with a transient error handled by the `require` package,
 	// the test runner will correctly still identify it as a flake and the run will have
@@ -702,7 +757,7 @@ func TestTransientErrorFallback(t *testing.T) {
 			},
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		require.NoError(t, err)
 	})
 
@@ -723,7 +778,7 @@ func TestTransientErrorFallback(t *testing.T) {
 			},
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		if !testutils.IsError(err, "some tests failed") {
 			t.Fatalf("expected error \"some tests failed\", got: %v", err)
 		}
@@ -740,6 +795,7 @@ func TestRunnerTasks(t *testing.T) {
 	var buf syncedBuffer
 	copt := defaultClusterOpt()
 	lopt := defaultLoggingOpt(&buf)
+	github := defaultGithub(runner.config.disableIssue)
 
 	mockTest := registry.TestSpec{
 		Name:             `mock test`,
@@ -765,7 +821,7 @@ func TestRunnerTasks(t *testing.T) {
 			<-ctx.Done()
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		if !testutils.IsError(err, "some tests failed") {
 			t.Fatalf("expected error \"some tests failed\", got: %v", err)
 		}
@@ -780,7 +836,7 @@ func TestRunnerTasks(t *testing.T) {
 			<-ctx.Done()
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		if !testutils.IsError(err, "some tests failed") {
 			t.Fatalf("expected error \"some tests failed\", got: %v", err)
 		}
@@ -800,7 +856,7 @@ func TestRunnerTasks(t *testing.T) {
 			t.Fatalf("test failed")
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		if !testutils.IsError(err, "some tests failed") {
 			t.Fatalf("expected error \"some tests failed\", got: %v", err)
 		}
@@ -820,7 +876,7 @@ func TestRunnerTasks(t *testing.T) {
 			}, task.Name("task"))
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		require.NoError(t, err)
 		require.Equal(t, uint32(1), tasksDone.Load())
 	})
@@ -836,6 +892,7 @@ func TestVMPreemptionPolling(t *testing.T) {
 	var buf syncedBuffer
 	copt := defaultClusterOpt()
 	lopt := defaultLoggingOpt(&buf)
+	github := defaultGithub(runner.config.disableIssue)
 
 	mockTest := registry.TestSpec{
 		Name:             `preemption`,
@@ -877,7 +934,7 @@ func TestVMPreemptionPolling(t *testing.T) {
 		setPollPreemptionInterval(50 * time.Millisecond)
 
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		// The preemption monitor should mark a VM as preempted and the test should
 		// be treated as a flake instead of a failed test.
 		require.NoError(t, err)
@@ -893,7 +950,7 @@ func TestVMPreemptionPolling(t *testing.T) {
 			t.Error("Should be ignored")
 		}
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 		// The post test failure check should mark a VM as preempted and the test should
 		// be treated as a flake instead of a failed test.
 		require.NoError(t, err)
@@ -927,7 +984,7 @@ func TestVMPreemptionPolling(t *testing.T) {
 		}
 
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 
 		require.NoError(t, err)
 	})
@@ -957,7 +1014,7 @@ func TestVMPreemptionPolling(t *testing.T) {
 		}
 
 		err := runner.Run(ctx, []registry.TestSpec{mockTest}, 1, /* count */
-			defaultParallelism, copt, testOpts{}, lopt)
+			defaultParallelism, copt, testOpts{}, lopt, github)
 
 		require.NoError(t, err)
 	})
@@ -975,6 +1032,7 @@ func TestRunnerFailureAfterTimeout(t *testing.T) {
 	defer stopper.Stop(ctx)
 	cr := newClusterRegistry()
 	runner := newUnitTestRunner(cr, stopper)
+	github := defaultGithub(runner.config.disableIssue)
 
 	var buf syncedBuffer
 	copt := defaultClusterOpt()
@@ -994,6 +1052,54 @@ func TestRunnerFailureAfterTimeout(t *testing.T) {
 		},
 	}
 	err := runner.Run(ctx, []registry.TestSpec{test}, 1, /* count */
-		defaultParallelism, copt, testOpts{}, lopt)
+		defaultParallelism, copt, testOpts{}, lopt, github)
 	require.Error(t, err)
+}
+
+// TestRunnerProvisionErrorGithubError
+//  1. Test runner worker experiences provisioning error
+//  2. After provisioning error, the worker will get a GitHub POST error
+//     (mocked)
+//  3. Worker will return because it has nothing else to do
+//  4. Runner should return a joined error for failing to provision, and a
+//     GitHub error and relevant error counters in [testRunner] should be
+//     incremented
+func TestRunnerProvisionErrorGithubError(t *testing.T) {
+	ctx := context.Background()
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	cr := newClusterRegistry()
+	runner := newUnitTestRunner(cr, stopper)
+	github := brokenGithub(runner.config.disableIssue)
+
+	var buf syncedBuffer
+	copt := clusterOptWithProvisioningError()
+	lopt := defaultLoggingOpt(&buf)
+	test := registry.TestSpec{
+		Name:             `TestThatShouldNotRun`,
+		Owner:            OwnerUnitTest,
+		Timeout:          10 * time.Second,
+		Cluster:          spec.MakeClusterSpec(0),
+		CompatibleClouds: registry.AllExceptAWS,
+		Suites:           registry.Suites(registry.Nightly),
+		CockroachBinary:  registry.StandardCockroach,
+		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
+			// If for some reason this test is executed, the test runner worker will
+			// recover from this panic as a test failure
+			panic("this test should never run")
+		},
+	}
+
+	err := runner.Run(ctx, []registry.TestSpec{test}, 1, /* count */
+		defaultParallelism, copt, testOpts{}, lopt, github)
+
+	// Assert test runner worker did not execute the test because infra shouldn't
+	// be provisioned
+	require.NotErrorIs(t, err, errTestsFailed)
+	// Assert error is of type errGithubPostFailed && errSomeClusterProvisioningFailed
+	require.ErrorIs(t, err, errGithubPostFailed)
+	require.ErrorIs(t, err, errSomeClusterProvisioningFailed)
+	// Assert test runner workers' error counts are as expected
+	require.Equal(t, runner.numGithubPostErrs, int32(1), "expected exactly 1 github post errors")
+	require.Equal(t, runner.numClusterErrs, int32(1), "expected exactly 1 cluster errors")
 }


### PR DESCRIPTION
Fixes #147116
### Changes
#### Highlevel Changes
Added a new failure path first by
* adding a new counter in `testRunner` struct which get's incremented when `github.MaybePost()` (called in `testRunner.runWorkers()` and `testRunner.runTests()` )returns an error. When this count > 0,  `testRunner.Run()` will return a new error `errGithubPostFailed` and when `main()` sees that error, it will return a new exit code `12` which will fail the pipeline (unlike exit code 10, 11)
* ^ very similar to how provisioning errors are tracked and returned to `main()`
* does not trigger test short circuiting mechanism because `testRunner.runWorkers()` doesn't return an error 
```
type testRunner struct {
...
// numGithubPostErrs Counts GitHub post errors across all workers
numGithubPostErrs int32
...
}
...
issue, err := github.MaybePost(t, issueInfo, l, output, params) // TODO add cluster specific args here
if err != nil {
    shout(ctx, l, stdout, "failed to post issue: %s", err)
    atomic.AddInt32(&r.numGithubPostErrs, 1)
}
```
#### Design
In order to do verification via unit tests, i'm used to using something like Python's magic mock, but that's not available in GoLang so i opted for a Dependency Injection approach.  (This was the best I could come up with, I wanted to avoid "if unit test, do this" logic. If anyone has any other approaches / suggestions let me know!) 
I made a new interface `GithubPoster` in such a way that the original `githubIssues` implements that new interface.  I then pass this interface in function signatures all the way from `Run()` to `runTests()`. Then in the unit tests, I could pass a different implementation of `GithubPoster` that has a `MaybePost()` that always fails.
`github.go`
```
type GithubPoster interface {
	MaybePost(
		t *testImpl, issueInfo *githubIssueInfo, l *logger.Logger, message string,
		params map[string]string) (
		*issues.TestFailureIssue, error)
}
```
Another issue with this approach is the original `githubIssues` has information that is cluster specific, but because of dependency injection, it's now a shared struct among all the workers, so it doesn't make sense to store certain fields that are worker dependent.
For the fields that are worker specific, I created a new struct `githubIssueInfo` that is created in `runWorkers()`, similar to how `githubIssues` used to be created there.
Note: I don't love the name `githubIssueInfo`, but i wanted to stick with a similar naming convention to `githubIssues`, open to name suggestions

```
// Original githubIssues
type githubIssues struct {
	disable      bool
	cluster      *clusterImpl
	vmCreateOpts *vm.CreateOpts
	issuePoster func(context.Context, issues.Logger, issues.IssueFormatter, issues.PostRequest,
		*issues.Options) (*issues.TestFailureIssue, error)
	teamLoader func() (team.Map, error)
}
// New githubIssues
type githubIssues struct {
	disable      bool
	issuePoster func(context.Context, issues.Logger, issues.IssueFormatter, issues.PostRequest,
		*issues.Options) (*issues.TestFailureIssue, error)
	teamLoader func() (team.Map, error)
}
```

All this was very verbose and didn't love that i had to change all the function signatures to do this, open to other ways to do verification. 

### Misc
Also first time writing in Go in like ~3 years very open to general go semantic feedback / best practices / design patterns


### Verification
Diff of binary I used to manually confirm if you wanna see where I hardcoded to return errors: https://github.com/cockroachdb/cockroach/commit/611adcce02dbc4934482e6648364d7a9c7d22b7b 
#### Manual Test Logs
> ➜  cockroach git:(wchoe/147116-github-err-will-fail-pipeline) ✗ tmp/roachtest run acceptance/build-info --cockroach /Users/wchoe/work/cockroachdb/cockroach/bin_linux/cockroach
> ...
> Running tests which match regex "acceptance/build-info" and are compatible with cloud "gce".
> 
> fallback runner logs in: artifacts/roachtest.crdb.log
> 2025/07/09 00:51:48 run.go:386: test runner logs in: artifacts/_runner-logs/test_runner-1752022308.log
> test runner logs in: artifacts/_runner-logs/test_runner-1752022308.log
> HTTP server listening on port 56238 on localhost: http://localhost:56238/
> 2025/07/09 00:51:48 run.go:148: global random seed: 1949199437086051249
> 2025/07/09 00:51:48 test_runner.go:398: test_run_id: will.choe-1752022308
> test_run_id: will.choe-1752022308
> [w0] 2025/07/09 00:51:48 work_pool.go:198: Acquired quota for 16 CPUs
> [w0] 2025/07/09 00:51:48 cluster.go:3204: Using randomly chosen arch="amd64", acceptance/build-info
> [w0] 2025/07/09 00:51:48 test_runner.go:798: Unable to create (or reuse) cluster for test acceptance/build-info due to: mocking.
> Unable to create (or reuse) cluster for test acceptance/build-info due to: mocking.
> 2025/07/09 00:51:48 test_impl.go:478: test failure #1: full stack retained in failure_1.log: (test_runner.go:873).func4: mocking [owner=test-eng]
> 2025/07/09 00:51:48 test_impl.go:200: Runtime assertions disabled
> [w0] 2025/07/09 00:51:48 test_runner.go:883: failed to post issue: mocking
> failed to post issue: mocking
> [w0] 2025/07/09 00:51:48 test_runner.go:1019: test failed: acceptance/build-info (run 1)
> [w0] 2025/07/09 00:51:48 test_runner.go:732: Releasing quota for 16 CPUs
> [w0] 2025/07/09 00:51:48 test_runner.go:744: No work remaining; runWorker is bailing out...
> No work remaining; runWorker is bailing out...
> [w0] 2025/07/09 00:51:48 test_runner.go:643: Worker exiting; no cluster to destroy.
> 2025/07/09 00:51:48 test_runner.go:460: PASS
> PASS
> 2025/07/09 00:51:48 test_runner.go:465: 1 clusters could not be created and 1 errors occurred while posting to github
> 1 clusters could not be created and 1 errors occurred while posting to github
> 2025/07/09 00:51:48 run.go:200: runTests destroying all clusters
> Error: some clusters could not be created
> failed to POST to GitHub
> ➜  cockroach git:(wchoe/147116-github-err-will-fail-pipeline) ✗ echo $?
> 12


