### PR TITLE
restore: log restore retries to job messages table

### DIFF
--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -206,3 +206,68 @@ func TestRestoreRetryFastFails(t *testing.T) {
 		require.Equal(t, expFastFailAttempts, attempts)
 	})
 }
+
+func TestRestoreJobMessages(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	mu := struct {
+		syncutil.Mutex
+		retryCount int
+	}{}
+	testKnobs := &sql.BackupRestoreTestingKnobs{
+		RestoreDistSQLRetryPolicy: &retry.Options{
+			InitialBackoff: time.Microsecond,
+			Multiplier:     1,
+			MaxBackoff:     time.Microsecond,
+			// We want enough messages to be logged so that we can verify the count,
+			// so we set MaxDuration long enough so that it doesn't get inadvertently
+			// triggered.
+			MaxDuration: 5 * time.Minute,
+		},
+		RunAfterRestoreFlow: func() error {
+			mu.Lock()
+			defer mu.Unlock()
+			mu.retryCount++
+			return syscall.ECONNRESET
+		},
+	}
+	var params base.TestClusterArgs
+	params.ServerArgs.Knobs.BackupRestore = testKnobs
+
+	const numAccounts = 1
+	_, sqlDB, _, cleanupFn := backuptestutils.StartBackupRestoreTestCluster(
+		t, singleNode, backuptestutils.WithParams(params), backuptestutils.WithBank(numAccounts),
+	)
+	defer cleanupFn()
+
+	sqlDB.Exec(t, "SET CLUSTER SETTING restore.retry_log_rate = '1000ms'")
+	sqlDB.Exec(t, "BACKUP DATABASE data INTO 'nodelocal://1/backup'")
+
+	var restoreJobID jobspb.JobID
+	sqlDB.QueryRow(
+		t, `RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/backup'
+					WITH detached, new_db_name = 'restored_data'`,
+	).Scan(&restoreJobID)
+
+	// We need to cancel the restore job or else it will block the test from
+	// completing on Engflow.
+	defer sqlDB.QueryRow(t, "CANCEL JOB $1", restoreJobID)
+
+	testutils.SucceedsSoon(t, func() error {
+		var numErrMessages int
+		sqlDB.QueryRow(
+			t, `SELECT count(*) FROM system.job_message WHERE job_id = $1 AND kind = $2`,
+			restoreJobID, "error",
+		).Scan(&numErrMessages)
+		if numErrMessages < 2 {
+			return errors.Newf("waiting for at least 2 retries to be logged")
+		}
+		mu.Lock()
+		defer mu.Unlock()
+		// Since we throttle the frequency of error messages, we expect there to be
+		// more retries than the number of error messages logged.
+		require.Greater(t, mu.retryCount, numErrMessages)
+		return nil
+	})
+}


### PR DESCRIPTION
Currently, when a restore job is stuck in a retry loop, no indication is made to the user that errors were encountered and the job is retrying (aside from within the logs). This commit teaches the restore retrier to now log errors to the job messages table, throttled to once every 5 minutes to avoid a hot loop.

Epic: CRDB-50823

Fixes: #149787, #148033

Release note (general change): Restore jobs now log errors on retry to the job messages table.