### PR TITLE
logictest: deflake partial_stats

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1390,7 +1390,12 @@ INSERT INTO ka VALUES (10, 10)
 statement ok
 CREATE STATISTICS ka_partialstat ON a FROM ka USING EXTREMES
 
-query T retry
+# Now clear the stats cache so that the query below is guaranteed to pick up the
+# new stats (partial and merged).
+statement ok
+SELECT crdb_internal.clear_table_stats_cache();
+
+query T
 EXPLAIN SELECT * FROM ka WHERE a > 5
 ----
 distribution: local


### PR DESCRIPTION
Whenever we collect a new statistic, in order to guarantee that it'll be observed by the optimizer on the following query, we must clear the stats cache after having collected that stat. This `Clear` call was missing after having collected the partial stat (which also results in generating the merged stat). It was incompletely fixed in 5707cf173b205e95f0a77ad15284c60f488977a2 by adding a retry to the EXPLAIN and resulted in a rare case where the merged stat is not observed by a later query. (I'm not quite sure why `retry` on an earlier statement is insufficient to guarantee that the merged stat is observed by a later statement, given that no more new stats are created. I did see the flake go away with this patch.) This commit clears the stats cache addressing the flake. (Also it looks like this flake was exposed via cabf4826c4fb2067d6e26581ce679c1ef4465cf2.)

Having a `retry` on the EXPLAIN query is an alternative way of fixing the flake. Some more context can be found at 5707cf173b205e95f0a77ad15284c60f488977a2.

Fixes: #149309.

Release note: None