### PR TITLE
jobs: update hot ranges logger details

### DIFF
--- a/pkg/jobs/jobspb/wrap.go
+++ b/pkg/jobs/jobspb/wrap.go
@@ -179,6 +179,7 @@ var AutomaticJobTypes = [...]Type{
 	TypeMVCCStatisticsUpdate,
 	TypeUpdateTableMetadataCache,
 	TypeSQLActivityFlush,
+	TypeHotRangesLogger,
 }
 
 // DetailsType returns the type for a payload detail.

--- a/pkg/upgrade/upgrades/v25_3_add_hot_range_logger_job.go
+++ b/pkg/upgrade/upgrades/v25_3_add_hot_range_logger_job.go
@@ -33,7 +33,7 @@ func createHotRangesLoggerJob(
 	return d.DB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
 		jr := jobs.Record{
 			JobID:         jobs.HotRangesLoggerJobID,
-			Description:   jobspb.TypeHotRangesLogger.String(),
+			Description:   "the background hot ranges logging job that runs on sql nodes",
 			Details:       jobspb.HotRangesLoggerDetails{},
 			Progress:      jobspb.HotRangesLoggerProgress{},
 			CreatedBy:     &jobs.CreatedByInfo{Name: username.NodeUser, ID: username.NodeUserID},


### PR DESCRIPTION
Two issues with the hot ranges logging job is that it is not marked as internal, and its description is capitalized, which does not follow convention.

This PR adds the job to the AutomaticJobTypes which ensures its hidden from the default view, in addition to updating the description to be more focused and appropriate.

Fixes: none
Epic: none
Release note: none