### PR TITLE
kvserver: clean up prepareSnapApply

### DIFF
--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -450,6 +450,7 @@ go_test(
         "//pkg/kv/kvserver/load",
         "//pkg/kv/kvserver/lockspanset",
         "//pkg/kv/kvserver/logstore",
+        "//pkg/kv/kvserver/print",
         "//pkg/kv/kvserver/protectedts",
         "//pkg/kv/kvserver/protectedts/ptpb",
         "//pkg/kv/kvserver/protectedts/ptstorage",

--- a/pkg/kv/kvserver/kvstorage/snaprecv/sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/kvstorage/snaprecv/sst_snapshot_storage.go
@@ -144,7 +144,7 @@ func (s *SSTSnapshotStorageScratch) NewFile(
 // WriteSST creates an SST populated with the given write function, and writes
 // it to a file. Does nothing if no data is written.
 func (s *SSTSnapshotStorageScratch) WriteSST(
-	ctx context.Context, write func(storage.Writer) error,
+	ctx context.Context, write func(context.Context, storage.Writer) error,
 ) error {
 	if s.closed {
 		return errors.AssertionFailedf("SSTSnapshotStorageScratch closed")
@@ -154,7 +154,7 @@ func (s *SSTSnapshotStorageScratch) WriteSST(
 	sstFile := &storage.MemObject{}
 	w := storage.MakeIngestionSSTWriter(ctx, s.st, sstFile)
 	defer w.Close()
-	if err := write(&w); err != nil {
+	if err := write(ctx, &w); err != nil {
 		return err
 	}
 	if err := w.Finish(); err != nil {

--- a/pkg/kv/kvserver/kvstorage/snaprecv/sst_snapshot_storage.go
+++ b/pkg/kv/kvserver/kvstorage/snaprecv/sst_snapshot_storage.go
@@ -146,6 +146,11 @@ func (s *SSTSnapshotStorageScratch) NewFile(
 func (s *SSTSnapshotStorageScratch) WriteSST(
 	ctx context.Context, write func(storage.Writer) error,
 ) error {
+	if s.closed {
+		return errors.AssertionFailedf("SSTSnapshotStorageScratch closed")
+	}
+
+	// TODO(itsbilal): Write to SST directly rather than buffer in a MemObject.
 	sstFile := &storage.MemObject{}
 	w := storage.MakeIngestionSSTWriter(ctx, s.st, sstFile)
 	defer w.Close()
@@ -155,28 +160,15 @@ func (s *SSTSnapshotStorageScratch) WriteSST(
 	if err := w.Finish(); err != nil {
 		return err
 	}
-	if w.DataSize > 0 {
-		// TODO(itsbilal): Write to SST directly rather than buffer in a MemObject.
-		return s.writeSSTData(ctx, sstFile.Data())
-	}
-	return nil
-}
-
-// writeSSTData writes SST data to a file. The method closes
-// the provided SST when it is finished using it. If the provided SST is empty,
-// then no file will be created and nothing will be written.
-func (s *SSTSnapshotStorageScratch) writeSSTData(ctx context.Context, data []byte) error {
-	if s.closed {
-		return errors.AssertionFailedf("SSTSnapshotStorageScratch closed")
-	}
-	if len(data) == 0 {
+	if w.DataSize == 0 {
 		return nil
 	}
+
 	f, err := s.NewFile(ctx, 512<<10 /* 512 KB */)
 	if err != nil {
 		return err
 	}
-	if err := f.Write(data); err != nil {
+	if err := f.Write(sstFile.Data()); err != nil {
 		f.Abort()
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/snaprecv/sst_snapshot_storage_test.go
+++ b/pkg/kv/kvserver/kvstorage/snaprecv/sst_snapshot_storage_test.go
@@ -57,7 +57,7 @@ func TestSSTSnapshotStorage(t *testing.T) {
 	defer eng.Close()
 
 	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
-	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID, nil)
 
 	// Check that the storage lazily creates the directories on first write.
 	_, err := eng.Env().Stat(scratch.snapDir)
@@ -139,7 +139,7 @@ func TestSSTSnapshotStorageConcurrentRange(t *testing.T) {
 	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
 
 	runForSnap := func(snapUUID uuid.UUID) error {
-		scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, snapUUID)
+		scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, snapUUID, nil)
 
 		// Check that the storage lazily creates the directories on first write.
 		_, err := eng.Env().Stat(scratch.snapDir)
@@ -242,7 +242,7 @@ func TestSSTSnapshotStorageContextCancellation(t *testing.T) {
 	defer eng.Close()
 
 	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
-	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID, nil)
 
 	var cancel func()
 	ctx, cancel = context.WithCancel(ctx)
@@ -283,7 +283,7 @@ func testMultiSSTWriterInitSSTInner(t *testing.T, interesting bool) {
 	defer eng.Close()
 
 	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
-	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID, nil)
 	desc := roachpb.RangeDescriptor{
 		RangeID:  100,
 		StartKey: roachpb.RKey("d"),
@@ -415,8 +415,8 @@ func TestMultiSSTWriterSize(t *testing.T) {
 	defer eng.Close()
 
 	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
-	ref := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
-	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+	ref := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID, nil)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID, nil)
 	settings := cluster.MakeTestingClusterSettings()
 
 	desc := roachpb.RangeDescriptor{
@@ -533,7 +533,7 @@ func TestMultiSSTWriterAddLastSpan(t *testing.T) {
 	defer eng.Close()
 
 	sstSnapshotStorage := NewSSTSnapshotStorage(eng, testLimiter)
-	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID)
+	scratch := sstSnapshotStorage.NewScratchSpace(testRangeID, testSnapUUID, nil)
 	desc := roachpb.RangeDescriptor{
 		StartKey: roachpb.RKey("d"),
 		EndKey:   roachpb.RKeyMax,

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -584,7 +584,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	}
 
 	st := r.ClusterSettings()
-	prepInput := prepareSnapApplyInput{
+	sb := snapWriteBuilder{
 		id: r.ID(),
 
 		st:       st,
@@ -599,7 +599,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	}
 
 	_ = applySnapshotTODO
-	clearedUnreplicatedSpan, clearedSubsumedSpans, err := prepareSnapApply(ctx, prepInput)
+	clearedUnreplicatedSpan, clearedSubsumedSpans, err := sb.prepareSnapApply(ctx)
 	if err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/replica_raftstorage.go
+++ b/pkg/kv/kvserver/replica_raftstorage.go
@@ -582,11 +582,9 @@ func (r *Replica) applySnapshotRaftMuLocked(
 		subsumedDescs = append(subsumedDescs, sr.Desc())
 	}
 
-	st := r.ClusterSettings()
 	sb := snapWriteBuilder{
 		id: r.ID(),
 
-		st:       st,
 		todoEng:  r.store.TODOEngine(),
 		sl:       r.raftMu.stateLoader,
 		writeSST: inSnap.SSTStorageScratch.WriteSST,
@@ -598,8 +596,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 
 		cleared: inSnap.clearedSpans,
 	}
-
-	_ = applySnapshotTODO
+	_ = applySnapshotTODO // 2.4 is written, the rest is handled below
 	if err := sb.prepareSnapApply(ctx); err != nil {
 		return err
 	}
@@ -620,7 +617,7 @@ func (r *Replica) applySnapshotRaftMuLocked(
 	}
 
 	if len(inSnap.externalSSTs)+len(inSnap.sharedSSTs) == 0 && /* simple */
-		inSnap.SSTSize <= snapshotIngestAsWriteThreshold.Get(&st.SV) /* small */ {
+		inSnap.SSTSize <= snapshotIngestAsWriteThreshold.Get(&r.ClusterSettings().SV) /* small */ {
 		applyAsIngest = false
 	}
 

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -46,7 +46,7 @@ func (s *snapWriteBuilder) prepareSnapApply(ctx context.Context) error {
 		return err
 	}
 	_ = applySnapshotTODO // 3.2 + 2.1 + 2.2 + 2.3
-	return s.clearSubsumedReplicaDiskData(ctx, s.todoEng)
+	return s.clearSubsumedReplicaDiskData(ctx)
 }
 
 // rewriteRaftState clears and rewrites the unreplicated rangeID-local key space
@@ -97,9 +97,10 @@ func (s *snapWriteBuilder) rewriteRaftState(ctx context.Context, w storage.Write
 // (i.e. Reader was instantiated after all raftMu were acquired).
 //
 // NB: does nothing if subsumedDescs is empty.
-func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(
-	ctx context.Context, reader storage.Reader,
-) error {
+func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(ctx context.Context) error {
+	// TODO(sep-raft-log): need different readers for raft and state engine.
+	reader := storage.Reader(s.todoEng)
+
 	// NB: we don't clear RangeID local key spans here. That happens
 	// via the call to DestroyReplica.
 	getKeySpans := func(d *roachpb.RangeDescriptor) []roachpb.Span {

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -15,7 +15,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
@@ -26,10 +25,9 @@ import (
 type snapWriteBuilder struct {
 	id storage.FullReplicaID
 
-	st       *cluster.Settings
 	todoEng  storage.Engine
 	sl       stateloader.StateLoader
-	writeSST func(context.Context, []byte) error
+	writeSST func(context.Context, func(storage.Writer) error) error
 
 	truncState    kvserverpb.RaftTruncatedState
 	hardState     raftpb.HardState
@@ -41,29 +39,10 @@ type snapWriteBuilder struct {
 	cleared []roachpb.Span
 }
 
-func (s *snapWriteBuilder) inSST(ctx context.Context, write func(storage.Writer) error) error {
-	sstFile := &storage.MemObject{}
-	w := storage.MakeIngestionSSTWriter(ctx, s.st, sstFile)
-	defer w.Close()
-	if err := write(&w); err != nil {
-		return err
-	}
-	if err := w.Finish(); err != nil {
-		return err
-	}
-	if w.DataSize > 0 {
-		// TODO(itsbilal): Write to SST directly rather than buffer in a MemObject.
-		return s.writeSST(ctx, sstFile.Data())
-	}
-	return nil
-}
-
 // prepareSnapApply writes the unreplicated SST for the snapshot and clears disk data for subsumed replicas.
 func (s *snapWriteBuilder) prepareSnapApply(ctx context.Context) error {
-	_ = applySnapshotTODO // 2.4 is already written
-
 	_ = applySnapshotTODO // 3.1 + 1.1 + 2.5.
-	if err := s.inSST(ctx, func(w storage.Writer) error {
+	if err := s.writeSST(ctx, func(w storage.Writer) error {
 		// Clear the raft state/log, and initialize it again with the provided
 		// HardState and RaftTruncatedState.
 		return s.rewriteRaftState(ctx, w)
@@ -142,7 +121,7 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(
 	totalKeySpans := append([]roachpb.Span(nil), keySpans...)
 	for _, subDesc := range s.subsumedDescs {
 		// We have to create an SST for the subsumed replica's range-id local keys.
-		if err := s.inSST(ctx, func(w storage.Writer) error {
+		if err := s.writeSST(ctx, func(w storage.Writer) error {
 			// NOTE: We set mustClearRange to true because we are setting
 			// RangeTombstoneKey. Since Clears and Puts need to be done in increasing
 			// order of keys, it is not safe to use ClearRangeIter.
@@ -221,7 +200,7 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(
 		//
 		// We need to additionally clear [b,sn).
 
-		if err := s.inSST(ctx, func(w storage.Writer) error {
+		if err := s.writeSST(ctx, func(w storage.Writer) error {
 			return storage.ClearRangeWithHeuristic(
 				ctx, reader, w,
 				keySpans[i].EndKey, totalKeySpans[i].EndKey,

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -52,6 +52,7 @@ func (s *snapWriteBuilder) inSST(ctx context.Context, write func(storage.Writer)
 		return err
 	}
 	if w.DataSize > 0 {
+		// TODO(itsbilal): Write to SST directly rather than buffer in a MemObject.
 		return s.writeSST(ctx, sstFile.Data())
 	}
 	return nil
@@ -141,36 +142,22 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(
 	totalKeySpans := append([]roachpb.Span(nil), keySpans...)
 	for _, subDesc := range s.subsumedDescs {
 		// We have to create an SST for the subsumed replica's range-id local keys.
-		subsumedReplSSTFile := &storage.MemObject{}
-		subsumedReplSST := storage.MakeIngestionSSTWriter(
-			ctx, s.st, subsumedReplSSTFile,
-		)
-		// NOTE: We set mustClearRange to true because we are setting
-		// RangeTombstoneKey. Since Clears and Puts need to be done in increasing
-		// order of keys, it is not safe to use ClearRangeIter.
-		opts := kvstorage.ClearRangeDataOptions{
-			ClearReplicatedByRangeID:   true,
-			ClearUnreplicatedByRangeID: true,
-			MustUseClearRange:          true,
-		}
-		subsumedClearedSpans := rditer.Select(subDesc.RangeID, rditer.SelectOpts{
-			ReplicatedByRangeID:   opts.ClearReplicatedByRangeID,
-			UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
-		})
-		s.cleared = append(s.cleared, subsumedClearedSpans...)
-		if err := kvstorage.DestroyReplica(ctx, subDesc.RangeID, reader, &subsumedReplSST, mergedTombstoneReplicaID, opts); err != nil {
-			subsumedReplSST.Close()
-			return err
-		}
-		if err := subsumedReplSST.Finish(); err != nil {
-			return err
-		}
-		if subsumedReplSST.DataSize > 0 {
-			// TODO(itsbilal): Write to SST directly in subsumedReplSST rather than
-			// buffering in a MemObject first.
-			if err := s.writeSST(ctx, subsumedReplSSTFile.Data()); err != nil {
-				return err
+		if err := s.inSST(ctx, func(w storage.Writer) error {
+			// NOTE: We set mustClearRange to true because we are setting
+			// RangeTombstoneKey. Since Clears and Puts need to be done in increasing
+			// order of keys, it is not safe to use ClearRangeIter.
+			opts := kvstorage.ClearRangeDataOptions{
+				ClearReplicatedByRangeID:   true,
+				ClearUnreplicatedByRangeID: true,
+				MustUseClearRange:          true,
 			}
+			s.cleared = append(s.cleared, rditer.Select(subDesc.RangeID, rditer.SelectOpts{
+				ReplicatedByRangeID:   opts.ClearReplicatedByRangeID,
+				UnreplicatedByRangeID: opts.ClearUnreplicatedByRangeID,
+			})...)
+			return kvstorage.DestroyReplica(ctx, subDesc.RangeID, reader, w, mergedTombstoneReplicaID, opts)
+		}); err != nil {
+			return err
 		}
 
 		srKeySpans := getKeySpans(subDesc)
@@ -234,33 +221,17 @@ func (s *snapWriteBuilder) clearSubsumedReplicaDiskData(
 		//
 		// We need to additionally clear [b,sn).
 
-		subsumedReplSSTFile := &storage.MemObject{}
-		subsumedReplSST := storage.MakeIngestionSSTWriter(
-			ctx, s.st, subsumedReplSSTFile,
-		)
-		if err := storage.ClearRangeWithHeuristic(
-			ctx,
-			reader,
-			&subsumedReplSST,
-			keySpans[i].EndKey,
-			totalKeySpans[i].EndKey,
-			kvstorage.ClearRangeThresholdPointKeys,
-		); err != nil {
-			subsumedReplSST.Close()
+		if err := s.inSST(ctx, func(w storage.Writer) error {
+			return storage.ClearRangeWithHeuristic(
+				ctx, reader, w,
+				keySpans[i].EndKey, totalKeySpans[i].EndKey,
+				kvstorage.ClearRangeThresholdPointKeys,
+			)
+		}); err != nil {
 			return err
 		}
 		s.cleared = append(s.cleared,
 			roachpb.Span{Key: keySpans[i].EndKey, EndKey: totalKeySpans[i].EndKey})
-		if err := subsumedReplSST.Finish(); err != nil {
-			return err
-		}
-		if subsumedReplSST.DataSize > 0 {
-			// TODO(itsbilal): Write to SST directly in subsumedReplSST rather than
-			// buffering in a MemObject first.
-			if err := s.writeSST(ctx, subsumedReplSSTFile.Data()); err != nil {
-				return err
-			}
-		}
 	}
 	return nil
 }

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -68,7 +68,7 @@ func TestPrepareSnapApply(t *testing.T) {
 		require.NoError(t, stateloader.Make(rID).SetRaftReplicaID(ctx, eng, id.ReplicaID))
 	}
 
-	in := prepareSnapApplyInput{
+	swb := snapWriteBuilder{
 		id:       id,
 		st:       cluster.MakeTestingClusterSettings(),
 		todoEng:  eng,
@@ -81,17 +81,17 @@ func TestPrepareSnapApply(t *testing.T) {
 		subsumedDescs: []*roachpb.RangeDescriptor{descA, descB},
 	}
 
-	clearedUnreplicatedSpan, clearedSubsumedSpans, err := prepareSnapApply(ctx, in)
+	clearedUnreplicatedSpan, clearedSubsumedSpans, err := swb.prepareSnapApply(ctx)
 	require.NoError(t, err)
 
 	sb.Printf(">> unrepl: %v\n", clearedUnreplicatedSpan)
-	for _, span := range rditer.MakeReplicatedKeySpans(in.desc) {
+	for _, span := range rditer.MakeReplicatedKeySpans(swb.desc) {
 		sb.Printf(">> repl: %v\n", span)
 	}
 	for _, span := range clearedSubsumedSpans {
 		sb.Printf(">> subsumed: %v\n", span)
 	}
-	sb.Printf(">> excise: %v\n", in.desc.KeySpan().AsRawSpanWithNoLocals())
+	sb.Printf(">> excise: %v\n", swb.desc.KeySpan().AsRawSpanWithNoLocals())
 
 	echotest.Require(t, sb.String(), filepath.Join("testdata", t.Name()+".txt"))
 }

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -7,20 +7,20 @@ package kvserver
 
 import (
 	"context"
+	"fmt"
 	"path/filepath"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/print"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/rditer"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
-	"github.com/cockroachdb/cockroach/pkg/testutils/storageutils"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -37,11 +37,28 @@ func TestPrepareSnapApply(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	storage.DisableMetamorphicSimpleValueEncoding(t) // for deterministic output
+	eng := storage.NewDefaultInMemForTesting()
+	defer eng.Close()
+
 	var sb redact.StringBuilder
-	writeSST := func(_ context.Context, data []byte) error {
-		// TODO(pav-kv): range deletions are printed separately from point keys, and
-		// this out-of-order output looks confusing. Improve it.
-		return storageutils.ReportSSTEntries(&sb, "sst", data)
+
+	writeSST := func(ctx context.Context, write func(storage.Writer) error) error {
+		// Use WriteBatch so that we print the writes in exactly the order in which
+		// they are made. The real code creates an SST writer.
+		b := eng.NewWriteBatch()
+		defer b.Close()
+		if err := write(b); err != nil {
+			return err
+		}
+		str, err := print.DecodeWriteBatch(b.Repr())
+		if err != nil {
+			return err
+		} else if str == "" {
+			return nil
+		}
+		_, err = sb.WriteString(fmt.Sprintf(">> sst:\n%s", str))
+		return err
 	}
 
 	desc := func(id roachpb.RangeID, start, end string) *roachpb.RangeDescriptor {
@@ -53,9 +70,6 @@ func TestPrepareSnapApply(t *testing.T) {
 	}
 
 	id := storage.FullReplicaID{RangeID: 123, ReplicaID: 4}
-	eng := storage.NewDefaultInMemForTesting()
-	defer eng.Close()
-
 	descA := desc(101, "a", "b")
 	descB := desc(102, "b", "z")
 	createRangeData(t, eng, *descA)
@@ -70,7 +84,6 @@ func TestPrepareSnapApply(t *testing.T) {
 
 	swb := snapWriteBuilder{
 		id:       id,
-		st:       cluster.MakeTestingClusterSettings(),
 		todoEng:  eng,
 		sl:       sl,
 		writeSST: writeSST,

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -81,15 +81,14 @@ func TestPrepareSnapApply(t *testing.T) {
 		subsumedDescs: []*roachpb.RangeDescriptor{descA, descB},
 	}
 
-	clearedUnreplicatedSpan, clearedSubsumedSpans, err := swb.prepareSnapApply(ctx)
+	err := swb.prepareSnapApply(ctx)
 	require.NoError(t, err)
 
-	sb.Printf(">> unrepl: %v\n", clearedUnreplicatedSpan)
 	for _, span := range rditer.MakeReplicatedKeySpans(swb.desc) {
 		sb.Printf(">> repl: %v\n", span)
 	}
-	for _, span := range clearedSubsumedSpans {
-		sb.Printf(">> subsumed: %v\n", span)
+	for _, span := range swb.cleared {
+		sb.Printf(">> cleared: %v\n", span)
 	}
 	sb.Printf(">> excise: %v\n", swb.desc.KeySpan().AsRawSpanWithNoLocals())
 

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -43,12 +43,12 @@ func TestPrepareSnapApply(t *testing.T) {
 
 	var sb redact.StringBuilder
 
-	writeSST := func(ctx context.Context, write func(storage.Writer) error) error {
+	writeSST := func(ctx context.Context, write func(context.Context, storage.Writer) error) error {
 		// Use WriteBatch so that we print the writes in exactly the order in which
 		// they are made. The real code creates an SST writer.
 		b := eng.NewWriteBatch()
 		defer b.Close()
-		if err := write(b); err != nil {
+		if err := write(ctx, b); err != nil {
 			return err
 		}
 		str, err := print.DecodeWriteBatch(b.Repr())

--- a/pkg/kv/kvserver/store_snapshot.go
+++ b/pkg/kv/kvserver/store_snapshot.go
@@ -552,7 +552,7 @@ func (s *Store) receiveSnapshot(
 	}
 
 	ss := &kvBatchSnapshotStrategy{
-		scratch:      s.sstSnapshotStorage.NewScratchSpace(header.State.Desc.RangeID, snapUUID),
+		scratch:      s.sstSnapshotStorage.NewScratchSpace(header.State.Desc.RangeID, snapUUID, s.ClusterSettings()),
 		sstChunkSize: snapshotSSTWriteSyncRate.Get(&s.cfg.Settings.SV),
 		st:           s.ClusterSettings(),
 		clusterID:    s.ClusterID(),

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -1,20 +1,20 @@
 echo
 ----
 >> sst:
-set: /Local/RangeID/123/u/RaftHardState/0,0 -> term:20 vote:0 commit:100 lead:0 lead_epoch:0 
-set: /Local/RangeID/123/u/RaftReplicaID/0,0 -> replica_id:4 
-set: /Local/RangeID/123/u/RaftTruncatedState/0,0 -> index:100 term:20 
-rangedel: /Local/RangeID/123/{u""-v""}
+Delete Range: [0,0 /Local/RangeID/123/u"" (0x0169f67b7500): , 0,0 /Local/RangeID/123/v"" (0x0169f67b7600): )
+Put: 0,0 /Local/RangeID/123/u/RaftHardState (0x0169f67b757266746800): term:20 vote:0 commit:100 lead:0 lead_epoch:0 
+Put: 0,0 /Local/RangeID/123/u/RaftReplicaID (0x0169f67b757266747200): replica_id:4 
+Put: 0,0 /Local/RangeID/123/u/RaftTruncatedState (0x0169f67b757266747400): index:100 term:20 
 >> sst:
-set: /Local/RangeID/101/u/RangeTombstone/0,0 -> next_replica_id:2147483647 
-rangedel: /Local/RangeID/101/{u/RaftReplicaID-v""}
+Delete Range: [0,0 /Local/RangeID/101/u/RaftReplicaID (0x0169ed757266747200): , 0,0 /Local/RangeID/101/v"" (0x0169ed7600): )
+Put: 0,0 /Local/RangeID/101/u/RangeTombstone (0x0169ed757266746200): next_replica_id:2147483647 
 >> sst:
-set: /Local/RangeID/102/u/RangeTombstone/0,0 -> next_replica_id:2147483647 
-rangedel: /Local/RangeID/102/{u/RaftReplicaID-v""}
+Delete Range: [0,0 /Local/RangeID/102/u/RaftReplicaID (0x0169ee757266747200): , 0,0 /Local/RangeID/102/v"" (0x0169ee7600): )
+Put: 0,0 /Local/RangeID/102/u/RangeTombstone (0x0169ee757266746200): next_replica_id:2147483647 
 >> sst:
-del: /Local/Lock"y\xff"/0300000000000000000000000000000000 -> /<empty>
+Delete (Sized at 27): /Local/Lock"y\xff" 0300000000000000000000000000000000 (0x017a6b1279ff000100030000000000000000000000000000000012): 
 >> sst:
-del: "y\xff"/0.000000001,0 -> /<empty>
+Delete (Sized at 12): 0.000000001,0 "y\xff" (0x79ff00000000000000000109): 
 >> repl: /Local/RangeID/123/{r""-s""}
 >> repl: /Local/Range"{a"-k"}
 >> repl: /Local/Lock/Local/Range"{a"-k"}

--- a/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
+++ b/pkg/kv/kvserver/testdata/TestPrepareSnapApply.txt
@@ -15,18 +15,18 @@ rangedel: /Local/RangeID/102/{u/RaftReplicaID-v""}
 del: /Local/Lock"y\xff"/0300000000000000000000000000000000 -> /<empty>
 >> sst:
 del: "y\xff"/0.000000001,0 -> /<empty>
->> unrepl: /Local/RangeID/123/{u""-v""}
 >> repl: /Local/RangeID/123/{r""-s""}
 >> repl: /Local/Range"{a"-k"}
 >> repl: /Local/Lock/Local/Range"{a"-k"}
 >> repl: /Local/Lock"{a"-k"}
 >> repl: {a-k}
->> subsumed: /Local/RangeID/101/{r""-s""}
->> subsumed: /Local/RangeID/101/{u""-v""}
->> subsumed: /Local/RangeID/102/{r""-s""}
->> subsumed: /Local/RangeID/102/{u""-v""}
->> subsumed: /Local/Range"{k"-z"}
->> subsumed: /Local/Lock/Local/Range"{k"-z"}
->> subsumed: /Local/Lock"{k"-z"}
->> subsumed: {k-z}
+>> cleared: /Local/RangeID/123/{u""-v""}
+>> cleared: /Local/RangeID/101/{r""-s""}
+>> cleared: /Local/RangeID/101/{u""-v""}
+>> cleared: /Local/RangeID/102/{r""-s""}
+>> cleared: /Local/RangeID/102/{u""-v""}
+>> cleared: /Local/Range"{k"-z"}
+>> cleared: /Local/Lock/Local/Range"{k"-z"}
+>> cleared: /Local/Lock"{k"-z"}
+>> cleared: {k-z}
 >> excise: {a-k}


### PR DESCRIPTION
This PR introduces a builder type which prepares a set of writes when applying a snapshot. This removes extensive lists of parameters dragged across function calls, and wraps repetitive SST creation code into a helper method.

It also fixes a TODO in `TestPrepareSnapApply`: all the writes are now printed in the original order, thanks to the `storage.Writer` abstraction instead of direct SST generation code.

The new `storage.Writer`-based interface is more flexible, and e.g. allows eliminating the `ConvertFilesToBatchAndCommit` [quirk](https://github.com/cockroachdb/cockroach/blob/255f60e14a03060b9b2ca81e38f7188c33173a7a/pkg/kv/kvserver/replica_raftstorage.go#L640) as well as the "cleared spans" tracking. We can know when the snapshot is ["simple/small"](https://github.com/cockroachdb/cockroach/blob/255f60e14a03060b9b2ca81e38f7188c33173a7a/pkg/kv/kvserver/replica_raftstorage.go#L624-L627) before `MultiSSTWriter` starts writing files (e.g. from the handshake), so we can generate a batch directly and skip the files writing phase; this batch can then be extended with `prepareSnapApply` data and committed. This would make small snapshot ingestions faster.

Epic: CRDB-49111