### PR TITLE
gceworker.sh: update default image family

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -23,7 +23,7 @@ FQNAME="${NAME}.${CLOUDSDK_COMPUTE_ZONE}.${CLOUDSDK_CORE_PROJECT}"
 #
 # Note that ubuntu-2004-lts is the only image that we know will consistently
 # work with respect to our build or scripts.
-IMAGE_FAMILY=${IMAGE_FAMILY-ubuntu-2004-lts}
+IMAGE_FAMILY=${IMAGE_FAMILY-ubuntu-2204-lts}
 
 cmd=${1-}
 if [[ "${cmd}" ]]; then


### PR DESCRIPTION
Ubuntu 20.04 LTS is past EOL and no longer available. I built a gceworker with 22.04 LTS and it seems fine. It's possible a newer version would also work, but I haven't tested it, so I'll stick with what I know works.

Epic: none
Release note: None