### PR TITLE
backup: move retry loop to entire download phase

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -1793,7 +1793,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_do_download_files"); err != nil {
 			return err
 		}
-		return r.doDownloadFiles(ctx, p)
+		return r.doDownloadFilesWithRetry(ctx, p)
 	}
 
 	if err := p.ExecCfg().JobRegistry.CheckPausepoint("restore.before_load_descriptors_from_backup"); err != nil {
@@ -2026,7 +2026,7 @@ func (r *restoreResumer) doResume(ctx context.Context, execCtx interface{}) erro
 		// TODO(msbutler): ideally doDownloadFiles would not depend on job details
 		// and is instead passed an execCfg and the download spans and anything else
 		// it needs. If that occured, we would not need to update details above.
-		if err := r.doDownloadFiles(ctx, p); err != nil {
+		if err := r.doDownloadFilesWithRetry(ctx, p); err != nil {
 			return err
 		}
 	}


### PR DESCRIPTION
The retry loop introduced in #148821 specifically would retry the `DownloadSpan` requests. Moving the retry loop to handle the entire download phase would also allow us to retry the cleanup step as well.

Epic: CRDB-51394

Release note: None