### PR TITLE
kvserver: pass NodeCapacityProviderConfig to NewNodeCapacityProvider

### DIFF
--- a/pkg/base/config.go
+++ b/pkg/base/config.go
@@ -96,6 +96,21 @@ const (
 	// DefaultLeaseRenewalCrossValidate is the default setting for if
 	// we should validate descriptors on lease renewals.
 	DefaultLeaseRenewalCrossValidate = false
+
+	// DefaultCPUUsageRefreshInterval controls how often cpu usage measurements
+	// are sampled by NodeCapacityProvider.
+	DefaultCPUUsageRefreshInterval = time.Second
+
+	// DefaultCPUCapacityRefreshInterval controls how often the total CPU capacity
+	// of the node is re-calculated by NodeCapacityProvider. This is less frequent
+	// than usage since capacity changes happen less often.
+	DefaultCPUCapacityRefreshInterval = 10 * time.Second
+
+	// DefaultCPUUsageMovingAverageAge defines the effective time window size for
+	// sampling cpu usage. With a value of 20, the 20th-to-last measurement
+	// contributes meaningfully to the average, while earlier measurements have
+	// diminishing impact.
+	DefaultCPUUsageMovingAverageAge = 20
 )
 
 // DefaultCertsDirectory is the default value for the cert directory flag.

--- a/pkg/kv/kvserver/load/node_capacity_provider_test.go
+++ b/pkg/kv/kvserver/load/node_capacity_provider_test.go
@@ -40,9 +40,10 @@ func TestNodeCapacityProvider(t *testing.T) {
 		storeCount: 3,
 	}
 
-	provider := load.NewNodeCapacityProvider(stopper, mockStores, &load.NodeCapacityProviderTestingKnobs{
-		CpuUsageRefreshInterval:    1 * time.Millisecond,
-		CpuCapacityRefreshInterval: 1 * time.Millisecond,
+	provider := load.NewNodeCapacityProvider(stopper, mockStores, load.NodeCapacityProviderConfig{
+		CPUUsageRefreshInterval:    1 * time.Millisecond,
+		CPUCapacityRefreshInterval: 1 * time.Millisecond,
+		CPUUsageMovingAverageAge:   20,
 	})
 
 	ctx, cancel := context.WithCancel(context.Background())

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -262,7 +262,12 @@ func createTestStoreWithoutStart(
 	stores := NewStores(cfg.AmbientCtx, cfg.Clock)
 	nodeDesc := &roachpb.NodeDescriptor{NodeID: 1}
 	if cfg.NodeCapacityProvider == nil {
-		cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(stopper, stores, nil)
+		// Faster refresh intervals for testing.
+		cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(stopper, stores, load.NodeCapacityProviderConfig{
+			CPUUsageRefreshInterval:    10 * time.Millisecond,
+			CPUCapacityRefreshInterval: 10 * time.Millisecond,
+			CPUUsageMovingAverageAge:   20,
+		})
 	}
 
 	rangeProv := &dummyFirstRangeProvider{}

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -693,9 +693,9 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 
 	cpuUsageRefreshInterval := base.DefaultCPUUsageRefreshInterval
 	cpuCapacityRefreshInterval := base.DefaultCPUCapacityRefreshInterval
-	if ncpKnobs := cfg.TestingKnobs.NodeCapacityProviderKnobs; ncpKnobs != nil {
-		cpuUsageRefreshInterval = ncpKnobs.(*load.NodeCapacityProviderTestingKnobs).CpuUsageRefreshInterval
-		cpuCapacityRefreshInterval = ncpKnobs.(*load.NodeCapacityProviderTestingKnobs).CpuCapacityRefreshInterval
+	if ncpKnobs, _ := cfg.TestingKnobs.NodeCapacityProviderKnobs.(*load.NodeCapacityProviderTestingKnobs); ncpKnobs != nil {
+		cpuUsageRefreshInterval = ncpKnobs.CpuUsageRefreshInterval
+		cpuCapacityRefreshInterval = ncpKnobs.CpuCapacityRefreshInterval
 	}
 	nodeCapacityProviderConfig := load.NodeCapacityProviderConfig{
 		CPUUsageRefreshInterval:    cpuUsageRefreshInterval,

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -128,7 +128,7 @@ import (
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
-	sentry "github.com/getsentry/sentry-go"
+	"github.com/getsentry/sentry-go"
 	"google.golang.org/grpc/codes"
 )
 

--- a/pkg/testutils/localtestcluster/local_test_cluster.go
+++ b/pkg/testutils/localtestcluster/local_test_cluster.go
@@ -167,7 +167,12 @@ func (ltc *LocalTestCluster) Start(t testing.TB, initFactory InitFactoryFn) {
 	ltc.stopper.AddCloser(ltc.Eng)
 
 	ltc.Stores = kvserver.NewStores(ambient, ltc.Clock)
-	cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(ltc.stopper, ltc.Stores, nil /*knobs*/)
+	// Faster refresh intervals for testing.
+	cfg.NodeCapacityProvider = load.NewNodeCapacityProvider(ltc.stopper, ltc.Stores, load.NodeCapacityProviderConfig{
+		CPUUsageRefreshInterval:    10 * time.Millisecond,
+		CPUCapacityRefreshInterval: 10 * time.Millisecond,
+		CPUUsageMovingAverageAge:   20,
+	})
 
 	factory := initFactory(ctx, cfg.Settings, nodeDesc, ltc.stopper.Tracer(), ltc.Clock, ltc.Latency, ltc.Stores, ltc.stopper, ltc.Gossip)
 


### PR DESCRIPTION
Previously, NewNodeCapacityProvider took NodeCapacityProviderTestingKnobs
directly and handled the logic for picking refresh intervals internally. This
wasn't ideal, as it is preferred for configuration to be handled by the caller,
keeping NewNodeCapacityProvider focused on its core logic. This change moves
that logic to the caller, which now constructs the config with the appropriate
interval values. The default setting is now also closer to the server
configuration in pkg/base/config.go.

Epic: none
Release note: none