### PR TITLE
sql: restrict admin inheritance for specific role options

### DIFF
--- a/pkg/sql/roleoption/role_option.go
+++ b/pkg/sql/roleoption/role_option.go
@@ -81,7 +81,20 @@ const (
 	PROVISIONSRC
 )
 
+// NonAdminInheritedOptions contains the role options that are not implicitly
+// applied to all admin roles.
 var NonAdminInheritedOptions = []Option{
+	NOCREATEROLE,
+	NOCONTROLJOB,
+	NOCREATEDB,
+	NOVIEWACTIVITY,
+	NOCANCELQUERY,
+	NOMODIFYCLUSTERSETTING,
+	NOVIEWACTIVITYREDACTED,
+	NOREPLICATION,
+	NOVIEWCLUSTERSETTING,
+	SUBJECT,
+	NOBYPASSRLS,
 	PROVISIONSRC,
 }
 


### PR DESCRIPTION
Certain role options SUBJECT and NOVIEWACTIVITY (and others) should be excluded
from inheritance by the admin roles in line with the comment here.
https://reviewable.io/reviews/cockroachdb/cockroach/149463#-OUenA-O4wYwadhkcBdW

We have already excluded the PROVISIONSRC option in the PR #149463 and would be
extending that list.

fixes #150300
Epic None

Release note: None