### PR TITLE
backup: create utility for checking if backup index exists

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -126,19 +126,17 @@ func filterSpans(includes []roachpb.Span, excludes []roachpb.Span) []roachpb.Spa
 func backup(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
-	defaultURI string,
-	urisByLocalityKV map[string]string,
+	details jobspb.BackupDetails,
 	settings *cluster.Settings,
 	defaultStore cloud.ExternalStorage,
 	storageByLocalityKV map[string]*cloudpb.ExternalStorage,
 	resumer *backupResumer,
 	backupManifest *backuppb.BackupManifest,
 	makeExternalStorage cloud.ExternalStorageFactory,
-	encryption *jobspb.BackupEncryptionOptions,
-	execLocality roachpb.Locality,
 ) (_ roachpb.RowCount, numBackupInstances int, _ error) {
 	resumerSpan := tracing.SpanFromContext(ctx)
 	var lastCheckpoint time.Time
+	encryption := details.EncryptionOptions
 
 	kmsEnv := backupencryption.MakeBackupKMSEnv(
 		execCtx.ExecCfg().Settings,
@@ -170,14 +168,16 @@ func backup(
 	oracle := physicalplan.DefaultReplicaChooser
 	if useBulkOracle.Get(&evalCtx.Settings.SV) {
 		oracle = kvfollowerreadsccl.NewBulkOracle(
-			dsp.ReplicaOracleConfig(evalCtx.Locality), execLocality, kvfollowerreadsccl.StreakConfig{},
+			dsp.ReplicaOracleConfig(evalCtx.Locality),
+			details.ExecutionLocality,
+			kvfollowerreadsccl.StreakConfig{},
 		)
 	}
 
 	// We don't return the compatible nodes here since PartitionSpans will
 	// filter out incompatible nodes.
 	planCtx, _, err := dsp.SetupAllNodesPlanningWithOracle(
-		ctx, evalCtx, execCtx.ExecCfg(), oracle, execLocality,
+		ctx, evalCtx, execCtx.ExecCfg(), oracle, details.ExecutionLocality,
 	)
 	if err != nil {
 		return roachpb.RowCount{}, 0, errors.Wrap(err, "failed to determine nodes on which to run")
@@ -193,8 +193,8 @@ func backup(
 		spans,
 		introducedSpans,
 		pkIDs,
-		defaultURI,
-		urisByLocalityKV,
+		details.URI,
+		details.URIsByLocalityKV,
 		encryption,
 		&kmsEnv,
 		kvpb.MVCCFilter(backupManifest.MVCCFilter),
@@ -302,7 +302,7 @@ func backup(
 				})
 
 				err := backupinfo.WriteBackupManifestCheckpoint(
-					ctx, defaultURI, encryption, &kmsEnv, backupManifest, execCtx.ExecCfg(), execCtx.User(),
+					ctx, details.URI, encryption, &kmsEnv, backupManifest, execCtx.ExecCfg(), execCtx.User(),
 				)
 				if err != nil {
 					log.Errorf(ctx, "unable to checkpoint backup descriptor: %+v", err)
@@ -437,6 +437,12 @@ func backup(
 	statsTable := getTableStatsForBackup(ctx, execCtx.ExecCfg().InternalDB.Executor(), backupManifest.Descriptors)
 	if err := backupinfo.WriteTableStatistics(ctx, defaultStore, encryption, &kmsEnv, &statsTable); err != nil {
 		return roachpb.RowCount{}, 0, err
+	}
+
+	if err := backupinfo.WriteBackupIndexMetadata(
+		ctx, execCtx.User(), execCtx.ExecCfg().DistSQLSrv.ExternalStorageFromURI, details,
+	); err != nil {
+		return roachpb.RowCount{}, 0, errors.Wrapf(err, "writing backup index metadata")
 	}
 
 	return backupManifest.EntryCounts, numBackupInstances, nil
@@ -723,16 +729,13 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 		res, numBackupInstances, err = backup(
 			ctx,
 			p,
-			details.URI,
-			details.URIsByLocalityKV,
+			details,
 			p.ExecCfg().Settings,
 			defaultStore,
 			storageByLocalityKV,
 			b,
 			backupManifest,
 			p.ExecCfg().DistSQLSrv.ExternalStorage,
-			details.EncryptionOptions,
-			details.ExecutionLocality,
 		)
 		if err == nil {
 			break

--- a/pkg/backup/backupbase/constants.go
+++ b/pkg/backup/backupbase/constants.go
@@ -63,4 +63,12 @@ const (
 	// and groups all the data sst files in each backup, which start with "data/",
 	// into a single result that can be skipped over quickly.
 	ListingDelimDataSlash = "data/"
+
+	// BackupIndexDirectoryName is the path from the root of the backup collection
+	// to the directory containing the index files for the backup collection.
+	BackupIndexDirectoryPath = "index"
+
+	// BackupIndexFilenameTimestampFormat is the format used for the human
+	// readable start and end times in the index file names.
+	BackupIndexFilenameTimestampFormat = "20060102-150405.00"
 )

--- a/pkg/backup/backupinfo/BUILD.bazel
+++ b/pkg/backup/backupinfo/BUILD.bazel
@@ -4,6 +4,7 @@ load("//pkg/testutils:buildutil/buildutil.bzl", "disallowed_imports_test")
 go_library(
     name = "backupinfo",
     srcs = [
+        "backup_index.go",
         "desc_sst.go",
         "external_sst_util.go",
         "file_sst.go",
@@ -58,16 +59,19 @@ go_library(
 go_test(
     name = "backupinfo_test",
     srcs = [
+        "backup_index_test.go",
         "main_test.go",
         "manifest_handling_test.go",
     ],
+    embed = [":backupinfo"],
     deps = [
-        ":backupinfo",
+        "//pkg/backup/backupbase",
         "//pkg/backup/backuppb",
         "//pkg/base",
         "//pkg/blobs",
         "//pkg/ccl",
         "//pkg/cloud",
+        "//pkg/cloud/cloudpb",
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/multitenant/mtinfopb",
@@ -83,9 +87,12 @@ go_test(
         "//pkg/util",
         "//pkg/util/bulk",
         "//pkg/util/hlc",
+        "//pkg/util/ioctx",
         "//pkg/util/leaktest",
         "//pkg/util/log",
+        "//pkg/util/protoutil",
         "//pkg/util/randutil",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/backup/backupinfo/backup_index.go
+++ b/pkg/backup/backupinfo/backup_index.go
@@ -1,0 +1,115 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backupinfo
+
+import (
+	"bytes"
+	"context"
+	"encoding/hex"
+	"fmt"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backupbase"
+	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/backup/backuputils"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/util/encoding"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/errors"
+)
+
+// WriteBackupIndexMetadata writes an index file for the backup described by the
+// job details. The provided ExternalStorage needs to be rooted at the specific
+// directory that the index file should be written to.
+//
+// Note: This file is not encrypted, so it should not contain any sensitive
+// information.
+func WriteBackupIndexMetadata(
+	ctx context.Context,
+	user username.SQLUsername,
+	makeExternalStorageFromURI cloud.ExternalStorageFromURIFactory,
+	details jobspb.BackupDetails,
+) error {
+	ctx, sp := tracing.ChildSpan(ctx, "backupinfo.WriteBackupIndexMetadata")
+	defer sp.Finish()
+
+	if details.EndTime.IsEmpty() {
+		return errors.AssertionFailedf("end time must be set in backup details")
+	}
+	if details.Destination.Exists && details.StartTime.IsEmpty() {
+		return errors.AssertionFailedf("incremental backup details missing a start time")
+	}
+
+	path, err := backuputils.RelativeBackupPathInCollectionURI(details.CollectionURI, details.URI)
+	if err != nil {
+		return errors.Wrapf(err, "failed to get relative backup path")
+	}
+	metadata := &backuppb.BackupIndexMetadata{
+		StartTime: details.StartTime,
+		EndTime:   details.EndTime,
+		Path:      path,
+	}
+	metadataBytes, err := protoutil.Marshal(metadata)
+	if err != nil {
+		return errors.Wrapf(err, "failed to marshal backup index metadata")
+	}
+
+	indexStore, err := makeExternalStorageFromURI(
+		ctx, details.CollectionURI, user,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "creating external storage")
+	}
+
+	indexFilePath, err := getBackupIndexFilePath(
+		details.Destination.Subdir,
+		details.StartTime,
+		details.EndTime,
+	)
+	if err != nil {
+		return errors.Wrapf(err, "getting index file path")
+	}
+
+	return cloud.WriteFile(
+		ctx, indexStore, indexFilePath, bytes.NewReader(metadataBytes),
+	)
+}
+
+// getBackupIndexFilePath returns the path to the backup index file representing
+// a backup that starts and ends at the given timestamps, including
+// the filename and extension. The path is relative to the collection URI.
+func getBackupIndexFilePath(subdir string, startTime, endTime hlc.Timestamp) (string, error) {
+	if strings.EqualFold(subdir, backupbase.LatestFileName) {
+		return "", errors.AssertionFailedf("expected subdir to be resolved and not be 'LATEST'")
+	}
+	return backuputils.JoinURLPath(
+		backupbase.BackupIndexDirectoryPath,
+		subdir,
+		getBackupIndexFileName(startTime, endTime),
+	), nil
+}
+
+// getBackupIndexFilename generates the filename (including the extension) for a
+// backup index file that represents a backup that starts ad ends at the given
+// timestamps.
+func getBackupIndexFileName(startTime, endTime hlc.Timestamp) string {
+	var buffer []byte
+	buffer = encoding.EncodeStringDescending(buffer, endTime.GoTime().String())
+	descEndTs := hex.EncodeToString(buffer)
+	formattedStartTime := startTime.GoTime().Format(backupbase.BackupIndexFilenameTimestampFormat)
+	if startTime.IsEmpty() {
+		formattedStartTime = "0" // Use a placeholder for empty start time.
+	}
+	formattedEndTime := endTime.GoTime().Format(backupbase.BackupIndexFilenameTimestampFormat)
+	return fmt.Sprintf(
+		"backup_%s_%s_%s_metadata.pb",
+		descEndTs, formattedStartTime, formattedEndTime,
+	)
+}

--- a/pkg/backup/backupinfo/backup_index_test.go
+++ b/pkg/backup/backupinfo/backup_index_test.go
@@ -1,0 +1,219 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package backupinfo
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"path"
+	"slices"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/backup/backupbase"
+	"github.com/cockroachdb/cockroach/pkg/backup/backuppb"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
+	"github.com/cockroachdb/cockroach/pkg/cloud/cloudpb"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/util"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/ioctx"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+	"github.com/stretchr/testify/require"
+)
+
+func TestGetBackupIndexFileName(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	type coverageTime struct {
+		// startTime and endTime represents hours in a single day. Because the
+		// generated filenames are only millisecond specific, it's just easier this
+		// way to ensure that the gaps between start and end time are large enough
+		// to have a meaningful difference in the generated filenames.
+		startTime int
+		endTime   int
+	}
+	// Inputs should be sorted in the order you expect their outputted filenames
+	// to be sorted in.
+	inputs := []coverageTime{
+		{startTime: 10, endTime: 12},
+		{startTime: 2, endTime: 10}, // Compacted backup timestamp
+		{startTime: 8, endTime: 10},
+		{startTime: 4, endTime: 8},
+		{startTime: 2, endTime: 4},
+		{startTime: 0, endTime: 2},
+	}
+
+	var sortedFilenames []string
+	timeToFilenames := make(map[coverageTime]string)
+	for _, input := range inputs {
+		start := time.Date(2025, 7, 18, input.startTime, 0, 0, 0, time.UTC)
+		end := time.Date(2025, 7, 18, input.endTime, 0, 0, 0, time.UTC)
+		name := getBackupIndexFileName(
+			hlc.Timestamp{WallTime: start.UnixNano()},
+			hlc.Timestamp{WallTime: end.UnixNano()},
+		)
+		if _, exists := timeToFilenames[input]; exists {
+			t.Fatalf("duplicate index file name generated for %v", input)
+		}
+		timeToFilenames[input] = name
+		sortedFilenames = append(sortedFilenames, name)
+	}
+
+	slices.Sort(sortedFilenames)
+	expectedSortedFilenames := util.Map(
+		inputs,
+		func(input coverageTime) string {
+			return timeToFilenames[input]
+		},
+	)
+
+	require.Equal(
+		t, expectedSortedFilenames, sortedFilenames, "sort order of index filenames does not match",
+	)
+}
+
+func TestGetBackupIndexFilePath(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	start, end := hlc.Timestamp{WallTime: 10}, hlc.Timestamp{WallTime: 20}
+	t.Run("fails if subdir is 'LATEST' and unresolved", func(t *testing.T) {
+		_, err := getBackupIndexFilePath("LATEST", start, end)
+		require.Error(t, err)
+	})
+	t.Run("returns correct path for resolved subdir", func(t *testing.T) {
+		subdir := "/2025/07/17-152115.00"
+		indexPath, err := getBackupIndexFilePath(subdir, start, end)
+		require.NoError(t, err)
+		require.True(
+			t, strings.HasPrefix(indexPath, path.Join(backupbase.BackupIndexDirectoryPath, subdir)),
+		)
+	})
+}
+
+func TestWriteBackupIndexMetadata(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	externalStorage := newFakeExternalStorage()
+	makeExternalStorage := func(
+		_ context.Context, _ string, _ username.SQLUsername, _ ...cloud.ExternalStorageOption,
+	) (cloud.ExternalStorage, error) {
+		return externalStorage, nil
+	}
+
+	start := hlc.Timestamp{WallTime: 10}
+	end := hlc.Timestamp{WallTime: 20}
+	collectionURI := "nodelocal://1/backup"
+	subdir := "2025/07/18-143826.00"
+	backupPath := fmt.Sprintf("/incrementals/%s", subdir)
+
+	details := jobspb.BackupDetails{
+		Destination: jobspb.BackupDetails_Destination{
+			Subdir: subdir,
+		},
+		StartTime:     start,
+		EndTime:       end,
+		CollectionURI: collectionURI,
+		URI:           collectionURI + backupPath,
+	}
+
+	require.NoError(t, WriteBackupIndexMetadata(
+		ctx, username.RootUserName(), makeExternalStorage, details,
+	))
+
+	filepath, err := getBackupIndexFilePath(subdir, start, end)
+	require.NoError(t, err)
+
+	reader, nBytes, err := externalStorage.ReadFile(ctx, filepath, cloud.ReadOptions{})
+	require.NoError(t, err)
+
+	contents := make([]byte, nBytes)
+	_, err = reader.Read(ctx, contents)
+	require.NoError(t, err)
+
+	var metadata backuppb.BackupIndexMetadata
+	require.NoError(t, protoutil.Unmarshal(contents, &metadata))
+
+	require.Equal(t, start, metadata.StartTime)
+	require.Equal(t, end, metadata.EndTime)
+	require.Equal(t, backupPath, metadata.Path)
+}
+
+type fakeExternalStorage struct {
+	cloud.ExternalStorage
+	files map[string]*closableBytesWriter
+}
+
+var _ cloud.ExternalStorage = &fakeExternalStorage{}
+
+func newFakeExternalStorage() *fakeExternalStorage {
+	return &fakeExternalStorage{
+		files: make(map[string]*closableBytesWriter),
+	}
+}
+
+func (f *fakeExternalStorage) Conf() cloudpb.ExternalStorage {
+	return cloudpb.ExternalStorage{
+		Provider: cloudpb.ExternalStorageProvider_Unknown,
+	}
+}
+
+type closableBytesWriter struct {
+	bytes.Buffer
+}
+
+func (b *closableBytesWriter) Close() error {
+	// No-op for bytes.Buffer, but satisfies io.WriteCloser interface.
+	return nil
+}
+
+func (f *fakeExternalStorage) Writer(ctx context.Context, filename string) (io.WriteCloser, error) {
+	if _, exists := f.files[filename]; exists {
+		return nil, errors.Errorf("file %s already exists", filename)
+	}
+	buf := closableBytesWriter{}
+	f.files[filename] = &buf
+	return &buf, nil
+}
+
+type bytesReaderCtx struct {
+	*bufio.Reader
+}
+
+func (br *bytesReaderCtx) Read(_ context.Context, p []byte) (n int, err error) {
+	// Use the context to satisfy the ReaderCtx interface, but ignore it.
+	return br.Reader.Read(p)
+}
+
+func (b *bytesReaderCtx) Close(_ context.Context) error {
+	// No-op for bufio.Reader, but satisfies io.ReadCloser interface.
+	return nil
+}
+
+func (f *fakeExternalStorage) ReadFile(
+	ctx context.Context, filename string, _ cloud.ReadOptions,
+) (ioctx.ReadCloserCtx, int64, error) {
+	bytes, exists := f.files[filename]
+	if !exists {
+		return nil, 0, errors.Errorf("file %s does not exist", filename)
+	}
+	reader := bytesReaderCtx{
+		Reader: bufio.NewReader(bytes),
+	}
+	return &reader, int64(bytes.Len()), nil
+}

--- a/pkg/backup/backuppb/backup.proto
+++ b/pkg/backup/backuppb/backup.proto
@@ -156,7 +156,16 @@ message BackupManifest {
   // NEXT ID: 30.
 }
 
-message BackupPartitionDescriptor{
+message BackupIndexMetadata {
+  util.hlc.Timestamp start_time = 1 [(gogoproto.nullable) = false];
+  util.hlc.Timestamp end_time = 2 [(gogoproto.nullable) = false];
+  // The path to the directory containing the backup relative to the collection
+  // URI.
+  string path = 3;
+  // Next ID: 4.
+}
+
+message BackupPartitionDescriptor {
   string locality_kv = 1 [(gogoproto.customname) = "LocalityKV"];
   repeated BackupManifest.File files = 2 [(gogoproto.nullable) = false];
   bytes backup_id = 3 [(gogoproto.nullable) = false,

--- a/pkg/backup/backuputils/utils.go
+++ b/pkg/backup/backuputils/utils.go
@@ -8,6 +8,7 @@ package backuputils
 import (
 	"net/url"
 	"path"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/cloud"
 )
@@ -81,4 +82,27 @@ func AppendPaths(uris []string, tailDir ...string) ([]string, error) {
 		retval[i] = parsed.String()
 	}
 	return retval, nil
+}
+
+// RelativeBackupPathInCollectionURI returns the relative path of a backup
+// within a collection URI. Backup URI represents the URI that points to the
+// directory containing the backup manifest of the backup.
+//
+// Example:
+//
+//	collectionURI: "nodelocal://1/collection"
+//	backupURI: "nodelocal://1/collection/backup1/"
+//	returns: "backup1/"
+func RelativeBackupPathInCollectionURI(collectionURI string, backupURI string) (string, error) {
+	backupURL, err := url.Parse(backupURI)
+	if err != nil {
+		return "", err
+	}
+	collectionURL, err := url.Parse(collectionURI)
+	if err != nil {
+		return "", err
+	}
+
+	relPath := strings.TrimPrefix(path.Clean(backupURL.Path), path.Clean(collectionURL.Path))
+	return relPath, nil
 }

--- a/pkg/backup/compaction_job.go
+++ b/pkg/backup/compaction_job.go
@@ -775,7 +775,7 @@ func concludeBackupCompaction(
 	ctx context.Context,
 	execCtx sql.JobExecContext,
 	store cloud.ExternalStorage,
-	encryption *jobspb.BackupEncryptionOptions,
+	details jobspb.BackupDetails,
 	kmsEnv cloud.KMSEnv,
 	backupManifest *backuppb.BackupManifest,
 ) error {
@@ -783,18 +783,29 @@ func concludeBackupCompaction(
 	backupManifest.ID = backupID
 
 	if err := backupinfo.WriteBackupManifest(ctx, store, backupbase.BackupManifestName,
-		encryption, kmsEnv, backupManifest); err != nil {
+		details.EncryptionOptions, kmsEnv, backupManifest); err != nil {
 		return err
 	}
 	if backupinfo.WriteMetadataWithExternalSSTsEnabled.Get(&execCtx.ExecCfg().Settings.SV) {
-		if err := backupinfo.WriteMetadataWithExternalSSTs(ctx, store, encryption,
+		if err := backupinfo.WriteMetadataWithExternalSSTs(ctx, store, details.EncryptionOptions,
 			kmsEnv, backupManifest); err != nil {
 			return err
 		}
 	}
 
 	statsTable := getTableStatsForBackup(ctx, execCtx.ExecCfg().InternalDB.Executor(), backupManifest.Descriptors)
-	return backupinfo.WriteTableStatistics(ctx, store, encryption, kmsEnv, &statsTable)
+	if err := backupinfo.WriteTableStatistics(
+		ctx, store, details.EncryptionOptions, kmsEnv, &statsTable,
+	); err != nil {
+		return errors.Wrapf(err, "writing table statistics")
+	}
+
+	return errors.Wrapf(
+		backupinfo.WriteBackupIndexMetadata(
+			ctx, execCtx.User(), execCtx.ExecCfg().DistSQLSrv.ExternalStorageFromURI, details,
+		),
+		"writing backup index metadata",
+	)
 }
 
 // processProgress processes progress updates from the bulk processor for a backup and updates
@@ -899,7 +910,7 @@ func doCompaction(
 	}
 
 	return concludeBackupCompaction(
-		ctx, execCtx, defaultStore, details.EncryptionOptions, kmsEnv, manifest,
+		ctx, execCtx, defaultStore, details, kmsEnv, manifest,
 	)
 }
 

--- a/pkg/jobs/jobspb/jobs.proto
+++ b/pkg/jobs/jobspb/jobs.proto
@@ -272,19 +272,19 @@ message LogicalReplicationDetails {
   }
 
   Discard discard = 11;
-  
+
   // CreateTable is true if the job should create the table(s) in the
   // destination.
   bool create_table = 12;
-  
+
   // IngestedExternalCatalog is the catalog written to the destination cluster
   // when CreateTable is true.
   sql.catalog.externalcatalog.externalpb.ExternalCatalog ingested_external_catalog = 13  [(gogoproto.nullable) = false];
-  
+
   // ReverseStreamCommand is CREATE LDR command the coordinator will issue once
   // the offline initial scan completes, but before the tables are made public.
   string reverse_stream_command = 14;
-  
+
   // ParentID is set on the reverse stream job in automatic bidirectional
   // replication, and is equal to the job ID that issued the reverse stream
   // command.
@@ -376,7 +376,7 @@ message BackupDetails {
   // sub-paths of it based on date and time, etc. The actual path -- which is
   // derived from this destination -- is then captured in the field "URI" below.
   message Destination {
-    // To is a collection path 
+    // To is a collection path
     repeated string to = 1;
     // Subdir is the path within the collection path in to to backup to.
     string subdir = 2;
@@ -401,7 +401,7 @@ message BackupDetails {
 
   // EncryptionOptions contains user inputed data initially, but once
   // ResolveDest is called at the beginning of resumption, this field will
-  // contain the encryption key. 
+  // contain the encryption key.
   //
   // TODO(msbutler): use seperate job info key to persist hydrated encryption
   // keys so encrypted backup logic becomes easier to reason about. This
@@ -410,7 +410,7 @@ message BackupDetails {
 
   // EncryptionInfo should only ever get set on the first encrypted backup in
   // the chain because it persists the salt that each key in the chain must
-  // have. 
+  // have.
   //
   // TODO(msbutler): understand if only the full ever sets EncryptionInfo.
   EncryptionInfo encryption_info = 9;
@@ -1574,7 +1574,7 @@ message Payload {
   string pause_reason = 28;
 
   reserved 32;
-  
+
   // CreationClusterID is populated at creation with the ClusterID, in case a
   // job resuming later, needs to use this information, e.g. to determine if it
   // has been restored into a different cluster, which might mean it should


### PR DESCRIPTION
This commit creates a utility function for checking if a full index directory exists for a given full backup subdirectory. Because it is possible for CRDB binaries that support backup indexes to read from older backups that do not contain indexes, we need some way of determining when to use the legacy code path and when to use the index as an optimization.

Epic: CRDB-47942

Release note: None