### PR TITLE
server: change sort order of local hot ranges to descending

### DIFF
--- a/pkg/server/application_api/storage_inspection_test.go
+++ b/pkg/server/application_api/storage_inspection_test.go
@@ -340,8 +340,6 @@ func TestHotRanges2Response(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
 
-	skip.WithIssue(t, 146917)
-
 	srv := rangetestutils.StartServer(t)
 	defer srv.Stopper().Stop(context.Background())
 	ts := srv.ApplicationLayer()

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -3069,7 +3069,7 @@ func (s *systemStatusServer) localHotRanges(
 
 	// sort the slices by cpu
 	slices.SortFunc(resp.Ranges, func(a, b *serverpb.HotRangesResponseV2_HotRange) int {
-		return cmp.Compare(a.CPUTimePerSecond, b.CPUTimePerSecond)
+		return cmp.Compare(b.CPUTimePerSecond, a.CPUTimePerSecond)
 	})
 
 	// truncate the response if localLimit is set


### PR DESCRIPTION
Currently the hot ranges logging system expects that ranges are sorted in descending order, so that it can inspect the values from greatest to least
([link](https://github.com/cockroachdb/cockroach/blob/master/pkg/server/application_api/storage_inspection_test.go#L377)). This is not the case, as the system currently returns those values in ascending order.

To fix this, we just reverse the comparison used for sorting at the local hot ranges collector.

Epic: none
Fixes: none
Release note: none