### PR TITLE
cli: add cluster_settings_history.txt to debug zip

### DIFF
--- a/pkg/cli/testdata/zip/file-filters/testzip_file_filters
+++ b/pkg/cli/testdata/zip/file-filters/testzip_file_filters
@@ -1,6 +1,7 @@
 #include all filters. We are excluding cpu.pprof file to avoid flakiness in tests.
 --include-files=* --exclude-files=cpu.pprof
 ----
+debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
@@ -144,6 +145,7 @@ debug/tenant_ranges.err.txt
 #include only txt files
 --include-files=*.txt
 ----
+debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
@@ -294,6 +296,7 @@ debug/tenant_ranges.err.txt
 #exclude only log files. We are excluding cpu.pprof file to avoid flakiness in tests.
 --exclude-files=*.log,cpu.pprof
 ----
+debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
@@ -438,6 +441,7 @@ debug/tenant_ranges.err.txt
 #exclude only json files. We are excluding cpu.pprof file to avoid flakiness in tests.
 --exclude-files=*.json,cpu.pprof
 ----
+debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt
@@ -550,6 +554,7 @@ debug/tenant_ranges.err.txt
 #include only txt files with system table file exclustion
 --include-files=*.txt --exclude-files=system.*.txt
 ----
+debug/cluster_settings_history.txt
 debug/crdb_internal.cluster_contention_events.txt
 debug/crdb_internal.cluster_database_privileges.txt
 debug/crdb_internal.cluster_distsql_flows.txt

--- a/pkg/cli/zip_test.go
+++ b/pkg/cli/zip_test.go
@@ -135,6 +135,7 @@ ORDER BY name ASC`)
 		tables = append(tables, table)
 	}
 	tables = append(tables, "crdb_internal.probe_ranges_1s_read_limit_100")
+	tables = append(tables, "cluster_settings_history")
 	sort.Strings(tables)
 
 	var exp []string


### PR DESCRIPTION
Adds a new file exported to debug zip called
"cluster_settings_history.txt" which provides a history of cluster setting changes, as they exist in the system event log table. This means history will only exist as long as the events haven't been removed from the table.

Sensitive cluster settings will always be redacted in this file, and non reportable cluster settings will be redacted for redacted debug zips.

Epic: CRDB-52093
Resolves: CRDB-50883
Release note (cli change): Adds a new file to debug zip that provides a history of cluster setting changes. Sensitive cluster settings will always be redacted in this file, and non reportable cluster settings will be redacted for redacted debug zips.