### PR TITLE
release-25.2: changefeedccl: fix TestNoBackfillAfterNonTargetColumnDrop

### DIFF
--- a/pkg/ccl/changefeedccl/changefeed_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_test.go
@@ -1819,9 +1819,9 @@ func TestNoStopAfterNonTargetColumnDrop(t *testing.T) {
 
 		// Check that dropping a watched column still stops the changefeed.
 		sqlDB.Exec(t, `ALTER TABLE hasfams DROP COLUMN b`)
-		if _, err := cf.Next(); !testutils.IsError(err, `schema change occurred at`) {
-			require.Regexp(t, `expected "schema change occurred at ..." got: %+v`, err)
-		}
+		msg, err := cf.Next()
+		require.True(t, testutils.IsError(err, `schema change occurred at`),
+			`expected "schema change occurred at ..." got: msg=%s, err=%+v`, msg, err)
 	}
 
 	runWithAndWithoutRegression141453(t, testFn, func(t *testing.T, testFn cdcTestFn) {


### PR DESCRIPTION
Backport 2/2 commits from #150215.

/cc @cockroachdb/release

---

This patch fixes `TestNoBackfillAfterNonTargetColumnDrop` so that it
actually checks that no backfills occur after a non-target column drop.

Fixes #150214

Release note: None

---

Release justification: test-only fix
