### PR TITLE
roachprod: fix ServiceDescriptor error handling

### DIFF
--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -519,6 +519,9 @@ func (c *SyncedCluster) ServiceDescriptor(
 	sqlInstance int,
 ) (ServiceDesc, error) {
 	services, err := c.ServiceDescriptors(ctx, Nodes{node}, virtualClusterName, serviceType, sqlInstance)
+	if err != nil {
+		return ServiceDesc{}, err
+	}
 	return services[0], err
 }
 


### PR DESCRIPTION
Previously, this could cause a panic if an error occurred while fetching the service descriptors.
Now when an error returns it will return an empty `ServiceDesc`

Epic: None
Release note: None