### PR TITLE
release-25.3: workflows: run update_releases on release-25.3

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -32,6 +32,7 @@ jobs:
           - "release-24.3"
           - "release-25.1"
           - "release-25.2"
+          - "release-25.3"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}
     runs-on: ubuntu-latest
     steps:


### PR DESCRIPTION
Backport 1/1 commits from #148796 on behalf of @rail.

----

Release note: none
Epic: none

----

Release justification: