### PR TITLE
sql/opt: improve HoistJoinProjectLeft to hoist more projections

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -1803,29 +1803,22 @@ vectorized: true
 │           │ render fk_lookup_crdb_region: fk_lookup_crdb_region
 │           │
 │           └── • render
-│               │ columns: (fk_lookup_crdb_region, k, crdb_region, rowid, k_new)
+│               │ columns: (fk_lookup_crdb_region, k_new, k, crdb_region, rowid)
 │               │ render fk_lookup_crdb_region: CASE WHEN crdb_region IS NOT DISTINCT FROM CAST(NULL AS public.crdb_internal_region) THEN crdb_region ELSE crdb_region END
+│               │ render k_new: 4
 │               │ render k: k
 │               │ render crdb_region: crdb_region
 │               │ render rowid: rowid
-│               │ render k_new: k_new
 │               │
 │               └── • cross join (left outer)
-│                   │ columns: (k_new, k, crdb_region, rowid, k, crdb_region)
+│                   │ columns: (k, crdb_region, rowid, k, crdb_region)
 │                   │ estimated row count: 10 (missing stats)
 │                   │
-│                   ├── • render
-│                   │   │ columns: (k_new, k, crdb_region, rowid)
-│                   │   │ render k_new: 4
-│                   │   │ render k: k
-│                   │   │ render crdb_region: crdb_region
-│                   │   │ render rowid: rowid
-│                   │   │
-│                   │   └── • scan
-│                   │         columns: (k, crdb_region, rowid)
-│                   │         estimated row count: 10 (missing stats)
-│                   │         table: child@child_k_idx
-│                   │         spans: /"@"/3-/"@"/4 /"\x80"/3-/"\x80"/4 /"\xc0"/3-/"\xc0"/4
+│                   ├── • scan
+│                   │     columns: (k, crdb_region, rowid)
+│                   │     estimated row count: 10 (missing stats)
+│                   │     table: child@child_k_idx
+│                   │     spans: /"@"/3-/"@"/4 /"\x80"/3-/"\x80"/4 /"\xc0"/3-/"\xc0"/4
 │                   │
 │                   └── • union all
 │                       │ columns: (k, crdb_region)

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_query_behavior
@@ -1746,10 +1746,8 @@ VALUES ('us-east-1', 23, 24, 25, 26), ('ca-central-1', 30, 30, 31, 32)] OFFSET 2
 │               │ remote lookup condition: (crdb_region IN ('ca-central-1', 'us-east-1')) AND (column2 = pk)
 │               │ locking strength: for update
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 5 columns, 2 rows
+│               └── • values
+│                     size: 5 columns, 2 rows
 │
 ├── • constraint-check
 │   │

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4388,6 +4388,10 @@ func (m *sessionDataMutator) SetAllowUnsafeInternals(val bool) {
 	m.data.AllowUnsafeInternals = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseImprovedHoistJoinProject(val bool) {
+	m.data.OptimizerUseImprovedHoistJoinProject = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4083,6 +4083,7 @@ optimizer_use_histograms                                         on
 optimizer_use_improved_computed_column_filters_derivation        on
 optimizer_use_improved_disjunction_stats                         on
 optimizer_use_improved_distinct_on_limit_hint_costing            on
+optimizer_use_improved_hoist_join_project                        off
 optimizer_use_improved_join_elimination                          on
 optimizer_use_improved_multi_column_selectivity_estimate         on
 optimizer_use_improved_split_disjunction_for_joins               on

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4083,7 +4083,7 @@ optimizer_use_histograms                                         on
 optimizer_use_improved_computed_column_filters_derivation        on
 optimizer_use_improved_disjunction_stats                         on
 optimizer_use_improved_distinct_on_limit_hint_costing            on
-optimizer_use_improved_hoist_join_project                        off
+optimizer_use_improved_hoist_join_project                        on
 optimizer_use_improved_join_elimination                          on
 optimizer_use_improved_multi_column_selectivity_estimate         on
 optimizer_use_improved_split_disjunction_for_joins               on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3095,7 +3095,7 @@ optimizer_use_histograms                                         on             
 optimizer_use_improved_computed_column_filters_derivation        on                  NULL      NULL        NULL        string
 optimizer_use_improved_disjunction_stats                         on                  NULL      NULL        NULL        string
 optimizer_use_improved_distinct_on_limit_hint_costing            on                  NULL      NULL        NULL        string
-optimizer_use_improved_hoist_join_project                        off                 NULL      NULL        NULL        string
+optimizer_use_improved_hoist_join_project                        on                  NULL      NULL        NULL        string
 optimizer_use_improved_join_elimination                          on                  NULL      NULL        NULL        string
 optimizer_use_improved_multi_column_selectivity_estimate         on                  NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins               on                  NULL      NULL        NULL        string
@@ -3339,7 +3339,7 @@ optimizer_use_histograms                                         on             
 optimizer_use_improved_computed_column_filters_derivation        on                  NULL  user     NULL      on                  on
 optimizer_use_improved_disjunction_stats                         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_distinct_on_limit_hint_costing            on                  NULL  user     NULL      on                  on
-optimizer_use_improved_hoist_join_project                        off                 NULL  user     NULL      off                 off
+optimizer_use_improved_hoist_join_project                        on                  NULL  user     NULL      on                  on
 optimizer_use_improved_join_elimination                          on                  NULL  user     NULL      on                  on
 optimizer_use_improved_multi_column_selectivity_estimate         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_split_disjunction_for_joins               on                  NULL  user     NULL      on                  on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3095,6 +3095,7 @@ optimizer_use_histograms                                         on             
 optimizer_use_improved_computed_column_filters_derivation        on                  NULL      NULL        NULL        string
 optimizer_use_improved_disjunction_stats                         on                  NULL      NULL        NULL        string
 optimizer_use_improved_distinct_on_limit_hint_costing            on                  NULL      NULL        NULL        string
+optimizer_use_improved_hoist_join_project                        off                 NULL      NULL        NULL        string
 optimizer_use_improved_join_elimination                          on                  NULL      NULL        NULL        string
 optimizer_use_improved_multi_column_selectivity_estimate         on                  NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins               on                  NULL      NULL        NULL        string
@@ -3338,6 +3339,7 @@ optimizer_use_histograms                                         on             
 optimizer_use_improved_computed_column_filters_derivation        on                  NULL  user     NULL      on                  on
 optimizer_use_improved_disjunction_stats                         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_distinct_on_limit_hint_costing            on                  NULL  user     NULL      on                  on
+optimizer_use_improved_hoist_join_project                        off                 NULL  user     NULL      off                 off
 optimizer_use_improved_join_elimination                          on                  NULL  user     NULL      on                  on
 optimizer_use_improved_multi_column_selectivity_estimate         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_split_disjunction_for_joins               on                  NULL  user     NULL      on                  on
@@ -3572,6 +3574,7 @@ optimizer_use_histograms                                         NULL    NULL   
 optimizer_use_improved_computed_column_filters_derivation        NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_disjunction_stats                         NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_distinct_on_limit_hint_costing            NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_hoist_join_project                        NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_join_elimination                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_multi_column_selectivity_estimate         NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_split_disjunction_for_joins               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -172,6 +172,7 @@ optimizer_use_histograms                                         on
 optimizer_use_improved_computed_column_filters_derivation        on
 optimizer_use_improved_disjunction_stats                         on
 optimizer_use_improved_distinct_on_limit_hint_costing            on
+optimizer_use_improved_hoist_join_project                        off
 optimizer_use_improved_join_elimination                          on
 optimizer_use_improved_multi_column_selectivity_estimate         on
 optimizer_use_improved_split_disjunction_for_joins               on

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -172,7 +172,7 @@ optimizer_use_histograms                                         on
 optimizer_use_improved_computed_column_filters_derivation        on
 optimizer_use_improved_disjunction_stats                         on
 optimizer_use_improved_distinct_on_limit_hint_costing            on
-optimizer_use_improved_hoist_join_project                        off
+optimizer_use_improved_hoist_join_project                        on
 optimizer_use_improved_join_elimination                          on
 optimizer_use_improved_multi_column_selectivity_estimate         on
 optimizer_use_improved_split_disjunction_for_joins               on

--- a/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
+++ b/pkg/sql/opt/exec/execbuilder/testdata/inverted_join_multi_column
@@ -68,17 +68,17 @@ vectorized: true
 └── • inverted join
     │ table: j2@isj_idx
     │
-    └── • cross join
+    └── • render
         │
-        ├── • render
-        │   │
-        │   └── • scan
-        │         missing stats
-        │         table: j1@j1_pkey
-        │         spans: FULL SCAN
-        │
-        └── • values
-              size: 1 column, 2 rows
+        └── • cross join
+            │
+            ├── • scan
+            │     missing stats
+            │     table: j1@j1_pkey
+            │     spans: FULL SCAN
+            │
+            └── • values
+                  size: 1 column, 2 rows
 
 query T
 EXPLAIN SELECT j1.k
@@ -124,14 +124,14 @@ vectorized: true
 └── • inverted join
     │ table: j2@isj_idx
     │
-    └── • cross join
+    └── • render
         │
-        ├── • render
-        │   │
-        │   └── • scan
-        │         missing stats
-        │         table: j1@j1_pkey
-        │         spans: FULL SCAN
-        │
-        └── • values
-              size: 1 column, 2 rows
+        └── • cross join
+            │
+            ├── • scan
+            │     missing stats
+            │     table: j1@j1_pkey
+            │     spans: FULL SCAN
+            │
+            └── • values
+                  size: 1 column, 2 rows

--- a/pkg/sql/opt/exec/execbuilder/testdata/unique
+++ b/pkg/sql/opt/exec/execbuilder/testdata/unique
@@ -3628,10 +3628,8 @@ vectorized: true
 │               │ equality cols are key
 │               │ locking strength: for update
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 3 columns, 2 rows
+│               └── • values
+│                     size: 3 columns, 2 rows
 │
 ├── • constraint-check
 │   │
@@ -3690,10 +3688,8 @@ vectorized: true
 │               │ equality cols are key
 │               │ locking strength: for update
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 3 columns, 2 rows
+│               └── • values
+│                     size: 3 columns, 2 rows
 │
 ├── • constraint-check
 │   │
@@ -3753,10 +3749,8 @@ vectorized: true
 │               │ equality cols are key
 │               │ locking strength: for update
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 2 columns, 2 rows
+│               └── • values
+│                     size: 2 columns, 2 rows
 │
 ├── • constraint-check
 │   │
@@ -3891,10 +3885,8 @@ vectorized: true
 │               │     table: uniq@uniq_pkey
 │               │     spans: FULL SCAN
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 3 columns, 2 rows
+│               └── • values
+│                     size: 3 columns, 2 rows
 │
 ├── • constraint-check
 │   │
@@ -4574,10 +4566,8 @@ vectorized: true
 │               │ equality cols are key
 │               │ locking strength: for update
 │               │
-│               └── • render
-│                   │
-│                   └── • values
-│                         size: 2 columns, 2 rows
+│               └── • values
+│                     size: 2 columns, 2 rows
 │
 ├── • constraint-check
 │   │

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -106,8 +106,8 @@ vectorized: true
 │
 └── • render
     │ columns: (k, v_default, k)
-    │ render k: k
     │ render v_default: CAST(NULL AS INT8)
+    │ render k: k
     │ render k: k
     │
     └── • top-k

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -210,6 +210,7 @@ type Memo struct {
 	usePre_25_2VariadicBuiltins                bool
 	useExistsFilterHoistRule                   bool
 	disableSlowCascadeFastPathForRBRTables     bool
+	useImprovedHoistJoinProject                bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -316,6 +317,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		usePre_25_2VariadicBuiltins:                evalCtx.SessionData().UsePre_25_2VariadicBuiltins,
 		useExistsFilterHoistRule:                   evalCtx.SessionData().OptimizerUseExistsFilterHoistRule,
 		disableSlowCascadeFastPathForRBRTables:     evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables,
+		useImprovedHoistJoinProject:                evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -490,6 +492,7 @@ func (m *Memo) IsStale(
 		m.usePre_25_2VariadicBuiltins != evalCtx.SessionData().UsePre_25_2VariadicBuiltins ||
 		m.useExistsFilterHoistRule != evalCtx.SessionData().OptimizerUseExistsFilterHoistRule ||
 		m.disableSlowCascadeFastPathForRBRTables != evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables ||
+		m.useImprovedHoistJoinProject != evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -590,6 +590,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject = true
+	stale()
+	evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/norm/project_funcs.go
+++ b/pkg/sql/opt/norm/project_funcs.go
@@ -946,6 +946,30 @@ func (c *CustomFuncs) AllAreRemappingProjections(projections memo.ProjectionsExp
 	return true
 }
 
+// CanHoistNonRemappingProjections splits the projections into those that are
+// simple remappings from one column to another of an identical type, and those
+// that are not, and returns true if the non-remapping projections can be
+// hoisted.
+func (c *CustomFuncs) CanHoistNonRemappingProjections(
+	projections memo.ProjectionsExpr,
+) (remap, other memo.ProjectionsExpr, ok bool) {
+	md := c.mem.Metadata()
+	for i := range projections {
+		varExpr, ok := projections[i].Element.(*memo.VariableExpr)
+		if ok {
+			if md.ColumnMeta(varExpr.Col).Type.Identical(md.ColumnMeta(projections[i].Col).Type) {
+				remap = append(remap, projections[i])
+				continue
+			}
+		}
+		other = append(other, projections[i])
+	}
+	// Hoisting is allowed if there are no non-remapping projections (the previous
+	// behavior) or if optimizer_use_improved_hoist_join_project is enabled.
+	canHoist := len(other) == 0 || c.f.evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject
+	return remap, other, canHoist
+}
+
 // UnbindFiltersFromProjections remaps column references in the given filters
 // to refer to input columns instead of projected output columns, based on the
 // given projections. It assumes that AllAreRemappingProjections returns true
@@ -972,4 +996,15 @@ func (c *CustomFuncs) HasAllLeakProofProjections(projections memo.ProjectionsExp
 		}
 	}
 	return true
+}
+
+// HasVolatileProjection returns true if any of the projection items of the
+// ProjectionsExpr contains a volatile expression.
+func (c *CustomFuncs) HasVolatileProjection(projections memo.ProjectionsExpr) bool {
+	for i := range projections {
+		if projections[i].ScalarProps().VolatilitySet.HasVolatile() {
+			return true
+		}
+	}
+	return false
 }

--- a/pkg/sql/opt/norm/rules/join.opt
+++ b/pkg/sql/opt/norm/rules/join.opt
@@ -425,6 +425,11 @@ $left
 # them down (to prune columns), or else to pull them up (to get them out of the
 # way of other operators).
 #
+# It's not always beneficial to hoist projections above joins, but we need some
+# projection hoisting to happen to help join reordering, and doing it all in an
+# exploration rule risks creating a huge number of plans when combined with join
+# reordering.
+#
 # Projections are allowed in the case when they are simple remaps from input to
 # output column IDs, in which case it is simple to replace the column references
 # in the join condition.
@@ -469,8 +474,7 @@ $left
 (InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
     $left:(Project
         $input:*
-        $projections:* &
-            (AllAreRemappingProjections $projections)
+        $projections:* & ^(HasVolatileProjection $projections)
         $passThrough:*
     )
     $right:* &
@@ -482,14 +486,41 @@ $left
         # TODO(drewk): we could remap the right input as well.
         ^(IsCorrelated $right (ProjectionCols $projections))
     $on:*
-    $private:*
+    $private:* &
+
+        # We can only hoist the projection if each new column is either:
+        # 1. a simple remapping that can be reversed in the join condition, OR
+        # 2. not referenced in the join condition AND
+        # 3. the projection does not reference input columns
+        #
+        # The last condition, (3), is a very conservative heuristic to avoid
+        # hoisting projections that could prevent column pruning. We might be
+        # able to remove it or make it smarter.
+        #
+        # TODO(michae2): we could work around (2) by inlining the projection
+        # expression into the join condition, similar to
+        # PushSelectIntoInlinableProject.
+        (Let
+            ($remap $other $ok):(CanHoistNonRemappingProjections
+                $projections
+            )
+            $ok
+        ) &
+        ^(ColsIntersect
+            (FilterOuterCols $on)
+            (ProjectionCols $other)
+        ) &
+        ^(ColsIntersect
+            (ProjectionOuterCols $other)
+            (OutputCols $input)
+        )
 )
 =>
 (Project
     ((OpName)
         $input
         $right
-        (UnbindFiltersFromProjections $projections $on)
+        (UnbindFiltersFromProjections $remap $on)
         $private
     )
     $projections

--- a/pkg/sql/opt/norm/testdata/rules/groupby
+++ b/pkg/sql/opt/norm/testdata/rules/groupby
@@ -2838,26 +2838,19 @@ upsert a
  ├── cardinality: [0 - 0]
  ├── volatile, mutations
  └── project
-      ├── columns: upsert_f:23 column1:8!null column2:9 column3:10 f_default:11 j_default:12 k:13 i:14 f:15 s:16 j:17
+      ├── columns: upsert_f:23 f_default:11 j_default:12 column1:8!null column2:9 column3:10 k:13 i:14 f:15 s:16 j:17
       ├── cardinality: [2 - 2]
-      ├── fd: ()-->(11,12), (13)-->(14-17), (14,16)-->(13,15,17), (14,15)~~>(13,16,17)
+      ├── fd: ()-->(11,12), (13)-->(14-17), (14,16)-->(13,15,17), (14,15)~~>(13,16,17), (16)-->(23)
       ├── left-join (hash)
-      │    ├── columns: column1:8!null column2:9 column3:10 f_default:11 j_default:12 k:13 i:14 f:15 s:16 j:17
+      │    ├── columns: column1:8!null column2:9 column3:10 k:13 i:14 f:15 s:16 j:17
       │    ├── cardinality: [2 - 2]
       │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
-      │    ├── fd: ()-->(11,12), (13)-->(14-17), (14,16)-->(13,15,17), (14,15)~~>(13,16,17)
-      │    ├── project
-      │    │    ├── columns: f_default:11 j_default:12 column1:8!null column2:9 column3:10
+      │    ├── fd: (13)-->(14-17), (14,16)-->(13,15,17), (14,15)~~>(13,16,17)
+      │    ├── values
+      │    │    ├── columns: column1:8!null column2:9 column3:10
       │    │    ├── cardinality: [2 - 2]
-      │    │    ├── fd: ()-->(11,12)
-      │    │    ├── values
-      │    │    │    ├── columns: column1:8!null column2:9 column3:10
-      │    │    │    ├── cardinality: [2 - 2]
-      │    │    │    ├── (1, NULL, NULL)
-      │    │    │    └── (1, NULL, NULL)
-      │    │    └── projections
-      │    │         ├── CAST(NULL AS FLOAT8) [as=f_default:11]
-      │    │         └── CAST(NULL AS JSONB) [as=j_default:12]
+      │    │    ├── (1, NULL, NULL)
+      │    │    └── (1, NULL, NULL)
       │    ├── scan a
       │    │    ├── columns: k:13!null i:14!null f:15 s:16!null j:17
       │    │    ├── flags: avoid-full-scan
@@ -2867,7 +2860,9 @@ upsert a
       │         ├── column3:10 = i:14 [outer=(10,14), constraints=(/10: (/NULL - ]; /14: (/NULL - ]), fd=(10)==(14), (14)==(10)]
       │         └── column2:9 = s:16 [outer=(9,16), constraints=(/9: (/NULL - ]; /16: (/NULL - ]), fd=(9)==(16), (16)==(9)]
       └── projections
-           └── CASE WHEN s:16 IS NULL THEN f_default:11 ELSE 1.0 END [as=upsert_f:23, outer=(11,16)]
+           ├── CASE WHEN s:16 IS NULL THEN CAST(NULL AS FLOAT8) ELSE 1.0 END [as=upsert_f:23, outer=(16)]
+           ├── CAST(NULL AS FLOAT8) [as=f_default:11]
+           └── CAST(NULL AS JSONB) [as=j_default:12]
 
 # EnsureUpsertDistinctOn is not removed when there are duplicates.
 norm expect-not=EliminateDistinctOnValues

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -3240,6 +3240,541 @@ inner-join-apply
  │         └── k:9 = baz:8 [outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
  └── filters (true)
 
+# Test hoisting projections above joins in more cases for #150704.
+
+exec-ddl
+CREATE TABLE t150704 (
+  x INT PRIMARY KEY,
+  y INT
+)
+----
+
+exec-ddl
+CREATE TABLE u150704 (
+  y INT PRIMARY KEY,
+  z INT
+)
+----
+
+# Check that we hoist the projection when no join conditions use p.
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, 4 AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+JOIN u150704 USING (y)
+----
+project
+ ├── columns: y:7!null x:6!null p:8!null z:10
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6-8,10)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2!null u150704.y:9!null z:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9,10), (2)==(9), (9)==(2)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:9!null z:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── t150704.y:2 = u150704.y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:6, outer=(1)]
+      ├── t150704.y:2 [as=y:7, outer=(2)]
+      └── 4 [as=p:8]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, 4 AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+LEFT JOIN u150704 USING (y)
+----
+project
+ ├── columns: y:7 x:6!null p:8!null z:10
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6-8,10)
+ ├── left-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2 u150704.y:9 z:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9,10)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:9!null z:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── t150704.y:2 = u150704.y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:6, outer=(1)]
+      ├── t150704.y:2 [as=y:7, outer=(2)]
+      └── 4 [as=p:8]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, 4 AS p FROM t150704 WHERE x = 1)
+SELECT w.*, (SELECT max(z) FROM u150704 WHERE y = w.y)
+FROM w
+----
+project
+ ├── columns: x:6!null y:7 p:8!null max:14
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6-8,14)
+ ├── group-by (streaming)
+ │    ├── columns: x:6!null y:7 p:8!null max:13
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8,13)
+ │    ├── project
+ │    │    ├── columns: x:6!null y:7 p:8!null z:10
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6-8,10)
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2 u150704.y:9 z:10
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(1,2,9,10)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    ├── scan t150704
+ │    │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    └── filters
+ │    │    │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    │    │    ├── scan u150704
+ │    │    │    │    ├── columns: u150704.y:9!null z:10
+ │    │    │    │    ├── key: (9)
+ │    │    │    │    └── fd: (9)-->(10)
+ │    │    │    └── filters
+ │    │    │         └── u150704.y:9 = t150704.y:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    │    └── projections
+ │    │         ├── t150704.x:1 [as=x:6, outer=(1)]
+ │    │         ├── t150704.y:2 [as=y:7, outer=(2)]
+ │    │         └── 4 [as=p:8]
+ │    └── aggregations
+ │         ├── max [as=max:13, outer=(10)]
+ │         │    └── z:10
+ │         ├── const-agg [as=x:6, outer=(6)]
+ │         │    └── x:6
+ │         ├── const-agg [as=y:7, outer=(7)]
+ │         │    └── y:7
+ │         └── const-agg [as=p:8, outer=(8)]
+ │              └── p:8
+ └── projections
+      └── max:13 [as=max:14, outer=(13)]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, 4 AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM u150704
+RIGHT JOIN w USING (y)
+----
+project
+ ├── columns: y:11 z:7 x:10!null p:12!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(7,10-12)
+ ├── left-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2 u150704.y:6 z:7
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,6,7)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:6!null z:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── u150704.y:6 = t150704.y:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:10, outer=(1)]
+      ├── t150704.y:2 [as=y:11, outer=(2)]
+      └── 4 [as=p:12]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, 4 AS p FROM t150704 WHERE x = 1),
+v AS (SELECT y, z, 5 AS q FROM u150704 WHERE y = 2)
+SELECT *
+FROM w
+JOIN v USING (y)
+----
+project
+ ├── columns: y:12!null x:11!null p:13!null z:15 q:16!null
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(11-13,15,16)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2!null y:14!null z:15 q:16!null
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,14-16), (2)==(14), (14)==(2)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── project
+ │    │    ├── columns: y:14!null z:15 q:16!null
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(14-16)
+ │    │    ├── select
+ │    │    │    ├── columns: u150704.y:6!null u150704.z:7
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(6,7)
+ │    │    │    ├── scan u150704
+ │    │    │    │    ├── columns: u150704.y:6!null u150704.z:7
+ │    │    │    │    ├── key: (6)
+ │    │    │    │    └── fd: (6)-->(7)
+ │    │    │    └── filters
+ │    │    │         └── u150704.y:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+ │    │    └── projections
+ │    │         ├── u150704.y:6 [as=y:14, outer=(6)]
+ │    │         ├── u150704.z:7 [as=z:15, outer=(7)]
+ │    │         └── 5 [as=q:16]
+ │    └── filters
+ │         └── t150704.y:2 = y:14 [outer=(2,14), constraints=(/2: (/NULL - ]; /14: (/NULL - ]), fd=(2)==(14), (14)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:11, outer=(1)]
+      ├── t150704.y:2 [as=y:12, outer=(2)]
+      └── 4 [as=p:13]
+
+# Check that we hoist the projection when no join conditions use p and there is
+# also a remapping projection.
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x AS m, y AS n, 4 AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+JOIN u150704 ON y = n
+----
+project
+ ├── columns: m:6!null n:7!null p:8!null y:9!null z:10
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(6-10), (7)==(9), (9)==(7)
+ ├── inner-join (hash)
+ │    ├── columns: x:1!null t150704.y:2!null u150704.y:9!null z:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9,10), (2)==(9), (9)==(2)
+ │    ├── select
+ │    │    ├── columns: x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:9!null z:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── u150704.y:9 = t150704.y:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      ├── x:1 [as=m:6, outer=(1)]
+      ├── t150704.y:2 [as=n:7, outer=(2)]
+      └── 4 [as=p:8]
+
+# Check that we do not hoist the projection when a join condition uses p.
+
+norm expect-not=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x AS m, y AS n, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+JOIN u150704 ON y = p
+----
+inner-join (hash)
+ ├── columns: m:6!null n:7 p:8!null y:9!null z:10
+ ├── cardinality: [0 - 1]
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-10), (8)==(9), (9)==(8)
+ ├── project
+ │    ├── columns: m:6!null n:7 p:8
+ │    ├── cardinality: [0 - 1]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8)
+ │    ├── select
+ │    │    ├── columns: x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    └── projections
+ │         ├── x:1 [as=m:6, outer=(1)]
+ │         ├── t150704.y:2 [as=n:7, outer=(2)]
+ │         └── x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+ ├── scan u150704
+ │    ├── columns: u150704.y:9!null z:10
+ │    ├── key: (9)
+ │    └── fd: (9)-->(10)
+ └── filters
+      └── u150704.y:9 = p:8 [outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+
+norm expect-not=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT w.*, (SELECT max(z) FROM u150704 WHERE y = w.p)
+FROM w
+----
+project
+ ├── columns: x:6!null y:7 p:8 max:14
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-8,14)
+ ├── group-by (streaming)
+ │    ├── columns: x:6!null y:7 p:8 max:13
+ │    ├── cardinality: [0 - 1]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8,13)
+ │    ├── left-join (hash)
+ │    │    ├── columns: x:6!null y:7 p:8 u150704.y:9 z:10
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── immutable
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6-10)
+ │    │    ├── project
+ │    │    │    ├── columns: x:6!null y:7 p:8
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── immutable
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(6-8)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    ├── scan t150704
+ │    │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    └── filters
+ │    │    │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    │    │    └── projections
+ │    │    │         ├── t150704.x:1 [as=x:6, outer=(1)]
+ │    │    │         ├── t150704.y:2 [as=y:7, outer=(2)]
+ │    │    │         └── t150704.x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+ │    │    ├── scan u150704
+ │    │    │    ├── columns: u150704.y:9!null z:10
+ │    │    │    ├── key: (9)
+ │    │    │    └── fd: (9)-->(10)
+ │    │    └── filters
+ │    │         └── u150704.y:9 = p:8 [outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+ │    └── aggregations
+ │         ├── max [as=max:13, outer=(10)]
+ │         │    └── z:10
+ │         ├── const-agg [as=x:6, outer=(6)]
+ │         │    └── x:6
+ │         ├── const-agg [as=y:7, outer=(7)]
+ │         │    └── y:7
+ │         └── const-agg [as=p:8, outer=(8)]
+ │              └── p:8
+ └── projections
+      └── max:13 [as=max:14, outer=(13)]
+
+# Check that we do not hoist the projection when an outer join could NULL-extend
+# it.
+
+norm expect-not=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, 4 AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+RIGHT JOIN u150704 USING (y)
+----
+project
+ ├── columns: y:9!null x:6 p:8 z:10
+ ├── key: (9)
+ ├── fd: (9)-->(6,8,10)
+ └── left-join (hash)
+      ├── columns: x:6 y:7 p:8 u150704.y:9!null z:10
+      ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      ├── key: (9)
+      ├── fd: (9)-->(6-8,10)
+      ├── scan u150704
+      │    ├── columns: u150704.y:9!null z:10
+      │    ├── key: (9)
+      │    └── fd: (9)-->(10)
+      ├── project
+      │    ├── columns: x:6!null y:7 p:8!null
+      │    ├── cardinality: [0 - 1]
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8)
+      │    ├── select
+      │    │    ├── columns: t150704.x:1!null t150704.y:2
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1,2)
+      │    │    ├── scan t150704
+      │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(2)
+      │    │    └── filters
+      │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      │    └── projections
+      │         ├── t150704.x:1 [as=x:6, outer=(1)]
+      │         ├── t150704.y:2 [as=y:7, outer=(2)]
+      │         └── 4 [as=p:8]
+      └── filters
+           └── y:7 = u150704.y:9 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+
+# Also test the view example from #150704.
+
+exec-ddl
+CREATE VIEW v150704 AS
+SELECT x, y, z, 4 AS d
+FROM t150704
+LEFT JOIN u150704 USING (y)
+----
+
+norm
+WITH w AS (SELECT unnest(ARRAY[1, 2, 3]) AS x)
+SELECT x, y, z, 4 AS d
+FROM t150704
+LEFT JOIN u150704 USING (y)
+JOIN w USING (x)
+----
+project
+ ├── columns: x:2!null y:3 z:7 d:11!null
+ ├── cardinality: [0 - 3]
+ ├── fd: ()-->(11), (2)-->(3,7)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7 x:10!null
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (2)-->(3,6,7), (6)-->(7), (2)==(10), (10)==(2)
+ │    ├── left-join (hash)
+ │    │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── key: (2)
+ │    │    ├── fd: (2)-->(3,6,7), (6)-->(7)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:2!null t150704.y:3
+ │    │    │    ├── key: (2)
+ │    │    │    └── fd: (2)-->(3)
+ │    │    ├── scan u150704
+ │    │    │    ├── columns: u150704.y:6!null z:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── t150704.y:3 = u150704.y:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ │    ├── values
+ │    │    ├── columns: x:10!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (1,)
+ │    │    ├── (2,)
+ │    │    └── (3,)
+ │    └── filters
+ │         └── t150704.x:2 = x:10 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ └── projections
+      └── 4 [as=d:11]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT unnest(ARRAY[1, 2, 3]) AS x)
+SELECT x, y, z, d
+FROM v150704
+JOIN w USING (x)
+----
+project
+ ├── columns: x:2!null y:3 z:7 d:10!null
+ ├── cardinality: [0 - 3]
+ ├── fd: ()-->(10), (2)-->(3,7)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7 x:11!null
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (2)-->(3,6,7), (6)-->(7), (2)==(11), (11)==(2)
+ │    ├── left-join (hash)
+ │    │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── key: (2)
+ │    │    ├── fd: (2)-->(3,6,7), (6)-->(7)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:2!null t150704.y:3
+ │    │    │    ├── key: (2)
+ │    │    │    └── fd: (2)-->(3)
+ │    │    ├── scan u150704
+ │    │    │    ├── columns: u150704.y:6!null z:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── t150704.y:3 = u150704.y:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ │    ├── values
+ │    │    ├── columns: x:11!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (1,)
+ │    │    ├── (2,)
+ │    │    └── (3,)
+ │    └── filters
+ │         └── t150704.x:2 = x:11 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
+ └── projections
+      └── 4 [as=d:10]
+
 # --------------------------------------------------
 # SimplifyJoinNotNullEquality
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/join_funcs.go
+++ b/pkg/sql/opt/xform/join_funcs.go
@@ -1203,17 +1203,6 @@ func (c *CustomFuncs) ConvertIndexToLookupJoinPrivate(
 	}
 }
 
-// HasVolatileProjection returns true if any of the projection items of the
-// ProjectionsExpr contains a volatile expression.
-func (c *CustomFuncs) HasVolatileProjection(projections memo.ProjectionsExpr) bool {
-	for i := range projections {
-		if projections[i].ScalarProps().VolatilitySet.HasVolatile() {
-			return true
-		}
-	}
-	return false
-}
-
 // FindLeftJoinCanaryColumn tries to find a "canary" column from the right input
 // of a left join. This is a column that is NULL in the join output iff the row
 // is an "outer left" row that had no match in the join.

--- a/pkg/sql/opt/xform/testdata/physprops/limit_hint
+++ b/pkg/sql/opt/xform/testdata/physprops/limit_hint
@@ -643,44 +643,38 @@ project
  ├── immutable
  ├── key: ()
  ├── fd: ()-->(5,6)
- └── limit
-      ├── columns: "?column?":5!null t0.c0:6!null t1.c0:10!null
-      ├── cardinality: [0 - 0]
-      ├── immutable
-      ├── key: ()
-      ├── fd: ()-->(5,6,10), (6)==(10), (10)==(6)
-      ├── inner-join (cross)
-      │    ├── columns: "?column?":5!null t0.c0:6!null t1.c0:10!null
-      │    ├── cardinality: [0 - 0]
-      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
-      │    ├── immutable
-      │    ├── fd: ()-->(5), (6)==(10), (10)==(6)
-      │    ├── limit hint: 1.00
-      │    ├── inner-join (hash)
-      │    │    ├── columns: t0.c0:6!null t1.c0:10!null
-      │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
-      │    │    ├── fd: (6)==(10), (10)==(6)
-      │    │    ├── scan t0
-      │    │    │    ├── columns: t0.c0:6
-      │    │    │    └── lax-key: (6)
-      │    │    ├── scan t1
-      │    │    │    └── columns: t1.c0:10
-      │    │    └── filters
-      │    │         └── t0.c0:6 = t1.c0:10 [outer=(6,10), fd=(6)==(10), (10)==(6)]
-      │    ├── project
-      │    │    ├── columns: "?column?":5!null
-      │    │    ├── cardinality: [0 - 0]
-      │    │    ├── immutable
-      │    │    ├── key: ()
-      │    │    ├── fd: ()-->(5)
-      │    │    ├── limit
-      │    │    │    ├── cardinality: [0 - 0]
-      │    │    │    ├── immutable
-      │    │    │    ├── key: ()
-      │    │    │    ├── scan t1
-      │    │    │    │    └── limit hint: 1.00
-      │    │    │    └── -1
-      │    │    └── projections
-      │    │         └── 0 [as="?column?":5]
-      │    └── filters (true)
-      └── -1
+ ├── limit
+ │    ├── columns: t0.c0:6!null t1.c0:10!null
+ │    ├── cardinality: [0 - 0]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(6,10), (6)==(10), (10)==(6)
+ │    ├── inner-join (cross)
+ │    │    ├── columns: t0.c0:6!null t1.c0:10!null
+ │    │    ├── cardinality: [0 - 0]
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── immutable
+ │    │    ├── fd: (6)==(10), (10)==(6)
+ │    │    ├── limit hint: 1.00
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: t0.c0:6!null t1.c0:10!null
+ │    │    │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    │    │    ├── fd: (6)==(10), (10)==(6)
+ │    │    │    ├── scan t0
+ │    │    │    │    ├── columns: t0.c0:6
+ │    │    │    │    └── lax-key: (6)
+ │    │    │    ├── scan t1
+ │    │    │    │    └── columns: t1.c0:10
+ │    │    │    └── filters
+ │    │    │         └── t0.c0:6 = t1.c0:10 [outer=(6,10), fd=(6)==(10), (10)==(6)]
+ │    │    ├── limit
+ │    │    │    ├── cardinality: [0 - 0]
+ │    │    │    ├── immutable
+ │    │    │    ├── key: ()
+ │    │    │    ├── scan t1
+ │    │    │    │    └── limit hint: 1.00
+ │    │    │    └── -1
+ │    │    └── filters (true)
+ │    └── -1
+ └── projections
+      └── 0 [as="?column?":5]

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -736,6 +736,10 @@ message LocalOnlySessionData {
   // hint - if available - when comparing against
   // DistributeScanRowCountThreshold.
   bool use_soft_limit_for_distribute_scan = 185;
+  // OptimizerUseImprovedHoistJoinProject controls whether the
+  // HoistJoinProjectLeft normalization rule hoists more kinds of projections
+  // above joins.
+  bool optimizer_use_improved_hoist_join_project = 186;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4383,7 +4383,7 @@ var varGen = map[string]sessionVar{
 				evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
 			), nil
 		},
-		GlobalDefault: globalFalse,
+		GlobalDefault: globalTrue,
 	},
 }
 

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4367,6 +4367,24 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	`optimizer_use_improved_hoist_join_project`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_hoist_join_project`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_hoist_join_project", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedHoistJoinProject(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
+			), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
**sql/opt: improve HoistJoinProjectLeft to hoist more projections**

Extend normalization rule `HoistJoinProjectLeft` to hoist projections
above joins in more cases. Before this, `HoistJoinProjectLeft` would
only hoist projections that were simple column remappings. This change
allows hoisting of more projections as long as (a) they are not
volatile, (b) they are not referenced by the join filters, and (c) they
do not reference input columns. (a) and (b) match the exploration rule
`HoistProjectFromInnerJoin`. (c) is a conservative heuristic to avoid
hoisting projections when doing so would prevent column
pruning. Furthermore, (d) the projections must not be referenced by the
right input, which was a pre-existing condition.

Fixes: #150704

Release note (sql change): Improve the optimizer to hoist projections
above joins in more cases, which can lead to better query plans. This
can be enabled by the new session variable
`optimizer_use_improved_hoist_join_project`.

----

**sql: enable optimizer_use_improved_hoist_join_project by default**

Informs: #150704

Release note: None