### PR TITLE
release-25.3: release: add support for no-telemetry build for FIPS

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-amd64-fips-no-telemetry.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-linux-amd64-fips-no-telemetry.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+
+# Copyright 2023 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+PLATFORM=linux-amd64-fips TELEMETRY_DISABLED=true ./build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh

--- a/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-artifacts-per-platform.sh
@@ -167,6 +167,7 @@ if [[ $telemetry_disabled == true ]]; then
 
 Additionally, the binaries with telemetry disabled will be available at:
   https://storage.googleapis.com/$gcs_bucket/${cockroach_archive_prefix}-${build_name}.linux-amd64.tgz
+  https://storage.googleapis.com/$gcs_bucket/${cockroach_archive_prefix}-${build_name}.linux-amd64-fips.tgz
   https://storage.googleapis.com/$gcs_bucket/${cockroach_archive_prefix}-${build_name}.linux-arm64.tgz
 
 EOF


### PR DESCRIPTION
Backport 1/1 commits from #150688 on behalf of @rail.

----

This commit adds a new wrapper to make and publish build artifacts for the FIPS-enabled Linux AMD64 platform without telemetry.

Release note: none
Epic: none

----

Release justification: release automation changes