### PR TITLE
crosscluster/physical: persist standby poller progress

### DIFF
--- a/pkg/crosscluster/physical/BUILD.bazel
+++ b/pkg/crosscluster/physical/BUILD.bazel
@@ -196,6 +196,7 @@ go_test(
         "//pkg/util/span",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_datadriven//:datadriven",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",

--- a/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/util/jobOptions.tsx
@@ -25,6 +25,9 @@ export function jobToVisual(job: Job): JobStatusVisual {
   if (job.type === "REPLICATION STREAM PRODUCER") {
     return JobStatusVisual.BadgeOnly;
   }
+  if (job.type === "STANDBY READ TS POLLER") {
+    return JobStatusVisual.BadgeOnly;
+  }
   if (
     job.type === "REPLICATION STREAM INGESTION" ||
     job.type === "LOGICAL REPLICATION"


### PR DESCRIPTION
This patch sets the standby poller job's resolved time to the system time that standby descriptors have been updated to. This allows a reader tenant user to easily check that the poller job is running smoothly via SHOW JOB.

Epic: none

Release note: none