### PR TITLE
kvstorage: fix CreateUninitializedReplica comment

### DIFF
--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -135,16 +135,10 @@ func CreateUninitializedReplica(
 
 	// Write the RaftReplicaID for this replica. This is the only place in the
 	// CockroachDB code that we are creating a new *uninitialized* replica.
-	// Note that it is possible that we have already created the HardState for
-	// an uninitialized replica, then crashed, and on recovery are receiving a
-	// raft message for the same or later replica.
-	// - Same replica: we are overwriting the RaftReplicaID with the same
-	//   value, which is harmless.
-	// - Later replica: there may be an existing HardState for the older
-	//   uninitialized replica with Commit=0 and non-zero Term and Vote. Using
-	//   the Term and Vote values for that older replica in the context of
-	//   this newer replica is harmless since it just limits the votes for
-	//   this replica.
+	//
+	// Before this point, raft and state machine state of this replica are
+	// non-existent. The only RangeID-specific key that can be present is the
+	// RangeTombstone inspected above.
 	_ = CreateUninitReplicaTODO
 	if err := sl.SetRaftReplicaID(ctx, eng, replicaID); err != nil {
 		return err


### PR DESCRIPTION
The scenario described in the comment was possible before it became an invariant that all replicas have a `RaftReplicaID` in storage. Since we completed a migration [#95513] which established this invariant, we can remove this comment.

Historical context: https://github.com/cockroachdb/cockroach/pull/75761/files#diff-208036c53fab5274d107185f7b974421738b6cd54b849000a60656c764ba2b08R224-R272

Epic: none
Release note: none