### PR TITLE
server: fixes test flaps due to drains timing out

### DIFF
--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -535,7 +535,7 @@ func TestCheckRestartSafe_Integration(t *testing.T) {
 }
 
 func drain(ctx context.Context, ts1 serverutils.TestServerInterface, t *testing.T) error {
-	timeoutCtx, cancel := context.WithTimeout(ctx, 30*time.Second)
+	timeoutCtx, cancel := context.WithTimeout(ctx, testutils.SucceedsSoonDuration())
 	defer cancel()
 
 	err := ts1.DrainClients(ctx)


### PR DESCRIPTION
Use the SucceedSoonDuration rather than a static 30s timeout. This is responsive to various test parameters.

Fixes: #149515, #149534

Release note: None