### PR TITLE
kvserver: use FullReplicaID in creation stack

### DIFF
--- a/pkg/kv/kvserver/kvstorage/datadriven_test.go
+++ b/pkg/kv/kvserver/kvstorage/datadriven_test.go
@@ -60,7 +60,7 @@ func (e *env) close() {
 func (e *env) handleNewReplica(
 	t *testing.T,
 	ctx context.Context,
-	id storage.FullReplicaID,
+	id roachpb.FullReplicaID,
 	skipRaftReplicaID bool,
 	k, ek roachpb.RKey,
 ) *roachpb.RangeDescriptor {
@@ -154,7 +154,7 @@ func TestDataDriven(t *testing.T) {
 					d.ScanArgs(t, "skip-raft-replica-id", &skipRaftReplicaID)
 				}
 				if desc := e.handleNewReplica(t, ctx,
-					storage.FullReplicaID{RangeID: roachpb.RangeID(rangeID), ReplicaID: roachpb.ReplicaID(replicaID)},
+					roachpb.FullReplicaID{RangeID: roachpb.RangeID(rangeID), ReplicaID: roachpb.ReplicaID(replicaID)},
 					skipRaftReplicaID, keys.MustAddr(roachpb.Key(k)), keys.MustAddr(roachpb.Key(ek)),
 				); desc != nil {
 					fmt.Fprintln(&buf, desc)

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -388,8 +388,8 @@ type Replica struct {
 }
 
 // ID returns the FullReplicaID.
-func (r Replica) ID() storage.FullReplicaID {
-	return storage.FullReplicaID{
+func (r Replica) ID() roachpb.FullReplicaID {
+	return roachpb.FullReplicaID{
 		RangeID:   r.RangeID,
 		ReplicaID: r.ReplicaID,
 	}

--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -71,8 +71,8 @@ func LoadReplicaState(
 	return ls, nil
 }
 
-func (r LoadedReplicaState) FullReplicaID() storage.FullReplicaID {
-	return storage.FullReplicaID{RangeID: r.ReplState.Desc.RangeID, ReplicaID: r.ReplicaID}
+func (r LoadedReplicaState) FullReplicaID() roachpb.FullReplicaID {
+	return roachpb.FullReplicaID{RangeID: r.ReplState.Desc.RangeID, ReplicaID: r.ReplicaID}
 }
 
 // check makes sure that the replica invariants hold for the loaded state.
@@ -120,7 +120,7 @@ const CreateUninitReplicaTODO = 0
 // Returns kvpb.RaftGroupDeletedError if this replica can not be created
 // because it has been deleted.
 func CreateUninitializedReplica(
-	ctx context.Context, eng storage.Engine, storeID roachpb.StoreID, id storage.FullReplicaID,
+	ctx context.Context, eng storage.Engine, storeID roachpb.StoreID, id roachpb.FullReplicaID,
 ) error {
 	sl := stateloader.Make(id.RangeID)
 	// Before creating the replica, see if there is a tombstone which would

--- a/pkg/kv/kvserver/replica.go
+++ b/pkg/kv/kvserver/replica.go
@@ -1096,8 +1096,8 @@ func (r *Replica) ReplicaID() roachpb.ReplicaID {
 }
 
 // ID returns the FullReplicaID for the Replica.
-func (r *Replica) ID() storage.FullReplicaID {
-	return storage.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID}
+func (r *Replica) ID() roachpb.FullReplicaID {
+	return roachpb.FullReplicaID{RangeID: r.RangeID, ReplicaID: r.replicaID}
 }
 
 // LogStorageRaftMuLocked returns the Replica's log storage.

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -29,7 +29,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -100,7 +99,7 @@ func newInitializedReplica(
 //
 // TODO(#94912): we actually have another initialization path which should be
 // refactored: Replica.initFromSnapshotLockedRaftMuLocked().
-func newUninitializedReplica(store *Store, id storage.FullReplicaID) (*Replica, error) {
+func newUninitializedReplica(store *Store, id roachpb.FullReplicaID) (*Replica, error) {
 	r := newUninitializedReplicaWithoutRaftGroup(store, id)
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
@@ -117,7 +116,7 @@ func newUninitializedReplica(store *Store, id storage.FullReplicaID) (*Replica, 
 // newUninitializedReplica() instead. This only exists for
 // newInitializedReplica() to avoid creating the Raft group twice (once when
 // creating the uninitialized replica, and once when initializing it).
-func newUninitializedReplicaWithoutRaftGroup(store *Store, id storage.FullReplicaID) *Replica {
+func newUninitializedReplicaWithoutRaftGroup(store *Store, id roachpb.FullReplicaID) *Replica {
 	uninitState := stateloader.UninitializedReplicaState(id.RangeID)
 	r := &Replica{
 		AmbientContext: store.cfg.AmbientCtx,

--- a/pkg/kv/kvserver/replica_init.go
+++ b/pkg/kv/kvserver/replica_init.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
 	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/envutil"
@@ -79,7 +80,7 @@ func loadInitializedReplicaForTesting(
 func newInitializedReplica(
 	store *Store, loaded kvstorage.LoadedReplicaState, waitForPrevLeaseToExpire bool,
 ) (*Replica, error) {
-	r := newUninitializedReplicaWithoutRaftGroup(store, loaded.ReplState.Desc.RangeID, loaded.ReplicaID)
+	r := newUninitializedReplicaWithoutRaftGroup(store, loaded.FullReplicaID())
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
@@ -99,10 +100,8 @@ func newInitializedReplica(
 //
 // TODO(#94912): we actually have another initialization path which should be
 // refactored: Replica.initFromSnapshotLockedRaftMuLocked().
-func newUninitializedReplica(
-	store *Store, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
-) (*Replica, error) {
-	r := newUninitializedReplicaWithoutRaftGroup(store, rangeID, replicaID)
+func newUninitializedReplica(store *Store, id storage.FullReplicaID) (*Replica, error) {
+	r := newUninitializedReplicaWithoutRaftGroup(store, id)
 	r.raftMu.Lock()
 	defer r.raftMu.Unlock()
 	r.mu.Lock()
@@ -118,17 +117,15 @@ func newUninitializedReplica(
 // newUninitializedReplica() instead. This only exists for
 // newInitializedReplica() to avoid creating the Raft group twice (once when
 // creating the uninitialized replica, and once when initializing it).
-func newUninitializedReplicaWithoutRaftGroup(
-	store *Store, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
-) *Replica {
-	uninitState := stateloader.UninitializedReplicaState(rangeID)
+func newUninitializedReplicaWithoutRaftGroup(store *Store, id storage.FullReplicaID) *Replica {
+	uninitState := stateloader.UninitializedReplicaState(id.RangeID)
 	r := &Replica{
 		AmbientContext: store.cfg.AmbientCtx,
-		RangeID:        rangeID,
-		replicaID:      replicaID,
+		RangeID:        id.RangeID,
+		replicaID:      id.ReplicaID,
 		creationTime:   timeutil.Now(),
 		store:          store,
-		abortSpan:      abortspan.New(rangeID),
+		abortSpan:      abortspan.New(id.RangeID),
 		concMgr: concurrency.NewManager(concurrency.Config{
 			NodeDesc:           store.nodeDesc,
 			RangeDesc:          uninitState.Desc,
@@ -145,7 +142,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 		}),
 		allocatorToken: &plan.AllocatorToken{},
 	}
-	r.sideTransportClosedTimestamp.init(store.cfg.ClosedTimestampReceiver, rangeID)
+	r.sideTransportClosedTimestamp.init(store.cfg.ClosedTimestampReceiver, id.RangeID)
 	r.cachedClosedTimestampPolicy.Store(new(ctpb.RangeClosedTimestampPolicy))
 
 	r.mu.pendingLeaseRequest = makePendingLeaseRequest(r)
@@ -165,9 +162,9 @@ func newUninitializedReplicaWithoutRaftGroup(
 			// Expose proposal data for external test packages.
 			return store.cfg.TestingKnobs.TestingProposalSubmitFilter(kvserverbase.ProposalFilterArgs{
 				Ctx:        p.Context(),
-				RangeID:    rangeID,
+				RangeID:    id.RangeID,
 				StoreID:    store.StoreID(),
-				ReplicaID:  replicaID,
+				ReplicaID:  id.ReplicaID,
 				Cmd:        p.command,
 				QuotaAlloc: p.quotaAlloc,
 				CmdID:      p.idKey,
@@ -196,7 +193,7 @@ func newUninitializedReplicaWithoutRaftGroup(
 	// NB: state will be loaded when the replica gets initialized.
 	r.shMu.state = uninitState
 
-	r.rangeStr.store(replicaID, uninitState.Desc)
+	r.rangeStr.store(id.ReplicaID, uninitState.Desc)
 	// Add replica log tag - the value is rangeStr.String().
 	r.AmbientContext.AddLogTag("r", &r.rangeStr)
 	r.raftCtx = logtags.AddTag(r.AnnotateCtx(context.Background()), "raft", nil /* value */)
@@ -205,14 +202,14 @@ func newUninitializedReplicaWithoutRaftGroup(
 	// r.AmbientContext.AddLogTag("@", fmt.Sprintf("%x", unsafe.Pointer(r)))
 
 	r.raftMu.rangefeedCTLagObserver = newRangeFeedCTLagObserver()
-	r.raftMu.stateLoader = stateloader.Make(rangeID)
+	r.raftMu.stateLoader = stateloader.Make(id.RangeID)
 
 	// Initialize all the components of the log storage. The state of the log
 	// storage, such as RaftTruncatedState and the last entry ID, will be loaded
 	// when the replica is initialized.
 	sideloaded := logstore.NewDiskSideloadStorage(
 		store.cfg.Settings,
-		rangeID,
+		id.RangeID,
 		// NB: sideloaded log entries are persisted in the state engine so that they
 		// can be ingested to the state machine locally, when being applied.
 		store.StateEngine().GetAuxiliaryDir(),
@@ -229,13 +226,13 @@ func newUninitializedReplicaWithoutRaftGroup(
 	r.logStorage.mu.RWMutex = (*syncutil.RWMutex)(&r.mu.ReplicaMutex)
 	r.logStorage.raftMu.Mutex = &r.raftMu.Mutex
 	r.logStorage.ls = &logstore.LogStore{
-		RangeID:     rangeID,
+		RangeID:     id.RangeID,
 		Engine:      store.LogEngine(),
 		Sideload:    sideloaded,
 		StateLoader: r.raftMu.stateLoader.StateLoader,
 		// NOTE: use the same SyncWaiter loop for all raft log writes performed by a
 		// given range ID, to ensure that callbacks are processed in order.
-		SyncWaiter: store.syncWaiters[int(rangeID)%len(store.syncWaiters)],
+		SyncWaiter: store.syncWaiters[int(id.RangeID)%len(store.syncWaiters)],
 		Settings:   store.cfg.Settings,
 		DisableSyncLogWriteToss: buildutil.CrdbTestBuild &&
 			store.TestingKnobs().DisableSyncLogWriteToss,

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2817,9 +2817,10 @@ func (r *Replica) acquireSplitLock(
 	ctx context.Context, split *roachpb.SplitTrigger,
 ) (func(), error) {
 	rightReplDesc, _ := split.RightDesc.GetReplicaDescriptor(r.StoreID())
-	rightRepl, _, err := r.store.getOrCreateReplica(
-		ctx, split.RightDesc.RangeID, rightReplDesc.ReplicaID, nil, /* creatingReplica */
-	)
+	rightRepl, _, err := r.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+		RangeID:   split.RightDesc.RangeID,
+		ReplicaID: rightReplDesc.ReplicaID,
+	}, nil /* creatingReplica */)
 	// If getOrCreateReplica returns RaftGroupDeletedError we know that the RHS
 	// has already been removed. This case is handled properly in splitPostApply.
 	if errors.HasType(err, (*kvpb.RaftGroupDeletedError)(nil)) {
@@ -2852,9 +2853,10 @@ func (r *Replica) acquireMergeLock(
 	// complete, after which the replica will realize it has been destroyed and
 	// reject the snapshot.
 	rightReplDesc, _ := merge.RightDesc.GetReplicaDescriptor(r.StoreID())
-	rightRepl, _, err := r.store.getOrCreateReplica(
-		ctx, merge.RightDesc.RangeID, rightReplDesc.ReplicaID, nil, /* creatingReplica */
-	)
+	rightRepl, _, err := r.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+		RangeID:   merge.RightDesc.RangeID,
+		ReplicaID: rightReplDesc.ReplicaID,
+	}, nil /* creatingReplica */)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -2817,7 +2817,7 @@ func (r *Replica) acquireSplitLock(
 	ctx context.Context, split *roachpb.SplitTrigger,
 ) (func(), error) {
 	rightReplDesc, _ := split.RightDesc.GetReplicaDescriptor(r.StoreID())
-	rightRepl, _, err := r.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+	rightRepl, _, err := r.store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID:   split.RightDesc.RangeID,
 		ReplicaID: rightReplDesc.ReplicaID,
 	}, nil /* creatingReplica */)
@@ -2853,7 +2853,7 @@ func (r *Replica) acquireMergeLock(
 	// complete, after which the replica will realize it has been destroyed and
 	// reject the snapshot.
 	rightReplDesc, _ := merge.RightDesc.GetReplicaDescriptor(r.StoreID())
-	rightRepl, _, err := r.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+	rightRepl, _, err := r.store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID:   merge.RightDesc.RangeID,
 		ReplicaID: rightReplDesc.ReplicaID,
 	}, nil /* creatingReplica */)

--- a/pkg/kv/kvserver/snapshot_apply_prepare.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare.go
@@ -23,7 +23,7 @@ import (
 // snapWriteBuilder contains the data needed to prepare the on-disk state for a
 // snapshot.
 type snapWriteBuilder struct {
-	id storage.FullReplicaID
+	id roachpb.FullReplicaID
 
 	todoEng  storage.Engine
 	sl       stateloader.StateLoader

--- a/pkg/kv/kvserver/snapshot_apply_prepare_test.go
+++ b/pkg/kv/kvserver/snapshot_apply_prepare_test.go
@@ -69,7 +69,7 @@ func TestPrepareSnapApply(t *testing.T) {
 		}
 	}
 
-	id := storage.FullReplicaID{RangeID: 123, ReplicaID: 4}
+	id := roachpb.FullReplicaID{RangeID: 123, ReplicaID: 4}
 	descA := desc(101, "a", "b")
 	descB := desc(102, "b", "z")
 	createRangeData(t, eng, *descA)

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -12,7 +12,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
@@ -52,7 +51,7 @@ var errRetry = errors.New("retry: orphaned replica")
 //
 // The caller must not hold the store's lock.
 func (s *Store) getOrCreateReplica(
-	ctx context.Context, id storage.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
+	ctx context.Context, id roachpb.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (_ *Replica, created bool, _ error) {
 	if id.ReplicaID == 0 {
 		log.Fatalf(ctx, "cannot construct a Replica for range %d with 0 id", id.RangeID)
@@ -85,7 +84,7 @@ func (s *Store) getOrCreateReplica(
 // removed. Returns errRetry error if the replica is in a transitional state and
 // its retrieval needs to be retried. Other errors are permanent.
 func (s *Store) tryGetReplica(
-	ctx context.Context, id storage.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
+	ctx context.Context, id roachpb.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (*Replica, error) {
 	repl, found := s.mu.replicasByRangeID.Load(id.RangeID)
 	if !found {
@@ -149,7 +148,7 @@ func (s *Store) tryGetReplica(
 // tryGetOrCreateReplica will likely succeed, hence the loop in
 // getOrCreateReplica.
 func (s *Store) tryGetOrCreateReplica(
-	ctx context.Context, id storage.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
+	ctx context.Context, id roachpb.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (_ *Replica, created bool, _ error) {
 	// The common case: look up an existing replica.
 	if repl, err := s.tryGetReplica(ctx, id, creatingReplica); err != nil {

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -12,6 +12,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
 	"github.com/cockroachdb/errors"
@@ -51,13 +52,10 @@ var errRetry = errors.New("retry: orphaned replica")
 //
 // The caller must not hold the store's lock.
 func (s *Store) getOrCreateReplica(
-	ctx context.Context,
-	rangeID roachpb.RangeID,
-	replicaID roachpb.ReplicaID,
-	creatingReplica *roachpb.ReplicaDescriptor,
+	ctx context.Context, id storage.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (_ *Replica, created bool, _ error) {
-	if replicaID == 0 {
-		log.Fatalf(ctx, "cannot construct a Replica for range %d with 0 id", rangeID)
+	if id.ReplicaID == 0 {
+		log.Fatalf(ctx, "cannot construct a Replica for range %d with 0 id", id.RangeID)
 	}
 	// We need a retry loop as the replica we find in the map may be in the
 	// process of being removed or may need to be removed. Retries in the loop
@@ -71,12 +69,7 @@ func (s *Store) getOrCreateReplica(
 	})
 	for {
 		r.Next()
-		r, created, err := s.tryGetOrCreateReplica(
-			ctx,
-			rangeID,
-			replicaID,
-			creatingReplica,
-		)
+		r, created, err := s.tryGetOrCreateReplica(ctx, id, creatingReplica)
 		if errors.Is(err, errRetry) {
 			continue
 		}
@@ -92,12 +85,9 @@ func (s *Store) getOrCreateReplica(
 // removed. Returns errRetry error if the replica is in a transitional state and
 // its retrieval needs to be retried. Other errors are permanent.
 func (s *Store) tryGetReplica(
-	ctx context.Context,
-	rangeID roachpb.RangeID,
-	replicaID roachpb.ReplicaID,
-	creatingReplica *roachpb.ReplicaDescriptor,
+	ctx context.Context, id storage.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (*Replica, error) {
-	repl, found := s.mu.replicasByRangeID.Load(rangeID)
+	repl, found := s.mu.replicasByRangeID.Load(id.RangeID)
 	if !found {
 		return nil, nil
 	}
@@ -120,14 +110,14 @@ func (s *Store) tryGetReplica(
 	}
 
 	// The current replica needs to be removed, remove it and go back around.
-	if toTooOld := repl.replicaID < replicaID; toTooOld {
+	if toTooOld := repl.replicaID < id.ReplicaID; toTooOld {
 		if shouldLog := log.V(1); shouldLog {
 			log.Infof(ctx, "found message for replica ID %d which is newer than %v",
-				replicaID, repl)
+				id.ReplicaID, repl)
 		}
 
 		repl.mu.RUnlock()
-		if err := s.removeReplicaRaftMuLocked(ctx, repl, replicaID, "superseded by newer Replica", RemoveOptions{
+		if err := s.removeReplicaRaftMuLocked(ctx, repl, id.ReplicaID, "superseded by newer Replica", RemoveOptions{
 			DestroyData: true,
 		}); err != nil {
 			log.Fatalf(ctx, "failed to remove replica: %v", err)
@@ -137,17 +127,17 @@ func (s *Store) tryGetReplica(
 	}
 	defer repl.mu.RUnlock()
 
-	if repl.replicaID > replicaID {
+	if repl.replicaID > id.ReplicaID {
 		// The sender is behind and is sending to an old replica.
 		// We could silently drop this message but this way we'll inform the
 		// sender that they may no longer exist.
 		repl.raftMu.Unlock()
 		return nil, &kvpb.RaftGroupDeletedError{}
 	}
-	if repl.replicaID != replicaID {
+	if repl.replicaID != id.ReplicaID {
 		// This case should have been caught by handleToReplicaTooOld.
 		log.Fatalf(ctx, "intended replica id %d unexpectedly does not match the current replica %v",
-			replicaID, repl)
+			id.ReplicaID, repl)
 	}
 	return repl, nil
 }
@@ -159,13 +149,10 @@ func (s *Store) tryGetReplica(
 // tryGetOrCreateReplica will likely succeed, hence the loop in
 // getOrCreateReplica.
 func (s *Store) tryGetOrCreateReplica(
-	ctx context.Context,
-	rangeID roachpb.RangeID,
-	replicaID roachpb.ReplicaID,
-	creatingReplica *roachpb.ReplicaDescriptor,
+	ctx context.Context, id storage.FullReplicaID, creatingReplica *roachpb.ReplicaDescriptor,
 ) (_ *Replica, created bool, _ error) {
 	// The common case: look up an existing replica.
-	if repl, err := s.tryGetReplica(ctx, rangeID, replicaID, creatingReplica); err != nil {
+	if repl, err := s.tryGetReplica(ctx, id, creatingReplica); err != nil {
 		return nil, false, err
 	} else if repl != nil {
 		return repl, false, nil
@@ -175,24 +162,24 @@ func (s *Store) tryGetOrCreateReplica(
 	// be racing at this point, so grab a "lock" over this rangeID (represented by
 	// s.mu.creatingReplicas[rangeID]) by one goroutine, and retry others.
 	s.mu.Lock()
-	if _, ok := s.mu.creatingReplicas[rangeID]; ok {
+	if _, ok := s.mu.creatingReplicas[id.RangeID]; ok {
 		// Lost the race - another goroutine is currently creating that replica. Let
 		// the caller retry so that they can eventually see it.
 		s.mu.Unlock()
 		return nil, false, errRetry
 	}
-	s.mu.creatingReplicas[rangeID] = struct{}{}
+	s.mu.creatingReplicas[id.RangeID] = struct{}{}
 	s.mu.Unlock()
 	defer func() {
 		s.mu.Lock()
-		delete(s.mu.creatingReplicas, rangeID)
+		delete(s.mu.creatingReplicas, id.RangeID)
 		s.mu.Unlock()
 	}()
 	// Now we are the only goroutine trying to create a replica for this rangeID.
 
 	// Repeat the quick path in case someone has overtaken us while we were
 	// grabbing the "lock".
-	if repl, err := s.tryGetReplica(ctx, rangeID, replicaID, creatingReplica); err != nil {
+	if repl, err := s.tryGetReplica(ctx, id, creatingReplica); err != nil {
 		return nil, false, err
 	} else if repl != nil {
 		return repl, false, nil
@@ -204,16 +191,16 @@ func (s *Store) tryGetOrCreateReplica(
 	// Replica for this rangeID, and that's us.
 
 	_ = kvstorage.CreateUninitReplicaTODO
+	// TODO(sep-raft-log): needs both engines due to tombstone (which lives on
+	// statemachine).
 	if err := kvstorage.CreateUninitializedReplica(
-		// TODO(sep-raft-log): needs both engines due to tombstone (which lives on
-		// statemachine).
-		ctx, s.TODOEngine(), s.StoreID(), rangeID, replicaID,
+		ctx, s.TODOEngine(), s.StoreID(), id,
 	); err != nil {
 		return nil, false, err
 	}
 
 	// Create a new uninitialized replica and lock it for raft processing.
-	repl, err := newUninitializedReplica(s, rangeID, replicaID)
+	repl, err := newUninitializedReplica(s, id)
 	if err != nil {
 		return nil, false, err
 	}

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -19,7 +19,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
-	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -422,7 +421,7 @@ func (s *Store) withReplicaForRequest(
 	f func(context.Context, *Replica) *kvpb.Error,
 ) *kvpb.Error {
 	// Lazily create the replica.
-	r, _, err := s.getOrCreateReplica(ctx, storage.FullReplicaID{
+	r, _, err := s.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID: req.RangeID, ReplicaID: req.ToReplica.ReplicaID,
 	}, &req.FromReplica)
 	if err != nil {

--- a/pkg/kv/kvserver/store_raft.go
+++ b/pkg/kv/kvserver/store_raft.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/raft/raftpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/storage"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/grunning"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -421,12 +422,9 @@ func (s *Store) withReplicaForRequest(
 	f func(context.Context, *Replica) *kvpb.Error,
 ) *kvpb.Error {
 	// Lazily create the replica.
-	r, _, err := s.getOrCreateReplica(
-		ctx,
-		req.RangeID,
-		req.ToReplica.ReplicaID,
-		&req.FromReplica,
-	)
+	r, _, err := s.getOrCreateReplica(ctx, storage.FullReplicaID{
+		RangeID: req.RangeID, ReplicaID: req.ToReplica.ReplicaID,
+	}, &req.FromReplica)
 	if err != nil {
 		return kvpb.NewError(err)
 	}

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -897,11 +897,11 @@ func TestMarkReplicaInitialized(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newRangeID := roachpb.RangeID(3)
-	const replicaID = 1
-	require.NoError(t, stateloader.Make(newRangeID).SetRaftReplicaID(ctx, store.TODOEngine(), replicaID))
+	newID := storage.FullReplicaID{RangeID: 3, ReplicaID: 1}
+	require.NoError(t, stateloader.Make(newID.RangeID).SetRaftReplicaID(
+		ctx, store.TODOEngine(), newID.ReplicaID))
 
-	r, err := newUninitializedReplica(store, newRangeID, replicaID)
+	r, err := newUninitializedReplica(store, newID)
 	require.NoError(t, err)
 
 	store.mu.Lock()
@@ -941,7 +941,7 @@ func TestMarkReplicaInitialized(t *testing.T) {
 		}
 	}()
 
-	store.mu.uninitReplicas[newRangeID] = r
+	store.mu.uninitReplicas[newID.RangeID] = r
 	require.NoError(t, store.addToReplicasByRangeIDLocked(r))
 
 	expectedResult = "overlaps with"
@@ -2839,12 +2839,13 @@ func TestRaceOnTryGetOrCreateReplicas(t *testing.T) {
 		wg.Add(1)
 		go func(rid roachpb.ReplicaID) {
 			defer wg.Done()
-			r, _, _ := s.getOrCreateReplica(ctx, 42, rid, &roachpb.ReplicaDescriptor{
+			if r, _, _ := s.getOrCreateReplica(ctx, storage.FullReplicaID{
+				RangeID: 42, ReplicaID: rid,
+			}, &roachpb.ReplicaDescriptor{
 				NodeID:    2,
 				StoreID:   2,
 				ReplicaID: 2,
-			})
-			if r != nil {
+			}); r != nil {
 				r.raftMu.Unlock()
 			}
 		}(roachpb.ReplicaID(i))
@@ -4091,7 +4092,9 @@ func TestManuallyEnqueueUninitializedReplica(t *testing.T) {
 	tc := testContext{}
 	tc.Start(ctx, t, stopper)
 
-	repl, _, _ := tc.store.getOrCreateReplica(ctx, 42, 7, &roachpb.ReplicaDescriptor{
+	repl, _, _ := tc.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+		RangeID: 42, ReplicaID: 7,
+	}, &roachpb.ReplicaDescriptor{
 		NodeID:    tc.store.NodeID(),
 		StoreID:   tc.store.StoreID(),
 		ReplicaID: 7,
@@ -4115,12 +4118,13 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 	tc := testContext{}
 	tc.Start(ctx, t, stopper)
 
-	repl, created, err := tc.store.getOrCreateReplica(
-		ctx, 42, 7, &roachpb.ReplicaDescriptor{
-			NodeID:    tc.store.NodeID(),
-			StoreID:   tc.store.StoreID(),
-			ReplicaID: 7,
-		})
+	repl, created, err := tc.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+		RangeID: 42, ReplicaID: 7,
+	}, &roachpb.ReplicaDescriptor{
+		NodeID:    tc.store.NodeID(),
+		StoreID:   tc.store.StoreID(),
+		ReplicaID: 7,
+	})
 	require.NoError(t, err)
 	require.True(t, created)
 	replicaID, err := stateloader.Make(repl.RangeID).LoadRaftReplicaID(
@@ -4180,9 +4184,10 @@ func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
 	rightDesc.InternalReplicas[0].ReplicaID++
 
 	// Create an uninitialized replica for the RHS. splitPreApply expects this.
-	_, _, err = store.getOrCreateReplica(
-		ctx, rightDesc.RangeID, rightDesc.InternalReplicas[0].ReplicaID, &rightDesc.InternalReplicas[0],
-	)
+	_, _, err = store.getOrCreateReplica(ctx, storage.FullReplicaID{
+		RangeID:   rightDesc.RangeID,
+		ReplicaID: rightDesc.InternalReplicas[0].ReplicaID,
+	}, &rightDesc.InternalReplicas[0])
 	require.NoError(t, err)
 
 	split := roachpb.SplitTrigger{

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -897,7 +897,7 @@ func TestMarkReplicaInitialized(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	newID := storage.FullReplicaID{RangeID: 3, ReplicaID: 1}
+	newID := roachpb.FullReplicaID{RangeID: 3, ReplicaID: 1}
 	require.NoError(t, stateloader.Make(newID.RangeID).SetRaftReplicaID(
 		ctx, store.TODOEngine(), newID.ReplicaID))
 
@@ -2839,7 +2839,7 @@ func TestRaceOnTryGetOrCreateReplicas(t *testing.T) {
 		wg.Add(1)
 		go func(rid roachpb.ReplicaID) {
 			defer wg.Done()
-			if r, _, _ := s.getOrCreateReplica(ctx, storage.FullReplicaID{
+			if r, _, _ := s.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 				RangeID: 42, ReplicaID: rid,
 			}, &roachpb.ReplicaDescriptor{
 				NodeID:    2,
@@ -4092,7 +4092,7 @@ func TestManuallyEnqueueUninitializedReplica(t *testing.T) {
 	tc := testContext{}
 	tc.Start(ctx, t, stopper)
 
-	repl, _, _ := tc.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+	repl, _, _ := tc.store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID: 42, ReplicaID: 7,
 	}, &roachpb.ReplicaDescriptor{
 		NodeID:    tc.store.NodeID(),
@@ -4118,7 +4118,7 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 	tc := testContext{}
 	tc.Start(ctx, t, stopper)
 
-	repl, created, err := tc.store.getOrCreateReplica(ctx, storage.FullReplicaID{
+	repl, created, err := tc.store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID: 42, ReplicaID: 7,
 	}, &roachpb.ReplicaDescriptor{
 		NodeID:    tc.store.NodeID(),
@@ -4184,7 +4184,7 @@ func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
 	rightDesc.InternalReplicas[0].ReplicaID++
 
 	// Create an uninitialized replica for the RHS. splitPreApply expects this.
-	_, _, err = store.getOrCreateReplica(ctx, storage.FullReplicaID{
+	_, _, err = store.getOrCreateReplica(ctx, roachpb.FullReplicaID{
 		RangeID:   rightDesc.RangeID,
 		ReplicaID: rightDesc.InternalReplicas[0].ReplicaID,
 	}, &rightDesc.InternalReplicas[0])

--- a/pkg/kv/kvserver/testing_knobs.go
+++ b/pkg/kv/kvserver/testing_knobs.go
@@ -89,7 +89,7 @@ type StoreTestingKnobs struct {
 	//
 	// TODO(pavelkalinnikov): have a more stable and less nuanced way of blocking
 	// the commands application flow for the entire store.
-	TestingAfterRaftLogSync func(storage.FullReplicaID)
+	TestingAfterRaftLogSync func(roachpb.FullReplicaID)
 
 	// TestingApplyCalledTwiceFilter is called before applying the results of a command on
 	// each replica assuming the command was cleared for application (i.e. no

--- a/pkg/roachpb/BUILD.bazel
+++ b/pkg/roachpb/BUILD.bazel
@@ -49,6 +49,7 @@ go_library(
         "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_redact//:redact",
+        "@com_github_cockroachdb_redact//interfaces",
         "@com_github_golang_mock//gomock",  # keep
         "@org_golang_google_grpc//metadata",  # keep
     ],

--- a/pkg/roachpb/metadata.go
+++ b/pkg/roachpb/metadata.go
@@ -17,6 +17,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/humanizeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
+	"github.com/cockroachdb/redact/interfaces"
 )
 
 // NodeID is a custom type for a cockroach node ID. (not a raft node ID)
@@ -104,6 +105,25 @@ func (r ReplicaID) String() string {
 
 // SafeValue implements the redact.SafeValue interface.
 func (r ReplicaID) SafeValue() {}
+
+// FullReplicaID is a fully-qualified replica ID.
+type FullReplicaID struct {
+	// RangeID is the id of the range.
+	RangeID RangeID
+	// ReplicaID is the id of the replica.
+	ReplicaID ReplicaID
+}
+
+// SafeFormat implements redact.SafeFormatter. It prints as
+// r<rangeID>/<replicaID>.
+func (id FullReplicaID) SafeFormat(s interfaces.SafePrinter, _ rune) {
+	s.Printf("r%d/%d", id.RangeID, id.ReplicaID)
+}
+
+// String implements the fmt.Stringer interface.
+func (id FullReplicaID) String() string {
+	return redact.StringWithoutMarkers(id)
+}
 
 // Equals returns whether the Attributes lists are equivalent. Attributes lists
 // are treated as sets, meaning that ordering and duplicates are ignored.

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -108,7 +108,6 @@ go_library(
         "@com_github_cockroachdb_pebble//vfs",
         "@com_github_cockroachdb_pebble//wal",
         "@com_github_cockroachdb_redact//:redact",
-        "@com_github_cockroachdb_redact//interfaces",
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_github_gogo_protobuf//proto",


### PR DESCRIPTION
This PR moves `FullReplicaID` to be next to `roachpb.{RangeID,ReplicaID}`, and uses it (for type safety) in a few replica creation places where `RangeID` and `ReplicaID` are passed in together.

Epic: CRDB-49111