### PR TITLE
opt: fix sysbench-update-non-index benchmark

### DIFF
--- a/pkg/sql/opt/bench/bench_test.go
+++ b/pkg/sql/opt/bench/bench_test.go
@@ -407,7 +407,7 @@ var queries = [...]benchQuery{
 	{
 		name:  "sysbench-update-non-index",
 		query: `UPDATE sbtest SET c=$2 WHERE id=$1`,
-		args:  []interface{}{10, "foo"},
+		args:  []interface{}{10, "'foo'"},
 	},
 
 	// 1. Table with many columns.


### PR DESCRIPTION
The `sysbench-update-non-index` optimizer benchmark would previously
fail with the error `variable sub-expressions are not allowed in...`
because the placeholder string value was not correctly quoted. This has
been fixed.

Release note: None
