### PR TITLE
sql: validate trigger backreferences in table descriptors

### DIFF
--- a/pkg/sql/catalog/tabledesc/validate.go
+++ b/pkg/sql/catalog/tabledesc/validate.go
@@ -361,8 +361,6 @@ func (desc *wrapper) ValidateBackReferences(
 		}
 		switch depDesc.DescriptorType() {
 		case catalog.Table:
-			// If this is a table, it may be referenced by a view, otherwise if this
-			// is a sequence, then it may be also be referenced by a table.
 			vea.Report(desc.validateInboundTableRef(by, vdg))
 		case catalog.Function:
 			// This relation may be referenced by a function.
@@ -504,49 +502,76 @@ func (desc *wrapper) validateInboundTableRef(
 			backReferencedTable.GetName(), backReferencedTable.GetID())
 	}
 	if desc.IsSequence() {
-		// The ColumnIDs field takes a different meaning when the validated
-		// descriptor is for a sequence. In this case, they refer to the columns
-		// in the referenced descriptor instead.
-		for _, colID := range by.ColumnIDs {
-			// Skip this check if the column ID is zero. This can happen due to
-			// bugs in 20.2.
-			//
-			// TODO(ajwerner): Make sure that a migration in 22.2 fixes this issue.
-			if colID == 0 {
-				continue
-			}
-			col := catalog.FindColumnByID(backReferencedTable, colID)
-			if col == nil {
-				return errors.AssertionFailedf("depended-on-by relation %q (%d) does not have a column with ID %d",
-					backReferencedTable.GetName(), by.ID, colID)
-			}
-			var found bool
-			for i := 0; i < col.NumUsesSequences(); i++ {
-				if col.GetUsesSequenceID(i) == desc.GetID() {
-					found = true
-					break
-				}
-			}
-			if found {
-				continue
-			}
-			return errors.AssertionFailedf(
-				"depended-on-by relation %q (%d) has no reference to this sequence in column %q (%d)",
-				backReferencedTable.GetName(), by.ID, col.GetName(), col.GetID())
+		if err := validateSequenceColumnBackrefs(desc, backReferencedTable, by); err != nil {
+			return err
 		}
 	}
 
 	// View back-references need corresponding forward reference.
-	if !backReferencedTable.IsView() {
-		return nil
-	}
-	for _, id := range backReferencedTable.TableDesc().DependsOn {
-		if id == desc.GetID() {
-			return nil
+	if backReferencedTable.IsView() {
+		for _, id := range backReferencedTable.TableDesc().DependsOn {
+			if id == desc.GetID() {
+				return nil
+			}
 		}
+		return errors.AssertionFailedf("depended-on-by view %q (%d) has no corresponding depends-on forward reference",
+			backReferencedTable.GetName(), by.ID)
 	}
-	return errors.AssertionFailedf("depended-on-by view %q (%d) has no corresponding depends-on forward reference",
-		backReferencedTable.GetName(), by.ID)
+
+	// Table to table back-references must have a trigger reference.
+	if backReferencedTable.IsTable() && desc.IsTable() {
+		for _, trigger := range backReferencedTable.TableDesc().Triggers {
+			for _, id := range trigger.DependsOn {
+				if id == desc.GetID() {
+					return nil
+				}
+			}
+		}
+
+		// No valid forward reference found to justify the backref.
+		return errors.AssertionFailedf(
+			"table %q (%d) does not have a forward reference to descriptor %q (%d)",
+			backReferencedTable.GetName(), by.ID, desc.GetName(), desc.GetID())
+	}
+	return nil
+}
+
+func validateSequenceColumnBackrefs(
+	seq catalog.Descriptor,
+	backReferencedTable catalog.TableDescriptor,
+	by descpb.TableDescriptor_Reference,
+) error {
+	// The ColumnIDs field takes a different meaning when the validated
+	// descriptor is for a sequence. In this case, they refer to the columns
+	// in the referenced descriptor instead.
+	for _, colID := range by.ColumnIDs {
+		// Skip this check if the column ID is zero. This can happen due to
+		// bugs in 20.2.
+		//
+		// TODO(ajwerner): Make sure that a migration in 22.2 fixes this issue.
+		if colID == 0 {
+			continue
+		}
+		col := catalog.FindColumnByID(backReferencedTable, colID)
+		if col == nil {
+			return errors.AssertionFailedf("depended-on-by relation %q (%d) does not have a column with ID %d",
+				backReferencedTable.GetName(), by.ID, colID)
+		}
+		var found bool
+		for i := 0; i < col.NumUsesSequences(); i++ {
+			if col.GetUsesSequenceID(i) == seq.GetID() {
+				found = true
+				break
+			}
+		}
+		if found {
+			continue
+		}
+		return errors.AssertionFailedf(
+			"depended-on-by relation %q (%d) has no reference to this sequence in column %q (%d)",
+			backReferencedTable.GetName(), by.ID, col.GetName(), col.GetID())
+	}
+	return nil
 }
 
 // validateFK asserts that references to desc from inbound and outbound FKs are

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -3956,6 +3956,103 @@ func TestValidateCrossTableReferences(t *testing.T) {
 				},
 			},
 		},
+		// 28
+		{
+			err: `depended-on-by relation "user_table_missing" (103) has no reference to this sequence in column "a" (1)`,
+			desc: descpb.TableDescriptor{
+				Name:                    "seq_broken",
+				ID:                      102,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				SequenceOpts:            &descpb.TableDescriptor_SequenceOpts{Increment: 1},
+				DependedOnBy: []descpb.TableDescriptor_Reference{
+					{ID: 103, ColumnIDs: []descpb.ColumnID{1}},
+				},
+			},
+			otherDescs: []descpb.TableDescriptor{{
+				Name:                    "user_table_missing",
+				ID:                      103,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				Columns: []descpb.ColumnDescriptor{{
+					ID:   1,
+					Name: "a",
+					Type: types.Int,
+				}},
+			}},
+		},
+		// 29
+		{
+			err: `table "table_with_trigger" (103) does not have a forward reference to descriptor "table_ref_in_trigger" (102)`,
+			desc: descpb.TableDescriptor{
+				Name:                    "table_ref_in_trigger",
+				ID:                      102,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				Columns: []descpb.ColumnDescriptor{{
+					ID:   1,
+					Name: "a",
+					Type: types.Int,
+				}},
+				DependedOnBy: []descpb.TableDescriptor_Reference{
+					{ID: 103},
+				},
+			},
+			otherDescs: []descpb.TableDescriptor{{
+				Name:                    "table_with_trigger",
+				ID:                      103,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				Columns: []descpb.ColumnDescriptor{{
+					ID:   1,
+					Name: "a",
+					Type: types.Int,
+				}},
+				Triggers: []descpb.TriggerDescriptor{
+					{
+						ID:        1,
+						Name:      "tr1",
+						DependsOn: []descpb.ID{}, // Forgot to put forward reference to table_ref_in_trigger
+					},
+				},
+			}},
+		},
+		// 30: like 29, but it does have a valid forward reference in a table
+		{
+			err: "",
+			desc: descpb.TableDescriptor{
+				Name:                    "table_ref_in_trigger",
+				ID:                      102,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				Columns: []descpb.ColumnDescriptor{{
+					ID:   1,
+					Name: "a",
+					Type: types.Int,
+				}},
+				DependedOnBy: []descpb.TableDescriptor_Reference{
+					{ID: 103},
+				},
+			},
+			otherDescs: []descpb.TableDescriptor{{
+				Name:                    "table_with_trigger",
+				ID:                      103,
+				ParentID:                1,
+				UnexposedParentSchemaID: keys.PublicSchemaID,
+				Columns: []descpb.ColumnDescriptor{{
+					ID:   1,
+					Name: "a",
+					Type: types.Int,
+				}},
+				Triggers: []descpb.TriggerDescriptor{
+					{
+						ID:        1,
+						Name:      "tr1",
+						DependsOn: []descpb.ID{102},
+					},
+				},
+			}},
+		},
 	}
 
 	for i, test := range tests {


### PR DESCRIPTION
Previously, descriptor validation only accounted for backreferences from sequences and views. However, the introduction of triggers introduces table-to-table references, which were not being validated. This change extends the validation logic to cover these cases, improving correctness and robustness of descriptor validation involving triggers.

Fixes: #148167
Epic: CRDB-42942

Release note: None