### PR TITLE
kv/bulk: make maxSlabGrow configurable for large KV entries

### DIFF
--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -27,6 +27,7 @@ go_library(
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/ctxgroup",
+        "//pkg/util/envutil",
         "//pkg/util/hlc",
         "//pkg/util/humanizeutil",
         "//pkg/util/limit",

--- a/pkg/kv/bulk/kv_buf.go
+++ b/pkg/kv/bulk/kv_buf.go
@@ -10,6 +10,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/util/envutil"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/errors"
 )
@@ -38,7 +39,9 @@ const entrySizeShift = 4     // sizeof(kvBufEntry) is 16, or shift 4.
 const minEntryGrow = 1 << 14 // 16k items or 256KiB of entry size.
 const maxEntryGrow = (4 << 20) >> entrySizeShift
 const minSlabGrow = 512 << 10
-const maxSlabGrow = 64 << 20
+const defaultMaxSlabGrow = 64 << 20 // 64MiB
+
+var maxSlabGrow = sz(envutil.EnvOrDefaultInt64("COCKROACH_KV_BULK_MAX_SLAB_GROW", defaultMaxSlabGrow))
 
 const (
 	lenBits, lenMask  = 28, 1<<lenBits - 1 // 512mb item limit, 32gb buffer limit.


### PR DESCRIPTION
Adds COCKROACH_KV_BULK_MAX_SLAB_GROW environment variable to override the default 64 MiB limit for rare cases with very large KV entries.

Fixes #150181

Release note: None

🤖 Generated with [Claude Code](https://claude.ai/code)