### PR TITLE
kvnemesis: add user priority

### DIFF
--- a/pkg/kv/kvnemesis/applier.go
+++ b/pkg/kv/kvnemesis/applier.go
@@ -157,6 +157,11 @@ func applyOp(ctx context.Context, env *Env, db *kv.DB, op *Operation) {
 			if err := txn.SetIsoLevel(o.IsoLevel); err != nil {
 				panic(err)
 			}
+			if o.UserPriority > 0 {
+				if err := txn.SetUserPriority(o.UserPriority); err != nil {
+					panic(err)
+				}
+			}
 			txn.SetBufferedWritesEnabled(o.BufferedWrites)
 			if savedTxn != nil && txn.TestingCloneTxn().Epoch == 0 {
 				// If the txn's current epoch is 0 and we've run at least one prior

--- a/pkg/kv/kvnemesis/operations.proto
+++ b/pkg/kv/kvnemesis/operations.proto
@@ -34,6 +34,7 @@ message ClosureTxnOperation {
   Result result = 5 [(gogoproto.nullable) = false];
   roachpb.Transaction txn = 6;
   bool buffered_writes = 8;
+  double user_priority = 9 [(gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/roachpb.UserPriority"];
 }
 
 message GetOperation {


### PR DESCRIPTION
This allows KVNemesis to randomly set user priority to either Min, Normal, or Max priority.

Epic: none
Release note: None