### PR TITLE
 changefeedccl: support protobuf in cloud storage with envelope=bare

### DIFF
--- a/pkg/ccl/changefeedccl/sink_cloudstorage.go
+++ b/pkg/ccl/changefeedccl/sink_cloudstorage.go
@@ -480,6 +480,9 @@ func makeCloudStorageSink(
 	case changefeedbase.OptFormatParquet:
 		s.ext = `.parquet`
 		s.rowDelimiter = nil
+	case changefeedbase.OptFormatProtobuf:
+		s.ext = `.pb`
+		s.rowDelimiter = nil
 	default:
 		return nil, errors.Errorf(`this sink is incompatible with %s=%s`,
 			changefeedbase.OptFormat, encodingOpts.Format)


### PR DESCRIPTION
This change adds support for emitting changefeeds in protobuf format
to cloud storage sinks when using envelope=bare.

Release note (general change): Changefeeds using the protobuf format
now support cloud storage sinks with envelope=bare.

Fixes https://github.com/cockroachdb/cockroach/issues/148935