### PR TITLE
changefeedccl: fix ALTER CHANGEFEED max PTS age bug

### DIFF
--- a/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
+++ b/pkg/ccl/changefeedccl/alter_changefeed_stmt.go
@@ -227,11 +227,11 @@ func alterChangefeedPlanHook(
 		newPayload.Details = jobspb.WrapPayloadDetails(newDetails)
 		newPayload.Description = jobRecord.Description
 		newPayload.DescriptorIDs = jobRecord.DescriptorIDs
-		newExpiration, err := newOptions.GetPTSExpiration()
-		if err != nil {
-			return err
-		}
-		newPayload.MaximumPTSAge = newExpiration
+
+		// The maximum PTS age on jobRecord will be set correctly (based on either
+		// the option or cluster setting) by createChangefeedJobRecord.
+		newPayload.MaximumPTSAge = jobRecord.MaximumPTSAge
+
 		j, err := p.ExecCfg().JobRegistry.LoadJobWithTxn(ctx, jobID, p.InternalSQLTxn())
 		if err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/testfeed_test.go
+++ b/pkg/ccl/changefeedccl/testfeed_test.go
@@ -491,7 +491,7 @@ func (f *jobFeed) WaitDurationForState(
 		if statusPred(jobs.State(status)) {
 			return nil
 		}
-		return errors.Newf("still waiting for job status; current %s", status)
+		return errors.Newf("still waiting for job status; current status is %q", status)
 	}, dur)
 }
 


### PR DESCRIPTION
This patch fixes a bug where modifying a changefeed with ALTER CHANGEFEED
that either unset or left the `gc_protect_expires_after` option unset would
cause the changefeed's max PTS age to become unbounded instead of being set to
the default value configured by the `changefeed.protect_timestamp.max_age`
cluster setting.

This bug was occurring because the ALTER CHANGEFEED code was manually querying
the option instead of relying on the CREATE CHANGEFEED code path that also
consulted the cluster setting. This inconsistency has now been corrected.

Fixes #148029

Release note (bug fix): A bug where modifying a changefeed with ALTER CHANGEFEED
that either unset or left the `gc_protect_expires_after` option unset would
cause the changefeed's max PTS age to become unbounded instead of being set to
the default value configured by the `changefeed.protect_timestamp.max_age`
cluster setting.
