### PR TITLE
rpc: add tcp_rtt and tcp_rtt_var metrics for gRPC

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -124,6 +124,10 @@ layers:
       description: |
         Sum of exponentially weighted moving average of round-trip latencies, as measured through a gRPC RPC.
 
+        Since this metric is based on gRPC RPCs, it is affected by application-level
+        processing delays and CPU overload effects. See rpc.connection.tcp_rtt for a
+        metric that is obtained from the kernel's TCP stack.
+
         Dividing this Gauge by rpc.connection.healthy gives an approximation of average
         latency, but the top-level round-trip-latency histogram is more useful. Instead,
         users should consult the label families of this metric if they are available
@@ -190,6 +194,40 @@ layers:
       aggregation: AVG
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: See Description.
+      essential: true
+    - name: rpc.connection.tcp_rtt
+      exported_name: rpc_connection_tcp_rtt
+      description: |
+        Kernel-level TCP round-trip time as measured by the Linux TCP stack.
+
+        This metric reports the smoothed round-trip time (SRTT) as maintained by the
+        kernel's TCP implementation. Unlike application-level RPC latency measurements,
+        this reflects pure network latency and is less affected by CPU overload effects.
+
+        This metric is only available on Linux.
+      y_axis_label: Latency
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: High TCP RTT values indicate network issues outside of CockroachDB that could be impacting the user's workload.
+      essential: true
+    - name: rpc.connection.tcp_rtt_var
+      exported_name: rpc_connection_tcp_rtt_var
+      description: |
+        Kernel-level TCP round-trip time variance as measured by the Linux TCP stack.
+
+        This metric reports the smoothed round-trip time variance (RTTVAR) as maintained
+        by the kernel's TCP implementation. This measures the stability of the
+        connection latency.
+
+        This metric is only available on Linux.
+      y_axis_label: Latency Variance
+      type: GAUGE
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
+      how_to_use: High TCP RTT variance values indicate network stability issues outside of CockroachDB that could be impacting the user's workload.
       essential: true
     - name: rpc.connection.unhealthy
       exported_name: rpc_connection_unhealthy

--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -62,6 +62,7 @@ go_library(
         "//pkg/util/netutil/addr",
         "//pkg/util/stop",
         "//pkg/util/syncutil",
+        "//pkg/util/sysutil",
         "//pkg/util/timeutil",
         "//pkg/util/tracing",
         "//pkg/util/tracing/grpcinterceptor",

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1389,12 +1389,23 @@ func (rpcCtx *Context) GRPCDialOptions(
 		// See the explanation on loopbackDialFn for an explanation about this.
 		transport = loopbackTransport
 	}
-	return rpcCtx.grpcDialOptionsInternal(ctx, target, class, transport)
+	// In other invokations of grpcDialOptionsInternal, we care about having a
+	// hook into each network dial so we can store the most recent TCP
+	// connection that we've dialed.
+	//
+	// Here, though, we don't currently care about the underlying TCP connection
+	// backing a gRPC channel so onNetworkDial is a no-op.
+	onNetworkDial := func(conn net.Conn) {}
+	return rpcCtx.grpcDialOptionsInternal(ctx, target, class, transport, onNetworkDial)
 }
 
 // grpcDialOptions produces dial options suitable for connecting to the given target and class.
 func (rpcCtx *Context) grpcDialOptionsInternal(
-	ctx context.Context, target string, class rpcbase.ConnectionClass, transport transportType,
+	ctx context.Context,
+	target string,
+	class rpcbase.ConnectionClass,
+	transport transportType,
+	onNetworkDial onDialFunc,
 ) ([]grpc.DialOption, error) {
 	dialOpts, err := rpcCtx.dialOptsCommon(ctx, target, class)
 	if err != nil {
@@ -1403,7 +1414,7 @@ func (rpcCtx *Context) grpcDialOptionsInternal(
 
 	switch transport {
 	case tcpTransport:
-		netOpts, err := rpcCtx.dialOptsNetwork(ctx, target, class)
+		netOpts, err := rpcCtx.dialOptsNetwork(ctx, target, class, onNetworkDial)
 		if err != nil {
 			return nil, err
 		}
@@ -1548,10 +1559,27 @@ func (t *statsTracker) HandleConn(ctx context.Context, s stats.ConnStats) {
 	}
 }
 
+type onDialFunc func(conn net.Conn)
+
+func (rpcCtx *Context) dialerWithCallback(
+	dialerFunc dialerFunc, onNetworkDial onDialFunc,
+) dialerFunc {
+	return func(ctx context.Context, addr string) (net.Conn, error) {
+		conn, err := dialerFunc(ctx, addr)
+		if err != nil {
+			return nil, err
+		}
+		if onNetworkDial != nil {
+			onNetworkDial(conn)
+		}
+		return conn, nil
+	}
+}
+
 // dialOptsNetwork compute options used only for over-the-network RPC
 // connections.
 func (rpcCtx *Context) dialOptsNetwork(
-	ctx context.Context, target string, class rpcbase.ConnectionClass,
+	ctx context.Context, target string, class rpcbase.ConnectionClass, onNetworkDial onDialFunc,
 ) ([]grpc.DialOption, error) {
 	dialOpts, err := rpcCtx.dialOptsNetworkCredentials()
 	if err != nil {
@@ -1638,6 +1666,11 @@ func (rpcCtx *Context) dialOptsNetwork(
 		}
 		dialerFunc = dialer.dial
 	}
+	// Wrap the dial function with the callback that's been passed down so we
+	// have a hook into each network dial from higher up.
+	//
+	// This allows us to keep the peer's tcpConn up to date.
+	dialerFunc = rpcCtx.dialerWithCallback(dialerFunc, onNetworkDial)
 	dialOpts = append(dialOpts, grpc.WithContextDialer(dialerFunc))
 
 	// Don't retry on dial errors either, otherwise the onlyOnceDialer will get
@@ -1981,6 +2014,7 @@ func (rpcCtx *Context) grpcDialRaw(
 	ctx context.Context,
 	target string,
 	class rpcbase.ConnectionClass,
+	onNetworkDial onDialFunc,
 	additionalOpts ...grpc.DialOption,
 ) (*grpc.ClientConn, error) {
 	transport := tcpTransport
@@ -1988,7 +2022,7 @@ func (rpcCtx *Context) grpcDialRaw(
 		// See the explanation on loopbackDialFn for an explanation about this.
 		transport = loopbackTransport
 	}
-	dialOpts, err := rpcCtx.grpcDialOptionsInternal(ctx, target, class, transport)
+	dialOpts, err := rpcCtx.grpcDialOptionsInternal(ctx, target, class, transport, onNetworkDial)
 	if err != nil {
 		return nil, err
 	}
@@ -2189,7 +2223,7 @@ type Dialbacker interface {
 	GRPCUnvalidatedDial(string, roachpb.Locality) *GRPCConnection
 	GRPCDialNode(string, roachpb.NodeID, roachpb.Locality, rpcbase.ConnectionClass) *GRPCConnection
 	grpcDialRaw(
-		context.Context, string, rpcbase.ConnectionClass, ...grpc.DialOption,
+		context.Context, string, rpcbase.ConnectionClass, onDialFunc, ...grpc.DialOption,
 	) (*grpc.ClientConn, error)
 	wrapCtx(
 		ctx context.Context, target string, remoteNodeID roachpb.NodeID, class rpcbase.ConnectionClass,
@@ -2265,7 +2299,8 @@ func VerifyDialback(
 		// A throwaway connection keeps it simple.
 		ctx := rpcCtx.wrapCtx(ctx, target, request.OriginNodeID, rpcbase.SystemClass)
 		ctx = logtags.AddTag(ctx, "dialback", nil)
-		conn, err := rpcCtx.grpcDialRaw(ctx, target, rpcbase.SystemClass, grpc.WithBlock())
+		onNetworkDial := func(conn net.Conn) {}
+		conn, err := rpcCtx.grpcDialRaw(ctx, target, rpcbase.SystemClass, onNetworkDial, grpc.WithBlock())
 		if conn != nil { // NB: the nil check simplifies mocking in TestVerifyDialback
 			_ = conn.Close() // nolint:grpcconnclose
 		}

--- a/pkg/rpc/grpc.go
+++ b/pkg/rpc/grpc.go
@@ -7,10 +7,12 @@ package rpc
 
 import (
 	"context"
+	"net"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/rpc/rpcbase"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/connectivity"
@@ -63,7 +65,26 @@ func newGRPCPeerOptions(
 			dial: func(ctx context.Context, target string, class rpcbase.ConnectionClass) (*grpc.ClientConn, error) {
 				additionalDialOpts := []grpc.DialOption{grpc.WithStatsHandler(&statsTracker{lm})}
 				additionalDialOpts = append(additionalDialOpts, rpcCtx.testingDialOpts...)
-				return rpcCtx.grpcDialRaw(ctx, target, class, additionalDialOpts...)
+				// onNetworkDial is a callback that is called after we dial a TCP connection.
+				// It is not called if we use the loopback dialer.
+				// We define it here because we need access to the peer map.
+				onNetworkDial := func(conn net.Conn) {
+					tcpConn, ok := conn.(*net.TCPConn)
+					if !ok {
+						return
+					}
+
+					rpcCtx.peers.mu.Lock()
+					defer rpcCtx.peers.mu.Unlock()
+					p := rpcCtx.peers.mu.m[k]
+
+					p.mu.Lock()
+					defer p.mu.Unlock()
+					p.mu.tcpConn = tcpConn
+
+					log.VEventf(ctx, 2, "gRPC network dial: laddr=%v", tcpConn.LocalAddr())
+				}
+				return rpcCtx.grpcDialRaw(ctx, target, class, onNetworkDial, additionalDialOpts...)
 			},
 			connEquals: func(a, b *grpc.ClientConn) bool {
 				return a == b

--- a/pkg/rpc/metrics_test.go
+++ b/pkg/rpc/metrics_test.go
@@ -60,7 +60,7 @@ func TestMetricsRelease(t *testing.T) {
 		return metricFields
 	}
 
-	const expectedCount = 11
+	const expectedCount = 13
 	k1 := peerKey{NodeID: 5, TargetAddr: "192.168.0.1:1234", Class: rpcbase.DefaultClass}
 	k2 := peerKey{NodeID: 6, TargetAddr: "192.168.0.1:1234", Class: rpcbase.DefaultClass}
 	l1 := roachpb.Locality{Tiers: []roachpb.Tier{{Key: "region", Value: "us-east"}}}

--- a/pkg/rpc/peer.go
+++ b/pkg/rpc/peer.go
@@ -8,6 +8,7 @@ package rpc
 import (
 	"context"
 	"fmt"
+	"net"
 	"runtime/pprof"
 	"time"
 
@@ -19,6 +20,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/netutil"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -58,6 +60,8 @@ func (p *peer[Conn]) setUnhealthyLocked(connUnhealthyFor int64) {
 	p.ConnectionHealthyFor.Update(0)
 	p.ConnectionUnhealthyFor.Update(connUnhealthyFor)
 	p.AvgRoundTripLatency.Update(0)
+	p.TCPRTT.Update(0)
+	p.TCPRTTVar.Update(0)
 
 	switch p.mu.peerStatus {
 	case peerStatusHealthy:
@@ -77,6 +81,8 @@ func (p *peer[Conn]) setInactiveLocked() {
 	p.ConnectionHealthyFor.Update(0)
 	p.ConnectionUnhealthyFor.Update(0)
 	p.AvgRoundTripLatency.Update(0)
+	p.TCPRTT.Update(0)
+	p.TCPRTTVar.Update(0)
 
 	switch p.mu.peerStatus {
 	case peerStatusHealthy:
@@ -196,6 +202,12 @@ type PeerSnap[Conn rpcConn] struct {
 	// INVARIANT: deleted once => deleted forever
 	// INVARIANT: deleted      => deleteAfter > 0
 	deleted bool
+	// tcpConn is the raw TCP network connection when available.
+	//
+	// We store the *net.TCPConn rather than the raw file descriptor so that we
+	// can invoke syscall.RawConn.Control() on it, which guarantees an
+	// up-to-date file descriptor.
+	tcpConn *net.TCPConn
 }
 
 func (p *peer[Conn]) snap() PeerSnap[Conn] {
@@ -602,10 +614,12 @@ func (p *peer[Conn]) onInitialHeartbeatSucceeded(
 }
 
 func (p *peer[Conn]) onSubsequentHeartbeatSucceeded(_ context.Context, now time.Time) {
+	snap := p.snap()
+
 	// Gauge updates.
 	// ConnectionHealthy is already one.
 	// ConnectionUnhealthy is already zero.
-	p.ConnectionHealthyFor.Update(now.Sub(p.snap().connected).Nanoseconds() + 1) // add 1ns for unit tests w/ manual clock
+	p.ConnectionHealthyFor.Update(now.Sub(snap.connected).Nanoseconds() + 1) // add 1ns for unit tests w/ manual clock
 	// ConnectionInactive is already zero.
 	// ConnectionUnhealthyFor is already zero.
 	p.AvgRoundTripLatency.Update(int64(p.roundTripLatency.Value()) + 1) // add 1ns for unit tests w/ manual clock
@@ -613,6 +627,11 @@ func (p *peer[Conn]) onSubsequentHeartbeatSucceeded(_ context.Context, now time.
 	// Counter updates.
 	p.ConnectionHeartbeats.Inc(1)
 	// ConnectionFailures is not updated here.
+
+	if rttInfo, ok := sysutil.GetRTTInfo(snap.tcpConn); ok {
+		p.TCPRTT.Update(rttInfo.RTT.Nanoseconds())
+		p.TCPRTTVar.Update(rttInfo.RTTVar.Nanoseconds())
+	}
 }
 
 func maybeLogOnFailedHeartbeat[Conn rpcConn](

--- a/pkg/rpc/rpc_mock_test.go
+++ b/pkg/rpc/rpc_mock_test.go
@@ -129,11 +129,15 @@ func (mr *MockDialbackerMockRecorder) GRPCUnvalidatedDial(arg0, arg1 interface{}
 
 // grpcDialRaw mocks base method.
 func (m *MockDialbacker) grpcDialRaw(
-	arg0 context.Context, arg1 string, arg2 rpcpb.ConnectionClass, arg3 ...grpc.DialOption,
+	arg0 context.Context,
+	arg1 string,
+	arg2 rpcpb.ConnectionClass,
+	arg3 onDialFunc,
+	arg4 ...grpc.DialOption,
 ) (*grpc.ClientConn, error) {
 	m.ctrl.T.Helper()
-	varargs := []interface{}{arg0, arg1, arg2}
-	for _, a := range arg3 {
+	varargs := []interface{}{arg0, arg1, arg2, arg3}
+	for _, a := range arg4 {
 		varargs = append(varargs, a)
 	}
 	ret := m.ctrl.Call(m, "grpcDialRaw", varargs...)
@@ -144,10 +148,10 @@ func (m *MockDialbacker) grpcDialRaw(
 
 // grpcDialRaw indicates an expected call of grpcDialRaw.
 func (mr *MockDialbackerMockRecorder) grpcDialRaw(
-	arg0, arg1, arg2 interface{}, arg3 ...interface{},
+	arg0, arg1, arg2, arg3 interface{}, arg4 ...interface{},
 ) *gomock.Call {
 	mr.mock.ctrl.T.Helper()
-	varargs := append([]interface{}{arg0, arg1, arg2}, arg3...)
+	varargs := append([]interface{}{arg0, arg1, arg2, arg3}, arg4...)
 	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "grpcDialRaw", reflect.TypeOf((*MockDialbacker)(nil).grpcDialRaw), varargs...)
 }
 

--- a/pkg/util/sysutil/BUILD.bazel
+++ b/pkg/util/sysutil/BUILD.bazel
@@ -16,6 +16,9 @@ go_library(
         "sysutil.go",
         "sysutil_unix.go",
         "sysutil_windows.go",
+        "tcpinfo.go",
+        "tcpinfo_linux.go",
+        "tcpinfo_stub.go",
     ],
     importpath = "github.com/cockroachdb/cockroach/pkg/util/sysutil",
     visibility = ["//visibility:public"],
@@ -94,6 +97,7 @@ go_test(
         "large_file_test.go",
         "sysutil_test.go",
         "sysutil_unix_test.go",
+        "tcpinfo_linux_test.go",
     ],
     embed = [":sysutil"],
     deps = [
@@ -105,6 +109,7 @@ go_test(
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:android": [
+            "//pkg/testutils/skip",
             "@com_github_stretchr_testify//assert",
             "@org_golang_x_sys//unix",
         ],
@@ -133,6 +138,7 @@ go_test(
             "@org_golang_x_sys//unix",
         ],
         "@io_bazel_rules_go//go/platform:linux": [
+            "//pkg/testutils/skip",
             "@com_github_stretchr_testify//assert",
             "@org_golang_x_sys//unix",
         ],

--- a/pkg/util/sysutil/tcpinfo.go
+++ b/pkg/util/sysutil/tcpinfo.go
@@ -1,0 +1,14 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package sysutil
+
+import "time"
+
+// RTTInfo holds the round-trip time information for a TCP connection.
+type RTTInfo struct {
+	RTT    time.Duration
+	RTTVar time.Duration
+}

--- a/pkg/util/sysutil/tcpinfo_linux.go
+++ b/pkg/util/sysutil/tcpinfo_linux.go
@@ -1,0 +1,52 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build linux
+
+package sysutil
+
+import (
+	"net"
+	"syscall"
+	"time"
+
+	"golang.org/x/sys/unix"
+)
+
+func getTCPInfo(conn syscall.RawConn) (*unix.TCPInfo, error) {
+	var (
+		tcpInfo    *unix.TCPInfo
+		syscallErr error
+	)
+	err := conn.Control(func(fd uintptr) {
+		tcpInfo, syscallErr = unix.GetsockoptTCPInfo(int(fd), unix.IPPROTO_TCP, unix.TCP_INFO)
+	})
+	if syscallErr != nil {
+		return nil, syscallErr
+	}
+	if err != nil {
+		return nil, err
+	}
+	return tcpInfo, nil
+}
+
+// GetRTTInfo retrieves round-trip time information from a TCP connection.
+func GetRTTInfo(conn *net.TCPConn) (value *RTTInfo, ok bool) {
+	if conn == nil {
+		return nil, false
+	}
+	rawConn, err := conn.SyscallConn()
+	if err != nil {
+		return nil, false
+	}
+	tcpInfo, err := getTCPInfo(rawConn)
+	if err != nil {
+		return nil, false
+	}
+	return &RTTInfo{
+		RTT:    time.Duration(tcpInfo.Rtt) * time.Microsecond,
+		RTTVar: time.Duration(tcpInfo.Rttvar) * time.Microsecond,
+	}, true
+}

--- a/pkg/util/sysutil/tcpinfo_linux_test.go
+++ b/pkg/util/sysutil/tcpinfo_linux_test.go
@@ -1,0 +1,110 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build linux
+
+package sysutil
+
+import (
+	"context"
+	"io"
+	"net"
+	"runtime"
+	"testing"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+	"github.com/stretchr/testify/require"
+)
+
+// GetRTTInfo doesn't panic when it's called with a nil connection.
+func TestGetTCPInfoNilConn(t *testing.T) {
+	var conn *net.TCPConn
+	info, ok := GetRTTInfo(conn)
+	require.Nil(t, info)
+	require.False(t, ok)
+}
+
+func TestGetTCPInfoLinux(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		skip.IgnoreLint(t, "skipping test; RTT inspection is only supported on Linux")
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	// Start a TCP echo server.
+	listener, _, err := createEchoServer(ctx, "127.0.0.1:0")
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, listener.Close())
+	}()
+
+	// Connect a client.
+	conn, err := net.Dial("tcp", listener.Addr().String())
+	require.NoError(t, err)
+	defer func() {
+		require.NoError(t, conn.Close())
+	}()
+
+	// Give the connection a moment to be established.
+	time.Sleep(10 * time.Millisecond)
+
+	pingPayload := []byte("ping")
+	pongBuffer := make([]byte, len(pingPayload))
+
+	// Write a "ping".
+	_, err = conn.Write(pingPayload)
+	require.NoError(t, err)
+
+	// Read the "pong" echo.
+	_, err = io.ReadFull(conn, pongBuffer)
+	require.NoError(t, err)
+
+	// RTT info is only available on TCP connections. GetRTTInfo takes a
+	// *net.TCPConn, forcing the caller to perform a type assertion.
+	tcpConn, ok := conn.(*net.TCPConn)
+	require.True(t, ok)
+
+	info, ok := GetRTTInfo(tcpConn)
+
+	require.True(t, ok)
+	require.NotNil(t, info)
+}
+
+// createEchoServer creates a TCP echo server that echoes back all received data.
+// It returns the listener and a channel that will receive any server errors.
+func createEchoServer(ctx context.Context, addr string) (net.Listener, <-chan error, error) {
+	listener, err := net.Listen("tcp", addr)
+	if err != nil {
+		return nil, nil, err
+	}
+
+	serverErrChan := make(chan error, 1)
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			// If the context is canceled, the listener may be closed,
+			// resulting in an error. This is expected during cleanup.
+			select {
+			case <-ctx.Done():
+				serverErrChan <- nil
+			default:
+				serverErrChan <- err
+			}
+			return
+		}
+		defer conn.Close()
+		// Echo all data received back to the client. This will run until
+		// the client closes the connection, resulting in an io.EOF.
+		if _, err := io.Copy(conn, conn); err != nil && err != io.EOF {
+			serverErrChan <- err
+		} else {
+			serverErrChan <- nil
+		}
+	}()
+
+	return listener, serverErrChan, nil
+}

--- a/pkg/util/sysutil/tcpinfo_stub.go
+++ b/pkg/util/sysutil/tcpinfo_stub.go
@@ -7,9 +7,9 @@
 
 package sysutil
 
-import "syscall"
+import "net"
 
 // GetRTTInfo is a stub implementation for non-Linux platforms returning (nil, false).
-func GetRTTInfo(conn syscall.RawConn) (value *RTTInfo, ok bool) {
+func GetRTTInfo(conn *net.TCPConn) (value *RTTInfo, ok bool) {
 	return nil, false
 }

--- a/pkg/util/sysutil/tcpinfo_stub.go
+++ b/pkg/util/sysutil/tcpinfo_stub.go
@@ -1,0 +1,15 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+//go:build !linux
+
+package sysutil
+
+import "syscall"
+
+// GetRTTInfo is a stub implementation for non-Linux platforms returning (nil, false).
+func GetRTTInfo(conn syscall.RawConn) (value *RTTInfo, ok bool) {
+	return nil, false
+}


### PR DESCRIPTION
### `util/sysutil: add functions for getting TCP round-trip time and variance`
Previously, we relied on timing heartbeats in the RPC layer to estimate network
latency (rpc.connection.avg_round_trip_latency). However, because these
measurements are computed within cockroach, they can be confounded by CPU-heavy
workloads.

Luckily, Linux maintains the smoothed round-trip time (SRTT) and RTT variance
for each TCP socket it opens. As kernel-computed metrics, these are less
sensitive to CPU overload.

This patch adds a sysutil function for obtaining SRTT and RTT variance given a
a net.TCPConn pointer.

Part of: https://github.com/cockroachdb/cockroach/issues/149959
Release note: None

### `rpc: add tcp_rtt and tcp_rtt_var metrics for gRPC`

Previously, our only metric for gauging network latency was
rpc.connection.avg_round_trip_latency. This metric was calculated by timing
heartbeats in the RPC layer. However, because these measurements are computed
within cockroach, they can be confounded by CPU-heavy workloads.

Through escalations, we've found that elevated network latencies (outside of
CRDB's control) can severely degrade cluster performance. So, being able to
directly and accurately identify these cases would be helpful.

To address this, this patch introduces two new metrics whose values are computed
by Linux. As kernel-computed metrics, these are less sensitive to CPU overload:
1. rpc.connection.tcp_rtt: TCP smoothed round-trip time
2. rpc.connection.tcp_rtt_var: TCP round-trip time variance

Since these metrics are internally aggregated by Linux, we only need to sample
them periodically. We update them in the heartbeat loop, at the same cadence as
the original avg_round_trip_latency.

To obtain these metrics, we need access to the underlying *net.TCPConn of our
gRPC peer connection. So, the dial function we pass to gRPC has been modified to
update the tcpConn field of the peer struct on each network dial.

Part of: https://github.com/cockroachdb/cockroach/issues/149959
Release note: None