### PR TITLE
auditloggingccl: fix TestReducedAuditConfig

### DIFF
--- a/pkg/ccl/auditloggingccl/audit_logging_test.go
+++ b/pkg/ccl/auditloggingccl/audit_logging_test.go
@@ -389,7 +389,7 @@ func TestReducedAuditConfig(t *testing.T) {
 			0,
 			math.MaxInt64,
 			10000,
-			regexp.MustCompile(stmt),
+			regexp.MustCompile(`"Statement":"`+stmt),
 			log.WithMarkedSensitiveData,
 		)
 


### PR DESCRIPTION
Test started flaking due to pebble logs containing matching the regex used to assert that certain audit logs existed.

Adds a more specific regex to assert found augit config logs.

Fixes: #150140
Epic: None
Release note: None