### PR TITLE
sql: enable write buffering for transactions at weak isolation levels

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -40,7 +40,8 @@ var BufferedWritesEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.enabled",
 	"if enabled, transactional writes are buffered on the client",
-	metamorphic.ConstantWithTestBool("kv.transaction.write_buffering.enabled", true /* defaultValue */),
+	// metamorphic.ConstantWithTestBool("kv.transaction.write_buffering.enabled", true /* defaultValue */),
+	true,
 	settings.WithPublic,
 )
 

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3765,7 +3765,7 @@ var allowBufferedWritesForWeakIsolation = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"sql.txn.write_buffering_for_weak_isolation.enabled",
 	"set to true to allow write buffering for transactions at weak isolation levels",
-	false,
+	true,
 )
 
 func (ex *connExecutor) txnIsolationLevelToKV(


### PR DESCRIPTION
Epic: none
Release note: None