### PR TITLE
psql: delete unnecessary `toolchain` line

### DIFF
--- a/pkg/acceptance/compose/gss/psql/go.mod
+++ b/pkg/acceptance/compose/gss/psql/go.mod
@@ -2,8 +2,6 @@ module github.com/cockroachdb/cockroach/pkg/acceptance/compose/gss/psql
 
 go 1.24.5
 
-toolchain go1.24.5
-
 require (
 	github.com/cockroachdb/errors v1.9.0
 	github.com/lib/pq v1.10.6


### PR DESCRIPTION
It's not necessary and some automation auto-deletes it.

Epic: DEVINF-1477
Release note: None