### PR TITLE
util/parquet,sql: clean up DOidWrapper handling a bit

### DIFF
--- a/pkg/sql/colconv/datum_to_vec.eg.go
+++ b/pkg/sql/colconv/datum_to_vec.eg.go
@@ -109,10 +109,7 @@ func GetDatumToPhysicalFn(ct *types.T) func(tree.Datum) interface{} {
 		default:
 			return func(datum tree.Datum) interface{} {
 				// Handle other STRING-related OID types, like oid.T_name.
-				wrapper, ok := datum.(*tree.DOidWrapper)
-				if ok {
-					datum = wrapper.Wrapped
-				}
+				datum = tree.UnwrapDOidWrapper(datum)
 				return encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DString)))
 			}
 		}

--- a/pkg/sql/colexec/execgen/cmd/execgen/rowtovec_gen.go
+++ b/pkg/sql/colexec/execgen/cmd/execgen/rowtovec_gen.go
@@ -69,10 +69,7 @@ type familyWidthPair struct {
 
 var rowToVecPreludeTmpls = map[familyWidthPair]string{
 	{types.StringFamily, anyWidth}: `// Handle other STRING-related OID types, like oid.T_name.
-												 wrapper, ok := %[1]s.(*tree.DOidWrapper)
-												 if ok {
-												     %[1]s = wrapper.Wrapped
-												 }`,
+												 %[1]s = tree.UnwrapDOidWrapper(%[1]s)`,
 }
 
 // rowToVecConversionTmpls maps the type families to the corresponding

--- a/pkg/sql/colexec/rowtovec.eg.go
+++ b/pkg/sql/colexec/rowtovec.eg.go
@@ -120,10 +120,7 @@ func EncDatumRowToColVecs(
 				case -1:
 				default:
 					// Handle other STRING-related OID types, like oid.T_name.
-					wrapper, ok := datum.(*tree.DOidWrapper)
-					if ok {
-						datum = wrapper.Wrapped
-					}
+					datum = tree.UnwrapDOidWrapper(datum)
 					v := encoding.UnsafeConvertStringToBytes(string(*datum.(*tree.DString)))
 					vecs.BytesCols[vecs.ColsMap[vecIdx]].Set(rowIdx, v)
 				}

--- a/pkg/sql/opt/norm/scalar_funcs.go
+++ b/pkg/sql/opt/norm/scalar_funcs.go
@@ -245,9 +245,7 @@ func (c *CustomFuncs) ConvertConstArrayToTuple(arr *memo.ConstExpr) opt.ScalarEx
 // collated string constant with the given locale.
 func (c *CustomFuncs) CastToCollatedString(str opt.ScalarExpr, locale string) opt.ScalarExpr {
 	datum := str.(*memo.ConstExpr).Value
-	if wrap, ok := datum.(*tree.DOidWrapper); ok {
-		datum = wrap.Wrapped
-	}
+	datum = tree.UnwrapDOidWrapper(datum)
 
 	// buildCollated is a recursive helper function to handle casting arrays.
 	var buildCollated func(datum tree.Datum) tree.Datum

--- a/pkg/sql/rowenc/valueside/array.go
+++ b/pkg/sql/rowenc/valueside/array.go
@@ -336,8 +336,6 @@ func encodeArrayElement(b []byte, d tree.Datum) ([]byte, error) {
 		return encoding.EncodeUntaggedIntValue(b, int64(t.Oid)), nil
 	case *tree.DCollatedString:
 		return encoding.EncodeUntaggedBytesValue(b, []byte(t.Contents)), nil
-	case *tree.DOidWrapper:
-		return encodeArrayElement(b, t.Wrapped)
 	case *tree.DEnum:
 		return encoding.EncodeUntaggedBytesValue(b, t.PhysicalRep), nil
 	case *tree.DJSON:

--- a/pkg/sql/stats/automatic_stats_test.go
+++ b/pkg/sql/stats/automatic_stats_test.go
@@ -903,7 +903,7 @@ func TestAnalyzeSystemTables(t *testing.T) {
 		return descpb.ID(tableID)
 	}
 	for _, row := range rows {
-		tableName := string(*row[0].(*tree.DOidWrapper).Wrapped.(*tree.DString))
+		tableName := string(*tree.UnwrapDOidWrapper(row[0]).(*tree.DString))
 		if DisallowedOnSystemTable(getTableID(tableName)) {
 			continue
 		}

--- a/pkg/util/parquet/testutils.go
+++ b/pkg/util/parquet/testutils.go
@@ -362,15 +362,6 @@ func decodeValuesIntoDatumsHelper(
 	}
 }
 
-func unwrapDatum(d tree.Datum) tree.Datum {
-	switch t := d.(type) {
-	case *tree.DOidWrapper:
-		return unwrapDatum(t.Wrapped)
-	default:
-		return d
-	}
-}
-
 // ValidateDatum validates that the "contents" of the expected datum matches the
 // contents of the actual datum. For example, when validating two arrays, we
 // only compare the datums in the arrays. We do not compare CRDB-specific
@@ -384,8 +375,8 @@ func ValidateDatum(t *testing.T, expected tree.Datum, actual tree.Datum) {
 	// The randgen library may generate datums wrapped in a *tree.DOidWrapper, so
 	// we should unwrap them. We unwrap at this stage as opposed to when
 	// generating datums to test that the writer can handle wrapped datums.
-	expected = unwrapDatum(expected)
-	actual = unwrapDatum(actual)
+	expected = tree.UnwrapDOidWrapper(expected)
+	actual = tree.UnwrapDOidWrapper(actual)
 
 	switch expected.ResolvedType().Family() {
 	case types.JsonFamily:


### PR DESCRIPTION
This commit removes redundant branch for `DOidWrapper` in `encodeArrayElement` (we already do the unwrapping at the top of the function, so this was dead code) as well as replaces the custom unwrap function in `parquet` package with the exported one. It also replaces some other unwrappers with that exported function.

Epic: None
Release note: None