### PR TITLE
sql: INVERTED JOIN acceleration for `json ? string`, `json ?& array`, `json ?| array` and `array && array`

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
@@ -1018,6 +1018,94 @@ SELECT * FROM array_tab@foo_inv AS a1, array_tab AS a2 WHERE a1.b @> a2.b ORDER 
 6  {1,2,3,4}  6  {1,2,3,4}
 7  {NULL}     1  {}
 
+# This query performs an inverted join with && (overlaps) operator in the
+# join condition. We limit it to a2.a > 1 AND a2.a < 7 to avoid empty and
+# null arrays.
+query ITIT
+SELECT * FROM array_tab@array_tab_pkey AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b && a2.b AND a2.a > 1 AND a2.a < 7
+ORDER BY a1.a, a2.a
+----
+2  {1}        2  {1}
+4  {1,2}      2  {1}
+5  {1,3}      2  {1}
+6  {1,2,3,4}  2  {1}
+3  {2}        3  {2}
+4  {1,2}      3  {2}
+6  {1,2,3,4}  3  {2}
+2  {1}        4  {1,2}
+3  {2}        4  {1,2}
+4  {1,2}      4  {1,2}
+5  {1,3}      4  {1,2}
+6  {1,2,3,4}  4  {1,2}
+2  {1}        5  {1,3}
+4  {1,2}      5  {1,3}
+5  {1,3}      5  {1,3}
+6  {1,2,3,4}  5  {1,3}
+2  {1}        6  {1,2,3,4}
+3  {2}        6  {1,2,3,4}
+4  {1,2}      6  {1,2,3,4}
+5  {1,3}      6  {1,2,3,4}
+6  {1,2,3,4}  6  {1,2,3,4}
+
+statement ok
+CREATE TABLE array_tab_not_idx (
+  a INT PRIMARY KEY,
+  b INT[]
+);
+
+statement ok
+INSERT INTO array_tab_not_idx VALUES
+  (1, '{}'),
+  (2, '{1}'),
+  (3, '{2}'),
+  (4, '{1, 2}'),
+  (5, '{1, 3}'),
+  (6, '{1, 2, 5}'),
+  (7, ARRAY[NULL]::INT[]),
+  (8, NULL)
+
+# Ensure that join confition with not-index-array && index-array will be
+# normalized to index-array && not-index-array.
+query ITIT
+SELECT * FROM array_tab_not_idx@array_tab_not_idx_pkey AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a2.b && a1.b AND a2.a > 1 AND a2.a < 7
+ORDER BY a1.a, a2.a
+----
+2  {1}      2  {1}
+4  {1,2}    2  {1}
+5  {1,3}    2  {1}
+6  {1,2,5}  2  {1}
+3  {2}      3  {2}
+4  {1,2}    3  {2}
+6  {1,2,5}  3  {2}
+2  {1}      4  {1,2}
+3  {2}      4  {1,2}
+4  {1,2}    4  {1,2}
+5  {1,3}    4  {1,2}
+6  {1,2,5}  4  {1,2}
+2  {1}      5  {1,3}
+4  {1,2}    5  {1,3}
+5  {1,3}    5  {1,3}
+6  {1,2,5}  5  {1,3}
+2  {1}      6  {1,2,3,4}
+3  {2}      6  {1,2,3,4}
+4  {1,2}    6  {1,2,3,4}
+5  {1,3}    6  {1,2,3,4}
+6  {1,2,5}  6  {1,2,3,4}
+
+# If the given array is directly empty (i.e. Len == 0),
+# or contains only NULLs and thus has effective length 0,
+# we cannot generate an inverted expression.
+# See encodeOverlapsArrayInvertedIndexSpans().
+statement error pq: unable to construct span expression
+SELECT * FROM array_tab@array_tab_pkey AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b && a2.b
+ORDER BY a1.a, a2.a
+
 # This query performs a cross join followed by a filter.
 query ITIT
 SELECT * FROM array_tab@array_tab_pkey AS a1 CROSS HASH JOIN array_tab AS a2 WHERE a1.b @> a2.b ORDER BY a1.a, a2.a
@@ -1336,3 +1424,190 @@ FROM j1 LEFT INVERTED JOIN j2@j_idx
 ORDER BY j1.k, j2.k
 ----
 1  {"a": "b"}  NULL  NULL
+
+query ITIT
+SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b ? (j2.b ->> 'a') ORDER BY j1.a, j2.a
+----
+45  {"a": "a"}  1   {"a": "b"}
+45  {"a": "a"}  3   {"a": {"b": "c"}}
+45  {"a": "a"}  4   {"a": {"b": [1]}}
+45  {"a": "a"}  5   {"a": {"b": [1, [2]]}}
+45  {"a": "a"}  6   {"a": {"b": [[2]]}}
+45  {"a": "a"}  7   {"a": "b", "c": "d"}
+46  {"a": "c"}  7   {"a": "b", "c": "d"}
+45  {"a": "a"}  8   {"a": {"b": true}}
+45  {"a": "a"}  9   {"a": {"b": false}}
+45  {"a": "a"}  10  "a"
+45  {"a": "a"}  19  ["a", "a"]
+45  {"a": "a"}  23  {"a": 123.123}
+45  {"a": "a"}  24  {"a": 123.123000}
+45  {"a": "a"}  25  {"a": [{}]}
+45  {"a": "a"}  27  [true, false, null, 1.23, "a"]
+45  {"a": "a"}  28  {"a": {}}
+45  {"a": "a"}  30  {"a": []}
+45  {"a": "a"}  31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+45  {"a": "a"}  32  {"a": [1]}
+45  {"a": "a"}  34  {"a": 1}
+45  {"a": "a"}  39  ["a"]
+45  {"a": "a"}  40  {"a": [[]]}
+45  {"a": "a"}  45  {"a": "a"}
+45  {"a": "a"}  46  {"a": "c"}
+
+query ITIT
+SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b @> j2.b AND j1.b ? (j2.b ->> 'a') ORDER BY j1.a, j2.a
+----
+45  {"a": "a"}  45  {"a": "a"}
+
+statement ok
+CREATE TABLE text_array_tab (
+  a INT PRIMARY KEY,
+  b TEXT[]
+);
+
+statement ok
+INSERT INTO text_array_tab VALUES
+  (1, '{}'),
+  (2, '{a}'),
+  (3, '{a, b}'),
+  (4, '{a, c}'),
+  (5, '{a, b, c}'),
+  (6, '{1}'),
+  (7, NULL);
+
+# INNER INVERTED JOIN only works if the right side has an inverted index.
+statement error pq: could not produce a query plan conforming to the INVERTED JOIN hint
+SELECT * FROM json_tab AS j INNER INVERTED JOIN text_array_tab AS t
+ON j.b ?| t.b ORDER BY t.a, j.a
+
+query ITIT
+SELECT * FROM text_array_tab AS t INNER INVERTED JOIN json_tab AS j
+ON j.b ?| t.b ORDER BY t.a, j.a
+----
+2  {a}      1   {"a": "b"}
+2  {a}      3   {"a": {"b": "c"}}
+2  {a}      4   {"a": {"b": [1]}}
+2  {a}      5   {"a": {"b": [1, [2]]}}
+2  {a}      6   {"a": {"b": [[2]]}}
+2  {a}      7   {"a": "b", "c": "d"}
+2  {a}      8   {"a": {"b": true}}
+2  {a}      9   {"a": {"b": false}}
+2  {a}      10  "a"
+2  {a}      19  ["a", "a"]
+2  {a}      23  {"a": 123.123}
+2  {a}      24  {"a": 123.123000}
+2  {a}      25  {"a": [{}]}
+2  {a}      27  [true, false, null, 1.23, "a"]
+2  {a}      28  {"a": {}}
+2  {a}      30  {"a": []}
+2  {a}      31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+2  {a}      32  {"a": [1]}
+2  {a}      34  {"a": 1}
+2  {a}      39  ["a"]
+2  {a}      40  {"a": [[]]}
+2  {a}      45  {"a": "a"}
+2  {a}      46  {"a": "c"}
+3  {a,b}    1   {"a": "b"}
+3  {a,b}    3   {"a": {"b": "c"}}
+3  {a,b}    4   {"a": {"b": [1]}}
+3  {a,b}    5   {"a": {"b": [1, [2]]}}
+3  {a,b}    6   {"a": {"b": [[2]]}}
+3  {a,b}    7   {"a": "b", "c": "d"}
+3  {a,b}    8   {"a": {"b": true}}
+3  {a,b}    9   {"a": {"b": false}}
+3  {a,b}    10  "a"
+3  {a,b}    19  ["a", "a"]
+3  {a,b}    23  {"a": 123.123}
+3  {a,b}    24  {"a": 123.123000}
+3  {a,b}    25  {"a": [{}]}
+3  {a,b}    27  [true, false, null, 1.23, "a"]
+3  {a,b}    28  {"a": {}}
+3  {a,b}    30  {"a": []}
+3  {a,b}    31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+3  {a,b}    32  {"a": [1]}
+3  {a,b}    34  {"a": 1}
+3  {a,b}    39  ["a"]
+3  {a,b}    40  {"a": [[]]}
+3  {a,b}    45  {"a": "a"}
+3  {a,b}    46  {"a": "c"}
+4  {a,c}    1   {"a": "b"}
+4  {a,c}    3   {"a": {"b": "c"}}
+4  {a,c}    4   {"a": {"b": [1]}}
+4  {a,c}    5   {"a": {"b": [1, [2]]}}
+4  {a,c}    6   {"a": {"b": [[2]]}}
+4  {a,c}    7   {"a": "b", "c": "d"}
+4  {a,c}    8   {"a": {"b": true}}
+4  {a,c}    9   {"a": {"b": false}}
+4  {a,c}    10  "a"
+4  {a,c}    19  ["a", "a"]
+4  {a,c}    23  {"a": 123.123}
+4  {a,c}    24  {"a": 123.123000}
+4  {a,c}    25  {"a": [{}]}
+4  {a,c}    27  [true, false, null, 1.23, "a"]
+4  {a,c}    28  {"a": {}}
+4  {a,c}    30  {"a": []}
+4  {a,c}    31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+4  {a,c}    32  {"a": [1]}
+4  {a,c}    34  {"a": 1}
+4  {a,c}    39  ["a"]
+4  {a,c}    40  {"a": [[]]}
+4  {a,c}    45  {"a": "a"}
+4  {a,c}    46  {"a": "c"}
+5  {a,b,c}  1   {"a": "b"}
+5  {a,b,c}  3   {"a": {"b": "c"}}
+5  {a,b,c}  4   {"a": {"b": [1]}}
+5  {a,b,c}  5   {"a": {"b": [1, [2]]}}
+5  {a,b,c}  6   {"a": {"b": [[2]]}}
+5  {a,b,c}  7   {"a": "b", "c": "d"}
+5  {a,b,c}  8   {"a": {"b": true}}
+5  {a,b,c}  9   {"a": {"b": false}}
+5  {a,b,c}  10  "a"
+5  {a,b,c}  19  ["a", "a"]
+5  {a,b,c}  23  {"a": 123.123}
+5  {a,b,c}  24  {"a": 123.123000}
+5  {a,b,c}  25  {"a": [{}]}
+5  {a,b,c}  27  [true, false, null, 1.23, "a"]
+5  {a,b,c}  28  {"a": {}}
+5  {a,b,c}  30  {"a": []}
+5  {a,b,c}  31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+5  {a,b,c}  32  {"a": [1]}
+5  {a,b,c}  34  {"a": 1}
+5  {a,b,c}  39  ["a"]
+5  {a,b,c}  40  {"a": [[]]}
+5  {a,b,c}  45  {"a": "a"}
+5  {a,b,c}  46  {"a": "c"}
+
+# INNER INVERTED JOIN only works if the right side has an inverted index.
+statement error pq: could not produce a query plan conforming to the INVERTED JOIN hint
+SELECT * FROM json_tab AS j INNER INVERTED JOIN text_array_tab AS t
+ON j.b ?& t.b ORDER BY j.a
+
+query ITIT
+SELECT * FROM text_array_tab AS t INNER INVERTED JOIN json_tab AS j
+ON j.b ?& t.b ORDER BY j.a
+----
+2  {a}    1   {"a": "b"}
+2  {a}    3   {"a": {"b": "c"}}
+2  {a}    4   {"a": {"b": [1]}}
+2  {a}    5   {"a": {"b": [1, [2]]}}
+2  {a}    6   {"a": {"b": [[2]]}}
+2  {a}    7   {"a": "b", "c": "d"}
+4  {a,c}  7   {"a": "b", "c": "d"}
+2  {a}    8   {"a": {"b": true}}
+2  {a}    9   {"a": {"b": false}}
+2  {a}    10  "a"
+2  {a}    19  ["a", "a"]
+2  {a}    23  {"a": 123.123}
+2  {a}    24  {"a": 123.123000}
+2  {a}    25  {"a": [{}]}
+2  {a}    27  [true, false, null, 1.23, "a"]
+2  {a}    28  {"a": {}}
+2  {a}    30  {"a": []}
+2  {a}    31  {"a": {"b": "c", "d": "e"}, "f": "g"}
+2  {a}    32  {"a": [1]}
+2  {a}    34  {"a": 1}
+2  {a}    39  ["a"]
+2  {a}    40  {"a": [[]]}
+2  {a}    45  {"a": "a"}
+2  {a}    46  {"a": "c"}

--- a/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_join_json_array
@@ -61,7 +61,9 @@ INSERT INTO json_tab VALUES
   (41, '[[1, 2]]'),
   (42, '[[1], [2]]'),
   (43, '[{"a": "b", "c": "d"}]'),
-  (44, '[{"a": "b"}, {"c": "d"}]')
+  (44, '[{"a": "b"}, {"c": "d"}]'),
+  (45, '{"a": "a"}'),
+  (46, '{"a": "c"}')
 
 # This query performs an inverted join.
 query ITIT
@@ -188,6 +190,10 @@ SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b @> j2.b ORDER BY
 43  [{"a": "b", "c": "d"}]                 44  [{"a": "b"}, {"c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]               18  []
 44  [{"a": "b"}, {"c": "d"}]               44  [{"a": "b"}, {"c": "d"}]
+45  {"a": "a"}                             17  {}
+45  {"a": "a"}                             45  {"a": "a"}
+46  {"a": "c"}                             17  {}
+46  {"a": "c"}                             46  {"a": "c"}
 
 # This query performs a cross join followed by a filter.
 query ITIT
@@ -314,6 +320,10 @@ SELECT * FROM json_tab@json_tab_pkey AS j1 CROSS HASH JOIN json_tab AS j2 WHERE 
 43  [{"a": "b", "c": "d"}]                 44  [{"a": "b"}, {"c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]               18  []
 44  [{"a": "b"}, {"c": "d"}]               44  [{"a": "b"}, {"c": "d"}]
+45  {"a": "a"}                             17  {}
+45  {"a": "a"}                             45  {"a": "a"}
+46  {"a": "c"}                             17  {}
+46  {"a": "c"}                             46  {"a": "c"}
 
 # This query is checking that the results of the previous two queries are identical.
 # There should be no rows output.
@@ -379,6 +389,8 @@ SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY
 17  {}                                     32  {"a": [1]}
 17  {}                                     34  {"a": 1}
 17  {}                                     40  {"a": [[]]}
+17  {}                                     45  {"a": "a"}
+17  {}                                     46  {"a": "c"}
 18  []                                     2   [1, 2, 3, 4, "foo"]
 18  []                                     16  [{"a": {"b": [1, [2]]}}, "d"]
 18  []                                     18  []
@@ -451,6 +463,8 @@ SELECT * FROM json_tab@foo_inv AS j1, json_tab AS j2 WHERE j1.b <@ j2.b ORDER BY
 43  [{"a": "b", "c": "d"}]                 43  [{"a": "b", "c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]               43  [{"a": "b", "c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]               44  [{"a": "b"}, {"c": "d"}]
+45  {"a": "a"}                             45  {"a": "a"}
+46  {"a": "c"}                             46  {"a": "c"}
 
 # This query performs a cross join followed by a filter.
 query ITIT
@@ -505,6 +519,8 @@ SELECT * FROM json_tab@json_tab_pkey AS j1 CROSS HASH JOIN json_tab AS j2 WHERE 
 17  {}                                     32  {"a": [1]}
 17  {}                                     34  {"a": 1}
 17  {}                                     40  {"a": [[]]}
+17  {}                                     45  {"a": "a"}
+17  {}                                     46  {"a": "c"}
 18  []                                     2   [1, 2, 3, 4, "foo"]
 18  []                                     16  [{"a": {"b": [1, [2]]}}, "d"]
 18  []                                     18  []
@@ -577,6 +593,8 @@ SELECT * FROM json_tab@json_tab_pkey AS j1 CROSS HASH JOIN json_tab AS j2 WHERE 
 43  [{"a": "b", "c": "d"}]                 43  [{"a": "b", "c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]               43  [{"a": "b", "c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]               44  [{"a": "b"}, {"c": "d"}]
+45  {"a": "a"}                             45  {"a": "a"}
+46  {"a": "c"}                             46  {"a": "c"}
 
 # This query is checking that the results of the previous two queries are identical.
 # There should be no rows output.
@@ -758,6 +776,8 @@ NULL  NULL                                   41  [[1, 2]]
 NULL  NULL                                   42  [[1], [2]]
 NULL  NULL                                   43  [{"a": "b", "c": "d"}]
 NULL  NULL                                   44  [{"a": "b"}, {"c": "d"}]
+NULL  NULL                                   45  {"a": "a"}
+NULL  NULL                                   46  {"a": "c"}
 3     {"a": {"b": "c"}}                      3   {"a": {"b": "c"}}
 3     {"a": {"b": "c"}}                      17  {}
 4     {"a": {"b": [1]}}                      4   {"a": {"b": [1]}}
@@ -817,6 +837,8 @@ NULL  NULL       41  [[1, 2]]
 NULL  NULL       42  [[1], [2]]
 NULL  NULL       43  [{"a": "b", "c": "d"}]
 NULL  NULL       44  [{"a": "b"}, {"c": "d"}]
+NULL  NULL       45  {"a": "a"}
+NULL  NULL       46  {"a": "c"}
 17    {}         1   {"a": "b"}
 17    {}         3   {"a": {"b": "c"}}
 17    {}         4   {"a": {"b": [1]}}
@@ -922,6 +944,8 @@ ORDER BY j2.a
 42  [[1], [2]]
 43  [{"a": "b", "c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]
+45  {"a": "a"}
+46  {"a": "c"}
 
 # This query performs an anti inverted join with an additional filter.
 query IT
@@ -956,6 +980,8 @@ ORDER BY j2.a
 42  [[1], [2]]
 43  [{"a": "b", "c": "d"}]
 44  [{"a": "b"}, {"c": "d"}]
+45  {"a": "a"}
+46  {"a": "c"}
 
 statement ok
 INSERT INTO array_tab VALUES

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_json_array
@@ -192,6 +192,139 @@ vectorized: true
               table: json_tab@json_tab_pkey
               spans: [ - /19]
 
+# This query performs an inverted join with jsonExists (?) operator.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b ? (j2.b ->> 'a')
+ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: json_tab@json_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b ? (b->>'a')
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: json_tab@json_tab_pkey
+              spans: FULL SCAN
+
+# This query performs an inverted join with jsonExists (?) operator, also with an additional filter.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b ? (j2.b ->> 'a') AND j2.a < 20
+ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: json_tab@json_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b ? (b->>'a')
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: json_tab@json_tab_pkey
+              spans: [ - /19]
+
+# This query performs an inverted join with both jsonExists (?) operator and the jsonContainsBy (@>) operator.
+query T
+EXPLAIN SELECT * FROM json_tab AS j2 INNER INVERTED JOIN json_tab AS j1
+ON j1.b @> j2.b AND j1.b ? (j2.b ->> 'a')
+ORDER BY j1.a, j2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: json_tab@json_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: (b @> b) AND (b ? (b->>'a'))
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: json_tab@json_tab_pkey
+              spans: FULL SCAN
+
+statement ok
+CREATE TABLE text_array_tab (
+  a INT PRIMARY KEY,
+  b TEXT[]
+);
+
+query T
+EXPLAIN SELECT * FROM text_array_tab AS t INNER INVERTED JOIN json_tab AS j
+ON j.b ?| t.b ORDER BY t.a, j.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│ already ordered: +a
+│
+└── • lookup join
+    │ table: json_tab@json_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b ?| b
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: text_array_tab@text_array_tab_pkey
+              spans: FULL SCAN
+
+query T
+EXPLAIN SELECT * FROM text_array_tab AS t INNER INVERTED JOIN json_tab AS j
+ON j.b ?& t.b ORDER BY j.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a
+│
+└── • lookup join
+    │ table: json_tab@json_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b ?& b
+    │
+    └── • inverted join
+        │ table: json_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: text_array_tab@text_array_tab_pkey
+              spans: FULL SCAN
+
 # This query performs a cross join followed by a filter.
 query T
 EXPLAIN SELECT * FROM json_tab@json_tab_pkey AS j1, json_tab AS j2
@@ -551,6 +684,69 @@ vectorized: true
               missing stats
               table: array_tab@array_tab_pkey
               spans: [ - /4]
+
+# This query performs an inverted join with && (overlaps) operator in the
+# join condition. We limit it to a2.a > 1 AND a2.a < 7 to avoid empty and
+# null arrays.
+query T
+EXPLAIN SELECT * FROM array_tab@array_tab_pkey AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a1.b && a2.b AND a2.a > 1 AND a2.a < 7
+ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: array_tab@array_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b && b
+    │
+    └── • inverted join
+        │ table: array_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: array_tab@array_tab_pkey
+              spans: [/2 - /6]
+
+statement ok
+CREATE TABLE array_tab_not_idx (
+  a INT PRIMARY KEY,
+  b INT[]
+);
+
+# Ensure that join confition with not-index-array && index-array will be
+# normalized to index-array && not-index-array.
+query T
+EXPLAIN SELECT * FROM array_tab_not_idx@array_tab_not_idx_pkey AS a2
+INNER INVERTED JOIN array_tab@foo_inv AS a1
+ON a2.b && a1.b AND a2.a > 1 AND a2.a < 7
+ORDER BY a1.a, a2.a
+----
+distribution: local
+vectorized: true
+·
+• sort
+│ order: +a,+a
+│
+└── • lookup join
+    │ table: array_tab@array_tab_pkey
+    │ equality: (a) = (a)
+    │ equality cols are key
+    │ pred: b && b
+    │
+    └── • inverted join
+        │ table: array_tab@foo_inv
+        │
+        └── • scan
+              missing stats
+              table: array_tab_not_idx@array_tab_not_idx_pkey
+              spans: [/2 - /6]
 
 # This query performs a cross join followed by a filter.
 query T

--- a/pkg/sql/opt/invertedidx/BUILD.bazel
+++ b/pkg/sql/opt/invertedidx/BUILD.bazel
@@ -34,6 +34,7 @@ go_library(
         "//pkg/sql/sem/tree",
         "//pkg/sql/sem/tree/treecmp",
         "//pkg/sql/types",
+        "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/json",
         "//pkg/util/trigram",

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree/treecmp"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 )
@@ -40,7 +41,7 @@ func (j *jsonOrArrayJoinPlanner) extractInvertedJoinConditionFromLeaf(
 	ctx context.Context, expr opt.ScalarExpr,
 ) opt.ScalarExpr {
 	switch t := expr.(type) {
-	case *memo.ContainsExpr, *memo.ContainedByExpr:
+	case *memo.ContainsExpr, *memo.ContainedByExpr, *memo.JsonExistsExpr, *memo.JsonSomeExistsExpr, *memo.JsonAllExistsExpr, *memo.OverlapsExpr:
 		return j.extractJSONOrArrayJoinCondition(t)
 	default:
 		return nil
@@ -55,7 +56,7 @@ func (j *jsonOrArrayJoinPlanner) extractJSONOrArrayJoinCondition(
 	expr opt.ScalarExpr,
 ) opt.ScalarExpr {
 	var left, right, indexCol, val opt.ScalarExpr
-	commuteArgs, containedBy := false, false
+	commuteArgs := false
 	switch t := expr.(type) {
 	case *memo.ContainsExpr:
 		left = t.Left
@@ -63,7 +64,18 @@ func (j *jsonOrArrayJoinPlanner) extractJSONOrArrayJoinCondition(
 	case *memo.ContainedByExpr:
 		left = t.Left
 		right = t.Right
-		containedBy = true
+	case *memo.OverlapsExpr:
+		left = t.Left
+		right = t.Right
+	case *memo.JsonExistsExpr:
+		left = t.Left
+		right = t.Right
+	case *memo.JsonSomeExistsExpr:
+		left = t.Left
+		right = t.Right
+	case *memo.JsonAllExistsExpr:
+		left = t.Left
+		right = t.Right
 	default:
 		return nil
 	}
@@ -107,10 +119,21 @@ func (j *jsonOrArrayJoinPlanner) extractJSONOrArrayJoinCondition(
 	// If commuteArgs is true, we construct a new equivalent expression so that
 	// the left argument is the indexed column.
 	if commuteArgs {
-		if containedBy {
+		switch expr.(type) {
+		case *memo.ContainsExpr:
+			return j.factory.ConstructContainedBy(right, left)
+		case *memo.ContainedByExpr:
 			return j.factory.ConstructContains(right, left)
+		case *memo.OverlapsExpr:
+			return j.factory.ConstructOverlaps(right, left)
+		default:
+			// commuteArgs should only be true for operators where both sides
+			// could be json or array columns.
+			if buildutil.CrdbTestBuild {
+				panic(errors.AssertionFailedf("commuteArg is unexpectedly true for expr type %T", expr))
+			}
+			return nil
 		}
-		return j.factory.ConstructContainedBy(right, left)
 	}
 	return expr
 }
@@ -216,6 +239,29 @@ func (g *jsonOrArrayDatumsToInvertedExpr) IndexedVarResolvedType(idx int) *types
 	return g.colTypes[idx]
 }
 
+// getInvertedExprForComparisonExpr returns the inverted expression for
+// the allowlisted comparison expressions and the given constant datums.
+func getInvertedExprForComparisonExpr(
+	ctx context.Context, evalCtx *eval.Context, t *tree.ComparisonExpr, d tree.Datum,
+) (inverted.Expression, error) {
+	switch t.Operator.Symbol {
+	case treecmp.ContainedBy:
+		return getInvertedExprForJSONOrArrayIndexForContainedBy(ctx, evalCtx, d), nil
+	case treecmp.Contains:
+		return getInvertedExprForJSONOrArrayIndexForContaining(ctx, evalCtx, d), nil
+	case treecmp.Overlaps:
+		return getInvertedExprForArrayIndexForOverlaps(ctx, evalCtx, d), nil
+	case treecmp.JSONExists:
+		return getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */), nil
+	case treecmp.JSONSomeExists:
+		return getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, false /* all */), nil
+	case treecmp.JSONAllExists:
+		return getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */), nil
+	default:
+		return nil, fmt.Errorf("%s cannot be index-accelerated", t)
+	}
+}
+
 // NewJSONOrArrayDatumsToInvertedExpr returns a new
 // jsonOrArrayDatumsToInvertedExpr.
 func NewJSONOrArrayDatumsToInvertedExpr(
@@ -243,22 +289,9 @@ func NewJSONOrArrayDatumsToInvertedExpr(
 			// it for every row.
 			var spanExpr *inverted.SpanExpression
 			if d, ok := nonIndexParam.(tree.Datum); ok {
-				var invertedExpr inverted.Expression
-				switch t.Operator.Symbol {
-				case treecmp.ContainedBy:
-					invertedExpr = getInvertedExprForJSONOrArrayIndexForContainedBy(ctx, evalCtx, d)
-				case treecmp.Contains:
-					invertedExpr = getInvertedExprForJSONOrArrayIndexForContaining(ctx, evalCtx, d)
-				case treecmp.Overlaps:
-					invertedExpr = getInvertedExprForArrayIndexForOverlaps(ctx, evalCtx, d)
-				case treecmp.JSONExists:
-					invertedExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */)
-				case treecmp.JSONSomeExists:
-					invertedExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, false /* all */)
-				case treecmp.JSONAllExists:
-					invertedExpr = getInvertedExprForJSONIndexForExists(ctx, evalCtx, d, true /* all */)
-				default:
-					return nil, fmt.Errorf("%s cannot be index-accelerated", t)
+				invertedExpr, err := getInvertedExprForComparisonExpr(ctx, evalCtx, t, d)
+				if err != nil {
+					return nil, err
 				}
 				spanExpr, _ = invertedExpr.(*inverted.SpanExpression)
 			}
@@ -304,16 +337,8 @@ func (g *jsonOrArrayDatumsToInvertedExpr) Convert(
 			if d == tree.DNull {
 				return nil, nil
 			}
-			switch t.Operator.Symbol {
-			case treecmp.Contains:
-				return getInvertedExprForJSONOrArrayIndexForContaining(ctx, g.evalCtx, d), nil
 
-			case treecmp.ContainedBy:
-				return getInvertedExprForJSONOrArrayIndexForContainedBy(ctx, g.evalCtx, d), nil
-
-			default:
-				return nil, fmt.Errorf("unsupported expression %v", t)
-			}
+			return getInvertedExprForComparisonExpr(ctx, g.evalCtx, &t.ComparisonExpr, d)
 
 		default:
 			return nil, fmt.Errorf("unsupported expression %v", t)


### PR DESCRIPTION
fixes https://github.com/cockroachdb/cockroach/issues/81642
fixes https://github.com/cockroachdb/cockroach/issues/81643

ref: https://github.com/cockroachdb/cockroach/pull/81253

This commit adds support for accelerating the json ? string, json ?& array, json ?| array and array && array operators for INVERTED JOIN when the json/array argument is a column that has an inverted index over it.

Release note (sql change): the json ? string, json ?& array, json ?| array and array && array operators are now index accelerated for INVERTED JOIN statement if there is an inverted index over the json column referred to on the left hand side of the expression.