### PR TITLE
kvcoord,kvserver: add a few more trace lines

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1223,6 +1223,8 @@ func (ds *DistSender) Send(
 	ctx, sp := tracing.ChildSpan(ctx, "dist sender send")
 	defer sp.Finish()
 
+	log.Eventf(ctx, "sending batch %s", ba)
+
 	// Send proxy requests directly through the transport. Any errors are
 	// encoded in the response.
 	if ba.ProxyRangeInfo != nil {
@@ -1246,9 +1248,13 @@ func (ds *DistSender) Send(
 	rplChunks := singleRplChunk[:0:1]
 
 	onePart := len(parts) == 1
+	if !onePart {
+		log.Eventf(ctx, "batch split into %d parts by (*kvpb.BatchRequest).Split with splitET=%v", len(parts), splitET)
+	}
 	errIdxOffset := 0
 	for len(parts) > 0 {
 		if !onePart {
+			log.Eventf(ctx, "sending batch %s", ba)
 			ba = ba.ShallowCopy()
 			ba.Requests = parts[0]
 		}

--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -547,6 +547,8 @@ func (tc *TxnCoordSender) Send(
 		}
 	}
 
+	log.Eventf(ctx, "coordinating batch %s", ba)
+
 	// It doesn't make sense to use inconsistent reads in a transaction. However,
 	// we still need to accept it as a parameter for this to compile.
 	if ba.ReadConsistency != kvpb.CONSISTENT {

--- a/pkg/kv/kvserver/replica_raft.go
+++ b/pkg/kv/kvserver/replica_raft.go
@@ -196,6 +196,8 @@ func (r *Replica) evalAndPropose(
 	maybeFinishSpan := func() {}
 	defer func() { maybeFinishSpan() }() // NB: late binding is important
 	if ba.AsyncConsensus {
+		log.VEventf(proposal.Context(), 2, "performing consensus asynchronously")
+
 		if ets := proposal.Local.DetachEndTxns(false /* alwaysOnly */); len(ets) != 0 {
 			// Disallow async consensus for commands with EndTxnIntents because
 			// any !Always EndTxnIntent can't be cleaned up until after the
@@ -231,6 +233,8 @@ func (r *Replica) evalAndPropose(
 		proposal.signalProposalResult(pr)
 
 		// Continue with proposal...
+	} else {
+		log.VEventf(proposal.Context(), 2, "performing consensus synchronously")
 	}
 
 	if meta := kvflowcontrol.MetaFromContext(ctx); meta != nil {


### PR DESCRIPTION
This adds a few new trace events:

- Make it clear whether a batch used async consensus or not. Currently, when reading a trace you have to just sort of know which log entries are missing when async consensus is used.

- Log the batch that the kv client handed to the coord sender. This log line may be a bit redundant for SQL-initiated transactions, but it seems like it would be helpful when debugging KVNemesis.

- Log the batch that the coord sender is handing to distsender. This batch may be substantively different than the original batch that was handed to the coord sender.

Informs #150304

Release note: None