### PR TITLE
roachtest: add PostValidationAll

### DIFF
--- a/pkg/cmd/roachtest/registry/test_spec.go
+++ b/pkg/cmd/roachtest/registry/test_spec.go
@@ -226,6 +226,12 @@ func (ts *TestSpec) GetPostProcessWorkloadMetricsFunction() func(string, *roacht
 }
 
 // PostValidation is a type of post-validation that runs after a test completes.
+// By default, all validations are run unless TestSpec.SkipPostValidations is set to a bitwise OR
+// of the validations to skip.
+//
+// E.g., SkipPostValidations : PostValidationReplicaDivergence | PostValidationInvalidDescriptors
+// would skip the replica divergence and invalid descriptors validations and run the rest.
+// SkipPostValidations: PostValidationAll would skip _all_ validations.
 type PostValidation int
 
 const (
@@ -241,6 +247,8 @@ const (
 	// In its current state it is no longer functional.
 	// See: https://github.com/cockroachdb/cockroach/issues/137329 for details.
 	PostValidationNoDeadNodes
+	// PostValidationAll is a bitwise OR of all post-validations to skip.
+	PostValidationAll = PostValidationReplicaDivergence | PostValidationInvalidDescriptors | PostValidationNoDeadNodes
 )
 
 // PromSub replaces all non prometheus friendly chars with "_". Note,

--- a/pkg/cmd/roachtest/test_runner.go
+++ b/pkg/cmd/roachtest/test_runner.go
@@ -1445,10 +1445,13 @@ func (r *testRunner) runTest(
 		// We still want to run the post-test assertions even if the test timed out as it
 		// might provide useful information about the health of the nodes. Any assertion failures
 		// will be recorded against, and eventually fail, the test.
-		if err := r.postTestAssertions(ctx, t, c, 10*time.Minute); err != nil {
-			l.Printf("error during post test assertions: %v; see test-post-assertions.log for details", err)
+		if t.spec.SkipPostValidations != registry.PostValidationAll {
+			if err := r.postTestAssertions(ctx, t, c, 10*time.Minute); err != nil {
+				l.Printf("error during post test assertions: %v; see test-post-assertions.log for details", err)
+			}
+		} else {
+			l.Printf("skipping all post test assertions due to `PostValidationAll`")
 		}
-
 	} else {
 		l.Printf("skipping post test assertions as test failed")
 	}

--- a/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
+++ b/pkg/cmd/roachtest/tests/loss_of_quorum_recovery.go
@@ -66,31 +66,29 @@ func registerLOQRecovery(r registry.Registry) {
 	} {
 		testSpec := s
 		r.Add(registry.TestSpec{
-			Name:             s.testName(""),
-			Owner:            registry.OwnerKV,
-			Benchmark:        true,
-			CompatibleClouds: registry.AllExceptAWS,
-			Suites:           registry.Suites(registry.Nightly),
-			Cluster:          spec,
-			Leases:           registry.MetamorphicLeases,
-			SkipPostValidations: registry.PostValidationReplicaDivergence |
-				registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
-			NonReleaseBlocker: true,
+			Name:                s.testName(""),
+			Owner:               registry.OwnerKV,
+			Benchmark:           true,
+			CompatibleClouds:    registry.AllExceptAWS,
+			Suites:              registry.Suites(registry.Nightly),
+			Cluster:             spec,
+			Leases:              registry.MetamorphicLeases,
+			SkipPostValidations: registry.PostValidationAll,
+			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},
 		})
 		r.Add(registry.TestSpec{
-			Name:             s.testName("half-online"),
-			Owner:            registry.OwnerKV,
-			Benchmark:        true,
-			CompatibleClouds: registry.AllExceptAWS,
-			Suites:           registry.Suites(registry.Nightly),
-			Cluster:          spec,
-			Leases:           registry.MetamorphicLeases,
-			SkipPostValidations: registry.PostValidationReplicaDivergence |
-				registry.PostValidationInvalidDescriptors | registry.PostValidationNoDeadNodes,
-			NonReleaseBlocker: true,
+			Name:                s.testName("half-online"),
+			Owner:               registry.OwnerKV,
+			Benchmark:           true,
+			CompatibleClouds:    registry.AllExceptAWS,
+			Suites:              registry.Suites(registry.Nightly),
+			Cluster:             spec,
+			Leases:              registry.MetamorphicLeases,
+			SkipPostValidations: registry.PostValidationAll,
+			NonReleaseBlocker:   true,
 			Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 				runHalfOnlineRecoverLossOfQuorum(ctx, t, c, testSpec)
 			},


### PR DESCRIPTION
Minor refactoring to simplify the expression of
"exclude all post-validation" checks.

Epic: none
Release note: None