### PR TITLE
sql/export: add header row option to export csv

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -61,6 +61,7 @@
 /pkg/sql/execstats/          @cockroachdb/sql-queries-prs
 /pkg/sql/execinfrapb/processors_bulk_io.proto     @cockroachdb/disaster-recovery
 /pkg/sql/execinfrapb/processors_changefeeds.proto @cockroachdb/cdc-prs
+/pkg/sql/execinfrapb/processors_export.proto      @cockroachdb/cdc-prs
 /pkg/sql/execinfrapb/processors_ttl.proto         @cockroachdb/sql-foundations
 /pkg/sql/execinfrapb/processors_inspect.proto     @cockroachdb/sql-foundations
 /pkg/sql/exec_factory_util.go          @cockroachdb/sql-queries-prs

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -5299,6 +5299,7 @@ func (dsp *DistSQLPlanner) planExport(
 		ChunkRows:   int64(planInfo.chunkRows),
 		ChunkSize:   planInfo.chunkSize,
 		ColNames:    planInfo.colNames,
+		HeaderRow:   planInfo.headerRow,
 		UserProto:   planCtx.planner.User().EncodeProto(),
 	}
 

--- a/pkg/sql/execinfrapb/BUILD.bazel
+++ b/pkg/sql/execinfrapb/BUILD.bazel
@@ -82,6 +82,7 @@ proto_library(
         "processors_base.proto",
         "processors_bulk_io.proto",
         "processors_changefeeds.proto",
+        "processors_export.proto",
         "processors_inspect.proto",
         "processors_sql.proto",
         "processors_table_stats.proto",

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -21,6 +21,7 @@ import "sql/execinfrapb/processors_ttl.proto";
 import "sql/execinfrapb/processors_inspect.proto";
 import "sql/execinfrapb/processors_bulk_io.proto";
 import "sql/execinfrapb/processors_changefeeds.proto";
+import "sql/execinfrapb/processors_export.proto";
 import "sql/execinfrapb/processors_table_stats.proto";
 import "sql/types/types.proto";
 import "gogoproto/gogo.proto";

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -380,29 +380,6 @@ message RestoreDataSpec {
   // NEXT ID: 11.
 }
 
-// ExporterSpec is the specification for a processor that consumes rows and
-// writes them to Parquet or CSV files at uri. It outputs a row per file written with
-// the file name, row count and byte size.
-message ExportSpec {
-  // destination as a cloud.ExternalStorage URI pointing to an export store
-  // location (directory).
-  optional string destination = 1 [(gogoproto.nullable) = false];
-  optional string name_pattern = 2 [(gogoproto.nullable) = false];
-  optional roachpb.IOFileFormat format = 3 [(gogoproto.nullable) = false];
-
-  // chunk_rows is num rows to write per file. 0 = no limit.
-  optional int64 chunk_rows = 4 [(gogoproto.nullable) = false];
-  // chunk_size is the target byte size per file.
-  optional int64 chunk_size = 5 [(gogoproto.nullable) = false];
-
-  // User who initiated the export. This is used to check access privileges
-  // when using FileTable ExternalStorage.
-  optional string user_proto = 6 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
-
-  // col_names specifies the logical column names for the exported parquet file.
-  repeated string col_names = 7 ;
-}
-
 // BulkRowWriterSpec is the specification for a processor that consumes rows and
 // writes them to a target table using AddSSTable. It outputs a BulkOpSummary.
 message BulkRowWriterSpec {

--- a/pkg/sql/execinfrapb/processors_export.proto
+++ b/pkg/sql/execinfrapb/processors_export.proto
@@ -39,4 +39,7 @@ message ExportSpec {
 
   // col_names specifies the logical column names for the exported parquet file.
   repeated string col_names = 7 ;
+
+  // header_row specifies if a csv file should include header rows
+  optional bool header_row = 8 [(gogoproto.nullable) = false];
 }

--- a/pkg/sql/execinfrapb/processors_export.proto
+++ b/pkg/sql/execinfrapb/processors_export.proto
@@ -1,0 +1,42 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+//
+// Processor definitions for distributed SQL APIs. See
+// docs/RFCS/distributed_sql.md.
+// All the concepts here are "physical plan" concepts.
+
+syntax = "proto2";
+// Beware! This package name must not be changed, even though it doesn't match
+// the Go package name, because it defines the Protobuf message names which
+// can't be changed without breaking backward compatibility.
+package cockroach.sql.distsqlrun;
+option go_package = "github.com/cockroachdb/cockroach/pkg/sql/execinfrapb";
+
+// import "roachpb/data.proto";
+import "roachpb/io-formats.proto";
+import "gogoproto/gogo.proto";
+
+// ExporterSpec is the specification for a processor that consumes rows and
+// writes them to Parquet or CSV files at uri. It outputs a row per file written with
+// the file name, row count and byte size.
+message ExportSpec {
+  // destination as a cloud.ExternalStorage URI pointing to an export store
+  // location (directory).
+  optional string destination = 1 [(gogoproto.nullable) = false];
+  optional string name_pattern = 2 [(gogoproto.nullable) = false];
+  optional roachpb.IOFileFormat format = 3 [(gogoproto.nullable) = false];
+
+  // chunk_rows is num rows to write per file. 0 = no limit.
+  optional int64 chunk_rows = 4 [(gogoproto.nullable) = false];
+  // chunk_size is the target byte size per file.
+  optional int64 chunk_size = 5 [(gogoproto.nullable) = false];
+
+  // User who initiated the export. This is used to check access privileges
+  // when using FileTable ExternalStorage.
+  optional string user_proto = 6 [(gogoproto.nullable) = false, (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/security/username.SQLUsernameProto"];
+
+  // col_names specifies the logical column names for the exported parquet file.
+  repeated string col_names = 7 ;
+}

--- a/pkg/sql/export/exportcsv.go
+++ b/pkg/sql/export/exportcsv.go
@@ -178,6 +178,11 @@ func (sp *csvWriter) Run(ctx context.Context, output execinfra.RowReceiver) {
 		alloc := &tree.DatumAlloc{}
 
 		writer := newCSVExporter(sp.spec)
+		if sp.spec.HeaderRow {
+			if err := writer.Write(sp.spec.ColNames); err != nil {
+				return err
+			}
+		}
 
 		var nullsAs string
 		if sp.spec.Format.Csv.NullEncoding != nil {


### PR DESCRIPTION
EXPORT currently does not include column headers, which can lead to issues when columns do not have the same ordinal number (i.e., order) in the database schema that the export is being loaded to. By including column headers, users will be able to disambiguate the columns in the export file.
    
Fixes: #143884
Epic: CRDB-49136
    
Release note (sql change): WITH header_row flag is added to EXPORT. Returns error for non-csv type. Another row is prepended to the csv file with the column names.