### PR TITLE
release-25.3: roachtest: unblock rust-postgres test case fixed by #22463

### DIFF
--- a/pkg/cmd/roachtest/tests/rust_postgres_blocklist.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres_blocklist.go
@@ -61,7 +61,6 @@ var rustPostgresBlocklist = blocklist{
 	"types.ltxtquery":                       "unsupported datatype - https://github.com/cockroachdb/cockroach/issues/44657",
 	"types.ltxtquery_any":                   "unsupported datatype - https://github.com/cockroachdb/cockroach/issues/44657",
 	"types.test_array_vec_params":           "default int size (int4 vs int8) mismatch",
-	"types.test_citext_params":              "unsupported citext type alias - https://github.com/cockroachdb/cockroach/issues/22463",
 	"types.test_hstore_params":              "unsupported datatype - https://github.com/cockroachdb/cockroach/issues/41284",
 	"types.test_i16_params":                 "default int size (int4 vs int8) mismatch",
 	"types.test_i32_params":                 "default int size (int4 vs int8) mismatch",


### PR DESCRIPTION
Backport 1/1 commits from #150427 on behalf of @spilchen.

----

A specific test case within the rust-postgres was blocklisted due to its reliance on CITEXT, which was recently implemented in #22463.  This commit removes the blocklist entry to reflect the success.

Closes #149973

Epic: none
Release note: none

----

Release justification: test only change