### PR TITLE
execbuilder: fix test flake in show_trace

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -5,6 +5,13 @@
 statement ok
 SET kv_transaction_buffered_writes_enabled = true
 
+# The buffer size can be changed metamoprhically, and if it happens to be too
+# small (around 1KiB), then some of the txns below might flush the buffer,
+# resulting in different KV requests. To ensure deterministic traces we always
+# update the buffer size to be large enough for txns in this file.
+statement ok
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '2KiB';
+
 # Check SHOW KV TRACE FOR SESSION.
 
 let $trace_query


### PR DESCRIPTION
We metamorphically change `kv.transaction.write_buffering.max_buffer_size` cluster setting in 1B - 4MiB range, and we happen to pick a small enough value, then one of the txns in `show_trace` test can disable write buffering, producing a different trace. This commit fixes the flake by ensuring a lower bound on the buffer size.

Fixes: #150719.

Release note: None