### PR TITLE
pgwire: add peer authentication method

### DIFF
--- a/pkg/sql/pgwire/BUILD.bazel
+++ b/pkg/sql/pgwire/BUILD.bazel
@@ -5,6 +5,8 @@ go_library(
     srcs = [
         "auth.go",
         "auth_behaviors.go",
+        "auth_darwin.go",
+        "auth_linux.go",
         "auth_methods.go",
         "authenticator.go",
         "authorizer.go",
@@ -100,7 +102,21 @@ go_library(
         "@io_opentelemetry_go_otel//attribute",
         "@org_golang_google_grpc//codes",
         "@org_golang_google_grpc//status",
-    ],
+    ] + select({
+        "@io_bazel_rules_go//go/platform:android": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:darwin": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:ios": [
+            "@org_golang_x_sys//unix",
+        ],
+        "@io_bazel_rules_go//go/platform:linux": [
+            "@org_golang_x_sys//unix",
+        ],
+        "//conditions:default": [],
+    }),
 )
 
 go_test(

--- a/pkg/sql/pgwire/auth_darwin.go
+++ b/pkg/sql/pgwire/auth_darwin.go
@@ -1,0 +1,49 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build darwin
+
+package pgwire
+
+import (
+	"fmt"
+	"net"
+	"os/user"
+
+	"github.com/cockroachdb/errors"
+	"golang.org/x/sys/unix"
+)
+
+func getOSUserFromUnixConn(conn net.Conn) (string, error) {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return "", errors.New("peer authentication is only available on unix socket connections")
+	}
+
+	rawConn, err := unixConn.SyscallConn()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get syscall conn")
+	}
+
+	var cred *unix.Xucred // Use Xucred for macOS/darwin
+	var credErr error
+	err = rawConn.Control(func(fd uintptr) {
+		// Use GetsockoptXucred and LOCAL_PEERCRED for macOS
+		cred, credErr = unix.GetsockoptXucred(int(fd), unix.SOL_LOCAL, unix.LOCAL_PEERCRED)
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "syscall control failed")
+	}
+	if credErr != nil {
+		return "", errors.Wrap(credErr, "getsockopt(LOCAL_PEERCRED) failed")
+	}
+
+	// The UID is in the Xucred struct
+	u, err := user.LookupId(fmt.Sprintf("%d", cred.Uid))
+	if err != nil {
+		return "", errors.Wrapf(err, "could not find user for uid %d", cred.Uid)
+	}
+	return u.Username, nil
+}

--- a/pkg/sql/pgwire/auth_linux.go
+++ b/pkg/sql/pgwire/auth_linux.go
@@ -1,0 +1,47 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build linux
+
+package pgwire
+
+import (
+	"fmt"
+	"net"
+	"os/user"
+
+	"github.com/cockroachdb/errors"
+	"golang.org/x/sys/unix"
+)
+
+func getOSUserFromUnixConn(conn net.Conn) (string, error) {
+	unixConn, ok := conn.(*net.UnixConn)
+	if !ok {
+		return "", errors.New("peer authentication is only available on unix socket connections")
+	}
+
+	rawConn, err := unixConn.SyscallConn()
+	if err != nil {
+		return "", errors.Wrap(err, "could not get syscall conn")
+	}
+
+	var cred *unix.Ucred
+	var credErr error
+	err = rawConn.Control(func(fd uintptr) {
+		cred, credErr = unix.GetsockoptUcred(int(fd), unix.SOL_SOCKET, unix.SO_PEERCRED)
+	})
+	if err != nil {
+		return "", errors.Wrap(err, "syscall control failed")
+	}
+	if credErr != nil {
+		return "", errors.Wrap(credErr, "getsockopt(SO_PEERCRED) failed")
+	}
+
+	u, err := user.LookupId(fmt.Sprintf("%d", cred.Uid))
+	if err != nil {
+		return "", errors.Wrapf(err, "could not find user for uid %d", cred.Uid)
+	}
+	return u.Username, nil
+}

--- a/pkg/sql/pgwire/testdata/auth/hba_syntax
+++ b/pkg/sql/pgwire/testdata/auth/hba_syntax
@@ -20,7 +20,7 @@ host all all 0.0.0.0/0 invalid
 ERROR: unimplemented: unknown auth method "invalid" (SQLSTATE 0A000)
 HINT: You have attempted to use a feature that is not yet implemented.<STANDARD REFERRAL>
 --
-Supported methods: cert, cert-password, cert-scram-sha-256, ldap, password, reject, scram-sha-256, trust
+Supported methods: cert, cert-password, cert-scram-sha-256, ldap, password, peer, reject, scram-sha-256, trust
 
 
 # CockroachDB does not (yet?) support per-db HBA rules.

--- a/pkg/sql/pgwire/testdata/auth/peer
+++ b/pkg/sql/pgwire/testdata/auth/peer
@@ -1,0 +1,208 @@
+# This test file validates the 'peer' authentication method.
+# It should only run in secure mode, as it's a security feature.
+config secure
+----
+
+# Create a user to test with.
+sql
+CREATE USER testpeer;
+----
+ok
+
+#
+# subtest: simple_peer_auth
+#
+# Test direct 1-to-1 peer authentication without an identity map.
+#
+
+subtest simple_peer_auth/success
+
+# HBA Rule: Allow 'testpeer' to connect via socket if the OS user is mapped via 'os_map'.
+# NOTE: This test is made portable by using the %CURRENT_OS_USER% placeholder,
+# which is substituted by the test runner at runtime.
+set_hba
+local all testpeer peer map=os_map
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# local all testpeer peer map=os_map
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER     ADDRESS METHOD        OPTIONS
+loopback all      all      all     trust
+host     all      root     all     cert-password
+local    all      testpeer         peer          map=os_map
+
+# Identity Map: Map the current OS user to the DB user 'testpeer'.
+set_identity_map
+os_map %CURRENT_OS_USER% testpeer
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# local all testpeer peer map=os_map
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER     ADDRESS METHOD        OPTIONS
+loopback all      all      all     trust
+host     all      root     all     cert-password
+local    all      testpeer         peer          map=os_map
+# Active identity mapping on this node:
+# Original configuration:
+# os_map %CURRENT_OS_USER% testpeer
+# Active configuration:
+# map-name system-username database-username
+os_map     ^%CURRENT_OS_USER%$       testpeer
+
+# Connect as 'testpeer'. The server will get the real OS user
+# via syscall and use the map to authorize the connection.
+connect_unix user=testpeer show_authentication_method
+----
+ok defaultdb peer
+
+authlog 5
+.*client_connection_end
+----
+4 {"EventType":"client_authentication_info","Info":"peer authentication: determined OS user as \"%CURRENT_OS_USER%\"","InstanceID":1,"Method":"peer","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testpeer","Timestamp":"XXX","Transport":"local"}
+5 {"EventType":"client_authentication_ok","InstanceID":1,"Method":"peer","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"%CURRENT_OS_USER%","Timestamp":"XXX","Transport":"local","User":"testpeer"}
+6 {"EventType":"client_authentication_info","Info":"session created with SessionDefaults=[database=defaultdb] and CustomOptions=[]","InstanceID":1,"Method":"peer","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"%CURRENT_OS_USER%","Timestamp":"XXX","Transport":"local","User":"testpeer"}
+7 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+8 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+
+subtest end
+
+subtest simple_peer_auth/failure_user_mismatch
+
+# HBA rule for a direct mapping that will fail.
+set_hba
+local all testpeer peer
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# local all testpeer peer
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER     ADDRESS METHOD        OPTIONS
+loopback all      all      all     trust
+host     all      root     all     cert-password
+local    all      testpeer         peer
+# Active identity mapping on this node:
+# Original configuration:
+# os_map %CURRENT_OS_USER% testpeer
+# Active configuration:
+# map-name system-username database-username
+os_map     ^%CURRENT_OS_USER%$       testpeer
+
+# Attempt to connect as 'testpeer'. This must fail because the real OS user
+# will not match the requested DB user 'testpeer'.
+connect_unix user=testpeer
+----
+ERROR: requested user identity "testpeer" does not correspond to any mapping for system identity "%CURRENT_OS_USER%" (SQLSTATE 28000)
+
+authlog 4
+.*client_connection_end
+----
+11 {"EventType":"client_authentication_info","Info":"peer authentication: determined OS user as \"%CURRENT_OS_USER%\"","InstanceID":1,"Method":"peer","Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"testpeer","Timestamp":"XXX","Transport":"local"}
+12 {"Detail":"requested user identity \"testpeer\" does not correspond to any mapping for system identity \"%CURRENT_OS_USER%\"","EventType":"client_authentication_failed","InstanceID":1,"Method":"peer","Network":"unix","Reason":"USER_NOT_FOUND","RemoteAddress":"XXX","SessionID":"XXX","SystemIdentity":"%CURRENT_OS_USER%","Timestamp":"XXX","Transport":"local"}
+13 {"Duration":"NNN","EventType":"client_session_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+14 {"Duration":"NNN","EventType":"client_connection_end","InstanceID":1,"Network":"unix","RemoteAddress":"XXX","SessionID":"XXX","Timestamp":"XXX"}
+
+subtest end
+
+#
+# subtest: mapped_peer_auth
+#
+
+subtest mapped_peer_auth/failure_map_mismatch
+
+# HBA Rule: Allow DB user 'testpeer' if the OS user is in the 'os_map'.
+set_hba
+local all testpeer peer map=os_map
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# local all testpeer peer map=os_map
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER     ADDRESS METHOD        OPTIONS
+loopback all      all      all     trust
+host     all      root     all     cert-password
+local    all      testpeer         peer          map=os_map
+# Active identity mapping on this node:
+# Original configuration:
+# os_map %CURRENT_OS_USER% testpeer
+# Active configuration:
+# map-name system-username database-username
+os_map     ^%CURRENT_OS_USER%$       testpeer
+
+# Identity Map: Map a fake OS user to the DB user 'testpeer'.
+set_identity_map
+os_map fake_os_user testpeer
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# local all testpeer peer map=os_map
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER     ADDRESS METHOD        OPTIONS
+loopback all      all      all     trust
+host     all      root     all     cert-password
+local    all      testpeer         peer          map=os_map
+# Active identity mapping on this node:
+# Original configuration:
+# os_map fake_os_user testpeer
+# Active configuration:
+# map-name system-username database-username
+os_map     ^fake_os_user$  testpeer
+
+# Connect as 'testpeer'. The syscall will get the real OS user,
+# which is not in the map, so the connection must fail.
+connect_unix user=testpeer
+----
+ERROR: system identity "%CURRENT_OS_USER%" did not map to a database role (SQLSTATE 28000)
+
+subtest end
+
+#
+# subtest: security_checks
+#
+
+subtest security_checks/peer_over_tcp_is_rejected
+
+# HBA Rule: A misconfigured rule allowing 'peer' for a TCP connection.
+# The server must reject this because 'peer' is registered for 'local' only.
+set_hba
+host all testpeer 127.0.0.1/32 peer
+----
+# Active authentication configuration on this node:
+# Original configuration:
+# loopback all all all trust       # built-in CockroachDB default
+# host  all root all cert-password # CockroachDB mandatory rule
+# host all testpeer 127.0.0.1/32 peer
+#
+# Interpreted configuration:
+# TYPE   DATABASE USER     ADDRESS      METHOD        OPTIONS
+loopback all      all      all          trust
+host     all      root     all          cert-password
+host     all      testpeer 127.0.0.1/32 peer
+# Active identity mapping on this node:
+# Original configuration:
+# os_map fake_os_user testpeer
+# Active configuration:
+# map-name system-username database-username
+os_map     ^fake_os_user$  testpeer
+
+connect user=testpeer
+----
+ERROR: method "peer" required for this user, but unusable over this connection type (SQLSTATE 28000)
+
+subtest end


### PR DESCRIPTION
Previously, CockroachDB did not support PostgreSQL's `peer` authentication mechanism for local connections over Unix domain sockets. Users were required to use other methods like `trust` or password-based authentication for local clients.

This was inconsistent with standard PostgreSQL behavior and prevented users from leveraging a common, secure, and passwordless authentication method. This also made certain client driver configurations more difficult.

To address this, this patch introduces the `peer` authentication method. It uses OS-specific system calls (`SO_PEERCRED` on Linux, `LOCAL_PEERCRED` on macOS) to securely identify the client's operating system user. The test suite has also been enhanced to support portable testing of this feature by adding a `%CURRENT_OS_USER%` placeholder to the data-driven test runner, which is substituted with the current OS user at runtime.

Epic: none
Release note (security update): CockroachDB now supports the `peer` authentication method for connections made over Unix domain sockets. This allows for passwordless authentication of local clients by verifying their operating system username, improving compatibility with standard PostgreSQL client tools and security practices.