### PR TITLE
cli: "no such host" error when starting CRDB on Mac

### DIFF
--- a/pkg/base/BUILD.bazel
+++ b/pkg/base/BUILD.bazel
@@ -30,6 +30,8 @@ go_library(
         "//pkg/util",
         "//pkg/util/envutil",
         "//pkg/util/humanizeutil",
+        "//pkg/util/log",
+        "//pkg/util/log/severity",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/netutil/addr",

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1169,7 +1169,7 @@ func (c *SyncedCluster) generateStartArgs(
 	}
 
 	listenHost := ""
-	if c.IsLocal() && runtime.GOOS == "darwin " {
+	if c.IsLocal() && runtime.GOOS == "darwin" {
 		// This avoids annoying firewall prompts on Mac OS X.
 		listenHost = "127.0.0.1"
 	}
@@ -1201,17 +1201,20 @@ func (c *SyncedCluster) generateStartArgs(
 	}
 	args = append(args, fmt.Sprintf("--http-addr=%s:%d", listenHost, desc.Port))
 
+	advertiseHost := ""
 	if !c.IsLocal() {
-		advertiseHost := ""
 		if c.shouldAdvertisePublicIP() {
 			advertiseHost = c.Host(node)
 		} else {
 			advertiseHost = c.VMs[node-1].PrivateIP
 		}
-		args = append(args,
-			fmt.Sprintf("--advertise-addr=%s:%d", advertiseHost, sqlPort),
-		)
+	} else {
+		// N.B. in local mode, fallback to listenHost; per above, it defaults to 127.0.0.1 on macOS.
+		advertiseHost = listenHost
 	}
+	args = append(args,
+		fmt.Sprintf("--advertise-addr=%s:%d", advertiseHost, sqlPort),
+	)
 
 	// --join flags are unsupported/unnecessary in `cockroach start-single-node`.
 	if startOpts.Target == StartDefault && !c.useStartSingleNode() {


### PR DESCRIPTION
When CockroachDB is started without `--advertise-addr`, it fallbacks to `--listen-addr`. If the latter is also unspecified, it defaults to the `hostname`.

Subsequently, `validateAdvertiseAddr` attempts to
resolve the hostname. If the resolution fails, the server aborts the startup sequence. This is a safe default because node discovery is compromised without a functioning DNS.

On Mac, `hostname` is resolved via mDNS / Bonjour. Unless it's suffixed with `.local`, it doesn't resolve. An obvious workaround is to add it to /etc/hosts, or to change it via `sudo hostname $USER.local`.

To make the (DEV) experience on Mac more seamless, this PR replaces DNS resolution error with a warning. Since we can't unambiguously determine if the user is running in DEV-mode, we assume that `--insecure` on Mac implies exactly that.

We also update `roachprod` to explicitly use `--advertised-addr` with `127.0.0.1`. This also fixes `roachtest` in local mode.

Fixes: #66426
Fixes: #149469
Release note: None