### PR TITLE
span: clean up test code after llrb frontier deletion

### DIFF
--- a/pkg/util/span/BUILD.bazel
+++ b/pkg/util/span/BUILD.bazel
@@ -34,7 +34,6 @@ go_test(
     embed = [":span"],
     deps = [
         "//pkg/roachpb",
-        "//pkg/testutils",
         "//pkg/util/hlc",
         "//pkg/util/leaktest",
         "//pkg/util/log",


### PR DESCRIPTION
This patch cleans up some code in the unit tests that previously
would toggle the frontier type but now just leads to each test
being running twice with the exact same configuration.

Informs #141668

Release note: None