### PR TITLE
Reapply "sql,log: add new txn_read_timestamp field to CommonSqlEventDetails"

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -648,6 +648,7 @@ An event of type `set_cluster_setting` is recorded when a cluster setting is cha
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `set_tenant_cluster_setting`
 
@@ -675,6 +676,7 @@ is changed, either for another tenant or for all tenants.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ## SQL Access Audit Events
 
@@ -708,6 +710,7 @@ is directly or indirectly a member of the admin role) executes a query.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -744,6 +747,7 @@ cluster setting.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -780,6 +784,7 @@ a table marked as audited.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -823,6 +828,7 @@ and the cluster setting `sql.log.all_statements.enabled` is set.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -871,6 +877,7 @@ An event of type `alter_database_add_region` is recorded when a region is added 
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_database_drop_region`
 
@@ -895,6 +902,7 @@ AlterDatabaseAddRegion is recorded when a region is added to a database.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_database_placement`
 
@@ -919,6 +927,7 @@ An event of type `alter_database_placement` is recorded when the database placem
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_database_primary_region`
 
@@ -943,6 +952,7 @@ An event of type `alter_database_primary_region` is recorded when a primary regi
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_database_set_zone_config_extension`
 
@@ -963,6 +973,7 @@ An event of type `alter_database_set_zone_config_extension` is recorded when a z
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Target` | The target object of the zone config change. | yes |
 | `Config` | The applied zone config in YAML format. | yes |
 | `Options` | The SQL representation of the applied zone config options. | yes |
@@ -990,6 +1001,7 @@ An event of type `alter_database_survival_goal` is recorded when the survival go
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_function_options`
 
@@ -1014,6 +1026,7 @@ altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_index`
 
@@ -1039,6 +1052,7 @@ An event of type `alter_index` is recorded when an index is altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_index_visible`
 
@@ -1065,6 +1079,7 @@ AlterIndex is recorded when an index visibility is altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_sequence`
 
@@ -1088,6 +1103,7 @@ An event of type `alter_sequence` is recorded when a sequence is altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_table`
 
@@ -1113,6 +1129,7 @@ An event of type `alter_table` is recorded when a table is altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_type`
 
@@ -1136,6 +1153,7 @@ EventAlterType is recorded when a user-defined type is altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_column`
 
@@ -1162,6 +1180,7 @@ An event of type `comment_on_column` is recorded when a column is commented.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_constraint`
 
@@ -1188,6 +1207,7 @@ An event of type `comment_on_constraint` is recorded when an constraint is comme
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_database`
 
@@ -1213,6 +1233,7 @@ CommentOnTable is recorded when a database is commented.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_index`
 
@@ -1239,6 +1260,7 @@ An event of type `comment_on_index` is recorded when an index is commented.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_schema`
 
@@ -1263,6 +1285,7 @@ An event of type `comment_on_index` is recorded when an index is commented.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_table`
 
@@ -1288,6 +1311,7 @@ An event of type `comment_on_table` is recorded when a table is commented.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `comment_on_type`
 
@@ -1313,6 +1337,7 @@ An event of type `comment_on_type` is recorded when a type is commented.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_database`
 
@@ -1336,6 +1361,7 @@ An event of type `create_database` is recorded when a database is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_function`
 
@@ -1360,6 +1386,7 @@ An event of type `create_function` is recorded when a user-defined function is c
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_index`
 
@@ -1385,6 +1412,7 @@ An event of type `create_index` is recorded when an index is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_policy`
 
@@ -1409,6 +1437,7 @@ An event of type `create_policy` is recorded when a policy is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_schema`
 
@@ -1433,6 +1462,7 @@ An event of type `create_schema` is recorded when a schema is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_sequence`
 
@@ -1457,6 +1487,7 @@ An event of type `create_sequence` is recorded when a sequence is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_statistics`
 
@@ -1484,6 +1515,7 @@ Events of this type are only collected when the cluster setting
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_table`
 
@@ -1508,6 +1540,7 @@ An event of type `create_table` is recorded when a table is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_trigger`
 
@@ -1532,6 +1565,7 @@ An event of type `create_trigger` is recorded when a trigger is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_type`
 
@@ -1556,6 +1590,7 @@ An event of type `create_type` is recorded when a user-defined type is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_view`
 
@@ -1581,6 +1616,7 @@ An event of type `create_view` is recorded when a view is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_database`
 
@@ -1605,6 +1641,7 @@ An event of type `drop_database` is recorded when a database is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_function`
 
@@ -1628,6 +1665,7 @@ An event of type `drop_function` is recorded when a user-defined function is dro
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_index`
 
@@ -1654,6 +1692,7 @@ An event of type `drop_index` is recorded when an index is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_policy`
 
@@ -1678,6 +1717,7 @@ An event of type `drop_policy` is recorded when a policy is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_schema`
 
@@ -1701,6 +1741,7 @@ An event of type `drop_schema` is recorded when a schema is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_sequence`
 
@@ -1724,6 +1765,7 @@ An event of type `drop_sequence` is recorded when a sequence is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_table`
 
@@ -1748,6 +1790,7 @@ An event of type `drop_table` is recorded when a table is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_trigger`
 
@@ -1772,6 +1815,7 @@ An event of type `drop_trigger` is recorded when a trigger is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_type`
 
@@ -1795,6 +1839,7 @@ An event of type `drop_type` is recorded when a user-defined type is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_view`
 
@@ -1819,6 +1864,7 @@ An event of type `drop_view` is recorded when a view is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `finish_schema_change`
 
@@ -1883,6 +1929,7 @@ initiated schema change rollback has completed.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `refresh_materialized_view`
 
@@ -1906,6 +1953,7 @@ An event of type `refresh_materialized_view` is recorded when a materialized vie
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `rename_database`
 
@@ -1930,6 +1978,7 @@ An event of type `rename_database` is recorded when a database is renamed.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `rename_function`
 
@@ -1954,6 +2003,7 @@ An event of type `rename_function` is recorded when a user-defined function is r
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `rename_schema`
 
@@ -1978,6 +2028,7 @@ An event of type `rename_schema` is recorded when a schema is renamed.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `rename_table`
 
@@ -2002,6 +2053,7 @@ An event of type `rename_table` is recorded when a table, sequence or view is re
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `rename_type`
 
@@ -2026,6 +2078,7 @@ An event of type `rename_type` is recorded when a user-defined type is renamed.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `reverse_schema_change`
 
@@ -2074,6 +2127,7 @@ An event of type `set_schema` is recorded when a table, view, sequence or type's
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `truncate_table`
 
@@ -2097,6 +2151,7 @@ An event of type `truncate_table` is recorded when a table is truncated.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `unsafe_delete_descriptor`
 
@@ -2128,6 +2183,7 @@ patch releases without advance notice.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `unsafe_delete_namespace_entry`
 
@@ -2159,6 +2215,7 @@ patch releases without advance notice.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `unsafe_upsert_descriptor`
 
@@ -2186,6 +2243,7 @@ using crdb_internal.unsafe_upsert_descriptor().
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `unsafe_upsert_namespace_entry`
 
@@ -2219,6 +2277,7 @@ patch releases without advance notice.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ## SQL Privilege changes
 
@@ -2256,6 +2315,7 @@ An event of type `alter_database_owner` is recorded when a database's owner is c
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_default_privileges`
 
@@ -2282,6 +2342,7 @@ An event of type `alter_default_privileges` is recorded when default privileges 
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Grantee` | The user/role affected by the grant or revoke operation. | yes |
 | `GrantedPrivileges` | The privileges being granted to the grantee. | no |
 | `RevokedPrivileges` | The privileges being revoked from the grantee. | no |
@@ -2309,6 +2370,7 @@ AlterTableOwner is recorded when the owner of a user-defined function is changed
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_schema_owner`
 
@@ -2333,6 +2395,7 @@ An event of type `alter_schema_owner` is recorded when a schema's owner is chang
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_table_owner`
 
@@ -2357,6 +2420,7 @@ An event of type `alter_table_owner` is recorded when the owner of a table, view
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `alter_type_owner`
 
@@ -2381,6 +2445,7 @@ An event of type `alter_type_owner` is recorded when the owner of a user-defiend
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `change_database_privilege`
 
@@ -2405,6 +2470,7 @@ added to / removed from a user for a database object.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Grantee` | The user/role affected by the grant or revoke operation. | yes |
 | `GrantedPrivileges` | The privileges being granted to the grantee. | no |
 | `RevokedPrivileges` | The privileges being revoked from the grantee. | no |
@@ -2430,6 +2496,7 @@ added to / removed from a user for a database object.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Grantee` | The user/role affected by the grant or revoke operation. | yes |
 | `GrantedPrivileges` | The privileges being granted to the grantee. | no |
 | `RevokedPrivileges` | The privileges being revoked from the grantee. | no |
@@ -2457,6 +2524,7 @@ removed from a user for a schema object.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Grantee` | The user/role affected by the grant or revoke operation. | yes |
 | `GrantedPrivileges` | The privileges being granted to the grantee. | no |
 | `RevokedPrivileges` | The privileges being revoked from the grantee. | no |
@@ -2484,6 +2552,7 @@ from a user for a table, sequence or view object.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Grantee` | The user/role affected by the grant or revoke operation. | yes |
 | `GrantedPrivileges` | The privileges being granted to the grantee. | no |
 | `RevokedPrivileges` | The privileges being revoked from the grantee. | no |
@@ -2511,6 +2580,7 @@ removed from a user for a type object.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Grantee` | The user/role affected by the grant or revoke operation. | yes |
 | `GrantedPrivileges` | The privileges being granted to the grantee. | no |
 | `RevokedPrivileges` | The privileges being revoked from the grantee. | no |
@@ -2751,6 +2821,7 @@ set to a non-zero value, AND
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -2785,6 +2856,7 @@ are more statement within the transaction that haven't been executed yet.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `TxnID` | TxnID is the ID of the transaction that hit the row count limit. | no |
 | `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
 | `NumRows` | NumRows is the number of rows written/read (depending on the event type) by the transaction that reached the corresponding guardrail. | no |
@@ -2812,6 +2884,7 @@ been executed yet.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `TxnID` | TxnID is the ID of the transaction that hit the row count limit. | no |
 | `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
 | `NumRows` | NumRows is the number of rows written/read (depending on the event type) by the transaction that reached the corresponding guardrail. | no |
@@ -2872,6 +2945,7 @@ the "slow query" condition.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -2907,6 +2981,7 @@ mutation statements within the transaction that haven't been executed yet.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `TxnID` | TxnID is the ID of the transaction that hit the row count limit. | no |
 | `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
 | `NumRows` | NumRows is the number of rows written/read (depending on the event type) by the transaction that reached the corresponding guardrail. | no |
@@ -2935,6 +3010,7 @@ mutation statements within the transaction that haven't been executed yet.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `TxnID` | TxnID is the ID of the transaction that hit the row count limit. | no |
 | `SessionID` | SessionID is the ID of the session that initiated the transaction. | no |
 | `NumRows` | NumRows is the number of rows written/read (depending on the event type) by the transaction that reached the corresponding guardrail. | no |
@@ -2975,6 +3051,7 @@ An event of type `alter_role` is recorded when a role is altered.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `create_role`
 
@@ -2998,6 +3075,7 @@ An event of type `create_role` is recorded when a role is created.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `drop_role`
 
@@ -3021,6 +3099,7 @@ An event of type `drop_role` is recorded when a role is dropped.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `grant_role`
 
@@ -3045,6 +3124,7 @@ An event of type `grant_role` is recorded when a role is granted.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 
 ### `password_hash_converted`
 
@@ -3373,6 +3453,7 @@ contains common SQL event/execution details.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
 | `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
 | `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
@@ -3513,6 +3594,7 @@ An event of type `remove_zone_config` is recorded when a zone config is removed.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Target` | The target object of the zone config change. | yes |
 | `Config` | The applied zone config in YAML format. | yes |
 | `Options` | The SQL representation of the applied zone config options. | yes |
@@ -3539,6 +3621,7 @@ An event of type `set_zone_config` is recorded when a zone config is changed.
 | `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
 | `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
 | `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
 | `Target` | The target object of the zone config change. | yes |
 | `Config` | The applied zone config in YAML format. | yes |
 | `Options` | The SQL representation of the applied zone config options. | yes |

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region
@@ -1097,7 +1097,7 @@ ALTER DATABASE drop_region_db DROP REGION IF EXISTS "us-east-1"
 
 # Ensure that events are generated for dropping the region
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'alter_database_drop_region'
 ----

--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -247,12 +247,8 @@ func logEventInternalForSQLStatements(
 ) error {
 	// Inject the common fields into the payload provided by the caller.
 	injectCommonFields := func(event logpb.EventPayload) error {
-		if txn == nil {
-			// No txn is set (e.g. for COPY or BEGIN), so use now instead.
-			event.CommonDetails().Timestamp = timeutil.Now().UnixNano()
-		} else {
-			event.CommonDetails().Timestamp = txn.KV().ReadTimestamp().WallTime
-		}
+		event.CommonDetails().Timestamp = timeutil.Now().UnixNano()
+
 		sqlCommon, ok := event.(eventpb.EventWithCommonSQLPayload)
 		if !ok {
 			return errors.AssertionFailedf("unknown event type: %T", event)
@@ -277,6 +273,10 @@ func logEventInternalForSQLStatements(
 
 		// Overwrite with the common details.
 		*m = commonSQLEventDetails
+
+		if txn != nil {
+			m.TxnReadTimestamp = txn.KV().ReadTimestamp().WallTime
+		}
 
 		// If the common details didn't have a descriptor ID, keep the
 		// one that was in the event already.

--- a/pkg/sql/logictest/testdata/logic_test/distsql_event_log
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_event_log
@@ -25,7 +25,7 @@ CREATE STATISTICS __auto__ FROM a
 # Check explicitly for table id 106. System tables could trigger autostats
 # collections at any time.
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'ApplicationName'
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'ApplicationName'
 FROM system.eventlog
 WHERE "eventType" = 'create_statistics' AND ("info"::JSONB ->> 'DescriptorID')::INT = 106
 ORDER BY "timestamp", info

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -30,7 +30,7 @@ statement ok
 DROP ROLE r, r2
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" IN ('create_role', 'drop_role', 'alter_role')
 ORDER BY "timestamp", info
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" = 'create_table'
 ORDER BY "timestamp", info
@@ -73,7 +73,7 @@ ORDER BY "timestamp", info
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_table'
   AND info::JSONB->>'Statement' LIKE 'CREATE TABLE test.public.a%'
@@ -81,7 +81,7 @@ WHERE "eventType" = 'create_table'
 1  {"EventType": "create_table", "Statement": "CREATE TABLE test.public.a (id INT8 PRIMARY KEY)", "TableName": "test.public.a", "Tag": "CREATE TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_table'
   AND info::JSONB->>'Statement' LIKE 'CREATE TABLE IF NOT EXISTS test.public.b%'
@@ -103,7 +103,7 @@ WHERE "eventType" = 'create_table'
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
 
@@ -111,13 +111,13 @@ statement ok
 ALTER TABLE a ADD val INT
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
 1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD COLUMN val INT8", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
@@ -136,7 +136,7 @@ WHERE "eventType" = 'reverse_schema_change'
 # statement.
 ##################
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
   AND info::JSONB->>'Statement' LIKE 'ALTER TABLE test.public.a%'
 ----
@@ -153,7 +153,7 @@ statement error pgcode 23505 violates unique constraint \"foo\"
 ALTER TABLE a ADD CONSTRAINT foo UNIQUE(val)
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" in ('alter_table', 'create_index')
 ORDER BY "timestamp", info
 ----
@@ -161,20 +161,20 @@ ORDER BY "timestamp", info
 1  {"EventType": "create_index", "IndexName": "foo", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD CONSTRAINT foo UNIQUE (val)", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error' - 'LatencyNanos'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'Error' - 'LatencyNanos'
   FROM system.eventlog
 WHERE "eventType" = 'reverse_schema_change'
 ----
 1  {"EventType": "reverse_schema_change", "InstanceID": 1, "SQLSTATE": "23505"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change_rollback'
 ----
 1  {"EventType": "finish_schema_change_rollback", "InstanceID": 1}
@@ -186,14 +186,14 @@ statement ok
 CREATE INDEX a_foo ON a (val)
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'create_index'
   AND info::JSONB->>'Statement' LIKE 'CREATE INDEX %a_foo%'
 ----
 1  {"EventType": "create_index", "IndexName": "a_foo", "MutationID": 1, "Statement": "CREATE INDEX a_foo ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -204,14 +204,14 @@ statement ok
 CREATE INDEX ON a (val)
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'create_index'
   AND info::JSONB->>'Statement' LIKE 'CREATE INDEX ON%'
 ----
 1  {"EventType": "create_index", "IndexName": "a_val_idx", "MutationID": 1, "Statement": "CREATE INDEX ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -226,14 +226,14 @@ statement ok
 DROP INDEX a@a_foo
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'drop_index'
   AND info::JSONB->>'Statement' LIKE 'DROP INDEX%a_foo'
 ----
 1  {"EventType": "drop_index", "IndexName": "a_foo", "MutationID": 1, "Statement": "DROP INDEX test.public.a@a_foo", "TableName": "test.public.a", "Tag": "DROP INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -249,7 +249,7 @@ statement ok
 TRUNCATE TABLE a
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'truncate_table'
 ----
@@ -273,7 +273,7 @@ DROP TABLE IF EXISTS b
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
 ORDER BY "timestamp", info
@@ -285,7 +285,7 @@ ORDER BY "timestamp", info
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
   AND info::JSONB->>'Statement' LIKE 'DROP TABLE test.public.a%'
@@ -293,7 +293,7 @@ WHERE "eventType" = 'drop_table'
 1  {"EventType": "drop_table", "Statement": "DROP TABLE test.public.a", "TableName": "test.public.a", "Tag": "DROP TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
   AND info::JSONB->>'Statement' LIKE 'DROP TABLE IF EXISTS test.public.b%'
@@ -314,7 +314,7 @@ ALTER TABLE toberenamed RENAME TO renamedtable;
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'rename_table'
   AND info::JSONB->>'Statement' LIKE 'ALTER TABLE %toberenamed% RENAME TO %renamedtable%'
@@ -343,7 +343,7 @@ CREATE DATABASE IF NOT EXISTS othereventlogtest
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_database'
   AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE eventlogtest%'
@@ -351,7 +351,7 @@ WHERE "eventType" = 'create_database'
 1  {"DatabaseName": "eventlogtest", "EventType": "create_database", "Statement": "CREATE DATABASE eventlogtest", "Tag": "CREATE DATABASE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_database'
   AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE IF NOT EXISTS othereventlogtest%'
@@ -389,7 +389,7 @@ DROP DATABASE IF EXISTS othereventlogtest CASCADE
 
 query IT
 SELECT "reportingID",
-       (info::JSONB - 'Timestamp' - 'DescriptorID')
+       (info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp')
        || (
 			SELECT json_build_object(
 					'DroppedSchemaObjects',
@@ -407,7 +407,7 @@ SELECT "reportingID",
 1  {"DatabaseName": "eventlogtest", "DroppedSchemaObjects": ["eventlogtest.public.anothertesttable", "eventlogtest.public.testtable"], "EventType": "drop_database", "Statement": "DROP DATABASE eventlogtest CASCADE", "Tag": "DROP DATABASE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_database'
   AND info::JSONB->>'Statement' LIKE 'DROP DATABASE IF EXISTS othereventlogtest%'
@@ -433,7 +433,7 @@ ALTER DATABASE eventlogtorename RENAME TO eventlogtonewname
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'rename_database'
   AND info::JSONB->>'Statement' LIKE 'ALTER DATABASE %eventlogtorename% RENAME TO %eventlogtonewname%'
@@ -471,7 +471,7 @@ EXECUTE set_setting('some string')
 ##################
 onlyif config local
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%'
@@ -492,7 +492,7 @@ ORDER BY "timestamp", info
 
 onlyif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%'
@@ -543,7 +543,7 @@ ALTER INDEX a@bar CONFIGURE ZONE USING gc.ttlseconds = 15000
 ##################
 skipif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'Statement'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'Statement'
 FROM system.eventlog
 WHERE "eventType" = 'set_zone_config'
 ORDER BY "timestamp", info
@@ -560,7 +560,7 @@ ORDER BY "timestamp", info
 
 skipif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'Statement'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'Statement'
 FROM system.eventlog
 WHERE "eventType" = 'remove_zone_config'
 ORDER BY "timestamp", info
@@ -583,7 +583,7 @@ statement ok
 DROP SEQUENCE s
 
 query TIT
-SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" in ('create_sequence', 'alter_sequence', 'drop_sequence')
 ORDER BY "timestamp", info
@@ -601,7 +601,7 @@ statement ok
 DROP VIEW v
 
 query TIT
-SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" in ('create_view', 'drop_view')
 ORDER BY "timestamp", info
@@ -668,10 +668,10 @@ statement ok
 REVOKE ALL ON * FROM u
 
 query ITT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID', "eventType"
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp', "eventType"
 FROM system.eventlog
 WHERE "eventType" LIKE 'change_%_privilege'
-ORDER BY "timestamp", info
+ORDER BY info::JSONB ->> 'TxnReadTimestamp', info::JSONB ->> 'Grantee', info::JSONB ->> 'TableName'
 ----
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["INSERT"], "Grantee": "u", "Statement": "GRANT INSERT ON TABLE a, b TO u", "TableName": "a", "Tag": "GRANT", "User": "root"}                   change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["INSERT"], "Grantee": "u", "Statement": "GRANT INSERT ON TABLE a, b TO u", "TableName": "b", "Tag": "GRANT", "User": "root"}                   change_table_privilege
@@ -683,15 +683,15 @@ ORDER BY "timestamp", info
 1  {"EventType": "change_schema_privilege", "Grantee": "v", "RevokedPrivileges": ["CREATE"], "SchemaName": "sc", "Statement": "REVOKE CREATE ON SCHEMA \"\".sc FROM u, v", "Tag": "REVOKE", "User": "root"}     change_schema_privilege
 1  {"DatabaseName": "dbt", "EventType": "change_database_privilege", "Grantee": "u", "RevokedPrivileges": ["CREATE"], "Statement": "REVOKE CREATE ON DATABASE dbt FROM u, v", "Tag": "REVOKE", "User": "root"}  change_database_privilege
 1  {"DatabaseName": "dbt", "EventType": "change_database_privilege", "Grantee": "v", "RevokedPrivileges": ["CREATE"], "Statement": "REVOKE CREATE ON DATABASE dbt FROM u, v", "Tag": "REVOKE", "User": "root"}  change_database_privilege
-1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "renamedtable", "Tag": "GRANT", "User": "root"}                 change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "a", "Tag": "GRANT", "User": "root"}                            change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "b", "Tag": "GRANT", "User": "root"}                            change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "c", "Tag": "GRANT", "User": "root"}                            change_table_privilege
+1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "renamedtable", "Tag": "GRANT", "User": "root"}                 change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "sq", "Tag": "GRANT", "User": "root"}                           change_table_privilege
-1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "renamedtable", "Tag": "REVOKE", "User": "root"}             change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "a", "Tag": "REVOKE", "User": "root"}                        change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "b", "Tag": "REVOKE", "User": "root"}                        change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "c", "Tag": "REVOKE", "User": "root"}                        change_table_privilege
+1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "renamedtable", "Tag": "REVOKE", "User": "root"}             change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "sq", "Tag": "REVOKE", "User": "root"}                       change_table_privilege
 
 statement ok
@@ -731,7 +731,7 @@ statement ok
 CREATE SCHEMA AUTHORIZATION u
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_schema'
 ORDER BY "timestamp", info
@@ -744,7 +744,7 @@ statement ok
 ALTER SCHEMA u RENAME TO t
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'rename_schema'
 ----
@@ -757,7 +757,7 @@ statement ok
 DROP USER u
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_schema'
 ORDER BY "timestamp", info
@@ -779,7 +779,7 @@ statement ok
 DROP ROLE rinvisible
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" LIKE '%_role' AND info LIKE '%invisible%'
 ----
@@ -875,7 +875,7 @@ sc      u     NULL  NULL  NULL  NULL
 
 # Verify that events were logged.
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" LIKE '%_owner'
 ORDER BY "timestamp", info
@@ -915,7 +915,7 @@ sc      v     NULL  NULL  NULL  NULL
 
 # Verify that the ownership was transferred to v even including the view and sequence.
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" LIKE '%_owner' AND info::JSONB->>'Owner' = 'v'
 ORDER BY "timestamp", info
@@ -946,7 +946,7 @@ statement ok
 CREATE TYPE eventlog AS ENUM ('event', 'log')
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" = 'create_type' AND info::JSONB->>'TypeName' LIKE '%eventlog'
 ORDER BY "timestamp", info
@@ -970,7 +970,7 @@ statement ok
 ALTER TYPE eventlog RENAME TO eventlog_renamed
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE ("eventType" = 'alter_type' OR "eventType" = 'rename_type') AND info::JSONB->>'TypeName' LIKE '%eventlog%'
 ORDER BY "timestamp", info
@@ -985,7 +985,7 @@ statement ok
 DROP TYPE eventlog_renamed
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" = 'drop_type' AND info::JSONB->>'TypeName' LIKE '%eventlog%'
 ORDER BY "timestamp", info
@@ -1002,7 +1002,7 @@ statement ok
 COMMENT ON COLUMN a.id IS 'This is a column.'
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_column'
 ----
@@ -1015,7 +1015,7 @@ statement ok
 COMMENT ON INDEX b_index IS 'This is an index.'
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_index'
 ----
@@ -1025,7 +1025,7 @@ statement ok
 COMMENT ON TABLE a IS 'This is a table.'
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_table'
 ----
@@ -1036,7 +1036,7 @@ CREATE SCHEMA sc;
 COMMENT ON SCHEMA defaultdb.sc IS 'This is a schema';
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_schema'
 ----
@@ -1067,7 +1067,7 @@ statement ok
 ALTER VIEW v SET SCHEMA test_sc
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_schema'
 ORDER BY "timestamp", info
@@ -1098,7 +1098,7 @@ DROP TABLE x CASCADE
 # Note that the CascadedDroppedViews field should be populated. It is omitted
 # temporarily because of #84206.
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'CascadedDroppedViews'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'CascadedDroppedViews'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
 ORDER BY "timestamp" DESC, info
@@ -1119,7 +1119,7 @@ statement ok
 DROP INDEX t@t_i_idx CASCADE
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_index'
 ORDER BY "timestamp" DESC, info
@@ -1140,7 +1140,7 @@ statement ok
 ALTER TABLE x DROP COLUMN b CASCADE
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ORDER BY "timestamp" DESC, info
@@ -1158,7 +1158,7 @@ statement ok
 drop function f
 
 query TT
-SELECT "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" IN ('create_function', 'drop_function')
 ORDER BY "timestamp" DESC, info
@@ -1176,7 +1176,7 @@ statement ok
 EXPLAIN (DDL) ALTER TABLE t1 ADD COLUMN j int;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 AND info::JSONB->>'Statement' LIKE 'ALTER TABLE t1%'
 ORDER BY "timestamp" DESC, info

--- a/pkg/sql/logictest/testdata/logic_test/event_log_legacy
+++ b/pkg/sql/logictest/testdata/logic_test/event_log_legacy
@@ -30,7 +30,7 @@ statement ok
 DROP ROLE r, r2
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" IN ('create_role', 'drop_role', 'alter_role')
 ORDER BY "timestamp", info
@@ -60,7 +60,7 @@ CREATE TABLE IF NOT EXISTS a (id INT PRIMARY KEY)
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" = 'create_table'
 ORDER BY "timestamp", info
@@ -73,7 +73,7 @@ ORDER BY "timestamp", info
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_table'
   AND info::JSONB->>'Statement' LIKE 'CREATE TABLE test.public.a%'
@@ -81,7 +81,7 @@ WHERE "eventType" = 'create_table'
 1  {"EventType": "create_table", "Statement": "CREATE TABLE test.public.a (id INT8 PRIMARY KEY)", "TableName": "test.public.a", "Tag": "CREATE TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_table'
   AND info::JSONB->>'Statement' LIKE 'CREATE TABLE IF NOT EXISTS test.public.b%'
@@ -103,7 +103,7 @@ WHERE "eventType" = 'create_table'
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
 
@@ -111,13 +111,13 @@ statement ok
 ALTER TABLE a ADD val INT
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ----
 1  {"EventType": "alter_table", "MutationID": 1, "Statement": "ALTER TABLE test.public.a ADD COLUMN val INT8", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
@@ -136,7 +136,7 @@ WHERE "eventType" = 'reverse_schema_change'
 # statement.
 ##################
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
   AND info::JSONB->>'Statement' LIKE 'ALTER TABLE test.public.a%'
 ----
@@ -153,7 +153,7 @@ statement error pgcode 23505 violates unique constraint \"foo\"
 ALTER TABLE a ADD CONSTRAINT foo UNIQUE(val)
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ORDER BY "timestamp", info
 ----
@@ -161,13 +161,13 @@ ORDER BY "timestamp", info
 1  {"EventType": "alter_table", "MutationID": 2, "Statement": "ALTER TABLE test.public.a ADD CONSTRAINT foo UNIQUE (val)", "TableName": "test.public.a", "Tag": "ALTER TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'  FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos'  FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ----
 1  {"EventType": "finish_schema_change", "InstanceID": 1, "MutationID": 1}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'Error' - 'LatencyNanos'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'Error' - 'LatencyNanos'
   FROM system.eventlog
 WHERE "eventType" = 'reverse_schema_change'
 ----
@@ -175,7 +175,7 @@ WHERE "eventType" = 'reverse_schema_change'
 
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change_rollback'
 ----
 1  {"EventType": "finish_schema_change_rollback", "InstanceID": 1, "MutationID": 2}
@@ -187,14 +187,14 @@ statement ok
 CREATE INDEX a_foo ON a (val)
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'create_index'
   AND info::JSONB->>'Statement' LIKE 'CREATE INDEX %a_foo%'
 ----
 1  {"EventType": "create_index", "IndexName": "a_foo", "MutationID": 3, "Statement": "CREATE INDEX a_foo ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -205,14 +205,14 @@ statement ok
 CREATE INDEX ON a (val)
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'create_index'
   AND info::JSONB->>'Statement' LIKE 'CREATE INDEX ON%'
 ----
 1  {"EventType": "create_index", "IndexName": "a_val_idx", "MutationID": 4, "Statement": "CREATE INDEX ON test.public.a (val)", "TableName": "test.public.a", "Tag": "CREATE INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -227,14 +227,14 @@ statement ok
 DROP INDEX a@a_foo
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' FROM system.eventlog
 WHERE "eventType" = 'drop_index'
   AND info::JSONB->>'Statement' LIKE 'DROP INDEX%a_foo'
 ----
 1  {"EventType": "drop_index", "IndexName": "a_foo", "MutationID": 5, "Statement": "DROP INDEX test.public.a@a_foo", "TableName": "test.public.a", "Tag": "DROP INDEX", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos' FROM system.eventlog
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos' FROM system.eventlog
 WHERE "eventType" = 'finish_schema_change'
 ORDER BY "timestamp", info
 ----
@@ -250,7 +250,7 @@ statement ok
 TRUNCATE TABLE a
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'truncate_table'
 ----
@@ -274,7 +274,7 @@ DROP TABLE IF EXISTS b
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
 ORDER BY "timestamp", info
@@ -286,7 +286,7 @@ ORDER BY "timestamp", info
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
   AND info::JSONB->>'Statement' LIKE 'DROP TABLE test.public.a%'
@@ -294,7 +294,7 @@ WHERE "eventType" = 'drop_table'
 1  {"EventType": "drop_table", "Statement": "DROP TABLE test.public.a", "TableName": "test.public.a", "Tag": "DROP TABLE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
   AND info::JSONB->>'Statement' LIKE 'DROP TABLE IF EXISTS test.public.b%'
@@ -315,7 +315,7 @@ ALTER TABLE toberenamed RENAME TO renamedtable;
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'rename_table'
   AND info::JSONB->>'Statement' LIKE 'ALTER TABLE %toberenamed% RENAME TO %renamedtable%'
@@ -344,7 +344,7 @@ CREATE DATABASE IF NOT EXISTS othereventlogtest
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_database'
   AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE eventlogtest%'
@@ -352,7 +352,7 @@ WHERE "eventType" = 'create_database'
 1  {"DatabaseName": "eventlogtest", "EventType": "create_database", "Statement": "CREATE DATABASE eventlogtest", "Tag": "CREATE DATABASE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_database'
   AND info::JSONB->>'Statement' LIKE 'CREATE DATABASE IF NOT EXISTS othereventlogtest%'
@@ -390,7 +390,7 @@ DROP DATABASE IF EXISTS othereventlogtest CASCADE
 
 query IT
 SELECT "reportingID",
-       (info::JSONB - 'Timestamp' - 'DescriptorID')
+       (info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp')
        || (
 			SELECT json_build_object(
 					'DroppedSchemaObjects',
@@ -408,7 +408,7 @@ SELECT "reportingID",
 1  {"DatabaseName": "eventlogtest", "DroppedSchemaObjects": ["eventlogtest.public.anothertesttable", "eventlogtest.public.testtable"], "EventType": "drop_database", "Statement": "DROP DATABASE eventlogtest CASCADE", "Tag": "DROP DATABASE", "User": "root"}
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_database'
   AND info::JSONB->>'Statement' LIKE 'DROP DATABASE IF EXISTS othereventlogtest%'
@@ -434,7 +434,7 @@ ALTER DATABASE eventlogtorename RENAME TO eventlogtonewname
 ##################
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'rename_database'
   AND info::JSONB->>'Statement' LIKE 'ALTER DATABASE %eventlogtorename% RENAME TO %eventlogtonewname%'
@@ -472,7 +472,7 @@ EXECUTE set_setting('some string')
 ##################
 onlyif config local
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%'
@@ -492,7 +492,7 @@ ORDER BY "timestamp", info
 
 onlyif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_cluster_setting'
 AND info NOT LIKE '%version%'
@@ -533,7 +533,7 @@ ALTER INDEX a@bar CONFIGURE ZONE USING gc.ttlseconds = 15000
 ##################
 skipif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_zone_config'
 ORDER BY "timestamp", info
@@ -549,7 +549,7 @@ ORDER BY "timestamp", info
 
 skipif config 3node-tenant-default-configs
 query IT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'remove_zone_config'
 ORDER BY "timestamp", info
@@ -571,7 +571,7 @@ statement ok
 DROP SEQUENCE s
 
 query TIT
-SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" in ('create_sequence', 'alter_sequence', 'drop_sequence')
 ORDER BY "timestamp", info
@@ -589,7 +589,7 @@ statement ok
 DROP VIEW v
 
 query TIT
-SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "eventType", "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" in ('create_view', 'drop_view')
 ORDER BY "timestamp", info
@@ -656,10 +656,10 @@ statement ok
 REVOKE ALL ON * FROM u
 
 query ITT
-SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID', "eventType"
+SELECT "reportingID", "info"::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp', "eventType"
 FROM system.eventlog
 WHERE "eventType" LIKE 'change_%_privilege'
-ORDER BY "timestamp", info
+ORDER BY info::JSONB ->> 'TxnReadTimestamp', info::JSONB ->> 'Grantee', info::JSONB ->> 'TableName'
 ----
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["INSERT"], "Grantee": "u", "Statement": "GRANT INSERT ON TABLE a, b TO u", "TableName": "a", "Tag": "GRANT", "User": "root"}                   change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["INSERT"], "Grantee": "u", "Statement": "GRANT INSERT ON TABLE a, b TO u", "TableName": "b", "Tag": "GRANT", "User": "root"}                   change_table_privilege
@@ -671,15 +671,15 @@ ORDER BY "timestamp", info
 1  {"EventType": "change_schema_privilege", "Grantee": "v", "RevokedPrivileges": ["CREATE"], "SchemaName": "sc", "Statement": "REVOKE CREATE ON SCHEMA \"\".sc FROM u, v", "Tag": "REVOKE", "User": "root"}     change_schema_privilege
 1  {"DatabaseName": "dbt", "EventType": "change_database_privilege", "Grantee": "u", "RevokedPrivileges": ["CREATE"], "Statement": "REVOKE CREATE ON DATABASE dbt FROM u, v", "Tag": "REVOKE", "User": "root"}  change_database_privilege
 1  {"DatabaseName": "dbt", "EventType": "change_database_privilege", "Grantee": "v", "RevokedPrivileges": ["CREATE"], "Statement": "REVOKE CREATE ON DATABASE dbt FROM u, v", "Tag": "REVOKE", "User": "root"}  change_database_privilege
-1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "renamedtable", "Tag": "GRANT", "User": "root"}                 change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "a", "Tag": "GRANT", "User": "root"}                            change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "b", "Tag": "GRANT", "User": "root"}                            change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "c", "Tag": "GRANT", "User": "root"}                            change_table_privilege
+1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "renamedtable", "Tag": "GRANT", "User": "root"}                 change_table_privilege
 1  {"EventType": "change_table_privilege", "GrantedPrivileges": ["ALL"], "Grantee": "u", "Statement": "GRANT ALL ON TABLE * TO u", "TableName": "sq", "Tag": "GRANT", "User": "root"}                           change_table_privilege
-1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "renamedtable", "Tag": "REVOKE", "User": "root"}             change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "a", "Tag": "REVOKE", "User": "root"}                        change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "b", "Tag": "REVOKE", "User": "root"}                        change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "c", "Tag": "REVOKE", "User": "root"}                        change_table_privilege
+1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "renamedtable", "Tag": "REVOKE", "User": "root"}             change_table_privilege
 1  {"EventType": "change_table_privilege", "Grantee": "u", "RevokedPrivileges": ["ALL"], "Statement": "REVOKE ALL ON TABLE * FROM u", "TableName": "sq", "Tag": "REVOKE", "User": "root"}                       change_table_privilege
 
 statement ok
@@ -719,7 +719,7 @@ statement ok
 CREATE SCHEMA AUTHORIZATION u
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'create_schema'
 ORDER BY "timestamp", info
@@ -732,7 +732,7 @@ statement ok
 ALTER SCHEMA u RENAME TO t
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'rename_schema'
 ----
@@ -745,7 +745,7 @@ statement ok
 DROP USER u
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_schema'
 ORDER BY "timestamp", info
@@ -767,7 +767,7 @@ statement ok
 DROP ROLE rinvisible
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" LIKE '%_role' AND info LIKE '%invisible%'
 ----
@@ -863,7 +863,7 @@ sc      u     NULL  NULL  NULL  NULL
 
 # Verify that events were logged.
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" LIKE '%_owner'
 ORDER BY "timestamp", info
@@ -903,7 +903,7 @@ sc      v     NULL  NULL  NULL  NULL
 
 # Verify that the ownership was transferred to v even including the view and sequence.
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" LIKE '%_owner' AND info::JSONB->>'Owner' = 'v'
 ORDER BY "timestamp", info
@@ -934,7 +934,7 @@ statement ok
 CREATE TYPE eventlog AS ENUM ('event', 'log')
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" = 'create_type' AND info::JSONB->>'TypeName' LIKE '%eventlog'
 ORDER BY "timestamp", info
@@ -958,7 +958,7 @@ statement ok
 ALTER TYPE eventlog RENAME TO eventlog_renamed
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE ("eventType" = 'alter_type' OR "eventType" = 'rename_type') AND info::JSONB->>'TypeName' LIKE '%eventlog%'
 ORDER BY "timestamp", info
@@ -973,13 +973,13 @@ statement ok
 DROP TYPE eventlog_renamed
 
 query ITT
-SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", "eventType", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
   FROM system.eventlog
  WHERE "eventType" = 'drop_type' AND info::JSONB->>'TypeName' LIKE '%eventlog%'
-ORDER BY "timestamp", info
+ORDER BY info::JSONB ->> 'TxnReadTimestamp', info::JSONB ->> 'TypeName'
 ----
-1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "Tag": "DROP TYPE", "TypeName": "defaultdb.public.eventlog_renamed", "User": "root"}
 1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "Tag": "DROP TYPE", "TypeName": "defaultdb.public._eventlog_renamed", "User": "root"}
+1  drop_type  {"EventType": "drop_type", "Statement": "DROP TYPE defaultdb.public.eventlog_renamed", "Tag": "DROP TYPE", "TypeName": "defaultdb.public.eventlog_renamed", "User": "root"}
 
 # Test the event logs generated by COMMENT ON ... commands.
 subtest eventlog_comments
@@ -991,7 +991,7 @@ statement ok
 COMMENT ON COLUMN a.id IS 'This is a column.'
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_column'
 ----
@@ -1004,7 +1004,7 @@ statement ok
 COMMENT ON INDEX b_index IS 'This is an index.'
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_index'
 ----
@@ -1014,7 +1014,7 @@ statement ok
 COMMENT ON TABLE a IS 'This is a table.'
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_table'
 ----
@@ -1025,7 +1025,7 @@ CREATE SCHEMA sc;
 COMMENT ON SCHEMA defaultdb.sc IS 'This is a schema';
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'comment_on_schema'
 ----
@@ -1056,7 +1056,7 @@ statement ok
 ALTER VIEW v SET SCHEMA test_sc
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'set_schema'
 ORDER BY "timestamp", info
@@ -1087,7 +1087,7 @@ DROP TABLE x CASCADE
 # Note that the CascadedDroppedViews field should be populated. It is omitted
 # temporarily because of #84206.
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'CascadedDroppedViews'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'CascadedDroppedViews'
 FROM system.eventlog
 WHERE "eventType" = 'drop_table'
 ORDER BY "timestamp" DESC, info
@@ -1108,7 +1108,7 @@ statement ok
 DROP INDEX t@t_i_idx CASCADE
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'drop_index'
 ORDER BY "timestamp" DESC, info
@@ -1129,7 +1129,7 @@ statement ok
 ALTER TABLE x DROP COLUMN b CASCADE
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp'
 FROM system.eventlog
 WHERE "eventType" = 'alter_table'
 ORDER BY "timestamp" DESC, info

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1116,7 +1116,7 @@ statement ok
 DROP VIEW v1ev CASCADE;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY "timestamp", info DESC
 ----
@@ -1141,12 +1141,12 @@ statement ok
 DROP TABLE t1ev,t2ev CASCADE;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
-1  {"CascadeDroppedViews": ["test.public.v2ev", "test.public.v3ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t2ev", "Tag": "DROP TABLE", "User": "root"}
 1  {"CascadeDroppedViews": ["test.public.v1ev", "test.public.v4ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t1ev", "Tag": "DROP TABLE", "User": "root"}
+1  {"CascadeDroppedViews": ["test.public.v2ev", "test.public.v3ev"], "EventType": "drop_table", "Statement": "DROP TABLE test.public.t1ev, test.public.t2ev CASCADE", "TableName": "test.public.t2ev", "Tag": "DROP TABLE", "User": "root"}
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
 1  {"EventType": "finish_schema_change", "InstanceID": 1}
 
@@ -1160,7 +1160,7 @@ statement ok
 ALTER TABLE fooev ADD COLUMN j INT
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----
@@ -1208,7 +1208,7 @@ statement ok
 DROP DATABASE db2 cascade;
 
 query IT
-SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'LatencyNanos'
+SELECT "reportingID", info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp' - 'LatencyNanos'
 FROM system.eventlog
 ORDER BY timestamp, info DESC;
 ----

--- a/pkg/sql/logictest/testdata/logic_test/views
+++ b/pkg/sql/logictest/testdata/logic_test/views
@@ -1546,7 +1546,7 @@ DROP table t1nest CASCADE
 # Validate the objects being dropped
 query IT
 SELECT "reportingID",
-       (info::JSONB - 'Timestamp' - 'DescriptorID')
+       (info::JSONB - 'Timestamp' - 'DescriptorID' - 'TxnReadTimestamp')
        || (
 			SELECT json_build_object(
 					'CascadeDroppedViews',

--- a/pkg/sql/tests/repair_test.go
+++ b/pkg/sql/tests/repair_test.go
@@ -331,11 +331,11 @@ func TestDescriptorRepair(t *testing.T) {
 				},
 				{
 					typ:  "change_table_privilege",
-					info: `"DescriptorID":$firstTableID,"Grantee":"newuser1","GrantedPrivileges":\["ALL"\]`,
+					info: `"DescriptorID":$firstTableID,"TxnReadTimestamp":.*,"Grantee":"newuser1","GrantedPrivileges":\["ALL"\]`,
 				},
 				{
 					typ:  "change_table_privilege",
-					info: `"DescriptorID":$firstTableID,"Grantee":"newuser2","GrantedPrivileges":\["ALL"\]`,
+					info: `"DescriptorID":$firstTableID,"TxnReadTimestamp":.*,"Grantee":"newuser2","GrantedPrivileges":\["ALL"\]`,
 				},
 			},
 		},
@@ -349,15 +349,15 @@ func TestDescriptorRepair(t *testing.T) {
 			expEventLogEntries: []eventLogPattern{
 				{
 					typ:  "alter_table_owner",
-					info: `"DescriptorID":$firstTableID,"TableName":"foo","Owner":"admin"`,
+					info: `"DescriptorID":$firstTableID,"TxnReadTimestamp":.*,"TableName":"foo","Owner":"admin"`,
 				},
 				{
 					typ:  "change_table_privilege",
-					info: `"DescriptorID":$firstTableID,"Grantee":"newuser1","GrantedPrivileges":\["DROP"\],"RevokedPrivileges":\["ALL"\]`,
+					info: `"DescriptorID":$firstTableID,"TxnReadTimestamp":.*,"Grantee":"newuser1","GrantedPrivileges":\["DROP"\],"RevokedPrivileges":\["ALL"\]`,
 				},
 				{
 					typ:  "change_table_privilege",
-					info: `"DescriptorID":$firstTableID,"Grantee":"newuser2","RevokedPrivileges":\["ALL"\]`,
+					info: `"DescriptorID":$firstTableID,"TxnReadTimestamp":.*,"Grantee":"newuser2","RevokedPrivileges":\["ALL"\]`,
 				},
 			},
 		},

--- a/pkg/util/log/eventpb/events.proto
+++ b/pkg/util/log/eventpb/events.proto
@@ -45,6 +45,10 @@ message CommonSQLEventDetails {
 
   // The mapping of SQL placeholders to their values, for prepared statements.
   repeated string placeholder_values = 5 [(gogoproto.jsontag) = ",omitempty"];
+
+  // The current read timestamp of the transaction that triggered the event, if
+  // in a transaction.
+  int64 txn_read_timestamp = 7 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // CommonJobEventDetails contains the fields common to all job events.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -1897,6 +1897,15 @@ func (m *CommonSQLEventDetails) AppendJSONFields(printComma bool, b redact.Redac
 		b = append(b, ']')
 	}
 
+	if m.TxnReadTimestamp != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"TxnReadTimestamp\":"...)
+		b = strconv.AppendInt(b, int64(m.TxnReadTimestamp), 10)
+	}
+
 	return printComma, b
 }
 


### PR DESCRIPTION
This reverts commit e8c121ebeb622c0c414b23a4dd79e67b2a726b00.

This commit was reverted because it introduced flaky tests due to non-deterministic queries in the event log logic tests. These flaky queries were updated to order results deterministically.

Epic: None
Release note: None