### PR TITLE
opt/optgen: refactor NormalizeLikeAny and compile string and integer literals as Go values

### DIFF
--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1540,6 +1540,11 @@ func (c *CustomFuncs) CanAddConstInts(first tree.Datum, second tree.Datum) bool 
 	return ok
 }
 
+// DInt returns a new *tree.DInt with the given integer value.
+func (c *CustomFuncs) DInt(i tree.DInt) *tree.DInt {
+	return tree.NewDInt(i)
+}
+
 // IntConst constructs a Const holding a DInt.
 func (c *CustomFuncs) IntConst(d *tree.DInt) opt.ScalarExpr {
 	return c.f.ConstructConst(d, types.Int)
@@ -1562,9 +1567,9 @@ func (c *CustomFuncs) StringFromConst(expr opt.ScalarExpr) (string, bool) {
 
 // ConstStringEquals returns true if e is a constant string expression and is
 // equal to other.
-func (c *CustomFuncs) ConstStringEquals(e opt.ScalarExpr, other *tree.DString) bool {
+func (c *CustomFuncs) ConstStringEquals(e opt.ScalarExpr, other string) bool {
 	if eStr, ok := c.StringFromConst(e); ok {
-		return eStr == string(*other)
+		return eStr == other
 	}
 	return false
 }

--- a/pkg/sql/opt/norm/general_funcs.go
+++ b/pkg/sql/opt/norm/general_funcs.go
@@ -1545,11 +1545,6 @@ func (c *CustomFuncs) IntConst(d *tree.DInt) opt.ScalarExpr {
 	return c.f.ConstructConst(d, types.Int)
 }
 
-// StrConst constructs a Const holding a DString.
-func (c *CustomFuncs) StrConst(d *tree.DString) opt.ScalarExpr {
-	return c.f.ConstructConst(d, types.String)
-}
-
 // StringFromConst extracts a string from a Const expression. It returns the
 // string and a boolean indicating whether the extraction was successful.
 func (c *CustomFuncs) StringFromConst(expr opt.ScalarExpr) (string, bool) {
@@ -1565,14 +1560,13 @@ func (c *CustomFuncs) StringFromConst(expr opt.ScalarExpr) (string, bool) {
 	return "", false
 }
 
-// EqualConstString compares two Const expressions to see if they hold equal string values.
-func (c *CustomFuncs) EqualConstStrings(left, right opt.ScalarExpr) bool {
-	leftStr, okLeft := c.StringFromConst(left)
-	rightStr, okRight := c.StringFromConst(right)
-	if !okLeft || !okRight {
-		return false
+// ConstStringEquals returns true if e is a constant string expression and is
+// equal to other.
+func (c *CustomFuncs) ConstStringEquals(e opt.ScalarExpr, other *tree.DString) bool {
+	if eStr, ok := c.StringFromConst(e); ok {
+		return eStr == string(*other)
 	}
-	return leftStr == rightStr
+	return false
 }
 
 // IsGreaterThan returns true if the first datum compares as greater than the

--- a/pkg/sql/opt/norm/rules/decorrelate.opt
+++ b/pkg/sql/opt/norm/rules/decorrelate.opt
@@ -707,7 +707,7 @@
     $left:*
     $right:(Limit $input:* (Const $limit:*) $ordering:*) &
         (HasOuterCols $right) &
-        (IsGreaterThan $limit 1)
+        (IsGreaterThan $limit (DInt 1))
     $on:*
     $private:*
 )

--- a/pkg/sql/opt/norm/rules/groupby.opt
+++ b/pkg/sql/opt/norm/rules/groupby.opt
@@ -324,7 +324,7 @@
 (ConstructProjectionFromDistinctOn
     (Limit
         $input
-        (IntConst 1)
+        (IntConst (DInt 1))
         (GroupingInputOrdering $groupingPrivate)
     )
     (MakeEmptyColSet)
@@ -610,7 +610,7 @@
 #      a. The aggregate only references cols from the Window operator's input.
 #      b. The aggregate is a ConstAgg (or ConstNotNull, AnyNotNull, or FirstAgg)
 #         that passes through the result of a window function.
-# 
+#
 # Assuming all of the above are satisfied, each GroupBy aggregate that only
 # references the Window's input can be left alone (5a). Then, each ConstAgg
 # referencing a window function can be replaced by that function (5b).

--- a/pkg/sql/opt/norm/rules/scalar.opt
+++ b/pkg/sql/opt/norm/rules/scalar.opt
@@ -240,7 +240,11 @@ $input
     [
         (Subquery
             (Project
-                (Limit $input (IntConst 1) (EmptyOrdering))
+                (Limit
+                    $input
+                    (IntConst (DInt 1))
+                    (EmptyOrdering)
+                )
                 [ (ProjectionsItem (True) (MakeBoolCol)) ]
                 (MakeEmptyColSet)
             )

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -534,7 +534,7 @@ $input
                 $left:* &
                     (ExprIsNeverNull $left (NotNullCols $input))
                 $pattern:(Const) &
-                    (EqualConstStrings $pattern (StrConst "%"))
+                    (ConstStringEquals $pattern "%")
             )
         )
         ...

--- a/pkg/sql/opt/optgen/cmd/optgen/explorer_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/explorer_gen.go
@@ -32,7 +32,6 @@ func (g *explorerGen) generate(compiled *lang.CompiledExpr, w io.Writer) {
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/memo\"\n")
 	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical\"\n")
-	g.w.writeIndent("\"github.com/cockroachdb/cockroach/pkg/sql/sem/tree\"\n")
 	g.w.unnest(")\n\n")
 
 	g.genDispatcher()

--- a/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
+++ b/pkg/sql/opt/optgen/cmd/optgen/rule_gen.go
@@ -916,12 +916,12 @@ func (g *newRuleGen) genNestedExpr(e lang.Expr) {
 		g.w.write("%s", string(t.Result.Label))
 
 	case *lang.StringExpr:
-		// Literal string expressions construct DString datums.
-		g.w.write("tree.NewDString(%s)", t)
+		// Literal string expressions construct Go strings.
+		g.w.write("%s", t)
 
 	case *lang.NumberExpr:
-		// Literal numeric expressions construct DInt datums.
-		g.w.write("tree.NewDInt(%s)", t)
+		// Literal numeric expressions construct Go ints.
+		g.w.write("%s", t)
 
 	case *lang.NameExpr:
 		// OpName literal expressions construct an op identifier like SelectOp,

--- a/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
+++ b/pkg/sql/opt/optgen/cmd/optgen/testdata/explorer
@@ -78,7 +78,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func (_e *explorer) exploreGroupMember(
@@ -270,7 +269,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func (_e *explorer) exploreGroupMember(
@@ -393,7 +391,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func (_e *explorer) exploreGroupMember(
@@ -550,7 +547,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/props/physical"
-	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
 func (_e *explorer) exploreGroupMember(

--- a/pkg/sql/opt/xform/rules/groupby.opt
+++ b/pkg/sql/opt/xform/rules/groupby.opt
@@ -60,7 +60,7 @@
             $input
             [ (FiltersItem (IsNot $variable (Null (AnyType)))) ]
         )
-        (IntConst 1)
+        (IntConst (DInt 1))
         (MakeOrderingChoiceFromColumn (OpName $agg) $col)
     )
     [ (AggregationsItem (ConstAgg $variable) $aggPrivate) ]
@@ -108,7 +108,7 @@
 (MakeProjectFromPassthroughAggs
     (Limit
         $input
-        (IntConst 1)
+        (IntConst (DInt 1))
         (MakeOrderingChoiceFromColumn Min $col)
     )
     $aggregations
@@ -140,7 +140,7 @@
 (MakeProjectFromPassthroughAggs
     (Limit
         $input
-        (IntConst 1)
+        (IntConst (DInt 1))
         (MakeOrderingChoiceFromColumn Max $col)
     )
     $aggregations


### PR DESCRIPTION
#### opt: refactor NormalizeLikeAny

The NormalizeLikeAny rule no longer allocates, memoizes, and interns a
constant string expression for the literal "%" value.

Release note: None

#### opt/optgen: compile string and integer literals as Go values

Previously, optgen would sometimes compile string and integer literals,
e.g., `"foo"` and `1`, as Go strings and integers, and other times as
`*tree.DString`s and `*tree.DInt`s, depending on the context. Now, these
literals are always compiled as Go values. In addition to helping
prevent confusion, this can help avoid unnecessary allocations for
datums when they are not needed, e.g., see `NormalizeLikeAny`.

Release note: None
