### PR TITLE
storage/disk: deflake TestMonitorManager_monitorDisks

### DIFF
--- a/pkg/storage/disk/monitor_test.go
+++ b/pkg/storage/disk/monitor_test.go
@@ -6,6 +6,7 @@
 package disk
 
 import (
+	"context"
 	"sync/atomic"
 	"testing"
 	"time"
@@ -43,13 +44,13 @@ func TestMonitorManager_monitorDisks(t *testing.T) {
 	manager.mu.disks = []*monitoredDisk{testDisk}
 
 	testCollector := &spyCollector{}
-	stop := make(chan struct{})
-	go manager.monitorDisks(testCollector, stop)
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	go manager.monitorDisks(ctx, testCollector)
 
 	require.Eventually(t, func() bool {
 		return testCollector.collectCallCount.Load() > 0
 	}, 100*DefaultDiskStatsPollingInterval, DefaultDiskStatsPollingInterval)
-	stop <- struct{}{}
 }
 
 func TestMonitor_StatsWindow(t *testing.T) {
@@ -136,8 +137,8 @@ func TestMonitor_Close(t *testing.T) {
 		},
 		refCount: 2,
 	}
-	stop := make(chan struct{})
-	manager.mu.stop = stop
+	ctx, cancel := context.WithCancel(context.Background())
+	manager.mu.cancel = cancel
 	manager.mu.disks = []*monitoredDisk{testDisk}
 	monitor1 := Monitor{monitoredDisk: testDisk}
 	monitor2 := Monitor{monitoredDisk: testDisk}
@@ -152,7 +153,7 @@ func TestMonitor_Close(t *testing.T) {
 	go monitor2.Close()
 	// If there are no monitors, stop the stat polling loop.
 	select {
-	case <-stop:
+	case <-ctx.Done():
 	case <-time.After(time.Second):
 		t.Fatal("Failed to receive stop signal")
 	}


### PR DESCRIPTION
**storage/disk: deflake TestMonitorManager_monitorDisks** 

Use `require.Eventually` to deflake this test.

Epic: none
Fixes: https://github.com/cockroachdb/cockroach/issues/148556.
Release note: none

**storage/disk: use context cancellation to stop monitoring** 

Address a pending TODO to use context cancellation, rather than an explicit
stop channel, to stop monitoring of a disk.

Epic: none
Release note: none