### PR TITLE
roachtest: fix cdc/message-too-large-error

### DIFF
--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2669,7 +2669,7 @@ func registerCDC(r registry.Registry) {
 		Leases:           registry.MetamorphicLeases,
 		Suites:           registry.Suites(registry.Nightly),
 		Timeout:          15 * time.Minute,
-		CompatibleClouds: registry.AllClouds,
+		CompatibleClouds: registry.AllExceptIBM,
 		Run:              runMessageTooLarge,
 	})
 }


### PR DESCRIPTION
Adjust cloud options to fix test failure.

Release note: None

Fixes: https://github.com/cockroachdb/cockroach/issues/150464#issue-3241834817
Jira issue: [CRDB-52716](https://cockroachlabs.atlassian.net/browse/CRDB-52716)
Epic [CRDB-21133](https://cockroachlabs.atlassian.net/browse/CRDB-21133)