### PR TITLE
release-24.1: restore: add retry loop to AdminSplit in split and scatterer

### DIFF
--- a/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
+++ b/pkg/ccl/backupccl/generative_split_and_scatter_processor.go
@@ -33,6 +33,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/cockroach/pkg/util/randutil"
+	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/errors"
@@ -40,6 +41,7 @@ import (
 )
 
 const generativeSplitAndScatterProcessorName = "generativeSplitAndScatter"
+const maxAdminSplitAttempts = 5
 
 var generativeSplitAndScatterOutputTypes = []*types.T{
 	types.Bytes, // Span key for the range router
@@ -159,11 +161,23 @@ func (s dbSplitAndScatterer) split(
 		newSplitKey = splitAt
 	}
 	log.VEventf(ctx, 1, "presplitting new key %+v", newSplitKey)
-	if err := s.db.AdminSplit(ctx, newSplitKey, expirationTime); err != nil {
-		return errors.Wrapf(err, "splitting key %s", newSplitKey)
+	retryOpts := retry.Options{
+		InitialBackoff: 100 * time.Millisecond,
+		MaxBackoff:     5 * time.Second,
+		Multiplier:     2,
+		MaxRetries:     maxAdminSplitAttempts,
+	}
+	for r := retry.StartWithCtx(ctx, retryOpts); r.Next(); {
+		if err = s.db.AdminSplit(ctx, newSplitKey, expirationTime); err != nil {
+			log.VInfof(
+				ctx, 1, "attempt %d failed to split at key %s: %v", r.CurrentAttempt(), newSplitKey, err,
+			)
+			continue
+		}
+		return nil
 	}
 
-	return nil
+	return errors.Wrapf(err, "retries exhausted for splitting at key %s", newSplitKey)
 }
 
 // scatter implements splitAndScatterer.


### PR DESCRIPTION
Backport 1/1 commits from #148484.

/cc @cockroachdb/release

---

Previously, restore jobs would fail upon encountering a failed split in the split and scatter processor. However, brief periods of unhealthiness at the KV layer can be expected under high workloads, and failing immediately on a failed spilt is too aggressive. This patch teaches the split and scatter processor to retry the `AdminSplit` before returning an error.

Epic: CRDB-50823

Fixes: #148026

Informs: #148027

Release note: Restore will now re-attempt `AdminSplit` KV requests instead of immediately failing and pausing the job.

---

Release justification: Fixing high priority issue with poor handling of failed AdminSplit requests.