### PR TITLE
opt: normalize `x LIKE '%'` to `x IS NOT NULL`

### DIFF
--- a/pkg/sql/opt/memo/testdata/logprops/constraints
+++ b/pkg/sql/opt/memo/testdata/logprops/constraints
@@ -1193,9 +1193,9 @@ select
  │    ├── prune: (1-3)
  │    └── interesting orderings: (+1)
  └── filters
-      └── like [type=bool, outer=(3), constraints=(/3: (/NULL - ])]
+      └── is-not [type=bool, outer=(3), constraints=(/3: (/NULL - ]; tight)]
            ├── variable: v:3 [type=string]
-           └── const: '%' [type=string]
+           └── null
 
 opt
 SELECT * FROM kuv WHERE v LIKE '%XY'

--- a/pkg/sql/opt/norm/rules/select.opt
+++ b/pkg/sql/opt/norm/rules/select.opt
@@ -523,7 +523,7 @@ $input
     $remainingFilters
 )
 
-# NormalizeLikeAny replaces non-Null x LIKE '%' with true.
+# NormalizeLikeAny replaces `x LIKE '%'` with `x IS NOT NULL`.
 [NormalizeLikeAny, Normalize]
 (Select
     $input:*
@@ -531,8 +531,7 @@ $input
         ...
         $item:(FiltersItem
             (Like | ILike
-                $left:* &
-                    (ExprIsNeverNull $left (NotNullCols $input))
+                $left:*
                 $pattern:(Const) &
                     (EqualConstStrings $pattern (StrConst "%"))
             )
@@ -541,4 +540,11 @@ $input
     ]
 )
 =>
-(Select $input (RemoveFiltersItem $filters $item))
+(Select
+    $input
+    (ReplaceFiltersItem
+        $filters
+        $item
+        (IsNot $left (Null (AnyType)))
+    )
+)

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -2710,15 +2710,59 @@ barrier
 # --------------------------------------------------
 
 exec-ddl
-CREATE TABLE strs_notnull (
+CREATE TABLE str_matching_test (
   s STRING NOT NULL,
   cs STRING COLLATE en_US NOT NULL,
-  name NAME NOT NULL
+  name NAME NOT NULL,
+  sn STRING NULL,
+  csn STRING COLLATE en_US NULL,
+  namen NAME NULL
 )
 ----
 
 norm expect=NormalizeLikeAny
-SELECT * FROM strs_notnull WHERE s LIKE '%' AND cs LIKE '%' COLLATE en_US AND name LIKE '%'::NAME;
+SELECT * FROM str_matching_test WHERE s LIKE '%' AND cs LIKE '%' COLLATE en_US AND name LIKE '%'::NAME AND s LIKE 'foo';
 ----
-scan strs_notnull
- └── columns: s:1!null cs:2!null name:3!null
+select
+ ├── columns: s:1!null cs:2!null name:3!null sn:4 csn:5 namen:6
+ ├── fd: ()-->(1)
+ ├── scan str_matching_test
+ │    └── columns: s:1!null cs:2!null name:3!null sn:4 csn:5 namen:6
+ └── filters
+      └── s:1 LIKE 'foo' [outer=(1), constraints=(/1: [/'foo' - /'foo']; tight), fd=()-->(1)]
+
+norm expect=NormalizeLikeAny
+SELECT * FROM str_matching_test WHERE sn LIKE '%' AND csn LIKE '%' COLLATE en_US AND namen LIKE '%'::NAME AND sn LIKE 'foo';
+----
+select
+ ├── columns: s:1!null cs:2!null name:3!null sn:4!null csn:5!null namen:6!null
+ ├── fd: ()-->(4)
+ ├── scan str_matching_test
+ │    └── columns: s:1!null cs:2!null name:3!null sn:4 csn:5 namen:6
+ └── filters
+      ├── (sn:4 LIKE 'foo') AND (sn:4 IS NOT NULL) [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      ├── csn:5 IS NOT NULL [outer=(5), constraints=(/5: (/NULL - ]; tight)]
+      └── namen:6 IS NOT NULL [outer=(6), constraints=(/6: (/NULL - ]; tight)]
+
+norm expect=NormalizeLikeAny
+SELECT * FROM str_matching_test WHERE s ILIKE '%' AND name ILIKE '%'::NAME AND s ILIKE 'foo';
+----
+select
+ ├── columns: s:1!null cs:2!null name:3!null sn:4 csn:5 namen:6
+ ├── scan str_matching_test
+ │    └── columns: s:1!null cs:2!null name:3!null sn:4 csn:5 namen:6
+ └── filters
+      └── s:1 ILIKE 'foo' [outer=(1), constraints=(/1: (/NULL - ])]
+
+norm expect=NormalizeLikeAny
+SELECT * FROM str_matching_test WHERE  sn LIKE '%' AND csn LIKE '%' COLLATE en_US AND namen LIKE '%'::NAME AND sn LIKE 'foo';
+----
+select
+ ├── columns: s:1!null cs:2!null name:3!null sn:4!null csn:5!null namen:6!null
+ ├── fd: ()-->(4)
+ ├── scan str_matching_test
+ │    └── columns: s:1!null cs:2!null name:3!null sn:4 csn:5 namen:6
+ └── filters
+      ├── (sn:4 LIKE 'foo') AND (sn:4 IS NOT NULL) [outer=(4), constraints=(/4: [/'foo' - /'foo']; tight), fd=()-->(4)]
+      ├── csn:5 IS NOT NULL [outer=(5), constraints=(/5: (/NULL - ]; tight)]
+      └── namen:6 IS NOT NULL [outer=(6), constraints=(/6: (/NULL - ]; tight)]

--- a/pkg/sql/opt/xform/testdata/external/pgjdbc
+++ b/pkg/sql/opt/xform/testdata/external/pgjdbc
@@ -364,7 +364,7 @@ sort
       │    │    └── windows
       │    │         └── row-number [as=row_number:165]
       │    └── filters
-      │         └── attname:45 LIKE '%' [outer=(45), constraints=(/45: (/NULL - ])]
+      │         └── attname:45 IS NOT NULL [outer=(45), constraints=(/45: (/NULL - ]; tight)]
       └── projections
            ├── a.attnotnull:56 OR ((typtype:77 = 'd') AND typnotnull:94) [as=attnotnull:166, outer=(56,77,94)]
            ├── NULL [as=attidentity:167]


### PR DESCRIPTION
#### opt: normalize `x LIKE '%'` to `x IS NOT NULL`

Epic: None
Fixes: cockroachdb#144523

Release note (performance improvement): Before we normalized filters `x LIKE
'%'` for non-null columns directly to true. This is limited for columns which
are nullable. This commit instead normalizes the aforementioned filter to `x IS
NOT NULL` for better performance improvements on all columns with this filter.
