### PR TITLE
util: add envAlwaysKeepTestLogsEnabled

### DIFF
--- a/pkg/util/log/test_log_scope.go
+++ b/pkg/util/log/test_log_scope.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/cli/exit"
 	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/fileutil"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
@@ -22,6 +23,11 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/errors/oserror"
 )
+
+// envAlwaysKeepTestLogsEnabled controls whether test and CRDB logs are kept
+// even when the test passes. By default, it’s disabled, so logs are deleted on
+// test success.
+var envAlwaysKeepTestLogsEnabled = envutil.EnvOrDefaultBool("COCKROACH_ALWAYS_KEEP_TEST_LOGS", false)
 
 // TestLogScope represents the lifetime of a logging output.  It
 // ensures that the log files are stored in a directory specific to a
@@ -410,7 +416,7 @@ func (l *TestLogScope) Close(t tShim) {
 				t.Fatal(err)
 			}
 			inPanic := calledDuringPanic()
-			if (t.Failed() && !emptyDir) || inPanic {
+			if (t.Failed() && !emptyDir) || inPanic || envAlwaysKeepTestLogsEnabled {
 				// If the test failed or there was a panic, we keep the log
 				// files for further investigation.
 				if inPanic {


### PR DESCRIPTION
This commit adds support for a new environment variable,
COCKROACH_ALWAYS_KEEP_TEST_LOGS, which ensures that crdb and test logs are kept
even when tests fail. Example usage:

```
./dev test .... -- --test_env=COCKROACH_ALWAYS_KEEP_TEST_LOGS=true
```

Epic: none
Release note: none

