### PR TITLE
kv/bulk: compute accurate stats in StreamSSTBatcher

### DIFF
--- a/pkg/cmd/roachtest/tests/cluster_to_cluster.go
+++ b/pkg/cmd/roachtest/tests/cluster_to_cluster.go
@@ -342,6 +342,7 @@ func (kv replicateKV) sourceRunCmd(tenantName string, nodes option.NodeListOptio
 		MaybeFlag(kv.debugRunDuration > 0, "duration", kv.debugRunDuration).
 		MaybeFlag(kv.maxQPS > 0, "max-rate", kv.maxQPS).
 		MaybeFlag(kv.readOnly, "prepare-read-only", true).
+		Option("zipfian").
 		Arg("{pgurl%s:%s}", nodes, tenantName).
 		WithEqualsSyntax()
 	return cmd.String()

--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -31,6 +31,7 @@ go_library(
         "//pkg/util/humanizeutil",
         "//pkg/util/limit",
         "//pkg/util/log",
+        "//pkg/util/metamorphic",
         "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/retry",

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -120,6 +120,7 @@ func MakeBulkAdder(
 				opts.WriteAtBatchTimestamp,
 				opts.DisallowShadowingBelow,
 				admissionpb.BulkNormalPri,
+				false,
 			),
 			settings:               settings,
 			skipDuplicates:         opts.SkipDuplicates,

--- a/pkg/kv/bulk/sst_adder.go
+++ b/pkg/kv/bulk/sst_adder.go
@@ -42,6 +42,8 @@ type sstAdder struct {
 	// the batch timestamp.
 	// TODO(jeffswenson): remove this from `sstAdder` in a stand alone PR.
 	writeAtBatchTS bool
+
+	computeStatsDiff bool
 }
 
 func newSSTAdder(
@@ -50,6 +52,7 @@ func newSSTAdder(
 	writeAtBatchTS bool,
 	disallowShadowingBelow hlc.Timestamp,
 	priority admissionpb.WorkPriority,
+	computeStatsDiff bool,
 ) *sstAdder {
 	return &sstAdder{
 		db:                     db,
@@ -57,6 +60,7 @@ func newSSTAdder(
 		priority:               priority,
 		settings:               settings,
 		writeAtBatchTS:         writeAtBatchTS,
+		computeStatsDiff:       computeStatsDiff,
 	}
 }
 
@@ -105,7 +109,7 @@ func (a *sstAdder) AddSSTable(
 	}
 	defer iter.Close()
 
-	if stats == (enginepb.MVCCStats{}) {
+	if stats == (enginepb.MVCCStats{}) && !a.computeStatsDiff {
 		// TODO(jeffswenson): Audit AddSST callers to see if they generate
 		// server side stats now. Accurately computing stats in the face of replays
 		// requires the server to do it.
@@ -154,12 +158,16 @@ func (a *sstAdder) AddSSTable(
 					RequestHeader:                          kvpb.RequestHeader{Key: item.start, EndKey: item.end},
 					Data:                                   item.sstBytes,
 					DisallowShadowingBelow:                 a.disallowShadowingBelow,
-					MVCCStats:                              &item.stats,
 					IngestAsWrites:                         ingestAsWriteBatch,
 					ReturnFollowingLikelyNonEmptySpanStart: true,
+					ComputeStatsDiff:                       a.computeStatsDiff,
 				}
 				if a.writeAtBatchTS {
 					req.SSTTimestampToRequestTimestamp = batchTS
+				}
+
+				if item.stats != (enginepb.MVCCStats{}) {
+					req.MVCCStats = &item.stats
 				}
 
 				ba := &kvpb.BatchRequest{
@@ -226,8 +234,10 @@ func (a *sstAdder) AddSSTable(
 					if err != nil {
 						return err
 					}
-					if err := addStatsToSplitTables(left, right, item, sendStart); err != nil {
-						return err
+					if item.stats != (enginepb.MVCCStats{}) {
+						if err := addStatsToSplitTables(left, right, item, sendStart); err != nil {
+							return err
+						}
 					}
 					// Add more work.
 					work = append([]*sstSpan{left, right}, work...)

--- a/pkg/kv/bulk/sst_batcher.go
+++ b/pkg/kv/bulk/sst_batcher.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/limit"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -62,6 +63,13 @@ var (
 		"maximum number of concurrent bulk ingest requests sent by any one sender, such as a processor in an IMPORT, index creation or RESTORE, etc (0 = no limit)",
 		0,
 		settings.NonNegativeInt,
+	)
+
+	computeStatsDiffInStreamBatcher = settings.RegisterBoolSetting(
+		settings.ApplicationLevel,
+		"bulkio.ingest.compute_stats_diff_in_stream_batcher.enabled",
+		"if set, kvserver will compute an accurate stats diff for every addsstable request",
+		metamorphic.ConstantWithTestBool("computeStatsDiffInStreamBatcher", true),
 	)
 )
 
@@ -297,7 +305,7 @@ func MakeSSTBatcher(
 	b := &SSTBatcher{
 		name:                   name,
 		db:                     db,
-		adder:                  newSSTAdder(db, settings, writeAtBatchTs, disallowShadowingBelow, admissionpb.BulkNormalPri),
+		adder:                  newSSTAdder(db, settings, writeAtBatchTs, disallowShadowingBelow, admissionpb.BulkNormalPri, false),
 		settings:               settings,
 		disallowShadowingBelow: disallowShadowingBelow,
 		writeAtBatchTS:         writeAtBatchTs,
@@ -330,7 +338,7 @@ func MakeStreamSSTBatcher(
 		// be able to handle reduced throughput. We are OK with his for now since
 		// the consuming cluster of a replication stream does not have a latency
 		// sensitive workload running against it.
-		adder:     newSSTAdder(db, settings, false /*writeAtBatchTS*/, hlc.Timestamp{}, admissionpb.BulkNormalPri),
+		adder:     newSSTAdder(db, settings, false /*writeAtBatchTS*/, hlc.Timestamp{}, admissionpb.BulkNormalPri, computeStatsDiffInStreamBatcher.Get(&settings.SV)),
 		settings:  settings,
 		ingestAll: true,
 		mem:       mem,
@@ -365,7 +373,7 @@ func MakeTestingSSTBatcher(
 ) (*SSTBatcher, error) {
 	b := &SSTBatcher{
 		db:             db,
-		adder:          newSSTAdder(db, settings, false, hlc.Timestamp{}, admissionpb.BulkNormalPri),
+		adder:          newSSTAdder(db, settings, false, hlc.Timestamp{}, admissionpb.BulkNormalPri, false),
 		settings:       settings,
 		skipDuplicates: skipDuplicates,
 		ingestAll:      ingestAll,

--- a/pkg/storage/sst.go
+++ b/pkg/storage/sst.go
@@ -18,6 +18,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/storage/mvccencoding"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/metamorphic"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/pebble/sstable"
 	"github.com/cockroachdb/pebble/vfs"
@@ -134,6 +135,8 @@ func errorIfReaderContainsRangeKeys(
 func ComputeSSTStatsDiff(
 	ctx context.Context, sst []byte, reader Reader, nowNanos int64, start, end MVCCKey,
 ) (enginepb.MVCCStats, error) {
+	ctx, sp := tracing.ChildSpan(ctx, "ComputeSSTStatsDiff")
+	defer sp.Finish()
 
 	var ms enginepb.MVCCStats
 


### PR DESCRIPTION
This patch teaches PCR to compute an accurate stats diff on its ingestion
path.

Fixes https://github.com/cockroachdb/cockroach/issues/145548

Release note: none