### PR TITLE
tree: clean up DOidWrapper usage

### DIFF
--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -161,11 +161,11 @@ func maybeStartCompactionJob(
 		if err != nil {
 			return err
 		}
-		idDatum, ok := tree.AsDInt(datums[0])
+		idDatum, ok := datums[0].(*tree.DInt)
 		if !ok {
 			return errors.Newf("expected job ID: unexpected result type %T", datums[0])
 		}
-		jobID = jobspb.JobID(idDatum)
+		jobID = jobspb.JobID(*idDatum)
 
 		scheduledJob := jobs.ScheduledJobTxn(txn)
 		backupSchedule, args, err := getScheduledBackupExecutionArgsFromSchedule(

--- a/pkg/backup/schedule_exec.go
+++ b/pkg/backup/schedule_exec.go
@@ -544,12 +544,12 @@ func getBackupFnTelemetry(
 			return jobspb.BackupDetails{}, errors.New("expected job ID as first column of result")
 		}
 
-		jobID, ok := tree.AsDInt(jobIDDatum)
+		jobID, ok := jobIDDatum.(*tree.DInt)
 		if !ok {
 			return jobspb.BackupDetails{}, errors.New("expected job ID as first column of result")
 		}
 
-		job, err := registry.LoadJobWithTxn(ctx, jobspb.JobID(jobID), txn)
+		job, err := registry.LoadJobWithTxn(ctx, jobspb.JobID(*jobID), txn)
 		if err != nil {
 			return jobspb.BackupDetails{}, errors.Wrap(err, "failed to load dry-run backup job")
 		}

--- a/pkg/ccl/changefeedccl/avro/avro.go
+++ b/pkg/ccl/changefeedccl/avro/avro.go
@@ -450,7 +450,11 @@ func typeToSchema(typ *types.T) (*SchemaField, error) {
 		setNullable(
 			SchemaTypeString,
 			func(d tree.Datum, _ interface{}) (interface{}, error) {
-				return string(*d.(*tree.DString)), nil
+				s, ok := tree.AsDString(d)
+				if !ok {
+					return nil, errors.Newf("expected string type, got %T", d)
+				}
+				return string(s), nil
 			},
 			func(x interface{}) (tree.Datum, error) {
 				return tree.NewDString(x.(string)), nil
@@ -460,7 +464,11 @@ func typeToSchema(typ *types.T) (*SchemaField, error) {
 		setNullable(
 			SchemaTypeString,
 			func(d tree.Datum, _ interface{}) (interface{}, error) {
-				return d.(*tree.DCollatedString).Contents, nil
+				cs, ok := tree.AsDCollatedString(d)
+				if !ok {
+					return nil, errors.Newf("expected collated string type, got %T", d)
+				}
+				return cs.Contents, nil
 			},
 			func(x interface{}) (tree.Datum, error) {
 				return tree.NewDCollatedString(x.(string), typ.Locale(), &tree.CollationEnvironment{})

--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -1284,7 +1284,7 @@ func TestJsonRountrip(t *testing.T) {
 			// In this case, we can just compare strings.
 			if isFloatOrDecimal(test.datum.ResolvedType()) {
 				require.Equal(t, d.String(), j.String())
-			} else if dArr, ok := tree.AsDArray(test.datum); ok && isFloatOrDecimal(dArr.ParamTyp) {
+			} else if dArr, ok := test.datum.(*tree.DArray); ok && isFloatOrDecimal(dArr.ParamTyp) {
 				require.Equal(t, d.String(), j.String())
 			} else {
 				cmp, err := d.Compare(j)

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -825,7 +825,7 @@ func readOneJSONValue(row cdcevent.Row, colName string) (*tree.DJSON, error) {
 		if d == tree.DNull {
 			return nil
 		}
-		if valJSON, ok = tree.AsDJSON(d); !ok {
+		if valJSON, ok = d.(*tree.DJSON); !ok {
 			return errors.Newf("expected a JSON object, got %s", d.ResolvedType())
 		}
 		return nil

--- a/pkg/crosscluster/logical/sql_row_reader.go
+++ b/pkg/crosscluster/logical/sql_row_reader.go
@@ -128,7 +128,7 @@ func (r *sqlRowReader) ReadRows(
 			isLocal = true
 		}
 
-		decimal, ok := tree.AsDDecimal(timestamp)
+		decimal, ok := timestamp.(*tree.DDecimal)
 		if !ok {
 			return nil, errors.AssertionFailedf("expected column 1 or 2 to be origin timestamp")
 		}

--- a/pkg/crosscluster/logical/sql_row_reader.go
+++ b/pkg/crosscluster/logical/sql_row_reader.go
@@ -116,7 +116,7 @@ func (r *sqlRowReader) ReadRows(
 			return nil, errors.AssertionFailedf("expected %d columns, got %d", len(r.columns)+3, len(row))
 		}
 
-		rowIndex, ok := tree.AsDInt(row[0])
+		rowIndex, ok := row[0].(*tree.DInt)
 		if !ok {
 			return nil, errors.AssertionFailedf("expected column 0 to be the row index")
 		}
@@ -138,7 +138,7 @@ func (r *sqlRowReader) ReadRows(
 			return nil, err
 		}
 
-		result[int(rowIndex)-1] = priorRow{
+		result[int(*rowIndex)-1] = priorRow{
 			row:              row[prefixColumns:],
 			logicalTimestamp: logicalTimestamp,
 			isLocal:          isLocal,

--- a/pkg/jobs/utils.go
+++ b/pkg/jobs/utils.go
@@ -171,11 +171,11 @@ func JobCoordinatorID(
 	if row == nil {
 		return 0, errors.Errorf("coordinator not found for job %d", jobID)
 	}
-	coordinatorID, ok := tree.AsDInt(row[0])
+	coordinatorID, ok := row[0].(*tree.DInt)
 	if !ok {
 		return 0, errors.AssertionFailedf("expected coordinator ID to be an int, got %T", row[0])
 	}
-	return int32(coordinatorID), nil
+	return int32(*coordinatorID), nil
 }
 
 // getJobTypeStrs is a helper function that returns a string representation of

--- a/pkg/multitenant/mtinfo/info.go
+++ b/pkg/multitenant/mtinfo/info.go
@@ -53,11 +53,11 @@ func GetTenantInfoFromSQLRow(
 	if len(row) < 2 || row[1] == tree.DNull {
 		return tid, nil, errors.AssertionFailedf("%v: missing data in info column", tid)
 	}
-	ival, ok := tree.AsDBytes(row[1])
+	ival, ok := row[1].(*tree.DBytes)
 	if !ok {
 		return tid, nil, errors.AssertionFailedf("%v: info: expected bytes, got %T", tid, row[1])
 	}
-	infoBytes := []byte(ival)
+	infoBytes := []byte(*ival)
 	if err := protoutil.Unmarshal(infoBytes, &info.ProtoInfo); err != nil {
 		return tid, nil, errors.NewAssertionErrorWithWrappedErrf(err, "%v: decoding info column", tid)
 	}

--- a/pkg/multitenant/mtinfo/info.go
+++ b/pkg/multitenant/mtinfo/info.go
@@ -36,11 +36,11 @@ func GetTenantInfoFromSQLRow(
 	}
 	info = &mtinfopb.TenantInfo{}
 
-	idval, ok := tree.AsDInt(row[0])
+	idval, ok := row[0].(*tree.DInt)
 	if !ok {
 		return tid, nil, errors.AssertionFailedf("tenant ID: expected int, got %T", row[0])
 	}
-	tid, err = roachpb.MakeTenantID(uint64(idval))
+	tid, err = roachpb.MakeTenantID(uint64(*idval))
 	if err != nil {
 		return tid, nil, errors.NewAssertionErrorWithWrappedErrf(err, "%v", idval)
 	}
@@ -92,14 +92,14 @@ func GetTenantInfoFromSQLRow(
 		return tid, nil, errors.AssertionFailedf("%v: unhandled: %d", tid, info.ProtoInfo.DeprecatedDataState)
 	}
 	if len(row) > 3 && row[3] != tree.DNull {
-		val, ok := tree.AsDInt(row[3])
+		val, ok := row[3].(*tree.DInt)
 		if !ok {
 			return tid, nil, errors.AssertionFailedf("%v: data state: expected int, got %T", tid, row[3])
 		}
-		if val < 0 || mtinfopb.TenantDataState(val) > mtinfopb.MaxDataState {
+		if *val < 0 || mtinfopb.TenantDataState(*val) > mtinfopb.MaxDataState {
 			return tid, nil, errors.AssertionFailedf("%v: invalid data state: %d", tid, val)
 		} else {
-			info.DataState = mtinfopb.TenantDataState(val)
+			info.DataState = mtinfopb.TenantDataState(*val)
 		}
 	}
 
@@ -112,14 +112,14 @@ func GetTenantInfoFromSQLRow(
 		info.ServiceMode = mtinfopb.ServiceModeNone
 	}
 	if len(row) > 4 && row[4] != tree.DNull {
-		val, ok := tree.AsDInt(row[4])
+		val, ok := row[4].(*tree.DInt)
 		if !ok {
 			return tid, nil, errors.AssertionFailedf("%v: service mode: expected int, got %T", tid, row[4])
 		}
-		if val < 0 || mtinfopb.TenantServiceMode(val) > mtinfopb.MaxServiceMode {
+		if *val < 0 || mtinfopb.TenantServiceMode(*val) > mtinfopb.MaxServiceMode {
 			return tid, nil, errors.AssertionFailedf("%v: invalid service mode: %d", tid, val)
 		} else {
-			info.ServiceMode = mtinfopb.TenantServiceMode(val)
+			info.ServiceMode = mtinfopb.TenantServiceMode(*val)
 		}
 	}
 

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3510,11 +3510,11 @@ func (rs resultScanner) ScanIndex(row tree.Datums, index int, dst interface{}) e
 		*d = &val
 
 	case *int64:
-		s, ok := tree.AsDInt(src)
+		s, ok := src.(*tree.DInt)
 		if !ok {
 			return errors.Errorf("source type assertion failed")
 		}
-		*d = int64(s)
+		*d = int64(*s)
 
 	case **int64:
 		s, ok := src.(*tree.DInt)
@@ -3534,11 +3534,11 @@ func (rs resultScanner) ScanIndex(row tree.Datums, index int, dst interface{}) e
 			return errors.Errorf("source type assertion failed")
 		}
 		for i := 0; i < s.Len(); i++ {
-			id, ok := tree.AsDInt(s.Array[i])
+			id, ok := s.Array[i].(*tree.DInt)
 			if !ok {
 				return errors.Errorf("source type assertion failed on index %d", i)
 			}
-			*d = append(*d, int64(id))
+			*d = append(*d, int64(*id))
 		}
 
 	case *[]descpb.ID:
@@ -3547,11 +3547,11 @@ func (rs resultScanner) ScanIndex(row tree.Datums, index int, dst interface{}) e
 			return errors.Errorf("source type assertion failed")
 		}
 		for i := 0; i < s.Len(); i++ {
-			id, ok := tree.AsDInt(s.Array[i])
+			id, ok := s.Array[i].(*tree.DInt)
 			if !ok {
 				return errors.Errorf("source type assertion failed on index %d", i)
 			}
-			*d = append(*d, descpb.ID(id))
+			*d = append(*d, descpb.ID(*id))
 		}
 
 	case *time.Time:

--- a/pkg/server/admin.go
+++ b/pkg/server/admin.go
@@ -3529,7 +3529,7 @@ func (rs resultScanner) ScanIndex(row tree.Datums, index int, dst interface{}) e
 		*d = &val
 
 	case *[]int64:
-		s, ok := tree.AsDArray(src)
+		s, ok := src.(*tree.DArray)
 		if !ok {
 			return errors.Errorf("source type assertion failed")
 		}
@@ -3542,7 +3542,7 @@ func (rs resultScanner) ScanIndex(row tree.Datums, index int, dst interface{}) e
 		}
 
 	case *[]descpb.ID:
-		s, ok := tree.AsDArray(src)
+		s, ok := src.(*tree.DArray)
 		if !ok {
 			return errors.Errorf("source type assertion failed")
 		}

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -522,7 +522,7 @@ func (vih *VectorIndexHelper) ReEncodeVector(
 	}
 	key.PartitionKey = cspann.PartitionKey(tree.MustBeDInt(searcher.PartitionKey()))
 	key.Level = cspann.LeafLevel
-	quantizedVector, ok := tree.AsDBytes(searcher.EncodedVector())
+	quantizedVector, ok := searcher.EncodedVector().(*tree.DBytes)
 	if !ok {
 		return &rowenc.IndexEntry{}, errors.AssertionFailedf("expected encoded vector to be of type DBytes")
 	}

--- a/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
+++ b/pkg/sql/catalog/schematelemetry/schematelemetrycontroller/controller.go
@@ -270,9 +270,9 @@ func GetSchemaTelemetryScheduleID(
 		return 0, errors.AssertionFailedf("unexpectedly received %d columns", len(row))
 	}
 	// Defensively check the type.
-	v, ok := tree.AsDInt(row[0])
+	v, ok := row[0].(*tree.DInt)
 	if !ok {
 		return 0, errors.AssertionFailedf("unexpectedly received non-integer value %v", row[0])
 	}
-	return jobspb.ScheduleID(v), nil
+	return jobspb.ScheduleID(*v), nil
 }

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2229,7 +2229,7 @@ func planSelectionOperators(
 				}
 			case treecmp.In, treecmp.NotIn:
 				negate := cmpOp.Symbol == treecmp.NotIn
-				datumTuple, ok := tree.AsDTuple(constArg)
+				datumTuple, ok := constArg.(*tree.DTuple)
 				if !ok || useDefaultCmpOpForIn(datumTuple) {
 					break
 				}
@@ -2882,7 +2882,7 @@ func planProjectionExpr(
 					}
 				case treecmp.In, treecmp.NotIn:
 					negate := cmpProjOp.Symbol == treecmp.NotIn
-					datumTuple, ok := tree.AsDTuple(rConstArg)
+					datumTuple, ok := rConstArg.(*tree.DTuple)
 					if !ok || useDefaultCmpOpForIn(datumTuple) {
 						break
 					}

--- a/pkg/sql/control_jobs.go
+++ b/pkg/sql/control_jobs.go
@@ -61,12 +61,12 @@ func (n *controlJobsNode) startExec(params runParams) error {
 			continue
 		}
 
-		jobID, ok := tree.AsDInt(jobIDDatum)
+		jobID, ok := jobIDDatum.(*tree.DInt)
 		if !ok {
 			return errors.AssertionFailedf("%q: expected *DInt, found %T", jobIDDatum, jobIDDatum)
 		}
 
-		if err := reg.UpdateJobWithTxn(params.ctx, jobspb.JobID(jobID), params.p.InternalSQLTxn(),
+		if err := reg.UpdateJobWithTxn(params.ctx, jobspb.JobID(*jobID), params.p.InternalSQLTxn(),
 			func(txn isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
 				if err := jobsauth.Authorize(params.ctx, params.p,
 					md.ID, md.Payload.UsernameProto.Decode(), jobsauth.ControlAccess, globalPrivileges); err != nil {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -7961,8 +7961,8 @@ CREATE TABLE crdb_internal.cluster_locks (
 		},
 		{
 			populate: genPopulateClusterLocksWithIndex("contended" /* idxColumnName */, func(filters *clusterLocksFilters, idxConstraint tree.Datum) {
-				if contended, ok := tree.AsDBool(idxConstraint); ok {
-					filters.contended = (*bool)(&contended)
+				if contended, ok := idxConstraint.(*tree.DBool); ok {
+					filters.contended = (*bool)(contended)
 				}
 			}),
 		},

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -7940,8 +7940,8 @@ CREATE TABLE crdb_internal.cluster_locks (
 	indexes: []virtualIndex{
 		{
 			populate: genPopulateClusterLocksWithIndex("table_id" /* idxColumnName */, func(filters *clusterLocksFilters, idxConstraint tree.Datum) {
-				if tableID, ok := tree.AsDInt(idxConstraint); ok {
-					filters.tableID = (*int64)(&tableID)
+				if tableID, ok := idxConstraint.(*tree.DInt); ok {
+					filters.tableID = (*int64)(tableID)
 				}
 			}),
 		},

--- a/pkg/sql/opt/norm/fold_constants_funcs.go
+++ b/pkg/sql/opt/norm/fold_constants_funcs.go
@@ -338,7 +338,7 @@ func (c *CustomFuncs) foldOIDFamilyCast(
 			if err != nil {
 				return nil, false, err
 			}
-			oid, ok := tree.AsDOid(cDatum)
+			oid, ok := cDatum.(*tree.DOid)
 			if !ok {
 				return nil, false, nil
 			}

--- a/pkg/sql/paramparse/paramparse.go
+++ b/pkg/sql/paramparse/paramparse.go
@@ -100,7 +100,7 @@ func DatumAsInt(
 	if err != nil {
 		return 0, err
 	}
-	iv, ok := tree.AsDInt(val)
+	iv, ok := val.(*tree.DInt)
 	if !ok {
 		err = pgerror.Newf(pgcode.InvalidParameterValue,
 			"parameter %q requires an integer value", name)
@@ -108,7 +108,7 @@ func DatumAsInt(
 			"%s is a %s", value, errors.Safe(val.ResolvedType()))
 		return 0, err
 	}
-	return int64(iv), nil
+	return int64(*iv), nil
 }
 
 // DatumAsString transforms a tree.TypedExpr containing a Datum into a string.

--- a/pkg/sql/paramparse/paramparse.go
+++ b/pkg/sql/paramparse/paramparse.go
@@ -138,7 +138,7 @@ func DatumAsBool(
 	if err != nil {
 		return false, err
 	}
-	b, ok := tree.AsDBool(val)
+	b, ok := val.(*tree.DBool)
 	if !ok {
 		err = pgerror.Newf(pgcode.InvalidParameterValue,
 			"parameter %q requires a Boolean value", name)
@@ -146,7 +146,7 @@ func DatumAsBool(
 			"%s is a %s", value, errors.Safe(val.ResolvedType()))
 		return false, err
 	}
-	return bool(b), nil
+	return bool(*b), nil
 }
 
 // GetSingleBool returns the boolean if the input Datum is a DBool,

--- a/pkg/sql/routine.go
+++ b/pkg/sql/routine.go
@@ -62,7 +62,7 @@ func (d *callNode) startExec(params runParams) error {
 	if res == tree.DNull {
 		return pgerror.New(pgcode.Internal, "procedure returned null record")
 	}
-	tuple, ok := tree.AsDTuple(res)
+	tuple, ok := res.(*tree.DTuple)
 	if !ok {
 		return errors.AssertionFailedf("expected a tuple, got %T", res)
 	}

--- a/pkg/sql/rowcontainer/datum_row_container_test.go
+++ b/pkg/sql/rowcontainer/datum_row_container_test.go
@@ -56,8 +56,8 @@ func TestRowContainer(t *testing.T) {
 				for i := 0; i < rc.Len(); i++ {
 					row := rc.At(i)
 					for j := range row {
-						dint, ok := tree.AsDInt(row[j])
-						if !ok || int(dint) != (i+numPops)*numCols+j {
+						dint, ok := row[j].(*tree.DInt)
+						if !ok || int(*dint) != (i+numPops)*numCols+j {
 							t.Fatalf("invalid value %+v on row %d, col %d", row[j], i+numPops, j)
 						}
 					}

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1651,7 +1651,7 @@ func encodeSecondaryIndexNoFamilies(
 		// Vector index values begin with the quantized and encoded vector. It is
 		// possible that it is not supplied here (e.g. for an index delete).
 		if encVector := vh.QuantizedVecs[index.GetID()]; encVector != nil {
-			encVectorBytes, ok := tree.AsDBytes(encVector)
+			encVectorBytes, ok := encVector.(*tree.DBytes)
 			if !ok {
 				return IndexEntry{}, errors.AssertionFailedf(
 					"unexpected type for vector index value: %T", encVector)

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -203,10 +203,7 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 			return r, nil
 		}
 	case types.CollatedStringFamily:
-		if colType.Oid() == oidext.T_citext {
-			val = tree.UnwrapDOidWrapper(val)
-		}
-		if v, ok := val.(*tree.DCollatedString); ok {
+		if v, ok := tree.AsDCollatedString(val); ok {
 			if lex.LocaleNamesAreEqual(v.Locale, colType.Locale()) {
 				r.SetString(v.Contents)
 				return r, nil

--- a/pkg/sql/rowenc/valueside/legacy.go
+++ b/pkg/sql/rowenc/valueside/legacy.go
@@ -52,8 +52,8 @@ func MarshalLegacy(colType *types.T, val tree.Datum) (roachpb.Value, error) {
 			return r, nil
 		}
 	case types.IntFamily:
-		if v, ok := tree.AsDInt(val); ok {
-			r.SetInt(int64(v))
+		if v, ok := val.(*tree.DInt); ok {
+			r.SetInt(int64(*v))
 			return r, nil
 		}
 	case types.FloatFamily:

--- a/pkg/sql/sem/builtins/aggregate_builtins.go
+++ b/pkg/sql/sem/builtins/aggregate_builtins.go
@@ -1867,7 +1867,7 @@ func mergeStatsMetadataHelper(
 		return nil
 	}
 
-	metadataJSON, ok := tree.AsDJSON(metadataDatum)
+	metadataJSON, ok := metadataDatum.(*tree.DJSON)
 	if !ok {
 		return nil
 	}
@@ -1899,7 +1899,7 @@ func mergeStatementStatsHelper(
 		return nil
 	}
 
-	statsJSON, ok := tree.AsDJSON(statsDatum)
+	statsJSON, ok := statsDatum.(*tree.DJSON)
 	if !ok {
 		return nil
 	}
@@ -1920,7 +1920,7 @@ func mergeTransactionStatsHelper(
 		return nil
 	}
 
-	statsJSON, ok := tree.AsDJSON(statsDatum)
+	statsJSON, ok := statsDatum.(*tree.DJSON)
 	if !ok {
 		return nil
 	}
@@ -1948,7 +1948,7 @@ func mergeAggregatedMetadataHelper(
 		return nil
 	}
 
-	metadataJSON, ok := tree.AsDJSON(datum)
+	metadataJSON, ok := datum.(*tree.DJSON)
 	if !ok {
 		return nil
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -2709,7 +2709,7 @@ var regularBuiltins = map[string]builtinDefinition{
 			Types:      tree.ParamTypes{{Name: "timestamp", Typ: types.Float}},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(_ context.Context, _ *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ts, ok := tree.AsDFloat(args[0])
+				ts, ok := args[0].(*tree.DFloat)
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected float argument for to_timestamp")
 				}
@@ -2854,7 +2854,7 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ts, ok := tree.AsDTimestampTZ(args[0])
+				ts, ok := args[0].(*tree.DTimestampTZ)
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected timestamptz argument for min_timestamp")
 				}
@@ -2870,7 +2870,7 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				ts, ok := tree.AsDTimestampTZ(args[0])
+				ts, ok := args[0].(*tree.DTimestampTZ)
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected timestamptz argument for min_timestamp")
 				}
@@ -2889,7 +2889,7 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				interval, ok := tree.AsDInterval(args[0])
+				interval, ok := args[0].(*tree.DInterval)
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected interval argument for max_staleness")
 				}
@@ -2905,7 +2905,7 @@ nearest replica.`, builtinconstants.DefaultFollowerReadDuration),
 			},
 			ReturnType: tree.FixedReturnType(types.TimestampTZ),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				interval, ok := tree.AsDInterval(args[0])
+				interval, ok := args[0].(*tree.DInterval)
 				if !ok {
 					return nil, pgerror.New(pgcode.InvalidParameterValue, "expected interval argument for max_staleness")
 				}
@@ -5628,7 +5628,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
 				tableID := catid.DescID(tree.MustBeDInt(args[0]))
 				indexID := catid.IndexID(tree.MustBeDInt(args[1]))
-				rowDatums, ok := tree.AsDTuple(args[2])
+				rowDatums, ok := args[2].(*tree.DTuple)
 				if !ok {
 					return nil, pgerror.Newf(
 						pgcode.DatatypeMismatch,
@@ -5664,11 +5664,11 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 			Types:      tree.ParamTypes{{Name: "descriptor", Typ: types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				s, ok := tree.AsDBytes(args[0])
+				s, ok := args[0].(*tree.DBytes)
 				if !ok {
 					return nil, errors.Newf("expected bytes value, got %T", args[0])
 				}
-				ret, err := evalCtx.CatalogBuiltins.RedactDescriptor(ctx, []byte(s))
+				ret, err := evalCtx.CatalogBuiltins.RedactDescriptor(ctx, []byte(*s))
 				if err != nil {
 					return nil, err
 				}
@@ -5688,7 +5688,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 			Types:      tree.ParamTypes{{Name: "descriptor", Typ: types.Bytes}},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				s, ok := tree.AsDBytes(args[0])
+				s, ok := args[0].(*tree.DBytes)
 				if !ok {
 					return nil, errors.Newf("expected bytes value, got %T", args[0])
 				}
@@ -5702,7 +5702,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 					return true
 				}
 				ret, err := evalCtx.CatalogBuiltins.RepairedDescriptor(
-					ctx, []byte(s), descIDAlwaysValid, jobIDAlwaysValid, roleAlwaysValid,
+					ctx, []byte(*s), descIDAlwaysValid, jobIDAlwaysValid, roleAlwaysValid,
 				)
 				if err != nil {
 					return nil, err
@@ -5728,7 +5728,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 			},
 			ReturnType: tree.FixedReturnType(types.Bytes),
 			Fn: func(ctx context.Context, evalCtx *eval.Context, args tree.Datums) (tree.Datum, error) {
-				s, ok := tree.AsDBytes(args[0])
+				s, ok := args[0].(*tree.DBytes)
 				if !ok {
 					return nil, errors.Newf("expected bytes value, got %T", args[0])
 				}
@@ -5794,7 +5794,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 					}
 				}
 				ret, err := evalCtx.CatalogBuiltins.RepairedDescriptor(
-					ctx, []byte(s), descIDMightExist, nonTerminalJobIDMightExist, roleMightExist,
+					ctx, []byte(*s), descIDMightExist, nonTerminalJobIDMightExist, roleMightExist,
 				)
 				if err != nil {
 					return nil, err
@@ -10326,7 +10326,7 @@ func verboseFingerprint(
 
 	// The startTime can either be a timestampTZ or a decimal.
 	var startTimestamp hlc.Timestamp
-	if parsedDecimal, ok := tree.AsDDecimal(args[1]); ok {
+	if parsedDecimal, ok := args[1].(*tree.DDecimal); ok {
 		startTimestamp, err = hlc.DecimalToHLC(&parsedDecimal.Decimal)
 		if err != nil {
 			return nil, err

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5734,7 +5734,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 				}
 				descIDMightExist := func(id descpb.ID) bool { return true }
 				if args[1] != tree.DNull {
-					descIDs, ok := tree.AsDArray(args[1])
+					descIDs, ok := args[1].(*tree.DArray)
 					if !ok {
 						return nil, errors.Newf("expected array value, got %T", args[1])
 					}
@@ -5753,7 +5753,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 				}
 				nonTerminalJobIDMightExist := func(id jobspb.JobID) bool { return true }
 				if args[2] != tree.DNull {
-					jobIDs, ok := tree.AsDArray(args[2])
+					jobIDs, ok := args[2].(*tree.DArray)
 					if !ok {
 						return nil, errors.Newf("expected array value, got %T", args[2])
 					}
@@ -5775,7 +5775,7 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 					return true
 				}
 				if args[3] != tree.DNull {
-					roles, ok := tree.AsDArray(args[3])
+					roles, ok := args[3].(*tree.DArray)
 					if !ok {
 						return nil, errors.Newf("expected array value, got %T", args[3])
 					}
@@ -11410,7 +11410,7 @@ func arrayLength(arr *tree.DArray, dim int64) tree.Datum {
 	if dim == 1 {
 		return tree.NewDInt(tree.DInt(arr.Len()))
 	}
-	a, ok := tree.AsDArray(arr.Array[0])
+	a, ok := arr.Array[0].(*tree.DArray)
 	if !ok {
 		return tree.DNull
 	}
@@ -11426,7 +11426,7 @@ func arrayLower(arr *tree.DArray, dim int64) tree.Datum {
 	if dim == 1 {
 		return intOne
 	}
-	a, ok := tree.AsDArray(arr.Array[0])
+	a, ok := arr.Array[0].(*tree.DArray)
 	if !ok {
 		return tree.DNull
 	}

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -5740,11 +5740,11 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 					}
 					descIDMap := make(map[descpb.ID]struct{}, descIDs.Len())
 					for i, n := 0, descIDs.Len(); i < n; i++ {
-						id, isInt := tree.AsDInt(descIDs.Array[i])
+						id, isInt := descIDs.Array[i].(*tree.DInt)
 						if !isInt {
 							return nil, errors.Newf("expected int value, got %T", descIDs.Array[i])
 						}
-						descIDMap[descpb.ID(id)] = struct{}{}
+						descIDMap[descpb.ID(*id)] = struct{}{}
 					}
 					descIDMightExist = func(id descpb.ID) bool {
 						_, found := descIDMap[id]
@@ -5759,11 +5759,11 @@ DO NOT USE -- USE 'CREATE VIRTUAL CLUSTER' INSTEAD`,
 					}
 					jobIDMap := make(map[jobspb.JobID]struct{}, jobIDs.Len())
 					for i, n := 0, jobIDs.Len(); i < n; i++ {
-						id, isInt := tree.AsDInt(jobIDs.Array[i])
+						id, isInt := jobIDs.Array[i].(*tree.DInt)
 						if !isInt {
 							return nil, errors.Newf("expected int value, got %T", jobIDs.Array[i])
 						}
-						jobIDMap[jobspb.JobID(id)] = struct{}{}
+						jobIDMap[jobspb.JobID(*id)] = struct{}{}
 					}
 					nonTerminalJobIDMightExist = func(id jobspb.JobID) bool {
 						_, found := jobIDMap[id]

--- a/pkg/sql/sem/builtins/window_frame_builtins_test.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins_test.go
@@ -81,7 +81,7 @@ func testMin(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 			if err != nil {
 				t.Errorf("Unexpected error received when getting min from sliding window: %+v", err)
 			}
-			minResult, _ := tree.AsDInt(res)
+			minResult := res.(*tree.DInt)
 			naiveMin := tree.DInt(maxInt)
 			for idx := wfr.RowIdx - offset; idx <= wfr.RowIdx+offset; idx++ {
 				if idx < 0 || idx >= wfr.PartitionSize() {
@@ -95,12 +95,12 @@ func testMin(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 				if err != nil {
 					panic(err)
 				}
-				el, _ := tree.AsDInt(datum)
-				if el < naiveMin {
-					naiveMin = el
+				el := datum.(*tree.DInt)
+				if *el < naiveMin {
+					naiveMin = *el
 				}
 			}
-			if minResult != naiveMin {
+			if *minResult != naiveMin {
 				t.Errorf("Min sliding window returned wrong result: expected %+v, found %+v", naiveMin, minResult)
 				t.Errorf("partitionSize: %+v idx: %+v offset: %+v", wfr.PartitionSize(), wfr.RowIdx, offset)
 				t.Error(min.sw.string())
@@ -124,7 +124,7 @@ func testMax(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 			if err != nil {
 				t.Errorf("Unexpected error received when getting max from sliding window: %+v", err)
 			}
-			maxResult, _ := tree.AsDInt(res)
+			maxResult := res.(*tree.DInt)
 			naiveMax := tree.DInt(-maxInt)
 			for idx := wfr.RowIdx - offset; idx <= wfr.RowIdx+offset; idx++ {
 				if idx < 0 || idx >= wfr.PartitionSize() {
@@ -138,12 +138,12 @@ func testMax(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun) {
 				if err != nil {
 					panic(err)
 				}
-				el, _ := tree.AsDInt(datum)
-				if el > naiveMax {
-					naiveMax = el
+				el := datum.(*tree.DInt)
+				if *el > naiveMax {
+					naiveMax = *el
 				}
 			}
-			if maxResult != naiveMax {
+			if *maxResult != naiveMax {
 				t.Errorf("Max sliding window returned wrong result: expected %+v, found %+v", naiveMax, maxResult)
 				t.Errorf("partitionSize: %+v idx: %+v offset: %+v", wfr.PartitionSize(), wfr.RowIdx, offset)
 				t.Error(max.sw.string())
@@ -184,8 +184,8 @@ func testSumAndAvg(t *testing.T, evalCtx *eval.Context, wfr *eval.WindowFrameRun
 				if err != nil {
 					panic(err)
 				}
-				el, _ := tree.AsDInt(datum)
-				naiveSum += int64(el)
+				el := datum.(*tree.DInt)
+				naiveSum += int64(*el)
 			}
 			s, err := sumResult.Int64()
 			if err != nil {

--- a/pkg/sql/sem/eval/comparison.go
+++ b/pkg/sql/sem/eval/comparison.go
@@ -26,7 +26,7 @@ func ComparisonExprWithSubOperator(
 		return tree.DNull, nil
 	} else if tuple, ok := tree.AsDTuple(right); ok {
 		datums = tuple.D
-	} else if array, ok := tree.AsDArray(right); ok {
+	} else if array, ok := right.(*tree.DArray); ok {
 		datums = array.Array
 	} else {
 		return nil, errors.AssertionFailedf("unhandled right expression %s", right)

--- a/pkg/sql/sem/eval/comparison.go
+++ b/pkg/sql/sem/eval/comparison.go
@@ -24,7 +24,7 @@ func ComparisonExprWithSubOperator(
 	// Right is either a tuple or an array of Datums.
 	if !expr.Op.CalledOnNullInput && right == tree.DNull {
 		return tree.DNull, nil
-	} else if tuple, ok := tree.AsDTuple(right); ok {
+	} else if tuple, ok := right.(*tree.DTuple); ok {
 		datums = tuple.D
 	} else if array, ok := right.(*tree.DArray); ok {
 		datums = array.Array

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -6572,7 +6572,7 @@ func AdjustValueToType(typ *types.T, inVal Datum) (outVal Datum, err error) {
 		if v, ok := AsDString(inVal); ok {
 			sv = string(v)
 			isString = true
-		} else if v, ok := inVal.(*DCollatedString); ok {
+		} else if v, ok := AsDCollatedString(inVal); ok {
 			sv = v.Contents
 			isCollatedString = true
 		}
@@ -6619,6 +6619,8 @@ func AdjustValueToType(typ *types.T, inVal Datum) (outVal Datum, err error) {
 				}
 				return NewDString(sv), nil
 			} else if isCollatedString {
+				// Note that we cannot have CITEXT here (because of Oid check
+				// above).
 				return NewDCollatedString(sv, typ.Locale(), &CollationEnvironment{})
 			}
 		}

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -261,22 +261,11 @@ func MakeDBool(d DBool) *DBool {
 // MustBeDBool attempts to retrieve a DBool from an Expr, panicking if the
 // assertion fails.
 func MustBeDBool(e Expr) DBool {
-	b, ok := AsDBool(e)
+	b, ok := e.(*DBool)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DBool, found %T", e))
 	}
-	return b
-}
-
-// AsDBool attempts to retrieve a *DBool from an Expr, returning a *DBool and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions.
-func AsDBool(e Expr) (DBool, bool) {
-	switch t := e.(type) {
-	case *DBool:
-		return *t, true
-	}
-	return false, false
+	return *b
 }
 
 // MakeParseError returns a parse error using the provided string and type. An
@@ -537,22 +526,11 @@ func MakeDBitArray(bitLen uint) DBitArray {
 // MustBeDBitArray attempts to retrieve a DBitArray from an Expr, panicking if the
 // assertion fails.
 func MustBeDBitArray(e Expr) *DBitArray {
-	b, ok := AsDBitArray(e)
+	b, ok := e.(*DBitArray)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DBitArray, found %T", e))
 	}
 	return b
-}
-
-// AsDBitArray attempts to retrieve a *DBitArray from an Expr, returning a *DBitArray and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions.
-func AsDBitArray(e Expr) (*DBitArray, bool) {
-	switch t := e.(type) {
-	case *DBitArray:
-		return t, true
-	}
-	return nil, false
 }
 
 var errCannotCastNegativeIntToBitArray = pgerror.Newf(pgcode.CannotCoerce,
@@ -804,20 +782,6 @@ func MustBeDFloat(e Expr) DFloat {
 	panic(errors.AssertionFailedf("expected *DFloat, found %T", e))
 }
 
-// AsDFloat attempts to retrieve a DFloat from an Expr, returning a DFloat and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DFloat wrapped by a
-// *DOidWrapper is possible.
-func AsDFloat(e Expr) (*DFloat, bool) {
-	switch t := e.(type) {
-	case *DFloat:
-		return t, true
-	case *DOidWrapper:
-		return AsDFloat(t.Wrapped)
-	}
-	return nil, false
-}
-
 // NewDFloat is a helper routine to create a *DFloat initialized from its
 // argument.
 func NewDFloat(d DFloat) *DFloat {
@@ -998,16 +962,6 @@ func MustBeDDecimal(e Expr) DDecimal {
 		return *t
 	}
 	panic(errors.AssertionFailedf("expected *DDecimal, found %T", e))
-}
-
-// AsDDecimal attempts to retrieve a DDecimal from an Expr, returning a DDecimal and
-// a flag signifying whether the assertion was successful.
-func AsDDecimal(e Expr) (*DDecimal, bool) {
-	switch t := e.(type) {
-	case *DDecimal:
-		return t, true
-	}
-	return nil, false
 }
 
 // ParseDDecimal parses and returns the *DDecimal Datum value represented by the
@@ -1474,21 +1428,11 @@ func NewDBytes(d DBytes) *DBytes {
 
 // MustBeDBytes attempts to convert an Expr into a DBytes, panicking if unsuccessful.
 func MustBeDBytes(e Expr) DBytes {
-	i, ok := AsDBytes(e)
+	i, ok := e.(*DBytes)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DBytes, found %T", e))
 	}
-	return i
-}
-
-// AsDBytes attempts to convert an Expr into a DBytes, returning a flag indicating
-// whether it was successful.
-func AsDBytes(e Expr) (DBytes, bool) {
-	switch t := e.(type) {
-	case *DBytes:
-		return *t, true
-	}
-	return "", false
+	return *i
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -1717,24 +1661,14 @@ func NewDUuid(d DUuid) *DUuid {
 	return &d
 }
 
-// AsDUuid attempts to retrieve a DUuid from an Expr, returning a DUuid and
-// a flag signifying whether the assertion was successful.
-func AsDUuid(e Expr) (DUuid, bool) {
-	switch t := e.(type) {
-	case *DUuid:
-		return *t, true
-	}
-	return DUuid{}, false
-}
-
 // MustBeDUuid attempts to retrieve a DUuid from an Expr, panicking if the
 // assertion fails.
 func MustBeDUuid(e Expr) DUuid {
-	i, ok := AsDUuid(e)
+	i, ok := e.(*DUuid)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DUuid, found %T", e))
 	}
-	return i
+	return *i
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -1837,28 +1771,14 @@ func NewDIPAddr(d DIPAddr) *DIPAddr {
 	return &d
 }
 
-// AsDIPAddr attempts to retrieve a *DIPAddr from an Expr, returning a *DIPAddr and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DIPAddr wrapped by a
-// *DOidWrapper is possible.
-func AsDIPAddr(e Expr) (DIPAddr, bool) {
-	switch t := e.(type) {
-	case *DIPAddr:
-		return *t, true
-	case *DOidWrapper:
-		return AsDIPAddr(t.Wrapped)
-	}
-	return DIPAddr{}, false
-}
-
 // MustBeDIPAddr attempts to retrieve a DIPAddr from an Expr, panicking if the
 // assertion fails.
 func MustBeDIPAddr(e Expr) DIPAddr {
-	i, ok := AsDIPAddr(e)
+	i, ok := e.(*DIPAddr)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DIPAddr, found %T", e))
 	}
-	return i
+	return *i
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -2130,28 +2050,14 @@ func ParseDDate(ctx ParseContext, s string) (_ *DDate, dependsOnContext bool, _ 
 	return NewDDate(t), dependsOnContext, err
 }
 
-// AsDDate attempts to retrieve a DDate from an Expr, returning a DDate and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DDate wrapped by a
-// *DOidWrapper is possible.
-func AsDDate(e Expr) (DDate, bool) {
-	switch t := e.(type) {
-	case *DDate:
-		return *t, true
-	case *DOidWrapper:
-		return AsDDate(t.Wrapped)
-	}
-	return DDate{}, false
-}
-
 // MustBeDDate attempts to retrieve a DDate from an Expr, panicking if the
 // assertion fails.
 func MustBeDDate(e Expr) DDate {
-	t, ok := AsDDate(e)
+	t, ok := e.(*DDate)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DDate, found %T", e))
 	}
-	return t
+	return *t
 }
 
 // ResolvedType implements the TypedExpr interface.
@@ -2274,20 +2180,6 @@ type DTime timeofday.TimeOfDay
 func MakeDTime(t timeofday.TimeOfDay) *DTime {
 	d := DTime(t)
 	return &d
-}
-
-// AsDTime attempts to retrieve a DTime from an Expr, returning a DTimestamp and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DTime wrapped by a
-// *DOidWrapper is possible.
-func AsDTime(e Expr) (DTime, bool) {
-	switch t := e.(type) {
-	case *DTime:
-		return *t, true
-	case *DOidWrapper:
-		return AsDTime(t.Wrapped)
-	}
-	return DTime(timeofday.FromInt(0)), false
 }
 
 // ParseDTime parses and returns the *DTime Datum value represented by the
@@ -2427,20 +2319,6 @@ func NewDTimeTZFromOffset(t timeofday.TimeOfDay, offsetSecs int32) *DTimeTZ {
 // NewDTimeTZFromLocation creates a DTimeTZ from a TimeOfDay and time.Location.
 func NewDTimeTZFromLocation(t timeofday.TimeOfDay, loc *time.Location) *DTimeTZ {
 	return &DTimeTZ{timetz.MakeTimeTZFromLocation(t, loc)}
-}
-
-// AsDTimeTZ attempts to retrieve a DTimeTZ from an Expr, returning a DTimeTZ and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DTimeTZ wrapped by a
-// *DOidWrapper is possible.
-func AsDTimeTZ(e Expr) (DTimeTZ, bool) {
-	switch t := e.(type) {
-	case *DTimeTZ:
-		return *t, true
-	case *DOidWrapper:
-		return AsDTimeTZ(t.Wrapped)
-	}
-	return DTimeTZ{}, false
 }
 
 // ParseDTimeTZ parses and returns the *DTime Datum value represented by the
@@ -2637,28 +2515,14 @@ func ParseDTimestamp(
 	return d, dependsOnContext, err
 }
 
-// AsDTimestamp attempts to retrieve a DTimestamp from an Expr, returning a DTimestamp and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DTimestamp wrapped by a
-// *DOidWrapper is possible.
-func AsDTimestamp(e Expr) (DTimestamp, bool) {
-	switch t := e.(type) {
-	case *DTimestamp:
-		return *t, true
-	case *DOidWrapper:
-		return AsDTimestamp(t.Wrapped)
-	}
-	return DTimestamp{}, false
-}
-
 // MustBeDTimestamp attempts to retrieve a DTimestamp from an Expr, panicking if the
 // assertion fails.
 func MustBeDTimestamp(e Expr) DTimestamp {
-	t, ok := AsDTimestamp(e)
+	t, ok := e.(*DTimestamp)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DTimestamp, found %T", e))
 	}
-	return t
+	return *t
 }
 
 // Round returns a new DTimestamp to the specified precision.
@@ -2960,28 +2824,14 @@ func ParseDTimestampTZ(
 // DZeroTimestampTZ is the zero-valued DTimestampTZ.
 var DZeroTimestampTZ = &DTimestampTZ{}
 
-// AsDTimestampTZ attempts to retrieve a DTimestampTZ from an Expr, returning a
-// DTimestampTZ and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DTimestamp wrapped by a *DOidWrapper is possible.
-func AsDTimestampTZ(e Expr) (DTimestampTZ, bool) {
-	switch t := e.(type) {
-	case *DTimestampTZ:
-		return *t, true
-	case *DOidWrapper:
-		return AsDTimestampTZ(t.Wrapped)
-	}
-	return DTimestampTZ{}, false
-}
-
 // MustBeDTimestampTZ attempts to retrieve a DTimestampTZ from an Expr,
 // panicking if the assertion fails.
 func MustBeDTimestampTZ(e Expr) DTimestampTZ {
-	t, ok := AsDTimestampTZ(e)
+	t, ok := e.(*DTimestampTZ)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DTimestampTZ, found %T", e))
 	}
-	return t
+	return *t
 }
 
 // Round returns a new DTimestampTZ to the specified precision.
@@ -3107,28 +2957,14 @@ type DInterval struct {
 	duration.Duration
 }
 
-// AsDInterval attempts to retrieve a DInterval from an Expr, returning a DInterval and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DInterval wrapped by a
-// *DOidWrapper is possible.
-func AsDInterval(e Expr) (*DInterval, bool) {
-	switch t := e.(type) {
-	case *DInterval:
-		return t, true
-	case *DOidWrapper:
-		return AsDInterval(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDInterval attempts to retrieve a DInterval from an Expr, panicking if the
 // assertion fails.
 func MustBeDInterval(e Expr) *DInterval {
-	t, ok := AsDInterval(e)
-	if ok {
-		return t
+	t, ok := e.(*DInterval)
+	if !ok {
+		panic(errors.AssertionFailedf("expected *DInterval, found %T", e))
 	}
-	panic(errors.AssertionFailedf("expected *DInterval, found %T", e))
+	return t
 }
 
 // NewDInterval creates a new DInterval.
@@ -3291,24 +3127,10 @@ func NewDGeography(g geo.Geography) *DGeography {
 	return &DGeography{Geography: g}
 }
 
-// AsDGeography attempts to retrieve a *DGeography from an Expr, returning a
-// *DGeography and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DGeography wrapped by a *DOidWrapper is possible.
-func AsDGeography(e Expr) (*DGeography, bool) {
-	switch t := e.(type) {
-	case *DGeography:
-		return t, true
-	case *DOidWrapper:
-		return AsDGeography(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDGeography attempts to retrieve a *DGeography from an Expr, panicking
 // if the assertion fails.
 func MustBeDGeography(e Expr) *DGeography {
-	i, ok := AsDGeography(e)
+	i, ok := e.(*DGeography)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DGeography, found %T", e))
 	}
@@ -3416,24 +3238,10 @@ func NewDGeometry(g geo.Geometry) *DGeometry {
 	return &DGeometry{Geometry: g}
 }
 
-// AsDGeometry attempts to retrieve a *DGeometry from an Expr, returning a
-// *DGeometry and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DGeometry wrapped by a *DOidWrapper is possible.
-func AsDGeometry(e Expr) (*DGeometry, bool) {
-	switch t := e.(type) {
-	case *DGeometry:
-		return t, true
-	case *DOidWrapper:
-		return AsDGeometry(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDGeometry attempts to retrieve a *DGeometry from an Expr, panicking
 // if the assertion fails.
 func MustBeDGeometry(e Expr) *DGeometry {
-	i, ok := AsDGeometry(e)
+	i, ok := e.(*DGeometry)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DGeometry, found %T", e))
 	}
@@ -3551,24 +3359,10 @@ func ParseDPGLSN(str string) (*DPGLSN, error) {
 	return NewDPGLSN(v), nil
 }
 
-// AsDPGLSN attempts to retrieve a *DPGLSN from an Expr, returning a
-// *DPGLSN and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DPGLSN wrapped by a *DOidWrapper is possible.
-func AsDPGLSN(e Expr) (*DPGLSN, bool) {
-	switch t := e.(type) {
-	case *DPGLSN:
-		return t, true
-	case *DOidWrapper:
-		return AsDPGLSN(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDPGLSN attempts to retrieve a *DPGLSN from an Expr, panicking
 // if the assertion fails.
 func MustBeDPGLSN(e Expr) *DPGLSN {
-	i, ok := AsDPGLSN(e)
+	i, ok := e.(*DPGLSN)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DPGLSN, found %T", e))
 	}
@@ -3658,24 +3452,10 @@ type DPGVector struct {
 // NewDPGVector returns a new PGVector Datum.
 func NewDPGVector(vector vector.T) *DPGVector { return &DPGVector{vector} }
 
-// AsDPGVector attempts to retrieve a DPGVector from an Expr, returning a
-// DPGVector and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DPGVector wrapped by a *DOidWrapper is possible.
-func AsDPGVector(e Expr) (*DPGVector, bool) {
-	switch t := e.(type) {
-	case *DPGVector:
-		return t, true
-	case *DOidWrapper:
-		return AsDPGVector(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDPGVector attempts to retrieve a DPGVector from an Expr, panicking if the
 // assertion fails.
 func MustBeDPGVector(e Expr) *DPGVector {
-	v, ok := AsDPGVector(e)
+	v, ok := e.(*DPGVector)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DPGVector, found %T", e))
 	}
@@ -3775,24 +3555,10 @@ func ParseDBox2D(str string) (*DBox2D, error) {
 	return &DBox2D{CartesianBoundingBox: b}, nil
 }
 
-// AsDBox2D attempts to retrieve a *DBox2D from an Expr, returning a
-// *DBox2D and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DBox2D wrapped by a *DOidWrapper is possible.
-func AsDBox2D(e Expr) (*DBox2D, bool) {
-	switch t := e.(type) {
-	case *DBox2D:
-		return t, true
-	case *DOidWrapper:
-		return AsDBox2D(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDBox2D attempts to retrieve a *DBox2D from an Expr, panicking
 // if the assertion fails.
 func MustBeDBox2D(e Expr) *DBox2D {
-	i, ok := AsDBox2D(e)
+	i, ok := e.(*DBox2D)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DBox2D, found %T", e))
 	}
@@ -3954,24 +3720,10 @@ func ParseDJsonpath(s string) (Datum, error) {
 	return NewDJsonpath(*jp), nil
 }
 
-// AsDJsonpath attempts to retrieve a *DJsonpath from an Expr, returning a *DJsonpath and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DJsonpath wrapped by a
-// *DOidWrapper is possible.
-func AsDJsonpath(e Expr) (*DJsonpath, bool) {
-	switch t := e.(type) {
-	case *DJsonpath:
-		return t, true
-	case *DOidWrapper:
-		return AsDJsonpath(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDJsonpath attempts to retrieve a DJsonpath from an Expr, panicking if the
 // assertion fails.
 func MustBeDJsonpath(e Expr) DJsonpath {
-	i, ok := AsDJsonpath(e)
+	i, ok := e.(*DJsonpath)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DJsonpath, found %T", e))
 	}
@@ -4052,24 +3804,10 @@ func MakeDJSON(d interface{}) (Datum, error) {
 
 var dNullJSON = NewDJSON(json.NullJSONValue)
 
-// AsDJSON attempts to retrieve a *DJSON from an Expr, returning a *DJSON and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DJSON wrapped by a
-// *DOidWrapper is possible.
-func AsDJSON(e Expr) (*DJSON, bool) {
-	switch t := e.(type) {
-	case *DJSON:
-		return t, true
-	case *DOidWrapper:
-		return AsDJSON(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDJSON attempts to retrieve a DJSON from an Expr, panicking if the
 // assertion fails.
 func MustBeDJSON(e Expr) DJSON {
-	i, ok := AsDJSON(e)
+	i, ok := e.(*DJSON)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DJSON, found %T", e))
 	}
@@ -4334,24 +4072,10 @@ func (d *DTSQuery) Size() uintptr {
 	return uintptr(len(d.TSQuery.String()))
 }
 
-// AsDTSQuery attempts to retrieve a DTSQuery from an Expr, returning a
-// DTSQuery and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DTSQuery wrapped by a *DOidWrapper is possible.
-func AsDTSQuery(e Expr) (*DTSQuery, bool) {
-	switch t := e.(type) {
-	case *DTSQuery:
-		return t, true
-	case *DOidWrapper:
-		return AsDTSQuery(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDTSQuery attempts to retrieve a DTSQuery from an Expr, panicking if the
 // assertion fails.
 func MustBeDTSQuery(e Expr) *DTSQuery {
-	v, ok := AsDTSQuery(e)
+	v, ok := e.(*DTSQuery)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DTSQuery, found %T", e))
 	}
@@ -4456,24 +4180,10 @@ func (d *DTSVector) Size() uintptr {
 	return uintptr(d.TSVector.StringSize())
 }
 
-// AsDTSVector attempts to retrieve a DTSVector from an Expr, returning a
-// DTSVector and a flag signifying whether the assertion was successful. The
-// function should be used instead of direct type assertions wherever a
-// *DTSVector wrapped by a *DOidWrapper is possible.
-func AsDTSVector(e Expr) (*DTSVector, bool) {
-	switch t := e.(type) {
-	case *DTSVector:
-		return t, true
-	case *DOidWrapper:
-		return AsDTSVector(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDTSVector attempts to retrieve a DTSVector from an Expr, panicking if the
 // assertion fails.
 func MustBeDTSVector(e Expr) *DTSVector {
-	v, ok := AsDTSVector(e)
+	v, ok := e.(*DTSVector)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DTSVector, found %T", e))
 	}
@@ -4628,24 +4338,10 @@ func MakeDTuple(typ *types.T, d ...Datum) DTuple {
 	return DTuple{D: d, typ: typ}
 }
 
-// AsDTuple attempts to retrieve a *DTuple from an Expr, returning a *DTuple and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DTuple wrapped by a
-// *DOidWrapper is possible.
-func AsDTuple(e Expr) (*DTuple, bool) {
-	switch t := e.(type) {
-	case *DTuple:
-		return t, true
-	case *DOidWrapper:
-		return AsDTuple(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MustBeDTuple attempts to retrieve a *DTuple from an Expr, panicking if the
 // assertion fails.
 func MustBeDTuple(e Expr) *DTuple {
-	i, ok := AsDTuple(e)
+	i, ok := e.(*DTuple)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DTuple, found %T", e))
 	}
@@ -5514,20 +5210,6 @@ func NewDEnum(e DEnum) *DEnum {
 	return &e
 }
 
-// AsDEnum attempts to retrieve a DEnum from an Expr, returning a DEnum and
-// a flag signifying whether the assertion was successful. The function should
-// // be used instead of direct type assertions wherever a *DEnum wrapped by a
-// // *DOidWrapper is possible.
-func AsDEnum(e Expr) (*DEnum, bool) {
-	switch t := e.(type) {
-	case *DEnum:
-		return t, true
-	case *DOidWrapper:
-		return AsDEnum(t.Wrapped)
-	}
-	return nil, false
-}
-
 // MakeDEnumFromPhysicalRepresentation creates a DEnum of the input type
 // and the input physical representation.
 func MakeDEnumFromPhysicalRepresentation(typ *types.T, rep []byte) (DEnum, error) {
@@ -5831,24 +5513,10 @@ func NewDOid(d oid.Oid) *DOid {
 	return &oidDatum
 }
 
-// AsDOid attempts to retrieve a DOid from an Expr, returning a DOid and
-// a flag signifying whether the assertion was successful. The function should
-// be used instead of direct type assertions wherever a *DOid wrapped by a
-// *DOidWrapper is possible.
-func AsDOid(e Expr) (*DOid, bool) {
-	switch t := e.(type) {
-	case *DOid:
-		return t, true
-	case *DOidWrapper:
-		return AsDOid(t.Wrapped)
-	}
-	return NewDOid(0), false
-}
-
 // MustBeDOid attempts to retrieve a DOid from an Expr, panicking if the
 // assertion fails.
 func MustBeDOid(e Expr) *DOid {
-	i, ok := AsDOid(e)
+	i, ok := e.(*DOid)
 	if !ok {
 		panic(errors.AssertionFailedf("expected *DOid, found %T", e))
 	}
@@ -5982,7 +5650,7 @@ func (d *DOid) Name() string {
 // Types that currently benefit from DOidWrapper are:
 // - DName => DOidWrapper(*DString, oid.T_name)
 // - DRefCursor => DOidWrapper(*DString, oid.T_refcursor)
-// - DCIText => DOIDWrapper(*DCollatedString, oidext.T_citext)
+// - DCIText => DOidWrapper(*DCollatedString, oidext.T_citext)
 type DOidWrapper struct {
 	Wrapped Datum
 	Oid     oid.Oid
@@ -6448,7 +6116,7 @@ func MaxDistinctCount(
 		}
 
 	case *DOid:
-		otherDOid, otherOk := AsDOid(last)
+		otherDOid, otherOk := last.(*DOid)
 		if otherOk {
 			start = int64(t.Oid)
 			end = int64(otherDOid.Oid)
@@ -6645,7 +6313,7 @@ func AdjustValueToType(typ *types.T, inVal Datum) (outVal Datum, err error) {
 			}
 		}
 	case types.BitFamily:
-		if v, ok := AsDBitArray(inVal); ok {
+		if v, ok := inVal.(*DBitArray); ok {
 			if typ.Width() > 0 {
 				bitLen := v.BitLen()
 				switch typ.Oid() {

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -541,7 +541,7 @@ func (tx *Txn) getFullVectorsFromPK(
 		if row == nil {
 			break
 		}
-		if v, ok := tree.AsDPGVector(row[0]); ok {
+		if v, ok := row[0].(*tree.DPGVector); ok {
 			refs[refIdx].Vector = v.T
 		} else {
 			refs[refIdx].Vector = nil

--- a/pkg/util/parquet/schema.go
+++ b/pkg/util/parquet/schema.go
@@ -485,6 +485,8 @@ func makeColumn(colName string, typ *types.T, repetitions parquet.Repetition) (d
 		}
 		return result, nil
 	default:
+		// TODO(cdc): VECTOR, JSONPATH, TSQUERY, TSVECTOR types are missing
+		// here.
 		return result, pgerror.Newf(pgcode.FeatureNotSupported,
 			"parquet writer does not support the type family %v", typ.Family())
 	}

--- a/pkg/util/parquet/write_functions.go
+++ b/pkg/util/parquet/write_functions.go
@@ -284,11 +284,11 @@ func writeInt32(
 	if d == tree.DNull {
 		return writeBatch[int32](w, a.int32Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDInt(d)
+	di, ok := d.(*tree.DInt)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DInt, found %T", d)
 	}
-	a.int32Batch[0] = int32(di)
+	a.int32Batch[0] = int32(*di)
 	return writeBatch[int32](w, a.int32Batch[:], defLevels, repLevels)
 }
 
@@ -298,11 +298,11 @@ func writeInt64(
 	if d == tree.DNull {
 		return writeBatch[int64](w, a.int64Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDInt(d)
+	di, ok := d.(*tree.DInt)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DInt, found %T", d)
 	}
-	a.int64Batch[0] = int64(di)
+	a.int64Batch[0] = int64(*di)
 	return writeBatch[int64](w, a.int64Batch[:], defLevels, repLevels)
 }
 

--- a/pkg/util/parquet/write_functions.go
+++ b/pkg/util/parquet/write_functions.go
@@ -181,7 +181,7 @@ func writeArray(d tree.Datum, w file.ColumnChunkWriter, a *batchAlloc, wFn write
 	if d == tree.DNull {
 		return wFn(tree.DNull, w, a, nilArrayDefLevel, newEntryRepLevel)
 	}
-	di, ok := tree.AsDArray(d)
+	di, ok := d.(*tree.DArray)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DArray, found %T", d)
 	}

--- a/pkg/util/parquet/write_functions.go
+++ b/pkg/util/parquet/write_functions.go
@@ -225,7 +225,7 @@ func writeTuple(
 ) (int64, error) {
 	var dt *tree.DTuple
 	if d != tree.DNull {
-		if tup, ok := tree.AsDTuple(d); ok {
+		if tup, ok := d.(*tree.DTuple); ok {
 			dt = tup
 		} else {
 			return 0, pgerror.Newf(pgcode.DatatypeMismatch, "expected DTuple, found %T", d)
@@ -312,7 +312,7 @@ func writePGLSN(
 	if d == tree.DNull {
 		return writeBatch[int64](w, a.int64Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDPGLSN(d)
+	di, ok := d.(*tree.DPGLSN)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DPGLSN, found %T", d)
 	}
@@ -326,11 +326,11 @@ func writeBool(
 	if d == tree.DNull {
 		return writeBatch[bool](w, a.boolBatch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDBool(d)
+	di, ok := d.(*tree.DBool)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DBool, found %T", d)
 	}
-	a.boolBatch[0] = bool(di)
+	a.boolBatch[0] = bool(*di)
 	return writeBatch[bool](w, a.boolBatch[:], defLevels, repLevels)
 }
 
@@ -392,7 +392,7 @@ func writeTimestamp(
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
 
-	_, ok := tree.AsDTimestamp(d)
+	_, ok := d.(*tree.DTimestamp)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DTimestamp, found %T", d)
 	}
@@ -410,7 +410,7 @@ func writeTimestampTZ(
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
 
-	_, ok := tree.AsDTimestampTZ(d)
+	_, ok := d.(*tree.DTimestampTZ)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DTimestampTZ, found %T", d)
 	}
@@ -428,7 +428,7 @@ func writeUUID(
 		return writeBatch[parquet.FixedLenByteArray](w, a.fixedLenByteArrayBatch[:], defLevels, repLevels)
 	}
 
-	di, ok := tree.AsDUuid(d)
+	di, ok := d.(*tree.DUuid)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DUuid, found %T", d)
 	}
@@ -442,7 +442,7 @@ func writeDecimal(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDDecimal(d)
+	_, ok := d.(*tree.DDecimal)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DDecimal, found %T", d)
 	}
@@ -458,7 +458,7 @@ func writeINet(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDIPAddr(d)
+	_, ok := d.(*tree.DIPAddr)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DIPAddr, found %T", d)
 	}
@@ -475,7 +475,7 @@ func writeJSON(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDJSON(d)
+	_, ok := d.(*tree.DJSON)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DJSON, found %T", d)
 	}
@@ -492,7 +492,7 @@ func writeBit(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDBitArray(d)
+	_, ok := d.(*tree.DBitArray)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DBitArray, found %T", d)
 	}
@@ -509,11 +509,11 @@ func writeBytes(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDBytes(d)
+	di, ok := d.(*tree.DBytes)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DBytes, found %T", d)
 	}
-	b, err := unsafeGetBytes(string(di))
+	b, err := unsafeGetBytes(string(*di))
 	if err != nil {
 		return err
 	}
@@ -528,7 +528,7 @@ func writeEnum(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDEnum(d)
+	di, ok := d.(*tree.DEnum)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DEnum, found %T", d)
 	}
@@ -547,7 +547,7 @@ func writeDate(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDDate(d)
+	_, ok := d.(*tree.DDate)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DDate, found %T", d)
 	}
@@ -564,7 +564,7 @@ func writeBox2D(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDBox2D(d)
+	_, ok := d.(*tree.DBox2D)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DBox2D, found %T", d)
 	}
@@ -580,7 +580,7 @@ func writeGeography(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDGeography(d)
+	di, ok := d.(*tree.DGeography)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DGeography, found %T", d)
 	}
@@ -595,7 +595,7 @@ func writeGeometry(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDGeometry(d)
+	di, ok := d.(*tree.DGeometry)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DGeometry, found %T", d)
 	}
@@ -609,7 +609,7 @@ func writeInterval(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDInterval(d)
+	_, ok := d.(*tree.DInterval)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DInterval, found %T", d)
 	}
@@ -626,11 +626,11 @@ func writeTime(
 	if d == tree.DNull {
 		return writeBatch[int64](w, a.int64Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDTime(d)
+	di, ok := d.(*tree.DTime)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DTime, found %T", d)
 	}
-	a.int64Batch[0] = int64(di)
+	a.int64Batch[0] = int64(*di)
 	return writeBatch[int64](w, a.int64Batch[:], defLevels, repLevels)
 }
 
@@ -640,7 +640,7 @@ func writeTimeTZ(
 	if d == tree.DNull {
 		return writeBatch[parquet.ByteArray](w, a.byteArrayBatch[:], defLevels, repLevels)
 	}
-	_, ok := tree.AsDTimeTZ(d)
+	_, ok := d.(*tree.DTimeTZ)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DTimeTZ, found %T", d)
 	}
@@ -656,7 +656,7 @@ func writeFloat32(
 	if d == tree.DNull {
 		return writeBatch[float32](w, a.float32Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDFloat(d)
+	di, ok := d.(*tree.DFloat)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DFloat, found %T", d)
 	}
@@ -670,7 +670,7 @@ func writeFloat64(
 	if d == tree.DNull {
 		return writeBatch[float64](w, a.float64Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDFloat(d)
+	di, ok := d.(*tree.DFloat)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DFloat, found %T", d)
 	}
@@ -684,7 +684,7 @@ func writeOid(
 	if d == tree.DNull {
 		return writeBatch[int32](w, a.int32Batch[:], defLevels, repLevels)
 	}
-	di, ok := tree.AsDOid(d)
+	di, ok := d.(*tree.DOid)
 	if !ok {
 		return pgerror.Newf(pgcode.DatatypeMismatch, "expected DInt, found %T", d)
 	}


### PR DESCRIPTION
This PR cleans up usage of `DOidWrapper` utility. Throughout the years we've accumulated some dead code as well as in many cases we had blind copy-paste of unnecessary code, and this PR gets rid of it. Namely, `DOidWrapper` utility is now used to support `DName` and `DRefCursor` (on top of `DString`) and `DCIText` (on top of `DCollatedString`), and any other usages are forbidden. This PR removes all those other usages.

Please see each commit for more details.

Epic: None
