### PR TITLE
release-25.2: logictest: make one query in `show_ranges` deterministic

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/show_ranges
+++ b/pkg/sql/logictest/testdata/logic_test/show_ranges
@@ -268,7 +268,7 @@ start_key  end_key  raw_start_key  raw_end_key  range_id  schema_name  table_nam
 query TTITTITT colnames
 SELECT start_key, end_key, range_id, schema_name, table_name, table_id, table_start_key, table_end_key
 FROM [SHOW RANGES WITH TABLES]
-ORDER BY range_id
+ORDER BY range_id, table_id
 ----
 start_key        end_key          range_id  schema_name  table_name  table_id  table_start_key  table_end_key
 /Table/72        /Table/106/1/10  74        public       t           106       /Table/106       /Table/106/1/10


### PR DESCRIPTION
Backport 1/1 commits from #150878 on behalf of @yuzefovich.

----

Two rows have the same `range_id` which was previously the only column in ORDER BY clause, so we include an extra column to make the order deterministic.

Fixes: #150795.

Release note: None

----

Release justification: test-only change.