### PR TITLE
roachtest: Fix JSON configuration file for db-console/endpoints

### DIFF
--- a/pkg/cmd/roachtest/tests/db-console/admin_endpoints.json
+++ b/pkg/cmd/roachtest/tests/db-console/admin_endpoints.json
@@ -77,7 +77,7 @@
     },
     {
       "url": "/_admin/v1/rangelog",
-      "method": "GET"
+      "method": "GET",
       "skip": "https://github.com/cockroachdb/cockroach/pull/148112#issuecomment-2960322577"
     },
     {


### PR DESCRIPTION
A previous PR modified one of the json configuration files for what endpoints to test. It forgot to include a comma...

Fixes: #149735, #149732
Release note: None