### PR TITLE
roachtest: actually fail TPCC bench if reached max warehouses

### DIFF
--- a/pkg/workload/tpcc/result.go
+++ b/pkg/workload/tpcc/result.go
@@ -169,7 +169,7 @@ func (r *Result) Efficiency() float64 {
 
 // FailureError returns nil if the Result is passing or an error describing
 // the failure if the result is failing.
-func (r *Result) FailureError(loadWarehouses int) error {
+func (r *Result) FailureError() error {
 	if _, newOrderExists := r.Cumulative["newOrder"]; !newOrderExists {
 		return errors.Errorf("no newOrder data exists")
 	}
@@ -192,20 +192,6 @@ func (r *Result) FailureError(loadWarehouses int) error {
 				errors.Errorf("90th percentile latency for %v at %v exceeds passing threshold of %v",
 					query, v, max90th))
 		}
-	}
-	// If the active warehouses have reached the load warehouses, fail the test;
-	// it needs to be updated to allow for more warehouses. Note that the line
-	// search assumes that the test fails at the number of load warehouses, so it
-	// never attempts to reach it exactly. Therefore, active warehouses can be at
-	// most loadWarehouses - 1.
-	if r.ActiveWarehouses >= loadWarehouses-1 {
-		err = errors.CombineErrors(
-			err,
-			errors.Errorf(
-				"the number of active warehouses (%d) reached the maximum number of "+
-					"warehouses; consider updating LoadWarehouses and EstimatedMax", r.ActiveWarehouses,
-			),
-		)
 	}
 	return err
 }

--- a/pkg/workload/tpcc/result_test.go
+++ b/pkg/workload/tpcc/result_test.go
@@ -15,7 +15,7 @@ func TestNewResult(t *testing.T) {
 	// Ensure you don't get panics when calling common methods
 	// on a trivial Result that doesn't have any data attached.
 	res := NewResult(1000, 0, 0, nil)
-	require.Error(t, res.FailureError(0))
+	require.Error(t, res.FailureError())
 	require.Zero(t, res.Efficiency())
 	require.Zero(t, res.TpmC())
 }


### PR DESCRIPTION
In 1bfe55b, we attempted to fail the TPCC bench test run if the configured maximum warehouses were reached and the success criteria were met. The idea was that this would prompt us to increase the max warehouses. However, that commit failed only the specific line search run, not the full test run.

This commit moves the max warehouses check out of the result handling and actually fatals the test.

Part of: #148235

Release note: None