### PR TITLE
release-25.2: roachtest: ignore testInsertWithManyToOne in hibernate test

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate_blocklist.go
+++ b/pkg/cmd/roachtest/tests/hibernate_blocklist.go
@@ -21,6 +21,7 @@ var hibernateSpatialIgnoreList = blocklist{
 var hibernateIgnoreList = blocklist{
 	"org.hibernate.orm.test.batch.BatchTest.testBatchInsertUpdate":                                       "flaky",
 	"org.hibernate.orm.test.bulkid.OracleInlineMutationStrategyIdTest.testDeleteFromEngineer":            "flaky",
+	"org.hibernate.orm.test.hql.BulkManipulationTest.testInsertWithManyToOne":                            "https://hibernate.atlassian.net/browse/HHH-19332",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testUnNamedSessionFactorySerialization": "flaky",
 	"org.hibernate.serialization.SessionFactorySerializationTest.testNamedSessionFactorySerialization":   "flaky",
 	"org.hibernate.test.batch.BatchTest.testBatchInsertUpdate":                                           "flaky",


### PR DESCRIPTION
Backport 1/1 commits from #150180 on behalf of @rafiss.

----

This test is skipped for CockroachDB upstream, so we do the same.

fixes https://github.com/cockroachdb/cockroach/issues/149879
fixes https://github.com/cockroachdb/cockroach/issues/149880
fixes https://github.com/cockroachdb/cockroach/issues/149884
fixes https://github.com/cockroachdb/cockroach/issues/149881
fixes https://github.com/cockroachdb/cockroach/issues/149877
fixes https://github.com/cockroachdb/cockroach/issues/149885
fixes https://github.com/cockroachdb/cockroach/issues/149883
fixes https://github.com/cockroachdb/cockroach/issues/149878

Release note: None

----

Release justification: test only change