### PR TITLE
jobs: plumb txn through FractionProgressed

### DIFF
--- a/pkg/backup/restore_online.go
+++ b/pkg/backup/restore_online.go
@@ -706,9 +706,12 @@ func (r *restoreResumer) waitForDownloadToComplete(
 	// either case we can mark the job as done.
 	if total == 0 {
 		r.downloadJobProg = 1.0
-		return r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
-			return 1.0
-		})
+		return r.job.NoTxn().FractionProgressed(
+			ctx,
+			func(ctx context.Context, _ isql.Txn, details jobspb.ProgressDetails) float32 {
+				return 1.0
+			},
+		)
 	}
 
 	var lastProgressUpdate time.Time
@@ -740,9 +743,12 @@ func (r *restoreResumer) waitForDownloadToComplete(
 		}
 
 		if timeutil.Since(lastProgressUpdate) > time.Minute {
-			if err := r.job.NoTxn().FractionProgressed(ctx, func(ctx context.Context, details jobspb.ProgressDetails) float32 {
-				return fractionComplete
-			}); err != nil {
+			if err := r.job.NoTxn().FractionProgressed(
+				ctx,
+				func(ctx context.Context, _ isql.Txn, details jobspb.ProgressDetails) float32 {
+					return fractionComplete
+				},
+			); err != nil {
 				return err
 			}
 			lastProgressUpdate = timeutil.Now()

--- a/pkg/backup/restore_progress.go
+++ b/pkg/backup/restore_progress.go
@@ -13,6 +13,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	spanUtils "github.com/cockroachdb/cockroach/pkg/util/span"
@@ -141,7 +142,7 @@ func persistFrontier(
 }
 
 func (pt *progressTracker) updateJobCallback(
-	progressedCtx context.Context, progressDetails jobspb.ProgressDetails,
+	progressedCtx context.Context, _ isql.Txn, progressDetails jobspb.ProgressDetails,
 ) {
 	switch d := progressDetails.(type) {
 	case *jobspb.Progress_Restore:

--- a/pkg/crosscluster/physical/stream_ingestion_job.go
+++ b/pkg/crosscluster/physical/stream_ingestion_job.go
@@ -785,7 +785,7 @@ func (c *cutoverProgressTracker) updateJobProgress(
 
 	fractionRangesFinished := float32(c.originalRangeCount-nRanges) / float32(c.originalRangeCount)
 
-	persistProgress := func(ctx context.Context, details jobspb.ProgressDetails) float32 {
+	persistProgress := func(ctx context.Context, _ isql.Txn, details jobspb.ProgressDetails) float32 {
 		prog := details.(*jobspb.Progress_StreamIngest).StreamIngest
 		prog.RemainingCutoverSpans = remainingSpans
 		return fractionRangesFinished

--- a/pkg/jobs/jobs_test.go
+++ b/pkg/jobs/jobs_test.go
@@ -1253,10 +1253,11 @@ func TestJobLifecycle(t *testing.T) {
 		}
 
 		// Test Progressed callbacks.
-		if err := woodyJob.NoTxn().FractionProgressed(ctx, func(_ context.Context, details jobspb.ProgressDetails) float32 {
-			details.(*jobspb.Progress_Restore).Restore.HighWater = roachpb.Key("mariana")
-			return 1.0
-		}); err != nil {
+		if err := woodyJob.NoTxn().FractionProgressed(
+			ctx, func(_ context.Context, _ isql.Txn, details jobspb.ProgressDetails) float32 {
+				details.(*jobspb.Progress_Restore).Restore.HighWater = roachpb.Key("mariana")
+				return 1.0
+			}); err != nil {
 			t.Fatal(err)
 		}
 		woodyExp.Record.Progress = jobspb.RestoreProgress{HighWater: roachpb.Key("mariana")}

--- a/pkg/sql/create_stats.go
+++ b/pkg/sql/create_stats.go
@@ -846,7 +846,7 @@ func (r *createStatsResumer) Resume(ctx context.Context, execCtx interface{}) er
 			// then return the original error, otherwise return this error instead so
 			// it can be cleaned up at a higher level.
 			if jobErr := r.job.NoTxn().FractionProgressed(ctx, func(
-				ctx context.Context, _ jobspb.ProgressDetails,
+				ctx context.Context, _ isql.Txn, _ jobspb.ProgressDetails,
 			) float32 {
 				// The job failed so the progress value here doesn't really matter.
 				return 0

--- a/pkg/sql/importer/import_processor_planning.go
+++ b/pkg/sql/importer/import_processor_planning.go
@@ -23,6 +23,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/tabledesc"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
@@ -135,7 +136,7 @@ func distImport(
 	if importDetails.ReadProgress == nil {
 		// Initialize the progress metrics on the first attempt.
 		if err := job.NoTxn().FractionProgressed(ctx, func(
-			ctx context.Context, details jobspb.ProgressDetails,
+			ctx context.Context, _ isql.Txn, details jobspb.ProgressDetails,
 		) float32 {
 			prog := details.(*jobspb.Progress_Import).Import
 			prog.ReadProgress = make([]float32, len(from))
@@ -159,7 +160,7 @@ func distImport(
 
 	updateJobProgress := func() error {
 		return job.NoTxn().FractionProgressed(ctx, func(
-			ctx context.Context, details jobspb.ProgressDetails,
+			ctx context.Context, _ isql.Txn, details jobspb.ProgressDetails,
 		) float32 {
 			var overall float32
 			prog := details.(*jobspb.Progress_Import).Import


### PR DESCRIPTION
This commit plumbs the underlying SQL transaction for the job updater through `FractionProgressed` and into its function argument. The purpose of this is to unblock #149821 and allow `FractionProgressed` to make updates to its underlying job.

Epic: None

Release note: None