### PR TITLE
pgwire: decouple jwt authentication and authorization logic

### DIFF
--- a/pkg/security/provisioning/settings.go
+++ b/pkg/security/provisioning/settings.go
@@ -24,18 +24,28 @@ const (
 
 	baseCounterPrefix = "auth.provisioning."
 	ldapCounterPrefix = baseCounterPrefix + "ldap."
+	jwtCounterPrefix  = baseCounterPrefix + "jwt."
 
 	beginLDAPProvisionCounterName   = ldapCounterPrefix + "begin"
 	provisionLDAPSuccessCounterName = ldapCounterPrefix + "success"
 	enableLDAPProvisionCounterName  = ldapCounterPrefix + "enable"
 
+	beginJWTProvisionCounterName   = jwtCounterPrefix + "begin"
+	provisionJWTSuccessCounterName = jwtCounterPrefix + "success"
+	enableJWTProvisionCounterName  = jwtCounterPrefix + "enable"
+
 	provisionedUserLoginSuccessCounterName = baseCounterPrefix + "login_success"
 )
 
 var (
-	BeginLDAPProvisionUseCounter       = telemetry.GetCounterOnce(beginLDAPProvisionCounterName)
-	ProvisionLDAPSuccessCounter        = telemetry.GetCounterOnce(provisionLDAPSuccessCounterName)
-	enableLDAPProvisionCounter         = telemetry.GetCounterOnce(enableLDAPProvisionCounterName)
+	BeginLDAPProvisionUseCounter = telemetry.GetCounterOnce(beginLDAPProvisionCounterName)
+	ProvisionLDAPSuccessCounter  = telemetry.GetCounterOnce(provisionLDAPSuccessCounterName)
+	enableLDAPProvisionCounter   = telemetry.GetCounterOnce(enableLDAPProvisionCounterName)
+
+	BeginJWTProvisionUseCounter = telemetry.GetCounterOnce(beginJWTProvisionCounterName)
+	ProvisionJWTSuccessCounter  = telemetry.GetCounterOnce(provisionJWTSuccessCounterName)
+	enableJWTProvisionCounter   = telemetry.GetCounterOnce(enableJWTProvisionCounterName)
+
 	ProvisionedUserLoginSuccessCounter = telemetry.GetCounterOnce(provisionedUserLoginSuccessCounterName)
 )
 
@@ -97,6 +107,11 @@ func ClusterProvisioningConfig(settings *cluster.Settings) UserProvisioningConfi
 	ldapProvisioningEnabled.SetOnChange(&settings.SV, func(_ context.Context) {
 		if ldapProvisioningEnabled.Get(&settings.SV) {
 			telemetry.Inc(enableLDAPProvisionCounter)
+		}
+	})
+	jwtProvisioningEnabled.SetOnChange(&settings.SV, func(_ context.Context) {
+		if jwtProvisioningEnabled.Get(&settings.SV) {
+			telemetry.Inc(enableJWTProvisionCounter)
 		}
 	})
 	return clusterProvisioningConfig{settings: settings}

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -916,6 +916,10 @@ func authJwtToken(
 			return authError
 		}
 
+		return nil
+	})
+
+	b.SetAuthorizer(func(ctx context.Context, systemIdentity string, clientConnection bool) error {
 		// Ask the CCL verifier for groups (nil slice means feature disabled).
 		groups, err := jwtVerifier.ExtractGroups(ctx, execCfg.Settings, []byte(token))
 		if err != nil {
@@ -959,6 +963,7 @@ func authJwtToken(
 
 		return nil
 	})
+
 	return b, nil
 }
 


### PR DESCRIPTION
Previously, the logic for JWT authorization (extracting group claims and synchronizing roles) was located within the `Authenticator` behavior. This was a necessary design when the JWT token was only exchanged from the `AuthConn` within the authenticator.

This was inadequate because it bundled authentication and authorization logic, violating the separation of concerns intended by the `AuthBehaviors` framework and creating an inconsistency with other methods like `AuthLDAP`. A recent change (#149415) made the token available via closure capture to all behaviors, removing the original constraint and making this refactoring possible.

To address this, this patch decouples the logic. The `Authenticator` is now solely responsible for validating the token (authentication). The authorization logic has been moved to a new `Authorizer` behavior, which aligns the implementation with the framework's design and improves code clarity and maintainability.

Fixes: #150720

Release note: None