### PR TITLE
kvcoord: make GetRequest transforms configurable 

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -31,6 +31,7 @@ func makeMockTxnWriteBuffer(
 ) (txnWriteBuffer, *mockLockedSender, *cluster.Settings) {
 	st := cluster.MakeClusterSettings()
 	bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
+	bufferedWritesGetTransformEnabled.Override(ctx, &st.SV, true)
 	bufferedWritesMaxBufferSize.Override(ctx, &st.SV, defaultBufferSize)
 
 	var metrics TxnMetrics
@@ -1406,6 +1407,12 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	txn.Sequence = 10
 	keyA := roachpb.Key("a")
 	keyB := roachpb.Key("b")
+	cfg := transformConfig{
+		transformScans: true,
+		transformGets:  true,
+	}
+	noScanCfg := cfg
+	noScanCfg.transformScans = false
 
 	valAStr := "valA"
 	valA := roachpb.MakeValueFromString(valAStr)
@@ -1419,7 +1426,7 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	ba.Add(putA)
 
 	expectedUnlockedPutSize := int64(len(keyA)+len(valA.RawBytes)) + bufferedWriteStructOverhead + bufferedValueStructOverhead
-	require.Equal(t, expectedUnlockedPutSize, twb.estimateSize(ba, true))
+	require.Equal(t, expectedUnlockedPutSize, twb.estimateSize(ba, cfg))
 
 	ba = &kvpb.BatchRequest{}
 	ba.Header = kvpb.Header{Txn: &txn}
@@ -1427,7 +1434,7 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	putA.MustAcquireExclusiveLock = true
 	ba.Add(putA)
 
-	require.Equal(t, expectedUnlockedPutSize+lockKeyInfoSize, twb.estimateSize(ba, true))
+	require.Equal(t, expectedUnlockedPutSize+lockKeyInfoSize, twb.estimateSize(ba, cfg))
 
 	ba = &kvpb.BatchRequest{}
 	cputLarge := cputArgs(keyLarge, valLargeStr, "", txn.Sequence)
@@ -1435,7 +1442,7 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 
 	require.Equal(t,
 		int64(len(keyLarge)+len(valLarge.RawBytes))+bufferedWriteStructOverhead+bufferedValueStructOverhead+lockKeyInfoSize,
-		twb.estimateSize(ba, true),
+		twb.estimateSize(ba, cfg),
 	)
 
 	ba = &kvpb.BatchRequest{}
@@ -1445,14 +1452,14 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	// NB: note that we're overcounting here, as we're deleting a key that's
 	// already present in the buffer. But that's what estimating is about.
 	expectedUnlockedDelSize := int64(len(keyA)) + bufferedWriteStructOverhead + bufferedValueStructOverhead
-	require.Equal(t, expectedUnlockedDelSize, twb.estimateSize(ba, true))
+	require.Equal(t, expectedUnlockedDelSize, twb.estimateSize(ba, cfg))
 
 	ba = &kvpb.BatchRequest{}
 	delA = delArgs(keyA, txn.Sequence)
 	delA.MustAcquireExclusiveLock = true
 	ba.Add(delA)
 
-	require.Equal(t, expectedUnlockedDelSize+lockKeyInfoSize, twb.estimateSize(ba, true))
+	require.Equal(t, expectedUnlockedDelSize+lockKeyInfoSize, twb.estimateSize(ba, cfg))
 
 	ba = &kvpb.BatchRequest{}
 	ba.Add(&kvpb.ScanRequest{
@@ -1462,8 +1469,8 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	})
 
 	expectedLockedScanSize := int64(len(keyA)) + bufferedWriteStructOverhead + bufferedValueStructOverhead + lockKeyInfoSize
-	require.Equal(t, expectedLockedScanSize, twb.estimateSize(ba, true))
-	require.Equal(t, int64(0), twb.estimateSize(ba, false))
+	require.Equal(t, expectedLockedScanSize, twb.estimateSize(ba, cfg))
+	require.Equal(t, int64(0), twb.estimateSize(ba, noScanCfg))
 
 	ba = &kvpb.BatchRequest{}
 	ba.Add(&kvpb.ReverseScanRequest{
@@ -1473,8 +1480,8 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	})
 
 	expectedLockedRScanSize := int64(len(keyA)) + bufferedWriteStructOverhead + bufferedValueStructOverhead + lockKeyInfoSize
-	require.Equal(t, expectedLockedRScanSize, twb.estimateSize(ba, true))
-	require.Equal(t, int64(0), twb.estimateSize(ba, false))
+	require.Equal(t, expectedLockedRScanSize, twb.estimateSize(ba, cfg))
+	require.Equal(t, int64(0), twb.estimateSize(ba, noScanCfg))
 
 	ba = &kvpb.BatchRequest{}
 	ba.Add(&kvpb.ScanRequest{
@@ -1482,7 +1489,7 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 		KeyLockingDurability: lock.Unreplicated,
 		RequestHeader:        kvpb.RequestHeader{Key: keyA, EndKey: keyB, Sequence: txn.Sequence},
 	})
-	require.Equal(t, int64(0), twb.estimateSize(ba, true))
+	require.Equal(t, int64(0), twb.estimateSize(ba, cfg))
 
 	ba = &kvpb.BatchRequest{}
 	ba.Add(&kvpb.ReverseScanRequest{
@@ -1490,7 +1497,7 @@ func TestTxnWriteBufferEstimateSize(t *testing.T) {
 		KeyLockingDurability: lock.Unreplicated,
 		RequestHeader:        kvpb.RequestHeader{Key: keyA, EndKey: keyB, Sequence: txn.Sequence},
 	})
-	require.Equal(t, int64(0), twb.estimateSize(ba, true))
+	require.Equal(t, int64(0), twb.estimateSize(ba, cfg))
 }
 
 // TestTxnWriteBufferFlushesWhenOverBudget verifies that the txnWriteBuffer


### PR DESCRIPTION
Making this metamorphic might help us discover other edge cases. Also,
it gives us the option to flip this off by default on 25.3 if we choose
to.

Release note: None

Epic: none