### PR TITLE
roachtest: fix nil team loader

### DIFF
--- a/pkg/cmd/roachtest/run.go
+++ b/pkg/cmd/roachtest/run.go
@@ -24,6 +24,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/registry"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/roachtestflags"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/spec"
+	"github.com/cockroachdb/cockroach/pkg/internal/team"
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
@@ -143,6 +144,7 @@ func runTests(register func(registry.Registry), filter *registry.TestFilter) err
 	github := &githubIssues{
 		disable:     runner.config.disableIssue,
 		issuePoster: issues.Post,
+		teamLoader:  team.DefaultLoadTeams,
 	}
 
 	l.Printf("global random seed: %d", roachtestflags.GlobalSeed)


### PR DESCRIPTION
During the migration of the github poster initialization in #149479, the default team loader configuration was inadvertently omitted. This change restores the default team loader setting to resolve the issue.

Informs: #149479

Epic: None
Release note: None