### PR TITLE
release-25.3: disable create_table_with_schema_locked outside of tests

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -760,9 +760,10 @@ var CreateTableWithSchemaLocked = settings.RegisterBoolSetting(
 	"default value for create_table_with_schema_locked; "+
 		"default value for the create_table_with_schema_locked session setting; controls "+
 		"if new created tables will have schema_locked set",
-	true)
+	buildutil.CrdbTestBuild /* only enabled on test builds */)
 
-// createTableWithSchemaLockedDefault override for the schema_locked
+// createTableWithSchemaLockedDefault override for the schema_locked default
+// override value for tests.
 var createTableWithSchemaLockedDefault = true
 
 // TestForceDisableCreateTableWithSchemaLocked disables schema_locked create table


### PR DESCRIPTION
Previously, create_table_with_schema_locked was enabled by default in 25.3. Due to recent test failures that need investigation we think its safer to leave this setting disabled outside of tests. This patch disables create_table_with_schema_locked outside of tests.

Release note: None
Informs: #129694 
informs https://github.com/cockroachdb/cockroach/issues/148907
informs https://github.com/cockroachdb/cockroach/issues/149163

Release justification: low risk change to disable create_table_with_schema_locked outside of tests.