### PR TITLE
storage: re-enable value separation by default, metamorphically

### DIFF
--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -421,7 +421,8 @@ var (
 		settings.SystemVisible,
 		"storage.value_separation.enabled",
 		"whether or not values may be separated into blob files",
-		false, /* defaultValue */
+		metamorphic.ConstantWithTestBool(
+			"storage.value_separation.enabled", true /* defaultValue */),
 	)
 	valueSeparationMinimumSize = settings.RegisterIntSetting(
 		settings.SystemVisible,


### PR DESCRIPTION
This commit re-enables value separation by default now that #150216 is resolved. It's now metamorphically toggled on/off as well.

Epic: none
Release note: none