### PR TITLE
workload_generator: introduce Generator interface and concrete genera…

### DIFF
--- a/pkg/workload/workload_generator/BUILD.bazel
+++ b/pkg/workload/workload_generator/BUILD.bazel
@@ -3,9 +3,11 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "workload_generator",
     srcs = [
+        "column_generator.go",
         "constants.go",
         "schema_designs.go",
         "schema_generator.go",
+        "types.go",
         "utils.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/workload/workload_generator",
@@ -19,6 +21,7 @@ go_library(
 go_test(
     name = "workload_generator_test",
     srcs = [
+        "column_generator_test.go",
         "schema_generator_test.go",
         "utils_test.go",
     ],

--- a/pkg/workload/workload_generator/column_generator.go
+++ b/pkg/workload/workload_generator/column_generator.go
@@ -1,0 +1,228 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package workload_generator
+
+import (
+	"fmt"
+	"math/rand"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// buildGenerator builds a Generator for one column given
+//   - col:       metadata for this column
+//   - batchIdx:  which batch we’re in (0,1,2…)
+//   - baseBatchSize: how many rows per batch (for sequences)
+//   - schema:    full YAML schema, so we can recurse on FKs
+func buildGenerator(col ColumnMeta, batchIdx, batchSize int, schema Schema) Generator {
+	// seed the per-batch RNG
+	origSeed := getIntArg(col.Args, "seed", 0)
+	seed64 := buildBatchSeed(origSeed, batchIdx)
+	rng := rand.New(rand.NewSource(seed64))
+
+	// pick the base generator by type
+	var base Generator
+	switch col.Type {
+	case GenTypeSequence:
+		// jump start by batchIdx*batchSize
+		base = buildSequenceGenerator(col, batchIdx, batchSize)
+	case GenTypeInteger:
+		base = buildIntegerGenerator(col, rng)
+	case GenTypeFloat:
+		base = buildFloatGenerator(col, rng)
+	case GenTypeString:
+		base = buildStringGenerator(col, rng)
+	case GenTypeTimestamp:
+		base = buildTimestampGenerator(col, rng)
+	case GenTypeUUID:
+		base = buildUuidGenerator(col, rng)
+	case GenTypeBool:
+		base = buildBooleanGenerator(col, rng)
+	case GenTypeJson: //missed json type ig, will check
+		base = buildJsonGenerator(col, rng)
+
+	default:
+		panic("type not supported: " + col.Type)
+	}
+
+	// layer on DefaultWrapper if required
+	if col.Default != "" && col.DefaultProb > 0 {
+		// use a distinct sub-seed so the literal probability RNG
+		// doesn’t collide with the main RNG
+		wrapperSeed := buildBatchSeed(origSeed, batchIdx^0xdeadbeef)
+		base = NewDefaultWrapper(base, col.DefaultProb, col.Default, wrapperSeed)
+	}
+
+	// layer on UniqueWrapper if required
+	if col.IsUnique && !col.HasForeignKey && col.Type != "sequence" {
+		base = NewUniqueWrapper(base, defaultUniqueCap) // or configurable capacity
+	}
+
+	// layer on FKWrapper if this column has a foreign key
+	if col.HasForeignKey {
+		// col.FK might be "tpcc__public__district.d_id"
+		parts := strings.SplitN(col.FK, ".", 2)
+		if len(parts) != 2 {
+			panic(fmt.Sprintf("invalid FK spec %q", col.FK))
+		}
+		fqTable, childCol := parts[0], parts[1]          // "tpcc__public__district", "d_id"
+		pathSegments := strings.Split(fqTable, "__")     // ["tpcc","public","district"]
+		parentTable := pathSegments[len(pathSegments)-1] // "district"
+
+		// now look up in your schema map:
+		parentMeta := schema[parentTable][0].Columns[childCol]
+		parentGen := buildGenerator(parentMeta, batchIdx, batchSize, schema)
+		base = NewFkWrapper(parentGen, col.Fanout)
+	}
+
+	return base
+}
+
+// getIntArg handles int|float64|string in YAML args
+func getIntArg(m map[string]interface{}, key string, defaultVal int) int {
+	switch v := m[key].(type) {
+	case int:
+		return v
+	case int64:
+		return int(v)
+	case float64:
+		return int(v)
+	case string:
+		i, _ := strconv.Atoi(v)
+		return i
+	default:
+		return defaultVal
+	}
+}
+
+// getFloatArg handles float64|int|string
+func getFloatArg(m map[string]interface{}, key string, defaultVal float64) float64 {
+	switch v := m[key].(type) {
+	case float64:
+		return v
+	case int:
+		return float64(v)
+	case int64:
+		return float64(v)
+	case string:
+		f, _ := strconv.ParseFloat(v, 64)
+		return f
+	default:
+		return defaultVal
+	}
+}
+
+// getStringArg handles string values
+func getStringArg(m map[string]interface{}, key string, defaultVal string) string {
+	if v, ok := m[key]; ok {
+		if s, ok2 := v.(string); ok2 {
+			return s
+		}
+	}
+	return defaultVal
+}
+
+// ─── Factory ──────────────────────────────────────────────────────────
+
+// splitmix64 scrambles a 32-bit key into a high-quality 64-bit value
+func splitmix64(x uint64) uint64 {
+	x += 0x9e3779b97f4a7c15
+	x = (x ^ (x >> 30)) * 0xbf58476d1ce4e5b9
+	x = (x ^ (x >> 27)) * 0x94d049bb133111eb
+	return x ^ (x >> 31)
+}
+
+// buildBatchSeed deterministically scrambles the original YAML seed
+// with the batch index so each batch uses a distinct RNG stream.
+func buildBatchSeed(origSeed, batchIdx int) int64 {
+	key := (uint64(origSeed) << 32) | uint64(batchIdx)
+	return int64(splitmix64(key))
+}
+
+// buildSequenceGenerator creates a SequenceGen that generates sequential integers
+func buildSequenceGenerator(col ColumnMeta, batchIdx int, batchSize int) Generator {
+	baseStart := getIntArg(col.Args, "start", 0)
+	return &SequenceGen{cur: baseStart + batchIdx*batchSize}
+}
+
+// buildIntegerGenerator creates an IntegerGen that generates random integers
+func buildIntegerGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	minArg := getIntArg(col.Args, "min", 0)
+	maxArg := getIntArg(col.Args, "max", 0)
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &IntegerGen{r: rng, min: minArg, max: maxArg, nullPct: nullPct}
+}
+
+// buildFloatGenerator creates a FloatGen that generates random floats
+func buildFloatGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	minArg := getFloatArg(col.Args, "min", 0.0)
+	maxArg := getFloatArg(col.Args, "max", 0.0)
+	round := getIntArg(col.Args, "round", 2)
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &FloatGen{r: rng, min: minArg, max: maxArg, round: round, nullPct: nullPct}
+}
+
+// buildStringGenerator creates a StringGen that generates random strings
+func buildStringGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	minArg := getIntArg(col.Args, "min", 0)
+	maxArg := getIntArg(col.Args, "max", 0)
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &StringGen{r: rng, min: minArg, max: maxArg, nullPct: nullPct}
+}
+
+// buildTimestampGenerator creates a TimestampGen that generates random timestamps
+func buildTimestampGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	// parse Python-style format → Go layout
+	startStr := getStringArg(col.Args, "start", "2000-01-01")
+	endStr := getStringArg(col.Args, "end", timeutil.Now().Format("2006-01-02"))
+	pyFmt := getStringArg(col.Args, "format", "%Y-%m-%d %H:%M:%S.%f")
+	var layout string
+	switch pyFmt {
+	case "%Y-%m-%d %H:%M:%S.%f":
+		layout = "2006-01-02 15:04:05.000000"
+	case "%Y-%m-%d":
+		layout = "2006-01-02"
+	default:
+		layout = time.RFC3339Nano
+	}
+	st, err1 := time.Parse(layout, startStr)
+	et, err2 := time.Parse(layout, endStr)
+	if err1 != nil || err2 != nil {
+		st, _ = time.Parse(time.RFC3339, startStr)
+		et, _ = time.Parse(time.RFC3339, endStr)
+		layout = time.RFC3339
+	}
+	span := et.UnixNano() - st.UnixNano()
+	if span <= 0 {
+		span = 1
+	}
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &TimestampGen{r: rng, startNS: st.UnixNano(), spanNS: span, layout: layout, nullPct: nullPct}
+}
+
+// buildUuidGenerator creates a UUIDGen that generates random UUIDs
+func buildUuidGenerator(_ ColumnMeta, rng *rand.Rand) Generator {
+	return &UUIDGen{r: rng}
+}
+
+// buildBooleanGenerator creates a BoolGen that generates random booleans
+func buildBooleanGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &BoolGen{r: rng, nullPct: nullPct}
+}
+
+// buildJsonGenerator creates a JsonGen that generates random JSON strings
+func buildJsonGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	// JSON is just a StringGen plus a wrapper
+	minArg := getIntArg(col.Args, "min", defaultJSONMinLen)
+	maxArg := getIntArg(col.Args, "max", defaultJSONMaxLen)
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	sg := &StringGen{r: rng, min: minArg, max: maxArg, nullPct: nullPct}
+	return &JsonGen{strGen: sg}
+}

--- a/pkg/workload/workload_generator/column_generator_test.go
+++ b/pkg/workload/workload_generator/column_generator_test.go
@@ -1,0 +1,184 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package workload_generator
+
+import (
+	"encoding/hex"
+	"math/rand"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestGetIntArg(t *testing.T) {
+	m := map[string]interface{}{
+		"i":   7,
+		"i64": int64(13),
+		"f":   5.0,
+		"s":   "21",
+	}
+	assert.Equal(t, 7, getIntArg(m, "i", 0), "getIntArg int")
+	assert.Equal(t, 13, getIntArg(m, "i64", 0), "getIntArg int64")
+	assert.Equal(t, 5, getIntArg(m, "f", 0), "getIntArg float64")
+	assert.Equal(t, 21, getIntArg(m, "s", 0), "getIntArg string")
+	assert.Equal(t, 42, getIntArg(m, "missing", 42), "getIntArg default")
+}
+
+func TestGetFloatArg(t *testing.T) {
+	m := map[string]interface{}{
+		"f":   3.14,
+		"i":   2,
+		"i64": int64(4),
+		"s":   "6.28",
+	}
+	assert.InDelta(t, 3.14, getFloatArg(m, "f", 0), 1e-9, "getFloatArg float64")
+	assert.InDelta(t, 2.0, getFloatArg(m, "i", 0), 1e-9, "getFloatArg int")
+	assert.InDelta(t, 4.0, getFloatArg(m, "i64", 0), 1e-9, "getFloatArg int64")
+	assert.InDelta(t, 6.28, getFloatArg(m, "s", 0), 1e-9, "getFloatArg string")
+	assert.InDelta(t, 9.9, getFloatArg(m, "missing", 9.9), 1e-9, "getFloatArg default")
+}
+
+func TestGetStringArg(t *testing.T) {
+	m := map[string]interface{}{"a": "hello", "b": 123}
+	assert.Equal(t, "hello", getStringArg(m, "a", "x"), "present")
+	assert.Equal(t, "x", getStringArg(m, "b", "x"), "wrong type")
+	assert.Equal(t, "y", getStringArg(m, "c", "y"), "missing")
+}
+
+func TestSplitmix64AndBatchSeed(t *testing.T) {
+	x := uint64(12345)
+	v1 := splitmix64(x)
+	assert.Equal(t, v1, splitmix64(x), "deterministic")
+	assert.NotEqual(t, v1, splitmix64(x+1), "no collision")
+	seed := buildBatchSeed(1, 2)
+	want := int64(splitmix64((uint64(1) << 32) | uint64(2)))
+	assert.Equal(t, want, seed, "batch seed")
+}
+
+func TestSequenceGenerator(t *testing.T) {
+	col := ColumnMeta{Args: map[string]interface{}{"start": 5}}
+	gen := buildSequenceGenerator(col, 2, 10)
+	assert.Equal(t, "25", gen.Next(), "first value")
+	assert.Equal(t, "26", gen.Next(), "second value")
+}
+
+func TestIntegerAndFloatGenerators(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+	icol := ColumnMeta{Args: map[string]interface{}{"min": 1, "max": 3, "null_pct": 0.0}}
+	igen := buildIntegerGenerator(icol, rng)
+	for i := 0; i < 10; i++ {
+		v := igen.Next()
+		n, err := strconv.Atoi(v)
+		assert.NoError(t, err)
+		assert.GreaterOrEqual(t, n, 1)
+		assert.LessOrEqual(t, n, 3)
+	}
+	fcol := ColumnMeta{Args: map[string]interface{}{"min": 1.0, "max": 2.0, "round": 1, "null_pct": 0.0}}
+	fgen := buildFloatGenerator(fcol, rng)
+	for i := 0; i < 10; i++ {
+		v := fgen.Next()
+		assert.Contains(t, v, ".", "should have decimal place")
+	}
+}
+
+func TestTimestampGenerator(t *testing.T) {
+	col := ColumnMeta{Args: map[string]interface{}{"start": "2000-01-02", "end": "2000-01-03", "format": "%Y-%m-%d"}}
+	rng := rand.New(rand.NewSource(0))
+	gen := buildTimestampGenerator(col, rng)
+	v := gen.Next()
+	_, err := time.Parse("2006-01-02", v)
+	assert.NoError(t, err, "parseable date")
+}
+
+func TestUuidGenerator(t *testing.T) {
+	rng := rand.New(rand.NewSource(0))
+	col := ColumnMeta{}
+	gen := buildUuidGenerator(col, rng)
+	v1 := gen.Next()
+	v2 := gen.Next()
+	assert.Len(t, v1, 32, "length")
+	_, err := hex.DecodeString(v1)
+	assert.NoError(t, err, "valid hex")
+	assert.NotEqual(t, v1, v2, "varies")
+}
+
+func TestStringBoolJsonGenerators(t *testing.T) {
+	rng := rand.New(rand.NewSource(1))
+	scol := ColumnMeta{Args: map[string]interface{}{"min": 2, "max": 4, "null_pct": 0.0}}
+	sgen := buildStringGenerator(scol, rng)
+	for i := 0; i < 5; i++ {
+		v := sgen.Next()
+		assert.GreaterOrEqual(t, len(v), 2)
+		assert.LessOrEqual(t, len(v), 4)
+	}
+	bcol := ColumnMeta{Args: map[string]interface{}{"null_pct": 0.0}}
+	bgen := buildBooleanGenerator(bcol, rng)
+	for i := 0; i < 5; i++ {
+		v := bgen.Next()
+		assert.Contains(t, []string{"0", "1"}, v)
+	}
+	jcol := ColumnMeta{Args: map[string]interface{}{"min": 1, "max": 1, "null_pct": 0.0}}
+	jgen := buildJsonGenerator(jcol, rng)
+	v := jgen.Next()
+	assert.True(t, strings.HasPrefix(v, "{\"k\":\"") && strings.HasSuffix(v, "\"}"), "JSON object")
+}
+
+func TestWrappers(t *testing.T) {
+	base := &SequenceGen{cur: 0}
+	dw := NewDefaultWrapper(base, 1.0, "L", 42)
+	assert.Equal(t, "L", dw.Next(), "DefaultWrapper literal")
+	ug := NewUniqueWrapper(base, 2)
+	v1 := ug.Next()
+	v2 := ug.Next()
+	assert.NotEqual(t, v1, v2, "UniqueWrapper uniqueness")
+	fg := NewFkWrapper(base, 3)
+	vals := []string{fg.Next(), fg.Next(), fg.Next(), fg.Next()}
+	assert.Equal(t, vals[0], vals[1], "FkWrapper repeat")
+	assert.Equal(t, vals[1], vals[2], "FkWrapper repeat")
+	assert.NotEqual(t, vals[2], vals[3], "FkWrapper advance")
+}
+
+func TestMakeGeneratorAllTypes(t *testing.T) {
+	schema := Schema{}
+	types := []struct {
+		typ     GeneratorType
+		args    map[string]interface{}
+		checker func(string) bool
+	}{
+		{"integer", map[string]interface{}{"min": 0, "max": 10, "null_pct": 0.0}, func(v string) bool {
+			_, err := strconv.Atoi(v)
+			return err == nil
+		}},
+		{"float", map[string]interface{}{"min": 0.0, "max": 1.0, "round": 2, "null_pct": 0.0}, func(v string) bool {
+			return strings.Contains(v, ".")
+		}},
+		{"string", map[string]interface{}{"min": 1, "max": 3, "null_pct": 0.0}, func(v string) bool {
+			return len(v) >= 1 && len(v) <= 3
+		}},
+		{"timestamp", map[string]interface{}{"start": "2000-01-01", "end": "2000-01-02", "format": "%Y-%m-%d"}, func(v string) bool {
+			_, err := time.Parse("2006-01-02", v)
+			return err == nil
+		}},
+		{"uuid", map[string]interface{}{}, func(v string) bool {
+			b, err := hex.DecodeString(v)
+			return err == nil && len(b) == 16
+		}},
+		{"bool", map[string]interface{}{"null_pct": 0.0}, func(v string) bool {
+			return v == "0" || v == "1"
+		}},
+		{"json", map[string]interface{}{"min": 1, "max": 1, "null_pct": 0.0}, func(v string) bool {
+			return strings.HasPrefix(v, "{\"k\":\"") && strings.HasSuffix(v, "\"}")
+		}},
+	}
+	for _, tt := range types {
+		gen := buildGenerator(ColumnMeta{Type: tt.typ, Args: tt.args}, 0, 1, schema)
+		v := gen.Next()
+		assert.True(t, tt.checker(v), "%s generator produced %q", tt.typ, v)
+	}
+}

--- a/pkg/workload/workload_generator/schema_designs.go
+++ b/pkg/workload/workload_generator/schema_designs.go
@@ -96,14 +96,14 @@ func (ts *TableSchema) String() string {
 		out = append(out, " PKs: "+strings.Join(ts.PrimaryKeys, ", "))
 	}
 	if len(ts.UniqueConstraints) > 0 {
-		tmp := []string{}
+		tmp := make([]string, 0)
 		for _, u := range ts.UniqueConstraints {
 			tmp = append(tmp, "("+strings.Join(u, ",")+")")
 		}
 		out = append(out, " UNIQUE: "+strings.Join(tmp, "; "))
 	}
 	if len(ts.ForeignKeys) > 0 {
-		tmp := []string{}
+		tmp := make([]string, 0)
 		for _, fk := range ts.ForeignKeys {
 			l := fk[0].([]string)
 			t := fk[1].(string)

--- a/pkg/workload/workload_generator/schema_generator.go
+++ b/pkg/workload/workload_generator/schema_generator.go
@@ -141,7 +141,7 @@ func generateDDLs(
 
 	// collect raw statements
 	tableStatements := make(map[string]string)
-	order := []string{}
+	order := make([]string, 0)
 	seen := map[string]bool{}
 	schemaReCache := map[string]*regexp.Regexp{}
 
@@ -349,7 +349,7 @@ func processColumnDefs(table *TableSchema, columnDefs []string) {
 func applyPrimaryKey(table *TableSchema, tableConstraint string) {
 	raw := tablePrimaryKeyRe.FindStringSubmatch(tableConstraint)
 	if raw != nil {
-		cols := []string{}
+		cols := make([]string, 0)
 		// Extract column names from the constraint
 		for _, col := range strings.Split(raw[1], ",") {
 			cols = append(cols, strings.Split(strings.TrimSpace(strings.Trim(col, `"`)), " ")[0])
@@ -363,7 +363,7 @@ func applyPrimaryKey(table *TableSchema, tableConstraint string) {
 func applyUniqueConstraint(table *TableSchema, tableConstraint string) {
 	raw := tableUniqueRe.FindStringSubmatch(tableConstraint)
 	if raw != nil {
-		cols := []string{}
+		cols := make([]string, 0)
 		// Extract column names from the constraint
 		for _, col := range strings.Split(raw[1], ",") {
 			cols = append(cols, strings.Split(strings.TrimSpace(strings.Trim(col, `"`)), " ")[0])
@@ -387,7 +387,7 @@ func applyUniqueConstraint(table *TableSchema, tableConstraint string) {
 func applyForeignKey(table *TableSchema, tableConstraint string) {
 	foreignKeyMatch := tableForeignKeyRe.FindStringSubmatch(tableConstraint)
 	if foreignKeyMatch != nil {
-		local := []string{}
+		local := make([]string, 0)
 		// Extract local columns (referencing columns)
 		for _, c := range strings.Split(foreignKeyMatch[1], ",") {
 			local = append(local, strings.TrimSpace(c))
@@ -396,7 +396,7 @@ func applyForeignKey(table *TableSchema, tableConstraint string) {
 		tbl := strings.TrimSpace(foreignKeyMatch[2])
 		tblRaw := strings.ReplaceAll(tbl, "\"", "")
 		// Extract referenced columns
-		foreign := []string{}
+		foreign := make([]string, 0)
 		for _, c := range strings.Split(foreignKeyMatch[3], ",") {
 			foreign = append(foreign, strings.TrimSpace(c))
 		}

--- a/pkg/workload/workload_generator/types.go
+++ b/pkg/workload/workload_generator/types.go
@@ -1,0 +1,260 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package workload_generator
+
+import (
+	"encoding/hex"
+	"fmt"
+	"math/rand"
+	"strconv"
+
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+const (
+	// defaultUniqueCap is the default history size for UniqueWrapper.
+	defaultUniqueCap = 100_000
+
+	// defaultJSONMinLen/MaxLen are fallbacks when no min/max are provided.
+	defaultJSONMinLen = 10
+	defaultJSONMaxLen = 50
+)
+
+// Generator is the interface for any workload value generator.
+// Each call to Next() returns the next string value (or "" to signal NULL)
+type Generator interface {
+	Next() string
+}
+
+// ─── Basic Generators ──────────────────────────────────────────────────
+
+// SequenceGen yields a sequence of integers starting from 0.
+type SequenceGen struct {
+	cur int
+}
+
+func (g *SequenceGen) Next() string {
+	v := g.cur
+	g.cur++
+	return strconv.Itoa(v)
+}
+
+// IntegerGen yields random integers in a given range.
+type IntegerGen struct {
+	r        *rand.Rand
+	min, max int
+	nullPct  float64
+}
+
+func (g *IntegerGen) Next() string {
+	if g.r.Float64() < g.nullPct {
+		return ""
+	}
+	return strconv.Itoa(g.r.Intn(g.max-g.min+1) + g.min)
+}
+
+// FloatGen yields random floating-point numbers in a given range and rounds off to a decided precision.
+type FloatGen struct {
+	r        *rand.Rand
+	min, max float64
+	round    int
+	nullPct  float64
+}
+
+func (g *FloatGen) Next() string {
+	if g.r.Float64() < g.nullPct {
+		return ""
+	}
+	v := g.r.Float64()*(g.max-g.min) + g.min
+	return fmt.Sprintf("%.*f", g.round, v)
+}
+
+// StringGen yields random ASCII strings of a given length range.
+type StringGen struct {
+	r        *rand.Rand
+	min, max int
+	nullPct  float64
+}
+
+func (g *StringGen) Next() string {
+	if g.r.Float64() < g.nullPct {
+		return ""
+	}
+	length := g.r.Intn(g.max-g.min+1) + g.min
+	buf := make([]byte, length)
+	for i := range buf {
+		buf[i] = byte('a' + g.r.Intn(26))
+	}
+	return string(buf)
+}
+
+// TimestampGen yields random timestamps between a start and end.
+type TimestampGen struct {
+	r       *rand.Rand
+	startNS int64
+	spanNS  int64
+	layout  string
+	nullPct float64
+}
+
+func (g *TimestampGen) Next() string {
+	if g.r.Float64() < g.nullPct {
+		return ""
+	}
+	// pick an offset in [0, spanNS)
+	offset := g.r.Int63n(g.spanNS)
+	t := timeutil.Unix(0, g.startNS+offset)
+	return t.Format(g.layout)
+}
+
+// UUIDGen yields a deterministic “UUID” hex string from the RNG.
+type UUIDGen struct {
+	r *rand.Rand
+}
+
+func (g *UUIDGen) Next() string {
+	buf := make([]byte, 16)
+	for i := range buf {
+		buf[i] = byte(g.r.Intn(256))
+	}
+	// hex without dashes is fine for now
+	return hex.EncodeToString(buf)
+}
+
+// BoolGen yields random boolean values as "1" or "0", with a chance of null.
+type BoolGen struct {
+	r       *rand.Rand
+	nullPct float64
+}
+
+func (g *BoolGen) Next() string {
+	// nullability
+	if g.nullPct > 0 && g.r.Float64() < g.nullPct {
+		return ""
+	}
+	// 1 if random>0.5 else 0
+	if g.r.Float64() > 0.5 {
+		return "1"
+	}
+	return "0"
+}
+
+// JsonGen wraps a StringGen to produce JSON-like strings.
+type JsonGen struct {
+	strGen *StringGen
+}
+
+func (g *JsonGen) Next() string {
+	// get the underlying ASCII string
+	v := g.strGen.Next()
+	if v == "" {
+		return "" // preserve null_pct from the StringGen
+	}
+	// wrap it in {"k":"…"}
+	return fmt.Sprintf(`{"k":"%s"}`, v)
+}
+
+// ─── Wrappers ──────────────────────────────────────────────────────────
+
+// DefaultWrapper wraps a base Generator and emits a fixed literal
+// with a given probability, otherwise delegates to the base generator.
+type DefaultWrapper struct {
+	base    Generator  // base is the underlying generator to delegate to.
+	prob    float64    // prob is the probability of emitting the literal instead.
+	literal string     // literal is the fixed value to emit when the coin flip hits.
+	rng     *rand.Rand // rng set its own RNG so that calls are reproducible.
+}
+
+func NewDefaultWrapper(base Generator, prob float64, literal string, seed int64) *DefaultWrapper {
+	return &DefaultWrapper{
+		base:    base,
+		prob:    prob,
+		literal: literal,
+		rng:     rand.New(rand.NewSource(seed)),
+	}
+}
+func (w *DefaultWrapper) Next() string {
+	if w.rng.Float64() < w.prob {
+		// “hit” — return the literal value
+		return w.literal
+	}
+	// “miss” — delegate to the underlying generator
+	return w.base.Next()
+}
+
+// UniqueWrapper wraps a base Generator and ensures
+// no value is repeated within the last `capacity` outputs.
+type UniqueWrapper struct {
+	base     Generator           // base is the underlying generator to delegate to.
+	seen     map[string]struct{} // seen is a set of recently inserted values.
+	order    []string            // order is a queue of the order in which values were inserted.
+	capacity int                 // capacity is the max number of recent values to remember.
+}
+
+// NewUniqueWrapper creates a UniqueWrapper around baseGen.
+// capacity is the max number of recent values to remember.
+func NewUniqueWrapper(baseGen Generator, capacity int) *UniqueWrapper {
+	return &UniqueWrapper{
+		base:     baseGen,
+		seen:     make(map[string]struct{}, capacity),
+		order:    make([]string, 0, capacity),
+		capacity: capacity,
+	}
+}
+
+// Next returns the next unique value, re-rolling until it
+// finds one not in the recent window.
+func (u *UniqueWrapper) Next() string {
+	for {
+		v := u.base.Next()
+		if _, exists := u.seen[v]; !exists {
+			// accept it
+			u.seen[v] = struct{}{}
+			u.order = append(u.order, v)
+			// evict oldest if over capacity
+			if len(u.order) > u.capacity {
+				oldest := u.order[0]
+				u.order = u.order[1:]
+				delete(u.seen, oldest)
+			}
+			return v
+		}
+		// otherwise: value was recently seen → retry
+	}
+}
+
+// FkWrapper takes a parent Generator and repeats each parent value
+// exactly fanout times before advancing.
+type FkWrapper struct {
+	parent  Generator // parent is the base generator to repeat values from.
+	fanout  int       // fanout decides how many repeats of each parent value.
+	counter int       // counter keeps track of how many times we've already returned current.
+	current string    // the current value from the parent generator.
+}
+
+// NewFkWrapper wraps a baseGen so that each value it produces
+// is repeated fanout times.
+func NewFkWrapper(baseGen Generator, fanout int) *FkWrapper {
+	if fanout < 1 {
+		fanout = 1
+	}
+	w := &FkWrapper{parent: baseGen, fanout: fanout}
+	// prime the pump
+	w.current = w.parent.Next()
+	w.counter = 0
+	return w
+}
+
+// Next returns the current parent value, and only when
+// it has been returned fanout times does it advance to the next.
+func (w *FkWrapper) Next() string {
+	if w.counter >= w.fanout {
+		w.current = w.parent.Next()
+		w.counter = 0
+	}
+	w.counter++
+	return w.current
+}


### PR DESCRIPTION
…tor types

Previously, workload_generator had only teh features for parsing teh input ddl to create all required schema and make proper structs with enough information for data generation. The implementation of actual generators to sue that information to generate data was not there.

This patch defines a Generator interface and provides a suite of concrete generator implementations—SequenceGen, IntegerGen, FloatGen, StringGen, TimestampGen, UUIDGen, BoolGen, and JsonGen—each producing strings (or "" for SQL NULL). It also adds wrapper types (DefaultWrapper, UniqueWrapper, FkWrapper) to layer default literals, uniqueness constraints, and foreign-key fanout behavior. Finally, makeGenerator is refactored into a clean factory that picks the right base generator from GenType metadata, seeds per-batch RNG streams, and composes wrappers based on ColumnMeta.

Fixes: CRDB-51752

Release note (cli change): The workload_generator now exposes a pluggable Generator interface with built-in generators and wrappers for various SQL types—enabling modular, extensible, and reusable workload data generation.