### PR TITLE
release-25.1: kvserver: skip TestFlowControlRaftMembership{,RemoveSelf}V2 under duress

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -35,6 +35,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/datapathutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/echotest"
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission"
@@ -164,7 +165,6 @@ ORDER BY name ASC;
 func TestFlowControlRangeSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TODO(pav-kv): remove when flakes are fixed.
 	defer setRACv2DebugVModule(t)()
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
@@ -393,7 +393,6 @@ func TestFlowControlBlockedAdmissionV2(t *testing.T) {
 func TestFlowControlAdmissionPostSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TODO(pav-kv): remove when flakes are fixed.
 	defer setRACv2DebugVModule(t)()
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
@@ -657,7 +656,6 @@ func TestFlowControlCrashedNodeV2(t *testing.T) {
 func TestFlowControlRaftSnapshotV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TODO(#138103): remove when flakes are fixed.
 	defer setRACv2DebugVModule(t)()
 
 	const numServers int = 5
@@ -918,6 +916,9 @@ SELECT store_id,
 func TestFlowControlRaftMembershipV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	// And also #148903, #148348, #144546, #141912.
+	skip.UnderDuressWithIssue(t, 149036)
+	defer setRACv2DebugVModule(t)()
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{
 		kvflowcontrol.V2EnabledWhenLeaderV1Encoding,
@@ -1055,12 +1056,14 @@ func TestFlowControlRaftMembershipV2(t *testing.T) {
 	})
 }
 
-// TestFlowControlRaftMembershipRemoveSelf tests flow token behavior when the
-// raft leader removes itself from the raft group.
+// TestFlowControlRaftMembershipRemoveSelfV2 tests flow token behavior when
+// the raft leader removes itself from the raft group.
 func TestFlowControlRaftMembershipRemoveSelfV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	// TODO(#137510): remove when flakes are fixed.
+	// Under overload, token deductions may not line up as expected, likely due
+	// to dropping streams.
+	skip.UnderDuressWithIssue(t, 148079)
 	defer setRACv2DebugVModule(t)()
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{


### PR DESCRIPTION
Backport 1/1 commits from #149661.

/cc @cockroachdb/release

---

These fail regularly, but always under a duress build (usually race). From various investigations, the picture emerges that under such load, some send streams can disconnect and throw off the test. This is  not a detailed RCA, but it seems prudent to skip these tests under potential overload scenarios as they rely on the system maintaining a steady state, which isn't always guaranteed under stress.

Verbose logging was added to the tests, making future failures more actionable.

Needs backports to:
- release-25.1
- release-25.2
- release-25.3

Closes #149331.
Closes #149036.
Closes #148903.
Closes #148348.
Closes #148079.
Closes #144546.
Closes #141912.

Epic: none

Release Justification: Test-only change
