### PR TITLE
release-25.3: workload/schemachanger: fix trigger function generation

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5398,8 +5398,9 @@ func (og *operationGenerator) createTrigger(ctx context.Context, tx pgx.Tx) (*op
 	if err != nil {
 		return nil, err
 	}
-
-	triggerFunction := fmt.Sprintf(`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s;RETURN NULL;END; $FUNC_BODY$ LANGUAGE PLpgSQL`, triggerFunctionName, selectStmt.sql)
+	// Our trigger function will always return the original value to avoid
+	// breaking inserts.
+	triggerFunction := fmt.Sprintf(`CREATE FUNCTION %s() RETURNS TRIGGER AS $FUNC_BODY$ BEGIN %s;RETURN NEW;END; $FUNC_BODY$ LANGUAGE PLpgSQL`, triggerFunctionName, selectStmt.sql)
 
 	og.LogMessage(fmt.Sprintf("Created trigger function %s", triggerFunction))
 


### PR DESCRIPTION
Backport 1/1 commits from #150979 on behalf of @fqazi.

----

Previously, the triggers we generated on tables would silently discard IUD operations. This patch makes sure that the trigger does random work and allows the IUD operation to continue.

Fixes: #150752

Release note: None

----

Release justification: test only change