### PR TITLE
tenantcostserver: give default tokens for testing

### DIFF
--- a/pkg/ccl/multitenantccl/tenantcostserver/system_table.go
+++ b/pkg/ccl/multitenantccl/tenantcostserver/system_table.go
@@ -67,6 +67,7 @@ func (ts *tenantState) update(now time.Time) {
 			FirstInstance: 0,
 			Bucket: tenanttokenbucket.State{
 				TokenRefillRate: defaultRefillRate,
+				TokenCurrent:    10 * defaultRefillRate,
 			},
 		}
 		return

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/cleanup
@@ -1,6 +1,12 @@
 create-tenant tenant=5
 ----
 
+configure tenant=5
+available_tokens: 0
+refill_rate: 10000
+max_burst_tokens: 0
+----
+
 
 # First, establish a few instances.
 token-bucket-request tenant=5
@@ -32,6 +38,12 @@ First active instance: 3
   Instance 9:  lease="foo"  seq=4  next-instance=0  last-update=00:00:00.000
 
 create-tenant tenant=13
+----
+
+configure tenant=13
+available_tokens: 0
+refill_rate: 10000
+max_burst_tokens: 0
 ----
 
 token-bucket-request tenant=13

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/instances
@@ -17,7 +17,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=25000
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 0 secs
 Rates: write-batches=0,0  estimated-cpu=0,0
 Last update: 00:00:00.000
@@ -30,7 +30,7 @@ instance_id: 10
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=43750
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 0 secs
 Rates: write-batches=0,0  estimated-cpu=0,0
 Last update: 00:00:00.000
@@ -43,7 +43,7 @@ instance_id: 20
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=57812.5
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 0 secs
 Rates: write-batches=0,0  estimated-cpu=0,0
 Last update: 00:00:00.000
@@ -57,7 +57,7 @@ instance_id: 15
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=68359.375
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 0 secs
 Rates: write-batches=0,0  estimated-cpu=0,0
 Last update: 00:00:00.000
@@ -72,7 +72,7 @@ instance_id: 1
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=76269.53125
 Consumption: ru=0 kvru=0  reads=0 in 0 batches (0 bytes)  writes=0 in 0 batches (0 bytes)  pod-cpu-usage: 0 secs  pgwire-egress=0 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 0 secs
 Rates: write-batches=0,0  estimated-cpu=0,0
 Last update: 00:00:00.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/metrics
@@ -71,7 +71,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=57812.5
 Consumption: ru=1110 kvru=888  reads=2220 in 222 batches (3330 bytes)  writes=4440 in 333 batches (5550 bytes)  pod-cpu-usage: 6660 secs  pgwire-egress=7770 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 9990 secs
 Rates: write-batches=0,33.3  estimated-cpu=0,999
 Last update: 00:00:00.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/rates
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/rates
@@ -22,7 +22,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=25000
 Consumption: ru=10 kvru=10  reads=20 in 1 batches (30 bytes)  writes=40 in 10 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 80 secs
 Rates: write-batches=0,1  estimated-cpu=0,8
 Last update: 00:00:00.000
@@ -53,7 +53,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=50000  token-current-avg=12500
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=150000  token-current-avg=56250
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 20 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 160 secs
 Rates: write-batches=0,2  estimated-cpu=0,16
 Last update: 00:00:05.000
@@ -84,7 +84,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=34375
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=200000  token-current-avg=92187.5
 Consumption: ru=30 kvru=30  reads=60 in 3 batches (90 bytes)  writes=120 in 30 batches (150 bytes)  pod-cpu-usage: 180 secs  pgwire-egress=210 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 240 secs
 Rates: write-batches=2,1  estimated-cpu=16,8
 Last update: 00:00:10.000
@@ -116,7 +116,7 @@ consumption_period: 40s
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=500000  token-current-avg=150781.25
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=600000  token-current-avg=219140.625
 Consumption: ru=40 kvru=40  reads=80 in 4 batches (120 bytes)  writes=160 in 50 batches (200 bytes)  pod-cpu-usage: 240 secs  pgwire-egress=280 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 320 secs
 Rates: write-batches=0.5,0.5  estimated-cpu=2,2
 Last update: 00:00:50.000

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/requests
@@ -5,6 +5,12 @@
 create-tenant tenant=5
 ----
 
+configure tenant=5
+available_tokens: 0
+refill_rate: 10000
+max_burst_tokens: 0
+----
+
 token-bucket-request tenant=5
 instance_id: 1
 tokens: 10

--- a/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
+++ b/pkg/ccl/multitenantccl/tenantcostserver/testdata/seqnum
@@ -21,7 +21,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=25000
 Consumption: ru=10 kvru=10  reads=20 in 1 batches (30 bytes)  writes=40 in 3 batches (50 bytes)  pod-cpu-usage: 60 secs  pgwire-egress=70 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 80 secs
 Rates: write-batches=0,0.3  estimated-cpu=0,8
 Last update: 00:00:00.000
@@ -49,7 +49,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=43750
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 160 secs
 Rates: write-batches=0,0.6  estimated-cpu=0,16
 Last update: 00:00:00.000
@@ -77,7 +77,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=57812.5
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 160 secs
 Rates: write-batches=0,0.6  estimated-cpu=0,16
 Last update: 00:00:00.000
@@ -104,7 +104,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=68359.375
 Consumption: ru=20 kvru=20  reads=40 in 2 batches (60 bytes)  writes=80 in 6 batches (100 bytes)  pod-cpu-usage: 120 secs  pgwire-egress=140 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 160 secs
 Rates: write-batches=0,0.6  estimated-cpu=0,16
 Last update: 00:00:00.000
@@ -132,7 +132,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=76269.53125
 Consumption: ru=30 kvru=40  reads=60 in 3 batches (90 bytes)  writes=120 in 9 batches (150 bytes)  pod-cpu-usage: 180 secs  pgwire-egress=210 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 240 secs
 Rates: write-batches=0,0.9  estimated-cpu=0,24
 Last update: 00:00:00.000
@@ -160,7 +160,7 @@ consumption:
 
 inspect tenant=5
 ----
-Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=0  token-current-avg=0
+Bucket state: token-burst-limit=0  token-refill-rate=10000  token-current=100000  token-current-avg=82202.1484375
 Consumption: ru=40 kvru=70  reads=80 in 4 batches (120 bytes)  writes=160 in 12 batches (200 bytes)  pod-cpu-usage: 240 secs  pgwire-egress=280 bytes  external-egress=0 bytes  external-ingress=0 bytes  estimated-cpu: 320 secs
 Rates: write-batches=0,1.2  estimated-cpu=0,32
 Last update: 00:00:00.000


### PR DESCRIPTION
Previously, the tenant token bucket server defaulted to 10K tokens/second. This rate is used by tests (in production, it is configured via calls to update_tenant_resource_limits). However, while the default grant included the 10K rate, it did not include any up-front tokens. This was causing some tests to be throttled. The fix is to grant 10 seconds worth of tokens up-front by setting TokenCurrent = 10 * the default 10K rate.

Epic: none
Release note: None