### PR TITLE
testutils/lint: add a linter to prohibit ignoring cancel func

### DIFF
--- a/pkg/ccl/cliccl/mt_proxy.go
+++ b/pkg/ccl/cliccl/mt_proxy.go
@@ -108,7 +108,9 @@ func initLogging(cmd *cobra.Command) (ctx context.Context, stopper *stop.Stopper
 	if err != nil {
 		return ctx, nil, err
 	}
-	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+	// The proxy will shutdown via the stopper, so we can ignore the
+	// cancellation function here.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
 	return ctx, stopper, err
 }
 

--- a/pkg/ccl/sqlproxyccl/balancer/balancer.go
+++ b/pkg/ccl/sqlproxyccl/balancer/balancer.go
@@ -223,7 +223,10 @@ func NewBalancer(
 	}
 
 	// Ensure that ctx gets cancelled on stopper's quiescing.
-	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+	//
+	// The balancer shares the same lifetime as the proxy which will shutdown
+	// via the stopper, so we can ignore the cancellation function here.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
 
 	q, err := newRebalancerQueue(ctx, metrics)
 	if err != nil {

--- a/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
+++ b/pkg/ccl/sqlproxyccl/balancer/conn_tracker.go
@@ -48,7 +48,10 @@ func NewConnTracker(
 	ctx context.Context, stopper *stop.Stopper, timeSource timeutil.TimeSource,
 ) (*ConnTracker, error) {
 	// Ensure that ctx gets cancelled on stopper's quiescing.
-	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+	//
+	// The tracker shares the same lifetime as the proxy which will shutdown
+	// via the stopper, so we can ignore the cancellation function here.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
 
 	if timeSource == nil {
 		timeSource = timeutil.DefaultTimeSource{}

--- a/pkg/ccl/sqlproxyccl/proxy_handler.go
+++ b/pkg/ccl/sqlproxyccl/proxy_handler.go
@@ -194,7 +194,9 @@ func newProxyHandler(
 	proxyMetrics *metrics,
 	options ProxyOptions,
 ) (*proxyHandler, error) {
-	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+	// The proxy handler shares the same lifetime as the proxy which will shutdown
+	// via the stopper, so we can ignore the cancellation function here.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
 
 	handler := proxyHandler{
 		stopper:       stopper,

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -546,7 +546,9 @@ func NewContext(ctx context.Context, opts ContextOptions) *Context {
 		}
 	}
 
-	masterCtx, _ := opts.Stopper.WithCancelOnQuiesce(ctx)
+	// The RPC context has the same lifetime as the stopper (which often matches
+	// the lifetime of the server), so we can ignore the cancellation function.
+	masterCtx, _ := opts.Stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
 
 	secCtx := NewSecurityContext(
 		SecurityContextOptions{

--- a/pkg/sql/stats/automatic_stats.go
+++ b/pkg/sql/stats/automatic_stats.go
@@ -533,7 +533,9 @@ func (r *Refresher) SetDraining() {
 func (r *Refresher) Start(
 	ctx context.Context, stopper *stop.Stopper, refreshInterval time.Duration,
 ) error {
-	stoppingCtx, _ := stopper.WithCancelOnQuiesce(context.Background())
+	// The refresher has the same lifetime as the server, so the cancellation
+	// function can be ignored and it'll be called by the stopper.
+	stoppingCtx, _ := stopper.WithCancelOnQuiesce(context.Background()) // nolint:quiesce
 	bgCtx := r.AnnotateCtx(stoppingCtx)
 	r.startedTasksWG.Add(1)
 	if err := stopper.RunAsyncTask(bgCtx, "refresher", func(ctx context.Context) {

--- a/pkg/sql/stmtdiagnostics/statement_diagnostics.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics.go
@@ -150,7 +150,9 @@ func NewRegistry(db isql.DB, st *cluster.Settings) *Registry {
 
 // Start will start the polling loop for the Registry.
 func (r *Registry) Start(ctx context.Context, stopper *stop.Stopper) {
-	ctx, _ = stopper.WithCancelOnQuiesce(ctx)
+	// The registry has the same lifetime as the server, so the cancellation
+	// function can be ignored and it'll be called by the stopper.
+	ctx, _ = stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
 
 	// Since background statement diagnostics collection is not under user
 	// control, exclude it from cost accounting and control.


### PR DESCRIPTION
We recently fixed a couple of issues (one was fresh, another was dormant
for several years) where we had a memory leak because the cancel
function returned on `stop.Stopper.WithCancelOnQuiesce` was ignored. In
some cases (like when we have a singleton component that has lifetime
matching that of the server) this is benign, but in some other cases
this can be problematic. In order to prevent similar memory leaks from
sneaking in in the future, this commit adds a linter that prohibits
ignoring the cancel func. For the cases where it's benign, we add
`nolint:quiesce` option.

Informs: #149658.
Epic: None

Release note: None