### PR TITLE
gssapiccl: revert "link with `keyutils` on `s390x`"

### DIFF
--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -413,18 +413,6 @@ config_setting(
     },
 )
 
-config_setting(
-    name = "is_dev_s390x",
-    constraint_values = [
-        "@io_bazel_rules_go//go/toolchain:linux",
-        "@platforms//cpu:s390x",
-    ],
-    flag_values = {
-        ":dev_flag": "true",
-        ":cross_flag": "false",
-    },
-)
-
 bool_flag(
     name = "force_build_cdeps_flag",
     build_setting_default = False,

--- a/pkg/ccl/gssapiccl/BUILD.bazel
+++ b/pkg/ccl/gssapiccl/BUILD.bazel
@@ -19,7 +19,6 @@ go_library(
         # NB: On Ubuntu, res_nsearch is found in the resolv_wrapper library,
         # found in the libresolv-wrapper package.
         "//build/toolchains:is_dev_linux": ["-ldl -lresolv -lresolv_wrapper"],
-        "//build/toolchains:is_dev_s390x": ["-ldl -lresolv -lresolv_wrapper -lkeyutils"],
         "@io_bazel_rules_go//go/platform:linux": ["-ldl -lresolv"],
         "//conditions:default": [],
     }),


### PR DESCRIPTION
This reverts commit fc34390a553cc825b710e6fe054264cd444212a5.

This turns out to not be necessary in the Docker container.

Epic: CRDB-21133
Release note: None