### PR TITLE
roachprod: update gc image

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:fd18c1bd63d
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:add1f523468
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
This PR updates the image used by the GC service to integrate the latest updates for IBM GC.

Epic: none
Release note: None