### PR TITLE
backup: reset retry counter for download job when progress is detected

### DIFF
--- a/pkg/backup/restore_job.go
+++ b/pkg/backup/restore_job.go
@@ -672,10 +672,11 @@ func loadBackupSQLDescs(
 type restoreResumer struct {
 	job *jobs.Job
 
-	settings      *cluster.Settings
-	execCfg       *sql.ExecutorConfig
-	restoreStats  roachpb.RowCount
-	downloadJobID jobspb.JobID
+	settings        *cluster.Settings
+	execCfg         *sql.ExecutorConfig
+	restoreStats    roachpb.RowCount
+	downloadJobID   jobspb.JobID
+	downloadJobProg float32
 
 	mu struct {
 		syncutil.Mutex

--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -705,6 +705,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	// Download is already complete or there is nothing to be downloaded, in
 	// either case we can mark the job as done.
 	if total == 0 {
+		r.downloadJobProg = 1.0
 		return r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
 			return 1.0
 		})
@@ -731,6 +732,7 @@ func (r *restoreResumer) waitForDownloadToComplete(
 		log.VInfof(ctx, 1, "restore download phase, %s downloaded, %s remaining of %s total (%.2f complete)",
 			sz(total-remaining), sz(remaining), sz(total), fractionComplete,
 		)
+		r.downloadJobProg = fractionComplete
 
 		if remaining == 0 {
 			r.notifyStatsRefresherOfNewTables()
@@ -808,6 +810,7 @@ func (r *restoreResumer) doDownloadFilesWithRetry(
 	ctx context.Context, execCtx sql.JobExecContext,
 ) error {
 	var err error
+	var lastProgress float32
 	for rt := retry.StartWithCtx(ctx, retry.Options{
 		InitialBackoff: time.Millisecond * 100,
 		MaxBackoff:     time.Second,
@@ -817,7 +820,12 @@ func (r *restoreResumer) doDownloadFilesWithRetry(
 		if err == nil {
 			return nil
 		}
-		log.Warningf(ctx, "failed attempt #%d to download files: %v", rt.CurrentAttempt(), err)
+		log.Warningf(ctx, "failed attempt to download files: %v", err)
+		if lastProgress != r.downloadJobProg {
+			lastProgress = r.downloadJobProg
+			rt.Reset()
+			log.Infof(ctx, "download progress has advanced since last retry, resetting retry counter")
+		}
 	}
 	return errors.Wrapf(err, "retries exhausted for downloading files")
 }
@@ -842,6 +850,13 @@ func (r *restoreResumer) doDownloadFiles(ctx context.Context, execCtx sql.JobExe
 			return jobs.MarkPauseRequestError(errors.UnwrapAll(err))
 		}
 		return errors.Wrap(err, "failed to generate and send download spans")
+	}
+
+	testingKnobs := execCtx.ExecCfg().BackupRestoreTestingKnobs
+	if testingKnobs != nil && testingKnobs.RunBeforeDownloadCleanup != nil {
+		if err := testingKnobs.RunBeforeDownloadCleanup(); err != nil {
+			return errors.Wrap(err, "testing knob RunBeforeDownloadCleanup failed")
+		}
 	}
 	return r.cleanupAfterDownload(ctx, details)
 }

--- a/pkg/sql/exec_util_backup.go
+++ b/pkg/sql/exec_util_backup.go
@@ -73,6 +73,10 @@ type BackupRestoreTestingKnobs struct {
 	// RunBeforeSendingDownloadSpan is called within the retry loop of the
 	// download span worker before sending the download span request.
 	RunBeforeSendingDownloadSpan func() error
+
+	// RunBeforeDownloadCleanup is called before we cleanup after all external
+	// files have been download.
+	RunBeforeDownloadCleanup func() error
 }
 
 var _ base.ModuleTestingKnobs = &BackupRestoreTestingKnobs{}


### PR DESCRIPTION
In #1448821, we added a retry loop to the download phase of online restore, but the retry policy allows at most 5 retries. In the event of download progress, we want to be more lenient with the retry policy, so this commit teaches the download phase to reset the retry counter if progress is detected.

Epic: CRDB-51394

Fixes: #149893