### PR TITLE
release-25.2: workload/schemachange: improve randUser function

### DIFF
--- a/pkg/workload/schemachange/operation_generator.go
+++ b/pkg/workload/schemachange/operation_generator.go
@@ -5351,27 +5351,16 @@ func (og *operationGenerator) alterPolicy(ctx context.Context, tx pgx.Tx) (*opSt
 // randUser returns a real username from the database.
 // It returns an error if no user is found.
 func (og *operationGenerator) randUser(ctx context.Context, tx pgx.Tx) (string, error) {
-	query := "SELECT username FROM [SHOW USERS] ORDER BY random() LIMIT 1"
-	rows, err := tx.Query(ctx, query)
-	if rows.Err() != nil {
-		return "", rows.Err()
-	}
-
-	if err != nil {
+	if err := og.setSeedInDB(ctx, tx); err != nil {
 		return "", err
 	}
-	defer rows.Close()
+	query := "SELECT username FROM [SHOW USERS] ORDER BY random() LIMIT 1"
+	row := tx.QueryRow(ctx, query)
 
 	var realUser string
-	if rows.Next() {
-		if err := rows.Scan(&realUser); err != nil {
-			return "", err
-		}
-		og.LogMessage(fmt.Sprintf("Found real user: '%s'", realUser))
-		return realUser, nil
+	if err := row.Scan(&realUser); err != nil {
+		return "", err
 	}
-
-	// This should never happen in a valid CockroachDB instance.
-	// There should always be at least one user.
-	return "", errors.New("no users found in the database")
+	og.LogMessage(fmt.Sprintf("Found real user: '%s'", realUser))
+	return realUser, nil
 }


### PR DESCRIPTION
Backport 1/1 commits from #147121 on behalf of @rafiss.

----

Since the query uses LIMIT 1, we can use QueryRow so we only get back one row. This means we don't need complicated error checking for rows.Err(), which was being done incorrectly before. (It's supposed to be checked _after_ iterating through all the rows.)

This also makes sure to set the random seed in the database, which is important to do before calling random() so that the test is more deterministic.

Informs https://github.com/cockroachdb/cockroach/issues/146066
Fixes: #150797
Release note: None

----

Release justification: test only change