### PR TITLE
ui: show tenant dropdown in insecure mode when multiple tenants exist

### DIFF
--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1303,6 +1303,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		tenantCapabilitiesWatcher,
 		cfg.DisableSQLServer,
 		cfg.BaseConfig.DisableTLSForHTTP,
+		cfg.Insecure,
 	)
 	drain.serverCtl = sc
 

--- a/pkg/server/server_controller.go
+++ b/pkg/server/server_controller.go
@@ -100,6 +100,8 @@ type serverController struct {
 
 	disableTLSForHTTP bool
 
+	insecure bool
+
 	mu struct {
 		syncutil.RWMutex
 
@@ -136,6 +138,7 @@ func newServerController(
 	watcher *tenantcapabilitieswatcher.Watcher,
 	disableSQLServer bool,
 	disableTLSForHTTP bool,
+	insecure bool,
 ) *serverController {
 	c := &serverController{
 		AmbientContext:      ambientCtx,
@@ -150,6 +153,7 @@ func newServerController(
 		drainCh:             make(chan struct{}),
 		disableSQLServer:    disableSQLServer,
 		disableTLSForHTTP:   disableTLSForHTTP,
+		insecure:            insecure,
 	}
 	c.orchestrator = newChannelOrchestrator(parentStopper, c)
 	c.mu.servers = map[roachpb.TenantName]*serverState{

--- a/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/app/components/tenantDropdown/tenantDropdown.tsx
@@ -7,6 +7,7 @@ import React from "react";
 
 import { getCookieValue, setCookie } from "src/redux/cookies";
 import { isSystemTenant } from "src/redux/tenants";
+import { getDataFromServer } from "src/util/dataFromServer";
 
 import ErrorBoundary from "../errorMessage/errorBoundary";
 
@@ -76,13 +77,27 @@ export default class TenantDropdown extends React.Component<
   }
 
   render() {
-    if (
-      !this.state.currentTenant ||
-      (this.state.virtualClusters?.length < 2 &&
-        isSystemTenant(this.state.currentTenant))
-    ) {
-      return null;
+    const dataFromServer = getDataFromServer();
+    const isInsecure = dataFromServer.Insecure;
+    // In insecure mode, show dropdown if there are >1 virtual clusters
+    if (isInsecure) {
+      if (this.state.virtualClusters?.length <= 1) {
+        return null;
+      }
+    } else {
+      // In secure mode, use the original logic
+      if (
+        !this.state.currentTenant ||
+        (this.state.virtualClusters?.length < 2 &&
+          isSystemTenant(this.state.currentTenant))
+      ) {
+        return null;
+      }
     }
+
+    // In insecure mode, show "default" if no tenant is set
+    const displayTenant =
+      this.state.currentTenant || (isInsecure ? "default" : "");
 
     return (
       <ErrorBoundary>
@@ -91,7 +106,7 @@ export default class TenantDropdown extends React.Component<
           onChange={(tenantID: string) => this.onTenantChange(tenantID)}
         >
           <div className="virtual-cluster-selected">
-            {"Virtual cluster: " + this.state.currentTenant}
+            {"Virtual cluster: " + displayTenant}
           </div>
         </Dropdown>
       </ErrorBoundary>


### PR DESCRIPTION
Previously, the tenant dropdown would not appear in insecure mode because it required a tenant cookie to be set, which only happens after authentication. This change modifies the dropdown logic to show when running in insecure mode and the virtual_clusters endpoint returns more than one tenant.

In insecure mode, the dropdown now displays "default" when no tenant cookie is set, allowing users to select from available virtual clusters without requiring authentication.

Subsumes #150143.
Closes #150143.

Release note (ui change): The tenant dropdown now appears in insecure mode when multiple virtual clusters are available.

Epic: none.