### PR TITLE
roachtest: print remaining replicas in change-replicas

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -81,6 +81,36 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 		return nil
 	}
 
+	printRemainingTestRangesOnNode := func(
+		ctx context.Context,
+		l *logger.Logger,
+		r *rand.Rand,
+		h *mixedversion.Helper,
+		nodeID int,
+		rangeCount int,
+	) error {
+		ranges := make([]int, 0, rangeCount)
+		rows, err := h.Query(r, `SELECT range_id FROM `+
+			`[SHOW RANGES FROM TABLE test] WHERE $1::int = ANY(replicas)`, nodeID)
+		if err != nil {
+			return err
+		}
+		defer func() { _ = rows.Close() }()
+
+		var rangeID int
+		for rows.Next() {
+			if err := rows.Scan(&rangeID); err != nil {
+				return err
+			}
+			ranges = append(ranges, rangeID)
+		}
+		if err := rows.Err(); err != nil {
+			return err
+		}
+		l.Printf("ranges: %v", ranges)
+		return nil
+	}
+
 	// evacuateNodeUsingZoneConfig moves replicas off of a node using a zone
 	// config.
 	evacuateNodeUsingZoneConfig := func(
@@ -120,6 +150,11 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 			l.Printf("%d replicas on n%d", rangeCount, node)
 			if rangeCount == 0 {
 				break
+			}
+			if rangeCount < 10 {
+				if err := printRemainingTestRangesOnNode(ctx, l, r, h, node, rangeCount); err != nil {
+					return err
+				}
 			}
 			time.Sleep(3 * time.Second)
 		}


### PR DESCRIPTION
This test has been flaking recently. There appears to be two failure regimes. In one, replicas are being slowly removed but the test hits its retry limit. In another, replicas are being added to the node while others are being removed. This additional logging will hopefully help more quickly spot when we are dealing with the second case.

Informs #149548

Release note: None