### PR TITLE
kvstorage: revise replica deletion plan

### DIFF
--- a/pkg/kv/kvserver/kvstorage/destroy.go
+++ b/pkg/kv/kvserver/kvstorage/destroy.go
@@ -95,16 +95,17 @@ func ClearRangeData(
 // writes.
 //
 //  1. Log storage write (durable):
-//     1.1. Write WAG node with the state machine mutation (2).
+//     1.1. WAG: apply to RaftAppliedIndex.
+//     1.2. WAG: apply mutation (2).
 //  2. State machine mutation:
 //     2.1. Clear RangeID-local un-/replicated state.
 //     2.2. (optional) Clear replicated MVCC span.
-//     2.3. Write RangeTombstone with next ReplicaID/LogID.
+//     2.3. Write RangeTombstone with next ReplicaID.
 //  3. Log engine GC (after state machine mutation 2 is durably applied):
-//     3.1. Remove previous LogID.
+//     3.1. Remove raft state.
 //
-// TODO(sep-raft-log): support the status quo in which 1+2+3 is written
-// atomically, and 1.1 is not written.
+// TODO(sep-raft-log): support the status quo in which 2+3 is written
+// atomically, and 1 is not written.
 const DestroyReplicaTODO = 0
 
 // DestroyReplica destroys all or a part of the Replica's state, installing a
@@ -130,7 +131,7 @@ func DestroyReplica(
 	if diskReplicaID.ReplicaID >= nextReplicaID {
 		return errors.AssertionFailedf("replica r%d/%d must not survive its own tombstone", rangeID, diskReplicaID)
 	}
-	_ = DestroyReplicaTODO // 2.1 + 3.1 + 2.2
+	_ = DestroyReplicaTODO // 2.1 + 2.2 + 3.1
 	if err := ClearRangeData(ctx, rangeID, reader, writer, opts); err != nil {
 		return err
 	}

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -107,7 +107,7 @@ func (r LoadedReplicaState) check(storeID roachpb.StoreID) error {
 //  1. Log storage write (durable):
 //     1.1. Write WAG node with the state machine mutation (2).
 //  2. State machine mutation:
-//     2.1. Write RaftReplicaID with the new ReplicaID/LogID.
+//     2.1. Write the new RaftReplicaID.
 //
 // TODO(sep-raft-log): support the status quo in which only 2.1 is written.
 const CreateUninitReplicaTODO = 0

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -41,11 +41,11 @@ type snapWriteBuilder struct {
 
 // prepareSnapApply writes the unreplicated SST for the snapshot and clears disk data for subsumed replicas.
 func (s *snapWriteBuilder) prepareSnapApply(ctx context.Context) error {
-	_ = applySnapshotTODO // 3.1 + 1.1 + 2.5.
+	_ = applySnapshotTODO // 1.1 + 1.3 + 2.4 + 3.1
 	if err := s.writeSST(ctx, s.rewriteRaftState); err != nil {
 		return err
 	}
-	_ = applySnapshotTODO // 3.2 + 2.1 + 2.2 + 2.3
+	_ = applySnapshotTODO // 1.2 + 2.1 + 2.2 + 2.3 (diff) + 3.2
 	return s.clearSubsumedReplicaDiskData(ctx)
 }
 


### PR DESCRIPTION
This PR modifies the plan for `CreateUninitializedReplica`, `DestroyReplica` and `applySnapshot`. The `LogID` concept is no longer needed, and the snapshot transitions can retain the old raft log up to `RaftAppliedIndex` since the snapshot is always created at a higher index.

Epic: CRDB-49111