### PR TITLE
changefeedccl: add CHANGEFEED privilege to DB and Schema privileges

### DIFF
--- a/pkg/backup/show_test.go
+++ b/pkg/backup/show_test.go
@@ -371,7 +371,7 @@ GRANT UPDATE ON top_secret TO agent_bond;
 				`GRANT CREATE, USAGE ON SCHEMA public TO public; ` +
 				`GRANT ALL ON SCHEMA public TO root WITH GRANT OPTION; `, `root`},
 			{`locator`, `schema`, `GRANT ALL ON SCHEMA locator TO admin WITH GRANT OPTION; ` +
-				`GRANT CREATE ON SCHEMA locator TO agent_bond; ` +
+				`GRANT CHANGEFEED, CREATE ON SCHEMA locator TO agent_bond; ` +
 				`GRANT ALL ON SCHEMA locator TO m; ` +
 				`GRANT ALL ON SCHEMA locator TO root WITH GRANT OPTION; `, `root`},
 			{`continent`, `type`, `GRANT ALL ON TYPE continent TO admin WITH GRANT OPTION; ` +

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3707,9 +3707,6 @@ func TestChangefeedGrant(t *testing.T) {
 		rootDB := sqlutils.MakeSQLRunner(s.DB)
 		rootDB.Exec(t, `create user guest`)
 
-		// GRANT CHANGEFEED ON DATABASE is an error.
-		rootDB.ExpectErr(t, `invalid privilege type CHANGEFEED for database`, `GRANT CHANGEFEED ON DATABASE d TO guest`)
-
 		// CHANGEFEED can be granted as a default privilege on all new tables in a schema
 		rootDB.ExecMultiple(t,
 			`ALTER DEFAULT PRIVILEGES IN SCHEMA d.public GRANT CHANGEFEED ON TABLES TO guest`,

--- a/pkg/sql/catalog/catpb/privilege_test.go
+++ b/pkg/sql/catalog/catpb/privilege_test.go
@@ -138,12 +138,12 @@ func TestPrivilege(t *testing.T) {
 			},
 			privilege.Table,
 		},
-		// Ensure revoking BACKUP, CONNECT, CREATE, DROP, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG, RESTORE
+		// Ensure revoking BACKUP, CONNECT, CREATE, DROP, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG, RESTORE, CHANGEFEED
 		// from a user with ALL privilege on a database leaves the user with no privileges.
 		{testUser,
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.BACKUP, privilege.CONNECT, privilege.CREATE, privilege.DROP, privilege.SELECT,
-				privilege.INSERT, privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG, privilege.RESTORE},
+				privilege.INSERT, privilege.DELETE, privilege.UPDATE, privilege.ZONECONFIG, privilege.RESTORE, privilege.CHANGEFEED},
 			[]catpb.UserPrivilege{
 				{User: username.AdminRoleName(), Privileges: []privilege.Privilege{{Kind: privilege.ALL, GrantOption: true}}},
 			},
@@ -555,6 +555,16 @@ func TestGrantWithGrantOption(t *testing.T) {
 			privilege.List{privilege.ALL, privilege.CREATE},
 			privilege.List{privilege.ALL},
 			privilege.List{privilege.ALL}},
+		{catpb.NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, username.AdminRoleName()),
+			testUser, privilege.Schema,
+			privilege.List{privilege.CHANGEFEED},
+			privilege.List{privilege.CHANGEFEED},
+			privilege.List{privilege.CHANGEFEED}},
+		{catpb.NewPrivilegeDescriptor(testUser, privilege.List{}, privilege.List{}, username.AdminRoleName()),
+			testUser, privilege.Database,
+			privilege.List{privilege.CHANGEFEED},
+			privilege.List{privilege.CHANGEFEED},
+			privilege.List{privilege.CHANGEFEED}},
 	}
 
 	for tcNum, tc := range testCases {
@@ -648,6 +658,20 @@ func TestRevokeWithGrantOption(t *testing.T) {
 			testUser, privilege.Table,
 			false,
 			privilege.List{privilege.ALL},
+			privilege.List{},
+			privilege.List{},
+			true},
+		{catpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CHANGEFEED}, privilege.List{privilege.CHANGEFEED}, username.AdminRoleName()),
+			testUser, privilege.Database,
+			false,
+			privilege.List{privilege.CHANGEFEED},
+			privilege.List{},
+			privilege.List{},
+			true},
+		{catpb.NewPrivilegeDescriptor(testUser, privilege.List{privilege.CHANGEFEED}, privilege.List{privilege.CHANGEFEED}, username.AdminRoleName()),
+			testUser, privilege.Schema,
+			false,
+			privilege.List{privilege.CHANGEFEED},
 			privilege.List{},
 			privilege.List{},
 			true},

--- a/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
+++ b/pkg/sql/logictest/testdata/logic_test/alter_default_privileges_for_schema
@@ -84,7 +84,9 @@ database_name  schema_name  grantee    privilege_type  is_grantable
 test           s2           admin      ALL             true
 test           s2           root       ALL             true
 test           s2           testuser   CREATE          false
+test           s2           testuser   CHANGEFEED      false
 test           s2           testuser2  CREATE          false
+test           s2           testuser2  CHANGEFEED      false
 
 statement ok
 ALTER DEFAULT PRIVILEGES REVOKE ALL ON SCHEMAS FROM testuser, testuser2

--- a/pkg/sql/logictest/testdata/logic_test/grant_database
+++ b/pkg/sql/logictest/testdata/logic_test/grant_database
@@ -58,12 +58,14 @@ SHOW GRANTS ON DATABASE a
 a  admin      ALL         true
 a  public     CONNECT     false
 a  readwrite  BACKUP      true
+a  readwrite  CHANGEFEED  true
 a  readwrite  CREATE      true
 a  readwrite  DROP        true
 a  readwrite  RESTORE     true
 a  readwrite  ZONECONFIG  true
 a  root       ALL         true
 a  test-user  BACKUP      true
+a  test-user  CHANGEFEED  true
 a  test-user  CREATE      true
 a  test-user  DROP        true
 a  test-user  RESTORE     true
@@ -74,11 +76,13 @@ SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
 a  public     CONNECT     false
 a  readwrite  BACKUP      true
+a  readwrite  CHANGEFEED  true
 a  readwrite  CREATE      true
 a  readwrite  DROP        true
 a  readwrite  RESTORE     true
 a  readwrite  ZONECONFIG  true
 a  test-user  BACKUP      true
+a  test-user  CHANGEFEED  true
 a  test-user  CREATE      true
 a  test-user  DROP        true
 a  test-user  RESTORE     true
@@ -93,12 +97,14 @@ SHOW GRANTS ON DATABASE a
 a  admin      ALL         true
 a  public     CONNECT     false
 a  readwrite  BACKUP      true
+a  readwrite  CHANGEFEED  true
 a  readwrite  CREATE      true
 a  readwrite  DROP        true
 a  readwrite  RESTORE     true
 a  readwrite  ZONECONFIG  true
 a  root       ALL         true
 a  test-user  BACKUP      true
+a  test-user  CHANGEFEED  true
 a  test-user  DROP        true
 a  test-user  RESTORE     true
 a  test-user  ZONECONFIG  true
@@ -111,6 +117,7 @@ SHOW GRANTS ON DATABASE a FOR readwrite, "test-user"
 ----
 a  public     CONNECT     false
 a  readwrite  BACKUP      true
+a  readwrite  CHANGEFEED  true
 a  readwrite  CREATE      true
 a  readwrite  DROP        true
 a  readwrite  RESTORE     true

--- a/pkg/sql/privilege/privilege.go
+++ b/pkg/sql/privilege/privilege.go
@@ -86,9 +86,9 @@ var (
 	ReadData              = List{SELECT}
 	ReadWriteData         = List{SELECT, INSERT, DELETE, UPDATE}
 	ReadWriteSequenceData = List{SELECT, UPDATE, USAGE}
-	DBPrivileges          = List{ALL, BACKUP, CONNECT, CREATE, DROP, RESTORE, ZONECONFIG}
+	DBPrivileges          = List{ALL, BACKUP, CHANGEFEED, CONNECT, CREATE, DROP, RESTORE, ZONECONFIG}
 	TablePrivileges       = List{ALL, BACKUP, CHANGEFEED, CREATE, DROP, SELECT, INSERT, DELETE, UPDATE, ZONECONFIG, TRIGGER, REPLICATIONDEST, REPLICATIONSOURCE}
-	SchemaPrivileges      = List{ALL, CREATE, USAGE}
+	SchemaPrivileges      = List{ALL, CREATE, CHANGEFEED, USAGE}
 	TypePrivileges        = List{ALL, USAGE}
 	RoutinePrivileges     = List{ALL, EXECUTE}
 	// SequencePrivileges is appended with TablePrivileges as well. This is because


### PR DESCRIPTION
add CHANGEFEED privilege to DB and Schema privileges to support 
database/schema-level changefeeds.

Resolves: #149470

Release note: None