### PR TITLE
kvserver: pass ReplicationTarget for TransferLease

### DIFF
--- a/pkg/kv/kvserver/asim/state/impl.go
+++ b/pkg/kv/kvserver/asim/state/impl.go
@@ -628,6 +628,7 @@ func (s *state) addReplica(
 
 	desc := rng.desc.AddReplica(roachpb.NodeID(nodeID), roachpb.StoreID(storeID), rtype)
 	replica := &replica{
+		nodeID:    nodeID,
 		replicaID: ReplicaID(desc.ReplicaID),
 		storeID:   storeID,
 		rangeID:   rangeID,
@@ -1607,6 +1608,7 @@ func (r *rng) Size() int64 {
 // replica is an implementation of the Replica interface.
 type replica struct {
 	replicaID  ReplicaID
+	nodeID     NodeID
 	storeID    StoreID
 	rangeID    RangeID
 	desc       roachpb.ReplicaDescriptor
@@ -1616,6 +1618,11 @@ type replica struct {
 // ReplicaID returns the ID of this replica.
 func (r *replica) ReplicaID() ReplicaID {
 	return r.replicaID
+}
+
+// NodeID returns the ID of the node this replica is on.
+func (r *replica) NodeID() NodeID {
+	return r.nodeID
 }
 
 // StoreID returns the ID of the store this replica is on.

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -270,6 +270,8 @@ type Range interface {
 type Replica interface {
 	// ReplicaID returns the ID of this replica.
 	ReplicaID() ReplicaID
+	// NodeID returns the ID of the node this replica is on.
+	NodeID() NodeID
 	// StoreID returns the ID of the store this replica is on.
 	StoreID() StoreID
 	// Descriptor returns the descriptor for this replica.

--- a/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
+++ b/pkg/kv/kvserver/asim/storerebalancer/candidate_replica.go
@@ -49,6 +49,11 @@ func (sr *simulatorReplica) OwnsValidLease(context.Context, hlc.ClockTimestamp) 
 	return sr.repl.HoldsLease()
 }
 
+// NodeID returns the Replica's NodeID.
+func (sr *simulatorReplica) NodeID() roachpb.NodeID {
+	return roachpb.NodeID(sr.repl.NodeID())
+}
+
 // StoreID returns the Replica's StoreID.
 func (sr *simulatorReplica) StoreID() roachpb.StoreID {
 	return roachpb.StoreID(sr.repl.StoreID())

--- a/pkg/kv/kvserver/replica_rankings.go
+++ b/pkg/kv/kvserver/replica_rankings.go
@@ -31,6 +31,8 @@ type CandidateReplica interface {
 	// OwnsValidLease returns whether this replica is the current valid
 	// leaseholder.
 	OwnsValidLease(context.Context, hlc.ClockTimestamp) bool
+	// NodeID returns the Replica's NodeID.
+	NodeID() roachpb.NodeID
 	// StoreID returns the Replica's StoreID.
 	StoreID() roachpb.StoreID
 	// GetRangeID returns the Range ID.

--- a/pkg/kv/kvserver/store_rebalancer.go
+++ b/pkg/kv/kvserver/store_rebalancer.go
@@ -581,8 +581,14 @@ func (sr *StoreRebalancer) applyLeaseRebalance(
 		return sr.rr.TransferLease(
 			ctx,
 			candidateReplica,
-			candidateReplica.StoreID(),
-			target.StoreID,
+			roachpb.ReplicationTarget{
+				NodeID:  candidateReplica.NodeID(),
+				StoreID: candidateReplica.StoreID(),
+			},
+			roachpb.ReplicationTarget{
+				NodeID:  target.NodeID,
+				StoreID: target.StoreID,
+			},
 			candidateReplica.RangeUsageInfo(),
 		)
 	}); err != nil {


### PR DESCRIPTION
**asim: add node id for simulator replica**

Previously, the simulator replica interface did not include a NodeID() method.
Future changes to replica_rankings.go will require this as part of the candidate
replica interface. This commit updates the simulator replica to implement
NodeID() method.

Epic: none
Release note: none

---

**kvserver: pass ReplicationTarget for TransferLease**

Previously, the replicate queue’s TransferLease used store IDs to represent the
source and target. This will change in upcoming mma work, which requires full
replication targets as arguments. This change also brings it in line with
RangeRebalancer.RelocateRange for consistency.

Epic: none
Release note: none
