### PR TITLE
oidcccl,serverpb: add PKCE support to OIDC authentication flow

### DIFF
--- a/pkg/ccl/oidcccl/authorization_oidc_test.go
+++ b/pkg/ccl/oidcccl/authorization_oidc_test.go
@@ -73,7 +73,7 @@ func (m mockManager) AuthCodeURL(state string, _ ...oauth2.AuthCodeOption) strin
 }
 
 func (m mockManager) ExchangeVerifyGetTokenInfo(
-	ctx context.Context, _, _ string, _ bool,
+	ctx context.Context, _, _ string, _ bool, _ ...oauth2.AuthCodeOption,
 ) (map[string]json.RawMessage, map[string]json.RawMessage, string, string, error) {
 	if m.rawIDToken == "" {
 		// The real implementation would fail to extract the ID token from the

--- a/pkg/ccl/oidcccl/settings.go
+++ b/pkg/ccl/oidcccl/settings.go
@@ -42,6 +42,7 @@ const (
 	OIDCAuthZEnabledSettingName                    = baseOIDCSettingName + "authorization.enabled"
 	OIDCAuthGroupClaimSettingName                  = baseOIDCSettingName + "group_claim"
 	OIDCAuthUserinfoGroupKeySettingName            = baseOIDCSettingName + "userinfo_group_key"
+	OIDCPKCEEnabledSettingName                     = baseOIDCSettingName + "pkce.enabled"
 )
 
 // OIDCEnabled enables or disabled OIDC login for the DB Console.
@@ -112,6 +113,15 @@ var OIDCAuthUserinfoGroupKey = settings.RegisterStringSetting(
 	OIDCAuthUserinfoGroupKeySettingName, // "server.oidc_authentication.userinfo_group_key"
 	"sets the field name in userinfo JSON containing the groups claim for authorization",
 	"groups",
+)
+
+// OIDCPKCEEnabled enables or disables PKCE for the OIDC authentication flow.
+// It is recommended to leave this enabled unless your OIDC provider does not support it.
+var OIDCPKCEEnabled = settings.RegisterBoolSetting(
+	settings.ApplicationLevel,
+	OIDCPKCEEnabledSettingName,
+	"enables or disables PKCE for the OIDC authentication flow; disabling is not recommended",
+	false, // default false for now, might want to make it default true
 )
 
 type redirectURLConf struct {

--- a/pkg/server/serverpb/authentication.proto
+++ b/pkg/server/serverpb/authentication.proto
@@ -67,6 +67,8 @@ message OIDCState {
 	bytes tokenMAC = 4;
 	// mode is the requested behavior of the OIDC callback handler
 	Mode mode = 5;
+	// pkce_code_verifier is the secret used for the PKCE flow.
+	string pkce_code_verifier = 6;
 }
 
 // LogIn and LogOut are the GRPC APIs used to create web authentication sessions.


### PR DESCRIPTION
Previously, the OIDC authentication flow did not implement the Proof Key for Code Exchange (PKCE) extension.

This was inadequate because it left the OIDC flow vulnerable to authorization code interception attacks, where a malicious actor could steal the authorization code and use it to obtain an access token. The [OAuth 2.1 Spec](https://oauth.net/2.1/) also mandates the use of PKCE for all OAuth clients using the Authorization Code Flow.

To address this, this patch implements the full PKCE flow (as described in RFC 7636). It generates a `code_verifier` at the start of the login process, derives a `code_challenge`, and includes it in the authorization request. During the token exchange, the `code_verifier` is sent to the OIDC provider for verification, thus ensuring that only the legitimate client can exchange the authorization code for a token. A new cluster setting,
`server.oidc_authentication.pkce.enabled`, is introduced to control this feature, and it is enabled by default.

Epic: none
Release note (security update): The OIDC login flow now implements the Proof Key for Code Exchange (PKCE) extension to enhance security against authorization code interception attacks. This feature is disabled by default. It is gated by the cluster setting `server.oidc_authentication.pkce.enabled`.