### PR TITLE
cli: unskip test_demo_multitenant

### DIFF
--- a/pkg/acceptance/generated_cli_test.go
+++ b/pkg/acceptance/generated_cli_test.go
@@ -118,6 +118,13 @@ func TestDockerCLI_test_demo_memory_warning(t *testing.T) {
 	runTestDockerCLI(t, "test_demo_memory_warning", "../cli/interactive_tests/test_demo_memory_warning.tcl")
 }
 
+func TestDockerCLI_test_demo_multitenant(t *testing.T) {
+	s := log.Scope(t)
+	defer s.Close(t)
+
+	runTestDockerCLI(t, "test_demo_multitenant", "../cli/interactive_tests/test_demo_multitenant.tcl")
+}
+
 func TestDockerCLI_test_demo_networking(t *testing.T) {
 	s := log.Scope(t)
 	defer s.Close(t)

--- a/pkg/cli/clisqlshell/sql.go
+++ b/pkg/cli/clisqlshell/sql.go
@@ -66,6 +66,7 @@ Connection
                     connect to a server or print the current connection URL.
                     Omitted values reuse previous parameters. Use '-' to skip a field.
                     The option "autocerts" attempts to auto-discover TLS client certs.
+                    The option "tenant=NAME" switches to the specified tenant.
   \password [USERNAME]
                     securely change the password for a user
 
@@ -1708,6 +1709,11 @@ func (c *cliState) handleConnectInternal(cmd []string, omitConnString bool) erro
 		if cmd[4] != "-" {
 			if cmd[4] == "autocerts" {
 				autoCerts = true
+			} else if strings.HasPrefix(cmd[4], "tenant=") {
+				tenantName := strings.TrimPrefix(cmd[4], "tenant=")
+				if err := newURL.SetOption("options", "-ccluster="+tenantName); err != nil {
+					return err
+				}
 			} else {
 				return errors.Newf(`unknown syntax: \c %s`, strings.Join(cmd, " "))
 			}


### PR DESCRIPTION
This applies the same fix that was made for test_demo_node_cmds in 015b29c7b421bec6d54058828c99015ff043066f.

To check the liveness range, the test needs to switch to the system
tenant, so a new shorthand was added for that. We also specify the demo
password deterministically so that we can switch connections.

fixes https://github.com/cockroachdb/cockroach/issues/141942
Release note: None