### PR TITLE
release-25.3: logictest: add back assertion that was rewritten accidentally

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config_system_tenant
@@ -121,6 +121,14 @@ SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
 FROM system.span_configurations
 WHERE end_key > (SELECT crdb_internal.table_span($t_id)[1])
 ----
+{"gcPolicy": {"ttlSeconds": 14400}, "numReplicas": 3, "rangeMaxBytes": "67108864", "rangeMinBytes": "1048576"}
+
+# Run the same query again and make sure there is 1 row. This assertion is
+# only here to prevent the previous test case from being rewritten accidentally.
+statement count 1
+SELECT crdb_internal.pb_to_json('cockroach.roachpb.SpanConfig', config)
+FROM system.span_configurations
+WHERE end_key > (SELECT crdb_internal.table_span($t_id)[1])
 
 statement ok
 CREATE TABLE db2.t2 (i INT PRIMARY KEY);


### PR DESCRIPTION
Backport 1/1 commits from #149717 on behalf of @rafiss.

----

ee263e2b214 rewrote this test so that it expects no spanconfig. This was likely a mistake caused by rewriting before retrying for long enough.

This patch adds back the assertion, and adds another one that should prevent accidental rewrites.

fixes https://github.com/cockroachdb/cockroach/issues/148603
Release note: None

----

Release justification: test only change