### PR TITLE
bulk,importer,rowexec: add CPU AC to bulk ops

### DIFF
--- a/pkg/kv/bulk/BUILD.bazel
+++ b/pkg/kv/bulk/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "buffering_adder.go",
         "bulk_metrics.go",
+        "cpu_pacer.go",
         "kv_buf.go",
         "setting.go",
         "sst_adder.go",
@@ -24,6 +25,7 @@ go_library(
         "//pkg/settings/cluster",
         "//pkg/storage",
         "//pkg/storage/enginepb",
+        "//pkg/util/admission",
         "//pkg/util/admission/admissionpb",
         "//pkg/util/buildutil",
         "//pkg/util/ctxgroup",

--- a/pkg/kv/bulk/buffering_adder.go
+++ b/pkg/kv/bulk/buffering_adder.go
@@ -153,6 +153,7 @@ func MakeBulkAdder(
 			writeAtBatchTS: opts.WriteAtBatchTimestamp,
 			mem:            bulkMon.MakeConcurrentBoundAccount(),
 			limiter:        sendLimiter,
+			pacer:          NewCPUPacer(ctx, db, sstBatcherElasticCPUControlEnabled),
 		},
 		timestamp:      timestamp,
 		maxBufferLimit: opts.MaxBufferSize,

--- a/pkg/kv/bulk/cpu_pacer.go
+++ b/pkg/kv/bulk/cpu_pacer.go
@@ -1,0 +1,71 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package bulk
+
+import (
+	"context"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/kv"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings"
+	"github.com/cockroachdb/cockroach/pkg/util/admission"
+	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+)
+
+// CPUPacer wraps an admission.Pacer for use in bulk operations where any errors
+// pacing can just be logged (at most once a minute).
+type CPUPacer struct {
+	pacer    *admission.Pacer
+	logEvery *log.EveryN
+}
+
+func (p *CPUPacer) Pace(ctx context.Context) {
+	if err := p.pacer.Pace(ctx); err != nil {
+		if p.logEvery.ShouldLog() {
+			// TODO(dt): consider just returning this error/eliminating this wrapper,
+			// and making callers bubble up this error if it is only ever a ctx cancel
+			// error that the caller should be bubbling up anyway.
+			log.Warningf(ctx, "failed to pace SST batcher: %v", err)
+		}
+	}
+}
+func (p *CPUPacer) Close() {
+	p.pacer.Close()
+}
+
+var cpuPacerRequestDuration = settings.RegisterDurationSetting(
+	settings.ApplicationLevel,
+	"bulkio.elastic_cpu_control.request_duration",
+	"exeuction time unit to request when pacing CPU requests during various bulk operations",
+	50*time.Millisecond,
+)
+
+// NewCPUPacer creates a new AC pacer for SST batcher. It may return an empty
+// Pacer which noops if pacing is disabled or its arguments are nil.
+func NewCPUPacer(ctx context.Context, db *kv.DB, setting *settings.BoolSetting) CPUPacer {
+	if db == nil || db.AdmissionPacerFactory == nil || !setting.Get(db.SettingsValues()) {
+		log.Infof(ctx, "admission control is not configured to pace bulk ingestion")
+		return CPUPacer{}
+	}
+	tenantID, ok := roachpb.ClientTenantFromContext(ctx)
+	if !ok {
+		tenantID = roachpb.SystemTenantID
+	}
+	every := log.Every(time.Minute)
+	return CPUPacer{pacer: db.AdmissionPacerFactory.NewPacer(
+		cpuPacerRequestDuration.Get(db.SettingsValues()),
+		admission.WorkInfo{
+			TenantID:        tenantID,
+			Priority:        admissionpb.BulkNormalPri,
+			CreateTime:      timeutil.Now().UnixNano(),
+			BypassAdmission: false,
+		}),
+		logEvery: &every,
+	}
+}

--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -35,6 +35,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/jobs/jobsprofiler",
         "//pkg/kv",
+        "//pkg/kv/bulk",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/roachpb",

--- a/pkg/sql/rowexec/BUILD.bazel
+++ b/pkg/sql/rowexec/BUILD.bazel
@@ -46,6 +46,7 @@ go_library(
         "//pkg/jobs/jobspb",
         "//pkg/keys",
         "//pkg/kv",
+        "//pkg/kv/bulk",
         "//pkg/kv/kvclient/kvstreamer",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver/kvserverbase",


### PR DESCRIPTION
This adds the option to enable a CPU-based pacer to a few loops that have the potential to become tight, CPU-bound loops during bulk operations, namely:
* SST Batcher's Add method, which is called in a tight loop after sorting a buffered pool of KVs
* index backfiller's key generation loop, which is a tight loop over a buffer of read rows
* IMPORT's row -> datum reader loop and datum -> KV loops.

Each of these are controlled by a setting, which are default off for now pending more production-scale testing and benchmarking. 