### PR TITLE
release-24.1: roachtest: init providers in main(), not init()

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -54,10 +54,6 @@ import (
 	"golang.org/x/sys/unix"
 )
 
-func init() {
-	_ = roachprod.InitProviders()
-}
-
 var (
 	// maps cpuArch to the corresponding crdb binary's absolute path
 	cockroach = make(map[vm.CPUArch]string)

--- a/pkg/cmd/roachtest/main.go
+++ b/pkg/cmd/roachtest/main.go
@@ -51,6 +51,8 @@ const (
 )
 
 func main() {
+	_ = roachprod.InitProviders()
+
 	cobra.EnableCommandSorting = false
 
 	var rootCmd = &cobra.Command{


### PR DESCRIPTION
Backport 1/1 commits from #146285.

/cc @cockroachdb/release

---

Initializing them in an init function means we're calling this method in tests,
where it is likely not useful and may even be implicated in opaque test
timeouts such as [1].

[1]: https://cockroachlabs.slack.com/archives/CJ0H8Q97C/p1746629472748029?thread_ts=1746626113.617579&cid=CJ0H8Q97C

The roachtest job still works[^1]:

<img width="1352" alt="image" src="https://github.com/user-attachments/assets/9233459b-5fd6-4e91-a8a5-deba1177eaab" />

[^1]: https://teamcity.cockroachdb.com/buildConfiguration/Cockroach_Nightlies_RoachtestNightlyGceBazel/19646638?buildTab=overview&hideProblemsFromDependencies=false&hideTestsFromDependencies=false&expandBuildChangesSection=true

Epic: none

Release Justification: test only change