### PR TITLE
ui: add tenant switching button for insecure mode

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -2108,9 +2108,12 @@ func (s *topLevelServer) PreStart(ctx context.Context) error {
 			sqlServer:        s.sqlServer,
 			db:               s.db,
 		}), /* apiServer */
-		serverpb.FeatureFlags{
-			CanViewKvMetricDashboards:   s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
-			DisableKvLevelAdvancedDebug: false,
+		func() serverpb.FeatureFlags {
+			return serverpb.FeatureFlags{
+				CanViewKvMetricDashboards:   s.rpcContext.TenantID.Equal(roachpb.SystemTenantID),
+				DisableKvLevelAdvancedDebug: false,
+				EnableManualTenantSwitcher:  s.cfg.Insecure && len(s.serverController.getServers()) > 1,
+			}
 		},
 	); err != nil {
 		return err

--- a/pkg/server/server_http.go
+++ b/pkg/server/server_http.go
@@ -152,7 +152,7 @@ func (s *httpServer) setupRoutes(
 	handleDebugUnauthenticated http.Handler,
 	handleInspectzUnauthenticated http.Handler,
 	apiServer http.Handler,
-	flags serverpb.FeatureFlags,
+	flags func() serverpb.FeatureFlags,
 ) error {
 	// OIDC Configuration must happen prior to the UI Handler being defined below so that we have
 	// the system settings initialized for it to pick up from the oidcAuthenticationServer.

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -1487,4 +1487,7 @@ message FeatureFlags {
   // debug operations. This is helpful in application tenant contexsts, where these requests
   // can only return errors since the tenant cannot perform the operations.
   bool disable_kv_level_advanced_debug = 3;
+  // EnableManualTenantSwitcher enables the manual tenant switcher button in the UI.
+  // This is enabled when there are multiple tenant servers running.
+  bool enable_manual_tenant_switcher = 4;
 }

--- a/pkg/server/tenant.go
+++ b/pkg/server/tenant.go
@@ -841,10 +841,13 @@ func (s *SQLServerWrapper) PreStart(ctx context.Context) error {
 			sqlServer:        s.sqlServer,
 			db:               s.db,
 		}), /* apiServer */
-		serverpb.FeatureFlags{
-			CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID) ||
-				s.sqlServer.serviceMode == mtinfopb.ServiceModeShared,
-			DisableKvLevelAdvancedDebug: s.sqlServer.serviceMode != mtinfopb.ServiceModeShared,
+		func() serverpb.FeatureFlags {
+			return serverpb.FeatureFlags{
+				CanViewKvMetricDashboards: s.rpcContext.TenantID.Equal(roachpb.SystemTenantID) ||
+					s.sqlServer.serviceMode == mtinfopb.ServiceModeShared,
+				DisableKvLevelAdvancedDebug: s.sqlServer.serviceMode != mtinfopb.ServiceModeShared,
+				EnableManualTenantSwitcher:  s.sqlServer.cfg.Insecure,
+			}
 		},
 	); err != nil {
 		return err

--- a/pkg/ui/ui.go
+++ b/pkg/ui/ui.go
@@ -125,7 +125,7 @@ type Config struct {
 	NodeID   *base.NodeIDContainer
 	GetUser  func(ctx context.Context) *string
 	OIDC     OIDCUI
-	Flags    serverpb.FeatureFlags
+	Flags    func() serverpb.FeatureFlags
 	Settings *cluster.Settings
 }
 
@@ -162,16 +162,19 @@ func Handler(cfg Config) http.Handler {
 		licenseTTL := base.GetLicenseTTL(r.Context(), cfg.Settings, timeutil.DefaultTimeSource{})
 		oidcConf := cfg.OIDC.GetOIDCConf()
 		major, minor := build.BranchReleaseSeries()
+		flags := serverpb.FeatureFlags{}
+		if cfg.Flags != nil {
+			flags = cfg.Flags()
+		}
 		args := indexHTMLArgs{
-			Insecure:         cfg.Insecure,
-			LoggedInUser:     cfg.GetUser(r.Context()),
-			Tag:              buildInfo.Tag,
-			Version:          fmt.Sprintf("v%d.%d", major, minor),
-			OIDCAutoLogin:    oidcConf.AutoLogin,
-			OIDCLoginEnabled: oidcConf.Enabled,
-			OIDCButtonText:   oidcConf.ButtonText,
-			FeatureFlags:     cfg.Flags,
-
+			Insecure:                        cfg.Insecure,
+			LoggedInUser:                    cfg.GetUser(r.Context()),
+			Tag:                             buildInfo.Tag,
+			Version:                         fmt.Sprintf("v%d.%d", major, minor),
+			OIDCAutoLogin:                   oidcConf.AutoLogin,
+			OIDCLoginEnabled:                oidcConf.Enabled,
+			OIDCButtonText:                  oidcConf.ButtonText,
+			FeatureFlags:                    flags,
 			OIDCGenerateJWTAuthTokenEnabled: oidcConf.GenerateJWTAuthTokenEnabled,
 
 			LicenseType:               licenseType,

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.styl
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.styl
@@ -11,3 +11,31 @@
     font-weight 600
     font-size 14px
     font-family $font-family--semi-bold
+
+.tenant-switcher
+    display flex
+    align-items center
+    gap 8px
+    
+.tenant-display-container
+    display flex
+    align-items center
+    gap 8px
+    
+.tenant-input-container
+    display flex
+    align-items center
+    gap 8px
+    
+.tenant-input
+    height $line-height--larger
+    padding 0 $spacing-small
+    border 1px solid $colors--neutral-4
+    border-radius 3px
+    font-size $font-size--medium
+    min-width 120px
+    box-sizing border-box
+    
+    &:focus
+        outline none
+        border-color $colors--primary-5

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
@@ -120,10 +120,12 @@ export default class TenantDropdown extends React.Component<
   }
 
   render() {
-    const isInsecure = getDataFromServer().Insecure;
+    const dataFromServer = getDataFromServer();
+    const enableManualTenantSwitcher =
+      dataFromServer.FeatureFlags?.enable_manual_tenant_switcher || false;
 
-    // In insecure mode, show the tenant switching interface
-    if (isInsecure) {
+    // Show the manual tenant switching interface when feature flag is enabled
+    if (enableManualTenantSwitcher) {
       return (
         <ErrorBoundary>
           <div className="tenant-switcher">


### PR DESCRIPTION
This adds a tenant switching interface to the Admin UI header that appears only when the server is running in `insecure` mode, which is generally only used for testing and in internal development. The interface allows users to switch between tenants by clicking a button showing the current tenant name, entering a new tenant name, and applying the change.

Features:
- Button displays current tenant name with "tenant" suffix
- Input field with autocomplete prevention for system identifiers
- Apply/Cancel buttons using existing UI component styles
- Input height matches button height for visual consistency
- Supports keyboard navigation (Enter/Escape)
- Page reload on tenant change to refresh connection
- Fallback to original dropdown behavior in secure mode

Release note (ui change): Added tenant switching button to Admin UI header in insecure mode for easier tenant navigation.
Epic: none.