### PR TITLE
Implement st forcerhr

### DIFF
--- a/pkg/geo/geomfn/orientation.go
+++ b/pkg/geo/geomfn/orientation.go
@@ -148,3 +148,9 @@ func forcePolygonOrientation(g geom.T, o Orientation) error {
 		return pgerror.Newf(pgcode.InvalidParameterValue, "unhandled geometry type: %T", g)
 	}
 }
+
+// ForceRHR forces the orientation of vertices in a polygon to follow the Right-Hand-Rule.
+// This is a synonym for ForcePolygonCW (exterior rings clockwise, interior rings counter-clockwise).
+func ForceRHR(g geo.Geometry) (geo.Geometry, error) {
+	return ForcePolygonOrientation(g, OrientationCW)
+}

--- a/pkg/geo/geomfn/orientation_test.go
+++ b/pkg/geo/geomfn/orientation_test.go
@@ -219,3 +219,16 @@ func TestForcePolygonOrientation(t *testing.T) {
 		})
 	}
 }
+
+func TestForceRHR(t *testing.T) {
+	for _, tc := range orientationTestCases {
+		t.Run(tc.desc, func(t *testing.T) {
+			g, err := geo.ParseGeometry(tc.wkt)
+			require.NoError(t, err)
+
+			ret, err := ForceRHR(g)
+			require.NoError(t, err)
+			require.Equal(t, geo.MustParseGeometry(tc.forcedCWWKT), ret)
+		})
+	}
+}

--- a/pkg/sql/logictest/testdata/logic_test/geospatial
+++ b/pkg/sql/logictest/testdata/logic_test/geospatial
@@ -1542,6 +1542,19 @@ Square (left)                             false  true  POLYGON ((-1 0, -1 1, 0 1
 Square (right)                            false  true  POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))                    POLYGON ((0 0, 1 0, 1 1, 0 1, 0 0))
 Square overlapping left and right square  false  true  POLYGON ((-0.1 0, -0.1 1, 1 1, 1 0, -0.1 0))           POLYGON ((-0.1 0, 1 0, 1 1, -0.1 1, -0.1 0))
 
+# ST_ForceRHR test (should be equivalent to ST_ForcePolygonCW)
+query TT
+SELECT
+  dsc,
+  ST_AsText(ST_ForceRHR(geom))
+FROM geom_operators_test
+WHERE dsc IN ('Square (left)', 'Square (right)', 'Point middle of Left Square')
+ORDER BY dsc
+----
+Point middle of Left Square  POINT (-0.5 0.5)
+Square (left)                POLYGON ((-1 0, -1 1, 0 1, 0 0, -1 0))
+Square (right)               POLYGON ((0 0, 0 1, 1 1, 1 0, 0 0))
+
 # Functions which take in strings as input as well.
 query TT
 SELECT

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2749,6 +2749,7 @@ var builtinOidsArray = []string{
 	2786: `citext(jsonpath: jsonpath) -> citext`,
 	2787: `citext(box2d: box2d) -> citext`,
 	2788: `citext(vector: vector) -> citext`,
+	2789: `st_forcerhr(geometry: geometry) -> geometry`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid

--- a/pkg/sql/sem/builtins/geo_builtins.go
+++ b/pkg/sql/sem/builtins/geo_builtins.go
@@ -2749,6 +2749,25 @@ The requested number of points must be not larger than 65336.`,
 			volatility.Immutable,
 		),
 	),
+	"st_forcerhr": makeBuiltin(
+		defProps(),
+		geometryOverload1(
+			func(_ context.Context, _ *eval.Context, g *tree.DGeometry) (tree.Datum, error) {
+				ret, err := geomfn.ForceRHR(g.Geometry)
+				if err != nil {
+					return nil, err
+				}
+				return tree.NewDGeometry(ret), nil
+			},
+			types.Geometry,
+			infoBuilder{
+				info: "Forces the orientation of vertices in a polygon to follow the Right-Hand-Rule. " +
+					"This is equivalent to ST_ForcePolygonCW where exterior rings are clockwise and interior rings are counter-clockwise. " +
+					"Non-Polygon objects are unchanged.",
+			},
+			volatility.Immutable,
+		),
+	),
 	"st_ispolygoncw": makeBuiltin(
 		defProps(),
 		geometryOverload1UnaryPredicate(


### PR DESCRIPTION
## Summary

This PR implements the `ST_ForceRHR` (Force Right-Hand Rule) geometry builtin function, which forces polygon vertices to follow the Right-Hand Rule orientation. This function is equivalent to `ST_ForcePolygonCW`, making exterior rings clockwise and interior rings counter-clockwise.

Fixes #60883

## Implementation Details

- **Core Function**: Added `ForceRHR` wrapper in `pkg/geo/geomfn/orientation.go` that calls existing `ForcePolygonOrientation` with clockwise orientation
- **SQL Builtin**: Registered `st_forcerhr` function in `pkg/sql/sem/builtins/geo_builtins.go` with proper metadata
- **OID Registration**: Added OID 2789 for the new function in `pkg/sql/sem/builtins/fixed_oids.go`
- **Testing**: Added comprehensive unit tests and SQL logic tests

## PostGIS Compatibility

This implementation follows PostGIS behavior exactly:
- Forces exterior rings to be clockwise
- Forces interior rings to be counter-clockwise  
- Non-polygon geometries remain unchanged
- Equivalent to `ST_ForcePolygonCW`

## Testing

- ✅ Unit tests pass (`TestForceRHR`)
- ✅ Build succeeds without errors
- ✅ Manual testing confirms correct orientation behavior
- ✅ Logic tests verify end-to-end SQL functionality

## Example Usage

```sql
-- Input: counter-clockwise polygon
SELECT ST_AsText(ST_ForceRHR('POLYGON((0 0, 1 0, 1 1, 0 1, 0 0))'));
-- Output: POLYGON((0 0, 0 1, 1 1, 1 0, 0 0)) -- now clockwise
```

## Release note

```
sql: Added ST_ForceRHR geometry builtin function that forces polygon vertices to follow the Right-Hand Rule (exterior rings clockwise, interior rings counter-clockwise). This function is equivalent to ST_ForcePolygonCW and provides PostGIS compatibility.
```