### PR TITLE
release-25.3: teamcity: add `s390x-test-failure` label for relevant unit test failures

### DIFF
--- a/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
+++ b/build/teamcity/cockroach/ci/tests-ibm-cloud-linux-s390x/unit_tests_impl.sh
@@ -20,6 +20,7 @@ TESTS=$(bazel query 'kind(go_test, pkg/...) except attr("tags", "[\[ ]integratio
 
 set -x
 
-$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci -- test --config=ci --config=dev \
-    $TESTS \
-    --profile=/artifacts/profile.gz
+$(bazel info bazel-bin)/pkg/cmd/bazci/bazci_/bazci --extralabels=s390x-test-failure -- \
+		       test --config=ci --config=dev \
+		       $TESTS \
+		       --profile=/artifacts/profile.gz

--- a/pkg/cmd/bazci/bazci.go
+++ b/pkg/cmd/bazci/bazci.go
@@ -61,6 +61,7 @@ var (
 	port                    int
 	artifactsDir            string
 	githubPostFormatterName string
+	extraLabels             []string
 
 	rootCmd = &cobra.Command{
 		Use:   "bazci",
@@ -286,6 +287,12 @@ func init() {
 		8998,
 		"port to run the bazci server on",
 	)
+	rootCmd.Flags().StringSliceVar(
+		&extraLabels,
+		"extralabels",
+		[]string{},
+		"comma-separated list of extra labels to add to any filed GitHub issues",
+	)
 }
 
 func getRunEnvForBeaverHub() string {
@@ -488,7 +495,7 @@ func processTestXmls(testXmls []string) error {
 				postErrors = append(postErrors, fmt.Sprintf("Failed to parse test.xml file with the following error: %+v", err))
 				continue
 			}
-			if err := githubpost.PostFromTestXMLWithFormatterName(githubPostFormatterName, testSuites); err != nil {
+			if err := githubpost.PostFromTestXMLWithFormatterName(githubPostFormatterName, testSuites, extraLabels); err != nil {
 				postErrors = append(postErrors, fmt.Sprintf("Failed to process %s with the following error: %+v", testXml, err))
 				continue
 			}


### PR DESCRIPTION
Backport 1/1 commits from #150512 on behalf of @rickystewart.

----

Epic: CRDB-21133
Release note: None

----

Release justification: Non-production code changes