### PR TITLE
crosscluster: fixup a few typos

### DIFF
--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -1114,8 +1114,8 @@ func splitRangeKeySSTAtKey(
 		// reachedSplit tracks if we've already reached our split key.
 		reachedSplit = false
 
-		// We start writting into the left side. Eventualy
-		// we'll swap in the RHS writer.
+		// We start writing into the left side. Eventually we'll swap in the RHS
+		// writer.
 		leftWriter  = storage.MakeIngestionSSTWriter(ctx, st, left)
 		rightWriter = storage.MakeIngestionSSTWriter(ctx, st, right)
 		writer      = &leftWriter
@@ -1128,7 +1128,7 @@ func splitRangeKeySSTAtKey(
 			return err
 		}
 		if first == nil || last == nil {
-			return errors.AssertionFailedf("likely prorgramming error: invalid SST bounds on RHS [%v, %v)", first, last)
+			return errors.AssertionFailedf("likely programming error: invalid SST bounds on RHS [%v, %v)", first, last)
 		}
 
 		leftRet = &rangeKeySST{start: first, end: last, data: left.Data()}


### PR DESCRIPTION
I found these when reading this function to verify that it didn't have a bug that was recently found in a similar function elsewhere in the code (it doesn't seem to).

Epic: none
Release note: none