### PR TITLE
roachtest: add `PostValidationAll`

### DIFF
--- a/pkg/cmd/roachtest/monitor.go
+++ b/pkg/cmd/roachtest/monitor.go
@@ -149,7 +149,7 @@ func (m *monitorImpl) ExpectProcessHealth(
 	m.expProcessHealth.set(nodes, virtualClusterOptions.VirtualClusterName, virtualClusterOptions.SQLInstance, health)
 }
 
-// ExpectProcessDeath lets the monitor know that a set of processes are about
+// ExpectProcessDead lets the monitor know that a set of processes are about
 // to be killed, and that their deaths should be ignored. Virtual cluster
 // options can be passed to denote a separate process.
 func (m *monitorImpl) ExpectProcessDead(nodes option.NodeListOption, opts ...option.OptionFunc) {
@@ -161,6 +161,22 @@ func (m *monitorImpl) ExpectProcessDead(nodes option.NodeListOption, opts ...opt
 // a separate process.
 func (m *monitorImpl) ExpectProcessAlive(nodes option.NodeListOption, opts ...option.OptionFunc) {
 	m.ExpectProcessHealth(nodes.InstallNodes(), ExpectedAlive, opts...)
+}
+
+// AvailableNodes returns the availability of nodes based on the expected
+// health of them, not by what the monitor is actually observing.
+func (m *monitorImpl) AvailableNodes(virtualClusterName string) option.NodeListOption {
+	var availableNodes install.Nodes
+	m.expProcessHealth.Range(func(process monitorProcess, health *MonitorExpectedProcessHealth) bool {
+		if process.virtualClusterName == virtualClusterName && *health == ExpectedAlive {
+			availableNodes = append(availableNodes, process.node)
+		}
+		return true
+	})
+	if len(availableNodes) == 0 {
+		return m.AvailableNodes(install.SystemInterfaceName)
+	}
+	return option.FromInstallNodes(availableNodes)
 }
 
 // ExpectDeath lets the monitor know that a node is about to be killed, and that

--- a/pkg/cmd/roachtest/option/node_list_option.go
+++ b/pkg/cmd/roachtest/option/node_list_option.go
@@ -63,6 +63,26 @@ func (n NodeListOption) Merge(o NodeListOption) NodeListOption {
 	return r
 }
 
+func (n NodeListOption) Intersect(o NodeListOption) NodeListOption {
+	set := make(map[int]struct{}, len(o))
+	for _, node := range o {
+		set[node] = struct{}{}
+	}
+
+	var result NodeListOption
+	seen := make(map[int]struct{}, len(n))
+	for _, node := range n {
+		if _, ok := set[node]; ok {
+			if _, already := seen[node]; !already {
+				result = append(result, node)
+				seen[node] = struct{}{}
+			}
+		}
+	}
+
+	return result
+}
+
 // RandNode returns a random node from the NodeListOption.
 func (n NodeListOption) RandNode() NodeListOption {
 	return NodeListOption{n[rand.Intn(len(n))]}

--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -226,6 +226,12 @@ func (ts *TestSpec) GetPostProcessWorkloadMetricsFunction() func(string, *roacht
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.
+// By default, all validations are run unless TestSpec.SkipPostValidations is set to a bitwise OR
+// of the validations to skip.
+//
+// E.g., SkipPostValidations : PostValidationReplicaDivergence | PostValidationInvalidDescriptors
+// would skip the replica divergence and invalid descriptors validations and run the rest.
+// SkipPostValidations: PostValidationAll would skip _all_ validations.
 type PostValidation int
 
 const (
@@ -241,6 +247,8 @@ const (
 	// In its current state it is no longer functional.
 	// See: https://github.com/cockroachdb/cockroach/issues/137329 for details.
 	PostValidationNoDeadNodes
+	// PostValidationAll is a bitwise OR of all post-validations to skip.
+	PostValidationAll = PostValidationReplicaDivergence | PostValidationInvalidDescriptors | PostValidationNoDeadNodes
 )
 
 // PromSub replaces all non prometheus friendly chars with "_". Note,

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/helper.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/clusterupgrade"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestutil/task"
+	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/test"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/cockroach/pkg/testutils/release"
@@ -47,6 +48,7 @@ type (
 		connFunc        func(int) *gosql.DB
 		stepLogger      *logger.Logger
 		clusterVersions *atomic.Value
+		monitor         test.Monitor
 	}
 
 	// Helper is the struct passed to `stepFunc`s (user-provided or
@@ -67,6 +69,15 @@ type (
 	}
 )
 
+func (s *Service) randomAvailableNode(rng *rand.Rand) int {
+	nodes := s.AvailableNodes()
+	return nodes.SeededRandNode(rng)[0]
+}
+
+func (s *Service) AvailableNodes() option.NodeListOption {
+	return s.monitor.AvailableNodes(s.Descriptor.Name)
+}
+
 // Connect returns a connection pool to the given node. Note that
 // these connection pools are managed by the framework and therefore
 // *must not* be closed. They are closed automatically when the test
@@ -79,7 +90,7 @@ func (s *Service) Connect(node int) *gosql.DB {
 // cluster. Do *not* call `Close` on the pool returned (see comment on
 // `Connect` function).
 func (s *Service) RandomDB(rng *rand.Rand) (int, *gosql.DB) {
-	node := s.Descriptor.Nodes.SeededRandNode(rng)[0]
+	node := s.randomAvailableNode(rng)
 	return node, s.Connect(node)
 }
 
@@ -89,7 +100,8 @@ func (s *Service) RandomDB(rng *rand.Rand) (int, *gosql.DB) {
 func (s *Service) prepareQuery(
 	rng *rand.Rand, nodes option.NodeListOption, query string, args ...any,
 ) (*gosql.DB, error) {
-	node := nodes.SeededRandNode(rng)[0]
+	availableNodes := s.AvailableNodes().Intersect(nodes)
+	node := availableNodes.SeededRandNode(rng)[0]
 	db := s.Connect(node)
 
 	v, err := s.NodeVersion(node)
@@ -122,7 +134,8 @@ func (s *Service) Exec(rng *rand.Rand, query string, args ...interface{}) error 
 func (s *Service) ExecWithGateway(
 	rng *rand.Rand, nodes option.NodeListOption, query string, args ...interface{},
 ) error {
-	db, err := s.prepareQuery(rng, nodes, query, args...)
+	availableNodes := s.AvailableNodes().Intersect(nodes)
+	db, err := s.prepareQuery(rng, availableNodes, query, args...)
 	if err != nil {
 		return err
 	}
@@ -174,6 +187,10 @@ func (h *Helper) DefaultService() *Service {
 	}
 
 	return h.System
+}
+
+func (h *Helper) AvailableNodes() option.NodeListOption {
+	return h.DefaultService().AvailableNodes()
 }
 
 func (h *Helper) Context() *ServiceContext {

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mixedversion.go
@@ -548,6 +548,17 @@ func DisableAllClusterSettingMutators() CustomOption {
 	}
 }
 
+// DisableAllFailureInjectionMutators will disable all available failure injection mutators.
+func DisableAllFailureInjectionMutators() CustomOption {
+	return func(opts *testOptions) {
+		names := []string{}
+		for _, m := range failureInjectionMutators {
+			names = append(names, m.Name())
+		}
+		DisableMutators(names...)(opts)
+	}
+}
+
 // WithTag allows callers give the mixedversion test instance a
 // `tag`. The tag is used as prefix in the log messages emitted by
 // this upgrade test. This is only useful when running multiple

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -383,8 +383,8 @@ func (m clusterSettingMutator) changeSteps(
 }
 
 const (
-	// PanicNode is a mutator that will randomly cause a node to crash
-	// during the test, before restarting the node within the same step.
+	// PanicNode is a mutator that will randomly cause a node to crash during
+	// the test, before safely restarting the node a random number of steps later.
 	PanicNode = "panic_node"
 )
 
@@ -403,26 +403,55 @@ func (m panicNodeMutator) Generate(
 	rng *rand.Rand, plan *TestPlan, planner *testPlanner,
 ) []mutation {
 	var mutations []mutation
-	maxPanics := len(plan.upgrades)
-	numPanics := 1 + rng.Intn(maxPanics)
-
+	upgrades := randomUpgrades(rng, plan)
 	idx := newStepIndex(plan)
-	possiblePointsInTime := plan.
-		newStepSelector().
-		// We don't want to panic concurrently with other steps, and inserting before a concurrent step
-		// causes the step to run concurrently with that step, so we filter out any concurrent steps.
-		Filter(func(s *singleStep) bool {
-			return s.context.System.Stage >= InitUpgradeStage && !idx.IsConcurrent(s)
+	nodeList := planner.currentContext.System.Descriptor.Nodes
+
+	for _, upgrade := range upgrades {
+		possiblePointsInTime := upgrade.
+			// We don't want to panic concurrently with other steps, and inserting before a concurrent step
+			// causes the step to run concurrently with that step, so we filter out any concurrent steps.
+			Filter(func(s *singleStep) bool {
+				return s.context.System.Stage >= InitUpgradeStage && !idx.IsConcurrent(s)
+			})
+
+		targetNode := nodeList.SeededRandNode(rng)
+		stepToPanic := possiblePointsInTime.RandomStep(rng)
+
+		isInvalidStartStep := func(s *singleStep) bool {
+			// Restarting the system on a node while a node is already dead can
+			// cause the cluster to lose quorum, so we avoid any system starts.
+			_, validStartSystem := s.impl.(restartWithNewBinaryStep)
+			// Waiting for stable cluster version targets every node in
+			// the cluster, so a node cannot be dead during this step.
+			_, waitForStable := s.impl.(waitForStableClusterVersionStep)
+			// Many hook steps do not support running with a dead node,
+			// so we avoid inserting after a hook step.
+			_, runHook := s.impl.(runHookStep)
+
+			return validStartSystem || waitForStable || runHook
+		}
+
+		// The node should be restarted after the panic, but before any steps that are
+		// incompatible with an unavailable node, so we find the first incompatible step
+		// after the panic step and randomly insert the restart step before it.
+		_, afterPanicSteps := possiblePointsInTime.CutAfter(func(s *singleStep) bool {
+			return s == stepToPanic[0]
 		})
 
-	for range numPanics {
-		nodeList := planner.currentContext.System.Descriptor.Nodes
-		targetNode := nodeList.SeededRandNode(rng)
-		addRandomly := possiblePointsInTime.
-			RandomStep(rng).
-			InsertBefore(panicNodeStep{planner.currentContext.System.Descriptor.Nodes[0], targetNode, planner.rt})
+		validStartInserts, _ := afterPanicSteps.CutBefore(func(s *singleStep) bool {
+			return isInvalidStartStep(s)
+		})
+		restartDesc := fmt.Sprintf("restarting node %d after panic", targetNode[0])
 
-		mutations = append(mutations, addRandomly...)
+		addPanicStep := stepToPanic.
+			InsertBefore(panicNodeStep{planner.currentContext.System.Descriptor.Nodes[0], targetNode})
+		addStartStep := validStartInserts.
+			RandomStep(rng).
+			InsertBefore(restartNodeStep{planner.currentContext.System.Descriptor.Nodes[0], targetNode, planner.rt, restartDesc})
+
+		mutations = append(mutations, addPanicStep...)
+		mutations = append(mutations, addStartStep...)
 	}
 
 	return mutations

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner.go
@@ -213,6 +213,8 @@ const (
 	spanConfigTenantLimit = 50000
 )
 
+// failureInjectionMutators includes a list of all
+// failure injection mutators.
 var failureInjectionMutators = []mutator{
 	panicNodeMutator{},
 }
@@ -255,15 +257,14 @@ var clusterSettingMutators = []mutator{
 
 // planMutators includes a list of all known `mutator`
 // implementations. A subset of these mutations might be enabled in
-// any mixedversion test plan.
-var planMutators = append(
-	append([]mutator{
-		preserveDowngradeOptionRandomizerMutator{},
-	},
-		failureInjectionMutators...,
-	),
-	clusterSettingMutators...,
-)
+// planMutators includes a list of all known `mutator`
+// implementations. A subset of these mutations might be enabled in
+var planMutators = func() []mutator {
+	mutators := []mutator{preserveDowngradeOptionRandomizerMutator{}}
+	mutators = append(mutators, clusterSettingMutators...)
+	mutators = append(mutators, failureInjectionMutators...)
+	return mutators
+}()
 
 // Plan returns the TestPlan used to upgrade the cluster from the
 // first to the final version in the `versions` field. The test plan
@@ -439,7 +440,7 @@ func (p *testPlanner) Plan() *TestPlan {
 	// panic failure).
 	for _, mut := range planMutators {
 		if p.mutatorEnabled(mut) {
-			if _, found := failureInjections[mut.Name()]; found && len(p.currentContext.System.Descriptor.Nodes) < 3 {
+			if _, found := failureInjections[mut.Name()]; found && len(p.currentContext.Nodes()) < 3 {
 				continue
 			}
 			mutations := mut.Generate(p.prng, testPlan, p)
@@ -1360,6 +1361,37 @@ func (ss stepSelector) Filter(predicate func(*singleStep) bool) stepSelector {
 	}
 
 	return result
+}
+
+// Cut finds the first step that matches the predicate given, returning
+// new selectors for the steps before and after the matching step. It also
+// returns a new selector for the matching cut step. If no step matches the
+// predicate, Cut returns `ss`, nil, nil.
+func (ss stepSelector) Cut(predicate func(*singleStep) bool) (before, after, cut stepSelector) {
+	predicateFound := false
+	for _, s := range ss {
+		if predicateFound {
+			after = append(after, s)
+		} else if predicate(s) {
+			predicateFound = true
+			cut = append(cut, s)
+		} else {
+			before = append(before, s)
+		}
+	}
+	return before, after, cut
+}
+
+// CutAfter is like Cut but the cut step is merged with the `after` selector
+func (ss stepSelector) CutAfter(predicate func(*singleStep) bool) (stepSelector, stepSelector) {
+	before, after, cut := ss.Cut(predicate)
+	return before, append(cut, after...)
+}
+
+// CutBefore is like Cut but the cut step is merged with the `before` selector
+func (ss stepSelector) CutBefore(predicate func(*singleStep) bool) (stepSelector, stepSelector) {
+	before, after, cut := ss.Cut(predicate)
+	return append(before, cut...), after
 }
 
 // RandomStep returns a new selector that selects a single step,

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/planner_test.go
@@ -553,7 +553,7 @@ func Test_stepSelectorFilter(t *testing.T) {
 			name:                   "no filter",
 			predicate:              func(*singleStep) bool { return true },
 			expectedAllSteps:       true,
-			expectedRandomStepType: restartWithNewBinaryStep{},
+			expectedRandomStepType: runHookStep{},
 		},
 		{
 			name: "filter eliminates all steps",

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/runner.go
@@ -518,7 +518,7 @@ func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *servic
 	defer cancel()
 
 	group := ctxgroup.WithContext(connectionCtx)
-	for j, node := range service.descriptor.Nodes {
+	for j, node := range tr.monitor.AvailableNodes(install.SystemInterfaceName) {
 		group.GoCtx(func(ctx context.Context) error {
 			bv, err := clusterupgrade.BinaryVersion(ctx, tr.conn(node, service.descriptor.Name))
 			if err != nil {
@@ -527,7 +527,6 @@ func (tr *testRunner) refreshBinaryVersions(ctx context.Context, service *servic
 					node, service.descriptor.Name, err,
 				)
 			}
-
 			newBinaryVersions[j] = bv
 			return nil
 		})
@@ -550,7 +549,7 @@ func (tr *testRunner) refreshClusterVersions(ctx context.Context, service *servi
 	defer cancel()
 
 	group := ctxgroup.WithContext(connectionCtx)
-	for j, node := range service.descriptor.Nodes {
+	for j, node := range tr.monitor.AvailableNodes(install.SystemInterfaceName) {
 		group.GoCtx(func(ctx context.Context) error {
 			cv, err := clusterupgrade.ClusterVersion(ctx, tr.conn(node, service.descriptor.Name))
 			if err != nil {
@@ -609,7 +608,7 @@ func (tr *testRunner) maybeInitConnections(service *serviceRuntime) error {
 	}
 
 	cc := map[int]*gosql.DB{}
-	for _, node := range service.descriptor.Nodes {
+	for _, node := range tr.monitor.AvailableNodes(install.SystemInterfaceName) {
 		conn, err := tr.cluster.ConnE(
 			tr.ctx, tr.logger, node, option.VirtualClusterName(service.descriptor.Name),
 		)
@@ -643,6 +642,7 @@ func (tr *testRunner) newHelper(
 			connFunc:        connFunc,
 			stepLogger:      l,
 			clusterVersions: cv,
+			monitor:         tr.monitor,
 		}
 	}
 

--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -513,7 +513,7 @@ func (s setClusterSettingStep) Run(
 	}
 
 	return serviceByName(h, serviceName).ExecWithGateway(
-		rng, nodesRunningAtLeast(s.virtualClusterName, s.minVersion, h), stmt, args...,
+		rng, nodesRunningAtLeast(serviceName, s.minVersion, h), stmt, args...,
 	)
 }
 
@@ -584,6 +584,7 @@ func (s resetClusterSettingStep) Run(
 	ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper,
 ) error {
 	stmt := fmt.Sprintf("RESET CLUSTER SETTING %s", s.name)
+
 	return serviceByName(h, s.virtualClusterName).ExecWithGateway(
 		rng, nodesRunningAtLeast(s.virtualClusterName, s.minVersion, h), stmt,
 	)
@@ -787,13 +788,9 @@ func startStopOpts(opts ...option.StartStopOption) []option.StartStopOption {
 }
 
 // TODO(kyleli): This step currently only affects the system tenant, should support panicking secondary tenants as well.
-// TODO(kyleli): Current mixedversion cannot support separating this into two steps (panic and restart) because during
-// each step the framework checks each node to ensure they are all alive and healthy. Ideally there should be a state
-// that allows the framework to skip this check, so that we can panic a node and then restart it in a separate step.
 type panicNodeStep struct {
 	initTarget int
 	targetNode option.NodeListOption
-	rt         test.Test
 }
 
 func (s panicNodeStep) Background() shouldStop { return nil }
@@ -803,6 +800,48 @@ func (s panicNodeStep) Description() string {
 }
 
 func (s panicNodeStep) Run(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *Helper) error {
+
+	h.runner.monitor.ExpectProcessDead(s.targetNode)
+
+	// ExecWithGateway cannot be used here because the monitor marks the target node as expected
+	// dead, and it will be filtered out of the list of available nodes. This a unique case, so
+	// we manually log the SQL statement and execute it directly on the target node.
+	const query = "SELECT crdb_internal.force_panic('expected panic from panicNodeMutator')"
+	db := h.System.Connect(s.targetNode[0])
+
+	v, err := h.System.NodeVersion(s.targetNode[0])
+	if err != nil {
+		return errors.Wrapf(err, "failed to get node version for %d", s.targetNode[0])
+	}
+	logSQL(
+		h.System.stepLogger, s.targetNode[0], v, h.System.Descriptor.Name, query,
+	)
+
+	if _, err = db.ExecContext(h.System.ctx, query); err == nil {
+		return errors.Errorf("expected panic statement to fail, but it succeeded on %s", s.targetNode)
+	}
+
+	return nil
+}
+
+func (s panicNodeStep) ConcurrencyDisabled() bool {
+	return true
+}
+
+type restartNodeStep struct {
+	initTarget  int
+	targetNode  option.NodeListOption
+	rt          test.Test
+	description string
+}
+
+func (restartNodeStep) Background() shouldStop { return nil }
+
+func (s restartNodeStep) Description() string {
+	return s.description
+}
+
+func (s restartNodeStep) Run(ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper) error {
 	nodeVersion, err := h.System.NodeVersion(s.targetNode[0])
 	if err != nil {
 		return errors.Wrapf(err, "failed to get node version for %s", s.targetNode)
@@ -814,31 +853,25 @@ func (s panicNodeStep) Run(ctx context.Context, l *logger.Logger, rng *rand.Rand
 	)
 	customStartOpts := restartSystemSettings(true, s.initTarget)
 
-	h.runner.monitor.ExpectProcessDead(s.targetNode)
-
-	const stmt = "SELECT crdb_internal.force_panic('expected panic from panicNodeMutator')"
-	err = h.System.ExecWithGateway(
-		rng,
-		s.targetNode,
-		stmt,
-	)
-
-	if err == nil {
-		return errors.Errorf("expected panic statement to fail, but it succeeded on %s", s.targetNode)
-	}
-
 	startCtx, cancel := context.WithTimeout(ctx, startTimeout)
 	defer cancel()
 
-	return h.runner.cluster.StartE(
+	err = h.runner.cluster.StartE(
 		startCtx,
 		l,
 		startOpts(customStartOpts...),
 		settings,
 		s.targetNode,
 	)
+	if err != nil {
+		return errors.Wrapf(
+			err, "failed to restart node %d with binary %s", s.targetNode[0], binary,
+		)
+	}
+	return nil
+
 }
 
-func (s panicNodeStep) ConcurrencyDisabled() bool {
+func (s restartNodeStep) ConcurrencyDisabled() bool {
 	return true
 }

--- a/pkg/cmd/roachtest/test/test_monitor.go
+++ b/pkg/cmd/roachtest/test/test_monitor.go
@@ -11,4 +11,5 @@ import "github.com/cockroachdb/cockroach/pkg/cmd/roachtest/option"
 type Monitor interface {
 	ExpectProcessDead(nodes option.NodeListOption, opts ...option.OptionFunc)
 	ExpectProcessAlive(nodes option.NodeListOption, opts ...option.OptionFunc)
+	AvailableNodes(virtualClusterName string) option.NodeListOption
 }

--- a/pkg/cmd/roachtest/test_monitor_test.go
+++ b/pkg/cmd/roachtest/test_monitor_test.go
@@ -31,6 +31,9 @@ func (s *stubTestMonitorError) ExpectProcessAlive(
 	nodes option.NodeListOption, opts ...option.OptionFunc,
 ) {
 }
+func (s *stubTestMonitorError) AvailableNodes(virtualClusterName string) option.NodeListOption {
+	return option.NodeListOption{}
+}
 
 func (s *stubTestMonitorError) WaitForNodeDeath() error {
 	return errors.New("test error")

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1445,10 +1445,13 @@ func (r *testRunner) runTest(
 		// We still want to run the post-test assertions even if the test timed out as it
 		// might provide useful information about the health of the nodes. Any assertion failures
 		// will be recorded against, and eventually fail, the test.
-		if err := r.postTestAssertions(ctx, t, c, 10*time.Minute); err != nil {
-			l.Printf("error during post test assertions: %v; see test-post-assertions.log for details", err)
+		if t.spec.SkipPostValidations != registry.PostValidationAll {
+			if err := r.postTestAssertions(ctx, t, c, 10*time.Minute); err != nil {
+				l.Printf("error during post test assertions: %v; see test-post-assertions.log for details", err)
+			}
+		} else {
+			l.Printf("skipping all post test assertions due to `PostValidationAll`")
 		}
-
 	} else {
 		l.Printf("skipping post test assertions as test failed")
 	}

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -66,31 +66,29 @@ func registerLOQRecovery(r registry.Registry) {
 	} {
 		testSpec := s
 		r.Add(registry.TestSpec{
-			Name:             s.testName(""),
-			Owner:            registry.OwnerKV,
-			Benchmark:        true,
-			CompatibleClouds: registry.AllExceptAWS,
-			Suites:           registry.Suites(registry.Nightly),
-			Cluster:          spec,
-			Leases:           registry.MetamorphicLeases,
-			SkipPostValidations: registry.PostValidationReplicaDivergence |
-				registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
-			NonReleaseBlocker: true,
+			Name:                s.testName(""),
+			Owner:               registry.OwnerKV,
+			Benchmark:           true,
+			CompatibleClouds:    registry.AllExceptAWS,
+			Suites:              registry.Suites(registry.Nightly),
+			Cluster:             spec,
+			Leases:              registry.MetamorphicLeases,
+			SkipPostValidations: registry.PostValidationAll,
+			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},
 		})
 		r.Add(registry.TestSpec{
-			Name:             s.testName("half-online"),
-			Owner:            registry.OwnerKV,
-			Benchmark:        true,
-			CompatibleClouds: registry.AllExceptAWS,
-			Suites:           registry.Suites(registry.Nightly),
-			Cluster:          spec,
-			Leases:           registry.MetamorphicLeases,
-			SkipPostValidations: registry.PostValidationReplicaDivergence |
-				registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
-			NonReleaseBlocker: true,
+			Name:                s.testName("half-online"),
+			Owner:               registry.OwnerKV,
+			Benchmark:           true,
+			CompatibleClouds:    registry.AllExceptAWS,
+			Suites:              registry.Suites(registry.Nightly),
+			Cluster:             spec,
+			Leases:              registry.MetamorphicLeases,
+			SkipPostValidations: registry.PostValidationAll,
+			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runHalfOnlineRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},

--- a/pkg/cmd/roachtest/tests/mixed_version_c2c.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_c2c.go
@@ -124,12 +124,15 @@ func InitC2CMixed(
 		return 0.0
 	}
 
+	// This test has the source and destination clusters interacting with each other
+	// through specific nodes, so it is incompatible with failure injections.
 	sourceMvt := mixedversion.NewTest(ctx, t, t.L(), c, c.Range(1, sp.srcNodes),
 		mixedversion.AlwaysUseLatestPredecessors,
 		mixedversion.NumUpgrades(expectedMajorUpgrades),
 		mixedversion.EnabledDeploymentModes(mixedversion.SharedProcessDeployment),
 		mixedversion.WithTag("source"),
 		mixedversion.WithSkipVersionProbability(boolToProb(sourceVersionSkips)),
+		mixedversion.DisableAllFailureInjectionMutators(),
 	)
 
 	destMvt := mixedversion.NewTest(ctx, t, t.L(), c, c.Range(sp.srcNodes+1, sp.srcNodes+sp.dstNodes),
@@ -138,6 +141,7 @@ func InitC2CMixed(
 		mixedversion.EnabledDeploymentModes(mixedversion.SystemOnlyDeployment),
 		mixedversion.WithTag("dest"),
 		mixedversion.WithSkipVersionProbability(boolToProb(destVersionSkips)),
+		mixedversion.DisableAllFailureInjectionMutators(),
 	)
 
 	return &c2cMixed{

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -1650,9 +1650,23 @@ func (c *SyncedCluster) upsertVirtualClusterMetadata(
 	ctx context.Context, l *logger.Logger, startOpts StartOpts,
 ) (int, error) {
 	runSQL := func(stmt string) (string, error) {
-		results, err := startOpts.StorageCluster.ExecSQL(
-			ctx, l, startOpts.StorageCluster.Nodes[:1], SystemInterfaceName, 0, DefaultAuthMode(), "", /* database */
-			[]string{"--format", "csv", "-e", stmt})
+		var results []*RunResultDetails
+		var err error
+		// It is possible to target a storage node that is currently down, so
+		// we should attempt connecting to all storage nodes before erroring out.
+		for n := 0; n < len(startOpts.StorageCluster.Nodes); n++ {
+			results, err = startOpts.StorageCluster.ExecSQL(
+				ctx, l, startOpts.StorageCluster.Nodes[n:n+1], SystemInterfaceName, 0, DefaultAuthMode(), "", /* database */
+				[]string{"--format", "csv", "-e", stmt})
+			if err == nil && results[0].Err == nil {
+				return results[0].CombinedOut, nil
+			}
+			if err != nil {
+				l.Printf("failed to execute SQL statement %q on node %d: %s", stmt, n, err)
+			} else if results[0].Err != nil {
+				l.Printf("failed to execute SQL statement %q on node %d: %s", stmt, n, err)
+			}
+		}
 		if err != nil {
 			return "", err
 		}


### PR DESCRIPTION
Minor refactoring to simplify the expression of
"exclude all post-validation" checks.

Epic: none
Release note: None