### PR TITLE
release: add linux-amd64-fips to GPG signing script

### DIFF
--- a/build/teamcity/internal/cockroach/release/publish/sign-custom-release.sh
+++ b/build/teamcity/internal/cockroach/release/publish/sign-custom-release.sh
@@ -53,7 +53,7 @@ log_into_gcloud
 mkdir -p artifacts
 cd artifacts
 
-for platform in linux-amd64 linux-arm64 linux-s390x; do
+for platform in linux-amd64 linux-amd64-fips linux-arm64 linux-s390x; do
   tarball=${cockroach_archive_prefix}-${version}.${platform}.tgz
 
   gsutil cp "gs://$gcs_staged_bucket/$tarball" "$tarball"


### PR DESCRIPTION
This commit adds the `linux-amd64-fips` platform to the GPG signing script for custom releases.

Release note: none
Epic: none