### PR TITLE
sql: include txn retry info into SHOW QUERIES

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
+++ b/pkg/ccl/logictestccl/testdata/logic_test/crdb_internal_tenant
@@ -142,15 +142,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTBTTT colnames
+query TTITTTTTTBTBTTTII colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level  num_txn_retries  num_txn_auto_retries
 
-query TTITTTTTTBTBTTT colnames
+query TTITTTTTTBTBTTTII colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level  num_txn_retries  num_txn_auto_retries
 
 query TITTTTIIITTTT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0

--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -198,6 +198,8 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 			"phase",
 			"full_scan",
 			"crdb_internal.hide_sql_constants(query) as query",
+			"num_txn_retries",
+			"num_txn_auto_retries",
 		},
 	},
 	"crdb_internal.cluster_sessions": {
@@ -921,6 +923,8 @@ var zipInternalTablesPerNode = DebugZipTableRegistry{
 			"phase",
 			"full_scan",
 			"crdb_internal.hide_sql_constants(query) as query",
+			"num_txn_retries",
+			"num_txn_auto_retries",
 		},
 	},
 	"crdb_internal.node_runtime_info": {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -2226,21 +2226,23 @@ func populateTransactionsTable(
 
 const queriesSchemaPattern = `
 CREATE TABLE crdb_internal.%s (
-  query_id         STRING,         -- the cluster-unique ID of the query
-  txn_id           UUID,           -- the unique ID of the query's transaction
-  node_id          INT NOT NULL,   -- the node on which the query is running
-  session_id       STRING,         -- the ID of the session
-  user_name        STRING,         -- the user running the query
-  start            TIMESTAMPTZ,    -- the start time of the query
-  query            STRING,         -- the SQL code of the query
-  client_address   STRING,         -- the address of the client that issued the query
-  application_name STRING,         -- the name of the application as per SET application_name
-  distributed      BOOL,           -- whether the query is running distributed
-  phase            STRING,         -- the current execution phase
-  full_scan        BOOL,           -- whether the query contains a full table or index scan
-  plan_gist        STRING,         -- Compressed logical plan.
-  database         STRING,         -- the database the statement was executed on
-  isolation_level  STRING          -- the isolation level of the query's transaction
+  query_id             STRING,         -- the cluster-unique ID of the query
+  txn_id               UUID,           -- the unique ID of the query's transaction
+  node_id              INT NOT NULL,   -- the node on which the query is running
+  session_id           STRING,         -- the ID of the session
+  user_name            STRING,         -- the user running the query
+  start                TIMESTAMPTZ,    -- the start time of the query
+  query                STRING,         -- the SQL code of the query
+  client_address       STRING,         -- the address of the client that issued the query
+  application_name     STRING,         -- the name of the application as per SET application_name
+  distributed          BOOL,           -- whether the query is running distributed
+  phase                STRING,         -- the current execution phase
+  full_scan            BOOL,           -- whether the query contains a full table or index scan
+  plan_gist            STRING,         -- Compressed logical plan.
+  database             STRING,         -- the database the statement was executed on
+  isolation_level      STRING,         -- the isolation level of the query's transaction
+  num_txn_retries      INT,            -- number of txn retries
+  num_txn_auto_retries INT             -- number of auto retries via SQL conn executor
 )`
 
 func (p *planner) makeSessionsRequest(
@@ -2358,6 +2360,11 @@ func populateQueriesTable(
 			continue
 		}
 		sessionID := getSessionID(session)
+		numTxnRetries, numTxnAutoRetries := tree.DNull, tree.DNull
+		if txn := session.ActiveTxn; txn != nil {
+			numTxnRetries = tree.NewDInt(tree.DInt(txn.NumRetries))
+			numTxnAutoRetries = tree.NewDInt(tree.DInt(txn.NumAutoRetries))
+		}
 		for _, query := range session.ActiveQueries {
 			isDistributedDatum := tree.DNull
 			isFullScanDatum := tree.DNull
@@ -2376,16 +2383,6 @@ func populateQueriesTable(
 
 			if query.Progress > 0 {
 				phase = fmt.Sprintf("%s (%.2f%%)", phase, query.Progress*100)
-			}
-
-			var txnID tree.Datum
-			// query.TxnID and query.TxnStart were only added in 20.1. In case this
-			// is a mixed cluster setting, report NULL if these values were not filled
-			// out by the remote session.
-			if query.ID == "" {
-				txnID = tree.DNull
-			} else {
-				txnID = tree.NewDUuid(tree.DUuid{UUID: query.TxnID})
 			}
 
 			ts, err := tree.MakeDTimestampTZ(query.Start, time.Microsecond)
@@ -2414,7 +2411,7 @@ func populateQueriesTable(
 
 			if err := addRow(
 				tree.NewDString(query.ID),
-				txnID,
+				tree.NewDUuid(tree.DUuid{UUID: query.TxnID}),
 				tree.NewDInt(tree.DInt(session.NodeID)),
 				sessionID,
 				tree.NewDString(session.Username),
@@ -2428,6 +2425,8 @@ func populateQueriesTable(
 				planGistDatum,
 				tree.NewDString(query.Database),
 				isolationLevelDatum,
+				numTxnRetries,
+				numTxnAutoRetries,
 			); err != nil {
 				return err
 			}
@@ -2455,6 +2454,8 @@ func populateQueriesTable(
 				tree.DNull,                             // plan_gist
 				tree.DNull,                             // database
 				tree.DNull,                             // isolation_level
+				tree.DNull,                             // num_txn_retries
+				tree.DNull,                             // num_txn_auto_retries
 			); err != nil {
 				return err
 			}

--- a/pkg/sql/delegate/show_queries.go
+++ b/pkg/sql/delegate/show_queries.go
@@ -26,7 +26,9 @@ SELECT
   distributed,
   full_scan,
   phase,
-  isolation_level
+  isolation_level,
+  num_txn_retries,
+  num_txn_auto_retries
 FROM crdb_internal.`
 	table := `node_queries`
 	if n.Cluster {

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -276,15 +276,15 @@ SELECT * FROM crdb_internal.session_variables WHERE variable = ''
 ----
 variable  value  hidden
 
-query TTITTTTTTBTBTTT colnames
+query TTITTTTTTBTBTTTII colnames
 SELECT * FROM crdb_internal.node_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level  num_txn_retries  num_txn_auto_retries
 
-query TTITTTTTTBTBTTT colnames
+query TTITTTTTTBTBTTTII colnames
 SELECT * FROM crdb_internal.cluster_queries WHERE node_id < 0
 ----
-query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level
+query_id  txn_id  node_id  session_id  user_name  start  query  client_address  application_name  distributed  phase  full_scan  plan_gist  database  isolation_level  num_txn_retries  num_txn_auto_retries
 
 query TITTTTIIITTTT colnames
 SELECT  * FROM crdb_internal.node_transactions WHERE node_id < 0


### PR DESCRIPTION
This commit attempts to make txn retry information more visible. We already expose the number of times the txn is retried via `num_retries` and `num_auto_retries` columns of `{cluster,node}_transactions` virtual tables. However, at least for me personally, SHOW QUERIES is often the first entry point to understand what's happening on the cluster right now, and I don't always remember that there might retries going on when a given query has been running for a long time. To make that jump quicker we now include `num_txn_retries` and `num_txn_auto_retries` into the output of SHOW QUERIES (as well as the virtual table that it's powered by).

Note that this might be a source of confusion in multi-stmt transactions because for each active query we'll print the number of txn retries regardless of which stmt encountered the retry. Still, it seems better than having to remember to join against the transactions virtual table on the session ID, plus we avoid possible fanout since we already have the necessary information in protos when populating the active queries.

Also note that I believe we don't need to do anything special for the mixed version state since the virtual table scans prohibits the query distribution, meaning that if new columns are requested for SHOW QUERIES, then we're on a new binary and it knows how to populate them (even if the proto response came from the older node).

Fixes: #148842.

Release note (sql change): New columns `num_txn_retries` and `num_txn_auto_retries` are included into
`crdb_internal.{cluster,node}_queries` virtual tables as well as output of SHOW QUERIES. These columns, when not NULL, have the same information as `num_retries` and `num_auto_retries` columns of `crdb_internal.{cluster,node}_transactions` virtual tables for the same transaction in which the active query is executed.