### PR TITLE
workload_generator: Fix for column parsing for statements

### DIFF
--- a/pkg/workload/workload_generator/workload.go
+++ b/pkg/workload/workload_generator/workload.go
@@ -378,8 +378,8 @@ func (w *workloadGenerator) Ops(
 	// Database name is set in the main workload struct.
 	w.setDbName()
 	// The schema information is loaded into memory from the yaml. This information is used for the runtime data generation.
-	errYaml, done := w.loadYamlData()
-	if done {
+	errYaml := w.loadYamlData()
+	if errYaml != nil {
 		return workload.QueryLoad{}, errYaml
 	}
 	// Transactions from the SQL file are parsed.
@@ -661,7 +661,7 @@ func (t *txnWorker) pickForeignKeyIndex(sqlQuery SQLQuery, d *workloadGenerator)
 
 // loadYamlData first checks whether the input yaml flag is set or not.
 // Accordingly, it loads the schema information into memory from the correct location.
-func (w *workloadGenerator) loadYamlData() (error, bool) {
+func (w *workloadGenerator) loadYamlData() error {
 	var path string
 	if w.inputYAML != "" {
 		path = w.inputYAML
@@ -670,10 +670,10 @@ func (w *workloadGenerator) loadYamlData() (error, bool) {
 	}
 	raw, err := os.ReadFile(path)
 	if err != nil {
-		return errors.Wrapf(err, "could not read schema YAML from %s", path), true
+		return errors.Wrapf(err, "could not read schema YAML from %s", path)
 	}
 	if err := yaml.UnmarshalStrict(raw, &w.workloadSchema); err != nil {
-		return errors.Wrapf(err, "couldn't unmarshal schema YAML"), true
+		return errors.Wrapf(err, "couldn't unmarshal schema YAML")
 	}
-	return nil, false
+	return nil
 }


### PR DESCRIPTION
This is a continuation of the effort for the workload generator which was worked on as an intern project.
The problems were not yet handled:
1. Columns were not identified properly in case there were Joins because only 1 table name was considered from a statement.
e.g. `SELECT o.id, r.c2, r.c3 FROM orders o JOIN ref_data r ON o.acc_no = r.acc_no JOIN ref_data r2 ON o.acc_no = r2.acc_no WHERE r.c2 = _`
2. Columns with table_alias.column_name is not handled as table aliases were not maintained.
e.g. `SELECT o.id, r.c2 FROM orders o, ref_data r WHERE o.acc_no = r.acc_no AND o.amount > _ AND r.acc_no = _ OR o.acc_no = _;`
3. table names prefixed with database name in it were not parsed correctly. In this case, the database in the `crdb_internal.node_statement_statistics.txt` database_name column against the statement is defaultdb and not the actual database name.
e.g. `select a,b,c from dbname.table_name`.

This PR addresses those issues.

Fixes: CRDB-51572
epic: none

Release note (cli change):
Join‐table workload columns are now properly qualified.