### PR TITLE
server: rolling restart planning endpoint

### DIFF
--- a/docs/generated/http/full.md
+++ b/docs/generated/http/full.md
@@ -5586,6 +5586,52 @@ show throttling warnings and alerts in DB Console.
 
 
 
+## NodeFaultToleranceStatus
+
+
+
+NodeFaultToleranceStatus indicates whether it's safe to terminate a
+node, and what that node's neighbor nodes are in the replication graph
+
+Support status: [reserved](#support-status)
+
+#### Request Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| node_id | [string](#cockroach.server.serverpb.NodeFaultToleranceRequest-string) |  |  | [reserved](#support-status) |
+
+
+
+
+
+
+
+#### Response Parameters
+
+
+
+
+
+
+
+| Field | Type | Label | Description | Support status |
+| ----- | ---- | ----- | ----------- | -------------- |
+| can_terminate | [bool](#cockroach.server.serverpb.NodeFaultToleranceResponse-bool) |  |  | [reserved](#support-status) |
+| neighbors | [int32](#cockroach.server.serverpb.NodeFaultToleranceResponse-int32) | repeated |  | [reserved](#support-status) |
+
+
+
+
+
+
+
 ## Users
 
 `GET /_admin/v1/users`

--- a/pkg/server/BUILD.bazel
+++ b/pkg/server/BUILD.bazel
@@ -388,6 +388,7 @@ go_library(
         "@org_golang_google_grpc//metadata",
         "@org_golang_google_grpc//status",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_time//rate",
     ] + select({
         "@io_bazel_rules_go//go/platform:aix": [
             "@org_golang_x_sys//unix",

--- a/pkg/server/api_v2_test.go
+++ b/pkg/server/api_v2_test.go
@@ -21,6 +21,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/liveness/livenesspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/server/apiconstants"
 	"github.com/cockroachdb/cockroach/pkg/server/authserver"
 	"github.com/cockroachdb/cockroach/pkg/server/serverpb"
@@ -210,6 +211,95 @@ func TestRestartSafetyV2(t *testing.T) {
 
 	require.Equal(t, 200, resp.StatusCode, "expected 200: %s", string(bodyBytes))
 	require.NoError(t, json.Unmarshal(bodyBytes, &response))
+}
+
+func TestPlanRestart(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// locality config to put 25 nodes in 5 localities
+	locs := []string{"a", "b", "c", "d", "e"}
+	const nodeCount = 25
+	args := base.TestClusterArgs{}
+	args.ServerArgsPerNode = make(map[int]base.TestServerArgs)
+	for i := 0; i < nodeCount; i++ {
+		args.ServerArgsPerNode[i] = base.TestServerArgs{
+			Locality: roachpb.Locality{
+				Tiers: []roachpb.Tier{
+					{
+						Key:   "region",
+						Value: "test",
+					},
+					{
+						Key:   "zone",
+						Value: locs[i%len(locs)],
+					},
+				},
+			},
+		}
+	}
+	testCluster := serverutils.StartCluster(t, nodeCount, args)
+	ctx := context.Background()
+	defer testCluster.Stopper().Stop(ctx)
+
+	ts1 := testCluster.Server(0)
+
+	client, err := ts1.GetAdminHTTPClient()
+	require.NoError(t, err)
+
+	const capacityTarget = 0.75
+	doneNodes := map[roachpb.NodeID]struct{}{}
+	moreBatches := true
+	for moreBatches {
+		url := ts1.AdminURL().WithPath(apiconstants.APIV2Path + "drain/plan/")
+		query := url.Query()
+		query.Add("capacityTarget", fmt.Sprintf("%f", capacityTarget))
+		for nodeID := range doneNodes {
+			query.Add("doneNodes", strconv.Itoa(int(nodeID)))
+		}
+		url.RawQuery = query.Encode()
+
+		req, err := http.NewRequest("GET", url.String(), nil)
+		require.NoError(t, err)
+		resp, err := client.Do(req)
+		require.NoError(t, err)
+		require.NotNil(t, resp)
+
+		// Check if the response was a 200.
+		require.Equal(t, 200, resp.StatusCode)
+		// Check if an unmarshal into the (empty) RestartPlanBatch struct works.
+		var batchResult serverpb.RestartPlanBatch
+		require.NoError(t, json.NewDecoder(resp.Body).Decode(&batchResult))
+		require.NoError(t, resp.Body.Close())
+
+		// Check that the drain cohort is non-empty (which is expected here, since we're not actually downing any nodes)
+		// NB: In a real client, an empty cohort should just cause you to sleep for like 30s and check again.
+		require.Greater(t, len(batchResult.Batch), 0)
+		// Check that we're not exceeding our disruption budget
+		disruptionBudget := (1.0 - capacityTarget) * nodeCount
+		require.LessOrEqual(t, len(batchResult.Batch), int(disruptionBudget))
+		t.Logf("Cohort size %d", len(batchResult.Batch))
+
+		// NB: In a real operations orchestrator, this is where you go drain and restart the nodes in
+		// batchResult.Batch in parallel
+
+		for _, toDrain := range batchResult.Batch {
+			_, ok := doneNodes[toDrain.NodeID]
+			// Check that we're not repeating any nodes that are already done
+			require.False(t, ok, "repeated drain node %d", toDrain.NodeID)
+
+			doneNodes[toDrain.NodeID] = struct{}{}
+		}
+
+		// Check the more flag
+		if len(doneNodes) < nodeCount {
+			require.True(t, batchResult.MoreBatches)
+		} else {
+			require.False(t, batchResult.MoreBatches)
+		}
+
+		moreBatches = batchResult.MoreBatches
+	}
 }
 
 // TestRulesV2 tests the /api/v2/rules endpoint to ensure it

--- a/pkg/server/serverpb/admin.proto
+++ b/pkg/server/serverpb/admin.proto
@@ -650,6 +650,11 @@ message HealthRequest {
 message HealthResponse {
 }
 
+message RestartPlanBatch {
+  repeated roachpb.NodeDescriptor batch = 1;
+  bool more_batches = 2;
+}
+
 // LivenessRequest requests liveness data for all nodes on the cluster.
 message LivenessRequest {
 }

--- a/pkg/server/serverpb/status.proto
+++ b/pkg/server/serverpb/status.proto
@@ -2157,6 +2157,15 @@ message GetThrottlingMetadataRequest {
   string node_id = 1 [(gogoproto.customname) = "NodeID"];
 }
 
+message NodeFaultToleranceRequest {
+  string node_id = 1 [(gogoproto.customname) = "NodeID"];
+}
+
+message NodeFaultToleranceResponse {
+  bool can_terminate = 1;
+  repeated int32 neighbors = 2;
+}
+
 // GetThrottlingMetadataResponse contains all information necessary to
 // show throttling warnings and alerts in DB Console.
 message GetThrottlingMetadataResponse {
@@ -2690,4 +2699,8 @@ service Status {
       get: "/_status/throttling"
     };
   }
+
+  // NodeFaultToleranceStatus indicates whether it's safe to terminate a
+  // node, and what that node's neighbor nodes are in the replication graph
+  rpc NodeFaultToleranceStatus(NodeFaultToleranceRequest) returns (NodeFaultToleranceResponse) {}
 }


### PR DESCRIPTION
Iterates over groups of nodes that can be drained and restarted in parallel without creating unavailability.

Epic: none
Part of: https://cockroachlabs.atlassian.net/browse/TREQ-929

Release node (ops change):
The drain planning endpoint aids in efficient rolling restarts by examining replica placement and range health, and identifying non-overlapping nodes that can be drained and restarted without creating unavailability. It also respects cluster capacity constraints.