### PR TITLE
cli: improve debug.zip transaction_contention_events query

### DIFF
--- a/pkg/cli/zip_table_registry.go
+++ b/pkg/cli/zip_table_registry.go
@@ -559,26 +559,43 @@ var zipInternalTablesPerCluster = DebugZipTableRegistry{
 	},
 	"crdb_internal.transaction_contention_events": {
 		customQueryUnredacted: `
-with fingerprint_queries as (
-	SELECT distinct fingerprint_id, metadata->> 'query' as query  
-	FROM system.statement_statistics
+WITH contention_fingerprints AS (
+    -- First, extract all relevant fingerprints from contention events
+    SELECT DISTINCT waiting_stmt_fingerprint_id, blocking_txn_fingerprint_id
+    FROM crdb_internal.transaction_contention_events
+    WHERE blocking_txn_fingerprint_id != '\x0000000000000000'
 ),
-transaction_fingerprints as (
-		SELECT distinct fingerprint_id, transaction_fingerprint_id
-		FROM system.statement_statistics
-), 
-transaction_queries as (
-		SELECT tf.transaction_fingerprint_id, array_agg(fq.query) as queries
-		FROM fingerprint_queries fq
-		JOIN transaction_fingerprints tf on tf.fingerprint_id = fq.fingerprint_id
-		GROUP BY tf.transaction_fingerprint_id
+fingerprint_queries AS (
+    -- Only fetch statement data for fingerprints that appear in contention events
+    SELECT DISTINCT fingerprint_id, metadata->>'query' as query
+    FROM system.statement_statistics ss
+    WHERE EXISTS (
+        SELECT 1 FROM contention_fingerprints cf
+        WHERE cf.waiting_stmt_fingerprint_id = ss.fingerprint_id
+    )
+),
+transaction_fingerprints AS (
+    -- Only fetch transaction data for fingerprints that appear in contention events
+    SELECT DISTINCT fingerprint_id, transaction_fingerprint_id
+    FROM system.statement_statistics ss
+    WHERE EXISTS (
+        SELECT 1 FROM contention_fingerprints cf
+        WHERE cf.waiting_stmt_fingerprint_id = ss.fingerprint_id
+    )
+),
+transaction_queries AS (
+    -- Build transaction queries only for relevant transactions
+    SELECT tf.transaction_fingerprint_id, array_agg(fq.query) as queries
+    FROM fingerprint_queries fq
+    JOIN transaction_fingerprints tf ON tf.fingerprint_id = fq.fingerprint_id
+    GROUP BY tf.transaction_fingerprint_id
 )
 SELECT collection_ts,
        contention_duration,
        waiting_txn_id,
        waiting_txn_fingerprint_id,
        waiting_stmt_fingerprint_id,
-       fq.query                      AS waiting_stmt_query,
+       fq.query AS waiting_stmt_query,
        blocking_txn_id,
        blocking_txn_fingerprint_id,
        tq.queries AS blocking_txn_queries_unordered,


### PR DESCRIPTION
Improvements to this query were made in #139735, however statement timeouts and memory budget exceeded errors were still occurring.

This commit improves the query dump by reducing the result set of the CTEs used in the query. Instead of retrieving all fingerprints from the statement_statistics table and using those in the joins, it first filters by the fingerprints present in the contention event registry.

Fixes: #146877

Release note (cli change): Improves the performance of the debug zip query that collects transaction_contention_events data, reducing the chances of "memory budget exceeded" or "query execution canceled due to statement timeout" errors.