### PR TITLE
tabledesc: allow TTL storage params to be set to 0

### DIFF
--- a/pkg/sql/catalog/tabledesc/ttl.go
+++ b/pkg/sql/catalog/tabledesc/ttl.go
@@ -131,10 +131,10 @@ func ValidateTTLExpirationColumn(desc catalog.TableDescriptor) error {
 
 // ValidateTTLBatchSize validates the batch size of a TTL.
 func ValidateTTLBatchSize(key string, val int64) error {
-	if val <= 0 {
+	if val < 0 {
 		return pgerror.Newf(
 			pgcode.InvalidParameterValue,
-			`"%s" must be at least 1`,
+			`"%s" must be at least 0`,
 			key,
 		)
 	}
@@ -157,10 +157,10 @@ func ValidateTTLCronExpr(key string, str string) error {
 // ValidateTTLRowStatsPollInterval validates the automatic statistics field
 // of TTL.
 func ValidateTTLRowStatsPollInterval(key string, val time.Duration) error {
-	if val <= 0 {
+	if val < 0 {
 		return pgerror.Newf(
 			pgcode.InvalidParameterValue,
-			`"%s" must be at least 1`,
+			`"%s" must be at least 0`,
 			key,
 		)
 	}
@@ -169,10 +169,10 @@ func ValidateTTLRowStatsPollInterval(key string, val time.Duration) error {
 
 // ValidateTTLRateLimit validates the rate limit parameters of TTL.
 func ValidateTTLRateLimit(key string, val int64) error {
-	if val <= 0 {
+	if val < 0 {
 		return pgerror.Newf(
 			pgcode.InvalidParameterValue,
-			`"%s" must be at least 1`,
+			`"%s" must be at least 0`,
 			key,
 		)
 	}

--- a/pkg/sql/catalog/tabledesc/validate_test.go
+++ b/pkg/sql/catalog/tabledesc/validate_test.go
@@ -2851,7 +2851,7 @@ func TestValidateTableDesc(t *testing.T) {
 					DurationExpr: catpb.Expression("INTERVAL '2 minutes'"),
 				},
 			}},
-		{err: `"ttl_select_batch_size" must be at least 1`,
+		{err: `"ttl_select_batch_size" must be at least 0`,
 			desc: descpb.TableDescriptor{
 				ID:            2,
 				ParentID:      1,

--- a/pkg/sql/logictest/testdata/logic_test/row_level_ttl
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_ttl
@@ -832,27 +832,42 @@ ALTER TABLE no_ttl_table SET (ttl_label_metrics = true)
 
 subtest end
 
-subtest ttl_params_positive
+subtest ttl_params_non_negative
 
 statement ok
-CREATE TABLE tbl_ttl_params_positive (
+CREATE TABLE tbl_ttl_params_non_negative (
   id INT PRIMARY KEY
 ) WITH (ttl_expire_after = '10 minutes')
 
-statement error "ttl_select_batch_size" must be at least 1
-ALTER TABLE tbl_ttl_params_positive SET (ttl_select_batch_size = -1)
+statement error "ttl_select_batch_size" must be at least 0
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_select_batch_size = -1)
 
-statement error "ttl_delete_batch_size" must be at least 1
-ALTER TABLE tbl_ttl_params_positive SET (ttl_delete_batch_size = -1)
+statement error "ttl_delete_batch_size" must be at least 0
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_delete_batch_size = -1)
 
-statement error "ttl_select_rate_limit" must be at least 1
-ALTER TABLE tbl_ttl_params_positive SET (ttl_select_rate_limit = -1)
+statement error "ttl_select_rate_limit" must be at least 0
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_select_rate_limit = -1)
 
-statement error "ttl_delete_rate_limit" must be at least 1
-ALTER TABLE tbl_ttl_params_positive SET (ttl_delete_rate_limit = -1)
+statement error "ttl_delete_rate_limit" must be at least 0
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_delete_rate_limit = -1)
 
-statement error "ttl_row_stats_poll_interval" must be at least 1
-ALTER TABLE tbl_ttl_params_positive SET (ttl_row_stats_poll_interval = '-1 second')
+statement error "ttl_row_stats_poll_interval" must be at least 0
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_row_stats_poll_interval = '-1 second')
+
+statement ok
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_select_batch_size = 0)
+
+statement ok
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_delete_batch_size = 0)
+
+statement ok
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_select_rate_limit = 0)
+
+statement ok
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_delete_rate_limit = 0)
+
+statement ok
+ALTER TABLE tbl_ttl_params_non_negative SET (ttl_row_stats_poll_interval = '0 second')
 
 subtest end
 


### PR DESCRIPTION
Epic: None
Release note (bug fix): Fixed a bug that prevented the row-level TTL table storage parameters (e.g. ttl_select_batch_size, ttl_delete_batch_size, ttl_delete_rate_limit, and ttl_select_rate_limit) from being set to 0, which is their default value.