### PR TITLE
backup/crosscluster: clean up verbose logs

### DIFF
--- a/pkg/backup/backup_job.go
+++ b/pkg/backup/backup_job.go
@@ -774,7 +774,7 @@ func (b *backupResumer) Resume(ctx context.Context, execCtx interface{}) error {
 			// If we made decent progress with the BACKUP, reset the last
 			// progress state.
 			if madeProgress := curProgress - lastProgress; madeProgress >= 0.01 {
-				log.Infof(ctx, "backport made %d%% progress, resetting retry duration", int(math.Round(float64(100*madeProgress))))
+				log.Infof(ctx, "backup made %d%% progress, resetting retry duration", int(math.Round(float64(100*madeProgress))))
 				lastProgress = curProgress
 				r.Reset()
 			}

--- a/pkg/backup/backup_processor.go
+++ b/pkg/backup/backup_processor.go
@@ -204,7 +204,6 @@ func (bp *backupDataProcessor) Start(ctx context.Context) {
 		for range bp.progCh {
 		}
 	}
-	log.Infof(ctx, "starting backup data")
 	if err := bp.FlowCtx.Stopper().RunAsyncTaskEx(ctx, stop.TaskOpts{
 		TaskName: "backupDataProcessor.runBackupProcessor",
 		SpanOpt:  stop.ChildSpan,

--- a/pkg/crosscluster/logical/logical_replication_writer_processor.go
+++ b/pkg/crosscluster/logical/logical_replication_writer_processor.go
@@ -492,7 +492,7 @@ func (lrw *logicalReplicationWriterProcessor) consumeEvents(ctx context.Context)
 		if timeutil.Since(lastLog) > 5*time.Minute {
 			lastLog = timeutil.Now()
 			if !lrw.frontier.Frontier().GoTime().After(timeutil.Now().Add(-5 * time.Minute)) {
-				log.Infof(lrw.Ctx(), "lagging frontier: %s with span %s", lrw.frontier.Frontier(), lrw.frontier.PeekFrontierSpan())
+				log.VEventf(lrw.Ctx(), 2, "lagging frontier: %s with span %s", lrw.frontier.Frontier(), lrw.frontier.PeekFrontierSpan())
 			}
 		}
 		lrw.debug.RecordRecvStart()
@@ -527,7 +527,7 @@ func (lrw *logicalReplicationWriterProcessor) handleEvent(
 		// via whatever mechanism handles schema changes.
 		return errors.Newf("unexpected event for online stream: %v", event)
 	case crosscluster.SplitEvent:
-		log.Infof(lrw.Ctx(), "SplitEvent received on logical replication stream")
+		log.VEvent(lrw.Ctx(), 2, "SplitEvent received on logical replication stream")
 	default:
 		return errors.Newf("unknown streaming event type %v", event.Type())
 	}

--- a/pkg/crosscluster/logical/offline_initial_scan_processor.go
+++ b/pkg/crosscluster/logical/offline_initial_scan_processor.go
@@ -351,7 +351,7 @@ func (o *offlineInitialScanProcessor) handleEvent(
 	case crosscluster.SSTableEvent, crosscluster.DeleteRangeEvent:
 		return errors.AssertionFailedf("unexpected event for offline initial scan: %v", event)
 	case crosscluster.SplitEvent:
-		log.Infof(o.Ctx(), "SplitEvent received on logical replication stream")
+		log.VEvent(o.Ctx(), 2, "SplitEvent received on logical replication stream")
 	default:
 		return errors.Newf("unknown streaming event type %v", event.Type())
 	}

--- a/pkg/crosscluster/physical/ingest_span_configs.go
+++ b/pkg/crosscluster/physical/ingest_span_configs.go
@@ -285,7 +285,7 @@ func (sc *spanConfigIngestor) flushEvents(ctx context.Context) error {
 				// We expect the underlying sqlliveness session's expiration to be
 				// extended automatically, which makes this retry loop effective in the
 				// face of these retryable lease expired errors from the RPC.
-				log.Infof(ctx, "lease expired while updating span config records, retrying..")
+				log.VEvent(ctx, 2, "lease expired while updating span config records, retrying..")
 				continue
 			}
 			return err // not a retryable error, bubble up

--- a/pkg/crosscluster/physical/stream_ingestion_processor.go
+++ b/pkg/crosscluster/physical/stream_ingestion_processor.go
@@ -387,7 +387,6 @@ func newStreamIngestionDataProcessor(
 func (sip *streamIngestionProcessor) Start(ctx context.Context) {
 	ctx = logtags.AddTag(ctx, "job", sip.spec.JobID)
 	ctx = logtags.AddTag(ctx, "proc", sip.ProcessorID)
-	log.Infof(ctx, "starting ingest proc")
 	sip.agg = tracing.TracingAggregatorForContext(ctx)
 
 	// If the aggregator is nil, we do not want the timer to fire.
@@ -763,7 +762,7 @@ func (sip *streamIngestionProcessor) handleEvent(event PartitionEvent) error {
 	}
 
 	if sip.logBufferEvery.ShouldLog() {
-		log.Infof(sip.Ctx(), "current KV batch size %d (%d items)", sip.buffer.curKVBatchSize, len(sip.buffer.curKVBatch))
+		log.VEventf(sip.Ctx(), 2, "current KV batch size %d (%d items)", sip.buffer.curKVBatchSize, len(sip.buffer.curKVBatch))
 	}
 
 	if sip.buffer.shouldFlushOnSize(sip.Ctx(), sv) {
@@ -870,7 +869,7 @@ func (sip *streamIngestionProcessor) handleSplitEvent(key *roachpb.Key) error {
 	if !ok {
 		return nil
 	}
-	log.Infof(ctx, "replicating split at %s", roachpb.Key(rekey).String())
+	log.VEventf(ctx, 2, "replicating split at %s", roachpb.Key(rekey).String())
 	expiration := kvDB.Clock().Now().AddDuration(time.Hour)
 	return kvDB.AdminSplit(ctx, rekey, expiration)
 }


### PR DESCRIPTION
The observability team has asked us to remove any useless logs and increase the verbosity of any chatty logs.

Epic: none

Release note: none