### PR TITLE
roachtest: Skip flaky endpoint and fix retry logic for db-console/endpoints

### DIFF
--- a/pkg/cmd/roachtest/tests/db-console/admin_endpoints.json
+++ b/pkg/cmd/roachtest/tests/db-console/admin_endpoints.json
@@ -78,6 +78,7 @@
     {
       "url": "/_admin/v1/rangelog",
       "method": "GET"
+      "skip": "https://github.com/cockroachdb/cockroach/pull/148112#issuecomment-2960322577"
     },
     {
       "url": "/_admin/v1/rangelog/{range_id}",

--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -248,7 +248,7 @@ func testEndpoint(
 		return nil
 	}
 
-	return withRetries(ctx, retry.Options{MaxRetries: 10}, f)
+	return withRetries(ctx, retry.Options{InitialBackoff: time.Second, MaxRetries: 10}, f)
 }
 
 // withRetries runs the given function f with the provided retry options.


### PR DESCRIPTION
This commit skips the rangelog endpoint on the admin server. This failure mode is described in:
https://github.com/cockroachdb/cockroach/pull/148112#issuecomment-2960322577

This commit also sets an initial backoff when retrying endpoints. The default of 50ms resulted in the 10 retries being exhausted too quickly. In mixed version tests nodes are taken down and brought up, and so we observed many 404 failures due to this.

Fixes: #148187
Release note: None