### PR TITLE
opt: use sparse arrays for operator maps

### DIFF
--- a/pkg/sql/opt/memo/typing.go
+++ b/pkg/sql/opt/memo/typing.go
@@ -112,7 +112,7 @@ var GetBuiltinProperties func(name string) (*tree.FunctionProperties, []tree.Ove
 // AggregateOverloadExists returns whether or not the given operator has a
 // unary overload which takes the given type as input.
 func AggregateOverloadExists(agg opt.Operator, typ *types.T) bool {
-	name := opt.AggregateOpReverseMap[agg]
+	name := opt.AggregateOpReverseMap(agg)
 	_, overloads := GetBuiltinProperties(name)
 	for _, o := range overloads {
 		if o.Types.MatchAt(typ, 0) {
@@ -152,7 +152,7 @@ func FindFunction(
 // FindWindowOverload finds a window function overload that matches the
 // given window function expression. It panics if no match can be found.
 func FindWindowOverload(e opt.ScalarExpr) (name string, overload *tree.Overload) {
-	name = opt.WindowOpReverseMap[e.Op()]
+	name = opt.WindowOpReverseMap(e.Op())
 	_, overload, ok := FindFunction(e, name)
 	if ok {
 		return name, overload
@@ -164,7 +164,7 @@ func FindWindowOverload(e opt.ScalarExpr) (name string, overload *tree.Overload)
 // FindAggregateOverload finds an aggregate function overload that matches the
 // given aggregate function expression. It panics if no match can be found.
 func FindAggregateOverload(e opt.ScalarExpr) (name string, overload *tree.Overload) {
-	name = opt.AggregateOpReverseMap[e.Op()]
+	name = opt.AggregateOpReverseMap(e.Op())
 	_, overload, ok := FindFunction(e, name)
 	if ok {
 		return name, overload

--- a/pkg/sql/opt/norm/bool_funcs.go
+++ b/pkg/sql/opt/norm/bool_funcs.go
@@ -37,8 +37,7 @@ func (c *CustomFuncs) NegateComparison(
 
 // CanNegateComparison returns whether the given comparison op can be negated.
 func (c *CustomFuncs) CanNegateComparison(cmp opt.Operator) bool {
-	_, ok := opt.NegateOpMap[cmp]
-	return ok
+	return opt.NegateOpMap[cmp] != opt.UnknownOp
 }
 
 // FindRedundantConjunct takes the left and right operands of an Or operator as

--- a/pkg/sql/opt/norm/decorrelate_funcs_test.go
+++ b/pkg/sql/opt/norm/decorrelate_funcs_test.go
@@ -17,15 +17,15 @@ import (
 // TranslateNonIgnoreAggs, that every aggregate will be handled somehow by it.
 // If that restriction is lifted this test can be deleted.
 func TestAllAggsIgnoreNullsOrNullOnEmpty(t *testing.T) {
-	for op := range opt.AggregateOpReverseMap {
+	opt.ForEachAggregateOp(func(op opt.Operator) {
 		if op == opt.CountRowsOp {
 			// CountRows is the only aggregate allowed to break this rule.
-			continue
+			return
 		}
 		if !opt.AggregateIgnoresNulls(op) && !opt.AggregateIsNullOnEmpty(op) {
 			panic(errors.AssertionFailedf(
 				"%s does not ignore nulls and is not null on empty", redact.Safe(op),
 			))
 		}
-	}
+	})
 }

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -195,75 +195,252 @@ const expectedUnaryOpReverseMapSize = 264
 // Ensure that the sparse array does not grow larger than expected.
 var _ [0]struct{} = [unsafe.Sizeof(UnaryOpReverseMap) - expectedUnaryOpReverseMapSize]struct{}{}
 
+type aggOpNameTag uint8
+
+const (
+	unknownAggOpNameTag aggOpNameTag = iota
+	opNameTagArrayAgg
+	opNameTagArrayCatAgg
+	opNameTagAvg
+	opNameTagBitAndAgg
+	opNameTagBitOrAgg
+	opNameTagBoolAnd
+	opNameTagBoolOr
+	opNameTagConcatAgg
+	opNameTagCount
+	opNameTagCorr
+	opNameTagCountRows
+	opNameTagCovarPop
+	opNameTagCovarSamp
+	opNameTagRegressionAvgX
+	opNameTagRegressionAvgY
+	opNameTagRegressionIntercept
+	opNameTagRegressionR2
+	opNameTagRegressionSlope
+	opNameTagRegressionSXX
+	opNameTagRegressionSXY
+	opNameTagRegressionSYY
+	opNameTagRegressionCount
+	opNameTagMax
+	opNameTagMin
+	opNameTagSumInt
+	opNameTagSum
+	opNameTagSqrDiff
+	opNameTagVariance
+	opNameTagStdDev
+	opNameTagXorAgg
+	opNameTagJsonAgg
+	opNameTagJsonbAgg
+	opNameTagJsonObjectAgg
+	opNameTagJsonbObjectAgg
+	opNameTagStringAgg
+	opNameTagConstAgg
+	opNameTagConstNotNullAgg
+	opNameTagAnyNotNullAgg
+	opNameTagPercentileDisc
+	opNameTagPercentileCont
+	opNameTagVarPop
+	opNameTagStdDevPop
+	opNameTagSTMakeLine
+	opNameTagSTUnion
+	opNameTagSTCollect
+	opNameTagSTExtent
+	opNameTagMergeAggregatedStmtMetadata
+	opNameTagMergeStatsMetadata
+	opNameTagMergeStatementStats
+	opNameTagMergeTransactionStats
+)
+
+var aggOpNames = [...]string{
+	opNameTagArrayAgg:                    "array_agg",
+	opNameTagArrayCatAgg:                 "array_cat_agg",
+	opNameTagAvg:                         "avg",
+	opNameTagBitAndAgg:                   "bit_and",
+	opNameTagBitOrAgg:                    "bit_or",
+	opNameTagBoolAnd:                     "bool_and",
+	opNameTagBoolOr:                      "bool_or",
+	opNameTagConcatAgg:                   "concat_agg",
+	opNameTagCount:                       "count",
+	opNameTagCorr:                        "corr",
+	opNameTagCountRows:                   "count_rows",
+	opNameTagCovarPop:                    "covar_pop",
+	opNameTagCovarSamp:                   "covar_samp",
+	opNameTagRegressionAvgX:              "regr_avgx",
+	opNameTagRegressionAvgY:              "regr_avgy",
+	opNameTagRegressionIntercept:         "regr_intercept",
+	opNameTagRegressionR2:                "regr_r2",
+	opNameTagRegressionSlope:             "regr_slope",
+	opNameTagRegressionSXX:               "regr_sxx",
+	opNameTagRegressionSXY:               "regr_sxy",
+	opNameTagRegressionSYY:               "regr_syy",
+	opNameTagRegressionCount:             "regr_count",
+	opNameTagMax:                         "max",
+	opNameTagMin:                         "min",
+	opNameTagSumInt:                      "sum_int",
+	opNameTagSum:                         "sum",
+	opNameTagSqrDiff:                     "sqrdiff",
+	opNameTagVariance:                    "variance",
+	opNameTagStdDev:                      "stddev",
+	opNameTagXorAgg:                      "xor_agg",
+	opNameTagJsonAgg:                     "json_agg",
+	opNameTagJsonbAgg:                    "jsonb_agg",
+	opNameTagJsonObjectAgg:               "json_object_agg",
+	opNameTagJsonbObjectAgg:              "jsonb_object_agg",
+	opNameTagStringAgg:                   "string_agg",
+	opNameTagConstAgg:                    "any_not_null",
+	opNameTagConstNotNullAgg:             "any_not_null",
+	opNameTagAnyNotNullAgg:               "any_not_null",
+	opNameTagPercentileDisc:              "percentile_disc_impl",
+	opNameTagPercentileCont:              "percentile_cont_impl",
+	opNameTagVarPop:                      "var_pop",
+	opNameTagStdDevPop:                   "stddev_pop",
+	opNameTagSTMakeLine:                  "st_makeline",
+	opNameTagSTUnion:                     "st_union",
+	opNameTagSTCollect:                   "st_collect",
+	opNameTagSTExtent:                    "st_extent",
+	opNameTagMergeAggregatedStmtMetadata: "merge_aggregated_stmt_metadata",
+	opNameTagMergeStatsMetadata:          "merge_stats_metadata",
+	opNameTagMergeStatementStats:         "merge_statement_stats",
+	opNameTagMergeTransactionStats:       "merge_transaction_stats",
+}
+
+const expectedAggOpNamesSize = 816
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(aggOpNames) - expectedAggOpNamesSize]struct{}{}
+
+var aggOpNameTags = [...]aggOpNameTag{
+	ArrayAggOp:                    opNameTagArrayAgg,
+	ArrayCatAggOp:                 opNameTagArrayCatAgg,
+	AvgOp:                         opNameTagAvg,
+	BitAndAggOp:                   opNameTagBitAndAgg,
+	BitOrAggOp:                    opNameTagBitOrAgg,
+	BoolAndOp:                     opNameTagBoolAnd,
+	BoolOrOp:                      opNameTagBoolOr,
+	ConcatAggOp:                   opNameTagConcatAgg,
+	CountOp:                       opNameTagCount,
+	CorrOp:                        opNameTagCorr,
+	CountRowsOp:                   opNameTagCountRows,
+	CovarPopOp:                    opNameTagCovarPop,
+	CovarSampOp:                   opNameTagCovarSamp,
+	RegressionAvgXOp:              opNameTagRegressionAvgX,
+	RegressionAvgYOp:              opNameTagRegressionAvgY,
+	RegressionInterceptOp:         opNameTagRegressionIntercept,
+	RegressionR2Op:                opNameTagRegressionR2,
+	RegressionSlopeOp:             opNameTagRegressionSlope,
+	RegressionSXXOp:               opNameTagRegressionSXX,
+	RegressionSXYOp:               opNameTagRegressionSXY,
+	RegressionSYYOp:               opNameTagRegressionSYY,
+	RegressionCountOp:             opNameTagRegressionCount,
+	MaxOp:                         opNameTagMax,
+	MinOp:                         opNameTagMin,
+	SumIntOp:                      opNameTagSumInt,
+	SumOp:                         opNameTagSum,
+	SqrDiffOp:                     opNameTagSqrDiff,
+	VarianceOp:                    opNameTagVariance,
+	StdDevOp:                      opNameTagStdDev,
+	XorAggOp:                      opNameTagXorAgg,
+	JsonAggOp:                     opNameTagJsonAgg,
+	JsonbAggOp:                    opNameTagJsonbAgg,
+	JsonObjectAggOp:               opNameTagJsonObjectAgg,
+	JsonbObjectAggOp:              opNameTagJsonbObjectAgg,
+	StringAggOp:                   opNameTagStringAgg,
+	ConstAggOp:                    opNameTagConstAgg,
+	ConstNotNullAggOp:             opNameTagConstNotNullAgg,
+	AnyNotNullAggOp:               opNameTagAnyNotNullAgg,
+	PercentileDiscOp:              opNameTagPercentileDisc,
+	PercentileContOp:              opNameTagPercentileCont,
+	VarPopOp:                      opNameTagVarPop,
+	StdDevPopOp:                   opNameTagStdDevPop,
+	STMakeLineOp:                  opNameTagSTMakeLine,
+	STUnionOp:                     opNameTagSTUnion,
+	STCollectOp:                   opNameTagSTCollect,
+	STExtentOp:                    opNameTagSTExtent,
+	MergeAggregatedStmtMetadataOp: opNameTagMergeAggregatedStmtMetadata,
+	MergeStatsMetadataOp:          opNameTagMergeStatsMetadata,
+	MergeStatementStatsOp:         opNameTagMergeStatementStats,
+	MergeTransactionStatsOp:       opNameTagMergeTransactionStats,
+}
+
+const expectedAggOpNameTagsSize = 297
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(aggOpNameTags) - expectedAggOpNameTagsSize]struct{}{}
+
 // AggregateOpReverseMap maps from an optimizer operator type to the name of an
 // aggregation function.
-var AggregateOpReverseMap = map[Operator]string{
-	ArrayAggOp:                    "array_agg",
-	ArrayCatAggOp:                 "array_cat_agg",
-	AvgOp:                         "avg",
-	BitAndAggOp:                   "bit_and",
-	BitOrAggOp:                    "bit_or",
-	BoolAndOp:                     "bool_and",
-	BoolOrOp:                      "bool_or",
-	ConcatAggOp:                   "concat_agg",
-	CountOp:                       "count",
-	CorrOp:                        "corr",
-	CountRowsOp:                   "count_rows",
-	CovarPopOp:                    "covar_pop",
-	CovarSampOp:                   "covar_samp",
-	RegressionAvgXOp:              "regr_avgx",
-	RegressionAvgYOp:              "regr_avgy",
-	RegressionInterceptOp:         "regr_intercept",
-	RegressionR2Op:                "regr_r2",
-	RegressionSlopeOp:             "regr_slope",
-	RegressionSXXOp:               "regr_sxx",
-	RegressionSXYOp:               "regr_sxy",
-	RegressionSYYOp:               "regr_syy",
-	RegressionCountOp:             "regr_count",
-	MaxOp:                         "max",
-	MinOp:                         "min",
-	SumIntOp:                      "sum_int",
-	SumOp:                         "sum",
-	SqrDiffOp:                     "sqrdiff",
-	VarianceOp:                    "variance",
-	StdDevOp:                      "stddev",
-	XorAggOp:                      "xor_agg",
-	JsonAggOp:                     "json_agg",
-	JsonbAggOp:                    "jsonb_agg",
-	JsonObjectAggOp:               "json_object_agg",
-	JsonbObjectAggOp:              "jsonb_object_agg",
-	StringAggOp:                   "string_agg",
-	ConstAggOp:                    "any_not_null",
-	ConstNotNullAggOp:             "any_not_null",
-	AnyNotNullAggOp:               "any_not_null",
-	PercentileDiscOp:              "percentile_disc_impl",
-	PercentileContOp:              "percentile_cont_impl",
-	VarPopOp:                      "var_pop",
-	StdDevPopOp:                   "stddev_pop",
-	STMakeLineOp:                  "st_makeline",
-	STUnionOp:                     "st_union",
-	STCollectOp:                   "st_collect",
-	STExtentOp:                    "st_extent",
-	MergeAggregatedStmtMetadataOp: "merge_aggregated_stmt_metadata",
-	MergeStatsMetadataOp:          "merge_stats_metadata",
-	MergeStatementStatsOp:         "merge_statement_stats",
-	MergeTransactionStatsOp:       "merge_transaction_stats",
+func AggregateOpReverseMap(op Operator) string {
+	return aggOpNames[aggOpNameTags[op]]
 }
+
+func ForEachAggregateOp(fn func(op Operator)) {
+	for op, nameTag := range aggOpNameTags {
+		if nameTag != unknownAggOpNameTag {
+			fn(Operator(op))
+		}
+	}
+}
+
+type windowOpNameTag uint8
+
+const (
+	unknownWindowOpNameTag windowOpNameTag = iota
+	opNameTagRank
+	opNameTagRowNumber
+	opNameTagDenseRank
+	opNameTagPercentRank
+	opNameTagCumeDist
+	opNameTagNtile
+	opNameTagLag
+	opNameTagLead
+	opNameTagFirstValue
+	opNameTagLastValue
+	opNameTagNthValue
+)
+
+// Window operators.
+var windowOpNames = [...]string{
+	opNameTagRank:        "rank",
+	opNameTagRowNumber:   "row_number",
+	opNameTagDenseRank:   "dense_rank",
+	opNameTagPercentRank: "percent_rank",
+	opNameTagCumeDist:    "cume_dist",
+	opNameTagNtile:       "ntile",
+	opNameTagLag:         "lag",
+	opNameTagLead:        "lead",
+	opNameTagFirstValue:  "first_value",
+	opNameTagLastValue:   "last_value",
+	opNameTagNthValue:    "nth_value",
+}
+
+const expectedWindowOpNamesSize = 192
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(windowOpNames) - expectedWindowOpNamesSize]struct{}{}
+
+var windowOpNameTags = [...]windowOpNameTag{
+	RankOp:        opNameTagRank,
+	RowNumberOp:   opNameTagRowNumber,
+	DenseRankOp:   opNameTagDenseRank,
+	PercentRankOp: opNameTagPercentRank,
+	CumeDistOp:    opNameTagCumeDist,
+	NtileOp:       opNameTagNtile,
+	LagOp:         opNameTagLag,
+	LeadOp:        opNameTagLead,
+	FirstValueOp:  opNameTagFirstValue,
+	LastValueOp:   opNameTagLastValue,
+	NthValueOp:    opNameTagNthValue,
+}
+
+const expectedWindowOpNameTagsSize = 222
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(windowOpNameTags) - expectedWindowOpNameTagsSize]struct{}{}
 
 // WindowOpReverseMap maps from an optimizer operator type to the name of a
 // window function.
-var WindowOpReverseMap = map[Operator]string{
-	RankOp:        "rank",
-	RowNumberOp:   "row_number",
-	DenseRankOp:   "dense_rank",
-	PercentRankOp: "percent_rank",
-	CumeDistOp:    "cume_dist",
-	NtileOp:       "ntile",
-	LagOp:         "lag",
-	LeadOp:        "lead",
-	FirstValueOp:  "first_value",
-	LastValueOp:   "last_value",
-	NthValueOp:    "nth_value",
+func WindowOpReverseMap(op Operator) string {
+	return windowOpNames[windowOpNameTags[op]]
 }
 
 // NegateOpMap maps from a comparison operator type to its negated operator

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -145,7 +145,7 @@ var ComparisonOpReverseMap = [...]treecmp.ComparisonOperatorSymbol{
 	TSMatchesOp:      treecmp.TSMatches,
 }
 
-const expectedComparisonOpReverseMapSize = 2008
+const expectedComparisonOpReverseMapSize = 251
 
 // Ensure that the sparse array does not grow larger than expected.
 var _ [0]struct{} = [unsafe.Sizeof(ComparisonOpReverseMap) - expectedComparisonOpReverseMapSize]struct{}{}

--- a/pkg/sql/opt/operator.go
+++ b/pkg/sql/opt/operator.go
@@ -7,6 +7,7 @@ package opt
 
 import (
 	"fmt"
+	"unsafe"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/colinfo"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
@@ -112,7 +113,7 @@ var ComparisonOpMap [treecmp.NumComparisonOperatorSymbols]Operator
 
 // ComparisonOpReverseMap maps from an optimizer operator type to a semantic
 // tree comparison operator type.
-var ComparisonOpReverseMap = map[Operator]treecmp.ComparisonOperatorSymbol{
+var ComparisonOpReverseMap = [...]treecmp.ComparisonOperatorSymbol{
 	EqOp:             treecmp.EQ,
 	LtOp:             treecmp.LT,
 	GtOp:             treecmp.GT,
@@ -144,9 +145,14 @@ var ComparisonOpReverseMap = map[Operator]treecmp.ComparisonOperatorSymbol{
 	TSMatchesOp:      treecmp.TSMatches,
 }
 
+const expectedComparisonOpReverseMapSize = 2008
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(ComparisonOpReverseMap) - expectedComparisonOpReverseMapSize]struct{}{}
+
 // BinaryOpReverseMap maps from an optimizer operator type to a semantic tree
 // binary operator type.
-var BinaryOpReverseMap = map[Operator]treebin.BinaryOperatorSymbol{
+var BinaryOpReverseMap = [...]treebin.BinaryOperatorSymbol{
 	BitandOp:                treebin.Bitand,
 	BitorOp:                 treebin.Bitor,
 	BitxorOp:                treebin.Bitxor,
@@ -169,15 +175,25 @@ var BinaryOpReverseMap = map[Operator]treebin.BinaryOperatorSymbol{
 	VectorNegInnerProductOp: treebin.NegInnerProduct,
 }
 
+const expectedBinaryOpReverseMapSize = 282
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(BinaryOpReverseMap) - expectedBinaryOpReverseMapSize]struct{}{}
+
 // UnaryOpReverseMap maps from an optimizer operator type to a semantic tree
 // unary operator type.
-var UnaryOpReverseMap = map[Operator]tree.UnaryOperatorSymbol{
+var UnaryOpReverseMap = [...]tree.UnaryOperatorSymbol{
 	UnaryMinusOp:      tree.UnaryMinus,
 	UnaryComplementOp: tree.UnaryComplement,
 	UnarySqrtOp:       tree.UnarySqrt,
 	UnaryCbrtOp:       tree.UnaryCbrt,
 	UnaryPlusOp:       tree.UnaryPlus,
 }
+
+const expectedUnaryOpReverseMapSize = 264
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(UnaryOpReverseMap) - expectedUnaryOpReverseMapSize]struct{}{}
 
 // AggregateOpReverseMap maps from an optimizer operator type to the name of an
 // aggregation function.
@@ -253,7 +269,7 @@ var WindowOpReverseMap = map[Operator]string{
 // NegateOpMap maps from a comparison operator type to its negated operator
 // type, as if the Not operator was applied to it. Some comparison operators,
 // like Contains and JsonExists, do not have negated versions.
-var NegateOpMap = map[Operator]Operator{
+var NegateOpMap = [...]Operator{
 	EqOp:           NeOp,
 	LtOp:           GeOp,
 	GtOp:           LeOp,
@@ -275,6 +291,11 @@ var NegateOpMap = map[Operator]Operator{
 	IsOp:           IsNotOp,
 	IsNotOp:        IsOp,
 }
+
+const expectedNegateOpMapSize = 482
+
+// Ensure that the sparse array does not grow larger than expected.
+var _ [0]struct{} = [unsafe.Sizeof(NegateOpMap) - expectedNegateOpMapSize]struct{}{}
 
 // ScalarOperatorTransmitsNulls returns true if the given scalar operator always
 // returns NULL when at least one of its inputs is NULL.
@@ -512,6 +533,6 @@ type OpaqueMetadata interface {
 
 func init() {
 	for optOp, treeOp := range ComparisonOpReverseMap {
-		ComparisonOpMap[treeOp] = optOp
+		ComparisonOpMap[treeOp] = Operator(optOp)
 	}
 }

--- a/pkg/sql/opt/operator_agg_test.go
+++ b/pkg/sql/opt/operator_agg_test.go
@@ -114,15 +114,16 @@ func TestAggregateIgnoresDuplicates(t *testing.T) {
 
 	// Ensure that a test case exists for each operator that
 	// AggregateIgnoresDuplicates returns true for.
-	for op := range opt.AggregateOpReverseMap {
+	// for op := range opt.AggregateOpReverseMap {
+	opt.ForEachAggregateOp(func(op opt.Operator) {
 		if !opt.AggregateIgnoresDuplicates(op) {
-			continue
+			return
 		}
 		switch op {
 		case opt.AnyNotNullAggOp, opt.ConstAggOp, opt.ConstNotNullAggOp, opt.FirstAggOp:
 			// These operators are for internal use and don't have SQL
 			// equivalents, so they cannot be tested with random inputs.
-			continue
+			return
 		}
 		foundTestCase := false
 		for _, tc := range testCases {
@@ -134,7 +135,7 @@ func TestAggregateIgnoresDuplicates(t *testing.T) {
 		if !foundTestCase {
 			t.Fatalf("test case required for %s operator", op.String())
 		}
-	}
+	})
 
 	const (
 		// numDatums is the number of random datums to test for each test case.
@@ -146,8 +147,8 @@ func TestAggregateIgnoresDuplicates(t *testing.T) {
 	rng, _ := randutil.NewTestRand()
 	var prevTyp *types.T
 	for _, tc := range testCases {
-		sqlOp, ok := opt.AggregateOpReverseMap[tc.op]
-		if !ok {
+		sqlOp := opt.AggregateOpReverseMap(tc.op)
+		if sqlOp == "" {
 			t.Fatalf("%s is not an aggregate function", tc.op.String())
 		}
 

--- a/pkg/sql/sem/tree/expr.go
+++ b/pkg/sql/sem/tree/expr.go
@@ -1171,7 +1171,8 @@ type UnaryOperatorSymbol uint8
 
 // UnaryExpr.Operator.Symbol
 const (
-	UnaryMinus UnaryOperatorSymbol = iota
+	UnknownUnaryOp UnaryOperatorSymbol = iota
+	UnaryMinus
 	UnaryComplement
 	UnarySqrt
 	UnaryCbrt

--- a/pkg/sql/sem/tree/treebin/binary_operator.go
+++ b/pkg/sql/sem/tree/treebin/binary_operator.go
@@ -38,7 +38,8 @@ type BinaryOperatorSymbol uint8
 
 // BinaryExpr.Operator
 const (
-	Bitand BinaryOperatorSymbol = iota
+	UnknownBinaryOp BinaryOperatorSymbol = iota
+	Bitand
 	Bitor
 	Bitxor
 	Plus

--- a/pkg/sql/sem/tree/treecmp/comparison_operator.go
+++ b/pkg/sql/sem/tree/treecmp/comparison_operator.go
@@ -34,7 +34,7 @@ func (o ComparisonOperator) String() string {
 func (ComparisonOperator) Operator() {}
 
 // ComparisonOperatorSymbol represents a comparison operator symbol.
-type ComparisonOperatorSymbol int
+type ComparisonOperatorSymbol uint8
 
 // ComparisonExpr.Operator
 const (

--- a/pkg/sql/sem/tree/treecmp/comparison_operator.go
+++ b/pkg/sql/sem/tree/treecmp/comparison_operator.go
@@ -38,7 +38,8 @@ type ComparisonOperatorSymbol uint8
 
 // ComparisonExpr.Operator
 const (
-	EQ ComparisonOperatorSymbol = iota
+	UnknownComparisonOp ComparisonOperatorSymbol = iota
+	EQ
 	LT
 	GT
 	LE


### PR DESCRIPTION
#### opt: use arrays for operator reverse maps

`ComparisonOpReverseMap`, `BinaryOpReverseMap`, `UnaryOpReverseMap`, and
`NegateOpMap` are now sparse arrays instead of maps. Using arrays avoids
the overhead of maps, e.g., hashing. The relatively small maximum value
for keys keeps the sparse arrays small in size. Assertions have been
added to make it obvious when the size of the arrays changes for any
reason.

`AggregateOpReverseMap` and `WindowOpReverseMap` remain maps for now
because sparse arrays would be thousands of bytes, mainly because a
`string` element in an array is 16 bytes.

Release note: None

#### sql,opt: use uint8 for treebin.ComparisonOperatorSymbol

The max value of `treebin.ComparisonOperatorSymbol` is 20, so it can be
a `uint8` instead of an `int`. This significantly reduces the size of
the `opt.ComparisonOpReverseMap` sparse array.

Release note: None

#### sql/sem/tree: add unknown zero-value operators

The zero values of `UnaryOperatorSymbol`, `BinaryOperatorSymbol`, and
`ComparisonOperatorSymbol` now represent unknown operators, rather than
actual operators. This will help find and prevent bugs when these zero
values are misused.

Release note: None

#### opt: use arrays for aggregate and window operator reverse maps

Mapping optimizer aggregrate and window operators to their names is now
performed via functions, instead of maps. The functions utilize one
sparse array and one dense array. The arrays avoid the overhead of maps,
e.g., hashing, and using a sparse and dense array, instead of a single
sparse array, keeps their total size in bytes relatively small - well
under 1kB.

Release note: None
