### PR TITLE
cmd/dev: remove warning about two year old change

### DIFF
--- a/pkg/cmd/dev/test.go
+++ b/pkg/cmd/dev/test.go
@@ -387,9 +387,6 @@ func (d *dev) test(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
-	if stress {
-		d.warnAboutChangeInStressBehavior(timeout)
-	}
 
 	// Do not log --build_event_binary_file=... because it is not relevant to the actual call
 	// from the user perspective.

--- a/pkg/cmd/dev/testdata/datadriven/testlogic
+++ b/pkg/cmd/dev/testdata/datadriven/testlogic
@@ -50,7 +50,6 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
@@ -60,7 +59,6 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --local_cpu_resources=8 --test_arg -show-sql --test_timeout=60 --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
@@ -70,7 +68,6 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
@@ -80,7 +77,6 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors
 
 exec
@@ -90,5 +86,4 @@ bazel info workspace --color=no
 bazel info workspace --color=no
 bazel run pkg/cmd/generate-logictest -- -out-dir=crdb-checkout
 bazel run //pkg/gen:schemachanger
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/sql/logictest/tests/... --test_env=GOTRACEBACK=all --test_arg -show-sql --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=500 --test_filter auto_span_config_reconciliation/ --test_sharding_strategy=disabled --test_output errors

--- a/pkg/cmd/dev/testdata/recorderdriven/test
+++ b/pkg/cmd/dev/testdata/recorderdriven/test
@@ -92,13 +92,11 @@ bazel test //pkg:all_tests --test_env=GOTRACEBACK=all --test_output errors --bui
 dev test pkg/spanconfig/spanconfigstore --stress
 ----
 bazel query 'kind(.*_test, pkg/spanconfig/spanconfigstore:all)'
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/spanconfig/spanconfigstore:spanconfigstore_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=1000 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 dev test pkg/spanconfig/spanconfigstore --stress --count 250
 ----
 bazel query 'kind(.*_test, pkg/spanconfig/spanconfigstore:all)'
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
 bazel test //pkg/spanconfig/spanconfigstore:spanconfigstore_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=250 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 
 dev test pkg/spanconfig/spanconfigstore --count 1

--- a/pkg/cmd/dev/testdata/recorderdriven/test.rec
+++ b/pkg/cmd/dev/testdata/recorderdriven/test.rec
@@ -134,18 +134,12 @@ bazel query 'kind(.*_test, pkg/spanconfig/spanconfigstore:all)'
 ----
 //pkg/spanconfig/spanconfigstore:spanconfigstore_test
 
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-----
-
 bazel test //pkg/spanconfig/spanconfigstore:spanconfigstore_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=1000 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 ----
 
 bazel query 'kind(.*_test, pkg/spanconfig/spanconfigstore:all)'
 ----
 //pkg/spanconfig/spanconfigstore:spanconfigstore_test
-
-getenv DEV_I_UNDERSTAND_ABOUT_STRESS
-----
 
 bazel test //pkg/spanconfig/spanconfigstore:spanconfigstore_test --test_env=GOTRACEBACK=all --test_env=COCKROACH_STRESS=true --notest_keep_going --runs_per_test=250 '--runs_per_test=.*disallowed_imports_test@1' --test_output errors --build_event_binary_file=/tmp/path
 ----

--- a/pkg/cmd/dev/testlogic.go
+++ b/pkg/cmd/dev/testlogic.go
@@ -282,9 +282,6 @@ func (d *dev) testlogic(cmd *cobra.Command, commandLine []string) error {
 	args = append(args, d.getTestOutputArgs(verbose, showLogs, streamOutput)...)
 	args = append(args, additionalBazelArgs...)
 	logCommand("bazel", args...)
-	if stress {
-		d.warnAboutChangeInStressBehavior(timeout)
-	}
 	if err := d.exec.CommandContextInheritingStdStreams(ctx, "bazel", args...); err != nil {
 		return err
 	}

--- a/pkg/cmd/dev/util.go
+++ b/pkg/cmd/dev/util.go
@@ -238,16 +238,6 @@ func sendBepDataToBeaverHubIfNeeded(bepFilepath string) error {
 	return nil
 }
 
-func (d *dev) warnAboutChangeInStressBehavior(timeout time.Duration) {
-	if e := d.os.Getenv("DEV_I_UNDERSTAND_ABOUT_STRESS"); e == "" {
-		log.Printf("NOTE: The behavior of `dev test --stress` has changed. The new default behavior is to run the test 1,000 times in parallel (500 for logictests), stopping if any of the tests fail. The number of runs can be tweaked with the `--count` parameter to `dev`.")
-		if timeout > 0 {
-			log.Printf("WARNING: The behavior of --timeout under --stress has changed. --timeout controls the timeout of the test, not the entire `stress` invocation.")
-		}
-		log.Printf("Set DEV_I_UNDERSTAND_ABOUT_STRESS=1 to squelch this message")
-	}
-}
-
 // This function retrieves the merge-base hash between the current branch and master
 func (d *dev) getMergeBaseHash(ctx context.Context) (string, error) {
 	// List files changed against `master`


### PR DESCRIPTION
This 'change' is no longer recent enough to nag about.

Release note: none.
Epic: none.