### PR TITLE
kvserver: record follower write bytes in replica load

### DIFF
--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -33,7 +33,9 @@ type appBatchStats struct {
 	numEntriesProcessedBytes   int64
 	numEmptyEntries            int
 	numAddSST, numAddSSTCopies int
-	numWriteBytes              int64
+	// numWriteAndIngestedBytes is the sum of number of bytes written to the replica and size
+	// of the sstable to ingest.
+	numWriteAndIngestedBytes int64
 
 	// NB: update `merge` when adding a new field.
 }
@@ -43,7 +45,7 @@ func (s *appBatchStats) merge(ss appBatchStats) {
 	s.numEntriesProcessed += ss.numEntriesProcessed
 	s.numEntriesProcessedBytes += ss.numEntriesProcessedBytes
 	ss.numEmptyEntries += ss.numEmptyEntries
-	s.numWriteBytes += ss.numWriteBytes
+	s.numWriteAndIngestedBytes += ss.numWriteAndIngestedBytes
 }
 
 // appBatch is the in-progress foundation for standalone log entry

--- a/pkg/kv/kvserver/app_batch.go
+++ b/pkg/kv/kvserver/app_batch.go
@@ -33,6 +33,7 @@ type appBatchStats struct {
 	numEntriesProcessedBytes   int64
 	numEmptyEntries            int
 	numAddSST, numAddSSTCopies int
+	numWriteBytes              int64
 
 	// NB: update `merge` when adding a new field.
 }
@@ -42,6 +43,7 @@ func (s *appBatchStats) merge(ss appBatchStats) {
 	s.numEntriesProcessed += ss.numEntriesProcessed
 	s.numEntriesProcessedBytes += ss.numEntriesProcessedBytes
 	ss.numEmptyEntries += ss.numEmptyEntries
+	s.numWriteBytes += ss.numWriteBytes
 }
 
 // appBatch is the in-progress foundation for standalone log entry

--- a/pkg/kv/kvserver/load/replica_load.go
+++ b/pkg/kv/kvserver/load/replica_load.go
@@ -65,7 +65,11 @@ type ReplicaLoadStats struct {
 	// follower and leaseholder reads.
 	ReadKeysPerSecond float64
 	// WriteBytesPerSecond is the replica's average bytes written per second. A
-	// "Write" is as described in WritesPerSecond.
+	// "Write" is as described in WritesPerSecond. If the replica is a leaseholder,
+	// this is recorded as the bytes that will be written by the replica during the
+	// application of the Raft command including write bytes and ingested bytes for
+	// AddSSTable requests. If the replica is a follower, this is recorded right
+	// before a command is applied to the state machine.
 	WriteBytesPerSecond float64
 	// ReadBytesPerSecond is the replica's average bytes read per second. A "Read" is as
 	// described in ReadsPerSecond.

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -256,7 +256,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	if !cmd.IsLocal() {
 		writeBytes, ingestedBytes := cmd.getStoreWriteByteSizes()
 		if writeBytes > 0 || ingestedBytes > 0 {
-			b.ab.numWriteBytes += writeBytes + ingestedBytes
+			b.ab.numWriteAndIngestedBytes += writeBytes + ingestedBytes
 		}
 		// TODO(irfansharif): This code block can be removed once below-raft
 		// admission control is the only form of IO admission control. It pre-dates
@@ -725,7 +725,7 @@ func (b *replicaAppBatch) recordStatsOnCommit() {
 	b.applyStats.appBatchStats.merge(b.ab.appBatchStats)
 	b.applyStats.numBatchesProcessed++
 	b.applyStats.followerStoreWriteBytes.Merge(b.followerStoreWriteBytes)
-	b.r.recordRequestWriteBytes(b.ab.numWriteBytes)
+	b.r.recordRequestWriteBytes(b.ab.numWriteAndIngestedBytes)
 
 	if n := b.ab.numAddSST; n > 0 {
 		b.r.store.metrics.AddSSTableApplications.Inc(int64(n))

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -253,16 +253,20 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	// We don't track these stats in standalone log application since they depend
 	// on whether the proposer is still waiting locally, and this concept does not
 	// apply in a standalone context.
-	//
-	// TODO(irfansharif): This code block can be removed once below-raft
-	// admission control is the only form of IO admission control. It pre-dates
-	// it -- these stats were previously used to deduct IO tokens for follower
-	// writes/ingests without waiting.
-	if !cmd.IsLocal() && !cmd.ApplyAdmissionControl() {
+	if !cmd.IsLocal() {
 		writeBytes, ingestedBytes := cmd.getStoreWriteByteSizes()
-		b.followerStoreWriteBytes.NumEntries++
-		b.followerStoreWriteBytes.WriteBytes += writeBytes
-		b.followerStoreWriteBytes.IngestedBytes += ingestedBytes
+		if writeBytes > 0 || ingestedBytes > 0 {
+			b.r.recordRequestWriteBytes(writeBytes, ingestedBytes)
+		}
+		// TODO(irfansharif): This code block can be removed once below-raft
+		// admission control is the only form of IO admission control. It pre-dates
+		// it -- these stats were previously used to deduct IO tokens for follower
+		// writes/ingests without waiting.
+		if !cmd.ApplyAdmissionControl() {
+			b.followerStoreWriteBytes.NumEntries++
+			b.followerStoreWriteBytes.WriteBytes += writeBytes
+			b.followerStoreWriteBytes.IngestedBytes += ingestedBytes
+		}
 	}
 
 	// MVCC history mutations violate the closed timestamp, modifying data that

--- a/pkg/kv/kvserver/replica_app_batch.go
+++ b/pkg/kv/kvserver/replica_app_batch.go
@@ -256,7 +256,7 @@ func (b *replicaAppBatch) runPostAddTriggersReplicaOnly(
 	if !cmd.IsLocal() {
 		writeBytes, ingestedBytes := cmd.getStoreWriteByteSizes()
 		if writeBytes > 0 || ingestedBytes > 0 {
-			b.r.recordRequestWriteBytes(writeBytes, ingestedBytes)
+			b.ab.numWriteBytes += writeBytes + ingestedBytes
 		}
 		// TODO(irfansharif): This code block can be removed once below-raft
 		// admission control is the only form of IO admission control. It pre-dates
@@ -725,6 +725,7 @@ func (b *replicaAppBatch) recordStatsOnCommit() {
 	b.applyStats.appBatchStats.merge(b.ab.appBatchStats)
 	b.applyStats.numBatchesProcessed++
 	b.applyStats.followerStoreWriteBytes.Merge(b.followerStoreWriteBytes)
+	b.r.recordRequestWriteBytes(b.ab.numWriteBytes)
 
 	if n := b.ab.numAddSST; n > 0 {
 		b.r.store.metrics.AddSSTableApplications.Inc(int64(n))

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -96,6 +96,8 @@ var ReplicaLeaderlessUnavailableThreshold = settings.RegisterDurationSettingWith
 //     terminate execution, although it is given no guarantee that the proposal
 //     won't still go on to commit and apply at some later time.
 //   - the proposal's ID.
+//   - the bytes that will be written by the replica during the application of
+//     the Raft command.
 //   - any error obtained during the creation or proposal of the command, in
 //     which case the other returned values are zero.
 func (r *Replica) evalAndPropose(

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -823,7 +823,7 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 			p.Printf(" (copies=%d)", c)
 		}
 	}
-	if b := s.apply.numWriteBytes; b > 0 {
+	if b := s.apply.numWriteAndIngestedBytes; b > 0 {
 		p.Printf(", apply-write-bytes=%s", humanizeutil.IBytes(b))
 	}
 	p.SafeString("]")

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -823,6 +823,9 @@ func (s handleRaftReadyStats) SafeFormat(p redact.SafePrinter, _ rune) {
 			p.Printf(" (copies=%d)", c)
 		}
 	}
+	if b := s.apply.numWriteBytes; b > 0 {
+		p.Printf(", apply-write-bytes=%s", humanizeutil.IBytes(b))
+	}
 	p.SafeString("]")
 
 	if n := s.apply.assertionsRequested; n > 0 {

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -220,7 +220,7 @@ func (r *Replica) SendWithWriteBytes(
 	// accounting.
 	r.recordBatchRequestLoad(ctx, ba)
 	if writeBytes != nil {
-		r.recordRequestWriteBytes(writeBytes.WriteBytes, writeBytes.IngestedBytes)
+		r.recordRequestWriteBytes(writeBytes.WriteBytes + writeBytes.IngestedBytes)
 	}
 	r.recordImpactOnRateLimiter(ctx, br, isReadOnly)
 	return br, writeBytes, pErr
@@ -1069,10 +1069,10 @@ func (r *Replica) getBatchRequestQPS(ctx context.Context, ba *kvpb.BatchRequest)
 
 // recordRequestWriteBytes records the write bytes from a replica batch
 // request.
-func (r *Replica) recordRequestWriteBytes(writeBytes int64, ingestedBytes int64) {
+func (r *Replica) recordRequestWriteBytes(writeBytes int64) {
 	// TODO(kvoli): Consider recording the ingested bytes (AddSST) separately
 	// to the write bytes.
-	r.loadStats.RecordWriteBytes(float64(writeBytes + ingestedBytes))
+	r.loadStats.RecordWriteBytes(float64(writeBytes))
 }
 
 // checkBatchRequest verifies BatchRequest validity requirements. In particular,

--- a/pkg/kv/kvserver/replica_send.go
+++ b/pkg/kv/kvserver/replica_send.go
@@ -219,7 +219,9 @@ func (r *Replica) SendWithWriteBytes(
 	// Record summary throughput information about the batch request for
 	// accounting.
 	r.recordBatchRequestLoad(ctx, ba)
-	r.recordRequestWriteBytes(writeBytes)
+	if writeBytes != nil {
+		r.recordRequestWriteBytes(writeBytes.WriteBytes, writeBytes.IngestedBytes)
+	}
 	r.recordImpactOnRateLimiter(ctx, br, isReadOnly)
 	return br, writeBytes, pErr
 }
@@ -1067,13 +1069,10 @@ func (r *Replica) getBatchRequestQPS(ctx context.Context, ba *kvpb.BatchRequest)
 
 // recordRequestWriteBytes records the write bytes from a replica batch
 // request.
-func (r *Replica) recordRequestWriteBytes(writeBytes *kvadmission.StoreWriteBytes) {
-	if writeBytes == nil {
-		return
-	}
+func (r *Replica) recordRequestWriteBytes(writeBytes int64, ingestedBytes int64) {
 	// TODO(kvoli): Consider recording the ingested bytes (AddSST) separately
 	// to the write bytes.
-	r.loadStats.RecordWriteBytes(float64(writeBytes.WriteBytes + writeBytes.IngestedBytes))
+	r.loadStats.RecordWriteBytes(float64(writeBytes + ingestedBytes))
 }
 
 // checkBatchRequest verifies BatchRequest validity requirements. In particular,


### PR DESCRIPTION

**kvserver: takes write and ingested bytes for recordRequestWriteBytes**

Previously, recordRequestWriteBytes took a *kvadmission.StoreWriteBytes, which
was unnecessary since we're only recording write and ingested bytes, not
anything admission control specific. This commit changes the function to accept
the raw byte counts directly. This also sets up a future change where follower
replicas would not pass in StoreWriteBytes during recording.

Epic: none
Release note: none

---

**kvserver: record follower write bytes in replica load**

Previously, write bytes for range load were only tracked on leaseholder replicas
during proposal, leaving write bytes written to follower replicas unaccounted
for. This commit updates the tracking to include write bytes on follower
replicas as well.

Epic: none
Release note: none

---

**kvserver: record follower write bytes during recordStatsOnCommit**

Previously, we recorded write bytes for follower replicas in
runPostAddTriggersReplicaOnly, right before apply, which could be inaccurate
since stats should be recorded at commit time. This commit moves the recording
to recordStatsOnCommit by including the write bytes in the batch stats.

Epic: none
Release note: none

---

**kvserver: rename numWriteBytes to numWriteAndIngestedBytes**

This commit renames numWriteBytes in appBatchStats to numWriteAndIngestedBytes
for accuracy, as it accounts for both bytes written to the replica and bytes
ingested via SSTables.

Epic: none
Release note: none
