### PR TITLE
sql: use timeout when populating estimated_last_login_time

### DIFF
--- a/pkg/ccl/multiregionccl/cold_start_latency_test.go
+++ b/pkg/ccl/multiregionccl/cold_start_latency_test.go
@@ -47,7 +47,6 @@ func TestColdStartLatency(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	skip.UnderDuress(t, "too slow")
-	skip.WithIssue(t, 150251, "skipping as timeout settings causes #150105 to fail")
 	// We'll need to make some per-node args to assign the different
 	// KV nodes to different regions and AZs. We'll want to do it to
 	// look somewhat like the real cluster topologies we have in mind.


### PR DESCRIPTION
In a multiregion multitenant cluster, updating the column can be slow enough to the point of preventing other login attempts from succeeding.

We use a fixed timeout since we don't need to guarantee that this column always gets updated, and it's more important to ensure that logins are not disrupted.

fixes https://github.com/cockroachdb/cockroach/issues/150417
fixes https://github.com/cockroachdb/cockroach/issues/150251
Release note: None