### PR TITLE
ci: copy roachtest perf artifact to designated (blob) path

### DIFF
--- a/build/teamcity/util/roachtest_util.sh
+++ b/build/teamcity/util/roachtest_util.sh
@@ -81,6 +81,8 @@ function upload_stats {
             artifacts_dir="${artifacts_dir}-arm64"
           elif [[ "${f}" == *"/cpu_arch=fips/"* ]]; then
             artifacts_dir="${artifacts_dir}-fips"
+          elif [[ "${f}" == *"/cpu_arch=s390x/"* ]]; then
+            artifacts_dir="${artifacts_dir}-s390x"
           fi
           gsutil cp "${f}" "gs://${bucket}/${artifacts_dir}/${stats_dir}/${f}"
         fi


### PR DESCRIPTION
Roachtest perf artifacts are bucketed by `cpu_arch`. 
The convention is to suffix the artifacts' release branch with `cpu_arch`. E.g.,
`gs://cockroach-nightly-ibm/artifacts-s390x`
corresponds to all the `s390x` perf runs
on `master`. This hack allows `roachperf`
to pull all artifacts by `cpu_arch` and
link them separately.

This PR just adds the `elif` clause for
the previously missing `s390x` case.
The rest is tackled in `roachperf`.

Epic: none
Release note: None