### PR TITLE
wip: restrict access to the crdb_internal and system databases

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -797,6 +797,42 @@ a table marked as audited.
 | `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
 | `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
 
+### `unsafe_table_access`
+
+An event of type `unsafe_table_access` is recorded when an access is performed to
+an unsafe internal table.
+
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Query` | The query which generated this access. | no |
+
+
+#### Common fields
+
+| Field | Description | Sensitive |
+|--|--|--|
+| `Timestamp` | The timestamp of the event. Expressed as nanoseconds since the Unix epoch. | no |
+| `EventType` | The type of the event. | no |
+| `Statement` | A normalized copy of the SQL statement that triggered the event. The statement string contains a mix of sensitive and non-sensitive details (it is redactable). | partially |
+| `Tag` | The statement tag. This is separate from the statement string, since the statement string can contain sensitive information. The tag is guaranteed not to. | no |
+| `User` | The user account that triggered the event. The special usernames `root` and `node` are not considered sensitive. | depends |
+| `DescriptorID` | The primary object descriptor affected by the operation. Set to zero for operations that don't affect descriptors. | no |
+| `ApplicationName` | The application name for the session where the event was emitted. This is included in the event to ease filtering of logging output by application. | no |
+| `PlaceholderValues` | The mapping of SQL placeholders to their values, for prepared statements. | yes |
+| `TxnReadTimestamp` | The current read timestamp of the transaction that triggered the event, if in a transaction. | no |
+| `ExecMode` | How the statement was being executed (exec/prepare, etc.) | no |
+| `NumRows` | Number of rows returned. For mutation statements (INSERT, etc) that do not produce result rows, this field reports the number of rows affected. | no |
+| `SQLSTATE` | The SQLSTATE code for the error, if an error was encountered. Empty/omitted if no error. | no |
+| `ErrorText` | The text of the error if any. | partially |
+| `Age` | Age of the query in milliseconds. | no |
+| `NumRetries` | Number of retries, when the txn was reretried automatically by the server. | no |
+| `FullTableScan` | Whether the query contains a full table scan. | no |
+| `FullIndexScan` | Whether the query contains a full secondary index scan of a non-partial index. | no |
+| `TxnCounter` | The sequence number of the SQL transaction inside its session. | no |
+| `BulkJobId` | The job id for bulk job (IMPORT/BACKUP/RESTORE). | no |
+| `StmtPosInTxn` | The statement's index in the transaction, starting at 1. | no |
+
 ## SQL Execution Log
 
 Events in this category report executed queries.

--- a/pkg/BUILD.bazel
+++ b/pkg/BUILD.bazel
@@ -2385,6 +2385,7 @@ GO_TARGETS = [
     "//pkg/sql/ttl/ttlschedule:ttlschedule",
     "//pkg/sql/types:types",
     "//pkg/sql/types:types_test",
+    "//pkg/sql/unsafe:unsafe",
     "//pkg/sql/vecindex/cspann/commontest:commontest",
     "//pkg/sql/vecindex/cspann/memstore:memstore",
     "//pkg/sql/vecindex/cspann/memstore:memstore_test",

--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -545,6 +545,7 @@ go_library(
         "//pkg/sql/tablemetadatacache/util",
         "//pkg/sql/ttl/ttlbase",
         "//pkg/sql/types",
+        "//pkg/sql/unsafe",
         "//pkg/sql/vecindex",
         "//pkg/sql/vecindex/vecpb",
         "//pkg/sql/vecindex/vecstore",

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -235,29 +235,29 @@ var crdbInternal = virtualSchema{
 	validWithNoDatabaseContext: true,
 }
 
-// SupportedVTables are the crdb_internal tables that are "supported" for real
+// SupportedCRDBInternalTables are the crdb_internal tables that are "supported" for real
 // customer use in production for legacy reasons. Avoid adding to this list if
 // possible and prefer to add new customer-facing tables that should be public
 // under the non-"internal" namespace of information_schema.
-var SupportedVTables = map[string]struct{}{
-	`"".crdb_internal.cluster_contended_indexes`:     {},
-	`"".crdb_internal.cluster_contended_keys`:        {},
-	`"".crdb_internal.cluster_contended_tables`:      {},
-	`"".crdb_internal.cluster_contention_events`:     {},
-	`"".crdb_internal.cluster_locks`:                 {},
-	`"".crdb_internal.cluster_queries`:               {},
-	`"".crdb_internal.cluster_sessions`:              {},
-	`"".crdb_internal.cluster_transactions`:          {},
-	`"".crdb_internal.index_usage_statistics`:        {},
-	`"".crdb_internal.statement_statistics`:          {},
-	`"".crdb_internal.transaction_contention_events`: {},
-	`"".crdb_internal.transaction_statistics`:        {},
-	`"".crdb_internal.zones`:                         {},
+var SupportedCRDBInternalTables = map[string]struct{}{
+	`cluster_contended_indexes`:     {},
+	`cluster_contended_keys`:        {},
+	`cluster_contended_tables`:      {},
+	`cluster_contention_events`:     {},
+	`cluster_locks`:                 {},
+	`cluster_queries`:               {},
+	`cluster_sessions`:              {},
+	`cluster_transactions`:          {},
+	`index_usage_statistics`:        {},
+	`statement_statistics`:          {},
+	`transaction_contention_events`: {},
+	`transaction_statistics`:        {},
+	`zones`:                         {},
 }
 
 // Note that this map is currently unused but serves to document which vtables
 // are expected to be used in production setting.
-var _ = SupportedVTables
+var _ = SupportedCRDBInternalTables
 
 var crdbInternalBuildInfoTable = virtualSchemaTable{
 	comment: `detailed identification strings (RAM, local node only)`,

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -263,8 +263,8 @@ func constructVirtualScan(
 	if err != nil {
 		return nil, err
 	}
-	if !canQueryVirtualTable(p.EvalContext(), virtual) {
-		return nil, newUnimplementedVirtualTableError(tn.Schema(), tn.Table())
+	if err := canQueryVirtualTable(p, virtual, tn); err != nil {
+		return nil, err
 	}
 	idx := index.(*optVirtualIndex).idx
 	columns, constructor := virtual.getPlanInfo(

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -4267,6 +4267,10 @@ func (m *sessionDataMutator) SetUseProcTxnControlExtendedProtocolFix(val bool) {
 	m.data.UseProcTxnControlExtendedProtocolFix = val
 }
 
+func (m *sessionDataMutator) SetAllowUnsafeInternals(val bool) {
+	m.data.AllowUnsafeInternals = val
+}
+
 // Utility functions related to scrubbing sensitive information on SQL Stats.
 
 // quantizeCounts ensures that the Count field in the

--- a/pkg/sql/opt/cat/catalog.go
+++ b/pkg/sql/opt/cat/catalog.go
@@ -286,4 +286,7 @@ type Catalog interface {
 
 	// IsOwner returns true if user is the owner of the object o
 	IsOwner(ctx context.Context, o Object, user username.SQLUsername) (bool, error)
+
+	// DisableUnsafeInternalCheck disables the checks on unsafe internal access
+	DisableUnsafeInternalCheck() func()
 }

--- a/pkg/sql/opt/optbuilder/BUILD.bazel
+++ b/pkg/sql/opt/optbuilder/BUILD.bazel
@@ -53,6 +53,7 @@ go_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/sql/opt/optbuilder",
     visibility = ["//visibility:public"],
     deps = [
+        "//pkg/base/serverident",
         "//pkg/build",
         "//pkg/clusterversion",
         "//pkg/kv/kvserver/concurrency/isolation",
@@ -101,6 +102,7 @@ go_library(
         "//pkg/sql/sqltelemetry",
         "//pkg/sql/syntheticprivilege",
         "//pkg/sql/types",
+        "//pkg/sql/unsafe",
         "//pkg/util",
         "//pkg/util/buildutil",
         "//pkg/util/errorutil",

--- a/pkg/sql/opt/testutils/testcat/test_catalog.go
+++ b/pkg/sql/opt/testutils/testcat/test_catalog.go
@@ -551,6 +551,10 @@ func (tc *Catalog) ExecuteMultipleDDL(sql string) error {
 	return nil
 }
 
+func (tc *Catalog) DisableUnsafeInternalCheck() func() {
+	return func() {}
+}
+
 // ExecuteDDL parses the given DDL SQL statement and creates objects in the test
 // catalog. This is used to test without spinning up a cluster.
 func (tc *Catalog) ExecuteDDL(sql string) (string, error) {

--- a/pkg/sql/opt_catalog.go
+++ b/pkg/sql/opt_catalog.go
@@ -742,6 +742,13 @@ func (oc *optCatalog) codec() keys.SQLCodec {
 	return oc.planner.ExecCfg().Codec
 }
 
+func (oc *optCatalog) DisableUnsafeInternalCheck() func() {
+	oc.planner.skipUnsafeInternalsCheck = true
+	return func() {
+		oc.planner.skipUnsafeInternalsCheck = false
+	}
+}
+
 // optView is a wrapper around catalog.TableDescriptor that implements
 // the cat.Object, cat.DataSource, and cat.View interfaces.
 type optView struct {

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -811,8 +811,8 @@ func constructVirtualTableLookupJoin(
 	if err != nil {
 		return nil, err
 	}
-	if !canQueryVirtualTable(p.EvalContext(), virtual) {
-		return nil, newUnimplementedVirtualTableError(tn.Schema(), tn.Table())
+	if err := canQueryVirtualTable(p, virtual, tn); err != nil {
+		return nil, err
 	}
 	if len(eqCols) > 1 {
 		return nil, errors.AssertionFailedf("vtable indexes with more than one column aren't supported yet")

--- a/pkg/sql/schema_resolver.go
+++ b/pkg/sql/schema_resolver.go
@@ -29,6 +29,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/errors"
 	"github.com/lib/pq/oid"
 )
@@ -46,6 +47,8 @@ type schemaResolver struct {
 	sessionDataStack *sessiondata.Stack
 	txn              *kv.Txn
 	authAccessor     scbuild.AuthorizationAccessor
+	ambientCtx       *log.AmbientContext
+	stmt             Statement
 
 	// skipDescriptorCache, when true, instructs all code that accesses table/view
 	// descriptors to force reading the descriptors within the transaction. This

--- a/pkg/sql/sessiondatapb/local_only_session_data.proto
+++ b/pkg/sql/sessiondatapb/local_only_session_data.proto
@@ -728,6 +728,9 @@ message LocalOnlySessionData {
   // then the heuristic applies to all statements (both read-only and
   // mutations), regardless of the table being multi-region.
   bool parallelize_multi_key_lookup_joins_only_on_mr_mutations = 182 [(gogoproto.customname) = "ParallelizeMultiKeyLookupJoinsOnlyOnMRMutations"];
+  // AllowUnsafeInternals allows the caller to access the crdb_internal
+  // or system databases within queries.
+  bool allow_unsafe_internals = 183;
 
   ///////////////////////////////////////////////////////////////////////////
   // WARNING: consider whether a session parameter you're adding needs to  //

--- a/pkg/sql/sqlerrors/errors.go
+++ b/pkg/sql/sqlerrors/errors.go
@@ -661,6 +661,7 @@ var (
 	ErrNoType            = pgerror.New(pgcode.InvalidName, "no type specified")
 	ErrNoFunction        = pgerror.New(pgcode.InvalidName, "no function specified")
 	ErrNoMatch           = pgerror.New(pgcode.UndefinedObject, "no object matched")
+	ErrUnsafeTableAccess = pgerror.New(pgcode.InsufficientPrivilege, "Access to crdb_internal and system is restricted. These interfaces are unsupported in production. To proceed, set the session variable allow_unsafe_internals = true (not recommended), or contact Cockroach Labs for a supported alternative.")
 )
 
 var ErrNoZoneConfigApplies = errors.New("no zone config applies")

--- a/pkg/sql/unsafe/BUILD.bazel
+++ b/pkg/sql/unsafe/BUILD.bazel
@@ -1,0 +1,16 @@
+load("@io_bazel_rules_go//go:def.bzl", "go_library")
+
+go_library(
+    name = "unsafe",
+    srcs = ["unsafe.go"],
+    importpath = "github.com/cockroachdb/cockroach/pkg/sql/unsafe",
+    visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/sql/sem/tree",
+        "//pkg/sql/sessiondata",
+        "//pkg/sql/sqlerrors",
+        "//pkg/util/log",
+        "//pkg/util/log/eventpb",
+        "@com_github_cockroachdb_redact//:redact",
+    ],
+)

--- a/pkg/sql/unsafe/unsafe.go
+++ b/pkg/sql/unsafe/unsafe.go
@@ -1,0 +1,59 @@
+// Copyright 2017 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package unsafe
+
+import (
+	"context"
+
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/sessiondata"
+	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/redact"
+)
+
+// HasUnsafeInternalsAccess checks if the current session has permission to access
+// unsafe internal tables and functionality. This includes system tables and
+// virtual tables in the crdb_internal schema.
+func HasUnsafeInternalsAccess(
+	ctx context.Context,
+	actx *log.AmbientContext,
+	sd *sessiondata.SessionData,
+	stmt tree.Statement,
+	ann *tree.Annotations,
+) error {
+	// If the querier is internal, we should allow it.
+	if sd.Internal {
+		return nil
+	}
+
+	// If an override is set, allow access to this virtual table.
+	if sd.AllowUnsafeInternals {
+		// As this is considered a "broken glass" situation, we report the access to the event log.
+		log.EventLog(ctx, actx, &eventpb.UnsafeTableAccess{Query: formatStmtKeyAsRedactableString(stmt, ann)})
+		return nil
+	}
+
+	log.SqlExec.Errorf(ctx, "unsafe table access attempted: %s", stmt)
+	return sqlerrors.ErrUnsafeTableAccess
+}
+
+// formatStmtKeyAsRedactableString given an AST node this function will fully
+// qualify names using annotations to format it out into a redactable string.
+// Object names are not redacted, but constants and datums are.
+func formatStmtKeyAsRedactableString(
+	rootAST tree.Statement, ann *tree.Annotations,
+) redact.RedactableString {
+	fs := tree.FmtSimple | tree.FmtAlwaysQualifyTableNames | tree.FmtMarkRedactionNode
+	f := tree.NewFmtCtx(
+		fs,
+		tree.FmtAnnotations(ann),
+	)
+	f.FormatNode(rootAST)
+	formattedRedactableStatementString := f.CloseAndGetString()
+	return redact.RedactableString(formattedRedactableStatementString)
+}

--- a/pkg/sql/vars.go
+++ b/pkg/sql/vars.go
@@ -4318,6 +4318,25 @@ var varGen = map[string]sessionVar{
 		},
 		GlobalDefault: globalTrue,
 	},
+
+	// CockroachDB extension.
+	`allow_unsafe_internals`: {
+		GetStringVal: makePostgresBoolGetStringValFn(`allow_unsafe_internals`),
+		Set: func(_ context.Context, m sessionDataMutator, s string) error {
+			b, err := paramparse.ParseBoolVar("allow_unsafe_internals", s)
+			if err != nil {
+				return err
+			}
+			m.SetAllowUnsafeInternals(b)
+			return nil
+		},
+		Get: func(evalCtx *extendedEvalContext, _ *kv.Txn) (string, error) {
+			return formatBoolAsPostgresSetting(evalCtx.SessionData().AllowUnsafeInternals), nil
+		},
+		GlobalDefault: func(sv *settings.Values) string {
+			return "false"
+		},
+	},
 }
 
 func ReplicationModeFromString(s string) (sessiondatapb.ReplicationMode, error) {

--- a/pkg/sql/virtual_schema.go
+++ b/pkg/sql/virtual_schema.go
@@ -574,11 +574,16 @@ func (e *virtualDefEntry) Desc() catalog.Descriptor {
 	return e.desc
 }
 
-func canQueryVirtualTable(evalCtx *eval.Context, e *virtualDefEntry) bool {
-	return !e.unimplemented ||
+func canQueryVirtualTable(p *planner, e *virtualDefEntry, tn *tree.TableName) error {
+	evalCtx := p.EvalContext()
+	implementedAndEnabled := !e.unimplemented ||
 		evalCtx == nil ||
 		evalCtx.SessionData() == nil ||
 		evalCtx.SessionData().StubCatalogTablesEnabled
+	if !implementedAndEnabled {
+		return newUnimplementedVirtualTableError(tn.Schema(), tn.Table())
+	}
+	return nil
 }
 
 type virtualTypeEntry struct {

--- a/pkg/util/log/eventpb/eventlog_channels_generated.go
+++ b/pkg/util/log/eventpb/eventlog_channels_generated.go
@@ -95,6 +95,9 @@ func (m *RoleBasedAuditEvent) LoggingChannel() logpb.Channel { return logpb.Chan
 func (m *SensitiveTableAccess) LoggingChannel() logpb.Channel { return logpb.Channel_SENSITIVE_ACCESS }
 
 // LoggingChannel implements the EventPayload interface.
+func (m *UnsafeTableAccess) LoggingChannel() logpb.Channel { return logpb.Channel_SENSITIVE_ACCESS }
+
+// LoggingChannel implements the EventPayload interface.
 func (m *QueryExecute) LoggingChannel() logpb.Channel { return logpb.Channel_SQL_EXEC }
 
 // LoggingChannel implements the EventPayload interface.

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -6542,6 +6542,28 @@ func (m *UnsafeDeleteNamespaceEntry) AppendJSONFields(printComma bool, b redact.
 }
 
 // AppendJSONFields implements the EventPayload interface.
+func (m *UnsafeTableAccess) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
+
+	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLEventDetails.AppendJSONFields(printComma, b)
+
+	printComma, b = m.CommonSQLExecDetails.AppendJSONFields(printComma, b)
+
+	if m.Query != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"Query\":\""...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(m.Query)))
+		b = append(b, '"')
+	}
+
+	return printComma, b
+}
+
+// AppendJSONFields implements the EventPayload interface.
 func (m *UnsafeUpsertDescriptor) AppendJSONFields(printComma bool, b redact.RedactableBytes) (bool, redact.RedactableBytes) {
 
 	printComma, b = m.CommonEventDetails.AppendJSONFields(printComma, b)

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -67,6 +67,16 @@ message SensitiveTableAccess {
   string access_mode = 5 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
 }
 
+// UnsafeTableAccess is recorded when an access is performed to
+// an unsafe internal table.
+message UnsafeTableAccess {
+  CommonEventDetails common = 1 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLEventDetails sql = 2 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  CommonSQLExecDetails exec = 3 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
+  // The query which generated this access.
+  string query = 4 [(gogoproto.jsontag) = ",omitempty", (gogoproto.customtype) = "github.com/cockroachdb/redact.RedactableString", (gogoproto.nullable) = false, (gogoproto.moretags) = "redact:\"nonsensitive\""];
+}
+
 // AdminQuery is recorded when a user with admin privileges (the user
 // is directly or indirectly a member of the admin role) executes a query.
 message AdminQuery {


### PR DESCRIPTION
This proof of concept shows what could be done to gate access to the `system` and `crdb_internal` tables, as well as audit its usage.

It does this by adding a `assertHasUnsafeInternals` function in `authorization.go` which is called in `CheckPrivilege` for the system database, `canQueryVirtualTable` for the `crdb_internal` schema, and `SchemaResolver.ResolveFunction` for the `crdb_internal` built ins.