### PR TITLE
release-24.3: roachtest: add flaky test cases to ruby-pg ignoreList

### DIFF
--- a/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg_blocklist.go
@@ -190,10 +190,12 @@ var rubyPGIgnorelist = blocklist{
 	`PG::Connection multinationalization support respect and convert character encoding of input strings should convert error string to #put_copy_end`:                             "unknown",
 	`PG::Connection in nonblocking mode rejects to send lots of COPY data`:                                                                                                         "flaky",
 	`PG::Connection times out after connect_timeout seconds`:                                                                                                                       "flaky",
+	`PG::Connection#copy_data can handle client errors in #copy_data for output`:                                                                                                   "flaky",
 	`running with sync_* methods PG::Connection in nonblocking mode rejects to send lots of COPY data`:                                                                             "flaky",
 	`running with sync_* methods PG::Connection consume_input should raise ConnectionBad for a closed connection`:                                                                  "flaky",
 	`running with sync_* methods PG::Connection OS thread support Connection.new shouldn't block a second thread`:                                                                  "flaky",
 	`running with sync_* methods PG::Connection handles server close while asynchronous connect`:                                                                                   "flaky",
 	`running with sync_* methods PG::Connection multinationalization support respect and convert character encoding of input strings should convert error string to #put_copy_end`: "flaky",
 	`running with sync_* methods PG::Connection times out after connect_timeout seconds`:                                                                                           "flaky",
+	`with a Fiber scheduler connects several times concurrently`:                                                                                                                   "flaky",
 }


### PR DESCRIPTION
Backport 1/1 commits from #150429 on behalf of @spilchen.

----

This ignores the result of a couple of flaky tests in the ruby-pg suite.

Closes #150127
Closes #149419

Epic: none
Release note: none

----

Release justification: test only fix