### PR TITLE
release-24.1: tests/cdc: start chaos testing after changefeed

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -1382,8 +1382,6 @@ func registerCDC(r registry.Registry) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
-			ct.startCRDBChaos()
-
 			ct.runTPCCWorkload(tpccArgs{warehouses: 100, duration: "30m", tolerateErrors: true})
 
 			feed := ct.newChangefeed(feedArgs{
@@ -1392,6 +1390,11 @@ func registerCDC(r registry.Registry) {
 				opts:           map[string]string{"initial_scan": "'no'"},
 				tolerateErrors: true,
 			})
+
+			// Restart nodes after starting the changefeed so that we avoid trying to
+			// start the feed on a down node.
+			ct.startCRDBChaos()
+
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
 				initialScanLatency: 3 * time.Minute,
 				steadyLatency:      5 * time.Minute,


### PR DESCRIPTION
Backport 1/1 commits from #128492 on behalf of @rharding6373 (actually @asg0451).

----

The cdc/crdb-chaos roachtest is now ordered so that the changefeed is created before launching the node restarts. Without this change changefeed creation could fail due to not being able to connect to a down node.

Epic: none
Fixes: #127109
Fixes: #126924
Fixes: #150221

Release note: none

----

Release justification: test only fix