### PR TITLE
sqlccl: bump engflow worker size

### DIFF
--- a/pkg/ccl/testccl/sqlccl/BUILD.bazel
+++ b/pkg/ccl/testccl/sqlccl/BUILD.bazel
@@ -19,6 +19,9 @@ go_test(
     data = [
         "//c-deps:libgeos",  # keep
     ],
+    exec_properties = select({
+        "//conditions:default": {"test.Pool": "large"},
+    }),
     shard_count = 16,
     deps = [
         "//pkg/base",


### PR DESCRIPTION
We just saw a failure that looks like an OOM, so let's bump the worker size.

Fixes: #150648.

Release note: None