### PR TITLE
release-23.2: server: do not use MustBeDString on nullable result col

### DIFF
--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3163,7 +3163,10 @@ func (s *adminServer) dataDistributionHelper(
 	for hasNext, err = it.Next(ctx); hasNext; hasNext, err = it.Next(ctx) {
 		row := it.Cur()
 		target := string(tree.MustBeDString(row[0]))
-		zcSQL := tree.MustBeDString(row[1])
+		var zcSQL string
+		if zcSQLDatum, ok := tree.AsDString(row[1]); ok {
+			zcSQL = string(zcSQLDatum)
+		}
 		zcBytes := tree.MustBeDBytes(row[2])
 		var zcProto zonepb.ZoneConfig
 		if err := protoutil.Unmarshal([]byte(zcBytes), &zcProto); err != nil {
@@ -3173,7 +3176,7 @@ func (s *adminServer) dataDistributionHelper(
 		resp.ZoneConfigs[target] = serverpb.DataDistributionResponse_ZoneConfig{
 			Target:    target,
 			Config:    zcProto,
-			ConfigSQL: string(zcSQL),
+			ConfigSQL: zcSQL,
 		}
 	}
 	if err != nil {


### PR DESCRIPTION
Backport 1/1 commits from #140066.

/cc @cockroachdb/release

---

In the data distribution handler we were attempting to read a
`raw_sql_config` on `crdb_internal.zones` using `MustBeDString`
which panics if the value is null.  This column is nullable.
We now allow null values to be read and make the response
value an empty string in that case.

Note: This backport changes one of the unit tests from
the original PR. Since the response type of API being tested
here was changed in 24.1, the unit test doesn't pass, requiring
some alterations. This doesn't impact any production code nor
does it impact the code coverage of the test.

Fixes: https://github.com/cockroachdb/cockroach/issues/140044

Release note (bug fix):  Data distribution page in
advanced debug will no longer crash if there are null
values for `raw_sql_config` in `crdb_internal.zones`.

---
Release Justification: Fixes a critical bug where loading a page in db-console potentially causes a NPE and crashes the gateway note serving the API. This has been backported to 24.1+ for some time but was never backported to 23.2 