### PR TITLE
sql/schemachanger: properly discard zone configs for sequences

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/zone_config
+++ b/pkg/sql/logictest/testdata/logic_test/zone_config
@@ -678,3 +678,49 @@ ORDER BY 1
 /3
 
 subtest end
+
+subtest discard_seq
+
+statement ok
+CREATE SEQUENCE seq1;
+
+statement ok
+ALTER TABLE seq1 CONFIGURE ZONE USING num_replicas=7;
+
+query I
+WITH config_lines AS (
+  SELECT
+    regexp_split_to_table(raw_config_sql, E'\n') AS line
+  FROM [SHOW ZONE CONFIGURATION FROM TABLE seq1]
+)
+SELECT
+  CAST(
+    regexp_replace(line, '[^0-9]', '', 'g') AS INT
+  ) AS num_replicas
+FROM config_lines
+WHERE line LIKE '%num_replicas%';
+----
+7
+
+statement ok
+ALTER TABLE seq1 CONFIGURE ZONE DISCARD;
+
+query I
+WITH config_lines AS (
+  SELECT
+    regexp_split_to_table(raw_config_sql, E'\n') AS line
+  FROM [SHOW ZONE CONFIGURATION FROM TABLE seq1]
+)
+SELECT
+  CAST(
+    regexp_replace(line, '[^0-9]', '', 'g') AS INT
+  ) AS num_replicas
+FROM config_lines
+WHERE line LIKE '%num_replicas%';
+----
+3
+
+statement ok
+DROP SEQUENCE seq1;
+
+subtest end

--- a/pkg/sql/schemachanger/scdecomp/decomp.go
+++ b/pkg/sql/schemachanger/scdecomp/decomp.go
@@ -433,7 +433,7 @@ func (w *walkCtx) walkRelation(tbl catalog.TableDescriptor) {
 	// Add a zone config element which is a stop gap to allow us to block
 	// operations on tables. To minimize RTT impact limit
 	// this to only tables and materialized views.
-	if (tbl.IsTable() && !tbl.IsVirtualTable()) || tbl.MaterializedView() {
+	if (tbl.IsTable() && !tbl.IsVirtualTable()) || tbl.MaterializedView() || tbl.IsSequence() {
 		zoneConfig, err := w.zoneConfigReader.GetZoneConfig(w.ctx, tbl.GetID())
 		if err != nil {
 			panic(err)


### PR DESCRIPTION
Discarding zone configs via the declarative schema changer was a no-op for sequences, leaving stale configs. This was due to not loading scpb.TableZoneConfig elements for sequences.

This change ensures those elements are loaded, so configs are properly removed.

Fixes #150252

Epic: none
Release note (bug fix): Fixes an issue where discarding zone configs on sequences did not remove the actual configuration.