### PR TITLE
e2e: Fix db console cypress tests after "Top Ranges" name change

### DIFF
--- a/pkg/ui/workspaces/e2e-tests/cypress/e2e/health-check/authenticated.cy.ts
+++ b/pkg/ui/workspaces/e2e-tests/cypress/e2e/health-check/authenticated.cy.ts
@@ -34,7 +34,7 @@ describe("health check: authenticated user", () => {
       cy.findByRole("link", { name: "Metrics" });
       cy.findByRole("link", { name: "Databases" });
       cy.findByRole("link", { name: "SQL Activity" });
-      cy.findByRole("link", { name: "Hot Ranges" });
+      cy.findByRole("link", { name: /^(Hot|Top) Ranges$/ });
       cy.findByRole("link", { name: "Jobs" });
       cy.findByRole("link", { name: "Advanced Debug" });
     });


### PR DESCRIPTION
PR #149713 updated the "Hot Ranges" page name to "Top Ranges". This caused the db console cypress roach tests to start failing.

Now, we look for either "Hot Ranges" or "Top Ranges". This is to ensure that the mixed version tests continue to pass, which still call the page "Hot Ranges"

Resolves: #149865
Epic: None
Release note: None