### PR TITLE
release-25.1: kvserver: skip TestFlowControlAdmissionPostSplitMergeV2 under duress

### DIFF
--- a/pkg/kv/kvserver/flow_control_integration_test.go
+++ b/pkg/kv/kvserver/flow_control_integration_test.go
@@ -393,6 +393,7 @@ func TestFlowControlBlockedAdmissionV2(t *testing.T) {
 func TestFlowControlAdmissionPostSplitMergeV2(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
+	skip.UnderDuressWithIssue(t, 150840)
 	defer setRACv2DebugVModule(t)()
 
 	testutils.RunValues(t, "v2_enabled_when_leader_level", []kvflowcontrol.V2EnabledWhenLeaderLevel{


### PR DESCRIPTION
Backport 1/1 commits from #150848.

/cc @cockroachdb/release

---

Closes #150840.

Epic: none
