### PR TITLE
workload: add simple CHECK constraint support and bit/bytes generators

### DIFF
--- a/pkg/workload/workload_generator/column_generator.go
+++ b/pkg/workload/workload_generator/column_generator.go
@@ -46,6 +46,10 @@ func buildGenerator(col ColumnMeta, batchIdx, batchSize int, schema Schema) Gene
 		base = buildBooleanGenerator(col, rng)
 	case GenTypeJson: //missed json type ig, will check
 		base = buildJsonGenerator(col, rng)
+	case GenTypeBit:
+		base = buildBitGenerator(col, rng)
+	case GenTypeBytes:
+		base = buildBytesGenerator(col, rng)
 
 	default:
 		panic("type not supported: " + col.Type)
@@ -225,4 +229,19 @@ func buildJsonGenerator(col ColumnMeta, rng *rand.Rand) Generator {
 	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
 	sg := &StringGen{r: rng, min: minArg, max: maxArg, nullPct: nullPct}
 	return &JsonGen{strGen: sg}
+}
+
+// buildBitGenerator produces random BIT(n) values as strings of '0'/'1'.
+func buildBitGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	// size comes from mapBitType → args["size"]
+	size := getIntArg(col.Args, "size", 1)
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &BitGen{r: rng, size: size, nullPct: nullPct}
+}
+
+// buildBytesGenerator produces random []byte for BYTEA/BYTES columns.
+func buildBytesGenerator(col ColumnMeta, rng *rand.Rand) Generator {
+	size := getIntArg(col.Args, "size", 1)
+	nullPct := getFloatArg(col.Args, "null_pct", 0.0)
+	return &BytesGen{r: rng, min: size, max: size, nullPct: nullPct}
 }

--- a/pkg/workload/workload_generator/schema_generator.go
+++ b/pkg/workload/workload_generator/schema_generator.go
@@ -288,8 +288,9 @@ func processColumnDefs(table *TableSchema, columnDefs []string) {
 		defaultVal := colMatch[4]       // DEFAULT value
 		foreignKeyTable := colMatch[5]  // Referenced table for foreign keys
 		foreignKeyColumn := colMatch[6] // Referenced column for foreign keys
-
-		table.ColumnOrder = append(table.ColumnOrder, name)
+		// While adding columns to the order, surrounding quotes are stripped if any.
+		// This is to ensure that column names here match with the column names used as keys in schema maps.
+		table.ColumnOrder = append(table.ColumnOrder, strings.Trim(name, `"`))
 		// Extract CHECK constraint if present (requires special handling for nested parentheses)
 		inlineCheck := ""
 		checkIdx := checkInlineRe.FindStringIndex(columnDef)
@@ -564,6 +565,8 @@ func buildWorkloadSchema(
 
 	// 1) Build initial blocks and capture FK seeds
 	blocks, fkSeed := buildInitialBlocks(allSchemas, dbName, rng, baseRowCount)
+
+	applyCheckConstraints(blocks, allSchemas)
 
 	// 2) Wire up foreign-key relationships in the blocks
 	wireForeignKeys(blocks, allSchemas, fkSeed, rng)

--- a/pkg/workload/workload_generator/sql_utils.go
+++ b/pkg/workload/workload_generator/sql_utils.go
@@ -516,10 +516,10 @@ func getFieldCol(
 	numParts := 1
 	parts := make([]string, numParts)
 	var placeholder string
-	for _, schema := range allSchemas {
+	for tn, schema := range allSchemas {
 		matched := false
 		for _, column := range schema.Columns {
-			if column.Name == col {
+			if column.Name == col && tn == tableName {
 				placeholder = column.String()
 				placeholder = placeholder[1 : len(placeholder)-1]
 				matched = true

--- a/pkg/workload/workload_generator/types.go
+++ b/pkg/workload/workload_generator/types.go
@@ -10,6 +10,7 @@ import (
 	"fmt"
 	"math/rand"
 	"strconv"
+	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 )
@@ -155,6 +156,45 @@ func (g *JsonGen) Next() string {
 	}
 	// wrap it in {"k":"…"}
 	return fmt.Sprintf(`{"k":"%s"}`, v)
+}
+
+// BitGen emits either nil (per nullPct) or a string like "101001".
+type BitGen struct {
+	r       *rand.Rand
+	size    int
+	nullPct float64
+}
+
+func (b *BitGen) Next() string {
+	if b.r.Float64() < b.nullPct {
+		return ""
+	}
+	var sb strings.Builder
+	for i := 0; i < b.size; i++ {
+		if b.r.Intn(2) == 0 {
+			sb.WriteByte('0')
+		} else {
+			sb.WriteByte('1')
+		}
+	}
+	return sb.String()
+}
+
+type BytesGen struct {
+	r        *rand.Rand
+	min, max int
+	nullPct  float64
+}
+
+func (b *BytesGen) Next() string {
+	if b.r.Float64() < b.nullPct {
+		return ""
+	}
+
+	length := b.min
+	buf := make([]byte, length)
+	b.r.Read(buf) // fill with random bytes
+	return string(buf)
 }
 
 // ─── Wrappers ──────────────────────────────────────────────────────────


### PR DESCRIPTION
This patch enhances the workload_generator command by:

  • Parsing simple comparison CHECK constraints (>, >=, <, <=) from DDL and
    applying them to the generated schema (setting min/max or start/end args).
  • Introducing GenTypeBit and GenTypeBytes to handle BIT(n) and BYTES/BYTEA
    columns with dedicated generators.
  • Fixing minor bugs in SQL/YAML generation and type mapping.

Fixes: CRDB-51752
Epic: None

Release note (cli change):
Adds support for simple CHECK constraints and bit/bytes column generators in workload_generator.