### PR TITLE
roachtest: increase restore timeouts for fingerprinting

### DIFF
--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -61,7 +61,7 @@ func registerRestoreNodeShutdown(r registry.Registry) {
 			cloud:   spec.GCE,
 			fixture: SmallFixture,
 		},
-		timeout: 1 * time.Hour,
+		timeout: 2 * time.Hour,
 	}
 
 	makeRestoreStarter := func(ctx context.Context, t test.Test, c cluster.Cluster,
@@ -131,7 +131,7 @@ func registerRestore(r registry.Registry) {
 			cloud:   spec.GCE,
 			fixture: SmallFixture,
 		},
-		timeout:    3 * time.Hour,
+		timeout:    4 * time.Hour,
 		namePrefix: "pause",
 	}
 	withPauseSpecs.initTestName()


### PR DESCRIPTION
Since validating fingerprints is now the default behavior for restore roachtests, we are seeing some test timeouts across the suite. This commit increases the timeout to account for any fingerprints on all of our restores.

Fixes: #149771

Release note: None