### PR TITLE
asim: more asim follow up 

### DIFF
--- a/pkg/kv/kvserver/asim/gen/generator.go
+++ b/pkg/kv/kvserver/asim/gen/generator.go
@@ -232,6 +232,10 @@ func (bc BasicCluster) info() state.ClusterInfo {
 		return state.ClusterInfoWithStoreCount(bc.Nodes, bc.StoresPerNode)
 	}
 
+	// TODO(wenyihu6): we have the number of nodes and their localities already.
+	// We could construct ClusterInfo without a ratio calculation. We are doing
+	// this for now just to reuse ClusterInfoWithDistribution. But there may be
+	// rounding errors.
 	regionNodeWeights := make([]float64, len(bc.NodesPerRegion))
 	totalNodes := 0
 	for i, nodes := range bc.NodesPerRegion {

--- a/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
+++ b/pkg/kv/kvserver/asim/tests/testdata/non_rand/example_splitting.txt
@@ -54,7 +54,7 @@ last store values: [s1=6] (stddev=0.00, mean=6.00, sum=6)
 # repeatedly - if the load split algorithm is good, we should expect the same
 # number of splits as the uniform workload. However, that is not the case as we
 # require more splits with a zipfian distribution.
-gen_load rate=10000 rw_ratio=1 access_skew=true
+gen_load rate=10000 rw_ratio=1 access_skew=true replace=true
 ----
 
 eval duration=5m samples=2 seed=42
@@ -63,24 +63,24 @@ OK
 
 plot stat=replicas sample=4
 ----
- 15.00 ┤                                ╭──────────────────────────────────────────────
- 14.07 ┤                             ╭──╯
- 13.13 ┤                         ╭───╯
- 12.20 ┤                      ╭──╯
- 11.27 ┤                   ╭──╯
- 10.33 ┤                ╭──╯
-  9.40 ┤            ╭───╯
-  8.47 ┤         ╭──╯
-  7.53 ┤         │
-  6.60 ┤         │
-  5.67 ┤         │
-  4.73 ┤         │
-  3.80 ┤      ╭──╯
-  2.87 ┤      │
-  1.93 ┤   ╭──╯
-  1.00 ┼───╯
-                                            replicas
+ 9.00 ┤                          ╭────────────────────────────────────────────────────
+ 8.47 ┤                          │
+ 7.93 ┤                      ╭───╯
+ 7.40 ┤                      │
+ 6.87 ┤                   ╭──╯
+ 6.33 ┤                   │
+ 5.80 ┤               ╭───╯
+ 5.27 ┤               │
+ 4.73 ┤            ╭──╯
+ 4.20 ┤         ╭──╯
+ 3.67 ┤         │
+ 3.13 ┤      ╭──╯
+ 2.60 ┤      │
+ 2.07 ┤   ╭──╯
+ 1.53 ┤   │
+ 1.00 ┼───╯
+                                           replicas
 initial store values: [s1=1] (stddev=0.00, mean=1.00, sum=1)
-last store values: [s1=15] (stddev=0.00, mean=15.00, sum=15)
+last store values: [s1=9] (stddev=0.00, mean=9.00, sum=9)
 
 # vim:ft=sh


### PR DESCRIPTION
**asim: add replace = true to example_splitting**

Previously, we added a replace option to gen_load in data driven tests to
control whether the load generator is replaced or appended. The new default is
replace = false (append) which changed the original behaviour of replacing the
generator. This test expected the original behavior when re-running eval, but we
forgot to explicitly set replace = true. This commit fixes that.

Epic: none
Release note: none

---

**asim: add comment for BasicCluster.info**

This commit adds a comment to BasicCluster.info to highlight the inefficiency of
constructing the region node ratio when nodes_per_region is used with
gen_cluster just to reuse ClusterInfoWithDistribution.

Epic: none
Release note: none
