### PR TITLE
release-25.2: kvserver: skip TestFlowControlAdmissionPostSplitMergeV2 under duress

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -382,6 +382,7 @@ func TestFlowControlBlockedAdmissionV2(t *testing.T) {
 func TestFlowControlAdmissionPostSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuressWithIssue(t, 150840)
 	defer setRACv2DebugVModule(t)()
 
 	testutils.RunValues(t, "kvadmission.flow_control.mode", []kvflowcontrol.ModeT{


### PR DESCRIPTION
Backport 1/1 commits from #150848 on behalf of @tbg.

----

Closes #150840.

Epic: none

----

Release justification: test deflake