### PR TITLE
release-25.1: sql: prevent auth failure when no roles are granted during sync

### DIFF
--- a/pkg/sql/authorization.go
+++ b/pkg/sql/authorization.go
@@ -583,6 +583,7 @@ func EnsureUserOnlyBelongsToRoles(
 			grantStmt := strings.Builder{}
 			grantStmt.WriteString("GRANT ")
 			addComma := false
+			rolesWereAdded := false // Flag to track if any roles are actually added
 			for _, role := range rolesToGrant {
 				if roleExists, _ := RoleExists(ctx, txn, role); roleExists {
 					if addComma {
@@ -590,14 +591,19 @@ func EnsureUserOnlyBelongsToRoles(
 					}
 					grantStmt.WriteString(role.SQLIdentifier())
 					addComma = true
+					rolesWereAdded = true // At least one role was added
 				}
 			}
-			grantStmt.WriteString(" TO ")
-			grantStmt.WriteString(user.SQLIdentifier())
-			if _, err := txn.Exec(
-				ctx, "EnsureUserOnlyBelongsToRoles-grant", txn.KV(), grantStmt.String(),
-			); err != nil {
-				return err
+
+			// Only execute the GRANT statement if at least one existing role was added.
+			if rolesWereAdded {
+				grantStmt.WriteString(" TO ")
+				grantStmt.WriteString(user.SQLIdentifier())
+				if _, err := txn.Exec(
+					ctx, "EnsureUserOnlyBelongsToRoles-grant", txn.KV(), grantStmt.String(),
+				); err != nil {
+					return err
+				}
 			}
 		}
 


### PR DESCRIPTION
Backport 1/1 commits from #149638 on behalf of @shriramters.

----

Previously, the EnsureUserOnlyBelongsToRoles function would construct and execute a GRANT statement even if the list of roles to grant was empty after filtering for roles that exist in the database.

This was inadequate because it caused authentication to fail for users logging in via external providers (LDAP, JWT, OIDC). If a user belonged to external groups that did not map to any existing roles in CockroachDB, the function would generate an invalid SQL statement (GRANT TO <user>), resulting in a syntax error that blocked the user's session.

To address this, this patch modifies EnsureUserOnlyBelongsToRoles to only build and execute the GRANT statement if at least one valid, existing role is being granted. This prevents the syntax error and allows users to log in successfully even if their external group memberships do not result in any new role grants.

This commit also adds unit tests for `EnsureUserOnlyBelongsToRoles()`.

Fixes: #143878 

Release note (bug fix): Fixed a bug where database login could fail during LDAP, JWT, or OIDC authentication if the user's external group memberships did not correspond to any existing roles in the database. The login will now succeed, and no roles will be granted or revoked in this scenario.

----

Release justification: This is a small change which fixes #143878 that was preventing users from logging in when no roles were granted during authorization