### PR TITLE
sqlstats: rename constructors and fields for legibility

### DIFF
--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -438,7 +438,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 	metrics := makeMetrics(false /* internal */, &cfg.Settings.SV)
 	serverMetrics := makeServerMetrics(cfg)
 	insightsProvider := insights.New(cfg.Settings, serverMetrics.InsightsMetrics)
-	reportedSQLStats := sslocal.New(
+	reportedSQLStats := sslocal.NewSQLStats(
 		cfg.Settings,
 		sqlstats.MaxMemReportedSQLStatsStmtFingerprints,
 		sqlstats.MaxMemReportedSQLStatsTxnFingerprints,
@@ -448,7 +448,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		nil, /* reportedProvider */
 		cfg.SQLStatsTestingKnobs,
 	)
-	memSQLStats := sslocal.New(
+	memSQLStats := sslocal.NewSQLStats(
 		cfg.Settings,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
 		sqlstats.MaxMemSQLStatsTxnFingerprints,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -336,8 +336,8 @@ type Server struct {
 
 	cfg *ExecutorConfig
 
-	// sqlStats provides the mechanisms for writing sql stats to system tables.
-	sqlStats *persistedsqlstats.PersistedSQLStats
+	// persistedSQLStats provides the mechanisms for writing sql stats to system tables.
+	persistedSQLStats *persistedsqlstats.PersistedSQLStats
 
 	// localSqlStats tracks per-application statistics for all applications on each
 	// node. Newly collected statistics flow into localSqlStats.
@@ -448,7 +448,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		nil, /* reportedProvider */
 		cfg.SQLStatsTestingKnobs,
 	)
-	memSQLStats := sslocal.NewSQLStats(
+	localSQLStats := sslocal.NewSQLStats(
 		cfg.Settings,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
@@ -471,7 +471,7 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		InternalMetrics:   makeMetrics(true /* internal */, &cfg.Settings.SV),
 		ServerMetrics:     serverMetrics,
 		pool:              pool,
-		localSqlStats:     memSQLStats,
+		localSqlStats:     localSQLStats,
 		reportedStats:     reportedSQLStats,
 		sqlStatsIngester:  sqlStatsIngester,
 		insights:          insightsProvider,
@@ -508,9 +508,9 @@ func NewServer(cfg *ExecutorConfig, pool *mon.BytesMonitor) *Server {
 		FlushedFingerprintCount: serverMetrics.StatsMetrics.SQLStatsFlushFingerprintCount,
 		FlushesFailed:           serverMetrics.StatsMetrics.SQLStatsFlushesFailed,
 		FlushLatency:            serverMetrics.StatsMetrics.SQLStatsFlushLatency,
-	}, memSQLStats)
+	}, localSQLStats)
 
-	s.sqlStats = persistedSQLStats
+	s.persistedSQLStats = persistedSQLStats
 	schemaTelemetryIEMonitor := MakeInternalExecutorMemMonitor(MemoryMetrics{}, s.GetExecutorConfig().Settings)
 	schemaTelemetryIEMonitor.StartNoReserved(context.Background(), s.GetBytesMonitor())
 	s.schemaTelemetryController = schematelemetrycontroller.NewController(
@@ -684,7 +684,7 @@ func (s *Server) Start(ctx context.Context, stopper *stop.Stopper) {
 	ctx = multitenant.WithTenantCostControlExemption(ctx)
 
 	s.sqlStatsIngester.Start(ctx, stopper)
-	s.sqlStats.Start(ctx, stopper)
+	s.persistedSQLStats.Start(ctx, stopper)
 
 	s.schemaTelemetryController.Start(ctx, stopper)
 
@@ -716,7 +716,7 @@ func (s *Server) GetInsightsReader() *insights.LockingStore {
 
 // GetSQLStatsProvider returns the provider for the sqlstats subsystem.
 func (s *Server) GetSQLStatsProvider() *persistedsqlstats.PersistedSQLStats {
-	return s.sqlStats
+	return s.persistedSQLStats
 }
 
 // GetLocalSQLStatsProvider returns the in-memory provider for the sqlstats subsystem.
@@ -3817,7 +3817,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 			SessionDataStack:               ex.sessionDataStack,
 			ReCache:                        ex.server.reCache,
 			ToCharFormatCache:              ex.server.toCharFormatCache,
-			SQLStatsController:             ex.server.sqlStats,
+			SQLStatsController:             ex.server.persistedSQLStats,
 			SchemaTelemetryController:      ex.server.schemaTelemetryController,
 			IndexUsageStatsController:      ex.server.indexUsageStatsController,
 			ConsistencyChecker:             p.execCfg.ConsistencyChecker,
@@ -3838,7 +3838,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		TxnModesSetter:       ex,
 		jobs:                 ex.extraTxnState.jobs,
 		validateDbZoneConfig: &ex.extraTxnState.validateDbZoneConfig,
-		statsProvider:        ex.server.sqlStats,
+		statsProvider:        ex.server.persistedSQLStats,
 		localStatsProvider:   ex.server.localSqlStats,
 		indexUsageStats:      ex.indexUsageStats,
 		statementPreparer:    ex,

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3839,7 +3839,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		jobs:                 ex.extraTxnState.jobs,
 		validateDbZoneConfig: &ex.extraTxnState.validateDbZoneConfig,
 		statsProvider:        ex.server.persistedSQLStats,
-		localStatsProvider:   ex.server.localSqlStats,
+		localSQLStats:        ex.server.localSqlStats,
 		indexUsageStats:      ex.indexUsageStats,
 		statementPreparer:    ex,
 	}

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3838,7 +3838,7 @@ func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalCo
 		TxnModesSetter:       ex,
 		jobs:                 ex.extraTxnState.jobs,
 		validateDbZoneConfig: &ex.extraTxnState.validateDbZoneConfig,
-		statsProvider:        ex.server.persistedSQLStats,
+		persistedSQLStats:    ex.server.persistedSQLStats,
 		localSQLStats:        ex.server.localSqlStats,
 		indexUsageStats:      ex.indexUsageStats,
 		statementPreparer:    ex,

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -1493,7 +1493,7 @@ CREATE TABLE crdb_internal.node_statement_statistics (
 		}
 
 		var alloc tree.DatumAlloc
-		localSqlStats := p.extendedEvalCtx.localStatsProvider
+		localSqlStats := p.extendedEvalCtx.localSQLStats
 		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		statementVisitor := func(_ context.Context, stats *appstatspb.CollectedStatementStatistics) error {
@@ -1716,7 +1716,7 @@ CREATE TABLE crdb_internal.node_transaction_statistics (
 			return noViewActivityOrViewActivityRedactedRoleError(p.User())
 		}
 
-		localMemSqlStats := p.extendedEvalCtx.localStatsProvider
+		localMemSqlStats := p.extendedEvalCtx.localSQLStats
 		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		var alloc tree.DatumAlloc
@@ -1818,7 +1818,7 @@ CREATE TABLE crdb_internal.node_txn_stats (
 			return err
 		}
 
-		localMemSqlStats := p.extendedEvalCtx.localStatsProvider
+		localMemSqlStats := p.extendedEvalCtx.localSQLStats
 		nodeID, _ := p.execCfg.NodeInfo.NodeID.OptionalNodeID() // zero if not available
 
 		appTxnStatsVisitor := func(appName string, stats *appstatspb.TxnStats) error {

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -6934,7 +6934,7 @@ CREATE TABLE crdb_internal.cluster_statement_statistics (
 			return nil, nil, err
 		}
 
-		s := p.extendedEvalCtx.statsProvider
+		s := p.extendedEvalCtx.persistedSQLStats
 		curAggTs := s.ComputeAggregatedTs()
 		aggInterval := s.GetAggregationInterval()
 
@@ -7360,7 +7360,7 @@ CREATE TABLE crdb_internal.cluster_transaction_statistics (
 			return nil, nil, err
 		}
 
-		s := p.extendedEvalCtx.statsProvider
+		s := p.extendedEvalCtx.persistedSQLStats
 		curAggTs := s.ComputeAggregatedTs()
 		aggInterval := s.GetAggregationInterval()
 

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -522,7 +522,7 @@ func internalExtendedEvalCtx(
 		if ief.server != nil {
 			indexUsageStats = ief.server.indexUsageStats
 			schemaTelemetryController = ief.server.schemaTelemetryController
-			sqlStatsProvider = ief.server.sqlStats
+			sqlStatsProvider = ief.server.persistedSQLStats
 			localSqlStatsProvider = ief.server.localSqlStats
 		} else {
 			// If the indexUsageStats is nil from the sql.Server, we create a dummy

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -102,7 +102,7 @@ type extendedEvalContext struct {
 
 	statsProvider *persistedsqlstats.PersistedSQLStats
 
-	localStatsProvider *sslocal.SQLStats
+	localSQLStats *sslocal.SQLStats
 
 	indexUsageStats *idxusage.LocalIndexUsageStats
 
@@ -558,7 +558,7 @@ func internalExtendedEvalCtx(
 		Descs:              tables,
 		indexUsageStats:    indexUsageStats,
 		statsProvider:      sqlStatsProvider,
-		localStatsProvider: localSqlStatsProvider,
+		localSQLStats: localSqlStatsProvider,
 		jobs:               newTxnJobsCollection(),
 	}
 	ret.copyFromExecCfg(execCfg)

--- a/pkg/sql/planner.go
+++ b/pkg/sql/planner.go
@@ -100,7 +100,7 @@ type extendedEvalContext struct {
 	// jobs refers to jobs in extraTxnState.
 	jobs *txnJobsCollection
 
-	statsProvider *persistedsqlstats.PersistedSQLStats
+	persistedSQLStats *persistedsqlstats.PersistedSQLStats
 
 	localSQLStats *sslocal.SQLStats
 
@@ -554,12 +554,12 @@ func internalExtendedEvalCtx(
 			StmtDiagnosticsRequestInserter: execCfg.StmtDiagnosticsRecorder.InsertRequest,
 			RangeStatsFetcher:              execCfg.RangeStatsFetcher,
 		},
-		Tracing:            &SessionTracing{},
-		Descs:              tables,
-		indexUsageStats:    indexUsageStats,
-		statsProvider:      sqlStatsProvider,
-		localSQLStats: localSqlStatsProvider,
-		jobs:               newTxnJobsCollection(),
+		Tracing:           &SessionTracing{},
+		Descs:             tables,
+		indexUsageStats:   indexUsageStats,
+		persistedSQLStats: sqlStatsProvider,
+		localSQLStats:     localSqlStatsProvider,
+		jobs:              newTxnJobsCollection(),
 	}
 	ret.copyFromExecCfg(execCfg)
 	return ret

--- a/pkg/sql/sql_activity_update_job.go
+++ b/pkg/sql/sql_activity_update_job.go
@@ -95,7 +95,7 @@ func (j *sqlActivityUpdateJob) Resume(ctx context.Context, execCtxI interface{})
 	execCtx := execCtxI.(JobExecContext)
 	stopper := execCtx.ExecCfg().DistSQLSrv.Stopper
 	settings := execCtx.ExecCfg().Settings
-	statsFlush := execCtx.ExecCfg().InternalDB.server.sqlStats
+	statsFlush := execCtx.ExecCfg().InternalDB.server.persistedSQLStats
 	metrics := execCtx.ExecCfg().JobRegistry.MetricsStruct().JobSpecificMetrics[jobspb.TypeAutoUpdateSQLActivity].(ActivityUpdaterMetrics)
 
 	flushDoneSignal := make(chan struct{})

--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -452,7 +452,7 @@ func TestExplicitTxnFingerprintAccounting(t *testing.T) {
 		Settings: st,
 	})
 
-	sqlStats := sslocal.New(
+	sqlStats := sslocal.NewSQLStats(
 		st,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
 		sqlstats.MaxMemSQLStatsTxnFingerprints,
@@ -583,7 +583,7 @@ func TestAssociatingStmtStatsWithTxnFingerprint(t *testing.T) {
 		require.NoError(t, err)
 
 		// Construct the SQL Stats machinery.
-		sqlStats := sslocal.New(
+		sqlStats := sslocal.NewSQLStats(
 			st,
 			sqlstats.MaxMemSQLStatsStmtFingerprints,
 			sqlstats.MaxMemSQLStatsTxnFingerprints,
@@ -2071,7 +2071,7 @@ func createNewSqlStats() *sslocal.SQLStats {
 	})
 	sqlstats.MaxMemSQLStatsStmtFingerprints.Override(context.Background(), &st.SV, 100000)
 	sqlstats.MaxMemSQLStatsTxnFingerprints.Override(context.Background(), &st.SV, 100000)
-	sqlStats := sslocal.New(
+	sqlStats := sslocal.NewSQLStats(
 		st,
 		sqlstats.MaxMemSQLStatsStmtFingerprints,
 		sqlstats.MaxMemSQLStatsTxnFingerprints,

--- a/pkg/sql/sqlstats/sslocal/sslocal_provider.go
+++ b/pkg/sql/sqlstats/sslocal/sslocal_provider.go
@@ -23,8 +23,8 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// New returns an instance of SQLStats.
-func New(
+// NewSQLStats returns an instance of SQLStats.
+func NewSQLStats(
 	settings *cluster.Settings,
 	maxStmtFingerprints *settings.IntSetting,
 	maxTxnFingerprints *settings.IntSetting,


### PR DESCRIPTION
rename sslocal.New to NewSQLStats
rename sqlStats field to persistedSQLStats
rename localStatsProvider to localSQLStats
rename statsProvider field to persistedSQLStats

Epic: None
Release note: None