### PR TITLE
sql: fix CITEXT formatting panic

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/citext
+++ b/pkg/sql/logictest/testdata/logic_test/citext
@@ -209,3 +209,8 @@ citext
 
 query error syntax error
 CREATE TABLE citext_with_width_tbl (a CITEXT(10));
+
+query T
+SELECT cast('test'::TEXT AS CITEXT);
+----
+test

--- a/pkg/sql/sem/tree/pretty.go
+++ b/pkg/sql/sem/tree/pretty.go
@@ -1051,7 +1051,7 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 			typ,
 		)
 	default:
-		if nTyp, ok := GetStaticallyKnownType(node.Type); ok && nTyp.Family() == types.CollatedStringFamily {
+		if nTyp, ok := GetStaticallyKnownType(node.Type); ok && typeDisplaysCollate(nTyp) {
 			// COLLATE clause needs to go after CAST expression, so create
 			// equivalent string type without the locale to get name of string
 			// type without the COLLATE.
@@ -1080,7 +1080,7 @@ func (node *CastExpr) doc(p *PrettyCfg) pretty.Doc {
 			),
 		)
 
-		if nTyp, ok := GetStaticallyKnownType(node.Type); ok && nTyp.Family() == types.CollatedStringFamily {
+		if nTyp, ok := GetStaticallyKnownType(node.Type); ok && typeDisplaysCollate(nTyp) {
 			ret = pretty.Fold(pretty.ConcatSpace,
 				ret,
 				pretty.Keyword("COLLATE"),


### PR DESCRIPTION
#### sql: fix CITEXT formatting panic

CITEXT was taking the default formatting path of `CollatedStringFamily` which formats datums with the COLLATE expression, causing a panic. This PR fixes this by separating CITEXT from the default collated string formatting path.

Fixes: cockroachdb#149876
Epic: None

Release note: None
