### PR TITLE
roachtest: bump upgrade timeout in jobs/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_jobs.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_jobs.go
@@ -42,7 +42,7 @@ func runJobsMixedVersions(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt := mixedversion.NewTest(
 		ctx, t, t.L(), c, c.All(),
 		mixedversion.NumUpgrades(2),
-		mixedversion.UpgradeTimeout(time.Minute*30),
+		mixedversion.UpgradeTimeout(time.Hour),
 		mixedversion.MinimumSupportedVersion("v24.3.0"),
 		mixedversion.AlwaysUseLatestPredecessors,
 		mixedversion.NeverUseFixtures,


### PR DESCRIPTION
We've seen a few runs of this roachtest time out even though the migration is happily chugging along. This patch bumps the timeout from 30 minutes to an hour.

Informs #146508
Informs #150104

Release note: none