### PR TITLE
backup: increase max duration for restore fast fail tests

### DIFF
--- a/pkg/backup/restore_test.go
+++ b/pkg/backup/restore_test.go
@@ -105,11 +105,11 @@ func TestRestoreRetryFastFails(t *testing.T) {
 	// Max duration needs to be long enough such that the restore job
 	// runtime does not exceed the max duration of the retry policy, or
 	// else very few attempts will be made.
-	maxDuration := 100 * time.Millisecond
+	maxDuration := 500 * time.Millisecond
 	if skip.Stress() {
 		// Under stress, the restore will take longer to complete, so we need to
 		// increase max duration accordingly.
-		maxDuration = time.Second
+		maxDuration = 1500 * time.Millisecond
 	}
 	const numAccounts = 10
 


### PR DESCRIPTION
Under enough load, the restore fast fail test is not able to complete restores in time before `MaxDuration` is hit, which causes test flakes because the restore quits early. This increases the duration in tests to reduce flakiness.

Fixes: #150197

Release note: None