### PR TITLE
storage: use AssertionFailedf for panics

### DIFF
--- a/pkg/storage/backup_compaction_iterator.go
+++ b/pkg/storage/backup_compaction_iterator.go
@@ -116,7 +116,7 @@ func (f *BackupCompactionIterator) ValueLen() int {
 func (f *BackupCompactionIterator) HasPointAndRange() (bool, bool) {
 	hasPoint, hasRange := f.iter.HasPointAndRange()
 	if hasRange {
-		panic("unexpected range tombstone")
+		panic(errors.AssertionFailedf("unexpected range tombstone"))
 	}
 	return hasPoint, hasRange
 }

--- a/pkg/storage/batch.go
+++ b/pkg/storage/batch.go
@@ -128,7 +128,7 @@ func (r *BatchReader) EngineKey() (EngineKey, error) {
 func (r *BatchReader) Value() []byte {
 	switch r.kind {
 	case pebble.InternalKeyKindDelete, pebble.InternalKeyKindSingleDelete:
-		panic("cannot call Value on a deletion entry")
+		panic(errors.AssertionFailedf("cannot call Value on a deletion entry"))
 	default:
 		return r.value
 	}

--- a/pkg/storage/fs/file_registry.go
+++ b/pkg/storage/fs/file_registry.go
@@ -316,7 +316,7 @@ func (r *FileRegistry) maybeElideEntries(ctx context.Context) error {
 	for _, filename := range filenames {
 		entry, ok := r.writeMu.mu.entries[filename]
 		if !ok {
-			panic("entry disappeared from map")
+			panic(errors.AssertionFailedf("entry disappeared from map"))
 		}
 
 		// Some entries may be elided. This is used within

--- a/pkg/storage/intent_interleaving_iter.go
+++ b/pkg/storage/intent_interleaving_iter.go
@@ -67,7 +67,7 @@ func (imr *intentInterleavingReader) NewMVCCIterator(
 ) (MVCCIterator, error) {
 	if (!opts.MinTimestamp.IsEmpty() || !opts.MaxTimestamp.IsEmpty()) &&
 		iterKind == MVCCKeyAndIntentsIterKind {
-		panic("cannot ask for interleaved intents when specifying timestamp hints")
+		return nil, errors.AssertionFailedf("cannot ask for interleaved intents when specifying timestamp hints")
 	}
 	if iterKind == MVCCKeyIterKind || opts.KeyTypes == IterKeyTypeRangesOnly {
 		return imr.wrappableReader.NewMVCCIterator(ctx, MVCCKeyIterKind, opts)
@@ -232,7 +232,7 @@ func newIntentInterleavingIterator(
 	ctx context.Context, reader Reader, opts IterOptions,
 ) (MVCCIterator, error) {
 	if !opts.MinTimestamp.IsEmpty() || !opts.MaxTimestamp.IsEmpty() {
-		panic("intentInterleavingIter must not be used with timestamp hints")
+		return nil, errors.AssertionFailedf("intentInterleavingIter must not be used with timestamp hints")
 	}
 	var lowerIsLocal, upperIsLocal bool
 	var constraint intentInterleavingIterConstraint
@@ -260,7 +260,7 @@ func newIntentInterleavingIterator(
 	if !opts.Prefix {
 		if opts.LowerBound == nil && opts.UpperBound == nil {
 			// This is the same requirement as pebbleIterator.
-			panic("iterator must set prefix or upper bound or lower bound")
+			return nil, errors.AssertionFailedf("iterator must set prefix or upper bound or lower bound")
 		}
 		// At least one bound is specified, so constraint != notConstrained. But
 		// may need to manufacture a bound for the currently unbounded side.

--- a/pkg/storage/lock_table_iterator.go
+++ b/pkg/storage/lock_table_iterator.go
@@ -301,7 +301,7 @@ func (i *LockTableIterator) advanceToMatchingLock(
 					// zero UUID if we are in this branch, with the iterator positioned
 					// after the matchTxnID. Assert for good measure.
 					if i.matchTxnID == uuid.Nil {
-						panic("matchTxnID is unexpectedly the zero UUID")
+						panic(errors.AssertionFailedf("matchTxnID is unexpectedly the zero UUID"))
 					}
 					ltKey.TxnUUID = uuid.FromUint128(i.matchTxnID.ToUint128().Sub(1))
 					seekKey, *seekKeyBuf = ltKey.ToEngineKey(*seekKeyBuf)

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -1005,7 +1005,7 @@ func updateStatsOnClear(
 	// restoredNanos to orig.Timestamp (rule 1).
 	if restored != nil {
 		if restored.Txn != nil {
-			panic("restored version should never be an intent")
+			panic(errors.AssertionFailedf("restored version should never be an intent"))
 		}
 
 		ms.AgeTo(restoredNanos)

--- a/pkg/storage/open.go
+++ b/pkg/storage/open.go
@@ -354,7 +354,7 @@ func WALFailover(
 				return nil
 			}
 		default:
-			panic("unreachable")
+			panic(errors.AssertionFailedf("unreachable"))
 		}
 	}
 
@@ -382,7 +382,7 @@ func WALFailover(
 	case storageconfig.WALFailoverAmongStores:
 		// Fallthrough
 	default:
-		panic("unreachable")
+		panic(errors.AssertionFailedf("unreachable"))
 	}
 
 	// Either

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -1539,7 +1539,7 @@ func (p *Pebble) ApplyBatchRepr(repr []byte, sync bool) error {
 // ClearMVCC implements the Engine interface.
 func (p *Pebble) ClearMVCC(key MVCCKey, opts ClearOptions) error {
 	if key.Timestamp.IsEmpty() {
-		panic("ClearMVCC timestamp is empty")
+		return errors.AssertionFailedf("ClearMVCC timestamp is empty")
 	}
 	return p.clear(key, opts)
 }
@@ -1673,7 +1673,7 @@ func (p *Pebble) Merge(key MVCCKey, value []byte) error {
 // PutMVCC implements the Engine interface.
 func (p *Pebble) PutMVCC(key MVCCKey, value MVCCValue) error {
 	if key.Timestamp.IsEmpty() {
-		panic("PutMVCC timestamp is empty")
+		return errors.AssertionFailedf("PutMVCC timestamp is empty")
 	}
 	encValue, err := EncodeMVCCValue(value)
 	if err != nil {
@@ -1685,7 +1685,7 @@ func (p *Pebble) PutMVCC(key MVCCKey, value MVCCValue) error {
 // PutRawMVCC implements the Engine interface.
 func (p *Pebble) PutRawMVCC(key MVCCKey, value []byte) error {
 	if key.Timestamp.IsEmpty() {
-		panic("PutRawMVCC timestamp is empty")
+		return errors.AssertionFailedf("PutRawMVCC timestamp is empty")
 	}
 	return p.put(key, value)
 }
@@ -2559,7 +2559,7 @@ func newPebbleReadOnly(parent *Pebble, durability DurabilityRequirement) *pebble
 
 func (p *pebbleReadOnly) Close() {
 	if p.closed {
-		panic("closing an already-closed pebbleReadOnly")
+		panic(errors.AssertionFailedf("closing an already-closed pebbleReadOnly"))
 	}
 	p.closed = true
 	if p.iter != nil && !p.iterUsed {
@@ -2594,7 +2594,7 @@ func (p *pebbleReadOnly) MVCCIterate(
 	f func(MVCCKeyValue, MVCCRangeKeyStack) error,
 ) error {
 	if p.closed {
-		panic("using a closed pebbleReadOnly")
+		return errors.AssertionFailedf("using a closed pebbleReadOnly")
 	}
 	if iterKind == MVCCKeyAndIntentsIterKind {
 		r := wrapReader(p)
@@ -2611,7 +2611,7 @@ func (p *pebbleReadOnly) NewMVCCIterator(
 	ctx context.Context, iterKind MVCCIterKind, opts IterOptions,
 ) (MVCCIterator, error) {
 	if p.closed {
-		panic("using a closed pebbleReadOnly")
+		return nil, errors.AssertionFailedf("using a closed pebbleReadOnly")
 	}
 
 	if iterKind == MVCCKeyAndIntentsIterKind {
@@ -2660,7 +2660,7 @@ func (p *pebbleReadOnly) NewEngineIterator(
 	ctx context.Context, opts IterOptions,
 ) (EngineIterator, error) {
 	if p.closed {
-		panic("using a closed pebbleReadOnly")
+		return nil, errors.AssertionFailedf("using a closed pebbleReadOnly")
 	}
 
 	iter := &p.normalEngineIter
@@ -2736,97 +2736,97 @@ func (p *pebbleReadOnly) ScanInternal(
 // Writer is the write interface to an engine's data.
 
 func (p *pebbleReadOnly) ApplyBatchRepr(repr []byte, sync bool) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearMVCC(key MVCCKey, opts ClearOptions) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearUnversioned(key roachpb.Key, opts ClearOptions) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearEngineKey(key EngineKey, opts ClearOptions) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) SingleClearEngineKey(key EngineKey) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearMVCCVersions(start, end MVCCKey) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearMVCCIteratorRange(
 	start, end roachpb.Key, pointKeys, rangeKeys bool,
 ) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutMVCCRangeKey(MVCCRangeKey, MVCCValue) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutRawMVCCRangeKey(MVCCRangeKey, []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutEngineRangeKey(roachpb.Key, roachpb.Key, []byte, []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearEngineRangeKey(roachpb.Key, roachpb.Key, []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) ClearMVCCRangeKey(MVCCRangeKey) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) Merge(key MVCCKey, value []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutMVCC(key MVCCKey, value MVCCValue) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutRawMVCC(key MVCCKey, value []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutUnversioned(key roachpb.Key, value []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) PutEngineKey(key EngineKey, value []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) LogData(data []byte) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 func (p *pebbleReadOnly) LogLogicalOp(op MVCCLogicalOpType, details MVCCLogicalOpDetails) {
-	panic("not implemented")
+	panic(errors.AssertionFailedf("not implemented"))
 }
 
 func (p *pebbleReadOnly) ShouldWriteLocalTimestamps(ctx context.Context) bool {
-	panic("not implemented")
+	panic(errors.AssertionFailedf("not implemented"))
 }
 
 func (p *pebbleReadOnly) BufferedSize() int {
-	panic("not implemented")
+	panic(errors.AssertionFailedf("not implemented"))
 }
 
 // pebbleSnapshot implements Reader, backed by a Pebble eventually file-only

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -85,7 +85,7 @@ func (wb *writeBatch) ApplyBatchRepr(repr []byte, sync bool) error {
 // ClearMVCC implements the Writer interface.
 func (wb *writeBatch) ClearMVCC(key MVCCKey, opts ClearOptions) error {
 	if key.Timestamp.IsEmpty() {
-		panic("ClearMVCC timestamp is empty")
+		return errors.AssertionFailedf("ClearMVCC timestamp is empty")
 	}
 	return wb.clear(key, opts)
 }
@@ -113,7 +113,7 @@ func (wb *writeBatch) ClearMVCCIteratorRange(
 ) error {
 	// TODO(jackson): Remove this method. See the TODO in its definition within
 	// the Writer interface.
-	panic("batch is write-only")
+	return errors.AssertionFailedf("batch is write-only")
 }
 
 func (wb *writeBatch) clear(key MVCCKey, opts ClearOptions) error {
@@ -242,7 +242,7 @@ func (wb *writeBatch) PutInternalRangeKey(start, end []byte, key rangekey.Key) e
 	case pebble.InternalKeyKindRangeKeyDelete:
 		return wb.batch.RangeKeyDelete(start, end, nil /* writeOptions */)
 	default:
-		panic("unexpected range key kind")
+		return errors.AssertionFailedf("unexpected range key kind")
 	}
 }
 
@@ -272,7 +272,7 @@ func (wb *writeBatch) Merge(key MVCCKey, value []byte) error {
 // PutMVCC implements the Writer interface.
 func (wb *writeBatch) PutMVCC(key MVCCKey, value MVCCValue) error {
 	if key.Timestamp.IsEmpty() {
-		panic("PutMVCC timestamp is empty")
+		return errors.AssertionFailedf("PutMVCC timestamp is empty")
 	}
 	return wb.putMVCC(key, value)
 }
@@ -280,7 +280,7 @@ func (wb *writeBatch) PutMVCC(key MVCCKey, value MVCCValue) error {
 // PutRawMVCC implements the Writer interface.
 func (wb *writeBatch) PutRawMVCC(key MVCCKey, value []byte) error {
 	if key.Timestamp.IsEmpty() {
-		panic("PutRawMVCC timestamp is empty")
+		return errors.AssertionFailedf("PutRawMVCC timestamp is empty")
 	}
 	return wb.put(key, value)
 }
@@ -352,7 +352,7 @@ func (wb *writeBatch) Commit(sync bool) error {
 		opts = pebble.Sync
 	}
 	if wb.batch == nil {
-		panic("called with nil batch")
+		return errors.AssertionFailedf("called with nil batch")
 	}
 	err := wb.batch.Commit(opts)
 	if err != nil {
@@ -373,7 +373,7 @@ func (wb *writeBatch) Commit(sync bool) error {
 // CommitNoSyncWait implements the WriteBatch interface.
 func (wb *writeBatch) CommitNoSyncWait() error {
 	if wb.batch == nil {
-		panic("called with nil batch")
+		return errors.AssertionFailedf("called with nil batch")
 	}
 	err := wb.db.ApplyNoSyncWait(wb.batch, pebble.Sync)
 	if err != nil {
@@ -392,7 +392,7 @@ func (wb *writeBatch) CommitNoSyncWait() error {
 // SyncWait implements the WriteBatch interface.
 func (wb *writeBatch) SyncWait() error {
 	if wb.batch == nil {
-		panic("called with nil batch")
+		return errors.AssertionFailedf("called with nil batch")
 	}
 	err := wb.batch.SyncWait()
 	if err != nil {
@@ -459,7 +459,7 @@ func (wb *writeBatch) Close() {
 
 func (wb *writeBatch) close() {
 	if wb.closed {
-		panic("closing an already-closed writeBatch")
+		panic(errors.AssertionFailedf("closing an already-closed writeBatch"))
 	}
 	wb.closed = true
 	_ = wb.batch.Close()
@@ -633,7 +633,7 @@ func (p *pebbleBatch) NewBatchOnlyMVCCIterator(
 	ctx context.Context, opts IterOptions,
 ) (MVCCIterator, error) {
 	if !p.batch.Indexed() {
-		panic("unindexed batch")
+		return nil, errors.AssertionFailedf("unindexed batch")
 	}
 	var err error
 	iter := pebbleIterPool.Get().(*pebbleIterator)
@@ -695,7 +695,7 @@ func (p *pebbleBatch) ScanInternal(
 	visitSharedFile func(sst *pebble.SharedSSTMeta) error,
 	visitExternalFile func(sst *pebble.ExternalFile) error,
 ) error {
-	panic("ScanInternal only supported on Engine and Snapshot.")
+	return errors.AssertionFailedf("ScanInternal only supported on Engine and Snapshot.")
 }
 
 // ConsistentIterators implements the Batch interface.

--- a/pkg/storage/pebble_iterator.go
+++ b/pkg/storage/pebble_iterator.go
@@ -212,13 +212,13 @@ func (p *pebbleIterator) setOptions(
 	ctx context.Context, opts IterOptions, durability DurabilityRequirement,
 ) {
 	if !opts.Prefix && len(opts.UpperBound) == 0 && len(opts.LowerBound) == 0 {
-		panic("iterator must set prefix or upper bound or lower bound")
+		panic(errors.AssertionFailedf("iterator must set prefix or upper bound or lower bound"))
 	}
 	if opts.MinTimestamp.IsSet() && opts.MaxTimestamp.IsEmpty() {
-		panic("min timestamp hint set without max timestamp hint")
+		panic(errors.AssertionFailedf("min timestamp hint set without max timestamp hint"))
 	}
 	if opts.Prefix && opts.RangeKeyMaskingBelow.IsSet() {
-		panic("can't use range key masking with prefix iterators") // very high overhead
+		panic(errors.AssertionFailedf("can't use range key masking with prefix iterators")) // very high overhead
 	}
 
 	// Generate new Pebble iterator options.
@@ -314,7 +314,7 @@ func (p *pebbleIterator) setOptions(
 // Close implements the MVCCIterator interface.
 func (p *pebbleIterator) Close() {
 	if !p.inuse {
-		panic("closing idle iterator")
+		panic(errors.AssertionFailedf("closing idle iterator"))
 	}
 	p.inuse = false
 
@@ -369,7 +369,7 @@ func (p *pebbleIterator) SeekEngineKeyGEWithLimit(
 	p.keyBuf = key.EncodeToBuf(p.keyBuf[:0])
 	if limit != nil {
 		if p.prefix {
-			panic("prefix iteration does not permit a limit")
+			panic(errors.AssertionFailedf("prefix iteration does not permit a limit"))
 		}
 		// Append the sentinel byte to make an EngineKey that has an empty
 		// version.
@@ -979,7 +979,7 @@ func (p *pebbleIterator) skipPointIfOutsideTimeBounds(key []byte) (skip bool) {
 
 func (p *pebbleIterator) destroy() {
 	if p.inuse {
-		panic("iterator still in use")
+		panic(errors.AssertionFailedf("iterator still in use"))
 	}
 	if p.iter != nil {
 		// If an error is encountered during iteration, it'll already have been

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -232,7 +232,7 @@ func (fw *SSTWriter) ClearRawRange(start, end roachpb.Key, pointKeys, rangeKeys 
 
 // ClearMVCCRange implements the Writer interface.
 func (fw *SSTWriter) ClearMVCCRange(start, end roachpb.Key, pointKeys, rangeKeys bool) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 // ClearMVCCVersions implements the Writer interface.
@@ -339,7 +339,7 @@ func (fw *SSTWriter) PutInternalRangeKey(start, end []byte, key rangekey.Key) er
 	case pebble.InternalKeyKindRangeKeyDelete:
 		return fw.fw.RangeKeyDelete(start, end)
 	default:
-		panic("unexpected range key kind")
+		return errors.AssertionFailedf("unexpected range key kind")
 	}
 }
 
@@ -387,7 +387,7 @@ func (fw *SSTWriter) Put(key MVCCKey, value []byte) error {
 // cannot have been called.
 func (fw *SSTWriter) PutMVCC(key MVCCKey, value MVCCValue) error {
 	if key.Timestamp.IsEmpty() {
-		panic("PutMVCC timestamp is empty")
+		return errors.AssertionFailedf("PutMVCC timestamp is empty")
 	}
 	encValue, err := EncodeMVCCValue(value)
 	if err != nil {
@@ -402,7 +402,7 @@ func (fw *SSTWriter) PutMVCC(key MVCCKey, value MVCCValue) error {
 // cannot have been called.
 func (fw *SSTWriter) PutRawMVCC(key MVCCKey, value []byte) error {
 	if key.Timestamp.IsEmpty() {
-		panic("PutRawMVCC timestamp is empty")
+		return errors.AssertionFailedf("PutRawMVCC timestamp is empty")
 	}
 	return fw.put(key, value)
 }
@@ -442,7 +442,7 @@ func (fw *SSTWriter) put(key MVCCKey, value []byte) error {
 
 // ApplyBatchRepr implements the Writer interface.
 func (fw *SSTWriter) ApplyBatchRepr(repr []byte, sync bool) error {
-	panic("unimplemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 // ClearMVCC implements the Writer interface. An error is returned if it is
@@ -451,7 +451,7 @@ func (fw *SSTWriter) ApplyBatchRepr(repr []byte, sync bool) error {
 // called.
 func (fw *SSTWriter) ClearMVCC(key MVCCKey, opts ClearOptions) error {
 	if key.Timestamp.IsEmpty() {
-		panic("ClearMVCC timestamp is empty")
+		return errors.AssertionFailedf("ClearMVCC timestamp is empty")
 	}
 	return fw.clear(key, opts)
 }
@@ -501,18 +501,18 @@ func (fw *SSTWriter) clear(key MVCCKey, opts ClearOptions) error {
 
 // SingleClearEngineKey implements the Writer interface.
 func (fw *SSTWriter) SingleClearEngineKey(key EngineKey) error {
-	panic("unimplemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 // ClearMVCCIteratorRange implements the Writer interface.
 func (fw *SSTWriter) ClearMVCCIteratorRange(_, _ roachpb.Key, _, _ bool) error {
-	panic("not implemented")
+	return errors.AssertionFailedf("not implemented")
 }
 
 // Merge implements the Writer interface.
 func (fw *SSTWriter) Merge(key MVCCKey, value []byte) error {
 	if fw.fw == nil {
-		return errors.New("cannot call Merge on a closed writer")
+		return errors.AssertionFailedf("cannot call Merge on a closed writer")
 	}
 	fw.DataSize += int64(len(key.Key)) + int64(len(value))
 	fw.scratch = EncodeMVCCKeyToBuf(fw.scratch[:0], key)


### PR DESCRIPTION
Update a few panics that threw a simple string to throw an error constructed through AssertionFailedf. Where applicable, this error is propagated through a return value instead.

This is motivated by #150058, an instance where the panic string gets redacted, requiring a bit more work to identify the origin of the panic (through mapping the line number on the appropriate commit SHA).

Epic: none
Release note: none