### PR TITLE
backup: fix download job progress tracker ctx awareness

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -713,7 +713,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	var lastProgressUpdate time.Time
 	for rt := retry.StartWithCtx(
 		ctx, retry.Options{InitialBackoff: time.Second, MaxBackoff: time.Second * 10},
-	); ; rt.Next() {
+	); rt.Next(); {
 		remaining, err := getExternalBytesOverSpans(ctx, execCtx.ExecCfg(), details.DownloadSpans)
 		if err != nil {
 			return errors.Wrap(err, "failed to get remaining external file bytes")
@@ -752,6 +752,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 		default:
 		}
 	}
+	return ctx.Err()
 }
 
 func unstickRestoreSpans(
@@ -981,7 +982,7 @@ func (r *restoreResumer) maybeCleanupFailedOnlineRestore(
 	ctx context.Context, p sql.JobExecContext, details jobspb.RestoreDetails,
 ) error {
 	if len(details.DownloadSpans) == 0 {
-		// If this job is completly unrelated OR, exit early.
+		// If this job is completely unrelated to OR, exit early.
 		return nil
 	}
 


### PR DESCRIPTION
Currently, `waitForDownloadToComplete` of the download job implicitly relies on calls to `getExternalBytes` to detect when the context has cancelled so that it can error accordingly. We should do this explicitly. The retry mechanism actually does support context awareness and calls to `retry.Next` will return `false` if the context is canceled, but we currently discard the results of `retry.Next`. This commit updates the tracker to properly break on a `false`.

Epic: None

Release note: None