### PR TITLE
release-25.3: kvcoord: common changes for multiple branches of in-flight work

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -48,15 +48,20 @@ var bufferedWritesScanTransformEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.transformations.scans.enabled",
 	"if enabled, locking scans and reverse scans with replicated durability are transformed to unreplicated durability",
-	false,
+	metamorphic.ConstantWithTestBool("kv.transaction.write_buffering.transformations.scans.enabled", false /* defaultValue */),
 )
 
+const defaultBufferSize = 1 << 22 // 4MB
 var bufferedWritesMaxBufferSize = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.max_buffer_size",
 	"if non-zero, defines that maximum size of the "+
 		"buffer that will be used to buffer transactional writes per-transaction",
-	1<<22, // 4MB
+	int64(metamorphic.ConstantWithTestRange("kv.transaction.write_buffering.max_buffer_size",
+		defaultBufferSize, // default
+		1,                 // min
+		defaultBufferSize, // max
+	)),
 	settings.NonNegativeInt,
 	settings.WithPublic,
 )

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -257,7 +257,11 @@ func (twb *txnWriteBuffer) SendLocked(
 		return twb.flushBufferAndSendBatch(ctx, ba)
 	}
 
-	if twb.batchRequiresFlush(ctx, ba) {
+	// We check if scan transforms are enabled once and use that answer until the
+	// end of SendLocked.
+	transformScans := bufferedWritesScanTransformEnabled.Get(&twb.st.SV)
+
+	if twb.batchRequiresFlush(ctx, ba, transformScans) {
 		return twb.flushBufferAndSendBatch(ctx, ba)
 	}
 
@@ -265,9 +269,6 @@ func (twb *txnWriteBuffer) SendLocked(
 	// budget. If it will, we shouldn't buffer writes from the current batch,
 	// and flush the buffer.
 	maxSize := bufferedWritesMaxBufferSize.Get(&twb.st.SV)
-	// We check if scan transforms are enabled once and use that answer until the
-	// end of SendLocked.
-	transformScans := bufferedWritesScanTransformEnabled.Get(&twb.st.SV)
 	bufSize := twb.estimateSize(ba, transformScans) + twb.bufferSize
 
 	// NB: if bufferedWritesMaxBufferSize is set to 0 then we effectively disable
@@ -321,7 +322,9 @@ func (twb *txnWriteBuffer) SendLocked(
 	return twb.mergeResponseWithRequestRecords(ctx, rr, br)
 }
 
-func (twb *txnWriteBuffer) batchRequiresFlush(ctx context.Context, ba *kvpb.BatchRequest) bool {
+func (twb *txnWriteBuffer) batchRequiresFlush(
+	ctx context.Context, ba *kvpb.BatchRequest, transformScans bool,
+) bool {
 	for _, ru := range ba.Requests {
 		req := ru.GetInner()
 		switch req.(type) {
@@ -467,7 +470,7 @@ func (twb *txnWriteBuffer) estimateSize(ba *kvpb.BatchRequest, transformScans bo
 			estimate += scratch.size()
 			estimate += lockKeyInfoSize
 		case *kvpb.GetRequest:
-			if t.KeyLockingDurability == lock.Replicated {
+			if IsReplicatedLockingRequest(t) {
 				scratch.key = t.Key
 				estimate += scratch.size()
 				estimate += lockKeyInfoSize
@@ -504,9 +507,7 @@ func (twb *txnWriteBuffer) estimateSize(ba *kvpb.BatchRequest, transformScans bo
 			// the buffer. Here, we assume at least 1 key will be returned that is
 			// about the size of the scan start boundary. We try to protect from large
 			// buffer overflows by transforming the batch's MaxSpanRequestKeys later.
-			shouldTransform := t.KeyLockingStrength > lock.None && t.KeyLockingDurability == lock.Replicated
-			shouldTransform = shouldTransform && transformScans
-			if shouldTransform {
+			if IsReplicatedLockingRequest(t) && transformScans {
 				scratch.key = t.Key
 				scratch.vals[0] = bufferedValue{
 					seq: t.Sequence,
@@ -515,9 +516,7 @@ func (twb *txnWriteBuffer) estimateSize(ba *kvpb.BatchRequest, transformScans bo
 			}
 		case *kvpb.ReverseScanRequest:
 			// See the comment on the ScanRequest case for more details.
-			shouldTransform := t.KeyLockingStrength > lock.None && t.KeyLockingDurability == lock.Replicated
-			shouldTransform = shouldTransform && transformScans
-			if shouldTransform {
+			if IsReplicatedLockingRequest(t) && transformScans {
 				scratch.key = t.Key
 				scratch.vals[0] = bufferedValue{
 					seq: t.Sequence,
@@ -919,7 +918,7 @@ func (twb *txnWriteBuffer) applyTransformations(
 			_, lockStr, served := twb.maybeServeRead(t.Key, t.Sequence)
 
 			requiresAdditionalLocking := t.KeyLockingStrength > lockStr
-			requiresLockTransform := t.KeyLockingStrength != lock.None && t.KeyLockingDurability == lock.Replicated
+			requiresLockTransform := IsReplicatedLockingRequest(t)
 			requestRequired := requiresAdditionalLocking || !served
 
 			if requestRequired && requiresLockTransform {
@@ -940,9 +939,7 @@ func (twb *txnWriteBuffer) applyTransformations(
 			// Regardless of whether the scan overlaps with any writes in the buffer
 			// or not, we must send the request to the KV layer. We can't know for
 			// sure that there's nothing else to read.
-			shouldTransform := t.KeyLockingStrength > lock.None && t.KeyLockingDurability == lock.Replicated
-			shouldTransform = shouldTransform && transformScans
-			if shouldTransform {
+			if IsReplicatedLockingRequest(t) && transformScans {
 				var scanReqU kvpb.RequestUnion
 				scanReq := t.ShallowCopy().(*kvpb.ScanRequest)
 				scanReq.KeyLockingDurability = lock.Unreplicated
@@ -960,9 +957,7 @@ func (twb *txnWriteBuffer) applyTransformations(
 			// Regardless of whether the reverse scan overlaps with any writes in the
 			// buffer or not, we must send the request to the KV layer. We can't know
 			// for sure that there's nothing else to read.
-			shouldTransform := t.KeyLockingStrength > lock.None && t.KeyLockingDurability == lock.Replicated
-			shouldTransform = shouldTransform && transformScans
-			if shouldTransform {
+			if IsReplicatedLockingRequest(t) && transformScans {
 				var rScanReqU kvpb.RequestUnion
 				rScanReq := t.ShallowCopy().(*kvpb.ReverseScanRequest)
 				rScanReq.KeyLockingDurability = lock.Unreplicated
@@ -1618,6 +1613,19 @@ func (twb *txnWriteBuffer) addToBuffer(
 		}
 		twb.buffer.Set(bw)
 		twb.bufferSize += bw.size()
+	}
+}
+
+func IsReplicatedLockingRequest(req kvpb.Request) bool {
+	switch r := req.(type) {
+	case *kvpb.ScanRequest:
+		return r.KeyLockingStrength > lock.None && r.KeyLockingDurability == lock.Replicated
+	case *kvpb.ReverseScanRequest:
+		return r.KeyLockingStrength > lock.None && r.KeyLockingDurability == lock.Replicated
+	case *kvpb.GetRequest:
+		return r.KeyLockingStrength > lock.None && r.KeyLockingDurability == lock.Replicated
+	default:
+		return false
 	}
 }
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -1987,10 +1987,10 @@ func TestTxnWriteBufferRollbackToSavepoint(t *testing.T) {
 	require.IsType(t, &kvpb.EndTxnResponse{}, br.Responses[0].GetInner())
 }
 
-// TestRollbackNeverHeldLock is a regression test for a bug around incorrect
+// TestTxnWriteBufferRollbackNeverHeldLock is a regression test for a bug around incorrect
 // accounting of the buffer size for completely unlocked writes that were rolled
 // back.
-func TestRollbackNeverHeldLock(t *testing.T) {
+func TestTxnWriteBufferRollbackNeverHeldLock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
@@ -2850,7 +2850,7 @@ func TestTxnWriteBufferCorrectlyRollsbackExclusionTimestamp(t *testing.T) {
 	require.NotNil(t, br)
 }
 
-func TestLockKeyInfo(t *testing.T) {
+func TestTxnWriteBufferLockKeyInfo(t *testing.T) {
 	ts1 := hlc.Timestamp{WallTime: 1}
 	ts2 := hlc.Timestamp{WallTime: 2}
 

--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer_test.go
@@ -26,15 +26,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func makeMockTxnWriteBuffer(st *cluster.Settings) (txnWriteBuffer, *mockLockedSender) {
+func makeMockTxnWriteBuffer(
+	ctx context.Context,
+) (txnWriteBuffer, *mockLockedSender, *cluster.Settings) {
 	metrics := MakeTxnMetrics(time.Hour)
+	st := cluster.MakeClusterSettings()
+	bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
+	bufferedWritesMaxBufferSize.Override(ctx, &st.SV, defaultBufferSize)
+
 	mockSender := &mockLockedSender{}
 	return txnWriteBuffer{
 		enabled:    true,
 		wrapped:    mockSender,
 		txnMetrics: &metrics,
 		st:         st,
-	}, mockSender
+	}, mockSender, st
 }
 
 func getArgs(key roachpb.Key) *kvpb.GetRequest {
@@ -92,7 +98,7 @@ func TestTxnWriteBufferBuffersBlindWrites(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 1
@@ -165,7 +171,7 @@ func TestTxnWriteBufferWritesToSameKey(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 1
@@ -263,7 +269,7 @@ func TestTxnWriteBufferBlindWritesIncludingOtherRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 1
@@ -358,7 +364,7 @@ func TestTxnWriteBufferCorrectlyAdjustsFlushErrors(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("errIdx=%d", errIdx), func(t *testing.T) {
 			ctx := context.Background()
-			twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+			twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 			txn := makeTxnProto()
 			txn.Sequence = 1
@@ -439,7 +445,7 @@ func TestTxnWriteBufferCorrectlyAdjustsErrorsAfterBuffering(t *testing.T) {
 	} {
 		t.Run(fmt.Sprintf("errIdx=%d", errIdx), func(t *testing.T) {
 			ctx := context.Background()
-			twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+			twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 			txn := makeTxnProto()
 			txn.Sequence = 1
@@ -529,7 +535,7 @@ func TestTxnWriteBufferServesPointReadsLocally(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	putAtSeq := func(key roachpb.Key, val string, seq enginepb.TxnSeq) {
 		txn := makeTxnProto()
@@ -723,7 +729,7 @@ func TestTxnWriteBufferServesPointReadsAfterScan(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -783,7 +789,7 @@ func TestTxnWriteBufferServesOverlappingReadsCorrectly(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	putAtSeq := func(key roachpb.Key, val string, seq enginepb.TxnSeq) {
 		txn := makeTxnProto()
@@ -1008,7 +1014,7 @@ func TestTxnWriteBufferLockingGetRequests(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -1116,7 +1122,7 @@ func TestTxnWriteBufferDecomposesConditionalPuts(t *testing.T) {
 
 	testutils.RunTrueAndFalse(t, "condEvalSuccessful", func(t *testing.T, condEvalSuccessful bool) {
 		ctx := context.Background()
-		twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+		twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 		twb.testingOverrideCPutEvalFn = func(expBytes []byte, actVal *roachpb.Value, actValPresent bool, allowNoExisting bool) *kvpb.ConditionFailedError {
 			if condEvalSuccessful {
 				return nil
@@ -1196,7 +1202,7 @@ func TestTxnWriteBufferDecomposesConditionalPutsExpectingNoRow(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	twb.testingOverrideCPutEvalFn = func(expBytes []byte, actVal *roachpb.Value, actValPresent bool, allowNoExisting bool) *kvpb.ConditionFailedError {
 		return nil
@@ -1258,7 +1264,7 @@ func TestTxnWriteBufferRespectsMustAcquireExclusiveLock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -1331,7 +1337,7 @@ func TestTxnWriteBufferMustSortBatchesBySequenceNumber(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -1387,10 +1393,9 @@ func TestTxnWriteBufferMustSortBatchesBySequenceNumber(t *testing.T) {
 func TestTxnWriteBufferEstimateSize(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	twb, _ := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	ctx := context.Background()
 
-	st := cluster.MakeTestingClusterSettings()
-	twb.st = st
+	twb, _, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -1490,8 +1495,7 @@ func TestTxnWriteBufferFlushesWhenOverBudget(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
-	twb, mockSender := makeMockTxnWriteBuffer(st)
+	twb, mockSender, st := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -1608,7 +1612,6 @@ func TestTxnWriteBufferLimitsSizeOfScans(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	st := cluster.MakeTestingClusterSettings()
 
 	keyA, keyB := roachpb.Key("a"), roachpb.Key("b")
 
@@ -1650,7 +1653,7 @@ func TestTxnWriteBufferLimitsSizeOfScans(t *testing.T) {
 			}
 			name := fmt.Sprintf("%s/%s", req, tc.name)
 			t.Run(name, func(t *testing.T) {
-				twb, mockSender := makeMockTxnWriteBuffer(st)
+				twb, mockSender, st := makeMockTxnWriteBuffer(ctx)
 				txn := makeTxnProto()
 				txn.Sequence = 10
 
@@ -1689,7 +1692,7 @@ func TestTxnWriteBufferLimitsSizeOfScans(t *testing.T) {
 		}
 	}
 	t.Run("no mutation when an unsupported request is in batch", func(t *testing.T) {
-		twb, mockSender := makeMockTxnWriteBuffer(st)
+		twb, mockSender, st := makeMockTxnWriteBuffer(ctx)
 		txn := makeTxnProto()
 		txn.Sequence = 10
 
@@ -1793,7 +1796,7 @@ func TestTxnWriteBufferFlushesIfBatchRequiresFlushing(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+			twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 			txn := makeTxnProto()
 			txn.Sequence = 10
@@ -1883,7 +1886,7 @@ func TestTxnWriteBufferRollbackToSavepoint(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -1991,7 +1994,7 @@ func TestRollbackNeverHeldLock(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -2031,7 +2034,7 @@ func TestTxnWriteBufferFlushesAfterDisabling(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 1
@@ -2139,7 +2142,7 @@ func TestTxnWriteBufferClearsBufferOnEpochBump(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 1
@@ -2173,7 +2176,7 @@ func TestTxnWriteBufferBatchRequestValidation(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	type testCase struct {
 		name string
@@ -2451,8 +2454,7 @@ func TestTxnWriteBufferHasBufferedAllPrecedingWrites(t *testing.T) {
 	} {
 		t.Run(tc.name, func(t *testing.T) {
 			ctx := context.Background()
-			st := cluster.MakeTestingClusterSettings()
-			twb, mockSender := makeMockTxnWriteBuffer(st)
+			twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 			if tc.setup != nil {
 				tc.setup(&twb)
@@ -2511,8 +2513,9 @@ func BenchmarkTxnWriteBuffer(b *testing.B) {
 		return strings.Repeat("a", kvSize*1024)
 	}
 	makeBuffer := func(kvSize int, txn *roachpb.Transaction, numWrites int) txnWriteBuffer {
-		twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+		twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 		twb.setEnabled(true)
+
 		sendFunc := func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {
 			br := ba.CreateReply()
 			br.Txn = ba.Txn
@@ -2665,7 +2668,7 @@ func TestTxnWriteBufferChecksForExclusionLoss(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -2769,7 +2772,7 @@ func TestTxnWriteBufferCorrectlyRollsbackExclusionTimestamp(t *testing.T) {
 	defer log.Scope(t).Close(t)
 
 	ctx := context.Background()
-	twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+	twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 
 	txn := makeTxnProto()
 	txn.Sequence = 10
@@ -3207,9 +3210,7 @@ func TestTxnWriteBufferElidesUnnecessaryLockingRequests(t *testing.T) {
 					skip.WithIssue(t, 142977, "%s requires a value but %s does not buffer its response", firstReq.name, secondReq.name)
 				}
 
-				st := cluster.MakeClusterSettings()
-				bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
-				twb, mockSender := makeMockTxnWriteBuffer(st)
+				twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 				txn := makeTxnProto()
 				txn.Sequence = 10
 				// Send first request and run firstRequest validation
@@ -3457,9 +3458,7 @@ func TestTxnWriteBufferLockingReadsTransformations(t *testing.T) {
 
 	for _, tc := range testCases {
 		t.Run(tc.name, func(t *testing.T) {
-			st := cluster.MakeClusterSettings()
-			bufferedWritesScanTransformEnabled.Override(ctx, &st.SV, true)
-			twb, mockSender := makeMockTxnWriteBuffer(st)
+			twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 			txn := makeTxnProto()
 			txn.Sequence = 10
 
@@ -3681,7 +3680,7 @@ func TestTxnWriteBufferLockingGetFlushing(t *testing.T) {
 	for _, tc := range testCases {
 		name := strings.Join(tc.ops, "_")
 		t.Run(name, func(t *testing.T) {
-			twb, mockSender := makeMockTxnWriteBuffer(cluster.MakeClusterSettings())
+			twb, mockSender, _ := makeMockTxnWriteBuffer(ctx)
 			txn := makeTxnProto()
 			txn.Sequence = 10
 			mockSender.MockSend(func(ba *kvpb.BatchRequest) (*kvpb.BatchResponse, *kvpb.Error) {


### PR DESCRIPTION
Backport 3/3 commits from #150404.

/cc @cockroachdb/release

---

See the individual commits for details..

I'd like to merge this and backport it to 25.3 separately to make it easier
to it a bit easier to manage this series of changes.

Epic: None

Release note: None

Release justification: Minor changes and test changes we are making in advance
of more critical bug fixes. All changes are to a settings-gated, off-by-default preview feature.