### PR TITLE
jobspb: use StatusMessage type for status message field

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -540,7 +540,7 @@ func (r *restoreResumer) maybeCalculateTotalDownloadSpans(
 
 	if err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 		md.Progress.GetRestore().TotalDownloadRequired = total
-		md.Progress.StatusMessage = fmt.Sprintf("Downloading %s of restored data...", sz(total))
+		md.Progress.StatusMessage = jobs.StatusMessage(fmt.Sprintf("Downloading %s of restored data...", sz(total)))
 		ju.UpdateProgress(md.Progress)
 		return nil
 	}); err != nil {

--- a/pkg/ccl/changefeedccl/changefeed_processors.go
+++ b/pkg/ccl/changefeedccl/changefeed_processors.go
@@ -1833,7 +1833,7 @@ func (cf *changeFrontier) checkpointJobProgress(
 			}
 
 			if updateRunStatus {
-				progress.StatusMessage = fmt.Sprintf("running: resolved=%s", frontier)
+				progress.StatusMessage = jobs.StatusMessage(fmt.Sprintf("running: resolved=%s", frontier))
 			}
 
 			ju.UpdateProgress(progress)

--- a/pkg/ccl/changefeedccl/changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/changefeed_stmt.go
@@ -1455,7 +1455,7 @@ func (b *changefeedResumer) handleChangefeedError(
 			changefeedbase.OptOnError, changefeedbase.OptOnErrorPause)
 		return b.job.NoTxn().PauseRequestedWithFunc(ctx, func(ctx context.Context, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 			// directly update running status to avoid the running/reverted job status check
-			md.Progress.StatusMessage = errorMessage
+			md.Progress.StatusMessage = jobs.StatusMessage(errorMessage)
 			ju.UpdateProgress(md.Progress)
 			log.Warningf(ctx, errorFmt, changefeedErr, changefeedbase.OptOnError, changefeedbase.OptOnErrorPause)
 			return nil

--- a/pkg/crosscluster/logical/logical_replication_job.go
+++ b/pkg/crosscluster/logical/logical_replication_job.go
@@ -114,7 +114,7 @@ func (r *logicalReplicationResumer) updateStatusMessage(
 ) {
 	log.Infof(ctx, "%s", status)
 	err := r.job.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-		md.Progress.StatusMessage = string(status.Redact())
+		md.Progress.StatusMessage = jobs.StatusMessage(status.Redact())
 		ju.UpdateProgress(md.Progress)
 		return nil
 	})

--- a/pkg/crosscluster/physical/stream_ingestion_dist.go
+++ b/pkg/crosscluster/physical/stream_ingestion_dist.go
@@ -266,7 +266,7 @@ func startDistIngestion(
 	if err := ingestionJob.NoTxn().Update(ctx, func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 		md.Progress.GetStreamIngest().ReplicationStatus = replicationStatusForFlow
 		md.Progress.GetStreamIngest().InitialSplitComplete = true
-		md.Progress.StatusMessage = replicationStatusForFlow.String()
+		md.Progress.StatusMessage = jobs.StatusMessage(replicationStatusForFlow.String())
 		ju.UpdateProgress(md.Progress)
 		return nil
 	}); err != nil {

--- a/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_frontier_processor.go
@@ -341,7 +341,7 @@ func (sf *streamIngestionFrontier) maybeUpdateProgress() error {
 
 		if replicatedTime.IsSet() && streamProgress.ReplicationStatus == jobspb.InitialScan {
 			streamProgress.ReplicationStatus = jobspb.Replicating
-			md.Progress.StatusMessage = streamProgress.ReplicationStatus.String()
+			md.Progress.StatusMessage = jobs.StatusMessage(streamProgress.ReplicationStatus.String())
 		}
 
 		// Keep the recorded replicatedTime empty until some advancement has been made

--- a/pkg/crosscluster/physical/stream_ingestion_job.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job.go
@@ -115,7 +115,7 @@ func updateStatusInternal(
 	md jobs.JobMetadata,
 	ju *jobs.JobUpdater,
 	replicationStatus jobspb.ReplicationStatus,
-	status string,
+	status jobs.StatusMessage,
 ) {
 	md.Progress.GetStreamIngest().ReplicationStatus = replicationStatus
 	md.Progress.StatusMessage = status

--- a/pkg/jobs/jobs.go
+++ b/pkg/jobs/jobs.go
@@ -277,7 +277,7 @@ func (u Updater) UpdateStatusMessage(ctx context.Context, status StatusMessage) 
 		if err := md.CheckRunningOrReverting(); err != nil {
 			return err
 		}
-		md.Progress.StatusMessage = string(status)
+		md.Progress.StatusMessage = status
 		ju.UpdateProgress(md.Progress)
 		return nil
 	})

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -1604,7 +1604,7 @@ message Progress {
   // StatusMessage contains the human readible status of a job (e.g. "running
   // initial scan"), which is distinct from the state of a job (e.g. PAUSED).
   // The status of a job is also stored in the system.job_status table.
-  string status_message = 4;
+  string status_message = 4 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/jobs.StatusMessage"];
 
   //                ------ COMPLIANCE NOTE ------
   // If you're updating this `Progress` proto, consider its impact on compliance.

--- a/pkg/jobs/registry.go
+++ b/pkg/jobs/registry.go
@@ -372,7 +372,7 @@ func (r *Registry) makePayload(ctx context.Context, record *Record) (jobspb.Payl
 func (r *Registry) makeProgress(record *Record) jobspb.Progress {
 	return jobspb.Progress{
 		Details:       jobspb.WrapProgressDetails(record.Progress),
-		StatusMessage: string(record.StatusMessage),
+		StatusMessage: record.StatusMessage,
 	}
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -5943,7 +5943,7 @@ func getPayloadAndProgressFromJobsRecord(
 	progressMarshalled, err := protoutil.Marshal(&jobspb.Progress{
 		ModifiedMicros: p.txn.ReadTimestamp().GoTime().UnixMicro(),
 		Details:        jobspb.WrapProgressDetails(job.Progress),
-		StatusMessage:  string(job.StatusMessage),
+		StatusMessage:  job.StatusMessage,
 	})
 	if err != nil {
 		return nil, nil, err

--- a/pkg/sql/gcjob/gc_job_utils.go
+++ b/pkg/sql/gcjob/gc_job_utils.go
@@ -262,7 +262,7 @@ func persistProgress(
 			if err := md.CheckRunningOrReverting(); err != nil {
 				return err
 			}
-			md.Progress.StatusMessage = string(status)
+			md.Progress.StatusMessage = status
 			md.Progress.Details = jobspb.WrapProgressDetails(*progress)
 			ju.UpdateProgress(md.Progress)
 			return nil

--- a/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
+++ b/pkg/sql/schemachanger/scexec/exec_deferred_mutation.go
@@ -41,7 +41,7 @@ type indexesToSplitAndScatter struct {
 
 type schemaChangerJobUpdate struct {
 	isNonCancelable       bool
-	runningStatus         string
+	runningStatus         jobs.StatusMessage
 	descriptorIDsToRemove catalog.DescriptorIDSet
 }
 

--- a/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
+++ b/pkg/sql/tablemetadatacache/update_table_metadata_cache_job.go
@@ -139,7 +139,7 @@ func (j *tableMetadataUpdateJobResumer) markAsRunning(ctx context.Context) {
 		progress := md.Progress
 		details := progress.Details.(*jobspb.Progress_TableMetadataCache).TableMetadataCache
 		now := timeutil.Now()
-		progress.StatusMessage = fmt.Sprintf("Job started at %s", now)
+		progress.StatusMessage = jobs.StatusMessage(fmt.Sprintf("Job started at %s", now))
 		details.LastStartTime = &now
 		details.Status = jobspb.UpdateTableMetadataCacheProgress_RUNNING
 		progress.Progress = &jobspb.Progress_FractionCompleted{
@@ -159,7 +159,7 @@ func (j *tableMetadataUpdateJobResumer) markAsCompleted(ctx context.Context) {
 		progress := md.Progress
 		details := progress.Details.(*jobspb.Progress_TableMetadataCache).TableMetadataCache
 		now := timeutil.Now()
-		progress.StatusMessage = fmt.Sprintf("Job completed at %s", now)
+		progress.StatusMessage = jobs.StatusMessage(fmt.Sprintf("Job completed at %s", now))
 		details.LastCompletedTime = &now
 		details.Status = jobspb.UpdateTableMetadataCacheProgress_NOT_RUNNING
 		progress.Progress = &jobspb.Progress_FractionCompleted{


### PR DESCRIPTION
This will help ensure that we don't accidentally redact the status message, which is always known to be safe since we construct it ourselves without any private data.

fixes https://github.com/cockroachdb/cockroach/issues/150233
Release note: None