### PR TITLE
builtins: fix `pg_collation_for` for CITEXT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/citext
+++ b/pkg/sql/logictest/testdata/logic_test/citext
@@ -214,3 +214,8 @@ query T
 SELECT cast('test'::TEXT AS CITEXT);
 ----
 test
+
+query T
+SELECT pg_collation_for('foo'::CITEXT);
+----
+"default"


### PR DESCRIPTION
We missed a spot where we need to unwrap the DOidWrapper corresponding to DCIText.

Fixes: #150386.

Release note: None