### PR TITLE
release-25.2: metric: Report aggregate metric when no child metrics are present

### DIFF
--- a/pkg/util/metric/prometheus_exporter.go
+++ b/pkg/util/metric/prometheus_exporter.go
@@ -78,9 +78,10 @@ func (pm *PrometheusExporter) findOrCreateFamily(
 }
 
 type scrapeOptions struct {
-	includeChildMetrics     bool
-	includeAggregateMetrics bool
-	useStaticLabels         bool
+	includeChildMetrics          bool
+	includeAggregateMetrics      bool
+	useStaticLabels              bool
+	reinitialisableBugFixEnabled bool
 }
 
 // ScrapeOption is a function that modifies scrapeOptions
@@ -107,6 +108,13 @@ func WithUseStaticLabels(use bool) ScrapeOption {
 	}
 }
 
+// WithReinitialisableBugFixEnabled returns an option to set whether the reinitialisable bug fix is enabled
+func WithReinitialisableBugFixEnabled(enabled bool) ScrapeOption {
+	return func(o *scrapeOptions) {
+		o.reinitialisableBugFixEnabled = enabled
+	}
+}
+
 // applyScrapeOptions creates a new scrapeOptions with the given options applied
 func applyScrapeOptions(options ...ScrapeOption) *scrapeOptions {
 	opts := &scrapeOptions{
@@ -125,6 +133,7 @@ func applyScrapeOptions(options ...ScrapeOption) *scrapeOptions {
 func (pm *PrometheusExporter) ScrapeRegistry(registry *Registry, options ...ScrapeOption) {
 	o := applyScrapeOptions(options...)
 	labels := registry.GetLabels()
+
 	f := func(name string, v interface{}) {
 		switch prom := v.(type) {
 		case PrometheusVector:
@@ -138,6 +147,34 @@ func (pm *PrometheusExporter) ScrapeRegistry(registry *Registry, options ...Scra
 			}
 
 		case PrometheusExportable:
+			if _, ok := v.(PrometheusReinitialisable); ok && o.reinitialisableBugFixEnabled {
+				m := prom.ToPrometheusMetric()
+				// Set registry and metric labels.
+				m.Label = append(labels, prom.GetLabels(o.useStaticLabels)...)
+				family := pm.findOrCreateFamily(prom, o)
+
+				if o.includeAggregateMetrics {
+					family.Metric = append(family.Metric, m)
+				}
+
+				promIter, ok := v.(PrometheusIterable)
+				numChildren := 0
+				if ok && o.includeChildMetrics {
+					promIter.Each(m.Label, func(metric *prometheusgo.Metric) {
+						family.Metric = append(family.Metric, metric)
+						numChildren += 1
+					})
+				}
+
+				// PrometheusReinitialisable metrics (like SQLMetric) dynamically
+				// add child metrics. If no child metrics are present we want to ensure
+				// we report the aggregate regardless of the respective cluster setting.
+				if numChildren == 0 && !o.includeAggregateMetrics {
+					family.Metric = append(family.Metric, m)
+				}
+				return
+			}
+
 			m := prom.ToPrometheusMetric()
 			// Set registry and metric labels.
 			m.Label = append(labels, prom.GetLabels(o.useStaticLabels)...)


### PR DESCRIPTION
Backport 1/1 commits from #149540.

/cc @cockroachdb/release

---

SQLMetrics are PrometheusIterable, they are the first and only instance of metrics that dynamically add and remove childset metrics.

This commit fixes a bug where the includeAggregate flag being false (cluster setting disabled) resulting in these SQLMetrics not being reported.

When a PrometheusIterable has no child metrics it should report the aggregate regardless of the cluster setting.

Fixes: #149481

Release note (bug fix): When child metrics are enabled, include_aggregate is disabled, and the sql.metric.application_name/database_name are disabled, a handful of `sql` metrics were not being reported.

----

Release justification: feature flagged fix for a critical metrics bug that can prevent observability into certain cluster metrics if a combination of other cluster settings is set. This change is minimal in that it adds a new clause to the metric export that only runs for the new metric types, it's safe because it's feature flagged and the new code only runs in the special case and if the flag is enabled, and it's necessary because the bug makes certain metrics disappear from our prometheus scrape endpoint which is a very widely used feature.