### PR TITLE
pkg/sql: Implement placeholder value truncation for SQL execution events

### DIFF
--- a/pkg/sql/event_log.go
+++ b/pkg/sql/event_log.go
@@ -168,7 +168,7 @@ func (p *planner) getCommonSQLEventDetails() eventpb.CommonSQLEventDetails {
 	if pls := p.extendedEvalCtx.Context.Placeholders.Values; len(pls) > 0 {
 		commonSQLEventDetails.PlaceholderValues = make([]string, len(pls))
 		for idx, val := range pls {
-			commonSQLEventDetails.PlaceholderValues[idx] = val.String()
+			commonSQLEventDetails.PlaceholderValues[idx] = truncatePlaceholderValue(val.String())
 		}
 	}
 	return commonSQLEventDetails


### PR DESCRIPTION
This commit introduces a mechanism to truncate large placeholder values in SQL 
execution events to prevent "message too long" errors in logging sinks. The 
`truncatePlaceholderValue` function ensures that placeholder values do not 
exceed a maximum length of 4096 bytes, while maintaining UTF-8 validity and 
appending an ellipsis for truncated values. Additionally, a new integration test, 
verifies the correct truncation behavior during SQL execution.

This solves the issue of #135610.

Part of: CRDB-44655
Epic: None
Release note: None