### PR TITLE
kvserver: add more logging to TestProcessSplitAfterRightHandSideHasBeenRemoved

### DIFF
--- a/pkg/kv/kvserver/client_raft_helpers_test.go
+++ b/pkg/kv/kvserver/client_raft_helpers_test.go
@@ -8,6 +8,8 @@ package kvserver_test
 import (
 	"context"
 	"fmt"
+	"maps"
+	"slices"
 	"sync/atomic"
 	"testing"
 
@@ -242,6 +244,15 @@ type testClusterPartitionedRange struct {
 		partitionedStores   map[roachpb.StoreID]bool
 	}
 	handlers []kvserver.IncomingRaftMessageHandler
+}
+
+func (p *testClusterPartitionedRange) String() string {
+	p.mu.RLock()
+	defer p.mu.RUnlock()
+	return fmt.Sprintf("partition[rangeID: %s, replicas: %v; stores: %v]",
+		p.rangeID,
+		slices.Collect(maps.Keys(p.mu.partitionedReplicas)),
+		slices.Collect(maps.Keys(p.mu.partitionedStores)))
 }
 
 // setupPartitionedRange sets up an testClusterPartitionedRange for the provided

--- a/pkg/kv/kvserver/client_test.go
+++ b/pkg/kv/kvserver/client_test.go
@@ -207,6 +207,7 @@ func assertRecomputedStats(
 func waitForTombstone(
 	t *testing.T, reader storage.Reader, rangeID roachpb.RangeID,
 ) (tombstone kvserverpb.RangeTombstone) {
+	t.Helper()
 	sl := stateloader.Make(rangeID)
 	testutils.SucceedsSoon(t, func() error {
 		ts, err := sl.LoadRangeTombstone(context.Background(), reader)


### PR DESCRIPTION
This is a complex test that modifies the state of the test server multiple times. As a result, the server logs can be hard to interpret because many errors are expected. Here we add some logging via our own `log` package so that the test actions can be correlated with errors other server log entries.

Informs #149669

Release note: None