### PR TITLE
roachtest: deflake splits/load/ycsb/e

### DIFF
--- a/pkg/cmd/roachtest/tests/split.go
+++ b/pkg/cmd/roachtest/tests/split.go
@@ -409,7 +409,7 @@ func registerLoadSplits(r registry.Registry) {
 				// YCSB/E has a zipfian distribution with 95% scans (limit 1k) and 5%
 				// inserts.
 				minimumRanges:     5,
-				maximumRanges:     30,
+				maximumRanges:     32,
 				initialRangeCount: 2,
 				load: ycsbSplitLoad{
 					workload:     "e",


### PR DESCRIPTION
This test has a long history of flakes. The main reason is that at the first couple of minutes of the test, there many splits could happen because of the init phase of the workload increases the CPU and it has many inserts. However, for the remainder of the test, the workload is mostly scans, and that shouldn't cause many splits.

This commit increases the maximumRanges allowed by 2. We ~recently increased it to
 the current number and saw almost now flakes, so increasing it by 2 should hopefully
 be enough.

In the future, if we see many flakes of this nature. I think we should ignore the splits that happen in the first 2 minutes of the test, and focus on the fact that the splits in the remainder of the test are minimal.

Fixes: #149516

Release Note: None