### PR TITLE
roachtest: elide 'estimated_last_login_time' in system.users fingerprint

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -842,6 +842,17 @@ func (sc *systemTableContents) scheduledJobsHandler(
 		Values()
 }
 
+// usersHandler replaces the contents of "estimated_last_login_time" which gets
+// updated on every user login attempt, which means the post restore fingerprint
+// could observe an updated log in time value.
+func (sc *systemTableContents) usersHandler(
+	values []interface{}, columns []string,
+) ([]interface{}, error) {
+	return newSystemTableRow(sc.table, values, columns).
+		WithSentinel("estimated_last_login_time").
+		Values()
+}
+
 func (sc *systemTableContents) commentsHandler(
 	values []interface{}, columns []string,
 ) ([]interface{}, error) {
@@ -879,6 +890,8 @@ func (sc *systemTableContents) handleSpecialCases(
 		return sc.commentsHandler(row, columns)
 	case "system.tenant_settings":
 		return sc.tenantSettingsHandler(row, columns)
+	case "system.users":
+		return sc.usersHandler(row, columns)
 	default:
 		return row, nil
 	}


### PR DESCRIPTION
The backup/restore roachtests have recently begun to flake (due to #150375) with a fingerprint error on the system.users table. The roachtest simply needs to be taught to elide the values of the estimated_last_login_time column, which can be updated before the test driver fingerprints the column.

Fixes #150400
Fixes #149316
Fixes #150471
Fixes https://github.com/cockroachdb/cockroach/issues/150472
Fixes https://github.com/cockroachdb/cockroach/issues/150399

Release note: none