### PR TITLE
admission: replace GrantCoordinator with storeGrantCoordinator

### DIFF
--- a/pkg/util/admission/admission.go
+++ b/pkg/util/admission/admission.go
@@ -56,9 +56,7 @@
 //   across WorkKinds that is used to reflect their shared need for underlying
 //   resources.
 // - The top-level GrantCoordinator which coordinates grants across these
-//   WorkKinds. The WorkKinds handled by an instantiation of GrantCoordinator
-//   will differ for single-tenant clusters, and multi-tenant clusters
-//   consisting of (multi-tenant) KV nodes and (single-tenant) SQL nodes.
+//   WorkKinds, for CPU.
 //
 // The interfaces involved:
 // - requester: handles all requests for a particular WorkKind. Implemented by
@@ -75,8 +73,7 @@
 //   the lock in WorkQueue).
 // - cpuOverloadIndicator: this serves as an optional additional gate on
 //   granting, by providing an (ideally) instantaneous signal of cpu overload.
-//   The kvSlotAdjuster is the concrete implementation, except for SQL
-//   nodes, where this will be implemented by sqlNodeCPUOverloadIndicator.
+//   The kvSlotAdjuster is the concrete implementation.
 //   CPULoadListener is also implemented by these structs, to listen to
 //   the latest CPU load information from the scheduler.
 //
@@ -97,7 +94,7 @@
 // that is setup here.
 //
 
-// Partial usage example (regular cluster):
+// Partial usage example:
 //
 // var metricRegistry *metric.Registry = ...
 // coord, metrics := admission.NewGrantCoordinator(admission.Options{...})
@@ -217,16 +214,17 @@ type granter interface {
 }
 
 // granterWithLockedCalls is an encapsulation of typically one
-// granter-requester pair, and for kvStoreTokenGranter of two
-// granter-requester pairs (one for each workClass). It is used as an internal
+// granter-requester pair. It is used as an internal
 // implementation detail of the GrantCoordinator. An implementer of
 // granterWithLockedCalls responds to calls from its granter(s) by calling
 // into the GrantCoordinator, which then calls the various *Locked() methods.
 // The demuxHandle is meant to be opaque to the GrantCoordinator, and is used
 // when this interface encapsulates multiple granter-requester pairs -- it is
-// currently used only by kvStoreTokenGranter, where it is a workClass. The
+// currently unused and will be removed. The
 // *Locked() methods are where the differences in slots and various kinds of
 // tokens are handled.
+//
+// TODO(sumeer): remove the demuxHandle.
 type granterWithLockedCalls interface {
 	// tryGetLocked is the real implementation of tryGet from the granter
 	// interface. demuxHandle is an opaque handle that was passed into the

--- a/pkg/util/admission/testdata/store_granter
+++ b/pkg/util/admission/testdata/store_granter
@@ -3,52 +3,52 @@
 init-store-grant-coordinator
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
+ io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
 
 # Set tokens to a large value that permits all request sizes in this file.
 # Set elastic tokens to a large value that permits all request sizes.
 set-tokens io-tokens=100000 disk-write-tokens=100000 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 100000(100000), disk-write-tokens-avail: 100000, disk-read-tokens-deducted: 0
+ io-avail: 100000(100000), disk-write-tokens-avail: 100000, disk-read-tokens-deducted: 0
 
 # Initial tokens are effectively unlimited.
 try-get work=regular v=10000
 ----
 kv-regular: tryGet(10000) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 90000(90000), disk-write-tokens-avail: 90000, disk-read-tokens-deducted: 0
+ io-avail: 90000(90000), disk-write-tokens-avail: 90000, disk-read-tokens-deducted: 0
 
 # Set the io tokens to a smaller value.
 set-tokens io-tokens=500 disk-write-tokens=100000 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 500(500), disk-write-tokens-avail: 100000, disk-read-tokens-deducted: 0
+ io-avail: 500(500), disk-write-tokens-avail: 100000, disk-read-tokens-deducted: 0
 
 # Subtract 100 tokens for elastic work. Note that disk-write-tokens-avail also decreases by 100.
 took-without-permission work=elastic v=100
 ----
 kv-elastic: tookWithoutPermission(100)
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 400(400), disk-write-tokens-avail: 99900, disk-read-tokens-deducted: 0
+ io-avail: 400(400), disk-write-tokens-avail: 99900, disk-read-tokens-deducted: 0
 
 # Add 200 tokens.
 return-grant work=regular v=200
 ----
 kv-regular: returnGrant(200)
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 600(600), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
+ io-avail: 600(600), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
 
 # Setup waiting requests that want 400 tokens each.
 set-has-waiting-requests work=regular v=true
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 600(600), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
+ io-avail: 600(600), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
 
 set-return-value-from-granted work=regular v=400
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 600(600), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
+ io-avail: 600(600), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
 
 # Returning tokens triggers granting and 2 requests will be granted until the
 # tokens become <= 0.
@@ -58,25 +58,25 @@ kv-regular: returnGrant(100)
 kv-regular: granted in chain 0, and returning 400
 kv-regular: granted in chain 0, and returning 400
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -100(-100), disk-write-tokens-avail: 99400, disk-read-tokens-deducted: 0
+ io-avail: -100(-100), disk-write-tokens-avail: 99400, disk-read-tokens-deducted: 0
 
 set-return-value-from-granted work=regular v=100
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -100(-100), disk-write-tokens-avail: 99400, disk-read-tokens-deducted: 0
+ io-avail: -100(-100), disk-write-tokens-avail: 99400, disk-read-tokens-deducted: 0
 
 # No tokens to give.
 try-get work=regular
 ----
 kv-regular: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -100(-100), disk-write-tokens-avail: 99400, disk-read-tokens-deducted: 0
+ io-avail: -100(-100), disk-write-tokens-avail: 99400, disk-read-tokens-deducted: 0
 
 # Increment by 50 tokens.
 set-tokens io-tokens=50 disk-write-tokens=99900 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -50(-50), disk-write-tokens-avail: 99900, disk-read-tokens-deducted: 0
+ io-avail: -50(-50), disk-write-tokens-avail: 99900, disk-read-tokens-deducted: 0
 
 # Return another 50 tokens. Since the number of tokens is 0, there is no
 # grant.
@@ -84,7 +84,7 @@ return-grant work=regular v=50
 ----
 kv-regular: returnGrant(50)
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 0(0), disk-write-tokens-avail: 99950, disk-read-tokens-deducted: 0
+ io-avail: 0(0), disk-write-tokens-avail: 99950, disk-read-tokens-deducted: 0
 
 # As soon as the tokens > 0, it will grant.
 return-grant work=regular v=1
@@ -92,19 +92,19 @@ return-grant work=regular v=1
 kv-regular: returnGrant(1)
 kv-regular: granted in chain 0, and returning 100
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
 
 # Have waiting requests for kv-elastic too.
 set-has-waiting-requests work=elastic v=true
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
 
 # The kv-elastic waiting requests need 200 tokens each.
 set-return-value-from-granted work=elastic v=200
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
 
 # Since there are regular requests waiting, those are granted first.
 return-grant work=elastic v=400
@@ -115,66 +115,66 @@ kv-regular: granted in chain 0, and returning 100
 kv-regular: granted in chain 0, and returning 100
 kv-regular: granted in chain 0, and returning 100
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
 
 # No more regular requests waiting.
 set-has-waiting-requests work=regular v=false
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: 99851, disk-read-tokens-deducted: 0
 
 # kv-elastic is granted.
 set-tokens io-tokens=100 disk-write-tokens=100300 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -199(-199), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
+ io-avail: -199(-199), disk-write-tokens-avail: 100100, disk-read-tokens-deducted: 0
 
 # Nothing is granted.
 set-tokens io-tokens=0 disk-write-tokens=50 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -199(-199), disk-write-tokens-avail: 50, disk-read-tokens-deducted: 0
+ io-avail: -199(-199), disk-write-tokens-avail: 50, disk-read-tokens-deducted: 0
 
 # Both kinds of tokens are decremented and become negative.
 set-tokens io-tokens=200 disk-write-tokens=50 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -199(-199), disk-write-tokens-avail: -150, disk-read-tokens-deducted: 0
+ io-avail: -199(-199), disk-write-tokens-avail: -150, disk-read-tokens-deducted: 0
 
 # IO tokens become positive. But no grant to elastic work since
 # elastic-disk-bw tokens are negative.
 set-tokens io-tokens=300 disk-write-tokens=0 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 101(101), disk-write-tokens-avail: -150, disk-read-tokens-deducted: 0
+ io-avail: 101(101), disk-write-tokens-avail: -150, disk-read-tokens-deducted: 0
 
 # Regular kv work can get tokens.
 try-get work=regular v=10
 ----
 kv-regular: tryGet(10) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 91(91), disk-write-tokens-avail: -160, disk-read-tokens-deducted: 0
+ io-avail: 91(91), disk-write-tokens-avail: -160, disk-read-tokens-deducted: 0
 
 # Elastic kv work cannot get tokens.
 try-get work=elastic v=10
 ----
 kv-elastic: tryGet(10) returned false
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 91(91), disk-write-tokens-avail: -160, disk-read-tokens-deducted: 0
+ io-avail: 91(91), disk-write-tokens-avail: -160, disk-read-tokens-deducted: 0
 
 # Still negative. Add disk-write-tokens, but don't change io tokens.
 set-tokens io-tokens=91 disk-write-tokens=50 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 91(91), disk-write-tokens-avail: -110, disk-read-tokens-deducted: 0
+ io-avail: 91(91), disk-write-tokens-avail: -110, disk-read-tokens-deducted: 0
 
 # Add some io-tokens.
 set-tokens io-tokens=400 disk-write-tokens=0 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 400(400), disk-write-tokens-avail: -110, disk-read-tokens-deducted: 0
+ io-avail: 400(400), disk-write-tokens-avail: -110, disk-read-tokens-deducted: 0
 
 # Finally both tokens are positive and we grant until the elastic-disk-bw
 # tokens become negative.
@@ -182,7 +182,7 @@ set-tokens io-tokens=400 disk-write-tokens=120 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 200(200), disk-write-tokens-avail: -190, disk-read-tokens-deducted: 0
+ io-avail: 200(200), disk-write-tokens-avail: -190, disk-read-tokens-deducted: 0
 
 # Note that TestGranterBasic hard-codes the models to be 0.5x+50, so
 # 0.5*40+50=70. So 70-10=60 additional tokens are needed based on the write
@@ -192,12 +192,12 @@ GrantCoordinator:
 store-write-done work=elastic orig-tokens=10 write-bytes=40
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 90(90), disk-write-tokens-avail: -300, disk-read-tokens-deducted: 0
+ io-avail: 90(90), disk-write-tokens-avail: -300, disk-read-tokens-deducted: 0
 
 store-write-done work=regular orig-tokens=400 write-bytes=40
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 370(370), disk-write-tokens-avail: -20, disk-read-tokens-deducted: 0
+ io-avail: 370(370), disk-write-tokens-avail: -20, disk-read-tokens-deducted: 0
 
 # Both tokens become positive, since 280 tokens are returned, so 2 work items
 # are admitted until the tokens become negative.
@@ -206,33 +206,33 @@ store-write-done work=elastic orig-tokens=400 write-bytes=40
 kv-elastic: granted in chain 0, and returning 200
 kv-elastic: granted in chain 0, and returning 200
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 250(250), disk-write-tokens-avail: -140, disk-read-tokens-deducted: 0
+ io-avail: 250(250), disk-write-tokens-avail: -140, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=400 elastic-io-tokens=50 disk-write-tokens=120 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 400(50), disk-write-tokens-avail: -20, disk-read-tokens-deducted: 0
+ io-avail: 400(50), disk-write-tokens-avail: -20, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=elastic v=false
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 400(50), disk-write-tokens-avail: -20, disk-read-tokens-deducted: 0
+ io-avail: 400(50), disk-write-tokens-avail: -20, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=400 elastic-io-tokens=50 disk-write-tokens=120 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 400(50), disk-write-tokens-avail: 100, disk-read-tokens-deducted: 0
+ io-avail: 400(50), disk-write-tokens-avail: 100, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=400 elastic-io-tokens=101 disk-write-tokens=120 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 400(101), disk-write-tokens-avail: 120, disk-read-tokens-deducted: 0
+ io-avail: 400(101), disk-write-tokens-avail: 120, disk-read-tokens-deducted: 0
 
 try-get work=elastic v=10
 ----
 kv-elastic: tryGet(10) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 390(91), disk-write-tokens-avail: 110, disk-read-tokens-deducted: 0
+ io-avail: 390(91), disk-write-tokens-avail: 110, disk-read-tokens-deducted: 0
 
 #####################################################################
 # Test store grant coordinator with 1ms tick rates for set-tokens, and transitions
@@ -245,26 +245,26 @@ GrantCoordinator:
 init-store-grant-coordinator
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
+ io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
 
 # Tokens set to 250 * 10 = 2500.
 set-tokens io-tokens=10 disk-write-tokens=10 tick-interval=1
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
+ io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
 
 try-get work=elastic v=2490
 ----
 kv-elastic: tryGet(2490) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 10(10), disk-write-tokens-avail: 10, disk-read-tokens-deducted: 0
+ io-avail: 10(10), disk-write-tokens-avail: 10, disk-read-tokens-deducted: 0
 
 # Initial tokens are effectively unlimited.
 try-get work=regular v=1
 ----
 kv-regular: tryGet(1) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 9(9), disk-write-tokens-avail: 9, disk-read-tokens-deducted: 0
+ io-avail: 9(9), disk-write-tokens-avail: 9, disk-read-tokens-deducted: 0
 
 # Set the io tokens to a smaller value. Note that since the IO tokens can
 # increase up to 6*250 and 10*250, we expect the tokens to increase to 15, and
@@ -272,39 +272,39 @@ GrantCoordinator:
 set-tokens io-tokens=6 disk-write-tokens=10 tick-interval=1
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 15(15), disk-write-tokens-avail: 19, disk-read-tokens-deducted: 0
+ io-avail: 15(15), disk-write-tokens-avail: 19, disk-read-tokens-deducted: 0
 
 # Subtract 10 tokens for elastic work. Note that disk-write-tokens-avail also decreases by 10.
 took-without-permission work=elastic v=10
 ----
 kv-elastic: tookWithoutPermission(10)
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 5(5), disk-write-tokens-avail: 9, disk-read-tokens-deducted: 0
+ io-avail: 5(5), disk-write-tokens-avail: 9, disk-read-tokens-deducted: 0
 
 # Add 10 tokens.
 return-grant work=elastic v=10
 ----
 kv-elastic: returnGrant(10)
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 15(15), disk-write-tokens-avail: 19, disk-read-tokens-deducted: 0
+ io-avail: 15(15), disk-write-tokens-avail: 19, disk-read-tokens-deducted: 0
 
 # If io-tokens is 10, we expect the tokens to accumulate upto 2500. So, we call
 # set-tokens 250 times, and ensure that the tokens are capped at 2500.
 set-tokens-loop io-tokens=10 disk-write-tokens=10 loop=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
+ io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
 
 # Setup waiting requests that want 1300 tokens each.
 set-has-waiting-requests work=elastic v=true
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
+ io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
 
 set-return-value-from-granted work=elastic v=1300
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
+ io-avail: 2500(2500), disk-write-tokens-avail: 2500, disk-read-tokens-deducted: 0
 
 # Returning tokens triggers granting and 2 requests will be granted until the
 # tokens become <= 0.
@@ -314,32 +314,32 @@ kv-regular: returnGrant(1)
 kv-elastic: granted in chain 0, and returning 1300
 kv-elastic: granted in chain 0, and returning 1300
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
 
 # No tokens to give.
 try-get work=regular
 ----
 kv-regular: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=elastic v=false
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: -99(-99), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
+ io-avail: -99(-99), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
 
 # Negative tokens available should be respected on a subsequent call to set-tokens.
 set-tokens io-tokens=100 disk-write-tokens=0 tick-interval=1
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 1(1), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
+ io-avail: 1(1), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
 
 # No elastic tokens to give.
 try-get work=elastic
 ----
 kv-elastic: tryGet(1) returned false
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 1(1), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
+ io-avail: 1(1), disk-write-tokens-avail: -99, disk-read-tokens-deducted: 0
 
 # Switch to an unloaded system which ticks at a 250ms rate. With this interval,
 # we expect the available tokens to be at most 50, 110 respectively. We see the
@@ -347,57 +347,57 @@ GrantCoordinator:
 set-tokens io-tokens=50 disk-write-tokens=110 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 11, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 11, disk-read-tokens-deducted: 0
 
 #####################################################################
 # Test store grant coordinator with snapshot ingests
 init-store-grant-coordinator
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
+ io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=50 disk-write-tokens=110 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 110, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 110, disk-read-tokens-deducted: 0
 
 # Try get disk write tokens for snapshots.
 try-get work=snapshot v=50
 ----
 kv-snapshot: tryGet(50) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 # Set waiting requests for all store requesters. Then test priority ordering of grants.
 set-has-waiting-requests work=regular v=true
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 set-return-value-from-granted work=regular v=10
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=elastic v=true
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 set-return-value-from-granted work=elastic v=5
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=snapshot v=true
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 set-return-value-from-granted work=snapshot v=20
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 60, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=50 disk-write-tokens=10 tick-interval=250
 ----
@@ -407,59 +407,59 @@ kv-regular: granted in chain 0, and returning 10
 kv-regular: granted in chain 0, and returning 10
 kv-regular: granted in chain 0, and returning 10
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 0(0), disk-write-tokens-avail: -40, disk-read-tokens-deducted: 0
+ io-avail: 0(0), disk-write-tokens-avail: -40, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=regular v=false
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 0(0), disk-write-tokens-avail: -40, disk-read-tokens-deducted: 0
+ io-avail: 0(0), disk-write-tokens-avail: -40, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=50 disk-write-tokens=50 tick-interval=250
 ----
 kv-snapshot: granted in chain 0, and returning 20
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: -10, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: -10, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=snapshot v=false
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: -10, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: -10, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=10 disk-write-tokens=15 tick-interval=250
 ----
 kv-elastic: granted in chain 0, and returning 5
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 5(5), disk-write-tokens-avail: 0, disk-read-tokens-deducted: 0
+ io-avail: 5(5), disk-write-tokens-avail: 0, disk-read-tokens-deducted: 0
 
 set-has-waiting-requests work=elastic v=false
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 5(5), disk-write-tokens-avail: 0, disk-read-tokens-deducted: 0
+ io-avail: 5(5), disk-write-tokens-avail: 0, disk-read-tokens-deducted: 0
 
 # Return grant for snapshots, should only return disk tokens.
 return-grant work=snapshot v=20
 ----
 kv-snapshot: returnGrant(20)
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 5(5), disk-write-tokens-avail: 20, disk-read-tokens-deducted: 0
+ io-avail: 5(5), disk-write-tokens-avail: 20, disk-read-tokens-deducted: 0
 
 #####################################################################
 # Test store grant coordinator disk error accounting
 init-store-grant-coordinator
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
+ io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912930, disk-read-tokens-deducted: 0
 
 # Tokens already deducted is 0. Any writes that occur will be considered error.
 adjust-disk-error actual-write-bytes=10 actual-read-bytes=10
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912910, disk-read-tokens-deducted: 0
+ io-avail: 153722867280912930(153722867280912930), disk-write-tokens-avail: 153722867280912910, disk-read-tokens-deducted: 0
 
 set-tokens io-tokens=50 disk-write-tokens=70 disk-read-tokens=20 tick-interval=250
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 70, disk-read-tokens-deducted: 20
+ io-avail: 50(50), disk-write-tokens-avail: 70, disk-read-tokens-deducted: 20
 
 # Tokens already deducted is 0. Any writes that occur will be considered error.
 # We accounted for 20B of reads, so reads in excess of that will be error. The
@@ -469,13 +469,13 @@ GrantCoordinator:
 adjust-disk-error actual-write-bytes=20 actual-read-bytes=50
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 50(50), disk-write-tokens-avail: 40, disk-read-tokens-deducted: 0
+ io-avail: 50(50), disk-write-tokens-avail: 40, disk-read-tokens-deducted: 0
 
 try-get work=regular v=10
 ----
 kv-regular: tryGet(10) returned true
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 40(40), disk-write-tokens-avail: 30, disk-read-tokens-deducted: 0
+ io-avail: 40(40), disk-write-tokens-avail: 30, disk-read-tokens-deducted: 0
 
 # +20B writes and +5B reads since last error accounting. Since we already
 # deducted 10B of write tokens during admission, the error here is 10B. We
@@ -483,4 +483,4 @@ GrantCoordinator:
 adjust-disk-error actual-write-bytes=40 actual-read-bytes=55
 ----
 GrantCoordinator:
-(chain: id: 0 active: false index: 3) io-avail: 40(40), disk-write-tokens-avail: 15, disk-read-tokens-deducted: 0
+ io-avail: 40(40), disk-write-tokens-avail: 15, disk-read-tokens-deducted: 0


### PR DESCRIPTION
Almost all the functionality of GrantCoordinator was unused and the
unnecessary abstractions were confusing. Only the requester's
(behind storeRequester, and the kvStoreGranter.*Requester fields)
are now abstracted out for testing.

The confusing locking is replaced by kvStoreTokenGranter having
its own mutex. A few fields were erroneously not inside
kvStoreTokenGranter.coordMu (even though they were always accessed
using the mutex, so there wasn't a bug), and that is fixed too.

The testdata changes are only an elimination of the unnecessary
prefix related to grant chaining when printing the state of the
GrantCoordinator: there was never any grant chaining for the store
GrantCoordinator.

Epic: none

Release note: None
