### PR TITLE
release-25.3: build: update `builder` docker image

### DIFF
--- a/build/.bazelbuilderversion
+++ b/build/.bazelbuilderversion
@@ -1,1 +1,1 @@
-us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250423-215642
+us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel:20250717-170828

--- a/build/toolchains/BUILD.bazel
+++ b/build/toolchains/BUILD.bazel
@@ -32,7 +32,7 @@ platform(
         "@platforms//cpu:x86_64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:394483c5651c395cb4d72f4f3551a3c5027ba5c0c278d79c819f7793bdbc5096",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:8e28252850bdd6f996d3d4087839be7a2e37d441f6f1e0d5c0a08fae82feacc3",
         "dockerReuse": "True",
         "Pool": "default",
     },
@@ -137,7 +137,7 @@ platform(
         "@platforms//cpu:arm64",
     ],
     exec_properties = {
-        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:d855a27ab26c92c2a8cdc56bcc22f24cb2b50d6d9742af3c8eb61755f00bcccb",
+        "container-image": "docker://us-east1-docker.pkg.dev/crl-ci-images/cockroach/bazel@sha256:a60cd34ece7f75930169653ce55eb6825775a5204152fb563276e6eb25c73ed1",
         "dockerReuse": "True",
         "Pool": "default",
     },


### PR DESCRIPTION
Backport 1/1 commits from #150443 on behalf of @rickystewart.

----

Consume `s390x` support.

Epic: CRDB-21133
Release note: None

----

Release justification: Non-production code changes