### PR TITLE
gossip: use crtime.Mono

### DIFF
--- a/pkg/gossip/BUILD.bazel
+++ b/pkg/gossip/BUILD.bazel
@@ -38,6 +38,7 @@ go_library(
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_crlib//crtime",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_cockroachdb_logtags//:logtags",
         "@com_github_cockroachdb_redact//:redact",

--- a/pkg/gossip/gossip.go
+++ b/pkg/gossip/gossip.go
@@ -66,6 +66,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
+	"github.com/cockroachdb/crlib/crtime"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
 	"github.com/cockroachdb/redact"
@@ -1619,7 +1620,7 @@ func (g *Gossip) TestingAddInfoProtoAndWaitForAllCallbacks(
 				method: func(_ string, _ roachpb.Value) {
 					wg.Done()
 				},
-				schedulingTime: timeutil.Now(),
+				schedulingTime: crtime.NowMono(),
 			})
 			cb.cw.mu.Unlock()
 		}


### PR DESCRIPTION
crtime.NowMono is a little more efficient. I haven't seen this on any profiles but noted it when reviewing some code recently. We also remove an extra clock reading that wasn't needed.

Epic: none
Release note: None