### PR TITLE
gceworker.sh: update default worker image

### DIFF
--- a/scripts/gceworker.sh
+++ b/scripts/gceworker.sh
@@ -17,13 +17,13 @@ USER_ID=$(id -un)
 NAME=${GCEWORKER_NAME-gceworker-${USER_ID//./}}
 FQNAME="${NAME}.${CLOUDSDK_COMPUTE_ZONE}.${CLOUDSDK_CORE_PROJECT}"
 
-# IMAGE_FAMILY can be used to override the image when creating a gceworker.
+# IMAGE can be used to override the image when creating a gceworker.
 # For example:
-#   IMAGE_FAMILY=ubuntu-2410-amd64 scripts/gceworker.sh create
+#   IMAGE=crl-ubuntu-2004 scripts/gceworker.sh create
 #
 # Note that ubuntu-2004-lts is the only image that we know will consistently
 # work with respect to our build or scripts.
-IMAGE_FAMILY=${IMAGE_FAMILY-ubuntu-2004-lts}
+IMAGE=${IMAGE-crl-ubuntu-2004}
 
 cmd=${1-}
 if [[ "${cmd}" ]]; then
@@ -111,8 +111,8 @@ create)
 		--machine-type "n2-custom-24-32768" \
 		--network "default" \
 		--maintenance-policy "MIGRATE" \
-		--image-project "ubuntu-os-cloud" \
-		--image-family "${IMAGE_FAMILY}" \
+		--image-project "cockroach-workers" \
+		--image "${IMAGE}" \
 		--boot-disk-size "250" \
 		--boot-disk-type "pd-ssd" \
 		--boot-disk-device-name "${NAME}" \


### PR DESCRIPTION
Ubuntu 20.04 LTS is past EOL and no longer available. DevInf has made
20.04 available in the cockroach-workers project as 'crl-ubuntu-2004'.
We also no longer suppoert image families, so this patch changes the
image project to 'cockroach-workers' and points at the new image.

Epic: none
Release note: None