### PR TITLE
release-25.3: provisioning: add usability counters for enabling ldap provisioning

### DIFF
--- a/pkg/security/provisioning/BUILD.bazel
+++ b/pkg/security/provisioning/BUILD.bazel
@@ -9,6 +9,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/security/provisioning",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/server/telemetry",
         "//pkg/settings",
         "//pkg/settings/cluster",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -19,6 +19,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/security/provisioning"
 	"github.com/cockroachdb/cockroach/pkg/security/sessionrevival"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql"
@@ -1055,6 +1056,7 @@ func AuthLDAP(
 
 	b.SetProvisioner(func(ctx context.Context) error {
 		c.LogAuthInfof(ctx, "LDAP authentication succeeded; attempting to provision user")
+		telemetry.Inc(provisioning.BeginLDAPProvisionUseCounter)
 		// Provision the user in the system.
 		idpString := entry.Method.String() + ":" + entry.GetOption("ldapserver")
 		provisioningSource, err := provisioning.ParseProvisioningSource(idpString)
@@ -1069,6 +1071,8 @@ func AuthLDAP(
 			c.LogAuthFailed(ctx, eventpb.AuthFailReason_PROVISIONING_ERROR, err)
 			return err
 		}
+
+		telemetry.Inc(provisioning.ProvisionLDAPSuccessCounter)
 		return nil
 	})
 


### PR DESCRIPTION
Backport 1/1 commits from #150476 on behalf of @souravcrl.

----

fixes #148876
Epic CRDB-21590

Release note (security update): The following provisioning usability metric counters were added for ldap based user provisioning.

* An enablement tracking counter for organizations enabling ldap provisioning (`auth.provisioning.ldap.enable`)
* A counter for number of organizations & tenants which have enabled ldap to auto-provision users(`auth.provisioning.ldap.begin`).
* A counter for the number of auto-provisioned users (`auth.provisioning.ldap.success`).
* A telemetry counter for number of logins performed by provisioned users (`auth.provisioning.login_success`).

----

Release justification: feature planned for 25.3