### PR TITLE
sniffarg: simplify and add bool parsing

### DIFF
--- a/pkg/testutils/sniffarg/BUILD.bazel
+++ b/pkg/testutils/sniffarg/BUILD.bazel
@@ -5,7 +5,10 @@ go_library(
     srcs = ["sniffarg.go"],
     importpath = "github.com/cockroachdb/cockroach/pkg/testutils/sniffarg",
     visibility = ["//visibility:public"],
-    deps = ["@com_github_spf13_pflag//:pflag"],
+    deps = [
+        "@com_github_cockroachdb_errors//:errors",
+        "@com_github_spf13_pflag//:pflag",
+    ],
 )
 
 go_test(

--- a/pkg/testutils/sniffarg/sniffarg_test.go
+++ b/pkg/testutils/sniffarg/sniffarg_test.go
@@ -21,18 +21,28 @@ func TestDo(t *testing.T) {
 		"-test.outputdir", "banana",
 		"something",
 		"--somethingelse", "foo",
-		"--boolflag",
+		"--falseflag=false",
+		"--trueflag",
 	}
 	var benchMem string
 	var outputDir string
 	var somethingElse string
+	var trueFlag bool
+	var falseFlag bool
+	var wrongType struct{}
 	notFound := "hello"
+	require.Error(t, Do(args, "test.benchmem", &wrongType))
 	require.NoError(t, Do(args, "test.benchmem", &benchMem))
 	require.NoError(t, Do(args, "test.outputdir", &outputDir))
 	require.NoError(t, Do(args, "somethingelse", &somethingElse))
 	require.NoError(t, Do(args, "notfound", &notFound))
+	require.NoError(t, Do(args, "falseflag", &falseFlag))
+	require.NoError(t, Do(args, "trueflag", &trueFlag))
 	assert.Equal(t, "5", benchMem)
 	assert.Equal(t, "banana", outputDir)
 	assert.Equal(t, "foo", somethingElse)
+	assert.False(t, falseFlag)
+	assert.True(t, trueFlag)
 	assert.Zero(t, notFound)
+
 }


### PR DESCRIPTION
See commits. This is in preparation for adding plotted charts (as images) to the asim datadriven tests, for which I'll want to detect the `-rewrite` flag from outside the `datadriven` package.

Epic: CRDB-25222