### PR TITLE
ui: rework network page

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/networking.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/networking.tsx
@@ -15,68 +15,6 @@ export default function (props: GraphDashboardProps) {
   const { nodeIDs, nodeDisplayNameByID, tenantSource } = props;
 
   return [
-    <LineGraph title="Network Bytes Received" showMetricsInTooltip={true}>
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.recv.bytes"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            tenantSource={tenantSource}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph title="Network Packets Received" showMetricsInTooltip={true}>
-      <Axis units={AxisUnits.Count} label="packets">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.recv.packets"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            tenantSource={tenantSource}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Network Packet Errors on Receive"
-      showMetricsInTooltip={true}
-    >
-      <Axis units={AxisUnits.Count} label="packets">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.recv.err"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            tenantSource={tenantSource}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Network Packet Drops on Receive"
-      showMetricsInTooltip={true}
-    >
-      <Axis units={AxisUnits.Count} label="packets">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.recv.drop"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            tenantSource={tenantSource}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
     <LineGraph title="Network Bytes Sent" showMetricsInTooltip={true}>
       <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
@@ -91,42 +29,11 @@ export default function (props: GraphDashboardProps) {
       </Axis>
     </LineGraph>,
 
-    <LineGraph title="Network Packets Sent" showMetricsInTooltip={true}>
-      <Axis units={AxisUnits.Count} label="packets">
+    <LineGraph title="Network Bytes Received" showMetricsInTooltip={true}>
+      <Axis units={AxisUnits.Bytes} label="bytes">
         {nodeIDs.map(nid => (
           <Metric
-            name="cr.node.sys.host.net.send.packets"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            tenantSource={tenantSource}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph
-      title="Network Packet Errors on Send"
-      showMetricsInTooltip={true}
-    >
-      <Axis units={AxisUnits.Count} label="packets">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.send.err"
-            title={nodeDisplayName(nodeDisplayNameByID, nid)}
-            sources={[nid]}
-            tenantSource={tenantSource}
-            nonNegativeRate
-          />
-        ))}
-      </Axis>
-    </LineGraph>,
-
-    <LineGraph title="Network Packet Drops on Send" showMetricsInTooltip={true}>
-      <Axis units={AxisUnits.Count} label="packets">
-        {nodeIDs.map(nid => (
-          <Metric
-            name="cr.node.sys.host.net.send.drop"
+            name="cr.node.sys.host.net.recv.bytes"
             title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             tenantSource={tenantSource}
@@ -188,6 +95,69 @@ export default function (props: GraphDashboardProps) {
             title={nodeDisplayName(nodeDisplayNameByID, nid)}
             sources={[nid]}
             tenantSource={tenantSource}
+          />
+        ))}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="Network Packet Errors and Drops"
+      showMetricsInTooltip={true}
+    >
+      <Axis units={AxisUnits.Count} label="packets">
+        {nodeIDs.flatMap(nid => [
+          <Metric
+            key={`${nid}-recv-err`}
+            name="cr.node.sys.host.net.recv.err"
+            title={`${nodeDisplayName(nodeDisplayNameByID, nid)} - Recv Errors`}
+            sources={[nid]}
+            tenantSource={tenantSource}
+            nonNegativeRate
+          />,
+          <Metric
+            key={`${nid}-recv-drop`}
+            name="cr.node.sys.host.net.recv.drop"
+            title={`${nodeDisplayName(nodeDisplayNameByID, nid)} - Recv Drops`}
+            sources={[nid]}
+            tenantSource={tenantSource}
+            nonNegativeRate
+          />,
+          <Metric
+            key={`${nid}-send-err`}
+            name="cr.node.sys.host.net.send.err"
+            title={`${nodeDisplayName(nodeDisplayNameByID, nid)} - Send Errors`}
+            sources={[nid]}
+            tenantSource={tenantSource}
+            nonNegativeRate
+          />,
+          <Metric
+            key={`${nid}-send-drop`}
+            name="cr.node.sys.host.net.send.drop"
+            title={`${nodeDisplayName(nodeDisplayNameByID, nid)} - Send Drops`}
+            sources={[nid]}
+            tenantSource={tenantSource}
+            nonNegativeRate
+          />,
+        ])}
+      </Axis>
+    </LineGraph>,
+
+    <LineGraph
+      title="TCP Retransmits"
+      tooltip={
+        "The number of TCP segments retransmitted. Some retransmissions are benign, but phase changes can be indicative of network congestion or overloaded peers."
+      }
+      showMetricsInTooltip={true}
+    >
+      <Axis label="segments">
+        {nodeIDs.map(nid => (
+          <Metric
+            key={nid}
+            name="cr.node.sys.host.net.send.tcp.retrans_segs"
+            title={nodeDisplayName(nodeDisplayNameByID, nid)}
+            sources={[nid]}
+            tenantSource={tenantSource}
+            nonNegativeRate
           />
         ))}
       </Axis>


### PR DESCRIPTION
Trying to make it a bit more functional. First, we put bytes sent/received first. We drop packets sent/received, which largely duplicates this (I could be talked out of that).

Packet errors and drops are jammed into a single chart. Step changes are (hopefully) still visible, and it avoids having to scroll through a set of empty graphs on the way down in the common case of no issues. (I might be wrong about this, but I've never seen errors, for example, only drops).

I added the new TCP retransmits chart from #149928.

The proxy charts probably not useful most of the time, but I kept them around. _If_ they do something, I assume we want to know.

| Old Chart Layout                      | New Chart Layout                         |
| :---------------------------------------- | :--------------------------------------- |
| Network Bytes Received                    | Network Bytes Sent                       |
| Network Packets Received                  | Network Bytes Received                   |
| Network Packet Errors on Receive          | RPC Heartbeat Latency: 50th percentile   |
| Network Packet Drops on Receive           | RPC Heartbeat Latency: 99th percentile   |
| Network Bytes Sent                        | Unhealthy RPC Connections                |
| Network Packets Sent                      | Network Packet Errors and Drops          |
| Network Packet Errors on Send             | TCP Retransmits                          |
| Network Packet Drops on Send              | Proxy requests                           |
| RPC Heartbeat Latency: 50th percentile    | Proxy request errors                     |
| RPC Heartbeat Latency: 99th percentile    | Proxy forwards                           |
| Unhealthy RPC Connections                 | Proxy forward errors                     |
| Proxy requests                            |                                          |
| Proxy request errors                      |                                          |
| Proxy forwards                            |                                          |

Epic: none