### PR TITLE
sqlstats: improve perf and memory consumption of json encode/decode

### DIFF
--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/BUILD.bazel
@@ -14,6 +14,7 @@ go_library(
     deps = [
         "//pkg/sql/appstatspb",
         "//pkg/sql/sem/tree",
+        "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/json",
         "//pkg/util/timeutil",
@@ -31,6 +32,7 @@ go_test(
     embed = [":sqlstatsutil"],
     deps = [
         "//pkg/sql/appstatspb",
+        "//pkg/testutils",
         "//pkg/util/json",
         "//pkg/util/leaktest",
         "//pkg/util/log",

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_decoding.go
@@ -7,9 +7,12 @@ package sqlstatsutil
 
 import (
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/errors"
 )
+
+var panicOnUnknownFieldsForTest = true
 
 // DecodeTxnStatsMetadataJSON decodes the 'metadata' field of the JSON
 // representation of transaction statistics into
@@ -17,9 +20,14 @@ import (
 func DecodeTxnStatsMetadataJSON(
 	metadata json.JSON, result *appstatspb.CollectedTransactionStatistics,
 ) error {
-	return jsonFields{
-		{"stmtFingerprintIDs", (*stmtFingerprintIDArray)(&result.StatementFingerprintIDs)},
-	}.decodeJSON(metadata)
+	valJSON, err := metadata.FetchValKey("stmtFingerprintIDs")
+	if err != nil {
+		return err
+	}
+	if valJSON != nil {
+		return (*stmtFingerprintIDArray)(&result.StatementFingerprintIDs).decodeJSON(valJSON)
+	}
+	return nil
 }
 
 // DecodeTxnStatsStatisticsJSON decodes the 'statistics' section of the
@@ -28,7 +36,23 @@ func DecodeTxnStatsMetadataJSON(
 func DecodeTxnStatsStatisticsJSON(
 	jsonVal json.JSON, result *appstatspb.TransactionStatistics,
 ) error {
-	return (*txnStats)(result).decodeJSON(jsonVal)
+	if statsJSON, err := jsonVal.FetchValKey("statistics"); err != nil {
+		return err
+	} else if statsJSON != nil {
+		if err := (*innerTxnStats)(result).decodeJSON(statsJSON); err != nil {
+			return err
+		}
+	}
+
+	if execJSON, err := jsonVal.FetchValKey("execution_statistics"); err != nil {
+		return err
+	} else if execJSON != nil {
+		if err := (*execStats)(&result.ExecStats).decodeJSON(execJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 // DecodeStmtStatsMetadataJSON decodes the 'metadata' field of the JSON
@@ -37,7 +61,7 @@ func DecodeTxnStatsStatisticsJSON(
 func DecodeStmtStatsMetadataJSON(
 	metadata json.JSON, result *appstatspb.CollectedStatementStatistics,
 ) error {
-	return (*stmtStatsMetadata)(result).jsonFields().decodeJSON(metadata)
+	return (*stmtStatsMetadata)(result).decodeJSON(metadata)
 }
 
 // DecodeStmtStatsMetadataFlagsOnlyJSON decodes the 'metadata' flags only fields
@@ -47,14 +71,274 @@ func DecodeStmtStatsMetadataJSON(
 func DecodeStmtStatsMetadataFlagsOnlyJSON(
 	metadata json.JSON, result *appstatspb.CollectedStatementStatistics,
 ) error {
-	return (*stmtStatsMetadata)(result).jsonFlagsOnlyFields().decodeJSON(metadata)
+	return (*stmtStatsMetadata)(result).decodeFlagsOnlyJSON(metadata)
 }
 
 // DecodeAggregatedMetadataJSON decodes the 'aggregated metadata' represented by appstatspb.AggregatedStatementMetadata.
 func DecodeAggregatedMetadataJSON(
 	metadata json.JSON, result *appstatspb.AggregatedStatementMetadata,
 ) error {
-	return (*aggregatedMetadata)(result).jsonFields().decodeJSON(metadata)
+	return (*aggregatedMetadata)(result).decodeJSON(metadata)
+}
+
+func (am *aggregatedMetadata) decodeJSON(js json.JSON) (err error) {
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "fingerprintID":
+			err = (*jsonString)(&am.FingerprintID).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "db":
+			err = (*stringArray)(&am.Databases).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "appNames":
+			err = (*stringArray)(&am.AppNames).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "distSQLCount":
+			err = (*jsonInt)(&am.DistSQLCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "fullScanCount":
+			err = (*jsonInt)(&am.FullScanCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "implicitTxn":
+			err = (*jsonBool)(&am.ImplicitTxn).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "query":
+			err = (*jsonString)(&am.Query).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "formattedQuery":
+			err = (*jsonString)(&am.FormattedQuery).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "querySummary":
+			err = (*jsonString)(&am.QuerySummary).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "stmtType":
+			err = (*jsonString)(&am.StmtType).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "vecCount":
+			err = (*jsonInt)(&am.VecCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "totalCount":
+			err = (*jsonInt)(&am.TotalCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		default:
+			if buildutil.CrdbTestBuild && panicOnUnknownFieldsForTest {
+				panic(errors.AssertionFailedf("unknown field: %s", iter.Key()))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (sm *stmtStatsMetadata) decodeJSON(js json.JSON) (err error) {
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "stmtType":
+			err = (*jsonString)(&sm.Stats.SQLType).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "query":
+			err = (*jsonString)(&sm.Key.Query).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "querySummary":
+			err = (*jsonString)(&sm.Key.QuerySummary).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "db":
+			err = (*jsonString)(&sm.Key.Database).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "distsql":
+			err = (*jsonBool)(&sm.Key.DistSQL).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "implicitTxn":
+			err = (*jsonBool)(&sm.Key.ImplicitTxn).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "vec":
+			err = (*jsonBool)(&sm.Key.Vec).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "fullScan":
+			err = (*jsonBool)(&sm.Key.FullScan).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		default:
+			if buildutil.CrdbTestBuild && panicOnUnknownFieldsForTest {
+				panic(errors.AssertionFailedf("unknown field: %s", iter.Key()))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (sm *stmtStatsMetadata) decodeFlagsOnlyJSON(js json.JSON) (err error) {
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "db":
+			err = (*jsonString)(&sm.Key.Database).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "distsql":
+			err = (*jsonBool)(&sm.Key.DistSQL).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "implicitTxn":
+			err = (*jsonBool)(&sm.Key.ImplicitTxn).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "vec":
+			err = (*jsonBool)(&sm.Key.Vec).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "fullScan":
+			err = (*jsonBool)(&sm.Key.FullScan).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		default:
+			if buildutil.CrdbTestBuild && panicOnUnknownFieldsForTest {
+				panic(errors.AssertionFailedf("unknown field: %s", iter.Key()))
+			}
+		}
+	}
+
+	return nil
+}
+
+func (am *aggregatedMetadata) decodeAggregatedFieldsOnlyJSON(js json.JSON) (err error) {
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "db":
+			err = (*stringArray)(&am.Databases).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "appNames":
+			err = (*stringArray)(&am.AppNames).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "distSQLCount":
+			err = (*jsonInt)(&am.DistSQLCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "fullScanCount":
+			err = (*jsonInt)(&am.FullScanCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "implicitTxn":
+			err = (*jsonBool)(&am.ImplicitTxn).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "vecCount":
+			err = (*jsonInt)(&am.VecCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "totalCount":
+			err = (*jsonInt)(&am.TotalCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		default:
+			if buildutil.CrdbTestBuild && panicOnUnknownFieldsForTest {
+				panic(errors.AssertionFailedf("unknown field: %s", iter.Key()))
+			}
+		}
+	}
+
+	return nil
 }
 
 // DecodeAggregatedMetadataAggregatedFieldsOnlyJSON decodes the 'aggregated metadata' represented by
@@ -63,7 +347,7 @@ func DecodeAggregatedMetadataJSON(
 func DecodeAggregatedMetadataAggregatedFieldsOnlyJSON(
 	metadata json.JSON, result *appstatspb.AggregatedStatementMetadata,
 ) error {
-	return (*aggregatedMetadata)(result).jsonAggregatedFields().decodeJSON(metadata)
+	return (*aggregatedMetadata)(result).decodeAggregatedFieldsOnlyJSON(metadata)
 }
 
 // DecodeStmtStatsStatisticsJSON decodes the 'statistics' field and the
@@ -71,8 +355,44 @@ func DecodeAggregatedMetadataAggregatedFieldsOnlyJSON(
 // appstatspb.StatementStatistics.
 func DecodeStmtStatsStatisticsJSON(
 	jsonVal json.JSON, result *appstatspb.StatementStatistics,
-) error {
-	return (*stmtStats)(result).decodeJSON(jsonVal)
+) (err error) {
+	iter, err := jsonVal.ObjectIter()
+	if err != nil {
+		return err
+	}
+
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "statistics":
+			err = (*innerStmtStats)(result).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "execution_statistics":
+			err = (*execStats)(&result.ExecStats).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "index_recommendations":
+			err = (*stringArray)(&result.IndexRecommendations).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		default:
+			if buildutil.CrdbTestBuild && panicOnUnknownFieldsForTest {
+				panic(errors.AssertionFailedf("unknown field: %s", iter.Key()))
+			}
+		}
+	}
+
+	return nil
 }
 
 // JSONToExplainTreePlanNode decodes the JSON-formatted ExplainTreePlanNode

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding.go
@@ -56,7 +56,48 @@ func ExplainTreePlanNodeToJSON(node *appstatspb.ExplainTreePlanNode) json.JSON {
 //	  }
 //	}
 func BuildStmtMetadataJSON(statistics *appstatspb.CollectedStatementStatistics) (json.JSON, error) {
-	return (*stmtStatsMetadata)(statistics).jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(8)
+	val, err := (*jsonString)(&statistics.Stats.SQLType).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("stmtType", val)
+	val, err = (*jsonString)(&statistics.Key.Query).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("query", val)
+	val, err = (*jsonString)(&statistics.Key.QuerySummary).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("querySummary", val)
+	val, err = (*jsonString)(&statistics.Key.Database).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("db", val)
+	val, err = (*jsonBool)(&statistics.Key.DistSQL).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("distsql", val)
+	val, err = (*jsonBool)(&statistics.Key.ImplicitTxn).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("implicitTxn", val)
+	val, err = (*jsonBool)(&statistics.Key.Vec).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("vec", val)
+	val, err = (*jsonBool)(&statistics.Key.FullScan).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("fullScan", val)
+	return builder.Build(), nil
 }
 
 // BuildStmtStatisticsJSON encodes the statistics section a given
@@ -236,7 +277,23 @@ func BuildStmtMetadataJSON(statistics *appstatspb.CollectedStatementStatistics) 
 //		    }
 //		}
 func BuildStmtStatisticsJSON(statistics *appstatspb.StatementStatistics) (json.JSON, error) {
-	return (*stmtStats)(statistics).encodeJSON()
+	builder := json.NewObjectBuilder(3)
+	val, err := (*innerStmtStats)(statistics).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("statistics", val)
+	val, err = (*execStats)(&statistics.ExecStats).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("execution_statistics", val)
+	val, err = (*stringArray)(&statistics.IndexRecommendations).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("index_recommendations", val)
+	return builder.Build(), nil
 }
 
 // BuildTxnMetadataJSON encodes the metadata portion a given
@@ -264,9 +321,13 @@ func BuildStmtStatisticsJSON(statistics *appstatspb.StatementStatistics) (json.J
 func BuildTxnMetadataJSON(
 	statistics *appstatspb.CollectedTransactionStatistics,
 ) (json.JSON, error) {
-	return jsonFields{
-		{"stmtFingerprintIDs", (*stmtFingerprintIDArray)(&statistics.StatementFingerprintIDs)},
-	}.encodeJSON()
+	builder := json.NewObjectBuilder(1)
+	val, err := (*stmtFingerprintIDArray)(&statistics.StatementFingerprintIDs).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("stmtFingerprintIDs", val)
+	return builder.Build(), nil
 }
 
 // BuildTxnStatisticsJSON encodes the statistics portion a given
@@ -405,7 +466,18 @@ func BuildTxnMetadataJSON(
 func BuildTxnStatisticsJSON(
 	statistics *appstatspb.CollectedTransactionStatistics,
 ) (json.JSON, error) {
-	return (*txnStats)(&statistics.Stats).encodeJSON()
+	builder := json.NewObjectBuilder(2)
+	val, err := (*innerTxnStats)(&statistics.Stats).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("statistics", val)
+	val, err = (*execStats)(&statistics.Stats.ExecStats).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("execution_statistics", val)
+	return builder.Build(), nil
 }
 
 // BuildStmtDetailsMetadataJSON returns a json.JSON object for the aggregated metadata
@@ -446,7 +518,68 @@ func BuildTxnStatisticsJSON(
 func BuildStmtDetailsMetadataJSON(
 	metadata *appstatspb.AggregatedStatementMetadata,
 ) (json.JSON, error) {
-	return (*aggregatedMetadata)(metadata).jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(12)
+	val, err := (*stringArray)(&metadata.Databases).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("db", val)
+	val, err = (*stringArray)(&metadata.AppNames).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("appNames", val)
+	val, err = (*jsonInt)(&metadata.DistSQLCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("distSQLCount", val)
+	val, err = (*jsonInt)(&metadata.FullScanCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("fullScanCount", val)
+	val, err = (*jsonBool)(&metadata.ImplicitTxn).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("implicitTxn", val)
+	val, err = (*jsonString)(&metadata.Query).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("query", val)
+	val, err = (*jsonString)(&metadata.FormattedQuery).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("formattedQuery", val)
+	val, err = (*jsonString)(&metadata.QuerySummary).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("querySummary", val)
+	val, err = (*jsonString)(&metadata.StmtType).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("stmtType", val)
+	val, err = (*jsonInt)(&metadata.VecCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("vecCount", val)
+	val, err = (*jsonInt)(&metadata.TotalCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("totalCount", val)
+	val, err = (*jsonString)(&metadata.FingerprintID).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("fingerprintID", val)
+	return builder.Build(), nil
 }
 
 // EncodeUint64ToBytes returns the []byte representation of an uint64 value.

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_encoding_test.go
@@ -12,6 +12,7 @@ import (
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/appstatspb"
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/json"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -612,6 +613,7 @@ func TestSQLStatsJsonEncoding(t *testing.T) {
 	})
 
 	t.Run("random metadata JSON structure and values", func(t *testing.T) {
+		defer testutils.HookGlobal[bool](&panicOnUnknownFieldsForTest, false)()
 		input := `{"HcEN0pht": null, "bar": [false, "foobar", true], "c": {"8r8qmK": 1.4687388461922657, "vbF3TH0I": null, "yNNmkGr6": 2.0887609844362762}, "db": {"KKDmambo": 0.10124464952424544}, "foobar": {"LM8G": {"zniUw24Z": 0.14422951431111297}, "bar": "lp7jfTq2"}, "r0O": false}`
 		value, err := json.ParseJSON(input)
 		require.NoError(t, err)

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -51,13 +51,6 @@ var (
 
 type txnStats appstatspb.TransactionStatistics
 
-func (t *txnStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"statistics", (*innerTxnStats)(t)},
-		{"execution_statistics", (*execStats)(&t.ExecStats)},
-	}
-}
-
 func (t *txnStats) decodeJSON(js json.JSON) error {
 	// Decode "statistics" field
 	if valJSON, err := js.FetchValKey("statistics"); err != nil {
@@ -96,14 +89,6 @@ func (t *txnStats) encodeJSON() (json.JSON, error) {
 }
 
 type stmtStats appstatspb.StatementStatistics
-
-func (s *stmtStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"statistics", (*innerStmtStats)(s)},
-		{"execution_statistics", (*execStats)(&s.ExecStats)},
-		{"index_recommendations", (*stringArray)(&s.IndexRecommendations)},
-	}
-}
 
 func (s *stmtStats) decodeJSON(js json.JSON) error {
 	// Decode "statistics" field
@@ -158,59 +143,7 @@ func (s *stmtStats) encodeJSON() (json.JSON, error) {
 
 type stmtStatsMetadata appstatspb.CollectedStatementStatistics
 
-func (s *stmtStatsMetadata) jsonFields() jsonFields {
-	return jsonFields{
-		{"stmtType", (*jsonString)(&s.Stats.SQLType)},
-		{"query", (*jsonString)(&s.Key.Query)},
-		{"querySummary", (*jsonString)(&s.Key.QuerySummary)},
-		{"db", (*jsonString)(&s.Key.Database)},
-		{"distsql", (*jsonBool)(&s.Key.DistSQL)},
-		{"implicitTxn", (*jsonBool)(&s.Key.ImplicitTxn)},
-		{"vec", (*jsonBool)(&s.Key.Vec)},
-		{"fullScan", (*jsonBool)(&s.Key.FullScan)},
-	}
-}
-
-func (s *stmtStatsMetadata) jsonFlagsOnlyFields() jsonFields {
-	return jsonFields{
-		{"db", (*jsonString)(&s.Key.Database)},
-		{"distsql", (*jsonBool)(&s.Key.DistSQL)},
-		{"implicitTxn", (*jsonBool)(&s.Key.ImplicitTxn)},
-		{"vec", (*jsonBool)(&s.Key.Vec)},
-		{"fullScan", (*jsonBool)(&s.Key.FullScan)},
-	}
-}
-
 type aggregatedMetadata appstatspb.AggregatedStatementMetadata
-
-func (s *aggregatedMetadata) jsonFields() jsonFields {
-	return jsonFields{
-		{"db", (*stringArray)(&s.Databases)},
-		{"appNames", (*stringArray)(&s.AppNames)},
-		{"distSQLCount", (*jsonInt)(&s.DistSQLCount)},
-		{"fullScanCount", (*jsonInt)(&s.FullScanCount)},
-		{"implicitTxn", (*jsonBool)(&s.ImplicitTxn)},
-		{"query", (*jsonString)(&s.Query)},
-		{"formattedQuery", (*jsonString)(&s.FormattedQuery)},
-		{"querySummary", (*jsonString)(&s.QuerySummary)},
-		{"stmtType", (*jsonString)(&s.StmtType)},
-		{"vecCount", (*jsonInt)(&s.VecCount)},
-		{"totalCount", (*jsonInt)(&s.TotalCount)},
-		{"fingerprintID", (*jsonString)(&s.FingerprintID)},
-	}
-}
-
-func (s *aggregatedMetadata) jsonAggregatedFields() jsonFields {
-	return jsonFields{
-		{"db", (*stringArray)(&s.Databases)},
-		{"appNames", (*stringArray)(&s.AppNames)},
-		{"distSQLCount", (*jsonInt)(&s.DistSQLCount)},
-		{"fullScanCount", (*jsonInt)(&s.FullScanCount)},
-		{"implicitTxn", (*jsonBool)(&s.ImplicitTxn)},
-		{"vecCount", (*jsonInt)(&s.VecCount)},
-		{"totalCount", (*jsonInt)(&s.TotalCount)},
-	}
-}
 
 type int64Array []int64
 
@@ -365,21 +298,6 @@ func (s *stmtFingerprintID) encodeJSON() (json.JSON, error) {
 }
 
 type innerTxnStats appstatspb.TransactionStatistics
-
-func (t *innerTxnStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"cnt", (*jsonInt)(&t.Count)},
-		{"maxRetries", (*jsonInt)(&t.MaxRetries)},
-		{"numRows", (*numericStats)(&t.NumRows)},
-		{"svcLat", (*numericStats)(&t.ServiceLat)},
-		{"retryLat", (*numericStats)(&t.RetryLat)},
-		{"commitLat", (*numericStats)(&t.CommitLat)},
-		{"idleLat", (*numericStats)(&t.IdleLat)},
-		{"bytesRead", (*numericStats)(&t.BytesRead)},
-		{"rowsRead", (*numericStats)(&t.RowsRead)},
-		{"rowsWritten", (*numericStats)(&t.RowsWritten)},
-	}
-}
 
 func (t *innerTxnStats) decodeJSON(js json.JSON) error {
 	// Decode "cnt" field
@@ -538,36 +456,6 @@ func (t *innerTxnStats) encodeJSON() (json.JSON, error) {
 }
 
 type innerStmtStats appstatspb.StatementStatistics
-
-func (s *innerStmtStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"cnt", (*jsonInt)(&s.Count)},
-		{"firstAttemptCnt", (*jsonInt)(&s.FirstAttemptCount)},
-		{"maxRetries", (*jsonInt)(&s.MaxRetries)},
-		{"lastExecAt", (*jsonTime)(&s.LastExecTimestamp)},
-		{"numRows", (*numericStats)(&s.NumRows)},
-		{"idleLat", (*numericStats)(&s.IdleLat)},
-		{"parseLat", (*numericStats)(&s.ParseLat)},
-		{"planLat", (*numericStats)(&s.PlanLat)},
-		{"runLat", (*numericStats)(&s.RunLat)},
-		{"svcLat", (*numericStats)(&s.ServiceLat)},
-		{"ovhLat", (*numericStats)(&s.OverheadLat)},
-		{"bytesRead", (*numericStats)(&s.BytesRead)},
-		{"rowsRead", (*numericStats)(&s.RowsRead)},
-		{"rowsWritten", (*numericStats)(&s.RowsWritten)},
-		{"nodes", (*int64Array)(&s.Nodes)},
-		{"kvNodeIds", (*int32Array)(&s.KVNodeIDs)},
-		{"regions", (*stringArray)(&s.Regions)},
-		{"usedFollowerRead", (*jsonBool)(&s.UsedFollowerRead)},
-		{"planGists", (*stringArray)(&s.PlanGists)},
-		{"indexes", (*stringArray)(&s.Indexes)},
-		{"latencyInfo", (*latencyInfo)(&s.LatencyInfo)},
-		{"lastErrorCode", (*jsonString)(&s.LastErrorCode)},
-		{"failureCount", (*jsonInt)(&s.FailureCount)},
-		{"genericCount", (*jsonInt)(&s.GenericCount)},
-		{"sqlType", (*jsonString)(&s.SQLType)},
-	}
-}
 
 func (s *innerStmtStats) decodeJSON(js json.JSON) (err error) {
 	var fieldName string
@@ -852,19 +740,6 @@ func (s *innerStmtStats) encodeJSON() (json.JSON, error) {
 
 type execStats appstatspb.ExecStats
 
-func (e *execStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"cnt", (*jsonInt)(&e.Count)},
-		{"networkBytes", (*numericStats)(&e.NetworkBytes)},
-		{"maxMemUsage", (*numericStats)(&e.MaxMemUsage)},
-		{"contentionTime", (*numericStats)(&e.ContentionTime)},
-		{"networkMsgs", (*numericStats)(&e.NetworkMessages)},
-		{"maxDiskUsage", (*numericStats)(&e.MaxDiskUsage)},
-		{"cpuSQLNanos", (*numericStats)(&e.CPUSQLNanos)},
-		{"mvccIteratorStats", (*iteratorStats)(&e.MVCCIteratorStats)},
-	}
-}
-
 func (e *execStats) decodeJSON(js json.JSON) (err error) {
 	var fieldName string
 	defer func() {
@@ -978,24 +853,6 @@ func (e *execStats) encodeJSON() (json.JSON, error) {
 }
 
 type iteratorStats appstatspb.MVCCIteratorStats
-
-func (e *iteratorStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"stepCount", (*numericStats)(&e.StepCount)},
-		{"stepCountInternal", (*numericStats)(&e.StepCountInternal)},
-		{"seekCount", (*numericStats)(&e.SeekCount)},
-		{"seekCountInternal", (*numericStats)(&e.SeekCountInternal)},
-		{"blockBytes", (*numericStats)(&e.BlockBytes)},
-		{"blockBytesInCache", (*numericStats)(&e.BlockBytesInCache)},
-		{"keyBytes", (*numericStats)(&e.KeyBytes)},
-		{"valueBytes", (*numericStats)(&e.ValueBytes)},
-		{"pointCount", (*numericStats)(&e.PointCount)},
-		{"pointsCoveredByRangeTombstones", (*numericStats)(&e.PointsCoveredByRangeTombstones)},
-		{"rangeKeyCount", (*numericStats)(&e.RangeKeyCount)},
-		{"rangeKeyContainedPoints", (*numericStats)(&e.RangeKeyContainedPoints)},
-		{"rangeKeySkippedPoints", (*numericStats)(&e.RangeKeySkippedPoints)},
-	}
-}
 
 func (e *iteratorStats) decodeJSON(js json.JSON) (err error) {
 	var fieldName string
@@ -1161,13 +1018,6 @@ func (e *iteratorStats) encodeJSON() (json.JSON, error) {
 
 type numericStats appstatspb.NumericStat
 
-func (n *numericStats) jsonFields() jsonFields {
-	return jsonFields{
-		{"mean", (*jsonFloat)(&n.Mean)},
-		{"sqDiff", (*jsonFloat)(&n.SquaredDiffs)},
-	}
-}
-
 func (n *numericStats) decodeJSON(js json.JSON) error {
 	// Decode "mean" field
 	if valJSON, err := js.FetchValKey("mean"); err != nil {
@@ -1228,13 +1078,6 @@ func (n *numericStats) encodeJSONWithBuilder(
 }
 
 type latencyInfo appstatspb.LatencyInfo
-
-func (l *latencyInfo) jsonFields() jsonFields {
-	return jsonFields{
-		{"min", (*jsonFloat)(&l.Min)},
-		{"max", (*jsonFloat)(&l.Max)},
-	}
-}
 
 func (l *latencyInfo) decodeJSON(js json.JSON) error {
 	// Decode "min" field

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -81,7 +81,18 @@ func (t *txnStats) decodeJSON(js json.JSON) error {
 }
 
 func (t *txnStats) encodeJSON() (json.JSON, error) {
-	return t.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(2)
+	val, err := (*innerTxnStats)(t).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("statistics", val)
+	val, err = (*execStats)(&t.ExecStats).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("execution_statistics", val)
+	return builder.Build(), nil
 }
 
 type stmtStats appstatspb.StatementStatistics
@@ -126,7 +137,23 @@ func (s *stmtStats) decodeJSON(js json.JSON) error {
 }
 
 func (s *stmtStats) encodeJSON() (json.JSON, error) {
-	return s.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(3)
+	val, err := (*innerStmtStats)(s).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("statistics", val)
+	val, err = (*execStats)(&s.ExecStats).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("execution_statistics", val)
+	val, err = (*stringArray)(&s.IndexRecommendations).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("index_recommendations", val)
+	return builder.Build(), nil
 }
 
 type stmtStatsMetadata appstatspb.CollectedStatementStatistics
@@ -449,7 +476,65 @@ func (t *innerTxnStats) decodeJSON(js json.JSON) error {
 }
 
 func (t *innerTxnStats) encodeJSON() (json.JSON, error) {
-	return t.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(10)
+
+	// Create a shared FixedKeysObjectBuilder for numericStats objects
+	numericStatsBuilder, err := json.NewFixedKeysObjectBuilder([]string{"mean", "sqDiff"})
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := (*jsonInt)(&t.Count).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("cnt", val)
+	val, err = (*jsonInt)(&t.MaxRetries).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("maxRetries", val)
+	val, err = (*numericStats)(&t.NumRows).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("numRows", val)
+	val, err = (*numericStats)(&t.ServiceLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("svcLat", val)
+	val, err = (*numericStats)(&t.RetryLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("retryLat", val)
+	val, err = (*numericStats)(&t.CommitLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("commitLat", val)
+	val, err = (*numericStats)(&t.IdleLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("idleLat", val)
+	val, err = (*numericStats)(&t.BytesRead).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("bytesRead", val)
+	val, err = (*numericStats)(&t.RowsRead).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rowsRead", val)
+	val, err = (*numericStats)(&t.RowsWritten).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rowsWritten", val)
+	return builder.Build(), nil
 }
 
 type innerStmtStats appstatspb.StatementStatistics
@@ -630,7 +715,139 @@ func (s *innerStmtStats) decodeJSON(js json.JSON) (err error) {
 }
 
 func (s *innerStmtStats) encodeJSON() (json.JSON, error) {
-	return s.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(24)
+
+	// Create a shared FixedKeysObjectBuilder for numericStats objects
+	numericStatsBuilder, err := json.NewFixedKeysObjectBuilder([]string{"mean", "sqDiff"})
+	if err != nil {
+		return nil, err
+	}
+	val, err := (*jsonInt)(&s.Count).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("cnt", val)
+	val, err = (*jsonInt)(&s.FirstAttemptCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("firstAttemptCnt", val)
+	val, err = (*jsonInt)(&s.MaxRetries).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("maxRetries", val)
+	val, err = (*jsonTime)(&s.LastExecTimestamp).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("lastExecAt", val)
+	val, err = (*numericStats)(&s.NumRows).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("numRows", val)
+	val, err = (*numericStats)(&s.IdleLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("idleLat", val)
+	val, err = (*numericStats)(&s.ParseLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("parseLat", val)
+	val, err = (*numericStats)(&s.PlanLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("planLat", val)
+	val, err = (*numericStats)(&s.RunLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("runLat", val)
+	val, err = (*numericStats)(&s.ServiceLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("svcLat", val)
+	val, err = (*numericStats)(&s.OverheadLat).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("ovhLat", val)
+	val, err = (*numericStats)(&s.BytesRead).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("bytesRead", val)
+	val, err = (*numericStats)(&s.RowsRead).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rowsRead", val)
+	val, err = (*numericStats)(&s.RowsWritten).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rowsWritten", val)
+	val, err = (*int64Array)(&s.Nodes).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("nodes", val)
+	val, err = (*int32Array)(&s.KVNodeIDs).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("kvNodeIds", val)
+	val, err = (*stringArray)(&s.Regions).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("regions", val)
+	val, err = (*jsonBool)(&s.UsedFollowerRead).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("usedFollowerRead", val)
+	val, err = (*stringArray)(&s.PlanGists).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("planGists", val)
+	val, err = (*stringArray)(&s.Indexes).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("indexes", val)
+	val, err = (*latencyInfo)(&s.LatencyInfo).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("latencyInfo", val)
+	val, err = (*jsonString)(&s.LastErrorCode).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("lastErrorCode", val)
+	val, err = (*jsonInt)(&s.FailureCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("failureCount", val)
+	val, err = (*jsonInt)(&s.GenericCount).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("genericCount", val)
+	val, err = (*jsonString)(&s.SQLType).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("sqlType", val)
+	return builder.Build(), nil
 }
 
 type execStats appstatspb.ExecStats
@@ -709,7 +926,55 @@ func (e *execStats) decodeJSON(js json.JSON) (err error) {
 }
 
 func (e *execStats) encodeJSON() (json.JSON, error) {
-	return e.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(8)
+
+	// Create a shared FixedKeysObjectBuilder for numericStats objects
+	numericStatsBuilder, err := json.NewFixedKeysObjectBuilder([]string{"mean", "sqDiff"})
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := (*jsonInt)(&e.Count).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("cnt", val)
+	val, err = (*numericStats)(&e.NetworkBytes).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("networkBytes", val)
+	val, err = (*numericStats)(&e.MaxMemUsage).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("maxMemUsage", val)
+	val, err = (*numericStats)(&e.ContentionTime).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("contentionTime", val)
+	val, err = (*numericStats)(&e.NetworkMessages).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("networkMsgs", val)
+	val, err = (*numericStats)(&e.MaxDiskUsage).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("maxDiskUsage", val)
+	val, err = (*numericStats)(&e.CPUSQLNanos).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("cpuSQLNanos", val)
+	val, err = (*iteratorStats)(&e.MVCCIteratorStats).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("mvccIteratorStats", val)
+	return builder.Build(), nil
 }
 
 type iteratorStats appstatspb.MVCCIteratorStats
@@ -818,7 +1083,80 @@ func (e *iteratorStats) decodeJSON(js json.JSON) (err error) {
 }
 
 func (e *iteratorStats) encodeJSON() (json.JSON, error) {
-	return e.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(13)
+
+	// Create a shared FixedKeysObjectBuilder for numericStats objects
+	numericStatsBuilder, err := json.NewFixedKeysObjectBuilder([]string{"mean", "sqDiff"})
+	if err != nil {
+		return nil, err
+	}
+
+	val, err := (*numericStats)(&e.StepCount).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("stepCount", val)
+	val, err = (*numericStats)(&e.StepCountInternal).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("stepCountInternal", val)
+	val, err = (*numericStats)(&e.SeekCount).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("seekCount", val)
+	val, err = (*numericStats)(&e.SeekCountInternal).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("seekCountInternal", val)
+	val, err = (*numericStats)(&e.BlockBytes).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("blockBytes", val)
+	val, err = (*numericStats)(&e.BlockBytesInCache).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("blockBytesInCache", val)
+	val, err = (*numericStats)(&e.KeyBytes).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("keyBytes", val)
+	val, err = (*numericStats)(&e.ValueBytes).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("valueBytes", val)
+	val, err = (*numericStats)(&e.PointCount).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("pointCount", val)
+	val, err = (*numericStats)(&e.PointsCoveredByRangeTombstones).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("pointsCoveredByRangeTombstones", val)
+	val, err = (*numericStats)(&e.RangeKeyCount).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rangeKeyCount", val)
+	val, err = (*numericStats)(&e.RangeKeyContainedPoints).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rangeKeyContainedPoints", val)
+	val, err = (*numericStats)(&e.RangeKeySkippedPoints).encodeJSONWithBuilder(numericStatsBuilder)
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("rangeKeySkippedPoints", val)
+	return builder.Build(), nil
 }
 
 type numericStats appstatspb.NumericStat
@@ -853,7 +1191,40 @@ func (n *numericStats) decodeJSON(js json.JSON) error {
 }
 
 func (n *numericStats) encodeJSON() (json.JSON, error) {
-	return n.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(2)
+	val, err := (*jsonFloat)(&n.Mean).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("mean", val)
+	val, err = (*jsonFloat)(&n.SquaredDiffs).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("sqDiff", val)
+	return builder.Build(), nil
+}
+
+func (n *numericStats) encodeJSONWithBuilder(
+	builder *json.FixedKeysObjectBuilder,
+) (json.JSON, error) {
+	meanVal, err := (*jsonFloat)(&n.Mean).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	if err := builder.Set("mean", meanVal); err != nil {
+		return nil, err
+	}
+
+	sqDiffVal, err := (*jsonFloat)(&n.SquaredDiffs).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	if err := builder.Set("sqDiff", sqDiffVal); err != nil {
+		return nil, err
+	}
+
+	return builder.Build()
 }
 
 type latencyInfo appstatspb.LatencyInfo
@@ -888,7 +1259,18 @@ func (l *latencyInfo) decodeJSON(js json.JSON) error {
 }
 
 func (l *latencyInfo) encodeJSON() (json.JSON, error) {
-	return l.jsonFields().encodeJSON()
+	builder := json.NewObjectBuilder(2)
+	val, err := (*jsonFloat)(&l.Min).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("min", val)
+	val, err = (*jsonFloat)(&l.Max).encodeJSON()
+	if err != nil {
+		return nil, err
+	}
+	builder.Add("max", val)
+	return builder.Build(), nil
 }
 
 type jsonFields []jsonField

--- a/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
+++ b/pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/json_impl.go
@@ -59,7 +59,25 @@ func (t *txnStats) jsonFields() jsonFields {
 }
 
 func (t *txnStats) decodeJSON(js json.JSON) error {
-	return t.jsonFields().decodeJSON(js)
+	// Decode "statistics" field
+	if valJSON, err := js.FetchValKey("statistics"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*innerTxnStats)(t).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "execution_statistics" field
+	if valJSON, err := js.FetchValKey("execution_statistics"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*execStats)(&t.ExecStats).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (t *txnStats) encodeJSON() (json.JSON, error) {
@@ -77,7 +95,34 @@ func (s *stmtStats) jsonFields() jsonFields {
 }
 
 func (s *stmtStats) decodeJSON(js json.JSON) error {
-	return s.jsonFields().decodeJSON(js)
+	// Decode "statistics" field
+	if valJSON, err := js.FetchValKey("statistics"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*innerStmtStats)(s).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "execution_statistics" field
+	if valJSON, err := js.FetchValKey("execution_statistics"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*execStats)(&s.ExecStats).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "index_recommendations" field
+	if valJSON, err := js.FetchValKey("index_recommendations"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*stringArray)(&s.IndexRecommendations).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (s *stmtStats) encodeJSON() (json.JSON, error) {
@@ -310,7 +355,97 @@ func (t *innerTxnStats) jsonFields() jsonFields {
 }
 
 func (t *innerTxnStats) decodeJSON(js json.JSON) error {
-	return t.jsonFields().decodeJSON(js)
+	// Decode "cnt" field
+	if valJSON, err := js.FetchValKey("cnt"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*jsonInt)(&t.Count).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "maxRetries" field
+	if valJSON, err := js.FetchValKey("maxRetries"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*jsonInt)(&t.MaxRetries).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "numRows" field
+	if valJSON, err := js.FetchValKey("numRows"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.NumRows).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "svcLat" field
+	if valJSON, err := js.FetchValKey("svcLat"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.ServiceLat).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "retryLat" field
+	if valJSON, err := js.FetchValKey("retryLat"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.RetryLat).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "commitLat" field
+	if valJSON, err := js.FetchValKey("commitLat"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.CommitLat).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "idleLat" field
+	if valJSON, err := js.FetchValKey("idleLat"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.IdleLat).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "bytesRead" field
+	if valJSON, err := js.FetchValKey("bytesRead"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.BytesRead).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "rowsRead" field
+	if valJSON, err := js.FetchValKey("rowsRead"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.RowsRead).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "rowsWritten" field
+	if valJSON, err := js.FetchValKey("rowsWritten"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*numericStats)(&t.RowsWritten).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (t *innerTxnStats) encodeJSON() (json.JSON, error) {
@@ -349,8 +484,149 @@ func (s *innerStmtStats) jsonFields() jsonFields {
 	}
 }
 
-func (s *innerStmtStats) decodeJSON(js json.JSON) error {
-	return s.jsonFields().decodeJSON(js)
+func (s *innerStmtStats) decodeJSON(js json.JSON) (err error) {
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "cnt":
+			err := (*jsonInt)(&s.Count).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "firstAttemptCnt":
+			err := (*jsonInt)(&s.FirstAttemptCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "maxRetries":
+			err := (*jsonInt)(&s.MaxRetries).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "lastExecAt":
+			err := (*jsonTime)(&s.LastExecTimestamp).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "numRows":
+			err := (*numericStats)(&s.NumRows).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "idleLat":
+			err := (*numericStats)(&s.IdleLat).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "parseLat":
+			err := (*numericStats)(&s.ParseLat).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "planLat":
+			err := (*numericStats)(&s.PlanLat).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "runLat":
+			err := (*numericStats)(&s.RunLat).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "svcLat":
+			err := (*numericStats)(&s.ServiceLat).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "ovhLat":
+			err := (*numericStats)(&s.OverheadLat).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "bytesRead":
+			err := (*numericStats)(&s.BytesRead).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "rowsRead":
+			err := (*numericStats)(&s.RowsRead).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "rowsWritten":
+			err := (*numericStats)(&s.RowsWritten).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "nodes":
+			err := (*int64Array)(&s.Nodes).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "kvNodeIds":
+			err := (*int32Array)(&s.KVNodeIDs).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "regions":
+			err := (*stringArray)(&s.Regions).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "usedFollowerRead":
+			err := (*jsonBool)(&s.UsedFollowerRead).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "planGists":
+			err := (*stringArray)(&s.PlanGists).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "indexes":
+			err := (*stringArray)(&s.Indexes).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "latencyInfo":
+			err := (*latencyInfo)(&s.LatencyInfo).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "lastErrorCode":
+			err := (*jsonString)(&s.LastErrorCode).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "failureCount":
+			err := (*jsonInt)(&s.FailureCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "genericCount":
+			err := (*jsonInt)(&s.GenericCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "sqlType":
+			err := (*jsonString)(&s.SQLType).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (s *innerStmtStats) encodeJSON() (json.JSON, error) {
@@ -372,8 +648,64 @@ func (e *execStats) jsonFields() jsonFields {
 	}
 }
 
-func (e *execStats) decodeJSON(js json.JSON) error {
-	return e.jsonFields().decodeJSON(js)
+func (e *execStats) decodeJSON(js json.JSON) (err error) {
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "cnt":
+			err := (*jsonInt)(&e.Count).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "networkBytes":
+			err := (*numericStats)(&e.NetworkBytes).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "maxMemUsage":
+			err := (*numericStats)(&e.MaxMemUsage).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "contentionTime":
+			err := (*numericStats)(&e.ContentionTime).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "networkMsgs":
+			err := (*numericStats)(&e.NetworkMessages).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "maxDiskUsage":
+			err := (*numericStats)(&e.MaxDiskUsage).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "cpuSQLNanos":
+			err := (*numericStats)(&e.CPUSQLNanos).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "mvccIteratorStats":
+			err := (*iteratorStats)(&e.MVCCIteratorStats).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (e *execStats) encodeJSON() (json.JSON, error) {
@@ -400,8 +732,89 @@ func (e *iteratorStats) jsonFields() jsonFields {
 	}
 }
 
-func (e *iteratorStats) decodeJSON(js json.JSON) error {
-	return e.jsonFields().decodeJSON(js)
+func (e *iteratorStats) decodeJSON(js json.JSON) (err error) {
+	var fieldName string
+	defer func() {
+		if err != nil {
+			err = errors.Wrapf(err, "decoding field %s", fieldName)
+		}
+	}()
+
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		switch iter.Key() {
+		case "stepCount":
+			err := (*numericStats)(&e.StepCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "stepCountInternal":
+			err := (*numericStats)(&e.StepCountInternal).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "seekCount":
+			err := (*numericStats)(&e.SeekCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "seekCountInternal":
+			err := (*numericStats)(&e.SeekCountInternal).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "blockBytes":
+			err := (*numericStats)(&e.BlockBytes).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "blockBytesInCache":
+			err := (*numericStats)(&e.BlockBytesInCache).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "keyBytes":
+			err := (*numericStats)(&e.KeyBytes).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "valueBytes":
+			err := (*numericStats)(&e.ValueBytes).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "pointCount":
+			err := (*numericStats)(&e.PointCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "pointsCoveredByRangeTombstones":
+			err := (*numericStats)(&e.PointsCoveredByRangeTombstones).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "rangeKeyCount":
+			err := (*numericStats)(&e.RangeKeyCount).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "rangeKeyContainedPoints":
+			err := (*numericStats)(&e.RangeKeyContainedPoints).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		case "rangeKeySkippedPoints":
+			err := (*numericStats)(&e.RangeKeySkippedPoints).decodeJSON(iter.Value())
+			if err != nil {
+				return err
+			}
+		}
+	}
+
+	return nil
 }
 
 func (e *iteratorStats) encodeJSON() (json.JSON, error) {
@@ -418,7 +831,25 @@ func (n *numericStats) jsonFields() jsonFields {
 }
 
 func (n *numericStats) decodeJSON(js json.JSON) error {
-	return n.jsonFields().decodeJSON(js)
+	// Decode "mean" field
+	if valJSON, err := js.FetchValKey("mean"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*jsonFloat)(&n.Mean).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "sqDiff" field
+	if valJSON, err := js.FetchValKey("sqDiff"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*jsonFloat)(&n.SquaredDiffs).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (n *numericStats) encodeJSON() (json.JSON, error) {
@@ -435,7 +866,25 @@ func (l *latencyInfo) jsonFields() jsonFields {
 }
 
 func (l *latencyInfo) decodeJSON(js json.JSON) error {
-	return l.jsonFields().decodeJSON(js)
+	// Decode "min" field
+	if valJSON, err := js.FetchValKey("min"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*jsonFloat)(&l.Min).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	// Decode "max" field
+	if valJSON, err := js.FetchValKey("max"); err != nil {
+		return err
+	} else if valJSON != nil {
+		if err := (*jsonFloat)(&l.Max).decodeJSON(valJSON); err != nil {
+			return err
+		}
+	}
+
+	return nil
 }
 
 func (l *latencyInfo) encodeJSON() (json.JSON, error) {
@@ -452,16 +901,17 @@ func (jf jsonFields) decodeJSON(js json.JSON) (err error) {
 		}
 	}()
 
-	for i := range jf {
-		fieldName = jf[i].field
-		field, err := js.FetchValKey(fieldName)
-		if err != nil {
-			return err
-		}
-		if field != nil {
-			err = jf[i].val.decodeJSON(field)
-			if err != nil {
-				return err
+	iter, err := js.ObjectIter()
+	if err != nil {
+		return err
+	}
+	for ok := iter.Next(); ok; ok = iter.Next() {
+		for i := range jf {
+			if jf[i].field == iter.Key() {
+				err := jf[i].val.decodeJSON(iter.Value())
+				if err != nil {
+					return err
+				}
 			}
 		}
 	}


### PR DESCRIPTION
## sqlstats: inline jsonFields and use iterator during 

Previously, we would look up individual fields in the JSON objects
when decoding, this would result in unnecessary iteration through
the object. We were also constructing a `jsonFields` on every decode
request.

```
❯ benchdiff ./pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/ --old https://github.com/cockroachdb/cockroach/commit/0e9251dba2fd91e153974e2701f73c93871f9d91 -b -r 'SQLStatsJson' -c 10 --preview
old:  https://github.com/cockroachdb/cockroach/commit/0e9251dba2fd91e153974e2701f73c93871f9d91 Merge https://github.com/cockroachdb/cockroach/pull/150535 https://github.com/cockroachdb/cockroach/pull/150771 https://github.com/cockroachdb/cockroach/pull/150947 https://github.com/cockroachdb/cockroach/pull/150949
new:  e768737 sqlstats: inline jsonFields during encode
args: benchdiff "./pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/" "--old" "0e9251db" "-b" "-r" "SQLStatsJson" "-c" "10" "--preview"

name                                         old time/op    new time/op    delta
SQLStatsJson/statement_metadata/decoding-10     406ns ± 1%     117ns ± 2%   -71.10%  (p=0.000 n=9+9)
SQLStatsJson/statement_stats/decoding-10       6.62µs ± 1%    4.41µs ± 0%   -33.36%  (p=0.000 n=9+10)
SQLStatsJson/transaction_stats/decoding-10     4.96µs ± 2%    3.67µs ± 0%   -26.08%  (p=0.000 n=10+9)

name                                         old speed      new speed      delta
SQLStatsJson/statement_metadata/decoding-10   986MB/s ± 1%  3412MB/s ± 2%  +245.96%  (p=0.000 n=9+9)
SQLStatsJson/statement_stats/decoding-10     1.11GB/s ± 1%  1.88GB/s ± 0%   +69.66%  (p=0.000 n=9+10)
SQLStatsJson/transaction_stats/decoding-10   1.14GB/s ± 2%  1.54GB/s ± 0%   +35.27%  (p=0.000 n=10+9)

name                                         old alloc/op   new alloc/op   delta
SQLStatsJson/statement_metadata/decoding-10      432B ± 0%       80B ± 0%   -81.48%  (p=0.000 n=10+10)
SQLStatsJson/statement_stats/decoding-10       3.54kB ± 0%    2.38kB ± 0%   -32.58%  (p=0.000 n=10+10)
SQLStatsJson/transaction_stats/decoding-10     2.56kB ± 0%    1.89kB ± 0%   -26.25%  (p=0.000 n=10+10)

name                                         old allocs/op  new allocs/op  delta
SQLStatsJson/transaction_stats/decoding-10       59.0 ± 0%      59.0 ± 0%      ~     (all equal)
SQLStatsJson/statement_metadata/decoding-10      4.00 ± 0%      4.00 ± 0%      ~     (all equal)
SQLStatsJson/statement_stats/decoding-10         75.0 ± 0%      78.0 ± 0%    +4.00%  (p=0.000 n=10+10)  
```

Epic: None
Release note: None

----

## sqlstats: inline jsonFields during encode

Previously, we would construct instances of `jsonFields` during
encoding which was unnecessary. This change unrolls those operations
and also uses a shared JSON builder object to reduce allocations.

```
❯ benchdiff ./pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/ --old https://github.com/cockroachdb/cockroach/commit/0e9251dba2fd91e153974e2701f73c93871f9d91 -b -r 'SQLStatsJson' -c 10 --preview
old:  https://github.com/cockroachdb/cockroach/commit/0e9251dba2fd91e153974e2701f73c93871f9d91 Merge https://github.com/cockroachdb/cockroach/pull/150535 https://github.com/cockroachdb/cockroach/pull/150771 https://github.com/cockroachdb/cockroach/pull/150947 https://github.com/cockroachdb/cockroach/pull/150949
new:  e768737 sqlstats: inline jsonFields during encode
args: benchdiff "./pkg/sql/sqlstats/persistedsqlstats/sqlstatsutil/" "--old" "0e9251db" "-b" "-r" "SQLStatsJson" "-c" "10" "--preview"

name                                         old time/op    new time/op    delta
SQLStatsJson/statement_metadata/encoding-10     738ns ± 1%     564ns ± 1%   -23.51%  (p=0.000 n=9+9)
SQLStatsJson/transaction_stats/encoding-10     13.3µs ± 1%    12.3µs ± 1%    -7.31%  (p=0.000 n=9+10)
SQLStatsJson/statement_stats/encoding-10       16.5µs ± 1%    15.6µs ± 1%    -5.32%  (p=0.000 n=10+9)

name                                         old speed      new speed      delta
SQLStatsJson/statement_metadata/encoding-10  1.01GB/s ± 1%  1.32GB/s ± 1%   +30.75%  (p=0.000 n=9+9)
SQLStatsJson/transaction_stats/encoding-10   43.1MB/s ± 1%  46.5MB/s ± 1%    +7.89%  (p=0.000 n=9+10)
SQLStatsJson/statement_stats/encoding-10     45.0MB/s ± 1%  47.6MB/s ± 1%    +5.62%  (p=0.000 n=10+9)

name                                         old alloc/op   new alloc/op   delta
SQLStatsJson/statement_metadata/encoding-10    1.13kB ± 0%    0.74kB ± 0%   -34.04%  (p=0.000 n=10+10)
SQLStatsJson/transaction_stats/encoding-10     9.79kB ± 0%    8.14kB ± 0%   -16.83%  (p=0.000 n=10+10)
SQLStatsJson/statement_stats/encoding-10       12.5kB ± 0%    11.9kB ± 0%    -4.74%  (p=0.000 n=10+10)

name                                         old allocs/op  new allocs/op  delta
SQLStatsJson/transaction_stats/encoding-10        296 ± 0%       255 ± 0%   -13.85%  (p=0.000 n=10+10)
SQLStatsJson/statement_stats/encoding-10          337 ± 0%       293 ± 0%   -13.06%  (p=0.000 n=10+10)
SQLStatsJson/statement_metadata/encoding-10      11.0 ± 0%      10.0 ± 0%    -9.09%  (p=0.000 n=10+10)
```

Epic: None
Release note: None