### PR TITLE
structlogging: skip hot range logging exit test

### DIFF
--- a/pkg/server/structlogging/hot_ranges_log_job_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_job_test.go
@@ -27,6 +27,7 @@ func TestHotRangesLoggingJobExitProcedure(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderStress(t)
 	skip.UnderRace(t)
+	skip.WithIssue(t, 149977)
 
 	ctx := context.Background()
 	ts := serverutils.StartServerOnly(t, base.TestServerArgs{


### PR DESCRIPTION
We added a test which verifies the behavior of the hot range logger, specifically that it should exit for system tenants but remain running for app tenants.

For whatever reason, it ends up exiting for app tenants for a reasons not well understood, so we skip this test while we investigate in the meantime.

Fixes: #149914
Epic: none
Release note: none