### PR TITLE
roachtest: increase backupRestoreRoundTrip split_queue verbosity

### DIFF
--- a/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
+++ b/pkg/cmd/roachtest/tests/backup_restore_roundtrip.go
@@ -130,7 +130,9 @@ func backupRestoreRoundTrip(
 		"COCKROACH_MIN_RANGE_MAX_BYTES=1",
 	})
 
-	c.Start(ctx, t.L(), roachtestutil.MaybeUseMemoryBudget(t, 50), install.MakeClusterSettings(envOption), c.CRDBNodes())
+	startOpts := roachtestutil.MaybeUseMemoryBudget(t, 50)
+	startOpts.RoachprodOpts.ExtraArgs = []string{"--vmodule=split_queue=3"}
+	c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(envOption), c.CRDBNodes())
 	m := c.NewDeprecatedMonitor(ctx, c.CRDBNodes())
 
 	m.Go(func(ctx context.Context) error {


### PR DESCRIPTION
We have seen cases where splits seems to be slow. Especially when running with very small ranges. Thic commit increases the verbosity of the split_queue hoping to find out what is happening when the splits are being slow.

Fixes: #148638

Release Note: None