### PR TITLE
roachtest: don't specify virtual cluster in debug zips

### DIFF
--- a/pkg/roachprod/roachprod.go
+++ b/pkg/roachprod/roachprod.go
@@ -1173,6 +1173,12 @@ func PgURL(
 	if len(urls) != len(nodes) {
 		return nil, errors.Errorf("have nodes %v, but urls %v from ips %v", nodes, urls, ips)
 	}
+	// We should never return an empty list of URLs as roachprod clusters always have at least
+	// one node. However, many callers of this function directly index into the slice returned,
+	// so check just in case.
+	if len(urls) == 0 {
+		return nil, errors.Newf("have nodes %v, but no urls were found", nodes)
+	}
 	return urls, nil
 }
 


### PR DESCRIPTION
Previously, we were always passing the system tenant when taking debug zips in case a roachtest had overriden the default virtual cluster. However, the debug zip command already attempts to fetch all virtual clusters by passing the --ccluster flag for each tenant. This behavior was suppresed due to our hard coding of the system tenant, causing all debug zips to be of the system tenant.

This changes it to instead pass nothing so the url has no existing --ccluster flag.

Fixes: https://github.com/cockroachdb/cockroach/issues/143841
Release note: none