### PR TITLE
cli(debug.zip): improve tsdump upload speed

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1617,6 +1617,7 @@ func init() {
 	f.StringVar(&debugTimeSeriesDumpOpts.userName, "user-name", "", "name of the user to perform datadog upload")
 	f.StringVar(&debugTimeSeriesDumpOpts.storeToNodeMapYAMLFile, "store-to-node-map-file", "", "yaml file path which contains the mapping of store ID to node ID for datadog upload.")
 	f.BoolVar(&debugTimeSeriesDumpOpts.dryRun, "dry-run", false, "run in dry-run mode without making any actual uploads")
+	f.IntVar(&debugTimeSeriesDumpOpts.noOfUploadWorkers, "upload-workers", 50, "number of workers to upload the time series data in parallel")
 
 	f = debugSendKVBatchCmd.Flags()
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,

--- a/pkg/cli/tsdump.go
+++ b/pkg/cli/tsdump.go
@@ -52,6 +52,7 @@ var debugTimeSeriesDumpOpts = struct {
 	userName               string
 	storeToNodeMapYAMLFile string
 	dryRun                 bool
+	noOfUploadWorkers      int
 }{
 	format:       tsDumpText,
 	from:         timestampValue{},
@@ -121,6 +122,7 @@ will then convert it to the --format requested in the current invocation.
 				debugTimeSeriesDumpOpts.ddApiKey,
 				100,
 				hostNameOverride,
+				debugTimeSeriesDumpOpts.noOfUploadWorkers,
 			)
 			if err != nil {
 				return err

--- a/pkg/cli/tsdump_test.go
+++ b/pkg/cli/tsdump_test.go
@@ -216,11 +216,12 @@ func TestTsDumpFormatsDataDriven(t *testing.T) {
 				debugTimeSeriesDumpOpts.zendeskTicket = "zd-test"
 				debugTimeSeriesDumpOpts.organizationName = "test-org"
 				debugTimeSeriesDumpOpts.userName = "test-user"
+				debugTimeSeriesDumpOpts.noOfUploadWorkers = 50
 				var series int
 				d.ScanArgs(t, "series-threshold", &series)
 				var ddwriter, err = makeDatadogWriter(
 					defaultDDSite, d.Cmd == "format-datadog-init", "api-key", series,
-					server.Listener.Addr().String(),
+					server.Listener.Addr().String(), debugTimeSeriesDumpOpts.noOfUploadWorkers,
 				)
 				require.NoError(t, err)
 


### PR DESCRIPTION
Previously, tsdump upload to Datadog was taking more time compare to stage tsdump in roachprod. This was inadequate because it would increase the  MTTD (Mean Time To Detect) an issue. This change introduces `upload-workers` as flag to set the number of Datadog upload workers. The default value is 50. This change includes the changes around the retry configuration to further improve performance.

Epic: None
Part of: CRDB-52094
Release note: None

-----
tsdump size: 11.19GB

roachprod upload time:
<img width="980" height="77" alt="Screenshot 2025-07-17 at 12 04 01 PM" src="https://github.com/user-attachments/assets/718d5f2b-142e-438c-9008-6739295e6930" />

Tsdump upload time (before changes):
<img width="904" height="17" alt="Screenshot 2025-07-17 at 11 52 37 AM" src="https://github.com/user-attachments/assets/9b844a58-7b5b-4e67-bad0-142f6c37673b" />

Tsdump upload time with default(after changes):
<img width="903" height="20" alt="Screenshot 2025-07-17 at 11 51 34 AM" src="https://github.com/user-attachments/assets/e6556e2a-d9bd-411b-acd1-591cc9971784" />
