### PR TITLE
pkg/util/log: reducing allocs in otlp sink

### DIFF
--- a/pkg/util/log/otlp_client_test.go
+++ b/pkg/util/log/otlp_client_test.go
@@ -219,3 +219,50 @@ func TestOTLPClientSeverity(t *testing.T) {
 		return strings.Join(output, "\n")
 	})
 }
+
+func TestOTLPExtractRecords(t *testing.T) {
+	tests := map[string]struct {
+		input  string
+		result []string
+	}{
+		"single_line": {
+			input:  "Hello World",
+			result: []string{"Hello World"},
+		},
+		"multiple_lines": {
+			input:  "Message 1\nMessage 2\n\nMessage 3",
+			result: []string{"Message 1", "Message 2", "Message 3"},
+		},
+		"trailing_newline": {
+			input:  "Message 1\nMessage 2\n",
+			result: []string{"Message 1", "Message 2"},
+		},
+		"leading_newline": {
+			input:  "\nMessage 1\nMessage 2",
+			result: []string{"Message 1", "Message 2"},
+		},
+		"redaction_markers": {
+			input:  "Message 1\n‹Message 2›\nMessage 3",
+			result: []string{"Message 1", "‹Message 2›", "Message 3"},
+		},
+		"empty_string": {
+			input:  "",
+			result: []string{},
+		},
+		"newline_only": {
+			input:  "\n\n",
+			result: []string{},
+		},
+	}
+
+	for name, test := range tests {
+		t.Run(name, func(t *testing.T) {
+			body := []byte(test.input)
+			records := otlpExtractRecords(body)
+			require.Len(t, records, len(test.result))
+			for i, record := range records {
+				require.Equal(t, test.result[i], record.Body.GetStringValue())
+			}
+		})
+	}
+}


### PR DESCRIPTION
this aims to increase the performance and decrease the number of
allocations made in the otlp sink.

Benchmark results:
```
name         old time/op    new time/op    delta
OTLPSink-12     536µs ± 1%     535µs ± 0%     ~     (p=0.156 n=10+9)

name         old alloc/op   new alloc/op   delta
OTLPSink-12    18.5kB ±25%    15.7kB ±11%  -14.97%  (p=0.004 n=9+9)

name         old allocs/op  new allocs/op  delta
OTLPSink-12       132 ± 0%       123 ± 0%   -6.82%  (p=0.000 n=10+10)
```

benchmark was done in a e2e environment (crdb->otel-collector->datadog)
and with gzip compression turned on.

part of: CRDB-51667

Release note: none