### PR TITLE
roachprod: gc ibm clusters with no tags

### DIFF
--- a/pkg/roachprod/vm/ibm/ibm_extended_types.go
+++ b/pkg/roachprod/vm/ibm/ibm_extended_types.go
@@ -588,6 +588,11 @@ func (i *instance) toVM() vm.VM {
 		if err != nil {
 			vmErrors = append(vmErrors, errors.Wrap(err, "unable to compute lifetime"))
 		}
+	} else {
+		// Missing lifetime tag, use the default lifetime.
+		// This is not an error, but a fallback to ensure the VM has a lifetime
+		// even if the tag is not set to avoid GCing it right away.
+		lifetime = vm.DefaultLifetime
 	}
 
 	privateIP := i.getPrivateIPAddress()

--- a/pkg/roachprod/vm/vm.go
+++ b/pkg/roachprod/vm/vm.go
@@ -43,6 +43,8 @@ const (
 	ArchFIPS    = CPUArch("fips")
 	ArchS390x   = CPUArch("s390x")
 	ArchUnknown = CPUArch("unknown")
+
+	DefaultLifetime = 12 * time.Hour
 )
 
 // UnimplementedError is returned when a method is not implemented by a
@@ -308,7 +310,7 @@ type CreateOpts struct {
 func DefaultCreateOpts() CreateOpts {
 	defaultCreateOpts := CreateOpts{
 		ClusterName:    "",
-		Lifetime:       12 * time.Hour,
+		Lifetime:       DefaultLifetime,
 		GeoDistributed: false,
 		VMProviders:    []string{},
 		OsVolumeSize:   10,


### PR DESCRIPTION
Starting with #148008, some partially created clusters (without tags) get listed for garbage collection, but are never actually deleted because the `DeleteCluster()` lists VMs to destroy via tags.

This PR updates the `DeleteCluster()` function to also list VMs by instance names and properly destroy some leftover clusters.

Epic: none
Release note: None