### PR TITLE
asim: update node capacity in updateStoreCapacity

### DIFF
--- a/pkg/kv/kvserver/asim/gossip/gossip.go
+++ b/pkg/kv/kvserver/asim/gossip/gossip.go
@@ -123,10 +123,7 @@ func (g *gossip) addStoreToGossip(s state.State, storeID state.StoreID, nodeID s
 	g.storeGossip[storeID] = &storeGossiper{addingStore: true}
 	g.storeGossip[storeID] = newStoreGossiper(
 		func(cached bool) roachpb.StoreDescriptor {
-			nc := s.NodeCapacity(nodeID)
-			desc := s.StoreDescriptors(cached, storeID)[0]
-			desc.NodeCapacity = nc
-			return desc
+			return s.StoreDescriptors(cached, storeID)[0]
 		},
 		s.Clock(), g.settings.ST)
 }

--- a/pkg/kv/kvserver/asim/state/state.go
+++ b/pkg/kv/kvserver/asim/state/state.go
@@ -205,7 +205,7 @@ type State interface {
 	// SetClusterSetting sets the cluster setting for the state.
 	SetClusterSetting(Key string, Value interface{})
 	// NodeCapacity returns the capacity of the node with ID NodeID.
-	NodeCapacity(NodeID) roachpb.NodeCapacity
+	NodeCapacity(nodeID NodeID, useCached bool) roachpb.NodeCapacity
 	// SetNodeCPURateCapacity sets the CPU rate capacity for the node with ID
 	// NodeID to be equal to the value given.
 	SetNodeCPURateCapacity(NodeID, int64)


### PR DESCRIPTION
This commit updates node capacity directly in updateStoreCapacity, which is called by StoreDescriptors - the component responsible for updating store capacity. This removes the need to populate the node capacity field before gossip and aligns the simulator more closely with the production code. Note that we update node capacity regardless of the useCached flag since this is also what the production code does.

Epic: none
Release note: none