### PR TITLE
roachpb: add proto changes for StoreCapacity, NodeCapacity

### DIFF
--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -284,6 +284,35 @@ message Percentiles {
   optional double pMax = 6 [(gogoproto.nullable) = false];
 }
 
+// NodeCapacity tracks CPU usage and capacity metrics at the node level. This
+// information is populated in the store descriptor before it is gossiped across
+// the network. MMA uses these metrics from gossiped store descriptors to
+// construct store load messages and calculate utilization ratios across
+// different dimensions.
+// TODO(wenyihu6): This field is currently unused and not populated. Populate
+// this field correctly and use it in MMA.
+message NodeCapacity {
+  // StoresCPURate is the total CPU usage across all stores on this node,
+  // measured in nanoseconds per second. It is calculated by summing the CPU
+  // time of all replicas on the node, as tracked in replica stats.
+  optional int64 stores_cpu_rate = 1 [(gogoproto.nullable) = false, (gogoproto.customname) = "StoresCPURate"];
+  
+  // NumStores is the count of stores on this node over which StoresCPURate is
+  // aggregated.
+  optional int32 num_stores = 2 [(gogoproto.nullable) = false];
+  
+  // NodeCPURateUsage is the node's actual CPU usage in ns/sec, measured by the
+  // runtime load monitor tracking user+system CPU time. This is typically
+  // higher than StoresCPURate gaps in the fine-grained instrumentation used to
+  // compute StoresCPURate.
+  optional int64 node_cpu_rate_usage = 3 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeCPURateUsage"];
+  
+  // NodeCPURateCapacity is the node's total CPU capacity in nanoseconds per
+  // sec, calculated by the runtime load monitor based on number of logical CPU
+  // processors available for use by the processor.
+  optional int64 node_cpu_rate_capacity = 4 [(gogoproto.nullable) = false, (gogoproto.customname) = "NodeCPURateCapacity"];
+}
+
 // StoreCapacity contains capacity information for a storage device.
 message StoreCapacity {
   option (gogoproto.goproto_stringer) = false;
@@ -412,6 +441,7 @@ message StoreDescriptor {
   optional NodeDescriptor node = 3 [(gogoproto.nullable) = false];
   optional StoreCapacity capacity = 4 [(gogoproto.nullable) = false];
   optional StoreProperties properties = 5 [(gogoproto.nullable) = false];
+  optional NodeCapacity node_capacity = 6 [(gogoproto.nullable) = false];
 }
 
 // Locality is an ordered set of key value Tiers that describe a node's

--- a/pkg/roachpb/metadata.proto
+++ b/pkg/roachpb/metadata.proto
@@ -321,6 +321,13 @@ message StoreCapacity {
   // io_threshold_max tracks the maximum io overload values the store has had
   // over the last 5 minutes.
   optional cockroach.util.admission.admissionpb.IOThreshold io_threshold_max = 15 [(gogoproto.nullable) = false, (gogoproto.customname) = "IOThresholdMax" ];
+  // writes_bytes_per_second aggregates the average number of bytes written per
+  // second across replicas in the store. The stat is tracked over the time
+  // period defined in storage/replica_stats.go, which as of July 2018 is 30
+  // minutes.
+  // TODO(wenyihu6): This field is currently unused and not populated. MMA will
+  // later use it to track write bandwidth usage.
+  optional double write_bytes_per_second = 16 [(gogoproto.nullable) = false];
   // bytes_per_replica and writes_per_replica contain percentiles for the
   // number of bytes and writes-per-second to each replica in the store.
   // This information can be used for rebalancing decisions.

--- a/pkg/roachpb/metadata_test.go
+++ b/pkg/roachpb/metadata_test.go
@@ -850,3 +850,68 @@ func TestRangeDescriptorsByStartKey(t *testing.T) {
 		}
 	}
 }
+
+// TestNodeCapacity tests the NodeCapacity struct.
+func TestNodeCapacity(t *testing.T) {
+	t.Run("basic", func(t *testing.T) {
+		actual := NodeCapacity{
+			StoresCPURate:       1,
+			NumStores:           1,
+			NodeCPURateUsage:    800000000,
+			NodeCPURateCapacity: 10,
+		}
+		require.Equal(t, int64(1), actual.StoresCPURate)
+		require.Equal(t, int32(1), actual.NumStores)
+		require.Equal(t, int64(800000000), actual.NodeCPURateUsage)
+		require.Equal(t, int64(10), actual.NodeCPURateCapacity)
+	})
+
+	t.Run("zero values", func(t *testing.T) {
+		actual := NodeCapacity{}
+		require.Equal(t, int64(0), actual.StoresCPURate)
+		require.Equal(t, int32(0), actual.NumStores)
+		require.Equal(t, int64(0), actual.NodeCPURateUsage)
+		require.Equal(t, int64(0), actual.NodeCPURateCapacity)
+	})
+
+	t.Run("equality", func(t *testing.T) {
+		nc1 := NodeCapacity{
+			StoresCPURate:       1000000000,
+			NumStores:           3,
+			NodeCPURateUsage:    800000000,
+			NodeCPURateCapacity: 1000000000,
+		}
+		nc2 := nc1
+		require.Equal(t, nc1, nc2)
+		require.Equal(t, int64(1000000000), nc2.StoresCPURate)
+		require.Equal(t, int32(3), nc2.NumStores)
+		require.Equal(t, int64(800000000), nc2.NodeCPURateUsage)
+		require.Equal(t, int64(1000000000), nc2.NodeCPURateCapacity)
+	})
+
+	t.Run("wrap in store descriptor", func(t *testing.T) {
+		nc := NodeCapacity{
+			StoresCPURate:       1000000000,
+			NumStores:           3,
+			NodeCPURateUsage:    800000000,
+			NodeCPURateCapacity: 1000000000,
+		}
+
+		storeDesc := StoreDescriptor{
+			StoreID: 1,
+			Node: NodeDescriptor{
+				NodeID: 1,
+			},
+			Capacity: StoreCapacity{
+				Capacity:   1000000000,
+				Available:  500000000,
+				RangeCount: 100,
+			},
+			NodeCapacity: nc,
+		}
+		require.Equal(t, int64(1000000000), storeDesc.NodeCapacity.StoresCPURate)
+		require.Equal(t, int32(3), storeDesc.NodeCapacity.NumStores)
+		require.Equal(t, int64(800000000), storeDesc.NodeCapacity.NodeCPURateUsage)
+		require.Equal(t, int64(1000000000), storeDesc.NodeCapacity.NodeCPURateCapacity)
+	})
+}


### PR DESCRIPTION
**roachpb: add proto changes for StoreCapacity**

This commit adds MMA-related proto changes to StoreCapacity, including the
writes_bytes_per_second field. It is the aggregated sum of average number of
bytes written per second across all replicas on the store. This field is
currently unused and will be populated in future commits. MMA will later use it
to track write bandwidth usage.

Epic: none
Release note: none

---

**roachpb: add proto changes for NodeCapacity**

This commit adds new proto changes to NodeCapacity to track CPU usage and
capacity at the node level. These metrics will be populated in the store
descriptor before it is gossiped. MMA will use them from gossiped store
descriptors to construct store load messages and compute utilization ratios
across multiple dimensions.

Epic: none
Release note: none
