### PR TITLE
release-25.3: roachtest: fix nodejs install helper function

### DIFF
--- a/pkg/cmd/roachtest/tests/javascript_helpers.go
+++ b/pkg/cmd/roachtest/tests/javascript_helpers.go
@@ -35,9 +35,9 @@ func installNode18(
 	if err := c.RunE(
 		ctx, option.WithNodes(node), `
 sudo npm i -g npm && \
-sudo find /usr/local/lib/node_modules/npm -type d -exec chmod 755 {} && \
-sudo find /usr/local/lib/node_modules/npm -type f -exec chmod 644 {} && \
-sudo find /usr/local/lib/node_modules/npm/bin -type f -exec chmod 755 {}
+sudo find /usr/local/lib/node_modules/npm -type d -exec chmod 755 {} \; && \
+sudo find /usr/local/lib/node_modules/npm -type f -exec chmod 644 {} \; && \
+sudo find /usr/local/lib/node_modules/npm/bin -type f -exec chmod 755 {} \;
 `,
 	); err != nil {
 


### PR DESCRIPTION
Backport 1/1 commits from #150415 on behalf of @rafiss.

----

The -exec action in find requires a terminating semicolon (`\;`) to indicate the end of the command. Without it, find doesn't know when the command ends, so this instalation check could fail.

fixes https://github.com/cockroachdb/cockroach/issues/150322
follow up from #150191
Release note: None

----

Release justification: test only change