### PR TITLE
sql: harden logging logic in an error case

### DIFF
--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -941,6 +941,7 @@ func (p *planner) resetPlanner(
 	p.txn = txn
 	p.stmt = Statement{}
 	p.instrumentation = instrumentationHelper{}
+	p.curPlan = planTop{}
 	p.monitor = plannerMon
 	p.sessionMonitor = sessionMon
 


### PR DESCRIPTION
We just saw a sentry report where we hit a nil pointer with `planner.curPlan.instrumentationHelper` being nil when trying to log a statement. This happened after we hit an error in `handleAOST`, so we short-circuited "dispatch to execution engine" part, meaning that the plan is left uninitialized. Previously, in eac197136e3b75b18cd7739c9c6bccbc18d2a46d we attempted to handle such scenarios by tracking a boolean indicating whether the dispatch has occurred, but in this case we marked the boolean "true" (meaning it has occurred), yet we short-circuited due to an error.

This commit refactors how we ensure that the plan is initialized by simply checking whether the corresponding fields are set or not. In turn, this exposed the fact that we previously didn't unset `planner.curPlan` when resetting the planner, which is now fixed.

I spent some time trying to come up with a repro but didn't succeed, so there is no regression test.

Fixes: #150717.

Release note: None