### PR TITLE
perf: faster allocator on sysbench settings

### DIFF
--- a/pkg/cmd/roachtest/tests/sysbench.go
+++ b/pkg/cmd/roachtest/tests/sysbench.go
@@ -380,6 +380,8 @@ func registerSysbench(r registry.Registry) {
 						`set cluster setting sql.metrics.statement_details.enabled = false`,
 						`set cluster setting kv.split_queue.enabled = false`,
 						`set cluster setting kv.transaction.write_buffering.enabled = true`,
+						`set cluster setting kv.allocator.load_based_rebalancing_interval = '10s'`,
+						`set cluster setting kv.allocator.store_cpu_rebalance_threshold = 0.01`,
 					},
 					useDRPC: true,
 				}


### PR DESCRIPTION
We're seeing some inter-run instability when running sysbench oltp_read_write to the tune of 1-2% CoV with repeated 10 minute runs. Some digging has pointed to the fact that the allocator is both not aggressive enough at the beginning of runs, and that its CPU threshold for moving leaseholders is too large. Racheting up the aggressiveness and lowering the thresholds helps improve repeated run performance and lower the CoV. Adding these settings to the "settings" run to see if it helps stabilize things there.

Epic: none
Release note: none