### PR TITLE
backfill: merge vectors from a temp forward index into a vector index

### DIFF
--- a/pkg/sql/backfill/BUILD.bazel
+++ b/pkg/sql/backfill/BUILD.bazel
@@ -40,6 +40,7 @@ go_library(
         "//pkg/sql/sem/idxtype",
         "//pkg/sql/sem/transform",
         "//pkg/sql/sem/tree",
+        "//pkg/sql/span",
         "//pkg/sql/sqlerrors",
         "//pkg/sql/types",
         "//pkg/sql/vecindex",

--- a/pkg/sql/backfill/backfill.go
+++ b/pkg/sql/backfill/backfill.go
@@ -12,6 +12,7 @@ import (
 	"time"
 	"unsafe"
 
+	"github.com/cockroachdb/cockroach/pkg/keys"
 	"github.com/cockroachdb/cockroach/pkg/kv"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/settings"
@@ -33,6 +34,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/transform"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
+	"github.com/cockroachdb/cockroach/pkg/sql/span"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex"
@@ -41,6 +43,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore"
 	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecstore/vecstorepb"
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
+	"github.com/cockroachdb/cockroach/pkg/util/intsets"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/mon"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
@@ -463,28 +466,114 @@ type muBoundAccount struct {
 	boundAccount mon.BoundAccount
 }
 
+// VectorIndexHelperBase contains the common fields shared between
+// VectorIndexHelper and VectorIndexMergeHelper.
+type VectorIndexHelperBase struct {
+	// vectorColID is the column ID of the vector column.
+	vectorColID catid.ColumnID
+	// numPrefixCols is the number of non-vector index key columns.
+	numPrefixCols int
+	// vecIndex is the vector index retrieved from the vector index manager.
+	vecIndex *cspann.Index
+	// tableDesc is the table descriptor for the table containing the vector index.
+	tableDesc catalog.TableDescriptor
+	// fullVecFetchSpec is the fetch spec for the full vector.
+	fullVecFetchSpec vecstorepb.GetFullVectorsFetchSpec
+}
+
+// initBase initializes the shared fields in VectorIndexHelperBase.
+func (vihb *VectorIndexHelperBase) initBase(
+	ctx context.Context,
+	evalCtx *eval.Context,
+	desc catalog.TableDescriptor,
+	destIndex catalog.Index,
+	sourceIndex catalog.Index,
+	vecIndexManager *vecindex.Manager,
+) error {
+	var err error
+
+	vihb.vectorColID = destIndex.VectorColumnID()
+	vihb.numPrefixCols = destIndex.NumKeyColumns() - 1
+	vihb.tableDesc = desc
+
+	vihb.vecIndex, err = vecIndexManager.Get(ctx, desc.GetID(), destIndex.GetID())
+	if err != nil {
+		return err
+	}
+
+	if err := vecstore.InitGetFullVectorsFetchSpec(
+		&vihb.fullVecFetchSpec,
+		evalCtx,
+		desc,
+		destIndex,
+		sourceIndex,
+	); err != nil {
+		return err
+	}
+
+	return nil
+}
+
 // VectorIndexHelper is used by backfill writers to re-encode vectors at write
 // time. This is necessary because the key written may change between the time
 // the key is read and the time it's written. So, instead of having the reader
 // write the exact keys it wants to be written, it uses some placeholder values
 // that are replaced at write time.
 type VectorIndexHelper struct {
+	VectorIndexHelperBase
 	// vectorOrd is the ordinal of the vector column in the table.
 	vectorOrd int
-	// centroid is an all zeros centroid of the appropriate dimension for the vector
-	// column. It's used to encode the vector in the reader. The writer will
-	// re-encode the vector with the centroid for the partition selected.
+	// centroid is an all zeros centroid of the appropriate dimension for the
+	// vector column. It's used to encode the vector in the reader. The writer
+	// will re-encode the vector with the centroid for the partition selected.
 	centroid vector.T
-	// number of non-vector index key columns
-	numPrefixCols int
-	// vecIndex is the vector index retrieved from the vector index manager.
-	vecIndex *cspann.Index
-	// fullVecFetchSpec is the fetch spec for the full vector.
-	fullVecFetchSpec vecstorepb.GetFullVectorsFetchSpec
 	// indexPrefix are the prefix bytes for this index (/Tenant/Table/Index).
 	indexPrefix []byte
 	// evalCtx is the evaluation context used for vector operations.
 	evalCtx *eval.Context
+	// vectorIndex is the vector index descriptor.
+	vectorIndex catalog.Index
+}
+
+// NewVectorIndexHelper initializes a VectorIndexHelper for the given index.
+// It returns a VectorIndexHelper that can be used to re-encode vectors for the
+// given index.
+func NewVectorIndexHelper(
+	ctx context.Context,
+	evalCtx *eval.Context,
+	desc catalog.TableDescriptor,
+	idx catalog.Index,
+	sourceIndexID catid.IndexID,
+	vecIndexManager *vecindex.Manager,
+) (*VectorIndexHelper, error) {
+	vectorCol, err := catalog.MustFindColumnByID(desc, idx.VectorColumnID())
+	if err != nil {
+		return nil, err
+	}
+
+	var sourceIndex catalog.Index
+	if sourceIndexID != 0 {
+		sourceIndex, err = catalog.MustFindIndexByID(desc, sourceIndexID)
+		if err != nil {
+			return nil, err
+		}
+	} else {
+		sourceIndex = desc.GetPrimaryIndex()
+	}
+
+	vih := &VectorIndexHelper{
+		vectorOrd:   vectorCol.Ordinal(),
+		centroid:    make(vector.T, idx.GetVecConfig().Dims),
+		indexPrefix: rowenc.MakeIndexKeyPrefix(evalCtx.Codec, desc.GetID(), idx.GetID()),
+		evalCtx:     evalCtx,
+		vectorIndex: idx,
+	}
+
+	if err := vih.initBase(ctx, evalCtx, desc, idx, sourceIndex, vecIndexManager); err != nil {
+		return nil, err
+	}
+
+	return vih, nil
 }
 
 // ReEncodeVector takes a rowenc.indexEntry, extracts the key values, unquantized
@@ -503,21 +592,19 @@ func (vih *VectorIndexHelper) ReEncodeVector(
 		return &rowenc.IndexEntry{}, err
 	}
 
-	// Decode vector and suffix bytes from the entry value.
 	valueBytes, err := inputEntry.Value.GetBytes()
 	if err != nil {
 		return &rowenc.IndexEntry{}, err
 	}
-	suffix, vec, err := vector.Decode(valueBytes)
+	suffix, vector, err := vector.Decode(valueBytes)
 	if err != nil {
 		return &rowenc.IndexEntry{}, err
 	}
 
-	// Locate a new partition for the key and re-encode the vector.
 	var searcher vecindex.MutationSearcher
 	searcher.Init(vih.evalCtx, vih.vecIndex, txn, &vih.fullVecFetchSpec)
 
-	if err := searcher.SearchForInsert(ctx, roachpb.Key(key.Prefix), vec); err != nil {
+	if err := searcher.SearchForInsert(ctx, roachpb.Key(key.Prefix), vector); err != nil {
 		return &rowenc.IndexEntry{}, err
 	}
 	key.PartitionKey = cspann.PartitionKey(tree.MustBeDInt(searcher.PartitionKey()))
@@ -537,6 +624,285 @@ func (vih *VectorIndexHelper) ReEncodeVector(
 	outputEntry.Family = inputEntry.Family
 
 	return outputEntry, nil
+}
+
+// VectorIndexMergeHelper is used to initialize the VectorIndexMergerTxn. It
+// contains the state that is stable over the lifetime of the merge operation
+// and is safe to share across different go routines.
+type VectorIndexMergeHelper struct {
+	VectorIndexHelperBase
+	// codec is the codec for the table.
+	codec keys.SQLCodec
+
+	// sourcePrefix is the prefix for the source index.
+	sourcePrefix []byte
+	// destIndex is the index descriptor of the vector index that is being built.
+	destIndex catalog.Index
+
+	// fetchSpec is the fetch spec for pulling values from the temporary index.
+	fetchSpec fetchpb.IndexFetchSpec
+	// colMap is the column map that maps column IDs to their position in the
+	// fetched rows of the fetchSpec.
+	colMap catalog.TableColMap
+	// vectorPos is the position of the vector column in the fetched rows
+	// of the fetchSpec.
+	vectorPos int
+
+	// primaryIndex is the primary index that should be used to execute this
+	// merge operation.
+	primaryIndex catalog.Index
+	// splitter is the span splitter for reading from the primary key.
+	splitter span.Splitter
+}
+
+// VectorIndexMergerTxn holds thread and transaction local state for repeated
+// calls to MergeVector to avoid allocations and repeated initialization.
+type VectorIndexMergerTxn struct {
+	vim *VectorIndexMergeHelper
+	// encRow is reused for decoding key values from temporary index entries
+	encRow rowenc.EncDatumRow
+	// rowDatums is reused for storing fetched row data from the primary key
+	rowDatums tree.Datums
+	// alloc is reused for datum allocations
+	alloc tree.DatumAlloc
+	// fetcher is reused for fetching row data from the primary key
+	fetcher row.Fetcher
+	// searcher is reused for vector index searches
+	searcher vecindex.MutationSearcher
+	// vectorEncodingHelper is reused for encoding vector index entries
+	vectorEncodingHelper rowenc.VectorIndexEncodingHelper
+	// spanToScan is the span to scan for the vector index
+	spansToScan roachpb.Spans
+	// builder is the span builder for reading from the primary key.
+	builder span.Builder
+}
+
+func (vimh *VectorIndexMergeHelper) Init(
+	ctx context.Context,
+	evalCtx *eval.Context,
+	desc catalog.TableDescriptor,
+	vecIndexManager *vecindex.Manager,
+	destIndex catalog.Index,
+	sourceIndex catalog.Index,
+) error {
+	// Initialize the base fields using the shared initialization
+	if err := vimh.initBase(ctx, evalCtx, desc, destIndex, desc.GetPrimaryIndex(), vecIndexManager); err != nil {
+		return err
+	}
+
+	vimh.sourcePrefix = rowenc.MakeIndexKeyPrefix(evalCtx.Codec, desc.GetID(), sourceIndex.GetID())
+	vimh.primaryIndex = desc.GetPrimaryIndex()
+	vimh.destIndex = destIndex
+	vimh.codec = evalCtx.Codec
+
+	// Initialize the merge fetch spec for extracting vector column and prefix
+	// columns from primary key. This is used by MergeVector to get the vector
+	// column and any prefix columns from primary key entries.
+	var columnsToFetch []descpb.ColumnID
+	var columnsSeen catalog.TableColSet
+
+	// Add all the vector index columns and then any unused PK columns
+	for _, index := range []catalog.Index{destIndex, vimh.primaryIndex} {
+		for i := range index.NumKeyColumns() {
+			colID := index.GetKeyColumnID(i)
+			if columnsSeen.Contains(colID) {
+				continue
+			}
+			columnsToFetch = append(columnsToFetch, colID)
+			columnsSeen.Add(colID)
+		}
+	}
+
+	// Initialize the fetch spec for pulling values from the primary key.
+	if err := rowenc.InitIndexFetchSpec(
+		&vimh.fetchSpec,
+		evalCtx.Codec,
+		desc,
+		vimh.primaryIndex,
+		columnsToFetch,
+	); err != nil {
+		return err
+	}
+
+	// Initialize the merge splitter for optimizing column family fetches
+	var neededColOrdinals intsets.Fast
+	for _, colSpec := range vimh.fetchSpec.FetchedColumns {
+		col, err := catalog.MustFindColumnByID(desc, colSpec.ColumnID)
+		if err != nil {
+			return err
+		}
+		neededColOrdinals.Add(col.Ordinal())
+	}
+	vimh.splitter = span.MakeSplitter(desc, vimh.primaryIndex, neededColOrdinals)
+
+	// Create a custom colMap that maps column IDs to positions in our packed
+	// rowDatums array. This includes both the vector index columns and the
+	// primary key columns.
+	for i, colSpec := range vimh.fetchSpec.FetchedColumns {
+		vimh.colMap.Set(colSpec.ColumnID, i)
+	}
+	// Extract the vector column from the fetched row using the colMap
+	// Find the position of the vector column in the rowDatums array
+	var found bool
+	vimh.vectorPos, found = vimh.colMap.Get(vimh.vectorColID)
+	if !found {
+		return errors.AssertionFailedf("vector column ID %d not found in colMap", vimh.vectorColID)
+	}
+
+	return nil
+}
+
+// NewVectorIndexMergerTxn initializes a VectorIndexMergerTxn for the given transaction.
+func (vimh *VectorIndexMergeHelper) NewVectorIndexMergerTxn(
+	ctx context.Context, evalCtx *eval.Context, txn *kv.Txn,
+) (*VectorIndexMergerTxn, error) {
+	vm := VectorIndexMergerTxn{
+		vim:         vimh,
+		encRow:      make(rowenc.EncDatumRow, len(vimh.fetchSpec.KeyAndSuffixColumns)),
+		rowDatums:   make(tree.Datums, len(vimh.fetchSpec.FetchedColumns)),
+		spansToScan: make(roachpb.Spans, 1),
+	}
+
+	if err := vm.fetcher.Init(ctx, row.FetcherInitArgs{
+		Txn:   txn,
+		Alloc: &vm.alloc,
+		Spec:  &vimh.fetchSpec,
+	}); err != nil {
+		return nil, err
+	}
+
+	vm.searcher.Init(evalCtx, vimh.vecIndex, txn, &vimh.fullVecFetchSpec)
+
+	// Initialize the span builder for reading from the primary key.
+	vm.builder.InitWithFetchSpec(evalCtx, evalCtx.Codec, &vimh.fetchSpec)
+
+	return &vm, nil
+}
+
+// MergeVector takes a key value read from the temporary index, looks up the
+// vector and prefix columns from the primary key, and then builds a new index
+// entry for the vector index. It returns a kv.KeyValue containing the merged
+// index entry and a boolean indicating if the entry was deleted. If the entry
+// was deleted, the returned kv.KeyValue is nil because there is no way to
+// calculate the key of a deleted entry (we need the full vector for that).
+// Deleted index entries are allowed to stay in the newly built index and will
+// eventually be deleted by the fixup process. In the meantime, the lack of a
+// corresponding PK value means we will never return stale results.
+func (vm *VectorIndexMergerTxn) MergeVector(
+	ctx context.Context, sourceKV *kv.KeyValue, destKey roachpb.Key,
+) (*kv.KeyValue, bool, error) {
+	tempWrapper, err := rowenc.DecodeWrapper(sourceKV.Value)
+	if err != nil {
+		return nil, false, err
+	}
+
+	if tempWrapper.Deleted {
+		// Not really anything we can do about a deleted key since that means
+		// the vector in the PK is already deleted.
+		return nil, true, nil
+	}
+
+	// Extract the key bytes from the temporary index entry. The temporary
+	// index has the same key structure as the primary key.
+	keyBytes := sourceKV.Key[len(vm.vim.sourcePrefix):]
+
+	// Decode the key bytes into EncDatumRow so we can use the span.Builder
+	// properly.
+	_, _, err = rowenc.DecodeKeyValsUsingSpec(vm.vim.fetchSpec.KeyAndSuffixColumns, keyBytes, vm.encRow)
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Use the span.Builder to create a proper span from the decoded
+	// EncDatumRow.
+	spanToScan, containsNull, err := vm.builder.SpanFromEncDatums(vm.encRow)
+	if err != nil {
+		return nil, false, err
+	}
+	if containsNull {
+		// Primary key contains null, skip this entry
+		return nil, true, nil
+	}
+
+	// Use the cached span.Splitter to only fetch the needed column families
+	vm.spansToScan = vm.spansToScan[:0]
+	vm.spansToScan = vm.vim.splitter.MaybeSplitSpanIntoSeparateFamilies(
+		vm.spansToScan,
+		spanToScan,
+		len(vm.encRow),
+		containsNull,
+	)
+
+	// Use the span to fetch the vector column and prefix columns from the
+	// primary index.
+	if err := vm.fetcher.StartScan(
+		ctx,
+		vm.spansToScan,
+		nil, /* spanIDs */
+		rowinfra.GetDefaultBatchBytesLimit(false /* forceProductionValue */),
+		1, /* rowLimit */
+	); err != nil {
+		return nil, false, err
+	}
+
+	// Fetch the row containing the vector column using pre-allocated memory
+	ok, _, err := vm.fetcher.NextRowDecodedInto(ctx, vm.rowDatums, vm.vim.colMap)
+	if err != nil {
+		return nil, false, err
+	} else if !ok {
+		// Primary key row not found -- this row is deleted
+		return nil, true, nil
+	}
+
+	vectorDatum := vm.rowDatums[vm.vim.vectorPos]
+	if vectorDatum == tree.DNull {
+		// Null vector, skip this entry
+		return nil, true, nil
+	}
+	vector := tree.MustBeDPGVector(vectorDatum).T
+
+	// Extract the prefix columns for the search from the fetched rowDatums
+	prefixCols := vm.vim.tableDesc.IndexFetchSpecKeyAndSuffixColumns(vm.vim.destIndex)[:vm.vim.destIndex.NumKeyColumns()-1]
+	prefixKey, _, err := rowenc.EncodePartialIndexKey(prefixCols, vm.vim.colMap, vm.rowDatums, []byte{})
+	if err != nil {
+		return nil, false, err
+	}
+
+	// Search for the partition that should contain the new index entry
+	if err := vm.searcher.SearchForInsert(ctx, prefixKey, vector); err != nil {
+		return nil, false, err
+	}
+	vm.vectorEncodingHelper.InitForPut()
+	vm.vectorEncodingHelper.PartitionKeys[vm.vim.destIndex.GetID()] = vm.searcher.PartitionKey()
+	vm.vectorEncodingHelper.QuantizedVecs[vm.vim.destIndex.GetID()] = vm.searcher.EncodedVector()
+
+	// Encode the index entry for the vector index
+	entries, err := rowenc.EncodeSecondaryIndex(
+		ctx,
+		vm.vim.codec,
+		vm.vim.tableDesc,
+		vm.vim.destIndex,
+		vm.vim.colMap,
+		vm.rowDatums,
+		vm.vectorEncodingHelper,
+		false, /* includeEmpty */
+	)
+	if err != nil {
+		return nil, false, err
+	}
+	if len(entries) != 1 {
+		return nil, false, errors.AssertionFailedf("expected exactly one index entry, got %d", len(entries))
+	}
+
+	return &kv.KeyValue{
+		Key:   entries[0].Key,
+		Value: &entries[0].Value,
+	}, false, nil
+}
+
+// Close closes the VectorIndexMergerTxn.
+func (vm *VectorIndexMergerTxn) Close(ctx context.Context) {
+	vm.fetcher.Close(ctx)
 }
 
 // IndexBackfiller is capable of backfilling all the added index.
@@ -571,7 +937,7 @@ type IndexBackfiller struct {
 
 	// map of index IDs to VectorIndexHelpers, so that writers can map from
 	// IndexEntry keys they see to the proper re-encoding logic.
-	VectorIndexes        map[descpb.IndexID]VectorIndexHelper
+	VectorIndexes        map[descpb.IndexID]*VectorIndexHelper
 	vectorEncodingHelper rowenc.VectorIndexEncodingHelper
 	VectorIndexManager   *vecindex.Manager
 	VectorOnly           bool
@@ -932,37 +1298,14 @@ func (ib *IndexBackfiller) initIndexes(
 		}
 
 		if ib.VectorIndexes == nil {
-			ib.VectorIndexes = make(map[descpb.IndexID]VectorIndexHelper)
+			ib.VectorIndexes = make(map[descpb.IndexID]*VectorIndexHelper)
 		}
 
-		vectorColID := idx.VectorColumnID()
-		vectorCol, err := catalog.MustFindColumnByID(desc, vectorColID)
+		helper, err := NewVectorIndexHelper(ctx, evalCtx, desc, idx, sourceIndexID, vecIndexManager)
 		if err != nil {
 			return err
 		}
 
-		vecIndex, err := vecIndexManager.Get(ctx, desc.GetID(), idx.GetID())
-		if err != nil {
-			return err
-		}
-
-		helper := VectorIndexHelper{
-			vectorOrd:     vectorCol.Ordinal(),
-			centroid:      make(vector.T, idx.GetVecConfig().Dims),
-			numPrefixCols: idx.NumKeyColumns() - 1,
-			vecIndex:      vecIndex,
-			indexPrefix:   rowenc.MakeIndexKeyPrefix(evalCtx.Codec, desc.GetID(), idx.GetID()),
-			evalCtx:       ib.evalCtx,
-		}
-		if err := vecstore.InitGetFullVectorsFetchSpec(
-			&helper.fullVecFetchSpec,
-			evalCtx,
-			desc,
-			idx,
-			ib.sourceIndex,
-		); err != nil {
-			return err
-		}
 		ib.VectorIndexes[idx.GetID()] = helper
 	}
 

--- a/pkg/sql/backfill/backfill_test.go
+++ b/pkg/sql/backfill/backfill_test.go
@@ -146,28 +146,28 @@ func TestConcurrentOperationsDuringVectorIndexCreation(t *testing.T) {
 	go func() {
 		defer wg.Done()
 		_, createIndexErr = db.ExecContext(ctx, `CREATE VECTOR INDEX vec_idx ON vectors (vec)`)
+		close(backfillBlocked)
 	}()
 
 	// Wait for the backfill to be blocked
 	<-backfillBlocked
+	require.NoError(t, createIndexErr)
 
+	var err error
 	// Attempt concurrent operations while the index is being created
 	// These should fail with the appropriate error
-	_, err := db.ExecContext(ctx, `UPDATE vectors SET vec = '[10, 11, 12]', data = 150 WHERE id = 1`)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Cannot write to a vector index while it is being built")
+	_, err = db.ExecContext(ctx, `UPDATE vectors SET vec = '[10, 11, 12]', data = 150 WHERE id = 1`)
+	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `INSERT INTO vectors (id, vec, data) VALUES (4, '[13, 14, 15]', 400)`)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Cannot write to a vector index while it is being built")
+	require.NoError(t, err)
 
 	_, err = db.ExecContext(ctx, `DELETE FROM vectors WHERE id = 2`)
-	require.Error(t, err)
-	require.Contains(t, err.Error(), "Cannot write to a vector index while it is being built")
+	require.NoError(t, err)
 
 	// This update should succeed since it only modifies the data column
-	_, err = db.ExecContext(ctx, `UPDATE vectors SET data = 250 WHERE id = 2`)
-	require.NoError(t, err, "Updating only the data column should succeed during index creation")
+	_, err = db.ExecContext(ctx, `UPDATE vectors SET data = 250 WHERE id = 3`)
+	require.NoError(t, err)
 
 	// Unblock the backfill process
 	close(blockBackfill)
@@ -178,8 +178,18 @@ func TestConcurrentOperationsDuringVectorIndexCreation(t *testing.T) {
 
 	// Verify the index was created successfully
 	var id int
-	sqlDB.QueryRow(t, `SELECT id FROM vectors@vec_idx ORDER BY vec <-> '[1, 2, 3]' LIMIT 1`).Scan(&id)
-	require.Equal(t, 1, id)
+	sqlDB.QueryRow(t, `SELECT id FROM vectors@vec_idx ORDER BY vec <-> '[13, 14, 15]' LIMIT 1`).Scan(&id)
+	require.Equal(t, 4, id)
+
+	// This doesn't really tell us anything because we always join on the PK, which will have properly
+	// deleted the row.
+	sqlDB.QueryRow(t, `SELECT id FROM vectors@vec_idx ORDER BY vec <-> '[4, 5, 6]' LIMIT 1`).Scan(&id)
+	require.NotEqual(t, 2, id)
+
+	var data int
+	sqlDB.QueryRow(t, `SELECT id, data FROM vectors@vec_idx ORDER BY vec <-> '[7, 8, 9]' LIMIT 1`).Scan(&id, &data)
+	require.Equal(t, 3, id)
+	require.Equal(t, 250, data)
 }
 
 // Regression for issue #145261: vector index backfill with a prefix column
@@ -239,5 +249,233 @@ func TestVectorIndexWithPrefixBackfill(t *testing.T) {
 			}
 			require.Equal(t, 100, count)
 		}()
+	}
+}
+
+func TestVectorIndexMergingDuringBackfill(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Channel to block the backfill process
+	blockBackfill := make(chan struct{})
+	backfillBlocked := make(chan struct{})
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				// Block the backfill process after the first batch
+				RunAfterBackfillChunk: func() {
+					backfillBlocked <- struct{}{}
+					<-blockBackfill
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// Enable vector indexes.
+	sqlDB.Exec(t, `SET CLUSTER SETTING feature.vector_index.enabled = true`)
+
+	// Enable deterministic vector index fixups for consistent testing.
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.vecindex.deterministic_fixups.enabled = true`)
+
+	// Create a table with an integer PK column and a dimension 1 vector column
+	sqlDB.Exec(t, `
+		CREATE TABLE test_vectors (
+			pk INT PRIMARY KEY,
+			vec VECTOR(1)
+		)
+	`)
+
+	// Insert 1000 rows where PK value and vector element are the same
+	sqlDB.Exec(t, `
+		INSERT INTO test_vectors (pk, vec)
+		SELECT
+			i as pk,
+			ARRAY[i::float]::vector(1) as vec
+		FROM generate_series(1, 1000) as i
+	`)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	// Start creating the vector index in a goroutine
+	var createIndexErr error
+	go func() {
+		defer wg.Done()
+		_, createIndexErr = db.ExecContext(ctx, `CREATE VECTOR INDEX vec_idx ON test_vectors (vec)`)
+		close(backfillBlocked)
+	}()
+
+	// Wait for the backfill to be blocked
+	<-backfillBlocked
+	require.NoError(t, createIndexErr)
+
+	// Insert 100 more vectors into the table (values 1001-1100)
+	sqlDB.Exec(t, `
+		INSERT INTO test_vectors (pk, vec)
+		SELECT
+			i as pk,
+			ARRAY[i::float]::vector(1) as vec
+		FROM generate_series(1001, 1100) as i
+	`)
+
+	// Unblock the backfill process
+	close(blockBackfill)
+
+	wg.Wait()
+	// Wait for the index creation to complete
+	require.NoError(t, createIndexErr)
+
+	// Search individually for vectors from the second set of inserts (1001-1100)
+	// We should find at least 90% of those vectors
+	for i := 1001; i <= 1100; i++ {
+		var pk int
+		err := sqlDB.DB.QueryRowContext(ctx, `
+			SELECT pk FROM test_vectors@vec_idx
+			ORDER BY vec <-> ARRAY[$1::float]::vector(1)
+			LIMIT 1
+		`, i).Scan(&pk)
+		require.NoError(t, err)
+		require.Equal(t, i, pk)
+	}
+}
+
+// TestVectorIndexMergingDuringBackfillWithPrefix tests vector index creation
+// with concurrent inserts during backfill, using a prefix column and multiple
+// column families. This validates both the merging functionality and the
+// span.Splitter optimization in MergeVector that only fetches needed column families.
+func TestVectorIndexMergingDuringBackfillWithPrefix(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	// Channel to block the backfill process
+	blockBackfill := make(chan struct{})
+	backfillBlocked := make(chan struct{})
+
+	ctx := context.Background()
+	srv, db, _ := serverutils.StartServer(t, base.TestServerArgs{
+		Knobs: base.TestingKnobs{
+			DistSQL: &execinfra.TestingKnobs{
+				// Block the backfill process after the first batch
+				RunAfterBackfillChunk: func() {
+					backfillBlocked <- struct{}{}
+					<-blockBackfill
+				},
+			},
+		},
+	})
+	defer srv.Stopper().Stop(ctx)
+	sqlDB := sqlutils.MakeSQLRunner(db)
+
+	// Enable vector indexes.
+	sqlDB.Exec(t, `SET CLUSTER SETTING feature.vector_index.enabled = true`)
+
+	// Enable deterministic vector index fixups for consistent testing.
+	sqlDB.Exec(t, `SET CLUSTER SETTING sql.vecindex.deterministic_fixups.enabled = true`)
+
+	// Create a table with an integer PK column, prefix column, and a dimension 1 vector column
+	// Use multiple column families to test the span.Splitter optimization in MergeVector
+	sqlDB.Exec(t, `
+		CREATE TABLE test_vectors_with_prefix (
+			pk INT PRIMARY KEY,
+			prefix_col INT,
+			vec VECTOR(1),
+			FAMILY key_family (pk, prefix_col),
+			FAMILY vector_family (vec)
+		)
+	`)
+
+	// Insert 5000 rows with random prefix distribution:
+	// 50% to prefix 1, 20% to prefix 2, 10% each to prefixes 3, 4, 5
+	sqlDB.Exec(t, `
+		INSERT INTO test_vectors_with_prefix (pk, prefix_col, vec)
+		SELECT
+			i as pk,
+			CASE
+				WHEN random() < 0.5 THEN 1
+				WHEN random() < 0.7 THEN 2  -- 20% of remaining 50%
+				WHEN random() < 0.8 THEN 3  -- 10% of remaining 30%
+				WHEN random() < 0.9 THEN 4  -- 10% of remaining 20%
+				ELSE 5                      -- 10% of remaining 10%
+			END as prefix_col,
+			ARRAY[i::float]::vector(1) as vec
+		FROM generate_series(1, 5000) as i
+	`)
+
+	wg := sync.WaitGroup{}
+	wg.Add(1)
+
+	// Start creating the vector index with prefix column in a goroutine
+	var createIndexErr error
+	go func() {
+		defer wg.Done()
+		_, createIndexErr = db.ExecContext(ctx, `CREATE VECTOR INDEX vec_prefix_idx ON test_vectors_with_prefix (prefix_col, vec)`)
+		close(backfillBlocked)
+	}()
+
+	// Wait for the backfill to be blocked
+	<-backfillBlocked
+	require.NoError(t, createIndexErr)
+
+	// Insert 100 more vectors into the table (values 5001-5100) with same distribution
+	sqlDB.Exec(t, `
+		INSERT INTO test_vectors_with_prefix (pk, prefix_col, vec)
+		SELECT
+			i as pk,
+			CASE
+				WHEN random() < 0.5 THEN 1
+				WHEN random() < 0.7 THEN 2
+				WHEN random() < 0.8 THEN 3
+				WHEN random() < 0.9 THEN 4
+				ELSE 5
+			END as prefix_col,
+			ARRAY[i::float]::vector(1) as vec
+		FROM generate_series(5001, 5100) as i
+	`)
+
+	// Unblock the backfill process
+	close(blockBackfill)
+
+	wg.Wait()
+	// Wait for the index creation to complete
+	require.NoError(t, createIndexErr)
+
+	// Search individually for vectors from the second set of inserts (5001-5100)
+	// We need to get the actual prefix values for each row since they were randomly assigned
+	type rowData struct {
+		pk     int
+		prefix int
+	}
+
+	var secondSetRows []rowData
+	rows := sqlDB.Query(t, `
+		SELECT pk, prefix_col
+		FROM test_vectors_with_prefix
+		WHERE pk BETWEEN 5001 AND 5100
+		ORDER BY pk
+	`)
+	defer rows.Close()
+
+	for rows.Next() {
+		var rd rowData
+		require.NoError(t, rows.Scan(&rd.pk, &rd.prefix))
+		secondSetRows = append(secondSetRows, rd)
+	}
+
+	// Search for each vector using the prefix-aware index
+	for _, row := range secondSetRows {
+		var pk int
+		// Use the pk value as the vector element since vec was created as ARRAY[i::float]
+		err := sqlDB.DB.QueryRowContext(ctx, `
+			SELECT pk FROM test_vectors_with_prefix@vec_prefix_idx
+			WHERE prefix_col = $1
+			ORDER BY vec <-> ARRAY[$2::float]::vector(1)
+			LIMIT 1
+		`, row.prefix, row.pk).Scan(&pk)
+		require.NoError(t, err)
+		require.Equal(t, row.pk, pk)
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/vector_index
+++ b/pkg/sql/logictest/testdata/logic_test/vector_index
@@ -7,11 +7,6 @@
 
 subtest create_table_index
 
-# Test guardrail for vector index creation.
-# TODO(mw5h): remove these two statements once online modifications are supported.
-statement ok
-SET sql_safe_updates = true
-
 # Simple vector index.
 statement ok
 CREATE TABLE simple (
@@ -22,23 +17,14 @@ CREATE TABLE simple (
   FAMILY (a, vec1)
 )
 
-statement error pgcode 01000 pq: rejected \(sql_safe_updates = true\): CREATE VECTOR INDEX will disable writes to the table while the index is being built
+statement ok
 CREATE VECTOR INDEX ON simple (vec1)
-
-statement error pgcode 01000 pq: rejected \(sql_safe_updates = true\): ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt
-ALTER TABLE simple ALTER PRIMARY KEY USING COLUMNS (b)
 
 statement ok
-SET sql_safe_updates = false
-
-statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
-CREATE VECTOR INDEX ON simple (vec1)
-
-statement notice ALTER PRIMARY KEY on a table with vector indexes will disable writes to the table while the index is being rebuilt
 ALTER TABLE simple ALTER PRIMARY KEY USING COLUMNS (b)
 
 # Alternate syntax.
-statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
+statement ok
 CREATE INDEX ON simple USING cspann (vec1);
 
 # We allow hnsw as an alias for cspann.
@@ -100,7 +86,7 @@ CREATE TABLE alt_syntax (
   FAMILY (a, vec1)
 )
 
-statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
+statement ok
 CREATE VECTOR INDEX another_index ON alt_syntax (vec1)
 
 onlyif config schema-locked-disabled
@@ -675,7 +661,7 @@ INSERT INTO backfill_test VALUES
   (2, 'jill', 20, '[4.0, 5.0, 6.0]', '[6.0, 5.0, 4.0]'),
   (3, 'ash',  30, '[7.0, 8.0, 9.0]', '[9.0, 8.0, 7.0]');
 
-statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
+statement ok
 CREATE VECTOR INDEX ON backfill_test (enc)
 
 query ITITT
@@ -727,7 +713,7 @@ SELECT * FROM backfill_test@backfill_test_enc_idx ORDER BY enc <-> '[1.0, 2.0, 3
 3  ash   30  [7,8,9]    [9,8,7]
 6  ash   60  [7.5,8,9]  [9,8,7.5]
 
-statement notice CREATE VECTOR INDEX will disable writes to the table while the index is being built
+statement ok
 CREATE VECTOR INDEX ON backfill_test (username, prefix_enc)
 
 query ITITT

--- a/pkg/sql/opt/optbuilder/mutation_builder.go
+++ b/pkg/sql/opt/optbuilder/mutation_builder.go
@@ -1645,9 +1645,6 @@ func (mb *mutationBuilder) projectVectorIndexColsImpl(op opt.Operator) {
 func (mb *mutationBuilder) buildVectorMutationSearch(
 	input memo.RelExpr, index cat.Index, partitionCol, quantizedVecCol opt.ColumnID, isIndexPut bool,
 ) memo.RelExpr {
-	if index.IsTemporaryIndexForBackfill() {
-		panic(unimplemented.NewWithIssue(144443, "Cannot write to a vector index while it is being built"))
-	}
 	getCol := func(colOrd int) (colID opt.ColumnID) {
 		// Check in turn if the column is being upserted, inserted, updated, or
 		// fetched.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/BUILD.bazel
@@ -113,6 +113,7 @@ go_library(
         "//pkg/sql/storageparam/indexstorageparam",
         "//pkg/sql/types",
         "//pkg/sql/vecindex",
+        "//pkg/sql/vecindex/vecpb",
         "//pkg/util/buildutil",
         "//pkg/util/encoding",
         "//pkg/util/errorutil/unimplemented",

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_column.go
@@ -831,7 +831,7 @@ func addSecondaryIndexTargetsForAddColumn(
 		IndexID: index.IndexID,
 		Name:    indexName,
 	})
-	tempSpec := makeTempIndexSpec(spec.indexSpec)
+	tempSpec := makeTempIndexSpec(b, spec.indexSpec)
 	tempSpec.apply(b.AddTransient)
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/create_index.go
@@ -44,15 +44,9 @@ import (
 
 // CreateIndex implements CREATE INDEX.
 func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
-	// Check if sql_safe_updates is enabled and this is a vector index
-	if n.Type == idxtype.VECTOR {
-		if !b.EvalCtx().Settings.Version.ActiveVersion(b).AtLeast(clusterversion.V25_2.Version()) {
-			panic(pgerror.Newf(pgcode.FeatureNotSupported, "cannot create a vector index until finalizing on 25.2"))
-		} else if b.EvalCtx().SessionData().SafeUpdates {
-			panic(pgerror.DangerousStatementf("CREATE VECTOR INDEX will disable writes to the table while the index is being built"))
-		} else {
-			b.EvalCtx().ClientNoticeSender.BufferClientNotice(b, pgnotice.Newf("CREATE VECTOR INDEX will disable writes to the table while the index is being built"))
-		}
+	// Ensure that the cluster is fully upgraded to 25.2 before creating a vector index.
+	if n.Type == idxtype.VECTOR && !b.EvalCtx().Settings.Version.ActiveVersion(b).AtLeast(clusterversion.V25_2.Version()) {
+		panic(pgerror.Newf(pgcode.FeatureNotSupported, "cannot create a vector index until finalizing on 25.2"))
 	}
 
 	b.IncrementSchemaChangeCreateCounter("index")
@@ -255,8 +249,9 @@ func CreateIndex(b BuildCtx, n *tree.CreateIndex) {
 	})
 	// Construct the temporary objects from the index spec, since these will
 	// be transient.
-	tempIdxSpec := makeTempIndexSpec(idxSpec)
+	tempIdxSpec := makeTempIndexSpec(b, idxSpec)
 	tempIdxSpec.apply(b.AddTransient)
+
 	// If the concurrent option is added emit a warning.
 	if n.Concurrently {
 		b.EvalCtx().ClientNoticeSender.BufferClientNotice(b,
@@ -736,6 +731,60 @@ func addColumnsForSecondaryIndex(
 			}
 		}
 		idxSpec.columns = append([]*scpb.IndexColumn{indexColumn}, idxSpec.columns...)
+	}
+}
+
+func fixupColumnsForTempVectorIndex(b BuildCtx, tempIdxSpec *indexSpec) {
+	// For vector indexes, the temporary index should only be keyed by the primary
+	// key columns. Get the actual primary key columns from the source index.
+
+	// Get the source index ID (which should be the primary index)
+	sourceIndexID := tempIdxSpec.temporary.SourceIndexID
+
+	// Query for the primary key columns from the source index
+	tableElts := b.QueryByID(tempIdxSpec.temporary.TableID)
+	primaryKeyColumns := getIndexColumns(tableElts, sourceIndexID, scpb.IndexColumn_KEY)
+
+	// Create new index columns for the temporary index based on primary key columns
+	var newTempColumns []*scpb.IndexColumn
+	for i, pkCol := range primaryKeyColumns {
+		newCol := &scpb.IndexColumn{
+			TableID:       tempIdxSpec.temporary.TableID,
+			IndexID:       tempIdxSpec.temporary.IndexID,
+			ColumnID:      pkCol.ColumnID,
+			OrdinalInKind: uint32(i),
+			Kind:          scpb.IndexColumn_KEY,
+			Direction:     pkCol.Direction,
+			Implicit:      pkCol.Implicit,
+		}
+		newTempColumns = append(newTempColumns, newCol)
+	}
+	// Replace the entire column set with just the primary key columns
+	tempIdxSpec.columns = newTempColumns
+}
+
+// fixupPartitioningForTempVectorIndex updates the partitioning for a temporary
+// vector index to inherit from the primary key instead of the vector index.
+func fixupPartitioningForTempVectorIndex(b BuildCtx, tempIdxSpec *indexSpec, tempID catid.IndexID) {
+	// Get the source index ID (which should be the primary index)
+	sourceIndexID := tempIdxSpec.temporary.SourceIndexID
+
+	// Query for the primary key's partitioning
+	tableElts := b.QueryByID(tempIdxSpec.temporary.TableID)
+	var primaryPartitioning *scpb.IndexPartitioning
+	scpb.ForEachIndexPartitioning(tableElts, func(_ scpb.Status, target scpb.TargetStatus, e *scpb.IndexPartitioning) {
+		if target == scpb.ToPublic && e.IndexID == sourceIndexID {
+			primaryPartitioning = e
+		}
+	})
+
+	if primaryPartitioning != nil {
+		// Clone the primary key's partitioning and update it for the temporary index
+		tempIdxSpec.partitioning = protoutil.Clone(primaryPartitioning).(*scpb.IndexPartitioning)
+		tempIdxSpec.partitioning.IndexID = tempID
+	} else {
+		// No partitioning on primary key, so temporary index shouldn't have partitioning either
+		tempIdxSpec.partitioning = nil
 	}
 }
 

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/helpers.go
@@ -26,10 +26,12 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/schemachanger/screl"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catconstants"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/catid"
+	"github.com/cockroachdb/cockroach/pkg/sql/sem/idxtype"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlclustersettings"
 	"github.com/cockroachdb/cockroach/pkg/sql/sqlerrors"
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
+	"github.com/cockroachdb/cockroach/pkg/sql/vecindex/vecpb"
 	"github.com/cockroachdb/cockroach/pkg/util/buildutil"
 	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
 	"github.com/cockroachdb/errors"
@@ -861,7 +863,7 @@ func makeIndexSpec(b BuildCtx, tableID catid.DescID, indexID catid.IndexID) (s i
 
 // makeTempIndexSpec clones the primary/secondary index spec into one for a
 // temporary index, based on the populated information.
-func makeTempIndexSpec(src indexSpec) indexSpec {
+func makeTempIndexSpec(b BuildCtx, src indexSpec) indexSpec {
 	if src.secondary == nil && src.primary == nil {
 		panic(errors.AssertionFailedf("make temp index converts a primary/secondary index into a temporary one"))
 	}
@@ -886,6 +888,15 @@ func makeTempIndexSpec(src indexSpec) indexSpec {
 	newTempSpec.temporary.TemporaryIndexID = 0
 	newTempSpec.temporary.IndexID = tempID
 	newTempSpec.temporary.ConstraintID = srcIdx.ConstraintID + 1
+	// The temporary index for a vector index is a FORWARD index that stores
+	// modifications temporarily until they can be applied during merge.
+	if newTempSpec.secondary != nil && newTempSpec.secondary.Type == idxtype.VECTOR {
+		newTempSpec.temporary.Type = idxtype.FORWARD
+		newTempSpec.temporary.VecConfig = &vecpb.Config{}
+		fixupColumnsForTempVectorIndex(b, &newTempSpec)
+		// Also need to fix partitioning to inherit from primary key instead of vector index
+		fixupPartitioningForTempVectorIndex(b, &newTempSpec, tempID)
+	}
 	newTempSpec.secondary = nil
 	newTempSpec.primary = nil
 
@@ -1028,7 +1039,7 @@ func makeSwapIndexSpec(
 	}
 	// Setup temporary index.
 	{
-		temp = makeTempIndexSpec(in)
+		temp = makeTempIndexSpec(b, in)
 	}
 	return in, temp
 }

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/config.go
@@ -8,6 +8,7 @@ package sctestdeps
 import (
 	"time"
 
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descidgen"
@@ -163,6 +164,16 @@ func WithIDGenerator(s serverutils.ApplicationLayerInterface) Option {
 func WithReferenceProviderFactory(f scbuild.ReferenceProviderFactory) Option {
 	return optionFunc(func(state *TestState) {
 		state.refProviderFactory = f
+	})
+}
+
+func WithClusterSettings(cs *cluster.Settings) Option {
+	return optionFunc(func(state *TestState) {
+		state.clusterSettings = cs
+		// Update evalCtx settings if it already exists
+		if state.evalCtx != nil {
+			state.evalCtx.Settings = cs
+		}
 	})
 }
 

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_deps.go
@@ -88,6 +88,9 @@ func (s *TestState) SessionData() *sessiondata.SessionData {
 
 // ClusterSettings implements the scbuild.Dependencies interface.
 func (s *TestState) ClusterSettings() *cluster.Settings {
+	if s.clusterSettings != nil {
+		return s.clusterSettings
+	}
 	return cluster.MakeTestingClusterSettings()
 }
 

--- a/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
+++ b/pkg/sql/schemachanger/scdeps/sctestdeps/test_state.go
@@ -15,6 +15,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/jobs"
 	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
 	"github.com/cockroachdb/cockroach/pkg/security/username"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catalogkeys"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb"
@@ -81,6 +82,7 @@ type TestState struct {
 
 	catalogChanges     catalogChanges
 	refProviderFactory scbuild.ReferenceProviderFactory
+	clusterSettings    *cluster.Settings
 }
 
 type catalogChanges struct {

--- a/pkg/sql/schemachanger/sctest/end_to_end.go
+++ b/pkg/sql/schemachanger/sctest/end_to_end.go
@@ -153,6 +153,7 @@ func EndToEndSideEffects(t *testing.T, relTestCaseDir string, factory TestServer
 					sctestdeps.WithComments(sctestdeps.ReadCommentsFromDB(t, tdb)),
 					sctestdeps.WithIDGenerator(s.ApplicationLayer()),
 					sctestdeps.WithReferenceProviderFactory(refFactory),
+					sctestdeps.WithClusterSettings(s.ClusterSettings()),
 				)
 				stmtStates := execStatementWithTestDeps(ctx, t, deps, stmts...)
 				var fileNameSuffix string

--- a/pkg/sql/vecindex/vecencoding/encoding.go
+++ b/pkg/sql/vecindex/vecencoding/encoding.go
@@ -57,7 +57,7 @@ Vector KV Value:
 func EncodeMetadataKey(
 	indexPrefix []byte, encodedPrefixCols []byte, partitionKey cspann.PartitionKey,
 ) roachpb.Key {
-	capacity := len(indexPrefix) + len(encodedPrefixCols) + EncodedPartitionKeyLen(partitionKey) + 1
+	capacity := len(indexPrefix) + len(encodedPrefixCols) + EncodedPartitionKeyLen(partitionKey) + EncodedPartitionLevelLen(cspann.InvalidLevel)
 	keyBuffer := make([]byte, 0, capacity)
 	keyBuffer = append(keyBuffer, indexPrefix...)
 	keyBuffer = append(keyBuffer, encodedPrefixCols...)
@@ -132,13 +132,16 @@ func DecodeVectorKey(
 		keyBytes = keyBytes[prefixLen:]
 	}
 
-	partitionKey, keyBytes, err := DecodePartitionKey(keyBytes)
+	// Decode the partition key and level.
+	var partitionKey cspann.PartitionKey
+	partitionKey, keyBytes, err = DecodePartitionKey(keyBytes)
 	if err != nil {
 		return vecIndexKey, err
 	}
 	vecIndexKey.PartitionKey = partitionKey
 
-	level, keyBytes, err := DecodePartitionLevel(keyBytes)
+	var level cspann.Level
+	level, keyBytes, err = DecodePartitionLevel(keyBytes)
 	if err != nil {
 		return vecIndexKey, err
 	}

--- a/pkg/sql/vecindex/vecencoding/encoding_test.go
+++ b/pkg/sql/vecindex/vecencoding/encoding_test.go
@@ -273,7 +273,7 @@ func TestDecodeVectorKey(t *testing.T) {
 	require.Equal(t, expectedSuffix, indexKey.Suffix)
 }
 
-func TestDecodeKeyPrefixColumns(t *testing.T) {
+func TestDecodeKeyWithPrefix(t *testing.T) {
 	var buf []byte
 
 	// Encode a prefix column.
@@ -301,7 +301,7 @@ func TestDecodeKeyPrefixColumns(t *testing.T) {
 	expectedSuffix := []byte("suffixData")
 	buf = append(buf, expectedSuffix...)
 
-	// Extract the key with one prefix column.
+	// Extract the key with two prefix columns.
 	key, err := vecencoding.DecodeVectorKey(buf, 2)
 	require.NoError(t, err)
 
@@ -312,4 +312,24 @@ func TestDecodeKeyPrefixColumns(t *testing.T) {
 	require.Equal(t, level, key.Level)
 	// Verify that the remaining bytes form the suffix.
 	require.Equal(t, expectedSuffix, key.Suffix)
+}
+
+func TestDecodeVectorKeyNoPrefix(t *testing.T) {
+	var buf []byte
+	// Encode a partition key.
+	partitionKey := cspann.PartitionKey(789)
+	buf = vecencoding.EncodePartitionKey(buf, partitionKey)
+	// Encode a partition level.
+	level := cspann.Level(3)
+	buf = vecencoding.EncodePartitionLevel(buf, level)
+	// Add some suffix bytes.
+	expectedSuffix := []byte("vectorSuffix")
+	buf = append(buf, expectedSuffix...)
+
+	indexKey, err := vecencoding.DecodeVectorKey(buf, 0)
+	require.NoError(t, err)
+	require.Empty(t, indexKey.Prefix)
+	require.Equal(t, partitionKey, indexKey.PartitionKey)
+	require.Equal(t, level, indexKey.Level)
+	require.Equal(t, expectedSuffix, indexKey.Suffix)
 }

--- a/pkg/sql/vecindex/vecstore/store_txn.go
+++ b/pkg/sql/vecindex/vecstore/store_txn.go
@@ -274,17 +274,15 @@ func (tx *Txn) SearchPartitions(
 	for i := range toSearch {
 		metadataKey := vecencoding.EncodeMetadataKey(tx.store.prefix, treeKey, toSearch[i].Key)
 		b.Get(metadataKey)
-		var startKey, endKey roachpb.Key
+		var startKey roachpb.Key
 		if toSearch[i].ExcludeLeafVectors {
 			// Skip past vectors at the leaf level.
 			startKey = vecencoding.EncodePrefixVectorKey(metadataKey, cspann.SecondLevel)
-			endKey = vecencoding.EncodeEndVectorKey(metadataKey)
-			b.Scan(startKey, endKey)
 		} else {
 			startKey = vecencoding.EncodeStartVectorKey(metadataKey)
-			endKey = vecencoding.EncodeEndVectorKey(metadataKey)
-			b.Scan(startKey, endKey)
 		}
+		endKey := vecencoding.EncodeEndVectorKey(metadataKey)
+		b.Scan(startKey, endKey)
 
 		if log.ExpensiveLogEnabled(ctx, 2) {
 			log.VEventf(ctx, 2, "Scan %s", roachpb.Span{Key: startKey, EndKey: endKey}.String())


### PR DESCRIPTION
Previously mutation of values in a vector index during backfill was prohibited, effectively taking the table offline while the index is built. This patch does a few things:

* Re-enables mutations on vector indexes undergoing backfill.
* Changes the temporary index created for vector indexes to capture changes during backfill from a VECTOR index to a FORWARD index.
* Changes the schema of the temporary index so that it is keyed by the index prefix and primary key columns, with the vector as a payload column.
* Refactors the mvcc merger to take a functor argument to merge individual entries, with the existing kv merger as the default.
* Adds a second merger that re-encodes vector index entries read from the temporary index.

Because forward indexes don't record values for tombstone entries, we don't delete vectors from the vector index that are deleted during backfill. Since reading from a vector index requires an index join on the PK, this doesn't create a correctness issue, but it could cause accuracy issues if a large number of vector index entries are deleted during backfill.

Fixes: #144443
Release note (sql change): Tables with vector indexes will no longer be taken offline while the vector index builds.