### PR TITLE
structlogging: fix flaky hot range job test

### DIFF
--- a/pkg/server/structlogging/hot_ranges_log_job_test.go
+++ b/pkg/server/structlogging/hot_ranges_log_job_test.go
@@ -27,10 +27,10 @@ func TestHotRangesLoggingJobExitProcedure(t *testing.T) {
 	defer log.Scope(t).Close(t)
 	skip.UnderStress(t)
 	skip.UnderRace(t)
-	skip.WithIssue(t, 149977)
 
 	ctx := context.Background()
 	ts := serverutils.StartServerOnly(t, base.TestServerArgs{
+		DefaultTestTenant: base.TestTenantAlwaysEnabled,
 		Knobs: base.TestingKnobs{
 			JobsTestingKnobs: jobs.NewTestingKnobsWithShortIntervals(),
 		},


### PR DESCRIPTION
A change introduced in 80d454f fixed the exit behavior of the hot range logging job so that it would restart if it were an app tenant, and exit gracefully if it were a system tenant.

However, due to the stochastic nature of the test deployment, when there is only a system tenant, it would mistakenly believe `ApplicationLayer().Codec` would not be the system codec, and therefore fail the test.

This PR fixes this test, by affixing the deployment mode of the test to include an app tenant.

Fixes: #149977
Epic: none
Release note: none