### PR TITLE
sql: remove citext from versions previous to 25.3

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/citext
+++ b/pkg/sql/logictest/testdata/logic_test/citext
@@ -1,3 +1,5 @@
+# LogicTest: !local-mixed-25.2
+
 query T
 SELECT pg_typeof(CITEXT 'Foo')
 ----

--- a/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/sql/logictest/tests/local-mixed-25.2/generated_test.go
@@ -353,13 +353,6 @@ func TestLogic_check_constraints(
 	runLogicTest(t, "check_constraints")
 }
 
-func TestLogic_citext(
-	t *testing.T,
-) {
-	defer leaktest.AfterTest(t)()
-	runLogicTest(t, "citext")
-}
-
 func TestLogic_cluster_settings(
 	t *testing.T,
 ) {

--- a/pkg/sql/sem/eval/unsupported_types.go
+++ b/pkg/sql/sem/eval/unsupported_types.go
@@ -52,5 +52,11 @@ func (tc *unsupportedTypeChecker) CheckType(ctx context.Context, typ *types.T) e
 			"%s not supported until version 25.2", typ.String(),
 		)
 	}
+	if (typ.Oid() == oidext.T_citext || typ.Oid() == oidext.T__citext) &&
+		!tc.version.IsActive(ctx, clusterversion.V25_3) {
+		return pgerror.Newf(pgcode.FeatureNotSupported,
+			"%s not supported until version 25.3", typ.String(),
+		)
+	}
 	return nil
 }


### PR DESCRIPTION
### sql: remove citext from versions previous to 25.3

This PR adds CITEXT as an unsupported type for older versions. CITEXT is only supported on versions 25.3 and up.

Fixes: None
Epic: None
Release note: None