### PR TITLE
release-25.2: multiregionccl: skip TestMultiRegionTenantRegions under duress

### DIFF
--- a/pkg/ccl/multiregionccl/multiregion_system_table_test.go
+++ b/pkg/ccl/multiregionccl/multiregion_system_table_test.go
@@ -330,6 +330,8 @@ func TestMultiRegionTenantRegions(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
+	skip.UnderDuress(t, "slow test")
+
 	tc, _, cleanup := multiregionccltestutils.TestingCreateMultiRegionCluster(
 		t, 3 /*numServers*/, base.TestingKnobs{},
 	)


### PR DESCRIPTION
Backport 1/1 commits from #149716 on behalf of @rafiss.

----

fixes https://github.com/cockroachdb/cockroach/issues/149010
Release note: None

----

Release justification: test only change