### PR TITLE
sql: fix spelling of committed

### DIFF
--- a/pkg/sql/alter_table.go
+++ b/pkg/sql/alter_table.go
@@ -2508,7 +2508,7 @@ func (p *planner) checkSchemaChangeIsAllowed(
 	ctx context.Context, desc catalog.TableDescriptor, n tree.Statement,
 ) (ret error) {
 	// Adding descriptors can be skipped.
-	if desc == nil || desc.Adding() || p.descCollection.IsNewUncommitedDescriptor(desc.GetID()) {
+	if desc == nil || desc.Adding() || p.descCollection.IsNewUncommittedDescriptor(desc.GetID()) {
 		return nil
 	}
 	// Check if this schema change is on the allowed list, which will only

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -258,9 +258,9 @@ func (tc *Collection) HasUncommittedDescriptors() bool {
 	return tc.uncommitted.uncommitted.Len() > 0
 }
 
-// IsNewUncommitedDescriptor returns true if the descriptor is newly created
+// IsNewUncommittedDescriptor returns true if the descriptor is newly created
 // within this txn.
-func (tc *Collection) IsNewUncommitedDescriptor(id descpb.ID) bool {
+func (tc *Collection) IsNewUncommittedDescriptor(id descpb.ID) bool {
 	if desc := tc.uncommitted.mutable.Get(id); desc != nil && desc.(catalog.MutableDescriptor).IsNew() {
 		return true
 	}

--- a/pkg/sql/catalog/typedesc/type_desc_builder.go
+++ b/pkg/sql/catalog/typedesc/type_desc_builder.go
@@ -204,10 +204,10 @@ func (tdb *typeDescriptorBuilder) BuildExistingMutableType() *Mutable {
 		tdb.maybeModified = protoutil.Clone(tdb.original).(*descpb.TypeDescriptor)
 	}
 	mutableType := makeImmutable(tdb.maybeModified,
-		false /* isUncommitedVersion */, tdb.changes)
+		false /* isUncommittedVersion */, tdb.changes)
 	mutableType.rawBytesInStorage = append([]byte(nil), tdb.rawBytesInStorage...) // deep-copy
 	clusterVersion := makeImmutable(tdb.original,
-		false /* isUncommitedVersion */, catalog.PostDeserializationChanges{})
+		false /* isUncommittedVersion */, catalog.PostDeserializationChanges{})
 	return &Mutable{
 		immutable:      mutableType,
 		ClusterVersion: &clusterVersion,

--- a/pkg/sql/internal.go
+++ b/pkg/sql/internal.go
@@ -1323,7 +1323,7 @@ func (ie *InternalExecutor) execInternal(
 				ParseStart:   parseStart,
 				ParseEnd:     parseEnd,
 				// This is the only and last statement in the batch, so that this
-				// transaction can be autocommited as a single statement transaction.
+				// transaction can be autocommitted as a single statement transaction.
 				LastInBatch: true,
 			}); err != nil {
 			return nil, err

--- a/pkg/sql/logictest/testdata/logic_test/two_phase_commit
+++ b/pkg/sql/logictest/testdata/logic_test/two_phase_commit
@@ -152,7 +152,7 @@ NoTxn
 statement ok
 COMMIT PREPARED 'duplicate'
 
-# Verify the intent for a=2 has been commited and the intent for a=3 has been
+# Verify the intent for a=2 has been committed and the intent for a=3 has been
 # rolled back.
 query I
 SELECT * FROM t ORDER BY a

--- a/pkg/sql/opt/locking.go
+++ b/pkg/sql/opt/locking.go
@@ -60,7 +60,7 @@ type Locking struct {
 	// the durability defaults to best-effort. We currently only require
 	// guaranteed-durable locks for SELECT FOR UPDATE statements and
 	// system-maintained constraint checks (e.g. FK checks) under snapshot and
-	// read commited isolation. Other locking statements, such as UPDATE, rely on
+	// read committed isolation. Other locking statements, such as UPDATE, rely on
 	// the durability of intents for correctness, rather than the durability of
 	// locks.
 	Durability tree.LockingDurability

--- a/pkg/sql/txn_restart_test.go
+++ b/pkg/sql/txn_restart_test.go
@@ -1331,7 +1331,7 @@ SELECT * from t.test WHERE k = 'test_key';
 //
 // This test triggers the above scenario by triggering a restart by returning
 // ReadWithinUncertaintyIntervalError on the first transaction attempt.
-func TestFlushUncommitedDescriptorCacheOnRestart(t *testing.T) {
+func TestFlushUncommittedDescriptorCacheOnRestart(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 


### PR DESCRIPTION
Fixes the spelling in the sql package.

```
(c|C)ommited
$1ommitted

pkg/sql/
```

Epic: none

Release note: None
