### PR TITLE
release-25.3: builtins: fix `pg_collation_for` for CITEXT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/citext
+++ b/pkg/sql/logictest/testdata/logic_test/citext
@@ -214,3 +214,8 @@ query T
 SELECT cast('test'::TEXT AS CITEXT);
 ----
 test
+
+query T
+SELECT pg_collation_for('foo'::CITEXT);
+----
+"default"


### PR DESCRIPTION
Backport 1/1 commits from #150387 on behalf of @yuzefovich.

----

We missed a spot where we need to unwrap the DOidWrapper corresponding to DCIText.

Fixes: #150386.

Release note: None

----

Release justification: bug fix.