### PR TITLE
asim: small clean up 

### DIFF
--- a/pkg/kv/kvserver/asim/state/helpers.go
+++ b/pkg/kv/kvserver/asim/state/helpers.go
@@ -63,7 +63,7 @@ func NewStorePool(
 	nodeLivenessFn storepool.NodeLivenessFunc,
 	hlc *hlc.Clock,
 	st *cluster.Settings,
-) (*storepool.StorePool, *cluster.Settings) {
+) *storepool.StorePool {
 	stopper := stop.NewStopper()
 	defer stopper.Stop(context.Background())
 
@@ -80,7 +80,7 @@ func NewStorePool(
 		nodeLivenessFn,
 		/* deterministic */ true,
 	)
-	return sp, st
+	return sp
 }
 
 // OffsetTick offsets start time by adding tick number of seconds to it.

--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -518,13 +518,13 @@ func (s *state) AddStore(nodeID NodeID) (Store, bool) {
 	node := s.nodes[nodeID]
 	s.storeSeqGen++
 	storeID := s.storeSeqGen
-	sp, st := NewStorePool(s.NodeCountFn(), s.NodeLivenessFn(), hlc.NewClockForTesting(s.clock), s.settings.ST)
+	sp := NewStorePool(s.NodeCountFn(), s.NodeLivenessFn(), hlc.NewClockForTesting(s.clock), s.settings.ST)
 	store := &store{
 		storeID:   storeID,
 		nodeID:    nodeID,
 		desc:      roachpb.StoreDescriptor{StoreID: roachpb.StoreID(storeID), Node: node.Descriptor()},
 		storepool: sp,
-		settings:  st,
+		settings:  s.settings.ST,
 		replicas:  make(map[RangeID]ReplicaID),
 	}
 

--- a/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
+++ b/pkg/kv/kvserver/asim/tests/datadriven_simulation_test.go
@@ -62,14 +62,14 @@ import (
 //   - "gen_ranges" [ranges=<int>]
 //     [placement_type=(even|skewed|weighted|replica_placement)]
 //     [repl_factor=<int>] [min_key=<int>] [max_key=<int>] [bytes=<int>]
-//     [reset=<bool>]
+//     [replace=<bool>]
 //     Initialize the range generator parameters. On the next call to eval, the
 //     range generator is called to assign an ranges and their replica
 //     placement. Unless `reset` is true, the range generator doesn't
 //     replace any existing range generators, it is instead added on-top.
 //     The default values are ranges=1 repl_factor=3 placement_type=even
-//     min_key=0 max_key=10000 reset=false. If replica_placement is used,
-//     an extra line should follow with the replica placement. A example of
+//     min_key=0 max_key=10000 replace=false. If replica_placement is used,
+//     an extra line should follow with the replica placement. An example of
 //     the replica placement is: {s1:*,s2,s3:NON_VOTER}:1 {s4:*,s5,s6}:1.
 //
 //   - set_liveness node=<int> liveness=(livenesspb.NodeLivenessStatus) [delay=<duration>]


### PR DESCRIPTION
**asim: remove unused return value from NewStorePool**

Previously, AddStore passed the cluster settings to NewStorePool only to and
NewStorePool unnecessarily returns the cluster setting again, which was
redundant since AddStore already had reference to them. This commit removes the
unnecessary return value.

Epic: none
Release note: none

---

**asim: correct gen_ranges command comments**

Previously, we incorrectly used reset instead of replace option in the comment.
This commit corrects the comment.

Epic: none
Release note: none
