### PR TITLE
tenantcostclient: fix leak of CancelFunc

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
+++ b/pkg/ccl/multitenantccl/tenantcostclient/tenant_side.go
@@ -601,8 +601,10 @@ func (c *tenantSideCostController) sendTokenBucketRequest(ctx context.Context) {
 		c.run.lastReportedTokens = c.metrics.TotalEstimatedCPUSeconds.Count() * tokensPerCPUSecond
 	}
 
-	ctx, _ = c.stopper.WithCancelOnQuiesce(ctx)
 	err := c.stopper.RunAsyncTask(ctx, "token-bucket-request", func(ctx context.Context) {
+		var cancel context.CancelFunc
+		ctx, cancel = c.stopper.WithCancelOnQuiesce(ctx)
+		defer cancel()
 		if log.ExpensiveLogEnabled(ctx, 1) {
 			log.Infof(ctx, "TokenBucket request: %s\n", req.String())
 		}


### PR DESCRIPTION
Previously, we would never call the CancelFunc that is returned on `WithCancelOnQuiesce` that we do for each token bucket request. This would result in accumulation of CancelFuncs in the stopper, leading to a memory leak, which would only be plugged on the server shutdown. This is now fixed.

Informs: #149658.
Epic: None

Release note: None