### PR TITLE
pgwire: publish authentication latency internal metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -1136,6 +1136,14 @@ layers:
       unit: NANOSECONDS
       aggregation: AVG
       derivative: NONE
+    - name: auth.ldap.conn.latency.internal
+      exported_name: auth_ldap_conn_latency_internal
+      description: Internal Auth Latency to establish and authenticate a SQL connection using LDAP(excludes external LDAP calls)
+      y_axis_label: Nanoseconds
+      type: HISTOGRAM
+      unit: NANOSECONDS
+      aggregation: AVG
+      derivative: NONE
     - name: auth.password.conn.latency
       exported_name: auth_password_conn_latency
       description: Latency to establish and authenticate a SQL connection using password

--- a/pkg/sql/pgwire/auth_methods.go
+++ b/pkg/sql/pgwire/auth_methods.go
@@ -32,6 +32,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/errorutil/unimplemented"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/cockroach/pkg/util/uuid"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/redact"
@@ -1084,6 +1085,9 @@ func AuthLDAP(
 	b := &AuthBehaviors{}
 	b.SetRoleMapper(UseSpecifiedIdentity(sessionUser))
 
+	// Audit the lookup start time.
+	ldapLookupStartTime := timeutil.Now()
+
 	ldapUserDN, detailedErrors, authError := ldapManager.m.FetchLDAPUserDN(sCtx, execCfg.Settings, sessionUser, entry, identMap)
 	if authError != nil {
 		errForLog := authError
@@ -1097,6 +1101,9 @@ func AuthLDAP(
 		// can then be used for authenticator & authorizer AuthBehaviors fn.
 		b.SetReplacementIdentity(ldapUserDN.String())
 	}
+
+	// Add the total lookup time to the external auth time.
+	b.AddExternalAuthTime(timeutil.Since(ldapLookupStartTime))
 
 	b.SetAuthenticator(func(
 		ctx context.Context, systemIdentity string, clientConnection bool, _ PasswordRetrievalFn, _ *ldap.DN,
@@ -1138,6 +1145,10 @@ func AuthLDAP(
 		if len(ldapPwd) == 0 {
 			return security.NewErrPasswordUserAuthFailed(sessionUser)
 		}
+
+		// Audit the authN start time.
+		ldapAuthNStartTime := timeutil.Now()
+
 		if detailedErrors, authError := ldapManager.m.ValidateLDAPLogin(
 			ctx, execCfg.Settings, ldapUserDN, sessionUser, ldapPwd, entry, identMap,
 		); authError != nil {
@@ -1148,6 +1159,9 @@ func AuthLDAP(
 			c.LogAuthFailed(ctx, eventpb.AuthFailReason_CREDENTIALS_INVALID, errForLog)
 			return authError
 		}
+
+		// Add the total authN time to the external auth time.
+		b.AddExternalAuthTime(timeutil.Since(ldapAuthNStartTime))
 		return nil
 	})
 
@@ -1184,6 +1198,9 @@ func AuthLDAP(
 				return err
 			}
 
+			// Audit the authZ start time.
+			ldapAuthZStartTime := timeutil.Now()
+
 			if ldapGroups, detailedErrors, authError := ldapManager.m.FetchLDAPGroups(
 				ctx, execCfg.Settings, ldapUserDN, sessionUser, entry, identMap,
 			); authError != nil {
@@ -1194,6 +1211,9 @@ func AuthLDAP(
 				c.LogAuthFailed(ctx, eventpb.AuthFailReason_AUTHORIZATION_ERROR, errForLog)
 				return authError
 			} else {
+				// Add the total authZ time to the external auth time.
+				b.AddExternalAuthTime(timeutil.Since(ldapAuthZStartTime))
+
 				c.LogAuthInfof(ctx, redact.Sprintf("LDAP authorization sync succeeded; attempting to assign roles for LDAP groups: %s", ldapGroups))
 				// Parse and apply transformation to LDAP group DNs for roles granter.
 				sqlRoles := make([]username.SQLUsername, 0, len(ldapGroups))

--- a/pkg/sql/pgwire/server.go
+++ b/pkg/sql/pgwire/server.go
@@ -224,6 +224,12 @@ var (
 		Measurement: "Nanoseconds",
 		Unit:        metric.Unit_NANOSECONDS,
 	}
+	AuthLDAPConnLatencyInternal = metric.Metadata{
+		Name:        "auth.ldap.conn.latency.internal",
+		Help:        "Internal Auth Latency to establish and authenticate a SQL connection using LDAP(excludes external LDAP calls)",
+		Measurement: "Nanoseconds",
+		Unit:        metric.Unit_NANOSECONDS,
+	}
 )
 
 const (
@@ -377,6 +383,7 @@ type tenantSpecificMetrics struct {
 	AuthLDAPConnLatency         metric.IHistogram
 	AuthGSSConnLatency          metric.IHistogram
 	AuthScramConnLatency        metric.IHistogram
+	AuthLDAPConnLatencyInternal metric.IHistogram
 }
 
 func newTenantSpecificMetrics(
@@ -411,6 +418,8 @@ func newTenantSpecificMetrics(
 			getHistogramOptionsForIOLatency(AuthGSSConnLatency, histogramWindow)),
 		AuthScramConnLatency: metric.NewHistogram(
 			getHistogramOptionsForIOLatency(AuthScramConnLatency, histogramWindow)),
+		AuthLDAPConnLatencyInternal: metric.NewHistogram(
+			getHistogramOptionsForIOLatency(AuthLDAPConnLatencyInternal, histogramWindow)),
 	}
 }
 


### PR DESCRIPTION
Currently, we don't have a way of estimating how much time external authentication methods like ldap take for an auth attempt. With provisioning and authorization enabled, we will be adding additional latency for the auth flow. Hence, we need to gather additional metrics for enabling user auth:
 - Introduce a logging metric to complement auth_ldap_conn_latency cockroachdbMetric. This will be called auth.ldap.conn.latency.internal
 - This will be the actual auth time (authentication +provisioning + authorization) time. We will get the RTT times to the ldap server (bind service plus search user plus bind user plus search groups) and subtract it from the total auth time.

fixes #148874
Epic CRDB-21590

Release note(ops change): `auth.ldap.conn.latency.internal` has been added to denote the internal authentication time for ldap auth method.