### PR TITLE
release: add support for s390x in custom release signing script

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign-custom-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign-custom-release.sh
@@ -53,7 +53,7 @@ log_into_gcloud
 mkdir -p artifacts
 cd artifacts
 
-for platform in linux-amd64 linux-arm64; do
+for platform in linux-amd64 linux-arm64 linux-s390x; do
   tarball=${cockroach_archive_prefix}-${version}.${platform}.tgz
 
   gsutil cp "gs://$gcs_staged_bucket/$tarball" "$tarball"

--- a/build/teamcity/internal/release/process/build-cockroach-release-linux-s390x-no-telemetry.sh
+++ b/build/teamcity/internal/release/process/build-cockroach-release-linux-s390x-no-telemetry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright 2025 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+PLATFORM=linux-s390x TELEMETRY_DISABLED=true ./build/teamcity/internal/release/process/build-cockroach-release-per-platform.sh


### PR DESCRIPTION
This commit adds support for the s390x architecture in the custom release signing script and introduces a new script to build CockroachDB releases for the s390x platform without telemetry.

Release note: none
Epic: none