### PR TITLE
kvserver/rangefeed: remove kv.rangefeed.mux_stream_send.latency histogram

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -12568,14 +12568,6 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
-    - name: kv.rangefeed.mux_stream_send.latency
-      exported_name: kv_rangefeed_mux_stream_send_latency
-      description: Latency of sending RangeFeed events to the client
-      y_axis_label: Latency
-      type: HISTOGRAM
-      unit: NANOSECONDS
-      aggregation: AVG
-      derivative: NONE
     - name: kv.rangefeed.mux_stream_send.slow_events
       exported_name: kv_rangefeed_mux_stream_send_slow_events
       description: Number of RangeFeed events that took longer than 10s to send to the client

--- a/pkg/kv/kvserver/rangefeed/metrics.go
+++ b/pkg/kv/kvserver/rangefeed/metrics.go
@@ -291,12 +291,6 @@ func NewBufferedSenderMetrics() *BufferedSenderMetrics {
 }
 
 var (
-	metaRangeFeedMuxStreamSendLatencyNanos = metric.Metadata{
-		Name:        "kv.rangefeed.mux_stream_send.latency",
-		Help:        "Latency of sending RangeFeed events to the client",
-		Measurement: "Latency",
-		Unit:        metric.Unit_NANOSECONDS,
-	}
 	metaRangeFeedMuxStreamSlowSends = metric.Metadata{
 		Name:        "kv.rangefeed.mux_stream_send.slow_events",
 		Help:        "Number of RangeFeed events that took longer than 10s to send to the client",
@@ -306,21 +300,14 @@ var (
 )
 
 type LockedMuxStreamMetrics struct {
-	SendLatencyNanos metric.IHistogram
-	SlowSends        *metric.Counter
+	SlowSends *metric.Counter
 }
 
 // MetricStruct implements metrics.Struct interface.
 func (*LockedMuxStreamMetrics) MetricStruct() {}
 
-func NewLockedMuxStreamMetrics(histogramWindow time.Duration) *LockedMuxStreamMetrics {
+func NewLockedMuxStreamMetrics() *LockedMuxStreamMetrics {
 	return &LockedMuxStreamMetrics{
-		SendLatencyNanos: metric.NewHistogram(metric.HistogramOptions{
-			Mode:         metric.HistogramModePrometheus,
-			Metadata:     metaRangeFeedMuxStreamSendLatencyNanos,
-			Duration:     histogramWindow,
-			BucketConfig: metric.IOLatencyBuckets,
-		}),
 		SlowSends: metric.NewCounter(metaRangeFeedMuxStreamSlowSends),
 	}
 }

--- a/pkg/server/node.go
+++ b/pkg/server/node.go
@@ -284,7 +284,7 @@ func makeNodeMetrics(reg *metric.Registry, histogramWindow time.Duration) *nodeM
 		CrossZoneBatchResponseBytes:   metric.NewCounter(metaCrossZoneBatchResponse),
 		StreamManagerMetrics:          rangefeed.NewStreamManagerMetrics(),
 		BufferedSenderMetrics:         rangefeed.NewBufferedSenderMetrics(),
-		LockedMuxStreamMetrics:        rangefeed.NewLockedMuxStreamMetrics(histogramWindow),
+		LockedMuxStreamMetrics:        rangefeed.NewLockedMuxStreamMetrics(),
 	}
 
 	for i := range nm.MethodCounts {
@@ -2124,7 +2124,6 @@ func (s *lockedMuxStream) Send(e *kvpb.MuxRangeFeedEvent) error {
 	start := crtime.NowMono()
 	defer func() {
 		dur := start.Elapsed()
-		s.metrics.SendLatencyNanos.RecordValue(dur.Nanoseconds())
 		if dur > slowMuxStreamSendThreshold {
 			s.metrics.SlowSends.Inc(1)
 			log.Infof(s.wrapped.Context(), "slow send on stream %d for r%d took %s", e.StreamID, e.RangeID, dur)


### PR DESCRIPTION
In #147440, we added the histogram metric `kv.rangefeed.mux_stream_send.latency` that provides observability into the latency of `lockedMuxStream.Send`.

However, further testing revealed that in workloads that trigger lots of catchup scans, the performance cost of this metric was ~5% of CPU per catchup scan.

<img width="1728" height="796" alt="Screenshot 2025-07-16 at 16 41 18" src="https://github.com/user-attachments/assets/3888cad3-b780-48b9-acfa-37dd834cb417" />

Our original motivation for adding this metric was to surface slow `lockedMuxStream.Send` calls, which is achieved by the `kv.rangefeed.mux_stream_send.slow_events` counter (also introduced in #147440).

So, this patch removes the histogram metric.

Epic: None
Release note: None