### PR TITLE
ui: fix text overflow on job details page

### DIFF
--- a/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
+++ b/pkg/ui/workspaces/cluster-ui/src/jobs/jobs.module.scss
@@ -210,6 +210,7 @@
 .inline-message {
   margin-top: $spacing-smaller;
   width: 100%;
+  overflow-wrap: anywhere;
 }
 
 .page--header {


### PR DESCRIPTION
If the error message for a failed job contained long unbreakable strings, it prevents the error message component from shrinking, causing it to be hidden under other components.

Now, the error message component will be able to break anywhere so that it can be legible on smaller viewports.

Resolves: CC-33142
Epic: CC-32806
Release note: None