### PR TITLE
ccl/oidcccl: increase client timeout to fix flaky test

### DIFF
--- a/pkg/ccl/oidcccl/authentication_oidc_test.go
+++ b/pkg/ccl/oidcccl/authentication_oidc_test.go
@@ -145,6 +145,9 @@ func TestOIDCEnabled(t *testing.T) {
 	client, err := testCertsContext.GetHTTPClient()
 	require.NoError(t, err)
 
+	// Set a reasonable timeout for the client to prevent flakiness under stress.
+	client.Timeout = 30 * time.Second
+
 	// Don't follow redirects so we can inspect the 302
 	client.CheckRedirect = func(req *http.Request, via []*http.Request) error {
 		return http.ErrUseLastResponse


### PR DESCRIPTION
ccl/oidcccl: increase client timeout to fix flaky test

The default HTTP client timeout was 10s which intermittently resulted in a context deadline exceeded error under stress. This has now been increased to 30s.

Fixes: #150136

Release note: None