### PR TITLE
[dnm] status: record linux-level connection RTTs

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10311,6 +10311,14 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sys.host.net.send.tcp.retrans_segs
+      exported_name: sys_host_net_send_tcp_retrans_segs
+      description: Segments retransmitted, typically because of packet loss. This is a good indicator of packet loss between nodes.
+      y_axis_label: Segments
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sys.totalmem
       exported_name: sys_totalmem
       description: Total memory (both free and used)

--- a/network_obs.md
+++ b/network_obs.md
@@ -1,0 +1,139 @@
+# CockroachDB Host-Level Network Metrics
+
+This document provides an overview of the host-level networking metrics available in CockroachDB that are sourced directly from the Linux kernel. These metrics are essential for diagnosing network-related performance issues and packet loss.
+
+## Summary of Metrics
+
+| Metric Name | Linux Counter | Likely Cause for Incrementing |
+| :--- | :--- | :--- |
+| **`sys.host.net.send.tcp.retrans_segs`** | `Tcp:RetransSegs` | Packets are being lost or delayed in transit on the network. |
+| **`sys.host.net.recv.err`** | `rx_errors` | Packets are being corrupted in transit by faulty hardware. |
+| **`sys.host.net.recv.drop`** | `rx_dropped` | The receiving host is overloaded and cannot process incoming packets fast enough. |
+| **`sys.host.net.send.err`** | `tx_errors` | The sending host's network hardware is having trouble transmitting data. |
+| **`sys.host.net.send.drop`** | `tx_dropped` | The sending host is overloaded and dropping packets before they are sent. |
+| `sys.host.net.recv.bytes` | `rx_bytes` | Measures volume of incoming traffic. |
+| `sys.host.net.recv.packets` | `rx_packets` | Measures count of incoming packets. |
+| `sys.host.net.send.bytes` | `tx_bytes` | Measures volume of outgoing traffic. |
+| `sys.host.net.send.packets` | `tx_packets` | Measures count of outgoing packets. |
+
+---
+
+## Detailed Metric Analysis
+
+### `sys.host.net.send.tcp.retrans_segs`
+*   **Linux Counter:** `Tcp:RetransSegs`
+
+This is the most reliable indicator that packets are being lost or significantly delayed on the network path, forcing the host to send them again.
+
+#### Captures
+*   **Network Congestion:** Packets dropped by overloaded switches or routers between hosts.
+*   **Faulty Network Hardware:** Loss from bad cables, failing switch ports, or NICs anywhere on the path.
+*   **Silent Drops:** Any scenario where a packet simply vanishes in transit without causing a visible error on either host.
+
+#### Misses
+*   The specific *location* or *reason* for the loss. It's a symptom, not a diagnosis.
+*   Packet loss for non-TCP traffic (e.g., UDP).
+
+---
+
+### `sys.host.net.recv.err`
+*   **Linux Counter:** `rx_errors`
+
+This metric indicates that packets are arriving at the host's network card, but they are damaged or malformed.
+
+#### Captures
+*   **Data Corruption:** Strongly points to physical layer issues like a faulty network cable, a bad fiber transceiver, or a failing switch port that is corrupting data frames.
+
+#### Misses
+*   "Clean" packet loss where packets are dropped entirely by an intermediate device and never reach the host. If the packet doesn't arrive, it can't be counted as an error.
+
+---
+
+### `sys.host.net.recv.drop`
+*   **Linux Counter:** `rx_dropped`
+
+This metric indicates the receiving host's kernel is discarding fully-formed, valid packets after they have been received by the network card.
+
+#### Captures
+*   **Receiver Overload:** The host's kernel is dropping packets because its network buffers are full. This is a classic sign that the node cannot process data as fast as it's arriving, often a symptom of extreme network congestion causing traffic bursts.
+
+#### Misses
+*   Packet loss that occurs anywhere *before* the receiving host. If an upstream switch drops the packet, this counter won't change.
+
+---
+
+### `sys.host.net.send.err`
+*   **Linux Counter:** `tx_errors`
+
+This metric indicates the sending host's network card failed to transmit a packet successfully.
+
+#### Captures
+*   **Sender Hardware/Link Issues:** Points to problems with the local NIC, the cable plugged into it, or the immediate switch port it connects to (e.g., loss of carrier signal). It tells you the host is struggling to physically transmit the data.
+
+#### Misses
+*   Any packet loss that occurs after the data has successfully left the sending machine's NIC.
+
+---
+
+### `sys.host.net.send.drop`
+*   **Linux Counter:** `tx_dropped`
+
+This metric indicates that the sending host's kernel dropped a packet before it was even handed to the network card for transmission.
+
+#### Captures
+*   **Sender-Side Congestion/Bottleneck:** The host's kernel is dropping packets because its transmit queues are full. This typically happens when an application is generating traffic faster than the OS/NIC can handle.
+
+#### Misses
+*   Any packet loss that occurs after the packet has been successfully passed to the network hardware.
+
+---
+
+### `sys.host.net.recv.bytes`
+*   **Linux Counter:** `rx_bytes`
+
+This is a simple counter for the volume of data arriving at the host.
+
+#### Captures
+*   Measures the volume of incoming traffic. Useful as a baseline and for identifying network saturation.
+
+#### Misses
+*   Does not directly indicate packet loss, only the volume of data that successfully arrived.
+
+---
+
+### `sys.host.net.recv.packets`
+*   **Linux Counter:** `rx_packets`
+
+This is a simple counter for the number of packets arriving at the host.
+
+#### Captures
+*   Measures the number of incoming packets. When correlated with the sender's `tx_packets`, it can provide evidence of intermediate loss, but this is difficult in a many-to-many communication pattern.
+
+#### Misses
+*   Does not directly indicate packet loss on its own.
+
+---
+
+### `sys.host.net.send.bytes`
+*   **Linux Counter:** `tx_bytes`
+
+This is a simple counter for the volume of data being sent by the host.
+
+#### Captures
+*   Measures the volume of outgoing traffic. Useful for identifying which nodes are generating the most traffic.
+
+#### Misses
+*   Does not indicate if that traffic successfully reached its destination.
+
+---
+
+### `sys.host.net.send.packets`
+*   **Linux Counter:** `tx_packets`
+
+This is a simple counter for the number of packets being sent by the host.
+
+#### Captures
+*   Measures the number of outgoing packets. Can be correlated with receiver stats to infer loss.
+
+#### Misses
+*   Does not indicate successful delivery on its own. 

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/sem/catconstants",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/ts/tspb",
         "//pkg/ts/tsutil",
         "//pkg/util/hlc",

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -6,6 +6,8 @@ go_library(
         "disk_counters.go",
         "disk_counters_darwin.go",
         "health_check.go",
+        "net_rtt_linux.go",
+        "net_rtt_stub.go",
         "recorder.go",
         "runtime.go",
         "runtime_generic.go",
@@ -85,6 +87,7 @@ go_library(
         ],
         "@io_bazel_rules_go//go/platform:android": [
             "@com_github_shirou_gopsutil_v3//disk",
+            "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:darwin": [
             "@com_github_lufia_iostat//:iostat",
@@ -106,6 +109,7 @@ go_library(
         ],
         "@io_bazel_rules_go//go/platform:linux": [
             "@com_github_shirou_gopsutil_v3//disk",
+            "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:netbsd": [
             "@com_github_shirou_gopsutil_v3//disk",
@@ -139,6 +143,7 @@ go_test(
         "health_check_test.go",
         "jemalloc_test.go",
         "main_test.go",
+        "net_rtt_test.go",
         "recorder_test.go",
         "runtime_linux_test.go",
         "runtime_stats_test.go",
@@ -172,6 +177,7 @@ go_test(
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_shirou_gopsutil_v3//net",
+        "@com_github_shirou_gopsutil_v3//process",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/status/net_rtt_linux.go
+++ b/pkg/server/status/net_rtt_linux.go
@@ -1,0 +1,37 @@
+//go:build linux
+
+package status
+
+import (
+	"time"
+
+	"github.com/shirou/gopsutil/v3/net"
+	"golang.org/x/sys/unix"
+)
+
+// RTTInfo holds the round-trip time information for a connection.
+type RTTInfo struct {
+	RTT    time.Duration
+	RTTVar time.Duration
+}
+
+// getRTTInfo retrieves TCP round-trip time information for a given connection
+// using a getsockopt syscall. This is only supported on Linux.
+func getRTTInfo(conn net.ConnectionStat) (*RTTInfo, error) {
+	// The file descriptor for the socket.
+	fd := int(conn.Fd)
+
+	// Retrieve TCP info for the socket.
+	info, err := unix.GetsockoptTCPInfo(fd, unix.IPPROTO_TCP, unix.TCP_INFO)
+	if err != nil {
+		return nil, err
+	}
+
+	rttInfo := &RTTInfo{
+		// RTT and RTTVar are in microseconds.
+		RTT:    time.Duration(info.Rtt) * time.Microsecond,
+		RTTVar: time.Duration(info.Rttvar) * time.Microsecond,
+	}
+
+	return rttInfo, nil
+}

--- a/pkg/server/status/net_rtt_stub.go
+++ b/pkg/server/status/net_rtt_stub.go
@@ -1,0 +1,21 @@
+//go:build !linux
+
+package status
+
+import (
+	"fmt"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/net"
+)
+
+// RTTInfo holds the round-trip time information for a connection.
+type RTTInfo struct {
+	RTT    time.Duration
+	RTTVar time.Duration
+}
+
+// getRTTInfo is a stub implementation for non-Linux platforms.
+func getRTTInfo(conn net.ConnectionStat) (*RTTInfo, error) {
+	return nil, fmt.Errorf("RTT inspection is only supported on Linux")
+}

--- a/pkg/server/status/net_rtt_test.go
+++ b/pkg/server/status/net_rtt_test.go
@@ -1,0 +1,101 @@
+package status
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net"
+	"os"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/shirou/gopsutil/v3/process"
+	"github.com/stretchr/testify/require"
+)
+
+func TestRTTLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skip("skipping test; RTT inspection is only supported on Linux")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// 1. Start a TCP server.
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	defer listener.Close()
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			// If the context is canceled, the listener may be closed,
+			// resulting in an error. This is expected during cleanup.
+			select {
+			case <-ctx.Done():
+				serverErrChan <- nil
+			default:
+				serverErrChan <- err
+			}
+			return
+		}
+		defer conn.Close()
+		// Keep the connection alive by reading from it.
+		// The client will close the connection, causing an EOF.
+		io.Copy(io.Discard, conn)
+		serverErrChan <- nil
+	}()
+
+	// 2. Connect a client to the server.
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer conn.Close()
+
+	// Give the connection a moment to be established.
+	time.Sleep(100 * time.Millisecond)
+
+	// 3. Find the connection using gopsutil.
+	pid := int32(os.Getpid())
+	proc, err := process.NewProcess(pid)
+	require.NoError(t, err)
+
+	// 4. Loop and print RTT info.
+	ticker := time.NewTicker(1 * time.Second)
+	defer ticker.Stop()
+
+	iterations := 5
+	fmt.Println("Reading RTT for 5 seconds...")
+
+	for i := 0; i < iterations; i++ {
+		select {
+		case <-ticker.C:
+			conns, err := proc.Connections()
+			require.NoError(t, err)
+
+			var foundConn bool
+			for _, c := range conns {
+				// Find the specific connection we just made.
+				laddr := conn.LocalAddr().(*net.TCPAddr)
+				raddr := conn.RemoteAddr().(*net.TCPAddr)
+
+				if c.Laddr.Port == uint32(laddr.Port) && c.Raddr.Port == uint32(raddr.Port) {
+					foundConn = true
+					rttInfo, err := getRTTInfo(c) // This will call the linux-specific implementation.
+					require.NoError(t, err)
+					require.NotNil(t, rttInfo)
+
+					fmt.Printf("Iteration %d: RTT=%s, RTTVar=%s\n", i+1, rttInfo.RTT, rttInfo.RTTVar)
+					// On a local connection, RTT should be very small but non-zero.
+					require.Greater(t, rttInfo.RTT, time.Duration(0))
+					break
+				}
+			}
+			require.True(t, foundConn, "did not find established connection")
+
+		case <-ctx.Done():
+			t.Fatal("test context cancelled")
+		}
+	}
+}

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -9,9 +9,11 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"runtime"
 	"runtime/metrics"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/shirou/gopsutil/v3/net"
@@ -134,35 +136,44 @@ func TestSubtractDiskCounters(t *testing.T) {
 func TestSubtractNetCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	from := net.IOCountersStat{
-		PacketsRecv: 3,
-		BytesRecv:   3,
-		Errin:       2,
-		Dropin:      2,
-		BytesSent:   3,
-		PacketsSent: 3,
-		Errout:      2,
-		Dropout:     2,
+	from := netCounters{
+		IOCountersStat: net.IOCountersStat{
+			PacketsRecv: 3,
+			BytesRecv:   3,
+			Errin:       2,
+			Dropin:      2,
+			BytesSent:   3,
+			PacketsSent: 3,
+			Errout:      2,
+			Dropout:     2,
+		},
+		TCPRetransSegs: 12,
 	}
-	sub := net.IOCountersStat{
-		PacketsRecv: 1,
-		BytesRecv:   1,
-		Errin:       1,
-		Dropin:      1,
-		BytesSent:   1,
-		PacketsSent: 1,
-		Errout:      1,
-		Dropout:     1,
+	sub := netCounters{
+		IOCountersStat: net.IOCountersStat{
+			PacketsRecv: 1,
+			BytesRecv:   1,
+			Errin:       1,
+			Dropin:      1,
+			BytesSent:   1,
+			PacketsSent: 1,
+			Errout:      1,
+			Dropout:     1,
+		},
+		TCPRetransSegs: 9,
 	}
-	expected := net.IOCountersStat{
-		BytesRecv:   2,
-		PacketsRecv: 2,
-		Dropin:      1,
-		Errin:       1,
-		BytesSent:   2,
-		PacketsSent: 2,
-		Errout:      1,
-		Dropout:     1,
+	expected := netCounters{
+		IOCountersStat: net.IOCountersStat{
+			BytesRecv:   2,
+			PacketsRecv: 2,
+			Dropin:      1,
+			Errin:       1,
+			BytesSent:   2,
+			PacketsSent: 2,
+			Errout:      1,
+			Dropout:     1,
+		},
+		TCPRetransSegs: 3,
 	}
 	subtractNetworkCounters(&from, sub)
 	if !reflect.DeepEqual(from, expected) {
@@ -209,4 +220,18 @@ func TestSampleEnvironment(t *testing.T) {
 	s.SampleEnvironment(ctx, cgoStats)
 
 	require.GreaterOrEqual(t, s.HostCPUCombinedPercentNorm.Value(), s.CPUCombinedPercentNorm.Value())
+}
+
+func TestNetworkStats(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	if runtime.GOOS != "linux" {
+		skip.IgnoreLint(t, "network stats only supported on linux")
+	}
+
+	nc, err := getSummedNetStats(context.Background())
+	require.NoError(t, err)
+	// Verify that we don't see -1 for TCPRetransSegs, which would indicate that
+	// the RetransSegs metric is not supported on this linux system.
+	require.LessOrEqual(t, int64(0), nc.TCPRetransSegs)
 }


### PR DESCRIPTION
See https://github.com/cockroachdb/cockroach/issues/149959.

```
$ go test -count 1 ./pkg/server/status -v -run TestRTTLinux
=== RUN   TestRTTLinux
Reading RTT for 25 seconds while actively sending data...
Iteration 1: RTT=10µs, RTTVar=1µs, Ping-Pongs=62597
Iteration 2: RTT=13µs, RTTVar=2µs, Ping-Pongs=125645
Iteration 3: RTT=10µs, RTTVar=1µs, Ping-Pongs=193704
Iteration 4: RTT=13µs, RTTVar=1µs, Ping-Pongs=257122
Iteration 5: RTT=10µs, RTTVar=3µs, Ping-Pongs=301344
Iteration 6: RTT=8µs, RTTVar=0s, Ping-Pongs=368651
Iteration 7: RTT=8µs, RTTVar=0s, Ping-Pongs=435693
Iteration 8: RTT=6µs, RTTVar=0s, Ping-Pongs=520229
Iteration 9: RTT=6µs, RTTVar=0s, Ping-Pongs=614853
Iteration 10: RTT=6µs, RTTVar=0s, Ping-Pongs=714452
Iteration 11: RTT=6µs, RTTVar=0s, Ping-Pongs=807207
Iteration 12: RTT=7µs, RTTVar=1µs, Ping-Pongs=902902
Iteration 13: RTT=10µs, RTTVar=1µs, Ping-Pongs=1000302
Iteration 14: RTT=9µs, RTTVar=2µs, Ping-Pongs=1072160
Iteration 15: RTT=11µs, RTTVar=2µs, Ping-Pongs=1098700
Iteration 16: RTT=2.318ms, RTTVar=4.62ms, Ping-Pongs=1119495
Iteration 17: RTT=10µs, RTTVar=1µs, Ping-Pongs=1139929
Iteration 18: RTT=10µs, RTTVar=0s, Ping-Pongs=1156968
Iteration 19: RTT=155µs, RTTVar=279µs, Ping-Pongs=1176115
Iteration 20: RTT=9µs, RTTVar=0s, Ping-Pongs=1195245
Iteration 21: RTT=8µs, RTTVar=0s, Ping-Pongs=1214140
Iteration 22: RTT=8µs, RTTVar=0s, Ping-Pongs=1232642
Iteration 23: RTT=9µs, RTTVar=0s, Ping-Pongs=1251115
Iteration 24: RTT=10µs, RTTVar=2µs, Ping-Pongs=1269858
Iteration 25: RTT=10µs, RTTVar=2µs, Ping-Pongs=1288366
--- PASS: TestRTTLinux (25.15s)
```

I made the values more interesting by starting this half way through:

```
$ sysbench cpu --cpu-max-prime=100000 --threads=100 --time=300 run
```

Epic: none
