### PR TITLE
opt: address minor test nits from a recent change

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -3621,23 +3621,6 @@ vectorized: true
           table: xyz@xyz_id2_str_abc_id_idx
           spans: /"@"/"h\b\x87\x06\x02\xc6Gѹ\x93\xa4!\xcdv\x1f+"-/"@"/"h\b\x87\x06\x02\xc6Gѹ\x93\xa4!\xcdv\x1f+"/PrefixEnd
 
-# Same query as above but ensure that the "average lookup ratio" parallelization
-# heuristic applies to the SELECT statement (both the index join and the lookup
-# join should be parallelized).
-statement ok
-SET parallelize_multi_key_lookup_joins_only_on_mr_mutations = false;
-
-query I
-SELECT count(*) FROM [
-  EXPLAIN (VERBOSE) SELECT xyz.str, abc.id, abc.id1, abc.id2, abc.created_at, abc.updated_at FROM abc JOIN xyz ON xyz.abc_id = abc.id AND xyz.id2 = abc.id2 AND xyz.crdb_region = abc.crdb_region WHERE abc.id1 = '6da4f356-e526-4b78-b9f9-bbb1a7fc12d6' AND abc.id2 = '68088706-02c6-47d1-b993-a421cd761f2b' AND abc.crdb_region = 'ap-southeast-2' AND xyz.crdb_region = 'ap-southeast-2'
-] WHERE info LIKE '%parallel%';
-----
-1
-
-statement ok
-RESET parallelize_multi_key_lookup_joins_only_on_mr_mutations;
-
-# The following should use a string of 4 lookup/index joins with a cost under 200.
 query T retry
 EXPLAIN(opt,verbose) SELECT
   x.str,

--- a/pkg/sql/opt/xform/optimizer_test.go
+++ b/pkg/sql/opt/xform/optimizer_test.go
@@ -137,8 +137,8 @@ func TestCoster(t *testing.T) {
 
 // TestPhysicalProps files can be run separately like this:
 //
-//	./dev test pkg/sql/opt/xform -f TestPhysicalPropsFactory/ordering
-//	./dev test pkg/sql/opt/xform -f TestPhysicalPropsFactory/presentation
+//	./dev test pkg/sql/opt/xform -f TestPhysicalProps/ordering
+//	./dev test pkg/sql/opt/xform -f TestPhysicalProps/presentation
 //	...
 func TestPhysicalProps(t *testing.T) {
 	defer leaktest.AfterTest(t)()

--- a/pkg/sql/opt/xform/testdata/physprops/ordering
+++ b/pkg/sql/opt/xform/testdata/physprops/ordering
@@ -3081,6 +3081,9 @@ CREATE TABLE table87806 (
 );
 ----
 
+# Note that this query no longer reproduces #87806 even when getting the same
+# plan as the one we had when the test case was introduced (it requires setting
+# optimizer_min_row_count=0 as well as reverting #116132).
 opt format=hide-all disable=(EliminateJoinUnderProjectLeft,EliminateJoinUnderProjectRight)
 SELECT tab_171969.col1_3
 FROM table87806 AS tab_171967


### PR DESCRIPTION
Touches: #150376.

Epic: None
Release note: None