### PR TITLE
changefeedccl: add privilege check for database-level changefeed

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -683,7 +683,8 @@ func generateAndValidateNewTargets(
 		hasSelectPrivOnAllTables = hasSelectPrivOnAllTables && hasSelect
 		hasChangefeedPrivOnAllTables = hasChangefeedPrivOnAllTables && hasChangefeed
 	}
-	if err := authorizeUserToCreateChangefeed(ctx, p, sinkURI, hasSelectPrivOnAllTables, hasChangefeedPrivOnAllTables); err != nil {
+	if err := authorizeUserToCreateChangefeed(
+		ctx, p, sinkURI, hasSelectPrivOnAllTables, hasChangefeedPrivOnAllTables, tree.ChangefeedLevelTable); err != nil {
 		return nil, nil, hlc.Timestamp{}, nil, err
 	}
 

--- a/pkg/ccl/changefeedccl/alter_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_test.go
@@ -1882,7 +1882,7 @@ func TestAlterChangefeedAccessControl(t *testing.T) {
 		})
 		// jobController can access the job, but will hit an error re-creating the changefeed.
 		asUser(t, f, `jobController`, func(userDB *sqlutils.SQLRunner) {
-			userDB.ExpectErr(t, "pq: user jobcontroller requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed", fmt.Sprintf(`ALTER CHANGEFEED %d DROP table_b`, currentFeed.JobID()))
+			userDB.ExpectErr(t, `pq: user "jobcontroller" requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed`, fmt.Sprintf(`ALTER CHANGEFEED %d DROP table_b`, currentFeed.JobID()))
 		})
 		asUser(t, f, `userWithSomeGrants`, func(userDB *sqlutils.SQLRunner) {
 			userDB.ExpectErr(t, "does not have privileges for job", fmt.Sprintf(`ALTER CHANGEFEED %d ADD table_b`, currentFeed.JobID()))

--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -3829,10 +3829,12 @@ func TestCoreChangefeedRequiresSelectPrivilege(t *testing.T) {
 			expectErrCreatingFeed(t, f, `CREATE CHANGEFEED FOR table_a`,
 				`user user1 requires the SELECT privilege on all target tables to be able to run a core changefeed`)
 		})
+		// Grant select on table_a to user1
 		rootDB.Exec(t, `GRANT SELECT ON table_a TO user1`)
 		asUser(t, f, `user1`, func(_ *sqlutils.SQLRunner) {
 			expectSuccess(`CREATE CHANGEFEED FOR table_a`)
 		})
+		// Expect error because user1 still doesn't have select on table_b
 		asUser(t, f, `user1`, func(_ *sqlutils.SQLRunner) {
 			expectErrCreatingFeed(t, f, `CREATE CHANGEFEED FOR table_a, table_b`,
 				`user user1 requires the SELECT privilege on all target tables to be able to run a core changefeed`)
@@ -3939,36 +3941,58 @@ func TestChangefeedCreateAuthorizationWithChangefeedPriv(t *testing.T) {
 
 	withUser(t, "user1", func(userDB *sqlutils.SQLRunner) {
 		userDB.ExpectErr(t,
-			"user user1 requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed",
-			"CREATE CHANGEFEED for table_a, table_b INTO 'external://nope'",
+			`user "user1" requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed`,
+			"CREATE CHANGEFEED FOR table_a, table_b INTO 'external://nope'",
+		)
+		userDB.ExpectErr(t,
+			`user "user1" requires the CHANGEFEED privilege on the target database to be able to run an enterprise changefeed`,
+			"CREATE CHANGEFEED FOR DATABASE defaultdb INTO 'kafka://nope'",
 		)
 	})
 	rootDB.Exec(t, "GRANT CHANGEFEED ON table_a TO user1")
 	withUser(t, "user1", func(userDB *sqlutils.SQLRunner) {
 		userDB.ExpectErr(t,
-			"user user1 requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed",
-			"CREATE CHANGEFEED for table_a, table_b INTO 'external://nope'",
+			`user "user1" requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed`,
+			"CREATE CHANGEFEED FOR table_a, table_b INTO 'external://nope'",
+		)
+		userDB.ExpectErr(t,
+			`user "user1" requires the CHANGEFEED privilege on the target database to be able to run an enterprise changefeed`,
+			"CREATE CHANGEFEED FOR DATABASE defaultdb INTO 'kafka://nope'",
 		)
 	})
 	rootDB.Exec(t, "GRANT CHANGEFEED ON table_b TO user1")
 	withUser(t, "user1", func(userDB *sqlutils.SQLRunner) {
 		userDB.Exec(t,
-			"CREATE CHANGEFEED for table_a, table_b INTO 'external://nope'",
+			"CREATE CHANGEFEED FOR table_a, table_b INTO 'external://nope'",
+		)
+		userDB.ExpectErr(t,
+			`user "user1" requires the CHANGEFEED privilege on the target database to be able to run an enterprise changefeed`,
+			"CREATE CHANGEFEED FOR DATABASE defaultdb INTO 'kafka://nope'",
 		)
 	})
 
 	// With require_external_connection_sink enabled, the user requires USAGE on the external connection.
 	rootDB.Exec(t, "SET CLUSTER SETTING changefeed.permissions.require_external_connection_sink.enabled = true")
+	rootDB.Exec(t, "GRANT CHANGEFEED ON DATABASE defaultdb TO user1")
 	withUser(t, "user1", func(userDB *sqlutils.SQLRunner) {
 		userDB.ExpectErr(t,
-			"pq: the CHANGEFEED privilege on all tables can only be used with external connection sinks",
-			"CREATE CHANGEFEED for table_a, table_b INTO 'kafka://nope'",
+			"pq: the CHANGEFEED privilege on all target tables can only be used with external connection sinks",
+			"CREATE CHANGEFEED FOR table_a, table_b INTO 'kafka://nope'",
+		)
+		userDB.ExpectErr(t,
+			"pq: the CHANGEFEED privilege on the target database can only be used with external connection sinks",
+			"CREATE CHANGEFEED FOR DATABASE defaultdb INTO 'kafka://nope'",
 		)
 	})
 	rootDB.Exec(t, "GRANT USAGE ON EXTERNAL CONNECTION nope to user1")
 	withUser(t, "user1", func(userDB *sqlutils.SQLRunner) {
 		userDB.Exec(t,
-			"CREATE CHANGEFEED for table_a, table_b INTO 'external://nope'",
+			"CREATE CHANGEFEED FOR table_a, table_b INTO 'external://nope'",
+		)
+	})
+	withUser(t, "user1", func(userDB *sqlutils.SQLRunner) {
+		userDB.Exec(t,
+			"CREATE CHANGEFEED FOR DATABASE defaultdb INTO 'external://nope'",
 		)
 	})
 	rootDB.Exec(t, "SET CLUSTER SETTING changefeed.permissions.require_external_connection_sink.enabled = false")
@@ -12581,7 +12605,9 @@ func TestDatabaseRenameDuringDatabaseLevelChangefeed(t *testing.T) {
 		}
 		assertPayloads(t, feed1, expectedRows)
 	}
-	cdcTest(t, testFn)
+	// TODO(#152196): Remove feedTestUseRootUserConnection once we have ALTER
+	// DEFAULT PRIVILEGES for databases
+	cdcTest(t, testFn, feedTestUseRootUserConnection)
 }
 
 func TestTableRenameDuringDatabaseLevelChangefeed(t *testing.T) {
@@ -12590,18 +12616,17 @@ func TestTableRenameDuringDatabaseLevelChangefeed(t *testing.T) {
 
 	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
 		sqlDB := sqlutils.MakeSQLRunner(s.DB)
-		sqlDB.Exec(t, `CREATE DATABASE foo;`)
-		sqlDB.Exec(t, `CREATE TABLE foo.bar (id INT PRIMARY KEY);`)
-		sqlDB.Exec(t, `INSERT INTO foo.bar VALUES (1);`)
+		sqlDB.Exec(t, `CREATE TABLE d.bar (id INT PRIMARY KEY);`)
+		sqlDB.Exec(t, `INSERT INTO d.bar VALUES (1);`)
 		expectedRows := []string{
 			`bar: [1]->{"after": {"id": 1}}`,
 		}
-		feed1 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE foo`)
+		feed1 := feed(t, f, `CREATE CHANGEFEED FOR DATABASE d`)
 		defer closeFeed(t, feed1)
 		assertPayloads(t, feed1, expectedRows)
 
-		sqlDB.Exec(t, `ALTER TABLE foo.bar RENAME TO foo;`)
-		sqlDB.Exec(t, `INSERT INTO foo.foo VALUES (2);`)
+		sqlDB.Exec(t, `ALTER TABLE d.bar RENAME TO foo;`)
+		sqlDB.Exec(t, `INSERT INTO d.foo VALUES (2);`)
 		expectedRows = []string{
 			`bar: [2]->{"after": {"id": 2}}`,
 		}
@@ -12615,4 +12640,31 @@ func getChangefeedLoggingChannel(sv *settings.Values) logpb.Channel {
 		return logpb.Channel_CHANGEFEED
 	}
 	return logpb.Channel_TELEMETRY
+}
+
+func TestCreateTableLevelChangefeedWithDBPrivilege(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		expectSuccess := func(stmt string) {
+			successfulFeed := feed(t, f, stmt)
+			defer closeFeed(t, successfulFeed)
+			_, err := successfulFeed.Next()
+			require.NoError(t, err)
+		}
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+		sqlDB.Exec(t, `CREATE USER user1`)
+		sqlDB.Exec(t, `CREATE TABLE d.bar (id INT PRIMARY KEY);`)
+		sqlDB.Exec(t, `INSERT INTO d.bar VALUES (1);`)
+		asUser(t, f, `user1`, func(_ *sqlutils.SQLRunner) {
+			expectErrCreatingFeed(t, f, `CREATE CHANGEFEED FOR d.bar`,
+				`user "user1" requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed`)
+		})
+		sqlDB.Exec(t, `GRANT CHANGEFEED ON DATABASE d TO user1`)
+		asUser(t, f, `user1`, func(_ *sqlutils.SQLRunner) {
+			expectSuccess(`CREATE CHANGEFEED FOR d.bar`)
+		})
+	}
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
 }

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1629,6 +1629,12 @@ func createUserWithDefaultPrivilege(
 		if err != nil {
 			t.Fatal(err)
 		}
+		if priv == "CHANGEFEED" {
+			_, err = rootDB.Exec(fmt.Sprintf(`GRANT %s ON DATABASE d TO %s`, priv, user))
+			if err != nil {
+				t.Fatal(err)
+			}
+		}
 	}
 }
 

--- a/pkg/ccl/changefeedccl/scheduled_changefeed_test.go
+++ b/pkg/ccl/changefeedccl/scheduled_changefeed_test.go
@@ -341,7 +341,7 @@ func TestCreateChangefeedScheduleChecksPermissionsDuringDryRun(t *testing.T) {
 	defer db2.Close()
 	userDB := sqlutils.MakeSQLRunner(db2)
 
-	userDB.ExpectErr(t, "Failed to dry run create changefeed: user testuser requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed",
+	userDB.ExpectErr(t, `Failed to dry run create changefeed: user "testuser" requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed`,
 		"CREATE SCHEDULE FOR CHANGEFEED TABLE table_a INTO 'somewhere' WITH initial_scan = 'only' RECURRING '@daily'")
 }
 

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -335,7 +335,6 @@ type externalConnectionCreator func(uri string) error
 func (e *externalConnectionFeedFactory) Feed(
 	create string, args ...interface{},
 ) (_ cdctest.TestFeed, err error) {
-
 	randomExternalConnectionName := fmt.Sprintf("testconn%d", rand.Int63())
 
 	var c externalConnectionCreator = func(uri string) error {

--- a/pkg/ccl/logictestccl/testdata/logic_test/changefeed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/changefeed
@@ -46,7 +46,7 @@ GRANT SELECT ON TABLE t TO testuser
 
 user testuser
 
-statement error user testuser requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed
+statement error user "testuser" requires the CHANGEFEED privilege on all target tables to be able to run an enterprise changefeed
 CREATE CHANGEFEED FOR t INTO 'null://sink' with initial_scan='only'
 
 user root


### PR DESCRIPTION
Only a user with changefeed privileges on a database can create an
enterprise changefeed on the database. This also allows them to create
an enterprise changefeed on any table in that database. Creation of core
changefeeds at the table-level will still require the select privilege 
on all tables being watched.

resolves #149470

Release note: None