### PR TITLE
kvserver: mv check from CreateUninitializedReplica

### DIFF
--- a/pkg/kv/kvserver/kvstorage/replica_state.go
+++ b/pkg/kv/kvserver/kvstorage/replica_state.go
@@ -116,11 +116,7 @@ const CreateUninitReplicaTODO = 0
 // Returns kvpb.RaftGroupDeletedError if this replica can not be created
 // because it has been deleted.
 func CreateUninitializedReplica(
-	ctx context.Context,
-	eng storage.Engine,
-	storeID roachpb.StoreID,
-	rangeID roachpb.RangeID,
-	replicaID roachpb.ReplicaID,
+	ctx context.Context, eng storage.Engine, rangeID roachpb.RangeID, replicaID roachpb.ReplicaID,
 ) error {
 	sl := stateloader.Make(rangeID)
 	// Before creating the replica, see if there is a tombstone which would
@@ -146,12 +142,5 @@ func CreateUninitializedReplica(
 	//   this newer replica is harmless since it just limits the votes for
 	//   this replica.
 	_ = CreateUninitReplicaTODO
-	if err := sl.SetRaftReplicaID(ctx, eng, replicaID); err != nil {
-		return err
-	}
-
-	// Make sure that storage invariants for this uninitialized replica hold.
-	uninitDesc := roachpb.RangeDescriptor{RangeID: rangeID}
-	_, err := LoadReplicaState(ctx, eng, storeID, &uninitDesc, replicaID)
-	return err
+	return sl.SetRaftReplicaID(ctx, eng, replicaID)
 }


### PR DESCRIPTION
This makes the `CreateUninitializedReplica` almost exclusively a write operation. For now, it still reads the `RangeTombstone`, but this at least doesn't need to read across raft and state engines.

In the future, it may be refactored such that `RangeTombstone` is read externally and provided to the func: this way, it will be write-only. A general pattern which we can aim for in replica lifecycle events: (1) read the current state (or provide it directly, e.g. if it's a test); (2) do the writes; (3) optionally, read back and check invariants.

Epic: CRDB-49111