### PR TITLE
distsql: fix recently introduced leak of CancelFunc

### DIFF
--- a/pkg/kv/kvclient/kvstreamer/streamer.go
+++ b/pkg/kv/kvclient/kvstreamer/streamer.go
@@ -532,6 +532,9 @@ func (s *Streamer) Enqueue(ctx context.Context, reqs []kvpb.RequestUnion) (retEr
 			},
 			s.coordinator.mainLoop,
 		); err != nil {
+			// The server is shutting down. It's ok to not call
+			// s.coordinatorCtxCancel in this case.
+			//
 			// The new goroutine wasn't spun up, so mainLoop won't get executed
 			// and we have to decrement the wait group ourselves.
 			s.waitGroup.Done()


### PR DESCRIPTION
In 27a65c961b55b2c3639828692b144e67ffc16b06 we introduced the logic to make sure that remote flows respect the quiesce signal. However, we consciusly ignored the returned CancelFunc since the lifetime of the context is non-trivial. This introduced a leak of that CancelFunc since we keep the reference to it in the stopper even when the flow exits, so every time a remote flow runs on a node, the leak would slowly grow.

This leak is now fixed by ensuring the cancellation function is always called. This is achieved by passing the function as another thing to do on the "flow cleanup" (we already always need to close the reserved memory account, so we have the necessary infrastructure set up).

Fixes: #149658.

Release note (bug fix): In 25.1.8, 25.2.1, 25.2.2, and 25.3 betas, a slow memory leak was introduced that would accumulate whenever a node executes a part of the distributed plan (the gateway node of the plan is not affected). The leak can only be mitigated by restarting the node and is now fixed.