### PR TITLE
build: add crdb_bench flag

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,6 +22,7 @@ startup --host_jvm_args=-DBAZEL_TRACK_SOURCE_DIRECTORIES=1
 build --flag_alias=bazel_code_coverage=//build/toolchains:bazel_code_coverage_flag
 build --flag_alias=crdb_test=//build/toolchains:crdb_test_flag
 build --flag_alias=crdb_test_off=//build/toolchains:crdb_test_off_flag
+build --flag_alias=crdb_bench=//build/toolchains:crdb_bench_flag
 build --flag_alias=cross=//build/toolchains:cross_flag
 build --flag_alias=dev=//build/toolchains:dev_flag
 build --flag_alias=force_build_cdeps=//build/toolchains:force_build_cdeps_flag

--- a/build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh
+++ b/build/teamcity/cockroach/nightlies/microbenchmark_build_support.sh
@@ -24,7 +24,13 @@ function build_and_upload_binaries() {
     return
   fi
 
-  config_args="--config=crosslinux --crdb_test_off"
+  # Check if crdb_bench flag is supported, since we could be building an older
+  # version that does not support it.
+  if grep -q "crdb_bench" .bazelrc; then
+    config_args="--config=crosslinux --crdb_test_off --crdb_bench"
+  else
+    config_args="--config=crosslinux --crdb_test_off"
+  fi
   bazel clean
   go_test_targets=$(bazel query kind\(go_test, //$BENCH_PACKAGE:all\))
   bazel build $config_args $go_test_targets

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -300,6 +300,19 @@ config_setting(
 )
 
 bool_flag(
+    name = "crdb_bench_flag",
+    build_setting_default = False,
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "crdb_bench",
+    flag_values = {
+        ":crdb_bench_flag": "true",
+    },
+)
+
+bool_flag(
     name = "dev_flag",
     build_setting_default = False,
     visibility = ["//visibility:public"],

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=111
+DEV_VERSION=112
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/bench.go
+++ b/pkg/cmd/dev/bench.go
@@ -140,7 +140,10 @@ func (d *dev) bench(cmd *cobra.Command, commandLine []string) error {
 	if runSepProcessTenant {
 		args = append(args, "--test_arg", "-run-sep-process-tenant")
 	}
-	args = append(args, "--crdb_test_off")
+	// The `crdb_test` flag enables metamorphic variables and various "extra" debug
+	// checking code paths that can interfere with performance testing, hence
+	// it should disabled for benchmarks.
+	args = append(args, "--crdb_test_off", "--crdb_bench")
 	if testArgs != "" {
 		goTestArgs, err := d.getGoTestArgs(ctx, testArgs)
 		if err != nil {

--- a/pkg/cmd/dev/testdata/datadriven/bench
+++ b/pkg/cmd/dev/testdata/datadriven/bench
@@ -2,35 +2,35 @@ exec
 dev bench pkg/spanconfig/...
 ----
 echo $HOME/.cache
-bazel test pkg/spanconfig/...:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=. --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/spanconfig/...:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=. --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --crdb_bench --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/sql/parser --filter=BenchmarkParse
 ----
 echo $HOME/.cache
-bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --crdb_bench --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/sql/parser --filter=BenchmarkParse --stream-output=false
 ----
 echo $HOME/.cache
-bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output errors
+bazel test pkg/sql/parser:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkParse --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --crdb_bench --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output errors
 
 exec
 dev bench pkg/bench -f=BenchmarkTracing/1node/scan/trace=off --count=2 --bench-time=10x --bench-mem=false
 ----
 echo $HOME/.cache
-bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.count=2 --test_arg -test.benchtime=10x --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.count=2 --test_arg -test.benchtime=10x --crdb_test_off --crdb_bench --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/spanconfig/spanconfigkvsubscriber -f=BenchmarkSpanConfigDecoder --cpus=10 --ignore-cache=false -v --timeout=50s
 ----
 echo $HOME/.cache
-bazel test --local_cpu_resources=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.v --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test --local_cpu_resources=10 --test_timeout=50 pkg/spanconfig/spanconfigkvsubscriber:all --test_arg -test.run=- --test_arg -test.bench=BenchmarkSpanConfigDecoder --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.v --test_arg -test.benchmem --crdb_test_off --crdb_bench --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
 
 exec
 dev bench pkg/bench -f='BenchmarkTracing/1node/scan/trace=off' --test-args '-test.memprofile=mem.out -test.cpuprofile=cpu.out'
 ----
 bazel info workspace --color=no
 echo $HOME/.cache
-bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_arg -test.cpuprofile=cpu.out --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed
+bazel test pkg/bench:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkTracing/1node/scan/trace=off --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --crdb_bench --test_arg -test.outputdir=crdb-checkout --sandbox_writable_path=crdb-checkout --test_arg -test.memprofile=mem.out --test_arg -test.cpuprofile=cpu.out --test_env COCKROACH_TEST_FIXTURES_DIR=crdb-mock-test-fixtures/crdb-test-fixtures --sandbox_writable_path=crdb-mock-test-fixtures/crdb-test-fixtures --test_output streamed

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -769,7 +769,7 @@ var createTableWithSchemaLockedDefault = true
 // TestForceDisableCreateTableWithSchemaLocked disables schema_locked create table
 // in entire packages.
 func TestForceDisableCreateTableWithSchemaLocked() {
-	if !buildutil.CrdbTestBuild {
+	if !buildutil.CrdbTestBuild && !buildutil.CrdbBenchBuild {
 		panic("Testing override for schema_locked used in non-test binary.")
 	}
 	createTableWithSchemaLockedDefault = false

--- a/pkg/util/buildutil/BUILD.bazel
+++ b/pkg/util/buildutil/BUILD.bazel
@@ -1,5 +1,7 @@
 load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
+# gazelle:exclude gen-crdb_bench_off.go
+# gazelle:exclude gen-crdb_bench_on.go
 # gazelle:exclude gen-crdb_test_off.go
 # gazelle:exclude gen-crdb_test_on.go
 
@@ -9,12 +11,29 @@ go_library(
     srcs = select({
         "//build/toolchains:crdb_test": [":gen-crdb-test-on"],
         "//conditions:default": [":gen-crdb-test-off"],
+    }) + select({
+        "//build/toolchains:crdb_bench": [":gen-crdb-bench-on"],
+        "//conditions:default": [":gen-crdb-bench-off"],
     }),
     importpath = "github.com/cockroachdb/cockroach/pkg/util/buildutil",
     visibility = ["//visibility:public"],
 )
 
 REMOVE_GO_BUILD_CONSTRAINTS = "cat $< | grep -v '//go:build' | grep -v '// +build' > $@"
+
+genrule(
+    name = "gen-crdb-bench-on",
+    srcs = ["crdb_bench_on.go"],
+    outs = ["gen-crdb_bench_on.go"],
+    cmd = REMOVE_GO_BUILD_CONSTRAINTS,
+)
+
+genrule(
+    name = "gen-crdb-bench-off",
+    srcs = ["crdb_bench_off.go"],
+    outs = ["gen-crdb_bench_off.go"],
+    cmd = REMOVE_GO_BUILD_CONSTRAINTS,
+)
 
 genrule(
     name = "gen-crdb-test-on",

--- a/pkg/util/buildutil/crdb_bench_off.go
+++ b/pkg/util/buildutil/crdb_bench_off.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build !crdb_bench || crdb_bench_off
+
+// Package buildutil provides a constant CrdbBenchBuild.
+package buildutil
+
+// CrdbBenchBuild is a flag that is set to true if the binary was compiled
+// with the 'crdb_bench' build tag (which is the case for all benchmark targets).
+const CrdbBenchBuild = false

--- a/pkg/util/buildutil/crdb_bench_on.go
+++ b/pkg/util/buildutil/crdb_bench_on.go
@@ -1,0 +1,13 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build crdb_bench && !crdb_bench_off
+
+// Package buildutil provides a constant CrdbBenchBuild.
+package buildutil
+
+// CrdbBenchBuild is a flag that is set to true if the binary was compiled
+// with the 'crdb_bench' build tag (which is the case for all benchmark targets).
+const CrdbBenchBuild = true


### PR DESCRIPTION
A recent change (#148576) causes some test initializations to throw a panic if
the binary was not built with `crdb_test`.

```
./dev bench pkg/sql/catalog/lease -f=BenchmarkAcquireLeaseConcurrent
$ bazel test pkg/sql/catalog/lease:all --nocache_test_results --test_arg -test.run=- --test_arg -test.bench=BenchmarkAcquireLeaseConcurrent --test_sharding_strategy=disabled --test_arg -test.cpu --test_arg 1 --test_arg -test.benchmem --crdb_test_off --test_env COCKROACH_TEST_FIXTURES_DIR=/Users/herko/Library/Caches/crdb-test-fixtures --sandbox_writable_path=/Users/herko/Library/Caches/crdb-test-fixtures --test_output streamed

panic: Testing override for schema_locked used in non-test binary.

goroutine 1 [running]:
github.com/cockroachdb/cockroach/pkg/sql.TestForceDisableCreateTableWithSchemaLocked(...)
	pkg/sql/exec_util.go:773
github.com/cockroachdb/cockroach/pkg/sql/catalog/lease_test.TestMain(0x1400132e620?)
	pkg/sql/catalog/lease/main_test.go:29 +0xcc
main.main()
```

This is problematic for benchmarks, which are not built with `crdb_test`.
Benchmarks are not built with the `crdb_test` flag, because this flag enables
metamorphic variables and extra assertions which could interfere with
performance testing.

This change adds a new `crdb_bench` flag, which is disabled by default. The
assertions added in #148576 are now also skipped when `crdb_bench` is enabled.

Informs: #148576
Fixes: #149339

Epic: None
Release note: None