### PR TITLE
sql/inspect: introduce new INSPECT processor into DistSQL flow

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -62,6 +62,7 @@
 /pkg/sql/execinfrapb/processors_bulk_io.proto     @cockroachdb/disaster-recovery
 /pkg/sql/execinfrapb/processors_changefeeds.proto @cockroachdb/cdc-prs
 /pkg/sql/execinfrapb/processors_ttl.proto         @cockroachdb/sql-foundations
+/pkg/sql/execinfrapb/processors_inspect.proto     @cockroachdb/sql-foundations
 /pkg/sql/exec_factory_util.go          @cockroachdb/sql-queries-prs
 #!/pkg/sql/exec_log*.go                @cockroachdb/sql-queries-noreview
 #!/pkg/sql/exec_util*.go               @cockroachdb/sql-queries-noreview
@@ -106,6 +107,7 @@
 /pkg/sql/tests/rsg_test.go   @cockroachdb/sql-foundations
 /pkg/sql/ttl                 @cockroachdb/sql-foundations
 /pkg/sql/spanutils/          @cockroachdb/sql-foundations
+/pkg/sql/inspect/            @cockroachdb/sql-foundations
 
 /pkg/sql/syntheticprivilege/      @cockroachdb/sql-foundations
 /pkg/sql/syntheticprivilegecache/ @cockroachdb/sql-foundations

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1405,7 +1405,42 @@ message HotRangesLoggerDetails {
 }
 
 message InspectDetails {
+  // Check represents a single validation task to perform as part of an INSPECT
+  // job. Each check targets a specific table or index and is associated with a
+  // validation type.
+  message Check {
+    enum InspectCheckType {
+      option (gogoproto.goproto_enum_prefix) = false;
+      option (gogoproto.goproto_enum_stringer) = false;
 
+      // UNSPECIFIED indicates an unset check type. This is invalid.
+      INSPECT_CHECK_UNSPECIFIED = 0 [(gogoproto.enumvalue_customname) = "InspectCheckUnspecified"];
+
+      // INDEX_CONSISTENCY performs validation between primary and secondary indexes
+      // to detect missing or dangling index entries.
+      INSPECT_CHECK_INDEX_CONSISTENCY = 1 [(gogoproto.enumvalue_customname) = "InspectCheckIndexConsistency"];
+    }
+
+    // Type is the kind of validation to perform.
+    InspectCheckType type = 1;
+
+    // TableID identifies the table this check applies to.
+    uint32 table_id = 2 [
+      (gogoproto.customname) = "TableID",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID"
+    ];
+
+    // IndexID identifies the specific index to check, if applicable. Only
+    // relevant for check types that operate at the index level. Should be unset
+    // or ignored for table-level checks.
+    uint32 index_id = 3 [
+      (gogoproto.customname) = "IndexID",
+      (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.IndexID"
+    ];
+  }
+
+  // Checks is the list of individual checks this job will perform.
+  repeated Check checks = 1;
 }
 
 message UpdateTableMetadataCacheDetails {}

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -320,6 +320,8 @@ func canWrap(mode sessiondatapb.VectorizeExecMode, core *execinfrapb.ProcessorCo
 		return errIndexBackfillMergerWrap
 	case core.Ttl != nil:
 		return errCoreNotWorthWrapping
+	case core.Inspect != nil:
+		return errCoreNotWorthWrapping
 	case core.HashGroupJoiner != nil:
 	case core.GenerativeSplitAndScatter != nil:
 		return errCoreNotWorthWrapping

--- a/pkg/sql/distsql_leaf_txn.go
+++ b/pkg/sql/distsql_leaf_txn.go
@@ -233,6 +233,8 @@ func planSafeForReducedLeaf(processors []physicalplan.Processor) bool {
 			return unoptimizedProcessor
 		case core.Ttl != nil:
 			return unoptimizedProcessor
+		case core.Inspect != nil:
+			return unoptimizedProcessor
 		case core.HashGroupJoiner != nil:
 			if unsafeExpr(core.HashGroupJoiner.HashJoinerSpec.OnExpr) {
 				return unsafeProcessor

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -82,6 +82,7 @@ proto_library(
         "processors_base.proto",
         "processors_bulk_io.proto",
         "processors_changefeeds.proto",
+        "processors_inspect.proto",
         "processors_sql.proto",
         "processors_table_stats.proto",
         "processors_ttl.proto",

--- a/pkg/sql/execinfrapb/flow_diagram.go
+++ b/pkg/sql/execinfrapb/flow_diagram.go
@@ -740,6 +740,13 @@ func (s *TTLSpec) summary() (string, []string) {
 }
 
 // summary implements the diagramCellType interface.
+func (s *InspectSpec) summary() (string, []string) {
+	return "INSPECT", []string{
+		fmt.Sprintf("JobID: %d", s.JobID),
+	}
+}
+
+// summary implements the diagramCellType interface.
 func (s *HashGroupJoinerSpec) summary() (string, []string) {
 	_, details := s.HashJoinerSpec.summary()
 	if len(s.JoinOutputColumns) > 0 {

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -18,6 +18,7 @@ import "sql/execinfrapb/data.proto";
 import "sql/execinfrapb/processors_base.proto";
 import "sql/execinfrapb/processors_sql.proto";
 import "sql/execinfrapb/processors_ttl.proto";
+import "sql/execinfrapb/processors_inspect.proto";
 import "sql/execinfrapb/processors_bulk_io.proto";
 import "sql/execinfrapb/processors_changefeeds.proto";
 import "sql/execinfrapb/processors_table_stats.proto";
@@ -126,9 +127,10 @@ message ProcessorCoreUnion {
   optional VectorSearchSpec vectorSearch = 47;
   optional VectorMutationSearchSpec vectorMutationSearch = 48;
   optional CompactBackupsSpec compactBackups = 49;
+  optional InspectSpec inspect = 50;
 
   reserved 6, 12, 14, 17, 18, 19, 20, 32;
-  // NEXT ID: 50.
+  // NEXT ID: 51.
 }
 
 // NoopCoreSpec indicates a "no-op" processor core. This is used when we just

--- a/pkg/sql/execinfrapb/processors_inspect.proto
+++ b/pkg/sql/execinfrapb/processors_inspect.proto
@@ -1,0 +1,38 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+// Processor definitions for distributed SQL APIs. See
+// docs/RFCS/distributed_sql.md.
+// All the concepts here are "physical plan" concepts.
+
+syntax = "proto2";
+// Beware! This package name must not be changed, even though it doesn't match
+// the Go package name, because it defines the Protobuf message names which
+// can't be changed without breaking backward compatibility.
+package cockroach.sql.distsqlrun;
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
+
+import "gogoproto/gogo.proto";
+import "roachpb/data.proto";
+import "jobs/jobspb/jobs.proto";
+
+message InspectSpec {
+  // JobID of the job that ran the inspect processor.
+  optional int64 job_id = 1 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "JobID",
+    (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/jobs/jobspb.JobID"
+  ];
+
+  // InspectDetails are the details of the job that ran the inspect processor.
+  optional jobs.jobspb.InspectDetails inspect_details = 2 [
+    (gogoproto.nullable) = false,
+    (gogoproto.customname) = "InspectDetails"
+  ];
+
+  // Spans determine which records are processed by which nodes in the DistSQL
+  // flow.
+  repeated roachpb.Span spans = 3 [(gogoproto.nullable) = false];
+}

--- a/pkg/sql/inspect/BUILD.bazel
+++ b/pkg/sql/inspect/BUILD.bazel
@@ -2,16 +2,29 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 
 go_library(
     name = "inspect",
-    srcs = ["inspect_job.go"],
+    srcs = [
+        "inspect_job.go",
+        "inspect_processor.go",
+    ],
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/inspect",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/jobs",
         "//pkg/jobs/jobspb",
+        "//pkg/roachpb",
         "//pkg/settings/cluster",
         "//pkg/sql",
+        "//pkg/sql/catalog/descs",
+        "//pkg/sql/execinfra",
+        "//pkg/sql/execinfrapb",
         "//pkg/sql/isql",
+        "//pkg/sql/physicalplan",
+        "//pkg/sql/rowexec",
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/types",
         "//pkg/util/log",
+        "//pkg/util/tracing",
+        "@com_github_cockroachdb_errors//:errors",
     ],
 )
 
@@ -27,6 +40,7 @@ go_test(
         "//pkg/security/securitytest",
         "//pkg/server",
         "//pkg/sql",
+        "//pkg/testutils",
         "//pkg/testutils/serverutils",
         "//pkg/testutils/sqlutils",
         "//pkg/testutils/testcluster",

--- a/pkg/sql/inspect/inspect_job.go
+++ b/pkg/sql/inspect/inspect_job.go
@@ -10,10 +10,17 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/errors"
 )
 
 type inspectResumer struct {
@@ -34,25 +41,26 @@ func (c *inspectResumer) Resume(ctx context.Context, execCtx interface{}) error 
 		knobs = *inspectKnobs
 	}
 
-	if knobs.OnInspectJobStart != nil {
-		if err := knobs.OnInspectJobStart(); err != nil {
-			return err
-		}
-	}
-
-	if err := c.job.NoTxn().Update(ctx,
-		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-			progress := md.Progress
-			progress.Progress = &jobspb.Progress_FractionCompleted{
-				FractionCompleted: 1,
-			}
-			ju.UpdateProgress(progress)
-			return nil
-		},
-	); err != nil {
+	if err := maybeRunOnJobStartHook(knobs); err != nil {
 		return err
 	}
-	return nil
+
+	pkSpans, err := c.getPrimaryIndexSpans(ctx, execCfg)
+	if err != nil {
+		return err
+	}
+
+	// TODO(149460): add a goroutine that will replan the job on topology changes
+	plan, planCtx, err := c.planInspectProcessors(ctx, jobExecCtx, pkSpans)
+	if err != nil {
+		return err
+	}
+
+	if err := c.runInspectPlan(ctx, jobExecCtx, planCtx, plan); err != nil {
+		return err
+	}
+
+	return c.markJobComplete(ctx)
 }
 
 // OnFailOrCancel implements the Resumer interface
@@ -65,6 +73,132 @@ func (c *inspectResumer) OnFailOrCancel(
 // CollectProfile implements the Resumer interface
 func (c *inspectResumer) CollectProfile(ctx context.Context, execCtx interface{}) error {
 	return nil
+}
+
+func maybeRunOnJobStartHook(knobs sql.InspectTestingKnobs) error {
+	if knobs.OnInspectJobStart != nil {
+		return knobs.OnInspectJobStart()
+	}
+	return nil
+}
+
+// getPrimaryIndexSpans returns the primary index spans for all tables involved in
+// the INSPECT job's checks.
+func (c *inspectResumer) getPrimaryIndexSpans(
+	ctx context.Context, execCfg *sql.ExecutorConfig,
+) ([]roachpb.Span, error) {
+	details := c.job.Details().(jobspb.InspectDetails)
+
+	spans := make([]roachpb.Span, 0, len(details.Checks))
+	err := execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		for i := range details.Checks {
+			desc, err := txn.Descriptors().ByIDWithLeased(txn.KV()).WithoutNonPublic().Get().Table(ctx, details.Checks[i].TableID)
+			if err != nil {
+				return err
+			}
+			spans = append(spans, desc.PrimaryIndexSpan(execCfg.Codec))
+		}
+		return nil
+	})
+	return spans, err
+}
+
+// planInspectProcessors constructs the physical plan for the INSPECT job by
+// partitioning the given primary index spans across all nodes in the cluster.
+// Each processor will be assigned one or more spans to run their checks on.
+func (c *inspectResumer) planInspectProcessors(
+	ctx context.Context, jobExecCtx sql.JobExecContext, entirePKSpans []roachpb.Span,
+) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
+	if len(entirePKSpans) > 1 {
+		return nil, nil, errors.AssertionFailedf("we only support one check: %d", len(entirePKSpans))
+	}
+	distSQLPlanner := jobExecCtx.DistSQLPlanner()
+	planCtx, _, err := distSQLPlanner.SetupAllNodesPlanning(ctx, jobExecCtx.ExtendedEvalContext(), jobExecCtx.ExecCfg())
+	if err != nil {
+		return nil, nil, err
+	}
+
+	spanPartitions, err := distSQLPlanner.PartitionSpans(ctx, planCtx, entirePKSpans, sql.PartitionSpansBoundDefault)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	jobID := c.job.ID()
+	newProcessorSpec := func(spans []roachpb.Span) *execinfrapb.InspectSpec {
+		return &execinfrapb.InspectSpec{
+			JobID: jobID,
+			Spans: spans,
+		}
+	}
+
+	// Set up a one-stage plan with one proc per input spec.
+	processorCorePlacements := make([]physicalplan.ProcessorCorePlacement, len(spanPartitions))
+	for i, spanPartition := range spanPartitions {
+		processorCorePlacements[i].SQLInstanceID = spanPartition.SQLInstanceID
+		processorCorePlacements[i].Core.Inspect = newProcessorSpec(spanPartition.Spans)
+	}
+
+	physicalPlan := planCtx.NewPhysicalPlan()
+	physicalPlan.AddNoInputStage(
+		processorCorePlacements,
+		execinfrapb.PostProcessSpec{},
+		[]*types.T{},
+		execinfrapb.Ordering{},
+		nil, /* finalizeLastStageCb */
+	)
+	physicalPlan.PlanToStreamColMap = []int{}
+
+	sql.FinalizePlan(ctx, planCtx, physicalPlan)
+	return physicalPlan, planCtx, nil
+}
+
+// runInspectPlan executes the distributed physical plan for the INSPECT job.
+// It sets up a metadata-only DistSQL receiver to collect any execution errors,
+// then runs the plan using the provided planning context and evaluation context.
+// This function returns any error surfaced via metadata from the processors.
+func (c *inspectResumer) runInspectPlan(
+	ctx context.Context,
+	jobExecCtx sql.JobExecContext,
+	planCtx *sql.PlanningCtx,
+	plan *sql.PhysicalPlan,
+) error {
+	execCfg := jobExecCtx.ExecCfg()
+
+	metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter()
+
+	distSQLReceiver := sql.MakeDistSQLReceiver(
+		ctx,
+		metadataCallbackWriter,
+		tree.Rows,
+		execCfg.RangeDescriptorCache,
+		nil, /* txn */
+		nil, /* clockUpdater */
+		jobExecCtx.ExtendedEvalContext().Tracing,
+	)
+	defer distSQLReceiver.Release()
+
+	distSQLPlanner := jobExecCtx.DistSQLPlanner()
+
+	// Copy the eval.Context, as dsp.Run() might change it.
+	evalCtxCopy := jobExecCtx.ExtendedEvalContext().Context.Copy()
+
+	distSQLPlanner.Run(ctx, planCtx, nil /* txn */, plan,
+		distSQLReceiver, evalCtxCopy, nil /* finishedSetupFn */)
+	return metadataCallbackWriter.Err()
+}
+
+func (c *inspectResumer) markJobComplete(ctx context.Context) error {
+	// TODO(148297): add fine-grained progress reporting
+	return c.job.NoTxn().Update(ctx,
+		func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+			progress := md.Progress
+			progress.Progress = &jobspb.Progress_FractionCompleted{
+				FractionCompleted: 1,
+			}
+			ju.UpdateProgress(progress)
+			return nil
+		},
+	)
 }
 
 func init() {

--- a/pkg/sql/inspect/inspect_processor.go
+++ b/pkg/sql/inspect/inspect_processor.go
@@ -1,0 +1,79 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package inspect
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfra"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/rowexec"
+	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+)
+
+type inspectProcessor struct {
+	processorID int32
+	flowCtx     *execinfra.FlowCtx
+	spec        execinfrapb.InspectSpec
+}
+
+var _ execinfra.Processor = (*inspectProcessor)(nil)
+
+// OutputTypes is part of the execinfra.Processor interface.
+func (*inspectProcessor) OutputTypes() []*types.T {
+	return nil
+}
+
+// MustBeStreaming is part of the execinfra.Processor interface.
+func (*inspectProcessor) MustBeStreaming() bool {
+	return false
+}
+
+// Resume is part of the execinfra.Processor interface.
+func (*inspectProcessor) Resume(execinfra.RowReceiver) {
+	panic("not implemented")
+}
+
+// Close is part of the execinfra.Processor interface.
+func (*inspectProcessor) Close(context.Context) {}
+
+// Run is part of the execinfra.Processor interface.
+func (p *inspectProcessor) Run(ctx context.Context, output execinfra.RowReceiver) {
+	var span *tracing.Span
+	noSpan := p.flowCtx != nil && p.flowCtx.Cfg != nil &&
+		p.flowCtx.Cfg.TestingKnobs.ProcessorNoTracingSpan
+	if !noSpan {
+		ctx, span = execinfra.ProcessorSpan(ctx, p.flowCtx, "inspect", p.processorID)
+		defer span.Finish()
+	}
+	err := p.runInspect(ctx, output)
+	if err != nil {
+		output.Push(nil, &execinfrapb.ProducerMetadata{Err: err})
+	}
+	execinfra.SendTraceData(ctx, p.flowCtx, output)
+	output.ProducerDone()
+}
+
+func (p *inspectProcessor) runInspect(ctx context.Context, output execinfra.RowReceiver) error {
+	log.Infof(ctx, "INSPECT processor started processorID=%d", p.processorID)
+	return nil
+}
+
+func newInspectProcessor(
+	ctx context.Context, flowCtx *execinfra.FlowCtx, processorID int32, spec execinfrapb.InspectSpec,
+) (execinfra.Processor, error) {
+	return &inspectProcessor{
+		spec:        spec,
+		processorID: processorID,
+		flowCtx:     flowCtx,
+	}, nil
+}
+
+func init() {
+	rowexec.NewInspectProcessor = newInspectProcessor
+}

--- a/pkg/sql/logictest/testdata/logic_test/distsql_inspect
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_inspect
@@ -1,0 +1,64 @@
+# LogicTest: 5node-default-configs
+
+subtest setup
+
+statement ok
+SET enable_scrub_job = true;
+
+statement ok
+CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, e BOOL, PRIMARY KEY (a, b, c, d), INDEX c_idx (c, d))
+
+# Split into ten parts.
+statement ok
+ALTER TABLE data SPLIT AT SELECT i FROM generate_series(1, 9) AS g(i)
+
+# Relocate the ten parts to the five nodes.
+retry
+statement ok
+ALTER TABLE data EXPERIMENTAL_RELOCATE
+  SELECT ARRAY[i%5+1], i FROM generate_series(0, 9) AS g(i)
+
+# Generate all combinations of values 1 to 10.
+statement ok
+INSERT INTO data SELECT a, b, c::FLOAT, d::DECIMAL FROM
+   generate_series(1, 10) AS a(a),
+   generate_series(1, 10) AS b(b),
+   generate_series(1, 10) AS c(c),
+   generate_series(1, 10) AS d(d)
+
+# Verify data placement.
+query TTTI colnames
+SELECT start_key, end_key, replicas, lease_holder FROM [SHOW RANGES FROM TABLE data WITH DETAILS] ORDER BY 1
+----
+start_key           end_key       replicas  lease_holder
+<before:/Table/72>  …/1/1         {1}       1
+…/1/1               …/1/2         {2}       2
+…/1/2               …/1/3         {3}       3
+…/1/3               …/1/4         {4}       4
+…/1/4               …/1/5         {5}       5
+…/1/5               …/1/6         {1}       1
+…/1/6               …/1/7         {2}       2
+…/1/7               …/1/8         {3}       3
+…/1/8               …/1/9         {4}       4
+…/1/9               <after:/Max>  {5}       5
+
+subtest end
+
+subtest scrub_job_implicit_txn
+
+statement ok
+EXPERIMENTAL SCRUB TABLE data;
+
+query TTB
+SELECT description, status, finished IS NOT NULL AS finished FROM [SHOW JOBS] WHERE job_type = 'INSPECT' ORDER BY created DESC LIMIT 1
+----
+EXPERIMENTAL SCRUB TABLE data  succeeded  true
+
+subtest end
+
+subtest cleanup
+
+statement ok
+DROP TABLE data;
+
+subtest end

--- a/pkg/sql/logictest/testdata/logic_test/inspect
+++ b/pkg/sql/logictest/testdata/logic_test/inspect
@@ -1,3 +1,9 @@
+# fakedist* configs are skipped because SetupAllNodesPlanning requires a
+# non-nil txn, which is not available in job-based flows like INSPECT. Using
+# them causes a nil pointer panic in the span resolver setup.
+#
+# LogicTest: !fakedist !fakedist-vec-off !fakedist-disk
+
 subtest setup
 
 statement ok

--- a/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 14,
+    shard_count = 15,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/5node-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/5node-disk/generated_test.go
@@ -129,6 +129,13 @@ func TestLogic_distsql_enum(
 	runLogicTest(t, "distsql_enum")
 }
 
+func TestLogic_distsql_inspect(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_inspect")
+}
+
 func TestLogic_distsql_numtables(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/5node/BUILD.bazel
+++ b/pkg/sql/logictest/tests/5node/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 20,
+    shard_count = 21,
     tags = ["cpu:3"],
     deps = [
         "//pkg/base",

--- a/pkg/sql/logictest/tests/5node/generated_test.go
+++ b/pkg/sql/logictest/tests/5node/generated_test.go
@@ -129,6 +129,13 @@ func TestLogic_distsql_enum(
 	runLogicTest(t, "distsql_enum")
 }
 
+func TestLogic_distsql_inspect(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runLogicTest(t, "distsql_inspect")
+}
+
 func TestLogic_distsql_numtables(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-disk/generated_test.go
@@ -1032,13 +1032,6 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
-func TestLogic_inspect(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "inspect")
-}
-
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist-vec-off/generated_test.go
@@ -1032,13 +1032,6 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
-func TestLogic_inspect(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "inspect")
-}
-
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/logictest/tests/fakedist/generated_test.go
+++ b/pkg/sql/logictest/tests/fakedist/generated_test.go
@@ -1039,13 +1039,6 @@ func TestLogic_insert(
 	runLogicTest(t, "insert")
 }
 
-func TestLogic_inspect(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "inspect")
-}
-
 func TestLogic_int_size(
 	t *testing.T,
 ) {

--- a/pkg/sql/rowexec/processors.go
+++ b/pkg/sql/rowexec/processors.go
@@ -379,6 +379,12 @@ func NewProcessor(
 		}
 		return NewTTLProcessor(ctx, flowCtx, processorID, *core.Ttl)
 	}
+	if core.Inspect != nil {
+		if err := checkNumIn(inputs, 0); err != nil {
+			return nil, err
+		}
+		return NewInspectProcessor(ctx, flowCtx, processorID, *core.Inspect)
+	}
 	if core.LogicalReplicationWriter != nil {
 		if err := checkNumIn(inputs, 0); err != nil {
 			return nil, err
@@ -447,6 +453,8 @@ var NewStreamIngestionFrontierProcessor func(context.Context, *execinfra.FlowCtx
 
 // NewTTLProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewTTLProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.TTLSpec) (execinfra.Processor, error)
+
+var NewInspectProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.InspectSpec) (execinfra.Processor, error)
 
 // NewGenerativeSplitAndScatterProcessor is implemented in the non-free (CCL) codebase and then injected here via runtime initialization.
 var NewGenerativeSplitAndScatterProcessor func(context.Context, *execinfra.FlowCtx, int32, execinfrapb.GenerativeSplitAndScatterSpec, *execinfrapb.PostProcessSpec) (execinfra.Processor, error)

--- a/pkg/sql/scrub.go
+++ b/pkg/sql/scrub.go
@@ -470,9 +470,25 @@ func (n *scrubNode) runScrubTableJob(
 ) error {
 	// Consistency check is done async via a job.
 	jobID := p.ExecCfg().JobRegistry.MakeJobID()
+
+	// TODO(148300): just grab the first secondary index and use that for the
+	// consistency check.
+	secIndexes := tableDesc.PublicNonPrimaryIndexes()
+	if len(secIndexes) == 0 {
+		return errors.AssertionFailedf("must have at least one secondary index")
+	}
+
 	jr := jobs.Record{
-		Description:   tree.Serialize(n.n),
-		Details:       jobspb.InspectDetails{},
+		Description: tree.Serialize(n.n),
+		Details: jobspb.InspectDetails{
+			Checks: []*jobspb.InspectDetails_Check{
+				{
+					Type:    jobspb.InspectCheckIndexConsistency,
+					TableID: tableDesc.GetID(),
+					IndexID: secIndexes[0].GetID(),
+				},
+			},
+		},
 		Progress:      jobspb.InspectProgress{},
 		CreatedBy:     nil,
 		Username:      username.NodeUserName(),


### PR DESCRIPTION
This change integrates a new INSPECT processor into the DistSQL framework. The job coordinator for INSPECT now builds a distributed plan across the key spans of a single table (currently only supports one table). The plan is executed across nodes based on the partitioning of the table, invoking the new INSPECT processor on each participating node.

At present, the processor is a no-op that simply returns success, laying groundwork for future changes.

Informs: #148683
Epic: CRDB-30356
Release note: none