### PR TITLE
sql/opt: add HoistLeftProjectFromJoin exploration rule

### DIFF
--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4267,6 +4267,10 @@ func (m *sessionDataMutator) SetUseProcTxnControlExtendedProtocolFix(val bool) {
 	m.data.UseProcTxnControlExtendedProtocolFix = val
 }
 
+func (m *sessionDataMutator) SetOptimizerUseImprovedHoistJoinProject(val bool) {
+	m.data.OptimizerUseImprovedHoistJoinProject = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -4064,6 +4064,7 @@ optimizer_use_histograms                                         on
 optimizer_use_improved_computed_column_filters_derivation        on
 optimizer_use_improved_disjunction_stats                         on
 optimizer_use_improved_distinct_on_limit_hint_costing            on
+optimizer_use_improved_hoist_join_project                        off
 optimizer_use_improved_join_elimination                          on
 optimizer_use_improved_multi_column_selectivity_estimate         on
 optimizer_use_improved_split_disjunction_for_joins               on

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -3067,6 +3067,7 @@ optimizer_use_histograms                                         on             
 optimizer_use_improved_computed_column_filters_derivation        on                  NULL      NULL        NULL        string
 optimizer_use_improved_disjunction_stats                         on                  NULL      NULL        NULL        string
 optimizer_use_improved_distinct_on_limit_hint_costing            on                  NULL      NULL        NULL        string
+optimizer_use_improved_hoist_join_project                        off                 NULL      NULL        NULL        string
 optimizer_use_improved_join_elimination                          on                  NULL      NULL        NULL        string
 optimizer_use_improved_multi_column_selectivity_estimate         on                  NULL      NULL        NULL        string
 optimizer_use_improved_split_disjunction_for_joins               on                  NULL      NULL        NULL        string
@@ -3308,6 +3309,7 @@ optimizer_use_histograms                                         on             
 optimizer_use_improved_computed_column_filters_derivation        on                  NULL  user     NULL      on                  on
 optimizer_use_improved_disjunction_stats                         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_distinct_on_limit_hint_costing            on                  NULL  user     NULL      on                  on
+optimizer_use_improved_hoist_join_project                        off                 NULL  user     NULL      off                 off
 optimizer_use_improved_join_elimination                          on                  NULL  user     NULL      on                  on
 optimizer_use_improved_multi_column_selectivity_estimate         on                  NULL  user     NULL      on                  on
 optimizer_use_improved_split_disjunction_for_joins               on                  NULL  user     NULL      on                  on
@@ -3540,6 +3542,7 @@ optimizer_use_histograms                                         NULL    NULL   
 optimizer_use_improved_computed_column_filters_derivation        NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_disjunction_stats                         NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_distinct_on_limit_hint_costing            NULL    NULL     NULL     NULL        NULL
+optimizer_use_improved_hoist_join_project                        NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_join_elimination                          NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_multi_column_selectivity_estimate         NULL    NULL     NULL     NULL        NULL
 optimizer_use_improved_split_disjunction_for_joins               NULL    NULL     NULL     NULL        NULL

--- a/pkg/sql/logictest/testdata/logic_test/show_source
+++ b/pkg/sql/logictest/testdata/logic_test/show_source
@@ -171,6 +171,7 @@ optimizer_use_histograms                                         on
 optimizer_use_improved_computed_column_filters_derivation        on
 optimizer_use_improved_disjunction_stats                         on
 optimizer_use_improved_distinct_on_limit_hint_costing            on
+optimizer_use_improved_hoist_join_project                        off
 optimizer_use_improved_join_elimination                          on
 optimizer_use_improved_multi_column_selectivity_estimate         on
 optimizer_use_improved_split_disjunction_for_joins               on

--- a/pkg/sql/opt/memo/memo.go
+++ b/pkg/sql/opt/memo/memo.go
@@ -208,6 +208,7 @@ type Memo struct {
 	usePre_25_2VariadicBuiltins                bool
 	useExistsFilterHoistRule                   bool
 	disableSlowCascadeFastPathForRBRTables     bool
+	useImprovedHoistJoinProject                bool
 
 	// txnIsoLevel is the isolation level under which the plan was created. This
 	// affects the planning of some locking operations, so it must be included in
@@ -313,6 +314,7 @@ func (m *Memo) Init(ctx context.Context, evalCtx *eval.Context) {
 		usePre_25_2VariadicBuiltins:                evalCtx.SessionData().UsePre_25_2VariadicBuiltins,
 		useExistsFilterHoistRule:                   evalCtx.SessionData().OptimizerUseExistsFilterHoistRule,
 		disableSlowCascadeFastPathForRBRTables:     evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables,
+		useImprovedHoistJoinProject:                evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
 		txnIsoLevel:                                evalCtx.TxnIsoLevel,
 	}
 	m.metadata.Init()
@@ -491,6 +493,7 @@ func (m *Memo) IsStale(
 		m.usePre_25_2VariadicBuiltins != evalCtx.SessionData().UsePre_25_2VariadicBuiltins ||
 		m.useExistsFilterHoistRule != evalCtx.SessionData().OptimizerUseExistsFilterHoistRule ||
 		m.disableSlowCascadeFastPathForRBRTables != evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables ||
+		m.useImprovedHoistJoinProject != evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject ||
 		m.txnIsoLevel != evalCtx.TxnIsoLevel {
 		return true, nil
 	}

--- a/pkg/sql/opt/memo/memo_test.go
+++ b/pkg/sql/opt/memo/memo_test.go
@@ -584,6 +584,11 @@ func TestMemoIsStale(t *testing.T) {
 	evalCtx.SessionData().OptimizerDisableCrossRegionCascadeFastPathForRBRTables = false
 	notStale()
 
+	evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject = true
+	stale()
+	evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject = false
+	notStale()
+
 	// User no longer has access to view.
 	catalog.View(tree.NewTableNameWithSchema("t", catconstants.PublicSchemaName, "abcview")).Revoked = true
 	_, err = o.Memo().IsStale(ctx, &evalCtx, catalog)

--- a/pkg/sql/opt/norm/project_funcs.go
+++ b/pkg/sql/opt/norm/project_funcs.go
@@ -946,6 +946,30 @@ func (c *CustomFuncs) AllAreRemappingProjections(projections memo.ProjectionsExp
 	return true
 }
 
+// CanHoistNonRemappingProjections splits the projections into those that are
+// simple remappings from one column to another of an identical type, and those
+// that are not, and returns true if the non-remapping projections can be
+// hoisted.
+func (c *CustomFuncs) CanHoistNonRemappingProjections(
+	projections memo.ProjectionsExpr,
+) (remap, other memo.ProjectionsExpr, ok bool) {
+	md := c.mem.Metadata()
+	for i := range projections {
+		varExpr, ok := projections[i].Element.(*memo.VariableExpr)
+		if ok {
+			if md.ColumnMeta(varExpr.Col).Type.Identical(md.ColumnMeta(projections[i].Col).Type) {
+				remap = append(remap, projections[i])
+				continue
+			}
+		}
+		other = append(other, projections[i])
+	}
+	// Hoisting is allowed if there are no non-remapping projections (the previous
+	// behavior) or if optimizer_use_improved_hoist_join_project is enabled.
+	canHoist := len(other) == 0 || c.f.evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject
+	return remap, other, canHoist
+}
+
 // UnbindFiltersFromProjections remaps column references in the given filters
 // to refer to input columns instead of projected output columns, based on the
 // given projections. It assumes that AllAreRemappingProjections returns true

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -3240,6 +3240,554 @@ inner-join-apply
  │         └── k:9 = baz:8 [outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
  └── filters (true)
 
+# Test hoisting projections above joins in more cases for #150704.
+
+exec-ddl
+CREATE TABLE t150704 (
+  x INT PRIMARY KEY,
+  y INT
+)
+----
+
+exec-ddl
+CREATE TABLE u150704 (
+  y INT PRIMARY KEY,
+  z INT
+)
+----
+
+# Check that we hoist the projection when no join conditions use p.
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+JOIN u150704 USING (y)
+----
+project
+ ├── columns: y:7!null x:6!null p:8!null z:10
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-8,10)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2!null u150704.y:9!null z:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9,10), (2)==(9), (9)==(2)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:9!null z:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── t150704.y:2 = u150704.y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:6, outer=(1)]
+      ├── t150704.y:2 [as=y:7, outer=(2)]
+      └── t150704.x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+LEFT JOIN u150704 USING (y)
+----
+project
+ ├── columns: y:7 x:6!null p:8 z:10
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-8,10)
+ ├── left-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2 u150704.y:9 z:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9,10)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:9!null z:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── t150704.y:2 = u150704.y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:6, outer=(1)]
+      ├── t150704.y:2 [as=y:7, outer=(2)]
+      └── t150704.x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT w.*, (SELECT max(z) FROM u150704 WHERE y = w.y)
+FROM w
+----
+project
+ ├── columns: x:6!null y:7 p:8 max:14
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-8,14)
+ ├── group-by (streaming)
+ │    ├── columns: x:6!null y:7 p:8 max:13
+ │    ├── cardinality: [0 - 1]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8,13)
+ │    ├── project
+ │    │    ├── columns: x:6!null y:7 p:8 z:10
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── immutable
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6-8,10)
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2 u150704.y:9 z:10
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(1,2,9,10)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    ├── scan t150704
+ │    │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    └── filters
+ │    │    │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    │    │    ├── scan u150704
+ │    │    │    │    ├── columns: u150704.y:9!null z:10
+ │    │    │    │    ├── key: (9)
+ │    │    │    │    └── fd: (9)-->(10)
+ │    │    │    └── filters
+ │    │    │         └── u150704.y:9 = t150704.y:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    │    └── projections
+ │    │         ├── t150704.x:1 [as=x:6, outer=(1)]
+ │    │         ├── t150704.y:2 [as=y:7, outer=(2)]
+ │    │         └── t150704.x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+ │    └── aggregations
+ │         ├── max [as=max:13, outer=(10)]
+ │         │    └── z:10
+ │         ├── const-agg [as=x:6, outer=(6)]
+ │         │    └── x:6
+ │         ├── const-agg [as=y:7, outer=(7)]
+ │         │    └── y:7
+ │         └── const-agg [as=p:8, outer=(8)]
+ │              └── p:8
+ └── projections
+      └── max:13 [as=max:14, outer=(13)]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM u150704
+RIGHT JOIN w USING (y)
+----
+project
+ ├── columns: y:11 z:7 x:10!null p:12
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(7,10-12)
+ ├── left-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2 u150704.y:6 z:7
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,6,7)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:6!null z:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── u150704.y:6 = t150704.y:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:10, outer=(1)]
+      ├── t150704.y:2 [as=y:11, outer=(2)]
+      └── t150704.x:1 + t150704.y:2 [as=p:12, outer=(1,2), immutable]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1),
+v AS (SELECT y, z, y + z AS q FROM u150704 WHERE y = 2)
+SELECT *
+FROM w
+JOIN v USING (y)
+----
+project
+ ├── columns: y:12!null x:11!null p:13!null z:15 q:16
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(11-13,15,16)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:1!null t150704.y:2!null y:14!null z:15 q:16
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,14-16), (2)==(14), (14)==(2)
+ │    ├── select
+ │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── project
+ │    │    ├── columns: y:14!null z:15 q:16
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── immutable
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(14-16)
+ │    │    ├── select
+ │    │    │    ├── columns: u150704.y:6!null u150704.z:7
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(6,7)
+ │    │    │    ├── scan u150704
+ │    │    │    │    ├── columns: u150704.y:6!null u150704.z:7
+ │    │    │    │    ├── key: (6)
+ │    │    │    │    └── fd: (6)-->(7)
+ │    │    │    └── filters
+ │    │    │         └── u150704.y:6 = 2 [outer=(6), constraints=(/6: [/2 - /2]; tight), fd=()-->(6)]
+ │    │    └── projections
+ │    │         ├── u150704.y:6 [as=y:14, outer=(6)]
+ │    │         ├── u150704.z:7 [as=z:15, outer=(7)]
+ │    │         └── u150704.y:6 + u150704.z:7 [as=q:16, outer=(6,7), immutable]
+ │    └── filters
+ │         └── t150704.y:2 = y:14 [outer=(2,14), constraints=(/2: (/NULL - ]; /14: (/NULL - ]), fd=(2)==(14), (14)==(2)]
+ └── projections
+      ├── t150704.x:1 [as=x:11, outer=(1)]
+      ├── t150704.y:2 [as=y:12, outer=(2)]
+      └── t150704.x:1 + t150704.y:2 [as=p:13, outer=(1,2), immutable]
+
+# Check that we hoist the projection when no join conditions use p and there is
+# also a remapping projection.
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x AS m, y AS n, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+JOIN u150704 ON y = n
+----
+project
+ ├── columns: m:6!null n:7!null p:8!null y:9!null z:10
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-10), (7)==(9), (9)==(7)
+ ├── inner-join (hash)
+ │    ├── columns: x:1!null t150704.y:2!null u150704.y:9!null z:10
+ │    ├── cardinality: [0 - 1]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,9,10), (2)==(9), (9)==(2)
+ │    ├── select
+ │    │    ├── columns: x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    ├── scan u150704
+ │    │    ├── columns: u150704.y:9!null z:10
+ │    │    ├── key: (9)
+ │    │    └── fd: (9)-->(10)
+ │    └── filters
+ │         └── u150704.y:9 = t150704.y:2 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── projections
+      ├── x:1 [as=m:6, outer=(1)]
+      ├── t150704.y:2 [as=n:7, outer=(2)]
+      └── x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+
+# Check that we do not hoist the projection when a join condition uses p.
+
+norm expect-not=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x AS m, y AS n, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+JOIN u150704 ON y = p
+----
+inner-join (hash)
+ ├── columns: m:6!null n:7 p:8!null y:9!null z:10
+ ├── cardinality: [0 - 1]
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-10), (8)==(9), (9)==(8)
+ ├── project
+ │    ├── columns: m:6!null n:7 p:8
+ │    ├── cardinality: [0 - 1]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8)
+ │    ├── select
+ │    │    ├── columns: x:1!null t150704.y:2
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: x:1!null t150704.y:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── filters
+ │    │         └── x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    └── projections
+ │         ├── x:1 [as=m:6, outer=(1)]
+ │         ├── t150704.y:2 [as=n:7, outer=(2)]
+ │         └── x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+ ├── scan u150704
+ │    ├── columns: u150704.y:9!null z:10
+ │    ├── key: (9)
+ │    └── fd: (9)-->(10)
+ └── filters
+      └── u150704.y:9 = p:8 [outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+
+norm expect-not=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT w.*, (SELECT max(z) FROM u150704 WHERE y = w.p)
+FROM w
+----
+project
+ ├── columns: x:6!null y:7 p:8 max:14
+ ├── cardinality: [0 - 1]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(6-8,14)
+ ├── group-by (streaming)
+ │    ├── columns: x:6!null y:7 p:8 max:13
+ │    ├── cardinality: [0 - 1]
+ │    ├── immutable
+ │    ├── key: ()
+ │    ├── fd: ()-->(6-8,13)
+ │    ├── left-join (hash)
+ │    │    ├── columns: x:6!null y:7 p:8 u150704.y:9 z:10
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    │    ├── immutable
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(6-10)
+ │    │    ├── project
+ │    │    │    ├── columns: x:6!null y:7 p:8
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── immutable
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(6-8)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    │    ├── scan t150704
+ │    │    │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    │    └── filters
+ │    │    │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    │    │    └── projections
+ │    │    │         ├── t150704.x:1 [as=x:6, outer=(1)]
+ │    │    │         ├── t150704.y:2 [as=y:7, outer=(2)]
+ │    │    │         └── t150704.x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+ │    │    ├── scan u150704
+ │    │    │    ├── columns: u150704.y:9!null z:10
+ │    │    │    ├── key: (9)
+ │    │    │    └── fd: (9)-->(10)
+ │    │    └── filters
+ │    │         └── u150704.y:9 = p:8 [outer=(8,9), constraints=(/8: (/NULL - ]; /9: (/NULL - ]), fd=(8)==(9), (9)==(8)]
+ │    └── aggregations
+ │         ├── max [as=max:13, outer=(10)]
+ │         │    └── z:10
+ │         ├── const-agg [as=x:6, outer=(6)]
+ │         │    └── x:6
+ │         ├── const-agg [as=y:7, outer=(7)]
+ │         │    └── y:7
+ │         └── const-agg [as=p:8, outer=(8)]
+ │              └── p:8
+ └── projections
+      └── max:13 [as=max:14, outer=(13)]
+
+# Check that we do not hoist the projection when an outer join could NULL-extend
+# it.
+
+norm expect-not=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT x, y, x + y AS p FROM t150704 WHERE x = 1)
+SELECT *
+FROM w
+RIGHT JOIN u150704 USING (y)
+----
+project
+ ├── columns: y:9!null x:6 p:8 z:10
+ ├── immutable
+ ├── key: (9)
+ ├── fd: (9)-->(6,8,10)
+ └── left-join (hash)
+      ├── columns: x:6 y:7 p:8 u150704.y:9!null z:10
+      ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      ├── immutable
+      ├── key: (9)
+      ├── fd: (9)-->(6-8,10)
+      ├── scan u150704
+      │    ├── columns: u150704.y:9!null z:10
+      │    ├── key: (9)
+      │    └── fd: (9)-->(10)
+      ├── project
+      │    ├── columns: x:6!null y:7 p:8
+      │    ├── cardinality: [0 - 1]
+      │    ├── immutable
+      │    ├── key: ()
+      │    ├── fd: ()-->(6-8)
+      │    ├── select
+      │    │    ├── columns: t150704.x:1!null t150704.y:2
+      │    │    ├── cardinality: [0 - 1]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(1,2)
+      │    │    ├── scan t150704
+      │    │    │    ├── columns: t150704.x:1!null t150704.y:2
+      │    │    │    ├── key: (1)
+      │    │    │    └── fd: (1)-->(2)
+      │    │    └── filters
+      │    │         └── t150704.x:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+      │    └── projections
+      │         ├── t150704.x:1 [as=x:6, outer=(1)]
+      │         ├── t150704.y:2 [as=y:7, outer=(2)]
+      │         └── t150704.x:1 + t150704.y:2 [as=p:8, outer=(1,2), immutable]
+      └── filters
+           └── y:7 = u150704.y:9 [outer=(7,9), constraints=(/7: (/NULL - ]; /9: (/NULL - ]), fd=(7)==(9), (9)==(7)]
+
+# Also test the view example from #150704.
+
+exec-ddl
+CREATE VIEW v150704 AS
+SELECT x, y, z, 4 AS d
+FROM t150704
+LEFT JOIN u150704 USING (y)
+----
+
+norm
+WITH w AS (SELECT unnest(ARRAY[1, 2, 3]) AS x)
+SELECT x, y, z, 4 AS d
+FROM t150704
+LEFT JOIN u150704 USING (y)
+JOIN w USING (x)
+----
+project
+ ├── columns: x:2!null y:3 z:7 d:11!null
+ ├── cardinality: [0 - 3]
+ ├── fd: ()-->(11), (2)-->(3,7)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7 x:10!null
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (2)-->(3,6,7), (6)-->(7), (2)==(10), (10)==(2)
+ │    ├── left-join (hash)
+ │    │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── key: (2)
+ │    │    ├── fd: (2)-->(3,6,7), (6)-->(7)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:2!null t150704.y:3
+ │    │    │    ├── key: (2)
+ │    │    │    └── fd: (2)-->(3)
+ │    │    ├── scan u150704
+ │    │    │    ├── columns: u150704.y:6!null z:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── t150704.y:3 = u150704.y:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ │    ├── values
+ │    │    ├── columns: x:10!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (1,)
+ │    │    ├── (2,)
+ │    │    └── (3,)
+ │    └── filters
+ │         └── t150704.x:2 = x:10 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ └── projections
+      └── 4 [as=d:11]
+
+norm expect=HoistJoinProjectLeft set=optimizer_use_improved_hoist_join_project=true
+WITH w AS (SELECT unnest(ARRAY[1, 2, 3]) AS x)
+SELECT x, y, z, d
+FROM v150704
+JOIN w USING (x)
+----
+project
+ ├── columns: x:2!null y:3 z:7 d:10!null
+ ├── cardinality: [0 - 3]
+ ├── fd: ()-->(10), (2)-->(3,7)
+ ├── inner-join (hash)
+ │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7 x:11!null
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ │    ├── fd: (2)-->(3,6,7), (6)-->(7), (2)==(11), (11)==(2)
+ │    ├── left-join (hash)
+ │    │    ├── columns: t150704.x:2!null t150704.y:3 u150704.y:6 z:7
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── key: (2)
+ │    │    ├── fd: (2)-->(3,6,7), (6)-->(7)
+ │    │    ├── scan t150704
+ │    │    │    ├── columns: t150704.x:2!null t150704.y:3
+ │    │    │    ├── key: (2)
+ │    │    │    └── fd: (2)-->(3)
+ │    │    ├── scan u150704
+ │    │    │    ├── columns: u150704.y:6!null z:7
+ │    │    │    ├── key: (6)
+ │    │    │    └── fd: (6)-->(7)
+ │    │    └── filters
+ │    │         └── t150704.y:3 = u150704.y:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+ │    ├── values
+ │    │    ├── columns: x:11!null
+ │    │    ├── cardinality: [3 - 3]
+ │    │    ├── (1,)
+ │    │    ├── (2,)
+ │    │    └── (3,)
+ │    └── filters
+ │         └── t150704.x:2 = x:11 [outer=(2,11), constraints=(/2: (/NULL - ]; /11: (/NULL - ]), fd=(2)==(11), (11)==(2)]
+ └── projections
+      └── 4 [as=d:10]
+
 # --------------------------------------------------
 # SimplifyJoinNotNullEquality
 # --------------------------------------------------

--- a/pkg/sql/opt/xform/rules/join.opt
+++ b/pkg/sql/opt/xform/rules/join.opt
@@ -530,6 +530,50 @@
     (UnionCols $passthrough (OutputCols $left))
 )
 
+[HoistLeftProjectFromJoin, Explore]
+(InnerJoin | InnerJoinApply | LeftJoin | LeftJoinApply
+    $left:(Project
+        $input:* # & (CanHoistProjectInput $input)
+        $projections:* & ^(HasVolatileProjection $projections)
+        $passThrough:*
+    )
+    $right:* &
+
+        # For apply-joins, the right input could reference the projected
+        # columns, in which case pulling the Project up would be incorrect.
+        # This isn't an issue for HoistJoinProjectRight because outer column
+        # references cannot be from the left input to the right input.
+        # TODO(drewk): we could remap the right input as well.
+        ^(IsCorrelated $right (ProjectionCols $projections))
+    $on:*
+    $private:* &
+
+        # We can only hoist the projection if each new column is either:
+        # 1. a simple remapping that can be reversed in the join condition
+        # 2. not referenced in the join condition
+        (Let
+            ($remap $other $ok):(CanHoistNonRemappingProjections
+                $projections
+            )
+            $ok
+        ) &
+        ^(ColsIntersect
+            (FilterOuterCols $on)
+            (ProjectionCols $other)
+        )
+)
+=>
+(Project
+    ((OpName)
+        $input
+        $right
+        (UnbindFiltersFromProjections $remap $on)
+        $private
+    )
+    $projections
+    (UnionCols $passThrough (OutputCols $right))
+)
+
 # GenerateLocalityOptimizedAntiJoin converts an anti join into a locality
 # optimized anti join if possible. A locality optimized anti join is implemented
 # as a nested pair of anti lookup joins and is designed to avoid communicating

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -728,7 +728,10 @@ message LocalOnlySessionData {
   // then the heuristic applies to all statements (both read-only and
   // mutations), regardless of the table being multi-region.
   bool parallelize_multi_key_lookup_joins_only_on_mr_mutations = 182 [(gogoproto.customname) = "ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations"];
-
+  // OptimizerUseImprovedHoistJoinProject controls whether the
+  // HoistJoinProjectLeft normalization rule hoists more kinds of projections
+  // above joins.
+  bool optimizer_use_improved_hoist_join_project = 183;
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //
   // be propagated to the remote nodes. If so, that parameter should live  //

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4318,6 +4318,25 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`optimizer_use_improved_hoist_join_project`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`optimizer_use_improved_hoist_join_project`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("optimizer_use_improved_hoist_join_project", s)
+			if err != nil {
+				return err
+			}
+			m.SetOptimizerUseImprovedHoistJoinProject(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(
+				evalCtx.SessionData().OptimizerUseImprovedHoistJoinProject,
+			), nil
+		},
+		GlobalDefault: globalFalse,
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {


### PR DESCRIPTION
Add exploration rule `HoistLeftProjectFromJoin` to hoist projections above joins in more cases. This rule is roughly the same as normalization rule `HoistJoinProjectLeft` but able to hoist more projections. It is very similar to `HoistProjectFromInnerJoin` but for a join with projection on the left instead of on the right.

Fixes: #150704

Release note (sql change): Improve the optimizer to hoist projections above joins in more cases, which can lead to better query plans. This can be enabled by the new session variable
`optimizer_use_improved_hoist_join_project`.