### PR TITLE
batcheval: introduce datadriven harness for the split trigger

### DIFF
--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -51,6 +51,7 @@ go_library(
         "lock.go",
         "ranges.go",
         "split_stats_helper.go",
+        "split_trigger_datadriven.go",
         "stateloader.go",
         "transaction.go",
     ],
@@ -95,6 +96,7 @@ go_library(
         "//pkg/util/protoutil",
         "//pkg/util/tracing",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_pebble//:pebble",
         "@com_github_cockroachdb_redact//:redact",
@@ -138,6 +140,7 @@ go_test(
         "testutils_test.go",
         "transaction_test.go",
     ],
+    data = glob(["testdata/**"]),
     embed = [":batcheval"],
     exec_properties = {"test.Pool": "large"},
     deps = [

--- a/pkg/kv/kvserver/batcheval/split_trigger_datadriven.go
+++ b/pkg/kv/kvserver/batcheval/split_trigger_datadriven.go
@@ -1,0 +1,461 @@
+// Copyright 2024 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package batcheval
+
+import (
+	"context"
+	"fmt"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/abortspan"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
+	"github.com/cockroachdb/cockroach/pkg/storage"
+	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/datadriven"
+	"github.com/stretchr/testify/require"
+)
+
+/*
+TestSplitTriggerDatadriven tests the use of the split trigger. The test uses the
+following format:
+
+create-descriptor start=<key> end=<key> [replicas=[<int>,<int>,...]]
+----
+
+  Creates a range descriptor with the specified start and end keys and optional
+  replica list. The range ID is auto-assigned. If provided, replicas specify
+  NodeIDs for replicas of the range. Note that ReplicaIDs are assigned
+  incrementally starting from 1.
+
+create-split range-id=<int> split-key=<key>
+----
+
+  Creates a split for the specified range at the given split key, which entails
+  creating a SplitTrigger with both the LHS and RHS descriptors. Much like how
+  things work in CRDB, the LHS descriptor is created by narrowing the original
+  range and a new range descriptor is created for the RHS with the same replica
+  set.
+
+set-lease range-id=<int> replica=<int> [lease-type=leader-lease|epoch|expiration]
+----
+
+  Sets the lease for the specified range to the supplied replica. Note that the
+  replica parameter specifies NodeIDs, not to be confused with ReplicaIDs. By
+  default, the lease is of the leader-lease variety, but this may be overriden to
+  an epoch or expiration based lease by using the lease-type parameter. For now,
+  we treat the associated lease metadata as uninteresting.
+
+print-lease range-id=<int>
+----
+
+  Prints the leaseholder replica and lease type for the specified range.
+
+print-range-state
+----
+
+  Prints the entire range state of the test context.
+
+run-split-trigger range-id=<int>
+----
+  Executes the split trigger for the specified range. The output shows all
+  keys and values written to the batch as part of this.
+
+TODO(arul): For now, we do not change things like GC Threshold, GC Hint, etc.
+We could/should modify the test to do so in the future. We should also add a
+directive to populate the abort span.
+*/
+
+func TestSplitTriggerDatadriven(t *testing.T) {
+	datadriven.Walk(t, filepath.Join("testdata", "split_trigger"), func(t *testing.T, path string) {
+		tc := newTestCtx()
+		ctx := context.Background()
+		datadriven.RunTest(t, path, func(t *testing.T, d *datadriven.TestData) string {
+			switch d.Cmd {
+			case "create-descriptor":
+				var startKey, endKey string
+				d.ScanArgs(t, "start", &startKey)
+				d.ScanArgs(t, "end", &endKey)
+				var replicaIDs []int
+				if d.HasArg("replicas") {
+					var replicasStr string
+					d.ScanArgs(t, "replicas", &replicasStr)
+					replicaIDs = parseReplicas(replicasStr)
+				}
+
+				rangeID := tc.nextRangeID
+				tc.nextRangeID++
+				var internalReplicas []roachpb.ReplicaDescriptor
+				for i, id := range replicaIDs {
+					internalReplicas = append(internalReplicas, roachpb.ReplicaDescriptor{
+						ReplicaID: roachpb.ReplicaID(i + 1),
+						NodeID:    roachpb.NodeID(id),
+						Type:      roachpb.VOTER_FULL,
+					})
+				}
+				desc := roachpb.RangeDescriptor{
+					RangeID:          roachpb.RangeID(rangeID),
+					StartKey:         roachpb.RKey(startKey),
+					EndKey:           roachpb.RKey(endKey),
+					InternalReplicas: internalReplicas,
+				}
+
+				// Ranges are expected to be non-overlapping. Before creating a
+				// new one, sanity check that we're not violating this property
+				// in the test context.
+				for existingRangeID, existingRS := range tc.ranges {
+					existingDesc := existingRS.desc
+					if desc.StartKey.Compare(existingDesc.EndKey) < 0 &&
+						existingDesc.StartKey.Compare(desc.EndKey) < 0 {
+						return fmt.Sprintf("descriptor overlaps with existing range %d [%s,%s)",
+							existingRangeID, existingDesc.StartKey, existingDesc.EndKey)
+					}
+				}
+
+				tc.ranges[rangeID] = newRangeState(desc)
+				return fmt.Sprintf("created descriptor: %v", desc)
+
+			case "create-split":
+				var rangeID int
+				var splitKey string
+				d.ScanArgs(t, "range-id", &rangeID)
+				d.ScanArgs(t, "split-key", &splitKey)
+				rs := tc.mustGetRangeState(t, rangeID)
+				desc := rs.desc
+				if !(roachpb.RKey(splitKey).Compare(desc.StartKey) > 0 && roachpb.RKey(splitKey).Compare(desc.EndKey) < 0) {
+					return fmt.Sprintf("split-key %q not within range [%q,%q)", splitKey, desc.StartKey, desc.EndKey)
+				}
+				leftDesc := desc
+				leftDesc.EndKey = roachpb.RKey(splitKey)
+				rightDesc := desc
+				rightDesc.RangeID = roachpb.RangeID(tc.nextRangeID)
+				tc.nextRangeID++
+				rightDesc.StartKey = roachpb.RKey(splitKey)
+				split := &roachpb.SplitTrigger{
+					LeftDesc:  leftDesc,
+					RightDesc: rightDesc,
+				}
+				tc.splits[rangeID] = split
+				return fmt.Sprintf("created split trigger for range-id %d at split-key %q", rangeID, splitKey)
+
+			case "set-lease":
+				var rangeID int
+				var replicaNodeID int
+				d.ScanArgs(t, "range-id", &rangeID)
+				d.ScanArgs(t, "replica", &replicaNodeID)
+				var leaseType string
+				if d.HasArg("lease-type") {
+					d.ScanArgs(t, "lease-type", &leaseType)
+				}
+				rs := tc.mustGetRangeState(t, rangeID)
+				// Find the replica in the range descriptor by NodeID.
+				var targetReplica *roachpb.ReplicaDescriptor
+				for i := range rs.desc.InternalReplicas {
+					if rs.desc.InternalReplicas[i].NodeID == roachpb.NodeID(replicaNodeID) {
+						targetReplica = &rs.desc.InternalReplicas[i]
+						break
+					}
+				}
+				if targetReplica == nil {
+					return fmt.Sprintf("replica with NodeID %d not found in range descriptor", replicaNodeID)
+				}
+				if leaseType == "" {
+					leaseType = "leader-lease" // default to leader-lease
+				}
+				// NB: The details of the lease are not important to the test;
+				// only the type is.
+				var lease roachpb.Lease
+				switch leaseType {
+				case "leader-lease":
+					lease = roachpb.Lease{
+						Replica:       *targetReplica,
+						Term:          10,
+						MinExpiration: hlc.Timestamp{WallTime: 100},
+					}
+				case "epoch":
+					lease = roachpb.Lease{
+						Replica: *targetReplica,
+						Epoch:   20,
+					}
+				case "expiration":
+					lease = roachpb.Lease{
+						Replica:    *targetReplica,
+						Expiration: &hlc.Timestamp{WallTime: 300},
+					}
+				default:
+					return fmt.Sprintf("unknown lease type: %s", leaseType)
+				}
+				rs.lease = lease
+				return fmt.Sprintf("set lease for range %d replica %d: %s", rangeID, replicaNodeID, leaseType)
+
+			case "print-lease":
+				var rangeID int
+				d.ScanArgs(t, "range-id", &rangeID)
+				rs := tc.mustGetRangeState(t, rangeID)
+
+				lease := rs.lease
+				var leaseType string
+				if lease.Epoch != 0 {
+					leaseType = "epoch"
+				} else if lease.Expiration != nil {
+					leaseType = "expiration"
+				} else {
+					leaseType = "leader-lease"
+				}
+				return fmt.Sprintf("range %d: leaseholder NodeID=%d, type=%s",
+					rangeID, lease.Replica.NodeID, leaseType)
+
+			case "print-range-state":
+				var sb strings.Builder
+				if len(tc.ranges) == 0 {
+					return "no ranges in test context"
+				}
+				// Sort range IDs for consistent output.
+				var rangeIDs []int
+				for rangeID := range tc.ranges {
+					rangeIDs = append(rangeIDs, rangeID)
+				}
+				sort.Ints(rangeIDs)
+
+				for _, rangeID := range rangeIDs {
+					rs := tc.ranges[rangeID]
+					sb.WriteString(fmt.Sprintf("range %d: [%s,%s) replicas=",
+						rangeID, rs.desc.StartKey, rs.desc.EndKey))
+
+					for i, replica := range rs.desc.InternalReplicas {
+						if i > 0 {
+							sb.WriteString(",")
+						}
+						sb.WriteString(fmt.Sprintf("n%d(r%d)", replica.NodeID, replica.ReplicaID))
+					}
+					sb.WriteString("\n")
+				}
+				return sb.String()
+
+			case "run-split-trigger":
+				var rangeID int
+				d.ScanArgs(t, "range-id", &rangeID)
+				split, ok := tc.splits[rangeID]
+				if !ok {
+					return fmt.Sprintf("no split trigger for range-id %d", rangeID)
+				}
+				rs := tc.mustGetRangeState(t, rangeID)
+				desc := rs.desc
+				db := storage.NewDefaultInMemForTesting()
+				defer db.Close()
+				batch := db.NewBatch()
+				defer batch.Close()
+
+				rec := (&MockEvalCtx{
+					ClusterSettings:        tc.st,
+					Desc:                   &desc,
+					Clock:                  tc.clock,
+					AbortSpan:              rs.abortspan,
+					LastReplicaGCTimestamp: rs.lastGCTimestamp,
+					RangeLeaseDuration:     tc.rangeLeaseDuration,
+				}).EvalContext()
+
+				// Write the range state that will be consulted and copied
+				// during the split.
+				sl := stateloader.Make(desc.RangeID)
+				err := sl.SetLease(ctx, batch, nil, rs.lease)
+				require.NoError(t, err)
+				err = sl.SetGCThreshold(ctx, batch, nil, &rs.gcThreshold)
+				require.NoError(t, err)
+				err = sl.SetGCHint(ctx, batch, nil, &rs.gcHint)
+				require.NoError(t, err)
+				err = sl.SetVersion(ctx, batch, nil, &rs.version)
+				require.NoError(t, err)
+
+				// Run the split trigger.
+				_, _, err = splitTrigger(ctx, rec, batch /* bothDeltaMS */, enginepb.MVCCStats{}, split, hlc.Timestamp{})
+				if err != nil {
+					return fmt.Sprintf("splitTrigger error: %v", err)
+				}
+
+				// Update the test context's notion of range state after split.
+				tc.updatePostSplitRangeState(t, ctx, batch, rangeID, split)
+
+				// Print the state of the batch (all keys/values written).
+				var sb strings.Builder
+				iter, err := batch.NewEngineIterator(ctx, storage.IterOptions{
+					UpperBound: roachpb.KeyMax,
+					KeyTypes:   storage.IterKeyTypePointsAndRanges,
+				})
+				require.NoError(t, err)
+
+				defer iter.Close()
+				var lines []string
+				valid, err := iter.SeekEngineKeyGE(storage.EngineKey{Key: roachpb.KeyMin})
+				require.NoError(t, err)
+				for valid {
+					hasPoint, hasRange := iter.HasPointAndRange()
+					if hasPoint {
+						k, err := iter.EngineKey()
+						require.NoError(t, err)
+						v, err := iter.UnsafeValue()
+						if err != nil {
+							return fmt.Sprintf("error getting value: %v", err)
+						}
+						lines = append(lines, fmt.Sprintf("point %s = %x", k, v))
+					}
+					if hasRange {
+						bounds, err := iter.EngineRangeBounds()
+						require.NoError(t, err)
+
+						v := iter.EngineRangeKeys()
+						for i := range v {
+							lines = append(lines, fmt.Sprintf(
+								"range [%s,%s) = %x/%x",
+								bounds.Key, bounds.EndKey, v[i].Value, v[i].Version))
+						}
+					}
+					valid, err = iter.NextEngineKey()
+					require.NoError(t, err)
+				}
+
+				for _, line := range lines {
+					sb.WriteString(line)
+					sb.WriteString("\n")
+				}
+				return sb.String()
+
+			default:
+				return fmt.Sprintf("unknown command: %s", d.Cmd)
+			}
+		})
+	})
+}
+
+type rangeState struct {
+	desc            roachpb.RangeDescriptor
+	lease           roachpb.Lease
+	gcThreshold     hlc.Timestamp
+	gcHint          roachpb.GCHint
+	version         roachpb.Version
+	abortspan       *abortspan.AbortSpan
+	lastGCTimestamp hlc.Timestamp
+}
+
+func newRangeState(desc roachpb.RangeDescriptor) *rangeState {
+	gcThreshold := hlc.Timestamp{WallTime: 4}
+	gcHint := roachpb.GCHint{GCTimestamp: gcThreshold}
+	return &rangeState{
+		desc:            desc,
+		gcThreshold:     gcThreshold,
+		gcHint:          gcHint,
+		version:         cluster.MakeTestingClusterSettings().Version.LatestVersion(),
+		abortspan:       abortspan.New(desc.RangeID),
+		lastGCTimestamp: hlc.Timestamp{},
+	}
+}
+
+type testCtx struct {
+	ranges             map[int]*rangeState
+	splits             map[int]*roachpb.SplitTrigger
+	nextRangeID        int
+	st                 *cluster.Settings
+	clock              *hlc.Clock
+	rangeLeaseDuration time.Duration
+}
+
+func newTestCtx() *testCtx {
+	st := cluster.MakeTestingClusterSettings()
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 10))
+	clock := hlc.NewClockForTesting(manual)
+	return &testCtx{
+		ranges:             make(map[int]*rangeState),
+		splits:             make(map[int]*roachpb.SplitTrigger),
+		nextRangeID:        1,
+		st:                 st,
+		clock:              clock,
+		rangeLeaseDuration: 99 * time.Nanosecond,
+	}
+}
+
+// mustGetRangeState returns the range state for the given range ID.
+func (tc *testCtx) mustGetRangeState(t *testing.T, rangeID int) *rangeState {
+	rs, ok := tc.ranges[rangeID]
+	if !ok {
+		t.Fatalf("range-id %d not found", rangeID)
+	}
+	return rs
+}
+
+// updatePostSplitRangeState updates the range state after a split.
+func (tc *testCtx) updatePostSplitRangeState(
+	t *testing.T,
+	ctx context.Context,
+	batch storage.Batch,
+	originalRangeID int,
+	split *roachpb.SplitTrigger,
+) {
+	// Get the original range state
+	originalRangeState, ok := tc.ranges[originalRangeID]
+	if !ok {
+		t.Fatalf("original range state not found for range ID %d", originalRangeID)
+	}
+
+	// The range ID should not change for LHS since it's the same range
+	if int(split.LeftDesc.RangeID) != originalRangeID {
+		t.Fatalf("LHS range ID changed from %d to %d", originalRangeID, split.LeftDesc.RangeID)
+	}
+	// Update LHS by just updating the descriptor
+	originalRangeState.desc = split.LeftDesc
+	tc.ranges[int(split.LeftDesc.RangeID)] = originalRangeState
+
+	// Create RHS range state by reading from the batch
+	rhsRangeState := newRangeState(split.RightDesc)
+	rhsSl := stateloader.Make(split.RightDesc.RangeID)
+
+	// Read lease from batch
+	rhsLease, err := rhsSl.LoadLease(ctx, batch)
+	if err == nil {
+		rhsRangeState.lease = rhsLease
+	}
+
+	// Read GC threshold from batch
+	rhsGCThreshold, err := rhsSl.LoadGCThreshold(ctx, batch)
+	if err == nil && rhsGCThreshold != nil {
+		rhsRangeState.gcThreshold = *rhsGCThreshold
+	}
+
+	// Read GC hint from batch
+	rhsGCHint, err := rhsSl.LoadGCHint(ctx, batch)
+	if err == nil && rhsGCHint != nil {
+		rhsRangeState.gcHint = *rhsGCHint
+	}
+
+	// Read version from batch
+	rhsVersion, err := rhsSl.LoadVersion(ctx, batch)
+	if err == nil {
+		rhsRangeState.version = rhsVersion
+	}
+
+	tc.ranges[int(split.RightDesc.RangeID)] = rhsRangeState
+}
+
+func parseReplicas(val string) []int {
+	var replicaIDs []int
+	if len(val) >= 2 && val[0] == '[' && val[len(val)-1] == ']' {
+		val = val[1 : len(val)-1]
+		if val != "" {
+			for _, s := range strings.Split(val, ",") {
+				var id int
+				fmt.Sscanf(strings.TrimSpace(s), "%d", &id)
+				replicaIDs = append(replicaIDs, id)
+			}
+		}
+	}
+	return replicaIDs
+}

--- a/pkg/kv/kvserver/batcheval/testdata/split_trigger/basic
+++ b/pkg/kv/kvserver/batcheval/testdata/split_trigger/basic
@@ -1,0 +1,107 @@
+create-descriptor start=a end=z replicas=[1,2,3]
+----
+created descriptor: r1:{a-z} [(n1,s0):1, (n2,s0):2, (n3,s0):3, next=0, gen=0]
+
+# Set the range's lease to be a leader lease. Then, post-split, ensure the RHS
+# gets the correct lease type -- an expiration based lease. This is because
+# a leader lease is specific to the LHS's raft group.
+set-lease range-id=1 replica=2
+----
+set lease for range 1 replica 2: leader-lease
+
+create-split range-id=1 split-key=m
+----
+created split trigger for range-id 1 at split-key "m"
+
+run-split-trigger range-id=1
+----
+point /Local/RangeID/1/r/RangeGCThreshold/ = 1204080010001800200028003207bba7f22a030804
+point /Local/RangeID/1/r/RangeGCHint/ = 120408001000180020002800320dfae07b7b030a00120208041a00
+point /Local/RangeID/1/r/RangeLease/ = 12040800100018002000280032191ec44dcc030a001a0808021000180220002a004a020864500a
+point /Local/RangeID/1/r/RangeVersion/ = 120408001000180020002800320fadb4b9130308d9843d100218002008
+point /Local/RangeID/2/r/RangeGCThreshold/ = 1204080010001800200028003207822aceef030804
+point /Local/RangeID/2/r/RangeAppliedState/ = 12040800100018002000280032146e3fa95f03080a100a1a0560c801680522002805
+point /Local/RangeID/2/r/RangeGCHint/ = 120408001000180020002800320deb9d1102030a00120208041a00
+point /Local/RangeID/2/r/RangeLease/ = 12040800100018002000280032194c8ba073030a001202086d1a0808011000180120002a004a00
+point /Local/RangeID/2/r/RangeVersion/ = 120408001000180020002800320ffe2ee2970308d9843d100218002008
+point /Local/RangeID/2/u/RaftTruncatedState/ = 1204080010001800200028003209175922ee03080a1005
+point /Local/RangeID/2/u/RangeLastReplicaGCTimestamp/ = 12040800100018002000280032053e9238d103
+point /Local/Range"m"/QueueLastProcessed/"consistencyChecker"/ = 1204080010001800200028003205d0ad93d003
+
+print-range-state
+----
+range 1: ["a","m") replicas=n1(r1),n2(r2),n3(r3)
+range 2: ["m","z") replicas=n1(r1),n2(r2),n3(r3)
+
+print-lease range-id=1
+----
+range 1: leaseholder NodeID=2, type=leader-lease
+
+print-lease range-id=2
+----
+range 2: leaseholder NodeID=1, type=expiration
+
+# Next, create two more splits, but this time for ranges that are using an
+# expiration based lease and an epoch based lease. Show that the same lease type
+# is copied over to the RHS in both these cases.
+
+create-split range-id=1 split-key=f
+----
+created split trigger for range-id 1 at split-key "f"
+
+set-lease range-id=1 replica=1 lease-type=epoch
+----
+set lease for range 1 replica 1: epoch
+
+run-split-trigger range-id=1
+----
+point /Local/RangeID/1/r/RangeGCThreshold/ = 1204080010001800200028003207bba7f22a030804
+point /Local/RangeID/1/r/RangeGCHint/ = 120408001000180020002800320dfae07b7b030a00120208041a00
+point /Local/RangeID/1/r/RangeLease/ = 120408001000180020002800321770820370030a001a0808011000180120002a0030144a00
+point /Local/RangeID/1/r/RangeVersion/ = 120408001000180020002800320fadb4b9130308d9843d100218002008
+point /Local/RangeID/3/r/RangeGCThreshold/ = 12040800100018002000280032079551daac030804
+point /Local/RangeID/3/r/RangeAppliedState/ = 12040800100018002000280032146c9ddfad03080a100a1a0560c601680522002805
+point /Local/RangeID/3/r/RangeGCHint/ = 120408001000180020002800320d5266caea030a00120208041a00
+point /Local/RangeID/3/r/RangeLease/ = 1204080010001800200028003217e0e4252d030a001a0808011000180120002a0030144a00
+point /Local/RangeID/3/r/RangeVersion/ = 120408001000180020002800320f798829d40308d9843d100218002008
+point /Local/RangeID/3/u/RaftTruncatedState/ = 1204080010001800200028003209d6d7fd2e03080a1005
+point /Local/RangeID/3/u/RangeLastReplicaGCTimestamp/ = 120408001000180020002800320598e5336503
+point /Local/Range"f"/QueueLastProcessed/"consistencyChecker"/ = 120408001000180020002800320577d3539403
+
+create-split range-id=2 split-key=v
+----
+created split trigger for range-id 2 at split-key "v"
+
+set-lease range-id=2 replica=3 lease-type=expiration
+----
+set lease for range 2 replica 3: expiration
+
+run-split-trigger range-id=2
+----
+point /Local/RangeID/2/r/RangeGCThreshold/ = 1204080010001800200028003207822aceef030804
+point /Local/RangeID/2/r/RangeGCHint/ = 120408001000180020002800320deb9d1102030a00120208041a00
+point /Local/RangeID/2/r/RangeLease/ = 120408001000180020002800321a17aff157030a00120308ac021a0808031000180320002a004a00
+point /Local/RangeID/2/r/RangeVersion/ = 120408001000180020002800320ffe2ee2970308d9843d100218002008
+point /Local/RangeID/4/r/RangeGCThreshold/ = 1204080010001800200028003207f130b765030804
+point /Local/RangeID/4/r/RangeAppliedState/ = 1204080010001800200028003214d064f34103080a100a1a0560c901680522002805
+point /Local/RangeID/4/r/RangeGCHint/ = 120408001000180020002800320dc967c5f0030a00120208041a00
+point /Local/RangeID/4/r/RangeLease/ = 120408001000180020002800321adde057f1030a00120308ac021a0808011000180120002a004a00
+point /Local/RangeID/4/r/RangeVersion/ = 120408001000180020002800320f591a559f0308d9843d100218002008
+point /Local/RangeID/4/u/RaftTruncatedState/ = 1204080010001800200028003209ffece8ad03080a1005
+point /Local/RangeID/4/u/RangeLastReplicaGCTimestamp/ = 12040800100018002000280032055d420deb03
+point /Local/Range"v"/QueueLastProcessed/"consistencyChecker"/ = 1204080010001800200028003205dd8108ec03
+
+print-range-state
+----
+range 1: ["a","f") replicas=n1(r1),n2(r2),n3(r3)
+range 2: ["m","v") replicas=n1(r1),n2(r2),n3(r3)
+range 3: ["f","m") replicas=n1(r1),n2(r2),n3(r3)
+range 4: ["v","z") replicas=n1(r1),n2(r2),n3(r3)
+
+print-lease range-id=3
+----
+range 3: leaseholder NodeID=1, type=epoch
+
+print-lease range-id=4
+----
+range 4: leaseholder NodeID=1, type=expiration


### PR DESCRIPTION
This patch introduces a new data-driven harness to test engine interactions when the split trigger is run.

We then use this harness to show that the post-split RHS gets an expiration based lease when the pre-split range used a leader lease.

References https://github.com/cockroachdb/cockroach/issues/144542

Release note: None