### PR TITLE
storage: disable value separation by default

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -421,8 +421,7 @@ var (
 		settings.SystemVisible,
 		"storage.value_separation.enabled",
 		"whether or not values may be separated into blob files",
-		metamorphic.ConstantWithTestBool(
-			"storage.value_separation.enabled", true /* defaultValue */),
+		false, /* defaultValue */
 	)
 	valueSeparationMinimumSize = settings.RegisterIntSetting(
 		settings.SystemVisible,


### PR DESCRIPTION
We disable value separation for now until we root
cause #150216.

Epic: none
Release note: None