### PR TITLE
bulk: avoid leaking sst writers

### DIFF
--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -45,6 +45,7 @@ go_test(
     name = "bulk_test",
     size = "medium",
     srcs = [
+        "buffering_adder_test.go",
         "kv_buf_test.go",
         "main_test.go",
         "split_sst_test.go",
@@ -69,6 +70,7 @@ go_test(
         "//pkg/sql/catalog/descpb",
         "//pkg/sql/catalog/desctestutils",
         "//pkg/sql/catalog/tabledesc",
+        "//pkg/sql/distsql",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/tree",
         "//pkg/storage",

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -107,9 +107,25 @@ func MakeBulkAdder(
 		opts.MaxBufferSize = func() int64 { return 128 << 20 }
 	}
 
+	// At minimum a bulk adder needs enough space to store a buffer of
+	// curBufferSize, and a subsequent SST of SSTSize in-memory. If the memory
+	// account is unable to reserve this minimum threshold we cannot continue.
+	//
+	// TODO(adityamaru): IMPORT should also reserve memory for a single SST which
+	// it will store in-memory before sending it to RocksDB.
+	memAcc := bulkMon.MakeEarmarkedBoundAccount()
+	if opts.MinBufferSize > 0 {
+		if err := memAcc.Reserve(ctx, opts.MinBufferSize); err != nil {
+			return nil, errors.WithHint(
+				errors.Wrap(err, "not enough memory available to create a BulkAdder"),
+				"Try setting a higher --max-sql-memory.")
+		}
+	}
+
 	b := &BufferingAdder{
 		name:        opts.Name,
 		importEpoch: opts.ImportEpoch,
+		memAcc:      memAcc,
 		sink: SSTBatcher{
 			name: opts.Name,
 			db:   db,
@@ -153,20 +169,6 @@ func MakeBulkAdder(
 	// currently buffered kvs.
 	b.sink.mu.onFlush = func(batchSummary kvpb.BulkOpSummary) {
 		b.curBufSummary.Add(batchSummary)
-	}
-	// At minimum a bulk adder needs enough space to store a buffer of
-	// curBufferSize, and a subsequent SST of SSTSize in-memory. If the memory
-	// account is unable to reserve this minimum threshold we cannot continue.
-	//
-	// TODO(adityamaru): IMPORT should also reserve memory for a single SST which
-	// it will store in-memory before sending it to RocksDB.
-	b.memAcc = bulkMon.MakeEarmarkedBoundAccount()
-	if opts.MinBufferSize > 0 {
-		if err := b.memAcc.Reserve(ctx, opts.MinBufferSize); err != nil {
-			return nil, errors.WithHint(
-				errors.Wrap(err, "not enough memory available to create a BulkAdder"),
-				"Try setting a higher --max-sql-memory.")
-		}
 	}
 	return b, nil
 }

--- a/pkg/kv/bulk/buffering_adder_test.go
+++ b/pkg/kv/bulk/buffering_adder_test.go
@@ -1,0 +1,46 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulk_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
+	"github.com/cockroachdb/cockroach/pkg/sql/distsql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestBufferingAdderMemoryExhaustion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	ctx := context.Background()
+
+	// This is a regression test for a bug that leaked the sstwriter within the
+	// sstbatcher if allocation failed due to memory exhaustion.
+
+	// Start a test server.
+	s := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer s.Stopper().Stop(ctx)
+
+	distSQLSrv := s.DistSQLServer().(*distsql.ServerImpl)
+	bulkAdderFactory := distSQLSrv.ServerConfig.BulkAdder
+
+	// Attempt to create a BufferingAdder while asking for 1 Gib more memory than is available.
+	opts := kvserverbase.BulkAdderOptions{
+		Name:          "test-adder",
+		MinBufferSize: distSQLSrv.ServerConfig.ParentMemoryMonitor.AllocBytes() + (1024 * 1024 * 1024),
+	}
+
+	// This should fail due to memory exhaustion, but importantly should not leak goroutines.
+	_, err := bulkAdderFactory(ctx, s.DB(), hlc.Timestamp{}, opts)
+	require.ErrorContains(t, err, "not enough memory available")
+}

--- a/pkg/kv/bulk/sst_adder.go
+++ b/pkg/kv/bulk/sst_adder.go
@@ -261,7 +261,7 @@ func createSplitSSTable(
 		return nil, nil, errors.AssertionFailedf("start key %s of original sst must be greater than than split key %s", start, splitKey)
 	}
 	w := storage.MakeIngestionSSTWriter(ctx, settings, sstFile)
-	defer w.Close()
+	defer func() { w.Close() }()
 
 	split := false
 	var first, last roachpb.Key
@@ -285,7 +285,10 @@ func createSplitSSTable(
 
 			left = &sstSpan{start: first, end: last.Next(), sstBytes: sstFile.Data()}
 			*sstFile = storage.MemObject{}
+
+			w.Close()
 			w = storage.MakeIngestionSSTWriter(ctx, settings, sstFile)
+
 			split = true
 			first = nil
 			last = nil


### PR DESCRIPTION
This fixes a bug introduced by #148395. Before #148395, the sst batcher would not be initialized until the first key was added to it. After the change, the sst batcher was initialized as part of the object construction. This introduced a bug where the initialization would leak an sst writer if the initialization failed with a memory accounting error. This leak is fixed by requesting the memory budget before initializing the writer.

This change also cleans up the .Close() handling within the sst_adder. Previously, the sst adder could leak a writer if SST construction fails. There is no new test for the only error returned by the sst writer is an error indicating out of order keys. But any new errors (for example handling context cancellation) would trigger a leak of the SST writer.

Informs: #148649
Release note: none