### PR TITLE
sql: block schema_locked with comma syntax

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -734,13 +734,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 
 		case *tree.AlterTableSetStorageParams:
 			setter := tablestorageparam.NewSetter(n.tableDesc, false /* isNewObject */)
-			if err := storageparam.Set(
-				params.ctx,
-				params.p.SemaCtx(),
-				params.EvalContext(),
-				t.StorageParams,
-				setter,
-			); err != nil {
+			if err := storageparam.Set(params.ctx, params.p.SemaCtx(), params.EvalContext(), t.StorageParams, setter, len(n.n.Cmds) > 1); err != nil {
 				return err
 			}
 
@@ -781,6 +775,7 @@ func (n *alterTableNode) startExec(params runParams) error {
 				params.EvalContext(),
 				t.Params,
 				setter,
+				len(n.n.Cmds) > 1,
 			); err != nil {
 				return err
 			}
@@ -2516,6 +2511,7 @@ func (p *planner) checkSchemaChangeIsAllowed(
 	// schema_locked are unsupported before 25.2
 	preventedBySchemaLocked := !p.ExecCfg().Settings.Version.IsActive(ctx, clusterversion.V25_3) &&
 		!tree.IsSetOrResetSchemaLocked(n)
+
 	// These schema changes are allowed because the events generated will always
 	// be ignored by the schema_locked. The tableEventFilter (in CDC schemafeed)
 	// only cares about a limited number of events:

--- a/pkg/sql/create_index.go
+++ b/pkg/sql/create_index.go
@@ -312,13 +312,7 @@ func makeIndexDescriptor(
 		return nil, err
 	}
 
-	if err := storageparam.Set(
-		params.ctx,
-		params.p.SemaCtx(),
-		params.EvalContext(),
-		n.StorageParams,
-		&indexstorageparam.Setter{IndexDesc: &indexDesc},
-	); err != nil {
+	if err := storageparam.Set(params.ctx, params.p.SemaCtx(), params.EvalContext(), n.StorageParams, &indexstorageparam.Setter{IndexDesc: &indexDesc}, false /*isMultiStatement*/); err != nil {
 		return nil, err
 	}
 

--- a/pkg/sql/create_table.go
+++ b/pkg/sql/create_table.go
@@ -1422,13 +1422,7 @@ func NewTableDesc(
 		id, dbID, sc.GetID(), n.Table.Table(), creationTime, privileges, persistence,
 	)
 	setter := tablestorageparam.NewSetter(&desc, true /* isNewObject */)
-	if err := storageparam.Set(
-		ctx,
-		semaCtx,
-		evalCtx,
-		n.StorageParams,
-		setter,
-	); err != nil {
+	if err := storageparam.Set(ctx, semaCtx, evalCtx, n.StorageParams, setter, false /*isMultiStatement*/); err != nil {
 		return nil, err
 	}
 
@@ -1883,14 +1877,9 @@ func NewTableDesc(
 			// Validate storage parameters for
 			// CREATE TABLE ... (x INT PRIMARY KEY USING HASH WITH (...));
 			if d.PrimaryKey.IsPrimaryKey {
-				if err := storageparam.Set(
-					ctx,
-					semaCtx,
-					evalCtx,
-					d.PrimaryKey.StorageParams,
-					&indexstorageparam.Setter{
-						IndexDesc: &descpb.IndexDescriptor{},
-					}); err != nil {
+				if err := storageparam.Set(ctx, semaCtx, evalCtx, d.PrimaryKey.StorageParams, &indexstorageparam.Setter{
+					IndexDesc: &descpb.IndexDescriptor{},
+				}, false /*isMultiStatement*/); err != nil {
 					return nil, err
 				}
 			}
@@ -2023,13 +2012,7 @@ func NewTableDesc(
 				}
 				idx.Predicate = expr
 			}
-			if err := storageparam.Set(
-				ctx,
-				semaCtx,
-				evalCtx,
-				d.StorageParams,
-				&indexstorageparam.Setter{IndexDesc: &idx},
-			); err != nil {
+			if err := storageparam.Set(ctx, semaCtx, evalCtx, d.StorageParams, &indexstorageparam.Setter{IndexDesc: &idx}, false /*isMultiStatement*/); err != nil {
 				return nil, err
 			}
 
@@ -2164,13 +2147,7 @@ func NewTableDesc(
 
 			// Validate storage parameters for
 			// CREATE TABLE ... (x INT, PRIMARY KEY (x) USING HASH WITH (...));
-			if err := storageparam.Set(
-				ctx,
-				semaCtx,
-				evalCtx,
-				d.StorageParams,
-				&indexstorageparam.Setter{IndexDesc: &idx},
-			); err != nil {
+			if err := storageparam.Set(ctx, semaCtx, evalCtx, d.StorageParams, &indexstorageparam.Setter{IndexDesc: &idx}, false); err != nil {
 				return nil, err
 			}
 		case *tree.CheckConstraintTableDef, *tree.ForeignKeyConstraintTableDef, *tree.FamilyTableDef:

--- a/pkg/sql/logictest/testdata/logic_test/schema_locked
+++ b/pkg/sql/logictest/testdata/logic_test/schema_locked
@@ -240,3 +240,22 @@ t_147993  CREATE TABLE public.t_147993 (
           ) WITH (schema_locked = true);
 
 subtest end
+
+subtest disallow_comma_syntax_in_legacy
+
+statement ok
+CREATE TABLE t_block_comma (i INT PRIMARY KEY) WITH (schema_locked = t);
+
+statement ok
+SET use_declarative_schema_changer=off
+
+
+statement error pgcode 57000 this schema change is disallowed because table "t_block_comma" is locked and this operation cannot automatically unlock the table
+ALTER TABLE t_block_comma SET (schema_locked=false), DROP COLUMN i;
+
+
+statement ok
+RESET use_declarative_schema_changer
+
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -967,7 +967,7 @@ func maybeApplyStorageParameters(b BuildCtx, storageParams tree.StorageParams, i
 	storageParamSetter := &indexstorageparam.Setter{
 		IndexDesc: dummyIndexDesc,
 	}
-	err := storageparam.Set(b, b.SemaCtx(), b.EvalCtx(), storageParams, storageParamSetter)
+	err := storageparam.Set(b, b.SemaCtx(), b.EvalCtx(), storageParams, storageParamSetter, false /*isMultiStatement*/)
 	if err != nil {
 		panic(err)
 	}

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -7995,13 +7995,7 @@ func applyGeoindexConfigStorageParams(
 		return geopb.Config{}, errors.Newf("invalid storage parameters specified: %s", params)
 	}
 	semaCtx := tree.MakeSemaContext(nil /* resolver */)
-	if err := storageparam.Set(
-		ctx,
-		&semaCtx,
-		evalCtx,
-		stmt.AST.(*tree.CreateIndex).StorageParams,
-		&indexstorageparam.Setter{IndexDesc: indexDesc},
-	); err != nil {
+	if err := storageparam.Set(ctx, &semaCtx, evalCtx, stmt.AST.(*tree.CreateIndex).StorageParams, &indexstorageparam.Setter{IndexDesc: indexDesc}, false /*isMultiStatement*/); err != nil {
 		return geopb.Config{}, err
 	}
 	return indexDesc.GeoConfig, nil


### PR DESCRIPTION
Previously, we incorrectly allowed schema_locked to be toggled with the comma syntax in the legacy schema changer. This behavior was incorrect and cause change feed issues. To address this, this patch limits toggling schema_locked to only single statement transactions.

Fixes: #150484

Release note (bug fix): Disallow schema_locked from being toggled inside transactions using comma syntax, which will lead to undefined behavior for change feeds.