### PR TITLE
pcr: reorder time series dashboards

### DIFF
--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/crossClusterReplication.tsx
@@ -19,20 +19,6 @@ export default function (props: GraphDashboardProps) {
 
   return [
     <LineGraph
-      title="Logical Bytes"
-      sources={storeSources}
-      tenantSource={tenantSource}
-      tooltip={`Rate at which the logical bytes (sum of keys + values) are ingested by all replication jobs`}
-    >
-      <Axis units={AxisUnits.Bytes} label="bytes">
-        <Metric
-          name="cr.node.physical_replication.logical_bytes"
-          title="Logical Bytes"
-          nonNegativeRate
-        />
-      </Axis>
-    </LineGraph>,
-    <LineGraph
       title="Replication Lag"
       sources={storeSources}
       tenantSource={tenantSource}
@@ -58,6 +44,20 @@ export default function (props: GraphDashboardProps) {
                   : d,
               )
           }
+        />
+      </Axis>
+    </LineGraph>,
+    <LineGraph
+      title="Logical Bytes"
+      sources={storeSources}
+      tenantSource={tenantSource}
+      tooltip={`Rate at which the logical bytes (sum of keys + values) are ingested by all replication jobs`}
+    >
+      <Axis units={AxisUnits.Bytes} label="bytes">
+        <Metric
+          name="cr.node.physical_replication.logical_bytes"
+          title="Logical Bytes"
+          nonNegativeRate
         />
       </Axis>
     </LineGraph>,


### PR DESCRIPTION
Swapped order of Replication Lag and Logical Bytes graphs in Physical Cluster Replication DB Console

Fixes: #147621 
Release note: none
