### PR TITLE
drtprod: PUA changes for v25.2

### DIFF
--- a/pkg/cmd/drtprod/configs/drt_pua_9.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_9.yaml
@@ -18,7 +18,8 @@ environment:
   WORKLOAD_CLUSTER: workload-pua-9
   WORKLOAD_NODES: 1
   STORE_COUNT: 2
-  COCKROACH_VERSION: v25.1.1
+  COCKROACH_VERSION: v25.2.0
+  COCKROACH_UPGRADE_VERSION: v25.2.1
 
   TPCC_WAREHOUSES: 5000
   TPCC_ACTIVE_WAREHOUSES: 5000
@@ -108,11 +109,18 @@ targets:
           - --
           - -e
           - "SET CLUSTER SETTING server.shutdown.drain_wait = '15s'"
-      - command: run
+      - command: sql
         args:
-          - $CLUSTER
+          - $CLUSTER:1
           - --
-          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
+          - -e
+          - "SET CLUSTER SETTING goschedstats.always_use_short_sample_period.enabled=true"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING kv.transaction.write_buffering.enabled = true"
       - command: load-balancer
         args:
           - create
@@ -269,7 +277,7 @@ targets:
         args:
           - $CLUSTER
           - release
-          - v25.1.2
+          - $COCKROACH_UPGRADE_VERSION
         flags:
           pause: 5m
           grace-period: 500

--- a/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
+++ b/pkg/cmd/drtprod/configs/drt_pua_mr.yaml
@@ -17,24 +17,25 @@ environment:
   CLUSTER_NODES: 15
   WORKLOAD_NODES: 3
   STORE_COUNT: 2
-  COCKROACH_VERSION: v25.1.1
+  COCKROACH_VERSION: v25.2.0
+  COCKROACH_UPGRADE_VERSION: v25.2.1
 
   # variables used by tpcc_run_multiregion.sh
   NUM_REGIONS: 3
   NODES_PER_REGION: 5
-  REGIONS: northamerica-northeast2,us-east5,us-east1
+  REGIONS: us-central1,us-east5,us-east1
   TPCC_WAREHOUSES: 10000
   TPCC_ACTIVE_WAREHOUSES: 7000
   DB_NAME: cct_tpcc
   SURVIVAL_GOAL: region
   RUN_DURATION: 15h
-  NUM_CONNECTIONS: 500
+  NUM_CONNECTIONS: 3000
   NUM_WORKERS: 500
   MAX_RATE: 500
   MAX_CONN_LIFETIME: 3m
 
   # GCP Cloud Storage bucket for storing locality-aware backups
-  BUCKET_NORTH_AMERICA: cockroach-drt-backup-northamerica-northeast2
+  BUCKET_NORTH_AMERICA: cockroach-drt-backup
   BUCKET_US_EAST_5: cockroach-drt-backup-us-east5
   BUCKET_US_EAST_1: cockroach-drt-backup-us-east1
 
@@ -59,7 +60,7 @@ targets:
           clouds: gce
           gce-managed: true
           gce-enable-multiple-stores: true
-          gce-zones: "northamerica-northeast2-a:2,northamerica-northeast2-b:2,northamerica-northeast2-c:1,us-east5-a:2,us-east5-b:2,us-east5-c:1,us-east1-b:2,us-east1-c:2,us-east1-d:1"
+          gce-zones: "us-central1-a:2,us-central1-b:2,us-central1-c:1,us-east5-a:2,us-east5-b:2,us-east5-c:1,us-east1-b:2,us-east1-c:2,us-east1-d:1"
           nodes: $CLUSTER_NODES
           gce-machine-type: n2-standard-16
           local-ssd: true
@@ -126,11 +127,18 @@ targets:
           - --
           - -e
           - "SET CLUSTER SETTING server.shutdown.drain_wait = '15s'"
-      - command: run
+      - command: sql
         args:
-          - $CLUSTER
+          - $CLUSTER:1
           - --
-          - "sudo systemctl unmask cron.service ; sudo systemctl enable cron.service ; echo \"crontab -l ; echo '@reboot sleep 100 && ~/cockroach.sh' | crontab -\" > t.sh ; sh t.sh ; rm t.sh"
+          - -e
+          - "SET CLUSTER SETTING goschedstats.always_use_short_sample_period.enabled = true"
+      - command: sql
+        args:
+          - $CLUSTER:1
+          - --
+          - -e
+          - "SET CLUSTER SETTING kv.transaction.write_buffering.enabled = true"
       - command: load-balancer
         args:
           - create
@@ -144,7 +152,7 @@ targets:
           - $WORKLOAD_CLUSTER
         flags:
           clouds: gce
-          gce-zones: "northamerica-northeast2-a,us-east5-a,us-east1-b"
+          gce-zones: "us-central1-a,us-east5-a,us-east1-b"
           nodes: $NUM_REGIONS
           gce-machine-type: n2d-standard-4
           os-volume-size: 100
@@ -275,7 +283,7 @@ targets:
         args:
           - $CLUSTER
           - release
-          - v25.1.2
+          - $COCKROACH_UPGRADE_VERSION
         flags:
           pause: 5m
           grace-period: 500

--- a/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
+++ b/pkg/cmd/drtprod/scripts/tpcc_run_multiregion.sh
@@ -71,6 +71,8 @@ echo ">> Starting tpcc workload"
     --survival-goal region \
     --regions=$REGIONS \
     --max-conn-lifetime=$MAX_CONN_LIFETIME \
+    --conns=$NUM_CONNECTIONS \
+    --local-warehouses=true \
     \${PGURLS_REGION[@]}
 EOF
 


### PR DESCRIPTION
This PR modifies yaml file to run PUA on CRDB
release v25.2.

Epic: none

Release note: None