### PR TITLE
kvserver: run TestCheckConsistencyInconsistent on real fs

### DIFF
--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -299,7 +299,7 @@ func IterateRangeDescriptorsFromDisk(
 				// This case shouldn't happen in practice: we have a key that isn't
 				// associated with any range descriptor.
 				if buildutil.CrdbTestBuild {
-					panic(errors.AssertionFailedf("range local key %s outside of a known range", key.Key))
+					return errors.AssertionFailedf("range local key %s outside of a known range", key.Key)
 				}
 				iter.NextKey()
 			}

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3689,6 +3689,7 @@ func (s *Store) checkpoint(tag string, spans []roachpb.Span) (string, error) {
 	}
 	// Atomically rename the directory when it represents a complete checkpoint.
 	checkpointDir := filepath.Join(checkpointBase, tag)
+
 	if err := s.TODOEngine().Env().Rename(pendingDir, checkpointDir); err != nil {
 		return "", err
 	}


### PR DESCRIPTION
It was using in-memory file systems. This makes it hard to understand what went
wrong in https://github.com/cockroachdb/cockroach/issues/150660.

Epic: none