### PR TITLE
roachtest: use leader leases by default in perturbation tests

### DIFF
--- a/pkg/cmd/roachtest/tests/perturbation/framework.go
+++ b/pkg/cmd/roachtest/tests/perturbation/framework.go
@@ -243,7 +243,7 @@ func (v variations) randomize(rng *rand.Rand) variations {
 func setup(p perturbation, acceptableChange float64) variations {
 	v := variations{}
 	v.workload = kvWorkload{}
-	v.leaseType = registry.EpochLeases
+	v.leaseType = registry.LeaderLeases
 	v.blockSize = 4096
 	v.splits = 10000
 	v.numNodes = 12


### PR DESCRIPTION
Leader leases are now the default, so they should also be the default in the perturbation tests.

Epic: none
Release note: None