### PR TITLE
sql: fix super region placement in 3-region database with secondary region

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
+++ b/pkg/ccl/logictestccl/testdata/logic_test/secondary_region
@@ -202,6 +202,24 @@ DATABASE db  ALTER DATABASE db CONFIGURE ZONE USING
                voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
+# All of the table zone configs are the result of an implicit super region. To
+# help make sense of those, dump out the current primary and secondary regions
+# in the database.
+query TT
+SELECT
+  region,
+  CASE
+    WHEN "primary" THEN 'primary'
+    WHEN "secondary" THEN 'secondary'
+    ELSE 'other'
+  END AS role
+FROM [SHOW REGIONS FROM DATABASE db]
+ORDER BY region;
+----
+ap-southeast-2  primary
+ca-central-1    secondary
+us-east-1       other
+
 # Verify that the zone configuration on the table is expected.
 query TT
 SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_primary
@@ -212,7 +230,7 @@ TABLE db.public.rbt_in_primary  ALTER TABLE db.public.rbt_in_primary CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                   lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -225,7 +243,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -252,7 +270,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                 voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                                 lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -265,7 +283,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -312,7 +330,7 @@ TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE Z
                                   gc.ttlseconds = 14400,
                                   num_replicas = 5,
                                   num_voters = 5,
-                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                   voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                   lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -339,7 +357,7 @@ PARTITION "us-east-1" OF TABLE db.public.rbr  ALTER PARTITION "us-east-1" OF TAB
                                                 gc.ttlseconds = 14400,
                                                 num_replicas = 5,
                                                 num_voters = 5,
-                                                constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                                constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                 voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
                                                 lease_preferences = '[[+region=us-east-1], [+region=ca-central-1]]'
 
@@ -352,7 +370,7 @@ PARTITION "ap-southeast-2" OF TABLE db.public.rbr  ALTER PARTITION "ap-southeast
                                                      gc.ttlseconds = 14400,
                                                      num_replicas = 5,
                                                      num_voters = 5,
-                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 2, +region=us-east-1: 1}',
+                                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
                                                      voter_constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 2}',
                                                      lease_preferences = '[[+region=ap-southeast-2], [+region=ca-central-1]]'
 
@@ -427,6 +445,98 @@ PARTITION "ca-central-1" OF TABLE db.public.rbr  ALTER PARTITION "ca-central-1" 
                                                    voter_constraints = '{+region=ca-central-1: 2}',
                                                    lease_preferences = '[[+region=ca-central-1]]'
 
+# Ensure that the implicit super region is updated now that the secondary region
+# was dropped. We will dump the regions and role so that we can more easily
+# understand the table zone configs that follow.
+query TT
+SELECT
+  region,
+  CASE
+    WHEN "primary" THEN 'primary'
+    WHEN "secondary" THEN 'secondary'
+    ELSE 'other'
+  END AS role
+FROM [SHOW REGIONS FROM DATABASE db]
+ORDER BY region;
+----
+ap-southeast-2  primary
+ca-central-1    other
+us-east-1       other
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
+----
+TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE ZONE USING
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=us-east-1: 2}',
+                                  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_ca_central
+----
+TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFIGURE ZONE USING
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     num_replicas = 5,
+                                     num_voters = 5,
+                                     constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '{+region=ca-central-1: 2}',
+                                     lease_preferences = '[[+region=ca-central-1]]'
+
+# Add a different secondary to confirm zone config adjusts based on the secondary.
+statement ok
+ALTER DATABASE db SET SECONDARY REGION "us-east-1"
+
+# Dump the regions and role so that we can understand table zone configs easier.
+query TT
+SELECT
+  region,
+  CASE
+    WHEN "primary" THEN 'primary'
+    WHEN "secondary" THEN 'secondary'
+    ELSE 'other'
+  END AS role
+FROM [SHOW REGIONS FROM DATABASE db]
+ORDER BY region;
+----
+ap-southeast-2  primary
+ca-central-1    other
+us-east-1       secondary
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_us_east
+----
+TABLE db.public.rbt_in_us_east  ALTER TABLE db.public.rbt_in_us_east CONFIGURE ZONE USING
+                                  range_min_bytes = 134217728,
+                                  range_max_bytes = 536870912,
+                                  gc.ttlseconds = 14400,
+                                  num_replicas = 5,
+                                  num_voters = 5,
+                                  constraints = '{+region=ap-southeast-2: 2, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                  voter_constraints = '{+region=us-east-1: 2}',
+                                  lease_preferences = '[[+region=us-east-1]]'
+
+query TT
+SHOW ZONE CONFIGURATION FOR TABLE db.rbt_in_ca_central
+----
+TABLE db.public.rbt_in_ca_central  ALTER TABLE db.public.rbt_in_ca_central CONFIGURE ZONE USING
+                                     range_min_bytes = 134217728,
+                                     range_max_bytes = 536870912,
+                                     gc.ttlseconds = 14400,
+                                     num_replicas = 5,
+                                     num_voters = 5,
+                                     constraints = '{+region=ap-southeast-2: 1, +region=ca-central-1: 1, +region=us-east-1: 1}',
+                                     voter_constraints = '{+region=ca-central-1: 2, +region=us-east-1: 2}',
+                                     lease_preferences = '[[+region=ca-central-1], [+region=us-east-1]]'
+
+statement ok
+ALTER DATABASE db DROP SECONDARY REGION
 
 # Verify super region interactions
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/super_regions
+++ b/pkg/ccl/logictestccl/testdata/logic_test/super_regions
@@ -559,6 +559,26 @@ ALTER DATABASE mr3 SURVIVE REGION FAILURE;
 statement error pq: super region r1 only has 2 region\(s\): at least 3 regions are required for surviving a region failure
 ALTER DATABASE mr3 ADD SUPER REGION "r1" VALUES "us-west-1", "us-central-1";
 
+# All of the table zone configs are easier to understand once we know what the
+# primary/secondary regions are. Dump them to make it easier to understand the
+# resulting table zone configs.
+query TT
+SELECT
+  region,
+  CASE
+    WHEN "primary" THEN 'primary'
+    WHEN "secondary" THEN 'secondary'
+    ELSE 'other'
+  END AS role
+FROM [SHOW REGIONS FROM DATABASE mr3]
+ORDER BY region;
+----
+ap-southeast-2  other
+ca-central-1    other
+us-central-1    other
+us-east-1       primary
+us-west-1       other
+
 # In the case where we have 3 regions within the super region under
 # survive region failure mode, the first non-primary region constraint should
 # have 2 replicas, this is so all replicas are accounted for.


### PR DESCRIPTION
When a super region was added to a 3-region database configured for region survivability, we applied zone constraints to ensure all 5 replicas were confined to the 3 defined regions. This was intended to prevent the super region from including any region outside the database.

However, the logic mishandled secondary regions. Both the primary and secondary regions receive 2 voter replicas. The zone config logic then incorrectly added 2 more replicas to an arbitrary non-primary region, regardless of whether it was already the secondary.

This resulted in an invalid configuration: 2 replicas in the primary, 2 in the secondary, and 2 in another region. This totals 6 replicas, which exceeds the allowed maximum of 5.

The fix ensures that the secondary region is correctly accounted for when setting constraints.

Fixes #150361
Release note (bug fix): Fixed invalid zone configurations when adding a super region to a 3-region database with a secondary region and region survivability. Previously, this could result in assigning more than the allowed number of replicas.