### PR TITLE
crosscluster/physical: fix status after init scan complete

### DIFF
--- a/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -341,6 +341,7 @@ func (sf *streamIngestionFrontier) maybeUpdateProgress() error {
 
 		if replicatedTime.IsSet() && streamProgress.ReplicationStatus == jobspb.InitialScan {
 			streamProgress.ReplicationStatus = jobspb.Replicating
+			md.Progress.StatusMessage = streamProgress.ReplicationStatus.String()
 		}
 
 		// Keep the recorded replicatedTime empty until some advancement has been made

--- a/pkg/crosscluster/replicationtestutils/testutils.go
+++ b/pkg/crosscluster/replicationtestutils/testutils.go
@@ -601,6 +601,10 @@ func WaitUntilStartTimeReached(t *testing.T, db *sqlutils.SQLRunner, ingestionJo
 
 		return requireReplicatedTime(startTime, jobutils.GetJobProgress(t, db, ingestionJobID))
 	}, timeout)
+
+	var runningStatus string
+	db.QueryRow(t, "SELECT running_status FROM [SHOW JOB $1]", ingestionJobID).Scan(&runningStatus)
+	require.Equal(t, "replicating", runningStatus, "job should be in replicating state after reaching start time")
 }
 
 func WaitUntilReplicatedTime(


### PR DESCRIPTION
The patch ensures PCR changes the job status message and replication status to replicating once the initial scan completes.

Fixes #148150

Release note: none