### PR TITLE
release-25.1: kvpb: avoid over redaction of prev_err field

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
+++ b/pkg/kv/kvclient/kvcoord/txn_coord_sender.go
@@ -1012,7 +1012,7 @@ func (tc *TxnCoordSender) updateStateLocked(
 	if kvpb.ErrPriority(pErr.GoError()) != kvpb.ErrorScoreUnambiguousError {
 		tc.mu.txnState = txnError
 		tc.mu.storedErr = kvpb.NewError(&kvpb.TxnAlreadyEncounteredErrorError{
-			PrevError: pErr.String(),
+			PrevError: redact.Sprintf("%v", pErr),
 		})
 	}
 

--- a/pkg/kv/kvpb/errors.proto
+++ b/pkg/kv/kvpb/errors.proto
@@ -573,7 +573,7 @@ message TransactionRetryWithProtoRefreshError {
 message TxnAlreadyEncounteredErrorError{
   // prev_error is the message from the error that the txn encountered
   // previously.
-  optional string prev_error = 1 [(gogoproto.nullable) = false];
+  optional string prev_error = 1 [(gogoproto.nullable) = false, (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString"];
 }
 
 // An IntegerOverflowError indicates that an operation was aborted because


### PR DESCRIPTION
Backport 1/1 commits from #150178 on behalf of @rafiss.

----

When logging a kvpb.TxnAlreadyEncounteredErrorError, the previous error was getting redacted too aggressively. This patch makes the error use a redactable string instead.

fixes https://github.com/cockroachdb/cockroach/issues/146588
Release note: None

----

Release justification: low risk change to enhance supportability; it only changes how a string is formatted in an error message.