### PR TITLE
settings: support enum cluster setting validation

### DIFF
--- a/pkg/settings/options.go
+++ b/pkg/settings/options.go
@@ -20,6 +20,7 @@ type SettingOption struct {
 	validateFloat64Fn  func(float64) error
 	validateStringFn   func(*Values, string) error
 	validateProtoFn    func(*Values, protoutil.Message) error
+	validateEnumFn     func(string) error
 }
 
 // NameStatus indicates the status of a setting name.
@@ -117,6 +118,11 @@ func WithValidateString(fn func(*Values, string) error) SettingOption {
 // WithValidateProto adds a validation function for a proto setting.
 func WithValidateProto(fn func(*Values, protoutil.Message) error) SettingOption {
 	return SettingOption{validateProtoFn: fn}
+}
+
+// WithValidateEnum adds a validation function for an enum setting.
+func WithValidateEnum(fn func(string) error) SettingOption {
+	return SettingOption{validateEnumFn: fn}
 }
 
 func (c *common) apply(opts []SettingOption) {

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -820,6 +820,9 @@ func toSettingString(
 		if i, intOK := d.(*tree.DInt); intOK {
 			v, ok := setting.ParseEnum(settings.EncodeInt(int64(*i)))
 			if ok {
+				if err := setting.Validate(v); err != nil {
+					return "", err
+				}
 				return settings.EncodeInt(v), nil
 			}
 			return "", errors.WithHint(errors.Errorf("invalid integer value '%d' for enum setting", *i), setting.GetAvailableValuesAsHint())
@@ -827,6 +830,9 @@ func toSettingString(
 			str := string(*s)
 			v, ok := setting.ParseEnum(str)
 			if ok {
+				if err := setting.Validate(v); err != nil {
+					return "", err
+				}
 				return settings.EncodeInt(v), nil
 			}
 			return "", errors.WithHint(errors.Errorf("invalid string value '%s' for enum setting", str), setting.GetAvailableValuesAsHint())


### PR DESCRIPTION
Previously, enum cluster settings did not support validation check. This commit 
adds one. I considered whether validation should take a string or an enum. If we
validate using the enum directly, we’d need separate validator function
signatures for each enum type, since `EnumSetting[T constraints.Integer]` is
generic but `SettingOption` isn’t.  If we take a string, `ParseEnum` happens earlier
and `SET` only sees the enum's integer value, validating directly would require
converting the int back to a string.

I ended up taking in a string since it aligns with the existing design pattern
around enum settings.

1. `RegisterEnumSetting` uses strings for default values. 2. It feels more intuitive
to set the cluster setting with the string input. It did require us adding
`parseEnumInt64`, which converts the enum's integer value back to its string
representation for validation.

Epic: none
Release note: none