### PR TITLE
staging-v24.1.22: backup: fix external storage error propagation

### DIFF
--- a/pkg/ccl/backupccl/backup_processor.go
+++ b/pkg/ccl/backupccl/backup_processor.go
@@ -317,6 +317,14 @@ type exportedSpan struct {
 	resumeKey      roachpb.Key
 }
 
+type errInjectingStorage struct {
+	cloud.ExternalStorage
+}
+
+func (e errInjectingStorage) Writer(_ context.Context, _ string) (io.WriteCloser, error) {
+	return nil, errors.New("injected error")
+}
+
 func runBackupProcessor(
 	ctx context.Context,
 	flowCtx *execinfra.FlowCtx,
@@ -417,11 +425,18 @@ func runBackupProcessor(
 		progCh:   progCh,
 		settings: &flowCtx.Cfg.Settings.SV,
 	}
+
 	storage, err := flowCtx.Cfg.ExternalStorage(ctx, dest, cloud.WithClientName("backup"))
 	if err != nil {
 		return err
 	}
 	defer logClose(ctx, storage, "external storage")
+
+	if backupKnobs, ok := flowCtx.TestingKnobs().BackupRestoreTestingKnobs.(*sql.BackupRestoreTestingKnobs); ok {
+		if fn := backupKnobs.InjectErrorsInBackupRowDataStorage; fn != nil && fn() {
+			storage = errInjectingStorage{storage}
+		}
+	}
 
 	// Start start a group of goroutines which each pull spans off of `todo` and
 	// send export requests. Any spans that encounter lock conflict errors during
@@ -721,7 +736,7 @@ func runBackupProcessor(
 							var writeErr error
 							resumeSpan.span.Key, writeErr = sink.write(ctx, ret)
 							if writeErr != nil {
-								return err
+								return writeErr
 							}
 						}
 						// Emit the stats for the processed ExportRequest.

--- a/pkg/ccl/backupccl/backup_test.go
+++ b/pkg/ccl/backupccl/backup_test.go
@@ -6401,6 +6401,36 @@ func TestPublicIndexTableSpans(t *testing.T) {
 	}
 }
 
+// TestBackupStorageErrorPropagates ensures that errors from writing to storage
+// propagate correctly during a backup operation.
+func TestBackupStorageErrorPropagates(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	const numAccounts = 1000
+
+	var fail atomic.Bool
+
+	params := base.TestClusterArgs{}
+	knobs := base.TestingKnobs{
+		DistSQL: &execinfra.TestingKnobs{BackupRestoreTestingKnobs: &sql.BackupRestoreTestingKnobs{
+			InjectErrorsInBackupRowDataStorage: func() bool { return fail.Load() },
+		}},
+	}
+	params.ServerArgs.Knobs = knobs
+
+	tc, _, _, cleanupFn := backupRestoreTestSetupWithParams(t, singleNode, numAccounts, InitManualReplication, params)
+	defer cleanupFn()
+	db := tc.ServerConn(0)
+	runner := sqlutils.MakeSQLRunner(db)
+
+	runner.Exec(t, "BACKUP DATABASE data INTO 'nodelocal://1/success'")
+	runner.Exec(t, "RESTORE DATABASE data FROM LATEST IN 'nodelocal://1/success' WITH new_db_name = 'restored'")
+	runner.CheckQueryResults(t, "SELECT count(*) FROM restored.bank", [][]string{{"1000"}})
+	fail.Store(true)
+	runner.ExpectErr(t, "injected", "BACKUP DATABASE data INTO 'nodelocal://1/failure'")
+}
+
 // TestRestoreJobErrorPropagates ensures that errors from creating the job
 // record propagate correctly.
 func TestRestoreErrorPropagates(t *testing.T) {

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1786,6 +1786,11 @@ type BackupRestoreTestingKnobs struct {
 	// span has been exported.
 	RunAfterExportingSpanEntry func(ctx context.Context, response *kvpb.ExportResponse)
 
+	// InjectErrorsInBackupRowDataStorage, if non-nil and returning true, causes
+	// errors to be injected when backup processors attempts to write row data to
+	// the external storage.
+	InjectErrorsInBackupRowDataStorage func() bool
+
 	// BackupMonitor is used to overwrite the monitor used by backup during
 	// testing. This is typically the bulk mem monitor if not
 	// specified here.


### PR DESCRIPTION
Backport 1/1 commits from #151083.

/cc @cockroachdb/release

---

Backport 1/1 commits from #151079.

/cc @cockroachdb/release

---

Backport 1/1 commits from #151058.

/cc @cockroachdb/release

---

See #151050.
Fixes #151050.

Release note (bug fix): fix a bug that could cause some error returned by attempts to upload backup data to external storage providers to be undetected, potentially causing incomplete backups.
Epic: none.
Release justification: fixes severe correctness bug.


