### PR TITLE
sql: populate estimated_last_login_time for all authenticating users

### DIFF
--- a/pkg/backup/backup_test.go
+++ b/pkg/backup/backup_test.go
@@ -1065,7 +1065,7 @@ func TestBackupRestoreSystemTables(t *testing.T) {
 	expectedFingerprints := map[string][][]string{}
 	err := crdb.ExecuteTx(ctx, conn, nil /* txopts */, func(tx *gosql.Tx) error {
 		for _, table := range tables {
-			rows, err := conn.Query("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE system." + table)
+			rows, err := tx.Query("SHOW EXPERIMENTAL_FINGERPRINTS FROM TABLE system." + table)
 			if err != nil {
 				return err
 			}
@@ -1077,7 +1077,7 @@ func TestBackupRestoreSystemTables(t *testing.T) {
 		}
 		// Record the transaction's timestamp so we can take a backup at the
 		// same time.
-		return conn.QueryRow("SELECT cluster_logical_timestamp()").Scan(&backupAsOf)
+		return tx.QueryRow("SELECT cluster_logical_timestamp()").Scan(&backupAsOf)
 	})
 	if err != nil {
 		t.Fatal(err)

--- a/pkg/backup/full_cluster_backup_restore_test.go
+++ b/pkg/backup/full_cluster_backup_restore_test.go
@@ -1189,29 +1189,29 @@ func TestFullClusterRestoreWithUserIDs(t *testing.T) {
 	sqlDB.Exec(t, `CREATE USER test2`)
 	sqlDB.Exec(t, `BACKUP INTO $1`, localFoo)
 
-	sqlDB.CheckQueryResults(t, `SELECT * FROM system.users ORDER BY user_id`, [][]string{
-		{"root", "", "false", "1", "NULL"},
-		{"admin", "", "true", "2", "NULL"},
-		{"test1", "NULL", "false", "100", "NULL"},
-		{"test2", "NULL", "false", "101", "NULL"},
+	sqlDB.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users ORDER BY user_id`, [][]string{
+		{"root", "", "false", "1"},
+		{"admin", "", "true", "2"},
+		{"test1", "NULL", "false", "100"},
+		{"test2", "NULL", "false", "101"},
 	})
 	// Ensure that the new backup succeeds.
 	sqlDBRestore.Exec(t, `RESTORE FROM LATEST IN $1`, localFoo)
 
-	sqlDBRestore.CheckQueryResults(t, `SELECT * FROM system.users ORDER BY user_id`, [][]string{
-		{"root", "", "false", "1", "NULL"},
-		{"admin", "", "true", "2", "NULL"},
-		{"test1", "NULL", "false", "100", "NULL"},
-		{"test2", "NULL", "false", "101", "NULL"},
+	sqlDBRestore.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users ORDER BY user_id`, [][]string{
+		{"root", "", "false", "1"},
+		{"admin", "", "true", "2"},
+		{"test1", "NULL", "false", "100"},
+		{"test2", "NULL", "false", "101"},
 	})
 
 	sqlDBRestore.Exec(t, `CREATE USER test3`)
 
-	sqlDBRestore.CheckQueryResults(t, `SELECT * FROM system.users ORDER BY user_id`, [][]string{
-		{"root", "", "false", "1", "NULL"},
-		{"admin", "", "true", "2", "NULL"},
-		{"test1", "NULL", "false", "100", "NULL"},
-		{"test2", "NULL", "false", "101", "NULL"},
-		{"test3", "NULL", "false", "102", "NULL"},
+	sqlDBRestore.CheckQueryResults(t, `SELECT username, "hashedPassword", "isRole", user_id FROM system.users ORDER BY user_id`, [][]string{
+		{"root", "", "false", "1"},
+		{"admin", "", "true", "2"},
+		{"test1", "NULL", "false", "100"},
+		{"test2", "NULL", "false", "101"},
+		{"test3", "NULL", "false", "102"},
 	})
 }

--- a/pkg/backup/testdata/backup-restore/restore-mixed-version
+++ b/pkg/backup/testdata/backup-restore/restore-mixed-version
@@ -6,6 +6,9 @@ CREATE DATABASE d;
 USE d;
 CREATE TABLE foo (i INT PRIMARY KEY, s STRING);
 INSERT INTO foo VALUES (1, 'x'),(2,'y');
+CREATE ROLE testrole NOLOGIN;
+CREATE USER testuser WITH PASSWORD 'testpass';
+GRANT testrole TO testuser;
 ----
 
 exec-sql
@@ -47,3 +50,15 @@ SELECT * FROM d.foo
 ----
 1 x
 2 y
+
+# Restore system users into the newer version cluster.
+exec-sql cluster=s2
+RESTORE SYSTEM USERS FROM LATEST IN 'nodelocal://1/full_cluster_backup/';
+----
+
+# Verify the users were restored correctly.
+query-sql cluster=s2
+SELECT username, options, member_of FROM [SHOW ROLES] WHERE username IN ('testrole', 'testuser')
+----
+testrole {NOLOGIN} {}
+testuser {} {testrole}

--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -47,6 +47,7 @@ func TestColdStartLatency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderDuress(t, "too slow")
+	skip.WithIssue(t, 150251, "skipping as timeout settings causes #150105 to fail")
 	// We'll need to make some per-node args to assign the different
 	// KV nodes to different regions and AZs. We'll want to do it to
 	// look somewhat like the real cluster topologies we have in mind.

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -2,51 +2,51 @@ statement ok
 CREATE USER user1
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user1     {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user1     {}       {}
 
 statement ok
 DROP USER user1
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 statement ok
 CREATE USER user1
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user1     {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user1     {}       {}
 
 statement ok
 DROP USER USEr1
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 statement error user "user1" does not exist
 DROP USER user1
@@ -88,45 +88,45 @@ statement ok
 CREATE USER user4
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user1     {}       {}        NULL
-user2     {}       {}        NULL
-user3     {}       {}        NULL
-user4     {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user1     {}       {}
+user2     {}       {}
+user3     {}       {}
+user4     {}       {}
 
 statement ok
 DROP USER user1,user2
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user3     {}       {}        NULL
-user4     {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user3     {}       {}
+user4     {}       {}
 
 statement error user "user1" does not exist
 DROP USER user1,user3
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user3     {}       {}        NULL
-user4     {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user3     {}       {}
+user4     {}       {}
 
 statement ok
 CREATE USER user1
@@ -156,13 +156,13 @@ PREPARE du AS DROP USER user4;
 EXECUTE du
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 user testuser
 

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -25,14 +25,14 @@ statement ok
 CREATE ROLE myrole
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW ROLES
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW ROLES]
 ----
-username  options   member_of estimated_last_login_time
-admin     {}        {}        NULL
-myrole    {NOLOGIN} {}        NULL
-root      {}        {admin}   NULL
-testuser  {}        {}        NULL
+username  options   member_of
+admin     {}        {}
+myrole    {NOLOGIN} {}
+root      {}        {admin}
+testuser  {}        {}
 
 statement error a role/user named myrole already exists
 CREATE ROLE myrole
@@ -56,26 +56,26 @@ statement error pq: cannot drop roles/users admin, myrole: grants still exist on
 DROP ROLE admin, myrole
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW ROLES
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW ROLES]
 ----
-username  options   member_of estimated_last_login_time
-admin     {}        {}        NULL
-myrole    {NOLOGIN} {}        NULL
-root      {}        {admin}   NULL
-testuser  {}        {}        NULL
+username  options   member_of
+admin     {}        {}
+myrole    {NOLOGIN} {}
+root      {}        {admin}
+testuser  {}        {}
 
 statement ok
 DROP ROLE myrole
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW ROLES
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW ROLES]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 statement error pq: role/user "myrole" does not exist
 DROP ROLE myrole
@@ -105,13 +105,13 @@ statement ok
 DROP ROLE rolea, roleb
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW ROLES
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW ROLES]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 skipif config local-mixed-25.2
 query T noticetrace
@@ -502,16 +502,16 @@ admin  root      true
 roled  testuser  false
 
 skipif config local-mixed-25.2
-query TTTT rowsort
-SHOW ROLES
+query TTT rowsort
+select username, options, member_of from [SHOW ROLES]
 ----
-admin      {}         {}       NULL
-roleb      {NOLOGIN}  {}       NULL
-roled      {NOLOGIN}  {}       NULL
-rolee      {NOLOGIN}  {}       NULL
-root       {}         {admin}  NULL
-testuser   {}         {roled}  NULL
-testuser2  {}         {}       NULL
+admin      {}         {}
+roleb      {NOLOGIN}  {}
+roled      {NOLOGIN}  {}
+rolee      {NOLOGIN}  {}
+root       {}         {admin}
+testuser   {}         {roled}
+testuser2  {}         {}
 
 statement ok
 DROP ROLE roleb

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -491,13 +491,13 @@ v           CREATE VIEW public.v (
 
 
 skipif config local-mixed-25.2
-query TTTT colnames
-SELECT * FROM [SHOW USERS] ORDER BY 1
+query TTT colnames
+SELECT username,options,member_of FROM [SHOW USERS] ORDER BY 1
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 
 query TTTI colnames

--- a/pkg/sql/logictest/testdata/logic_test/user
+++ b/pkg/sql/logictest/testdata/logic_test/user
@@ -6,26 +6,26 @@ SHOW is_superuser
 on
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
 
 statement ok
 CREATE USER user1
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user1     {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user1     {}       {}
 
 skipif config local-mixed-25.2
 query T noticetrace
@@ -97,19 +97,19 @@ PREPARE chpw2 AS ALTER USER blix WITH PASSWORD $1;
   EXECUTE chpw2('baz')
 
 skipif config local-mixed-25.2
-query TTTT colnames,rowsort
-SHOW USERS
+query TTT colnames,rowsort
+select username, options, member_of from [SHOW USERS]
 ----
-username  options  member_of estimated_last_login_time
-admin     {}       {}        NULL
-foo       {}       {}        NULL
-foo-bar   {}       {}        NULL
-root      {}       {admin}   NULL
-testuser  {}       {}        NULL
-user1     {}       {}        NULL
-user2     {}       {}        NULL
-user3     {}       {}        NULL
-ομηρος    {}       {}        NULL
+username  options  member_of
+admin     {}       {}
+foo       {}       {}
+foo-bar   {}       {}
+root      {}       {admin}
+testuser  {}       {}
+user1     {}       {}
+user2     {}       {}
+user3     {}       {}
+ομηρος    {}       {}
 
 statement error "": username is empty
 CREATE USER ""
@@ -272,3 +272,38 @@ statement error pq: user identity unknown for identity provider
 SHOW session_user
 
 subtest end
+
+subtest validate_estimated_last_login_time
+
+user root
+
+statement ok
+CREATE user IF NOT EXISTS testuser
+
+user testuser
+
+# Since the logictest framework does not connect with the user until a command
+# is executed, we need to run a command before checking estimated_last_login_time.
+query T
+SHOW session_user
+----
+testuser
+
+user root
+
+# The estimated_last_login_time is not guaranteed to be populated synchronously,
+# so we poll until testuser's entry was updated with the last login time.
+skipif config local-mixed-25.2
+query I retry
+SELECT count(*) FROM system.users WHERE estimated_last_login_time IS NOT NULL AND username = 'testuser'
+----
+1
+
+user root
+
+onlyif config local-mixed-25.2
+statement error pq: column "estimated_last_login_time" does not exist
+select estimated_last_login_time from [SHOW USERS] where username = 'testuser';
+
+subtest end
+

--- a/pkg/sql/user.go
+++ b/pkg/sql/user.go
@@ -836,3 +836,23 @@ func updateUserPasswordHash(
 		})
 	})
 }
+
+// UpdateLastLoginTime updates the estimated_last_login_time column for the user
+// logging in to the current time in the system.users table.
+func UpdateLastLoginTime(ctx context.Context, execCfg *ExecutorConfig, dbUser string) error {
+	now := timeutil.Now()
+	if err := execCfg.InternalDB.DescsTxn(ctx, func(ctx context.Context, txn descs.Txn) error {
+		if _, err := txn.Exec(
+			ctx, "UpdateLastLoginTime-authsuccess", txn.KV(),
+			"UPDATE system.users SET estimated_last_login_time = $1 WHERE username = $2",
+			now,
+			dbUser,
+		); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		return err
+	}
+	return nil
+}


### PR DESCRIPTION
We would like to add more observability around authenticating users since we will be working towards user provisioning and this will require stronger auditing functionality for the users gaining access to cockroach sql cluster. A new column for estimated_last_login_time was added in #148056 for the system.users table. We will now populate the column with timestamp from the session authentication end time(time when authentication was successful for the users).

fixes #148876
Epic CRDB-21590

Release note (sql change): The column for `estimated_last_login_time` in `system.users` will be updated with the TIMESTAMP of user login post successful authentication. The `SHOW users` view will now show the updated value.

```
root@localhost:26257/defaultdb> SHOW users;
     username    |                                       options                                       | member_of |   estimated_last_login_time
-----------------+-------------------------------------------------------------------------------------+-----------+--------------------------------
  admin          | {}                                                                                  | {}        | NULL
  root           | {}                                                                                  | {admin}   | 2025-07-13 11:51:29.406216+00
  sourav.sarangi | {}                                                                                  | {}        | NULL
(3 rows)

NOTICE: estimated_last_login_time is computed on a best effort basis; it is not guaranteed to capture every login event
```