### PR TITLE
nilness: catch cases of returning a known-nil err variable

### DIFF
--- a/pkg/backup/backupsink/file_sst_sink.go
+++ b/pkg/backup/backupsink/file_sst_sink.go
@@ -215,7 +215,7 @@ func (s *FileSSTSink) Write(ctx context.Context, resp ExportedSpan) (roachpb.Key
 	} else {
 		log.VEventf(ctx, 3, "continuing to write to backup file %s of size %d", s.outName, s.flushedSize)
 	}
-	return resp.ResumeKey, err
+	return resp.ResumeKey, nil
 }
 
 func (s *FileSSTSink) WriteWithNoData(resp ExportedSpan) {

--- a/pkg/backup/key_rewriter.go
+++ b/pkg/backup/key_rewriter.go
@@ -310,7 +310,7 @@ func (kr *KeyRewriter) rewriteKey(
 		rekeyed = tmp
 	}
 
-	return rekeyed, ok, err
+	return rekeyed, ok, nil
 }
 
 // checkAndRewriteTableKey rewrites the table IDs in the key. It assumes that

--- a/pkg/backup/restore_planning.go
+++ b/pkg/backup/restore_planning.go
@@ -1364,7 +1364,7 @@ func restorePlanHook(
 				if err != nil {
 					return nil, err
 				}
-				return &tid, err
+				return &tid, nil
 			}()
 			if err != nil {
 				return nil, nil, false, err

--- a/pkg/ccl/changefeedccl/cdceval/func_resolver.go
+++ b/pkg/ccl/changefeedccl/cdceval/func_resolver.go
@@ -92,7 +92,7 @@ func (rs *cdcFunctionResolver) ResolveFunctionByOID(
 	if err := checkOverloadSupported(fnName.Object(), overload); err != nil {
 		return nil, nil, err
 	}
-	return fnName, overload, err
+	return fnName, overload, nil
 }
 
 // checkOverloadsSupported verifies function overload is supported by CDC.

--- a/pkg/ccl/changefeedccl/changefeedbase/sink_url.go
+++ b/pkg/ccl/changefeedccl/changefeedbase/sink_url.go
@@ -65,7 +65,7 @@ func (u *SinkURL) ConsumeBool(param string, dest *bool) (wasSet bool, err error)
 		if err != nil {
 			return false, errors.Wrapf(err, "param %s must be a bool", param)
 		}
-		return wasSet, err
+		return wasSet, nil
 	}
 	return false, nil
 }

--- a/pkg/ccl/changefeedccl/event_processing.go
+++ b/pkg/ccl/changefeedccl/event_processing.go
@@ -183,7 +183,7 @@ func newEventConsumer(
 		if err != nil {
 			return nil, nil, err
 		}
-		return c, sink, err
+		return c, sink, nil
 	}
 
 	c := &parallelEventConsumer{

--- a/pkg/ccl/changefeedccl/sink_kafka.go
+++ b/pkg/ccl/changefeedccl/sink_kafka.go
@@ -306,7 +306,7 @@ func (s *kafkaSink) newClient(config *sarama.Config) (kafkaClient, error) {
 		return nil, pgerror.Wrapf(err, pgcode.CannotConnectNow,
 			`connecting to kafka: %s`, s.bootstrapAddrs)
 	}
-	return client, err
+	return client, nil
 }
 
 func (s *kafkaSink) newAsyncProducer(client kafkaClient) (sarama.AsyncProducer, error) {

--- a/pkg/ccl/cliccl/mt_proxy.go
+++ b/pkg/ccl/cliccl/mt_proxy.go
@@ -111,7 +111,7 @@ func initLogging(cmd *cobra.Command) (ctx context.Context, stopper *stop.Stopper
 	// The proxy will shutdown via the stopper, so we can ignore the
 	// cancellation function here.
 	ctx, _ = stopper.WithCancelOnQuiesce(ctx) // nolint:quiesce
-	return ctx, stopper, err
+	return ctx, stopper, nil
 }
 
 func waitForSignals(

--- a/pkg/ccl/partitionccl/partition.go
+++ b/pkg/ccl/partitionccl/partition.go
@@ -394,7 +394,7 @@ func createPartitioning(
 	if err != nil {
 		return nil, catpb.PartitioningDescriptor{}, err
 	}
-	return newImplicitCols, newPartitioning, err
+	return newImplicitCols, newPartitioning, nil
 }
 
 func init() {

--- a/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
+++ b/pkg/ccl/sqlproxyccl/tenant/directory_cache.go
@@ -443,7 +443,7 @@ func (d *directoryCache) watchPods(ctx context.Context, stopper *stop.Stopper) e
 
 	// Block until the initial pod watcher client stream is constructed.
 	waitInit.Wait()
-	return err
+	return nil
 }
 
 // updateTenantPodEntry keeps tenant directory entries up-to-date by handling pod

--- a/pkg/ccl/storageccl/encryption.go
+++ b/pkg/ccl/storageccl/encryption.go
@@ -249,7 +249,7 @@ func decryptingReader(ciphertext readerAndReaderAt, key []byte) (sstable.Readabl
 	ivScratch := buf[:nonceSize]
 	buf = buf[nonceSize:]
 	r := &decryptReader{g: gcm, fileIV: iv, ivScratch: ivScratch, ciphertext: ciphertext, buf: buf, chunk: -1}
-	return r, err
+	return r, nil
 }
 
 // fill loads the requested chunk into the buffer.
@@ -274,7 +274,7 @@ func (r *decryptReader) fill(chunk int64) error {
 	}
 	r.buf = buf
 	r.chunk = chunk
-	return err
+	return nil
 }
 
 func (r *decryptReader) chunkIV(num int64) []byte {

--- a/pkg/cli/cert.go
+++ b/pkg/cli/cert.go
@@ -403,7 +403,7 @@ func encodeURI(cmd *cobra.Command, args []string) error {
 		if err != nil {
 			return "", err
 		}
-		return string(content), err
+		return string(content), nil
 	}
 
 	if encodeURIOpts.caCertPath != "" {

--- a/pkg/cli/clienturl/client_url.go
+++ b/pkg/cli/clienturl/client_url.go
@@ -136,7 +136,7 @@ func (u *urlParser) Set(v string) error {
 
 	// Store the parsed URL for later.
 	u.clientOpts.ExplicitURL = purl
-	return err
+	return nil
 }
 
 var _ clientsecopts.CLIFlagInterfaceForClientURL = (*urlParser)(nil)

--- a/pkg/cli/clisqlcfg/context.go
+++ b/pkg/cli/clisqlcfg/context.go
@@ -99,18 +99,20 @@ func (c *Context) LoadDefaults(cmdOut, cmdErr *os.File) {
 // populated into the configuration fields.
 // The specified input stream is only used if the configuration
 // does not otherwise specify a file to read from.
-func (c *Context) Open(defaultInput *os.File) (closeFn func(), err error) {
+func (c *Context) Open(defaultInput *os.File) (func(), error) {
 	if c.opened {
 		return nil, errors.AssertionFailedf("programming error: Open called twice")
 	}
 
+	var closeFn func()
+	var err error
 	c.cmdIn, closeFn, err = c.getInputFile(defaultInput)
 	if err != nil {
-		return nil, err
+		return closeFn, err
 	}
 	c.checkInteractive()
 	c.opened = true
-	return closeFn, err
+	return closeFn, nil
 }
 
 // getInputFile establishes where we are reading from.

--- a/pkg/cli/clisqlclient/rows.go
+++ b/pkg/cli/clisqlclient/rows.go
@@ -73,7 +73,7 @@ func (r *sqlRows) Next(values []driver.Value) error {
 	// After the first row was received, we want to delay all
 	// further notices until the end of execution.
 	r.conn.delayNotices = true
-	return err
+	return nil
 }
 
 // NextResultSet prepares the next result set for reading.

--- a/pkg/cloud/httpsink/http_storage.go
+++ b/pkg/cloud/httpsink/http_storage.go
@@ -119,7 +119,7 @@ func (h *httpStorage) openStreamAt(
 	for attempt, retries := 0, retry.StartWithCtx(ctx, cloud.HTTPRetryOptions); retries.Next(); attempt++ {
 		resp, err := h.req(ctx, "GET", url, nil, headers)
 		if err == nil {
-			return resp, err
+			return resp, nil
 		}
 
 		log.Errorf(ctx, "HTTP:Req error: err=%s (attempt %d)", err, attempt)
@@ -160,7 +160,7 @@ func (h *httpStorage) ReadFile(
 			if err != nil {
 				return nil, 0, err
 			}
-			return s.Body, size, err
+			return s.Body, size, nil
 		}
 		return cloud.NewResumingReader(ctx, opener, stream.Body, opts.Offset, size, basename,
 			cloud.ResumingReaderRetryOnErrFnForSettings(ctx, h.settings), nil), size, nil

--- a/pkg/config/zonepb/zone.go
+++ b/pkg/config/zonepb/zone.go
@@ -194,7 +194,7 @@ func ResolveZoneSpecifier(
 	if err != nil {
 		return 0, err
 	}
-	return tableID, err
+	return tableID, nil
 }
 
 func (c Constraint) String() string {

--- a/pkg/crosscluster/logical/lww_row_processor.go
+++ b/pkg/crosscluster/logical/lww_row_processor.go
@@ -873,7 +873,7 @@ func makeLWWInsertQueries(
 			inputColumns:         inputColumnNames,
 			scratchDatums:        make([]interface{}, len(inputColumnNames)+1),
 		}
-		return err
+		return nil
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/crosscluster/logical/sql_row_writer.go
+++ b/pkg/crosscluster/logical/sql_row_writer.go
@@ -120,7 +120,7 @@ func (s *sqlRowWriter) UpdateRow(
 	if rowsAffected != 1 {
 		return errStalePreviousValue
 	}
-	return err
+	return nil
 }
 
 func newSQLRowWriter(

--- a/pkg/crosscluster/logical/udf_row_processor.go
+++ b/pkg/crosscluster/logical/udf_row_processor.go
@@ -437,7 +437,7 @@ func makeApplierInsertQueries(
 			inputColumns:  inputColumnNames,
 			scratchDatums: make([]interface{}, len(inputColumnNames)),
 		}
-		return err
+		return nil
 	}); err != nil {
 		return nil, err
 	}

--- a/pkg/crosscluster/producer/producer_job.go
+++ b/pkg/crosscluster/producer/producer_job.go
@@ -236,7 +236,7 @@ func (p *producerJobResumer) removeJobFromTenantRecord(
 		if err := sql.UpdateTenantRecord(ctx, execCfg.Settings, txn, tenantRecord); err != nil {
 			return err
 		}
-		return err
+		return nil
 	})
 }
 

--- a/pkg/geo/encode.go
+++ b/pkg/geo/encode.go
@@ -55,7 +55,7 @@ func SpatialObjectToEWKT(so geopb.SpatialObject, maxDecimalDigits int) (geopb.EW
 	if t.SRID() != 0 {
 		ret = fmt.Sprintf("SRID=%d;%s", t.SRID(), ret)
 	}
-	return geopb.EWKT(ret), err
+	return geopb.EWKT(ret), nil
 }
 
 // SpatialObjectToWKB transforms a given SpatialObject to WKB.

--- a/pkg/geo/geomfn/distance.go
+++ b/pkg/geo/geomfn/distance.go
@@ -220,7 +220,7 @@ func distanceInternal(
 	aIt := geo.NewGeomTIterator(aGeomT, emptyBehavior)
 	aGeom, aNext, aErr := aIt.Next()
 	if aErr != nil {
-		return 0, err
+		return 0, aErr
 	}
 	for aNext {
 		aGeodist, err := geomToGeodist(aGeom)
@@ -231,7 +231,7 @@ func distanceInternal(
 		bIt := geo.NewGeomTIterator(bGeomT, emptyBehavior)
 		bGeom, bNext, bErr := bIt.Next()
 		if bErr != nil {
-			return 0, err
+			return 0, bErr
 		}
 		for bNext {
 			bGeodist, err := geomToGeodist(bGeom)
@@ -248,13 +248,13 @@ func distanceInternal(
 
 			bGeom, bNext, bErr = bIt.Next()
 			if bErr != nil {
-				return 0, err
+				return 0, bErr
 			}
 		}
 
 		aGeom, aNext, aErr = aIt.Next()
 		if aErr != nil {
-			return 0, err
+			return 0, aErr
 		}
 	}
 	return c.DistanceUpdater().Distance(), nil

--- a/pkg/jobs/execution_detail_utils.go
+++ b/pkg/jobs/execution_detail_utils.go
@@ -87,7 +87,7 @@ func stringifyProtobinFile(filename string, fileContents []byte) ([]byte, error)
 	if !ok {
 		return nil, errors.Newf("protobuf in file %s is not a ProtobinExecutionDetailFile", filename)
 	}
-	return f.ToText(), err
+	return f.ToText(), nil
 }
 
 // ReadExecutionDetailFile will stitch together all the chunks corresponding to the

--- a/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
+++ b/pkg/jobs/jobsprotectedts/jobs_protected_ts.go
@@ -109,10 +109,10 @@ func encodeID(id int64) []byte {
 }
 
 // DecodeID decodes ID stored in the PTS record.
-func DecodeID(meta []byte) (id int64, err error) {
-	id, err = strconv.ParseInt(string(meta), 10, 64)
+func DecodeID(meta []byte) (int64, error) {
+	id, err := strconv.ParseInt(string(meta), 10, 64)
 	if err != nil {
 		return 0, errors.Wrapf(err, "failed to interpret meta %q as bytes", meta)
 	}
-	return id, err
+	return id, nil
 }

--- a/pkg/kv/kvserver/kvstorage/init.go
+++ b/pkg/kv/kvserver/kvstorage/init.go
@@ -237,7 +237,7 @@ func ReadStoreIdent(ctx context.Context, eng storage.Engine) (roachpb.StoreIdent
 	} else if !ok {
 		return roachpb.StoreIdent{}, &NotBootstrappedError{}
 	}
-	return ident, err
+	return ident, nil
 }
 
 // IterateRangeDescriptorsFromDisk discovers the initialized replicas and calls

--- a/pkg/kv/kvserver/loqrecovery/plan.go
+++ b/pkg/kv/kvserver/loqrecovery/plan.go
@@ -191,7 +191,7 @@ func PlanReplicas(
 		ClusterID:               clusterInfo.ClusterID,
 		StaleLeaseholderNodeIDs: staleLeaseholderNodes,
 		Version:                 clusterInfo.Version,
-	}, report, err
+	}, report, nil
 }
 
 func planReplicasWithMeta(

--- a/pkg/kv/kvserver/queue.go
+++ b/pkg/kv/kvserver/queue.go
@@ -488,7 +488,7 @@ func newBaseQueue(name string, impl queueImpl, store *Store, cfg queueConfig) *b
 				// ensue.
 				return nil, err
 			}
-			return repl, err
+			return repl, nil
 		},
 	}
 	bq.mu.replicas = map[roachpb.RangeID]*replicaItem{}

--- a/pkg/kv/kvserver/replica_command.go
+++ b/pkg/kv/kvserver/replica_command.go
@@ -1521,7 +1521,7 @@ func (r *Replica) TestingRemoveLearner(
 	if err != nil {
 		return nil, errors.Wrapf(err, `removing learners from %s`, beforeDesc)
 	}
-	return desc, err
+	return desc, nil
 }
 
 // errCannotRemoveLearnerWhileSnapshotInFlight is returned when we cannot remove

--- a/pkg/kv/kvserver/replica_range_lease.go
+++ b/pkg/kv/kvserver/replica_range_lease.go
@@ -1140,11 +1140,10 @@ func (r *Replica) leaseGoodToGoRLocked(
 ) (kvserverpb.LeaseStatus, error) {
 	st := r.leaseStatusForRequest(ctx, now, reqTS, r.mu.minLeaseProposedTS,
 		r.mu.minValidObservedTimestamp, r.shMu.state.Lease, r.raftBasicStatusRLocked())
-	err := r.leaseGoodToGoForStatus(ctx, now, reqTS, st, r.descRLocked())
-	if err != nil {
+	if err := r.leaseGoodToGoForStatus(ctx, now, reqTS, st, r.descRLocked()); err != nil {
 		return kvserverpb.LeaseStatus{}, err
 	}
-	return st, err
+	return st, nil
 }
 
 func (r *Replica) leaseGoodToGoForStatus(

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -308,29 +308,33 @@ func (i *EngineIterator) PrevEngineKey() (valid bool, err error) {
 // SeekEngineKeyGEWithLimit is part of the storage.EngineIterator interface.
 func (i *EngineIterator) SeekEngineKeyGEWithLimit(
 	key storage.EngineKey, limit roachpb.Key,
-) (state pebble.IterValidityState, err error) {
-	state, err = i.i.SeekEngineKeyGEWithLimit(key, limit)
-	if state != pebble.IterValid {
+) (pebble.IterValidityState, error) {
+	state, err := i.i.SeekEngineKeyGEWithLimit(key, limit)
+	// TODO(REVIEW): This is more than a mechanical change. Do we want to
+	// CheckAllowed in the case of an error, was this purposeful?
+	if state != pebble.IterValid || err != nil {
 		return state, err
 	}
-	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
+	if err := i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{Key: key.Key}); err != nil {
 		return pebble.IterExhausted, err
 	}
-	return state, err
+	return state, nil
 }
 
 // SeekEngineKeyLTWithLimit is part of the storage.EngineIterator interface.
 func (i *EngineIterator) SeekEngineKeyLTWithLimit(
 	key storage.EngineKey, limit roachpb.Key,
-) (state pebble.IterValidityState, err error) {
-	state, err = i.i.SeekEngineKeyLTWithLimit(key, limit)
-	if state != pebble.IterValid {
+) (pebble.IterValidityState, error) {
+	// TODO(REVIEW): This is more than a mechanical change. Do we want to
+	// CheckAllowed in the case of an error, was this purposeful?
+	state, err := i.i.SeekEngineKeyLTWithLimit(key, limit)
+	if state != pebble.IterValid || err != nil {
 		return state, err
 	}
 	if err = i.spans.CheckAllowed(SpanReadOnly, roachpb.Span{EndKey: key.Key}); err != nil {
 		return pebble.IterExhausted, err
 	}
-	return state, err
+	return state, nil
 }
 
 // NextEngineKeyWithLimit is part of the storage.EngineIterator interface.

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3985,7 +3985,7 @@ func (s *Store) AllocatorCheckRange(
 
 	// In the case that the action does not require a target, return immediately.
 	if !(action.Add() || action.Replace()) {
-		return action, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), err
+		return action, roachpb.ReplicationTarget{}, sp.FinishAndGetConfiguredRecording(), nil
 	}
 
 	filteredVoters, filteredNonVoters, replacing, nothingToDo, err :=

--- a/pkg/kv/kvserver/store_create_replica.go
+++ b/pkg/kv/kvserver/store_create_replica.go
@@ -75,7 +75,7 @@ func (s *Store) getOrCreateReplica(
 		if err != nil {
 			return nil, false, err
 		}
-		return r, created, err
+		return r, created, nil
 	}
 }
 

--- a/pkg/rpc/context.go
+++ b/pkg/rpc/context.go
@@ -1442,7 +1442,7 @@ func (rpcCtx *Context) dialOptsLocal() ([]grpc.DialOption, error) {
 			return rpcCtx.loopbackDialFn(ctx)
 		}))
 
-	return dialOpts, err
+	return dialOpts, nil
 }
 
 // GetBreakerForAddr looks up a breaker for the matching (NodeID,Class,Addr).

--- a/pkg/rpc/nodedialer/nodedialer.go
+++ b/pkg/rpc/nodedialer/nodedialer.go
@@ -97,7 +97,7 @@ func (n *Dialer) Dial(
 	if err != nil {
 		return gc, errors.Wrapf(err, "gRPC")
 	}
-	return gc, err
+	return gc, nil
 }
 
 // DRPCDial returns a drpc connection to the given node. It logs whenever the
@@ -113,7 +113,7 @@ func (n *Dialer) DRPCDial(
 	if err != nil {
 		return nil, errors.Wrapf(err, "DRPC")
 	}
-	return dc, err
+	return dc, nil
 }
 
 // DialNoBreaker is like Dial, but will not check the circuit breaker before
@@ -129,7 +129,7 @@ func (n *Dialer) DialNoBreaker(
 	if err != nil {
 		return nil, errors.Wrapf(err, "gRPC")
 	}
-	return gc, err
+	return gc, nil
 }
 
 // DRPCDialNoBreaker is like DRPCDial, but will not check the circuit breaker
@@ -145,7 +145,7 @@ func (n *Dialer) DRPCDialNoBreaker(
 	if err != nil {
 		return nil, errors.Wrapf(err, "DRPC")
 	}
-	return dc, err
+	return dc, nil
 }
 
 // DialInternalClient is a specialization of DialClass for callers that
@@ -275,7 +275,7 @@ func (n *Dialer) ConnHealth(nodeID roachpb.NodeID, class rpcbase.ConnectionClass
 func (n *Dialer) ConnHealthTryDial(nodeID roachpb.NodeID, class rpcbase.ConnectionClass) error {
 	err := n.ConnHealth(nodeID, class)
 	if err == nil {
-		return err
+		return nil
 	}
 	addr, locality, err := n.resolver(nodeID)
 	if err != nil {

--- a/pkg/security/distinguishedname/parse.go
+++ b/pkg/security/distinguishedname/parse.go
@@ -110,5 +110,5 @@ rdn_loop:
 	if sqlRole.IsEmptyRole() {
 		return username.EmptyRoleName(), false, nil
 	}
-	return sqlRole, true, err
+	return sqlRole, true, nil
 }

--- a/pkg/security/provisioning/provisioning_source.go
+++ b/pkg/security/provisioning/provisioning_source.go
@@ -63,17 +63,18 @@ func parseAuthMethod(sourceStr string) (authMethod string, idp string, err error
 	return "", "", errors.Newf("PROVISIONSRC %q was not prefixed with any valid auth methods %q", sourceStr, supportedProvisioningMethods)
 }
 
-func parseIDP(idp string) (u *url.URL, err error) {
+func parseIDP(idp string) (*url.URL, error) {
 	if len(idp) == 0 {
 		return nil, errors.Newf("PROVISIONSRC IDP cannot be empty")
 	}
-	if u, err = url.Parse(idp); err != nil {
+	u, err := url.Parse(idp)
+	if err != nil {
 		return nil, errors.Wrapf(err, "provided IDP %q in PROVISIONSRC is non parseable", idp)
 	}
 	if len(u.Port()) != 0 || u.Opaque != "" {
 		return nil, errors.Newf("unknown PROVISIONSRC IDP url format in %q", idp)
 	}
-	return
+	return u, nil
 }
 
 func (source *Source) Size() int {

--- a/pkg/server/fanout_clients.go
+++ b/pkg/server/fanout_clients.go
@@ -121,7 +121,7 @@ func (t *tenantFanoutClient) nodesList(ctx context.Context) (*serverpb.NodesList
 		}
 		resp.Nodes = append(resp.Nodes, nodeDetails)
 	}
-	return &resp, err
+	return &resp, nil
 }
 
 var _ ServerIterator = &tenantFanoutClient{}

--- a/pkg/server/key_visualizer_server.go
+++ b/pkg/server/key_visualizer_server.go
@@ -82,7 +82,7 @@ func (s *KeyVisualizerServer) getSamplesFromFanOut(
 		if err != nil {
 			return nil, err
 		}
-		return samples, err
+		return samples, nil
 	}
 
 	globalSamples := make(map[int64][]keyvispb.Sample)

--- a/pkg/server/server.go
+++ b/pkg/server/server.go
@@ -1411,7 +1411,7 @@ func NewServer(cfg Config, stopper *stop.Stopper) (serverctl.ServerStartupInterf
 		inspectzServer:            inspectzServer,
 	}
 
-	return lateBoundServer, err
+	return lateBoundServer, nil
 }
 
 // newClockFromConfig creates a HLC clock from the server configuration.

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -782,7 +782,7 @@ func (s *systemStatusServer) Gossip(
 		gossipData = s.redactGossipResponse(gossipData)
 	}
 
-	return gossipData, err
+	return gossipData, nil
 }
 
 // TODO: Enhance with redaction middleware, refer: https://github.com/cockroachdb/cockroach/issues/109594
@@ -1226,7 +1226,7 @@ func (s *statusServer) Details(
 			detailsResponse = s.redactDetailsResponse(detailsResponse)
 		}
 
-		return detailsResponse, err
+		return detailsResponse, nil
 	}
 
 	remoteNodeID := roachpb.NodeID(s.serverIterator.getID())

--- a/pkg/server/testserver.go
+++ b/pkg/server/testserver.go
@@ -1492,7 +1492,7 @@ func (ts *testServer) StartSharedProcessTenant(
 	if err != nil {
 		return nil, nil, err
 	}
-	return tt, sqlDB, err
+	return tt, sqlDB, nil
 }
 
 // DisableStartTenant is part of the serverutils.TenantControlInterface.
@@ -1864,7 +1864,7 @@ func (ts *testServer) StartTenant(
 		drain:          sw.drainServer,
 		pgL:            sw.loopbackPgL,
 		deploymentMode: serverutils.ExternalProcess,
-	}, err
+	}, nil
 }
 
 // ExpectedInitialRangeCount returns the expected number of ranges that should

--- a/pkg/settings/rulebasedscanner/scanner.go
+++ b/pkg/settings/rulebasedscanner/scanner.go
@@ -147,21 +147,23 @@ outer:
 // commas count as separator only when they immediately follow a string.
 //
 // Inspired from pg's src/backend/libpq/hba.c, next_field_expand().
-func nextFieldExpand(buf string) (remaining string, field []String, err error) {
-	remaining = buf
+func nextFieldExpand(buf string) (string, []String, error) {
+	field := []String{}
+	remaining := buf
 	for {
 		var trailingComma, trailingEquals bool
 		var tok String
+		var err error
 		remaining, tok, trailingComma, trailingEquals, err = NextToken(remaining)
 		if tok.Empty() || err != nil {
-			return
+			return remaining, field, err
 		}
 		field = append(field, tok)
 		if !(trailingComma || trailingEquals) {
 			break
 		}
 	}
-	return
+	return remaining, field, nil
 }
 
 // Tokenize splits the input into tokens.

--- a/pkg/sql/alter_default_privileges.go
+++ b/pkg/sql/alter_default_privileges.go
@@ -94,7 +94,7 @@ func (p *planner) alterDefaultPrivileges(
 		n:           n,
 		dbDesc:      dbDesc,
 		schemaDescs: schemaDescs,
-	}, err
+	}, nil
 }
 
 func (n *alterDefaultPrivilegesNode) startExec(params runParams) error {

--- a/pkg/sql/alter_primary_key.go
+++ b/pkg/sql/alter_primary_key.go
@@ -428,7 +428,7 @@ func (p *planner) AlterPrimaryKey(
 					return false, err
 				}
 				if col.IsVirtual() && !newPrimaryKeyColIDs.Contains(colID) {
-					return true, err
+					return true, nil
 				}
 			}
 		}

--- a/pkg/sql/catalog/descs/collection.go
+++ b/pkg/sql/catalog/descs/collection.go
@@ -1380,7 +1380,7 @@ func (tc *Collection) LockDescriptorWithLease(
 	if shouldReadFromStore {
 		return 0, ErrDescCannotBeLeased{id: id}
 	}
-	return uint64(desc.GetVersion()), err
+	return uint64(desc.GetVersion()), nil
 }
 
 // MakeTestCollection makes a Collection that can be used for tests.

--- a/pkg/sql/catalog/descs/getters.go
+++ b/pkg/sql/catalog/descs/getters.go
@@ -175,7 +175,7 @@ func (g MutableByIDGetter) Descs(
 	for i, desc := range descs {
 		ret[i] = desc.(catalog.MutableDescriptor)
 	}
-	return ret, err
+	return ret, nil
 }
 
 // Desc looks up a mutable descriptor by ID.

--- a/pkg/sql/catalog/internal/validate/validate.go
+++ b/pkg/sql/catalog/internal/validate/validate.go
@@ -343,7 +343,7 @@ func (vdg *validationDescGetterImpl) GetTypeDescriptor(
 	if err != nil {
 		return nil, err
 	}
-	return descriptor, err
+	return descriptor, nil
 }
 
 func (vdg *validationDescGetterImpl) GetFunctionDescriptor(

--- a/pkg/sql/catalog/lease/count.go
+++ b/pkg/sql/catalog/lease/count.go
@@ -155,7 +155,7 @@ func countLeasesNonMultiRegion(
 	ctx context.Context, txn isql.Txn, at hlc.Timestamp, whereClauses []string,
 ) (countDetail, error) {
 	stmt := fmt.Sprintf(
-		`SELECT %[1]s FROM system.public.lease AS OF SYSTEM TIME '%[2]s' WHERE 
+		`SELECT %[1]s FROM system.public.lease AS OF SYSTEM TIME '%[2]s' WHERE
 crdb_region=$2 AND %[3]s`,
 		getCountLeaseColumns(),
 		at.AsOfSystemTime(),
@@ -280,5 +280,5 @@ func handleRegionLivenessErrors(
 		}
 		return err
 	}
-	return err
+	return nil
 }

--- a/pkg/sql/catalog/schemaexpr/column.go
+++ b/pkg/sql/catalog/schemaexpr/column.go
@@ -215,7 +215,7 @@ func iterColDescriptors(
 		if err := f(col); err != nil {
 			return false, nil, err
 		}
-		return false, expr, err
+		return false, expr, nil
 	})
 
 	return err

--- a/pkg/sql/catalog/table_elements.go
+++ b/pkg/sql/catalog/table_elements.go
@@ -1087,7 +1087,7 @@ func FindTargetIndexNameByID(desc TableDescriptor, indexID descpb.IndexID) (stri
 	if err != nil {
 		return "", err
 	}
-	return index.GetName(), err
+	return index.GetName(), nil
 }
 
 // ColumnNamesForIDs returns the names for the given column IDs, or an error

--- a/pkg/sql/catalog/tabledesc/table_desc_builder.go
+++ b/pkg/sql/catalog/tabledesc/table_desc_builder.go
@@ -239,7 +239,7 @@ func (tdb *tableDescriptorBuilder) RunRestoreChanges(
 		tdb.changes.Add(catalog.UpgradedDeclarativeSchemaChangerState)
 	}
 
-	return err
+	return nil
 }
 
 // StripDanglingBackReferences implements the catalog.DescriptorBuilder
@@ -1194,7 +1194,7 @@ func maybeUpgradeSequenceReferenceForView(
 		}
 
 		hasUpgraded = hasUpgraded || hasUpgradedInExpr
-		return false, newExpr, err
+		return false, newExpr, nil
 	}
 
 	stmt, err := parser.ParseOne(viewDesc.GetViewQuery())
@@ -1209,7 +1209,7 @@ func maybeUpgradeSequenceReferenceForView(
 
 	viewDesc.ViewQuery = newStmt.String()
 
-	return hasUpgraded, err
+	return hasUpgraded, nil
 }
 
 // Attempt to fully resolve table names for `ids` from a list of descriptors.

--- a/pkg/sql/colcontainer/diskqueue.go
+++ b/pkg/sql/colcontainer/diskqueue.go
@@ -143,7 +143,7 @@ func (w *diskQueueWriter) compressAndFlush(ctx context.Context) (int, error) {
 		return 0, err
 	}
 	w.buffer.Reset()
-	return nType + nBody, err
+	return nType + nBody, nil
 }
 
 func (w *diskQueueWriter) numBytesBuffered() int {

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2216,7 +2216,7 @@ func planSelectionOperators(
 				// the result will be NULL and the selection vector will always
 				// be empty. So we can simply plan a zero operator.
 				op = colexecutils.NewZeroOp(input)
-				return op, resultIdx, ct, err
+				return op, resultIdx, ct, nil
 			}
 			switch cmpOp.Symbol {
 			case treecmp.Like, treecmp.NotLike, treecmp.ILike, treecmp.NotILike:
@@ -2286,7 +2286,7 @@ func planSelectionOperators(
 		op = colexec.NewIsNullSelOp(
 			op, resultIdx, true /* negate */, typs[resultIdx].Family() == types.TupleFamily,
 		)
-		return op, resultIdx, typs, err
+		return op, resultIdx, typs, nil
 	case *tree.IsNullExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
 			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables,
@@ -2297,7 +2297,7 @@ func planSelectionOperators(
 		op = colexec.NewIsNullSelOp(
 			op, resultIdx, false /* negate */, typs[resultIdx].Family() == types.TupleFamily,
 		)
-		return op, resultIdx, typs, err
+		return op, resultIdx, typs, nil
 	case *tree.NotExpr:
 		op, resultIdx, typs, err = planProjectionOperators(
 			ctx, evalCtx, t.TypedInnerExpr(), columnTypes, input, allocator, releasables,
@@ -2935,7 +2935,7 @@ func planProjectionExpr(
 		*releasables = append(*releasables, r)
 	}
 	typs = append(typs, outputType)
-	return op, resultIdx, typs, err
+	return op, resultIdx, typs, nil
 }
 
 // planLogicalProjectionOp plans all the needed operators for a projection of

--- a/pkg/sql/colflow/colrpc/inbox.go
+++ b/pkg/sql/colflow/colrpc/inbox.go
@@ -167,7 +167,7 @@ func NewInboxWithAdmissionControl(
 	}
 	i.admissionQ = admissionQ
 	i.admissionInfo = admissionInfo
-	return i, err
+	return i, nil
 }
 
 // close closes the inbox, ensuring that any call to RunWithStream will return

--- a/pkg/sql/create_role.go
+++ b/pkg/sql/create_role.go
@@ -262,7 +262,7 @@ func updateRoleOptions(
 		rowsAffected += affected
 	}
 
-	return rowsAffected, err
+	return rowsAffected, nil
 }
 
 // Next implements the planNode interface.

--- a/pkg/sql/delegate/delegate.go
+++ b/pkg/sql/delegate/delegate.go
@@ -217,7 +217,7 @@ func (d *delegator) parse(sql string) (tree.Statement, error) {
 		return s.AST, err
 	}
 	d.evalCtx.Planner.MaybeReallocateAnnotations(s.NumAnnotations)
-	return s.AST, err
+	return s.AST, nil
 }
 
 // We avoid the cache so that we can observe the details without
@@ -288,7 +288,7 @@ func (d *delegator) getCommentQuery(
 	commentJoin := fmt.Sprintf(`
 			LEFT JOIN
 				(
-					SELECT 
+					SELECT
 						objoid, description as comment
 					FROM
 						%s

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -4265,7 +4265,7 @@ func (dsp *DistSQLPlanner) createPhysPlanForPlanNode(
 		associateWithPlanNode(&plan.PhysicalPlan)
 	}
 
-	return plan, err
+	return plan, nil
 }
 
 // wrapPlan produces a DistSQL processor for an arbitrary planNode. This is

--- a/pkg/sql/doctor/doctor.go
+++ b/pkg/sql/doctor/doctor.go
@@ -215,7 +215,7 @@ func ExamineDescriptors(
 		}
 	}
 
-	return !problemsFound, err
+	return !problemsFound, nil
 }
 
 // ExamineJobs runs a suite of consistency checks over the system.jobs table.

--- a/pkg/sql/drop_table.go
+++ b/pkg/sql/drop_table.go
@@ -166,7 +166,7 @@ func (p *planner) prepareDrop(
 		return nil, err
 	}
 	if tableDesc == nil {
-		return nil, err
+		return nil, nil
 	}
 	if err := p.canDropTable(ctx, tableDesc, true /* checkOwnership */); err != nil {
 		return nil, err

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -2372,7 +2372,7 @@ func (p *planner) isAsOf(ctx context.Context, stmt tree.Statement) (*eval.AsOfSy
 		return nil, err
 	}
 	asOfRet.ForBackfill = forBackfill
-	return &asOfRet, err
+	return &asOfRet, nil
 }
 
 // isSavepoint returns true if ast is a SAVEPOINT statement.

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -1030,7 +1030,7 @@ func (c *stmtEnvCollector) PrintVersion(w io.Writer) error {
 		version = testingOverrideExplainEnvVersion
 	}
 	fmt.Fprintf(w, "-- Version: %s\n", version)
-	return err
+	return nil
 }
 
 func (c *stmtEnvCollector) PrintUser(w io.Writer) {

--- a/pkg/sql/exprutil/evaluator.go
+++ b/pkg/sql/exprutil/evaluator.go
@@ -146,7 +146,7 @@ func (e Evaluator) LazyStringOrNull(
 		if d == tree.DNull {
 			return true, "", nil
 		}
-		return false, string(tree.MustBeDString(d)), err
+		return false, string(tree.MustBeDString(d)), nil
 	}, nil
 }
 

--- a/pkg/sql/importer/import_planning.go
+++ b/pkg/sql/importer/import_planning.go
@@ -279,7 +279,7 @@ func resolveUDTsUsedByImportInto(
 			}
 			typeDescs = append(typeDescs, immutDesc)
 		}
-		return err
+		return nil
 	})
 	return typeDescs, err
 }

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -2361,7 +2361,7 @@ func (b *Builder) buildDistribute(
 		// Don't bother creating a no-op distribution. This likely exists because
 		// the input is a Sort expression, and this is an artifact of how physical
 		// properties are enforced.
-		return input, inputCols, err
+		return input, inputCols, nil
 	}
 
 	if b.evalCtx.SessionData().EnforceHomeRegion && b.IsANSIDML {
@@ -2421,7 +2421,7 @@ func (b *Builder) buildDistribute(
 
 	// TODO(rytaft): This is currently a no-op. We should pass this distribution
 	// info to the DistSQL planner.
-	return input, inputCols, err
+	return input, inputCols, nil
 }
 
 func (b *Builder) buildOrdinality(
@@ -4072,7 +4072,7 @@ func (b *Builder) applySaveTable(
 	if err != nil {
 		return execPlan{}, err
 	}
-	return input, err
+	return input, nil
 }
 
 func (b *Builder) buildOpaque(
@@ -4360,7 +4360,7 @@ func (b *Builder) getEnvData() (exec.ExplainEnvData, error) {
 	if err != nil {
 		return envOpts, err
 	}
-	return envOpts, err
+	return envOpts, nil
 }
 
 // statementTag returns a string that can be used in an error message regarding

--- a/pkg/sql/opt/workloadindexrec/workload_indexrecs.go
+++ b/pkg/sql/opt/workloadindexrec/workload_indexrecs.go
@@ -95,7 +95,7 @@ func collectIndexRecs(
 		indexes := tree.MustBeDArray(indexRecs.Cur()[0])
 		fingerprintId, e := sqlstatsutil.DatumToUint64(indexRecs.Cur()[1])
 		if e != nil {
-			return cis, dis, err
+			return cis, dis, e
 		}
 		for _, index := range indexes.Array {
 			indexStr, ok := index.(*tree.DString)

--- a/pkg/sql/pgwire/auth.go
+++ b/pkg/sql/pgwire/auth.go
@@ -405,8 +405,9 @@ func (c *conn) findAuthenticationMethod(
 		}
 		tlsState = tlsConn.ConnectionState()
 	}
-
-	return
+	// TODO(REVIEW): This and other functions that use naked returns are
+	// interesting examples.
+	return // nolint:nilness
 }
 
 func (c *conn) lookupAuthenticationMethodUsingRules(

--- a/pkg/sql/region_util.go
+++ b/pkg/sql/region_util.go
@@ -1448,7 +1448,7 @@ func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) getExpected
 	if err != nil {
 		return zonepb.ZoneConfig{}, err
 	}
-	return expectedZoneConfig, err
+	return expectedZoneConfig, nil
 }
 
 func (v *zoneConfigForMultiRegionValidatorExistingMultiRegionObject) transitioningRegions() catpb.RegionNames {

--- a/pkg/sql/resolver.go
+++ b/pkg/sql/resolver.go
@@ -1204,7 +1204,7 @@ func (p *planner) ResolveMutableTableDescriptorExAllowNoPrimaryKey(
 		return catalog.ResolvedObjectPrefix{}, nil, err
 	}
 
-	return prefix, table, err
+	return prefix, table, nil
 }
 
 // See ResolveUncachedTableDescriptor.

--- a/pkg/sql/rolemembershipcache/cache.go
+++ b/pkg/sql/rolemembershipcache/cache.go
@@ -278,7 +278,7 @@ func (m *MembershipCache) GetRolesForMember(
 				if err != nil {
 					return err
 				}
-				return err
+				return nil
 			})
 			if err != nil {
 				return nil, err

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -250,7 +250,7 @@ func (rd *Deleter) encodeValueForPrimaryIndexFamily(
 			return roachpb.Value{}, err
 		}
 
-		return marshaled, err
+		return marshaled, nil
 	}
 
 	rd.rawValueBuf = rd.rawValueBuf[:0]

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -78,7 +78,7 @@ func EncodeIndexKey(
 	if err != nil {
 		return nil, false, err
 	}
-	return key, containsNull, err
+	return key, containsNull, nil
 }
 
 // EncodePartialIndexSpan creates the minimal key span for the key specified by the
@@ -422,7 +422,7 @@ func DecodeIndexKeyPrefix(
 		return 0, nil, errors.Errorf(
 			"unexpected table ID %d, expected %d instead", tableID, expectedTableID)
 	}
-	return indexID, key, err
+	return indexID, key, nil
 }
 
 // DecodeIndexKey decodes the values that are a part of the specified index
@@ -1160,7 +1160,7 @@ func encodeVectorIndexKey(
 	}
 	key = vecencoding.EncodePartitionKey(key, partitionKey)
 	key = vecencoding.EncodePartitionLevel(key, cspann.LeafLevel)
-	return key, err
+	return key, nil
 }
 
 // EncodePrimaryIndex constructs the key prefix for the primary index and

--- a/pkg/sql/rowenc/keyside/decode.go
+++ b/pkg/sql/rowenc/keyside/decode.go
@@ -139,7 +139,7 @@ func Decode(
 			return nil, nil, err
 		}
 		d := a.NewDJSON(tree.DJSON{JSON: json})
-		return d, rkey, err
+		return d, rkey, nil
 	case types.BytesFamily:
 		var r []byte
 		if dir == encoding.Ascending {

--- a/pkg/sql/schema_changer.go
+++ b/pkg/sql/schema_changer.go
@@ -1625,7 +1625,7 @@ func WaitToUpdateLeases(
 		return nil, err
 	}
 	log.Infof(ctx, "waiting for a single version... done (at v %d), took %v", desc.GetVersion(), timeutil.Since(start))
-	return desc, err
+	return desc, nil
 }
 
 // done finalizes the mutations (adds new cols/indexes to the table).
@@ -3618,7 +3618,7 @@ func (p *planner) CanPerformDropOwnedBy(
 	if err != nil {
 		return false, err
 	}
-	return tree.MustBeDInt(row[0]) == 0, err
+	return tree.MustBeDInt(row[0]) == 0, nil
 }
 
 // CanCreateCrossDBSequenceOwnerRef returns if cross database sequence

--- a/pkg/sql/schemachanger/rel/query_lang_yaml.go
+++ b/pkg/sql/schemachanger/rel/query_lang_yaml.go
@@ -61,7 +61,7 @@ func exprToString(e expr) (string, error) {
 	if err != nil {
 		return "", err
 	}
-	return strings.TrimSpace(string(out)), err
+	return strings.TrimSpace(string(out)), nil
 }
 
 func (f tripleDecl) MarshalYAML() (interface{}, error) {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/alter_table_add_constraint.go
@@ -785,7 +785,7 @@ func iterateColNamesInExpr(
 		if err := f(colNameElem.Name); err != nil {
 			return false, nil, err
 		}
-		return false, expr, err
+		return false, expr, nil
 	})
 
 	if err != nil {

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/database_zone_config.go
@@ -185,7 +185,7 @@ func (dzo *databaseZoneConfigObj) getZoneConfig(
 	}
 	// If the zone config exists, return.
 	if zc != nil {
-		return zc, err
+		return zc, nil
 	}
 
 	// Otherwise, no zone config for this ID. Retrieve the default zone config,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/index_zone_config.go
@@ -394,7 +394,7 @@ func (izo *indexZoneConfigObj) applyZoneConfig(
 		return nil, err
 	}
 	izo.setZoneConfigToWrite(partialZone)
-	return oldZone, err
+	return oldZone, nil
 }
 
 // fillIndexFromZoneSpecifier fills out the index id in the zone

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/named_range_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/named_range_zone_config.go
@@ -160,7 +160,7 @@ func (rzo *namedRangeZoneConfigObj) getZoneConfig(
 	}
 	// If the zone config exists, return.
 	if zc != nil {
-		return zc, err
+		return zc, nil
 	}
 
 	// Otherwise, no zone config for this ID. Retrieve the default zone config,

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_helpers.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_helpers.go
@@ -380,7 +380,7 @@ func createPartitioning(
 	if err != nil {
 		return nil, catpb.PartitioningDescriptor{}, err
 	}
-	return newImplicitCols, newPartitioning, err
+	return newImplicitCols, newPartitioning, nil
 }
 
 // collectImplicitPartitionColumns collects implicit partitioning columns.

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/partition_zone_config.go
@@ -404,7 +404,7 @@ func (pzo *partitionZoneConfigObj) applyZoneConfig(
 		return nil, err
 	}
 	pzo.setZoneConfigToWrite(partialZone)
-	return oldZone, err
+	return oldZone, nil
 }
 
 // panicIfNoPartitionExistsOnIdx panics if the partition referenced in a

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/table_zone_config.go
@@ -178,7 +178,7 @@ func (tzo *tableZoneConfigObj) getZoneConfig(
 	}
 	// If the zone config exists and is not a subzone placeholder, return.
 	if zc != nil && !zc.IsSubzonePlaceholder() {
-		return zc, err
+		return zc, nil
 	}
 
 	// Otherwise, since our target is a table, recursively get the zone config

--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -3624,12 +3624,12 @@ func (tssi *tableSpanStatsIterator) fetchSpanStats(ctx context.Context) (bool, e
 	// If we have spans, request span stats
 	if len(spans) > 0 {
 		tssi.currStatsResponse, err = tssi.p.SpanStats(ctx, spans)
+		if err != nil {
+			return false, err
+		}
 	}
 
-	if err != nil {
-		return false, err
-	}
-	return ok, err
+	return ok, nil
 }
 
 // Values implements the eval.ValueGenerator interface.

--- a/pkg/sql/sem/eval/expr.go
+++ b/pkg/sql/sem/eval/expr.go
@@ -123,7 +123,7 @@ func (e *evaluator) EvalBinaryExpr(ctx context.Context, expr *tree.BinaryExpr) (
 				"binary op %q", expr)
 		}
 	}
-	return res, err
+	return res, nil
 }
 
 func (e *evaluator) EvalCaseExpr(ctx context.Context, expr *tree.CaseExpr) (tree.Datum, error) {
@@ -488,7 +488,7 @@ func (e *evaluator) EvalFuncExpr(ctx context.Context, expr *tree.FuncExpr) (tree
 		return nil, err
 	}
 	if nullResult {
-		return tree.DNull, err
+		return tree.DNull, nil
 	}
 
 	if fn.Body != "" {
@@ -716,7 +716,7 @@ func (e *evaluator) EvalUnaryExpr(ctx context.Context, expr *tree.UnaryExpr) (tr
 			return nil, errors.NewAssertionErrorWithWrappedErrf(err, "unary op %q", expr)
 		}
 	}
-	return res, err
+	return res, nil
 }
 
 func (e *evaluator) EvalUnresolvedName(

--- a/pkg/sql/sem/tree/datum.go
+++ b/pkg/sql/sem/tree/datum.go
@@ -2966,7 +2966,7 @@ func ParseDTimestampTZ(
 	if err != nil {
 		return nil, false, err
 	}
-	return &DTimestampTZ{Time: t}, dependsOnContext, err
+	return &DTimestampTZ{Time: t}, dependsOnContext, nil
 }
 
 // DZeroTimestampTZ is the zero-valued DTimestampTZ.

--- a/pkg/sql/sem/tree/overload.go
+++ b/pkg/sql/sem/tree/overload.go
@@ -1644,7 +1644,7 @@ func filterAttempt(
 			return false, err
 		}
 		if ok {
-			return true, err
+			return true, nil
 		}
 	}
 	s.overloadIdxs = before

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -873,7 +873,7 @@ func (expr *TupleStar) TypeCheck(
 		return nil, NewTypeIsNotCompositeError(resolvedType)
 	}
 
-	return subExpr, err
+	return subExpr, nil
 }
 
 // ResolvedType implements the TypedExpr interface.

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -664,10 +664,10 @@ func setVersionSetting(
 			// servers present at the time of the settings update, matches the
 			// set that was present when the fence bump occurred (see comment in
 			// upgrademanager.Migrate() for more details).
-			if err = postSettingValidate(ctx, txn); err != nil {
+			if err := postSettingValidate(ctx, txn); err != nil {
 				return err
 			}
-			return err
+			return nil
 		})
 	}
 

--- a/pkg/sql/set_zone_config.go
+++ b/pkg/sql/set_zone_config.go
@@ -1092,7 +1092,7 @@ func writeZoneConfigUpdate(
 	if len(r.Keys) > 0 {
 		numAffected = 1
 	}
-	return numAffected, err
+	return numAffected, nil
 }
 
 // RemoveIndexZoneConfigs removes the zone configurations for some

--- a/pkg/sql/sqlinstance/instancestorage/instancestorage.go
+++ b/pkg/sql/sqlinstance/instancestorage/instancestorage.go
@@ -347,7 +347,7 @@ func (s *Storage) createInstanceRow(
 				SessionID:       session.ID(),
 				Locality:        locality,
 				BinaryVersion:   binaryVersion,
-			}, err
+			}, nil
 		}
 		if !errors.Is(err, errNoPreallocatedRows) {
 			return sqlinstance.InstanceInfo{}, err

--- a/pkg/sql/virtual_table.go
+++ b/pkg/sql/virtual_table.go
@@ -278,13 +278,12 @@ func (v *vTableLookupJoinNode) startExec(params runParams) error {
 		return errors.AssertionFailedf("unexpected join type for virtual lookup join: %s", v.joinType.String())
 	}
 	v.run.indexKeyDatums = make(tree.Datums, len(v.columns))
-	var err error
 	db, err := params.p.byNameGetterBuilder().Get().Database(params.ctx, v.dbName)
 	if err != nil {
 		return err
 	}
 	v.db = db
-	return err
+	return nil
 }
 
 // Next implements the planNode interface.

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4575,7 +4575,7 @@ func mvccScanToKvs(
 	}); err != nil {
 		return MVCCScanResult{}, err
 	}
-	return res, err
+	return res, nil
 }
 
 func buildScanIntents(data []byte) ([]roachpb.Intent, error) {

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -367,7 +367,7 @@ func (wb *writeBatch) Commit(sync bool) error {
 	}
 	wb.batchStatsReporter.aggregateBatchCommitStats(
 		BatchCommitStats{wb.batch.CommitStats()})
-	return err
+	return nil
 }
 
 // CommitNoSyncWait implements the WriteBatch interface.
@@ -386,7 +386,7 @@ func (wb *writeBatch) CommitNoSyncWait() error {
 		// or don't have after they receive an error from this method.
 		panic(err)
 	}
-	return err
+	return nil
 }
 
 // SyncWait implements the WriteBatch interface.
@@ -407,7 +407,7 @@ func (wb *writeBatch) SyncWait() error {
 	}
 	wb.batchStatsReporter.aggregateBatchCommitStats(
 		BatchCommitStats{wb.batch.CommitStats()})
-	return err
+	return nil
 }
 
 // Empty implements the WriteBatch interface.

--- a/pkg/util/cgroups/cgroups.go
+++ b/pkg/util/cgroups/cgroups.go
@@ -244,7 +244,7 @@ func cgroupFileToUint64(filepath, desc string) (res uint64, err error) {
 	if err != nil {
 		return 0, errors.Wrapf(err, "error when parsing %s from cgroup v1 at %s", desc, filepath)
 	}
-	return res, err
+	return res, nil
 }
 
 func cgroupFileToInt64(filepath, desc string) (res int64, err error) {
@@ -271,7 +271,7 @@ func detectCPUQuotaInV1(cRoot string) (period, quota int64, err error) {
 		return 0, 0, err
 	}
 
-	return period, quota, err
+	return period, quota, nil
 }
 
 func detectCPUUsageInV1(cRoot string) (stime, utime uint64, err error) {
@@ -286,7 +286,7 @@ func detectCPUUsageInV1(cRoot string) (stime, utime uint64, err error) {
 		return 0, 0, err
 	}
 
-	return stime, utime, err
+	return stime, utime, nil
 }
 
 func detectCPUQuotaInV2(cRoot string) (period, quota int64, err error) {

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -3051,7 +3051,7 @@ func DecodeUntaggedBox2DValue(b []byte) (remaining []byte, box geopb.BoundingBox
 	if err != nil {
 		return b, box, err
 	}
-	return remaining, box, err
+	return remaining, box, nil
 }
 
 // DecodeUntaggedGeoValue decodes a value encoded by EncodeUntaggedGeoValue into
@@ -3258,7 +3258,7 @@ func PeekValueLengthWithOffsetsAndType(b []byte, dataOffset int, typ Type) (leng
 			return 0, err
 		}
 		numWords, _ := bitarray.SizesForBitLen(uint(bitLen))
-		return dataOffset + n + int(numWords)*8, err
+		return dataOffset + n + int(numWords)*8, nil
 	case Tuple:
 		rem, l, numTuples, err := DecodeNonsortingUvarint(b)
 		if err != nil {

--- a/pkg/util/interval/btree_based_interval.go
+++ b/pkg/util/interval/btree_based_interval.go
@@ -993,10 +993,10 @@ func (c *copyOnWriteContext) freeNode(n *node) freeType {
 	return ftNotOwned
 }
 
-func (t *btree) Insert(e Interface, fast bool) (err error) {
+func (t *btree) Insert(e Interface, fast bool) error {
 	// t.metrics("Insert")
-	if err = isValidInterface(e); err != nil {
-		return
+	if err := isValidInterface(e); err != nil {
+		return err
 	}
 
 	if t.root == nil {
@@ -1027,19 +1027,19 @@ func (t *btree) Insert(e Interface, fast bool) (err error) {
 	if out == nil {
 		t.length++
 	}
-	return
+	return nil
 }
 
-func (t *btree) Delete(e Interface, fast bool) (err error) {
+func (t *btree) Delete(e Interface, fast bool) error {
 	// t.metrics("Delete")
-	if err = isValidInterface(e); err != nil {
-		return
+	if err := isValidInterface(e); err != nil {
+		return err
 	}
 	if !t.overlappable(e.Range()) {
-		return
+		return nil
 	}
 	t.delete(e, removeItem, fast)
-	return
+	return nil
 }
 
 func (t *btree) delete(e Interface, typ toRemove, fast bool) Interface {

--- a/pkg/util/parquet/decoders.go
+++ b/pkg/util/parquet/decoders.go
@@ -142,7 +142,7 @@ func (bitDecoder) decode(v parquet.ByteArray) (tree.Datum, error) {
 	if err != nil {
 		return nil, err
 	}
-	return &tree.DBitArray{BitArray: ba}, err
+	return &tree.DBitArray{BitArray: ba}, nil
 }
 
 type bytesDecoder struct{}

--- a/pkg/util/tsearch/tsquery.go
+++ b/pkg/util/tsearch/tsquery.go
@@ -518,7 +518,7 @@ func toTSQuery(config string, interpose tsOperator, input string) (TSQuery, erro
 			return query, pgerror.Newf(pgcode.Syntax, "text-search query doesn't contain lexemes: %s", input)
 		}
 	}
-	return query, err
+	return query, nil
 }
 
 func cleanupStopwords(query TSQuery) TSQuery {

--- a/pkg/workload/movr/workload.go
+++ b/pkg/workload/movr/workload.go
@@ -179,7 +179,7 @@ func (m *movrWorker) startRide(id uuid.UUID, city string) error {
 		return err
 	}
 	m.activeRides = append(m.activeRides, rideInfo{id.String(), city})
-	return err
+	return nil
 }
 
 func (m *movrWorker) endRide(id uuid.UUID, city string) error {


### PR DESCRIPTION
While there is nothing incorrect about returning a known-nil return variable, forcing the caller to return a nil constant instead may help catch bugs where the wrong error is being returned.

This won't pass CI yet as I only fixed production code.

Epic: none

Release note: None