### PR TITLE
release-25.3: upgradeccl: ensure multiple releases for TestTenantUpgradeFailure test

### DIFF
--- a/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
+++ b/pkg/ccl/kvccl/kvtenantccl/upgradeccl/tenant_upgrade_test.go
@@ -346,20 +346,21 @@ func TestTenantUpgradeFailure(t *testing.T) {
 
 	v0 := clusterversion.MinSupported.Version()
 	v2 := clusterversion.Latest.Version()
-	// v1 needs to be between v0 and v2. Set it to the minor release
-	// after v0 and before v2.
+	// v1 needs to be between v0 and v2. Set it to the first version with a
+	// different major/minor from v0.
 	var v1 roachpb.Version
 	for _, version := range clusterversion.ListBetween(v0, v2) {
-		if version.Minor != v0.Minor {
+		if version.Major != v0.Major && version.Minor != v0.Minor {
 			v1 = version
 			break
 		}
 	}
-	if v1 == (roachpb.Version{}) {
+	if v1 == (roachpb.Version{}) || v1 == v2 {
 		// There is no in-between version supported; skip this test.
 		skip.IgnoreLint(t, "test can only run when we support two previous releases")
 	}
 
+	t.Logf("v0=%s  v1=%s  v2=%s", v0, v1, v2)
 	t.Log("starting server")
 	ctx := context.Background()
 	settings := cluster.MakeTestingClusterSettingsWithVersions(


### PR DESCRIPTION
Backport 1/1 commits from #150436 on behalf of @celiala.

----

TestTenantUpgradeFailure can only run when we support more than one previous release. This PR ensures that we setup multple releases for this test.

This unblocks the PR needed to mint release-25.3:
https://github.com/cockroachdb/cockroach/pull/150211#issuecomment-3084826799
- Once 150436 is backported onto release-25.3, I'll remove https://github.com/cockroachdb/cockroach/pull/150211/commits/a38ea8fde36ee7845f1f36e5567716783cefb565 from https://github.com/cockroachdb/cockroach/pull/150211, and just rebase on top of this backported fix.



Epic: None
Release note: None
Release justification: test-only fix.

----

Release justification: