### PR TITLE
release-25.3: valueside: fix missing support for CITEXT

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/citext
+++ b/pkg/sql/logictest/testdata/logic_test/citext
@@ -79,6 +79,84 @@ SELECT c FROM r WHERE c = ARRAY['tEsT', 'tEsTeR']::CITEXT[];
 ----
 {test,TESTER}
 
+subtest column_families
+
+statement ok
+DROP TABLE IF EXISTS t;
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  c CITEXT,
+  FAMILY (k),
+  FAMILY (c)
+)
+
+onlyif config schema-locked-disabled
+query TT colnames
+SHOW CREATE TABLE t
+----
+table_name  create_statement
+t           CREATE TABLE public.t (
+              k INT8 NOT NULL,
+              c CITEXT NULL,
+              CONSTRAINT t_pkey PRIMARY KEY (k ASC),
+              FAMILY fam_0_k (k),
+              FAMILY fam_1_c (c)
+            );
+
+statement ok
+INSERT INTO t VALUES (1, 'test')
+
+query T
+SELECT pg_typeof(c) FROM t LIMIT 1;
+----
+citext
+
+query T
+SELECT c FROM t WHERE c = 'tEsT';
+----
+test
+
+statement ok
+DROP TABLE IF EXISTS r;
+
+statement ok
+CREATE TABLE r (
+  k INT PRIMARY KEY,
+  c CITEXT[],
+  FAMILY (k),
+  FAMILY (c)
+)
+
+onlyif config schema-locked-disabled
+query TT colnames
+SHOW CREATE TABLE r
+----
+table_name  create_statement
+r           CREATE TABLE public.r (
+              k INT8 NOT NULL,
+              c CITEXT[] NULL,
+              CONSTRAINT r_pkey PRIMARY KEY (k ASC),
+              FAMILY fam_0_k (k),
+              FAMILY fam_1_c (c)
+            );
+
+statement ok
+INSERT INTO r VALUES (1, ARRAY['test', 'TESTER'])
+
+query T
+SELECT pg_typeof(c) FROM r LIMIT 1;
+----
+citext[]
+
+query T
+SELECT c FROM r WHERE c = ARRAY['tEsT', 'tEsTeR']::CITEXT[];
+----
+{test,TESTER}
+
+subtest end
+
 query error multiple COLLATE declarations
 CREATE TABLE s (c CITEXT COLLATE "en_US");
 
@@ -191,10 +269,10 @@ statement ok
 CREATE TYPE IF NOT EXISTS ctype AS (id INT, c CITEXT);
 
 statement ok
-CREATE TABLE composite_citext_tbl (a ctype);
+CREATE TABLE composite_citext_tbl (k INT PRIMARY KEY, a ctype);
 
 statement ok
-INSERT INTO composite_citext_tbl VALUES (ROW(1, 'TeSt')), (ROW(2, 'TESTER')), (ROW(3, 'tEsT'));
+INSERT INTO composite_citext_tbl VALUES (1, ROW(1, 'TeSt')), (2, ROW(2, 'TESTER')), (3, ROW(3, 'tEsT'));
 
 query T
 SELECT (a).c FROM composite_citext_tbl WHERE (a).c = 'test' ORDER BY (a).id;


### PR DESCRIPTION
Backport 1/1 commits from #150391 on behalf of @yuzefovich.

----

We forgot to add support for CITEXT in MarshalLegacy value encoding. We forgot to add support for CITEXT in MarshalLegacy value encoding. (This encoding type is used when multiple column families are present, and the CITEXT is included not in the zeroth column family.)

No stable release with this bug, so we omit the release note.

Fixes: #150389.
Release none: None

----

Release justification: bug fix.