### PR TITLE
roachtest: fail on bad table lookup when fingerprinting fixtures

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -931,7 +931,7 @@ func (rd *restoreDriver) maybeValidateFingerprint(ctx context.Context) {
 	require.NoError(rd.t, err)
 	defer conn.Close()
 	fingerprint := fingerprintDatabase(
-		ctx, rd.t, conn, rd.sp.backup.fixture.DatabaseName(), "", /* aost */
+		rd.t, conn, rd.sp.backup.fixture.DatabaseName(), "", /* aost */
 	)
 	require.Equal(rd.t, rd.fixtureMetadata.Fingerprint, fingerprint, "fingerprint mismatch after restore")
 }


### PR DESCRIPTION
Some fixtures are missing table fingerprints, which results in failing restore roachtests. However, the failure is actually caused by bad fixture fingerprints, which were silently ignored due to the fact that we simply log an error and continue if we are unable to fetch all tables of a database. This commit updates the roachtest to properly fail if we fail to fetch a table.

Informs: #149555, #149556, #149557, #149558, #149559, #149560, #149561