### PR TITLE
release-25.3: teamcity: add `s390x` unit tests build configuration

### DIFF
--- a/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests.sh
+++ b/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # For $root
+source "$dir/teamcity-bazel-support.sh"  # For run_bazel
+
+tc_start_block "Run unit tests"
+BAZEL_SUPPORT_EXTRA_DOCKER_ARGS="-e TC_BUILD_BRANCH -e GITHUB_API_TOKEN -e BUILD_VCS_NUMBER -e TC_BUILD_ID -e TC_SERVER_URL -e TC_BUILDTYPE_ID -e GITHUB_REPO" run_bazel build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
+tc_end_block "Run unit tests"

--- a/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
@@ -1,0 +1,25 @@
+#!/usr/bin/env bash
+
+# Copyright 2024 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euo pipefail
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+
+source "$dir/teamcity-support.sh"  # for 'tc_release_branch'
+
+bazel build //pkg/cmd/bazci
+
+# Omit the ui_test as it depends on Javascript stuff; we don't have nodejs stuff
+# for s390x and it's expensive to pull in anyway.
+TESTS=$(bazel query 'kind(go_test, pkg/...) except attr("tags", "[\[ ]integration[,\]]", kind(go_test, pkg/...))' | grep -v ui_test)
+
+set -x
+
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=dev \
+    $TESTS \
+    --profile=/artifacts/profile.gz


### PR DESCRIPTION
Backport 1/1 commits from #150418 on behalf of @rickystewart.

----

Epic: CRDB-21133
Release note: None

----

Release justification: Non-production code changes