### PR TITLE
release-24.3: security: fix memory accounting issue in client certificate cache

### DIFF
--- a/pkg/security/clientcert/cert_expiry_cache_test.go
+++ b/pkg/security/clientcert/cert_expiry_cache_test.go
@@ -371,6 +371,7 @@ func TestAllocationTracking(t *testing.T) {
 		cache.MaybeUpsert(ctx, "user1", "serial2", 120)
 		cache.MaybeUpsert(ctx, "user2", "serial3", 65)
 		clock.Advance(time.Minute)
+		require.Equal(t, (3*certInfoSize)+(4*gaugeSize), account.Used())
 		cache.Purge(ctx)
 		cache.MaybeUpsert(ctx, "user2", "serial4", 75)
 		require.Equal(t, certInfoSize+(2*gaugeSize), account.Used())
@@ -383,8 +384,21 @@ func TestAllocationTracking(t *testing.T) {
 		cache.MaybeUpsert(ctx, "user1", "serial2", 120)
 		cache.MaybeUpsert(ctx, "user2", "serial3", 65)
 		cache.MaybeUpsert(ctx, "user2", "serial4", 75)
+		require.Equal(t, (4*certInfoSize)+(4*gaugeSize), account.Used())
 		cache.Clear()
 		require.Equal(t, int64(0), account.Used())
+	})
+
+	t.Run("overwriting an existing certificate does not change the reported memory allocation", func(t *testing.T) {
+		cache := newCache(ctx, clock, stopper)
+		account := cache.Account()
+		require.Equal(t, int64(0), account.Used())
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		require.Equal(t, certInfoSize+(2*gaugeSize), account.Used())
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		require.Equal(t, certInfoSize+(2*gaugeSize), account.Used())
+		cache.MaybeUpsert(ctx, "user1", "serial1", 100)
+		require.Equal(t, certInfoSize+(2*gaugeSize), account.Used())
 	})
 }
 


### PR DESCRIPTION
Backport 1/1 commits from #151041.

/cc @cockroachdb/release

---

The client certificate cache is a simple utility cache which keeps track of the nearest certificate expiration times by user. It does this by reading in certificates as they are used, and then updating the gauge associated with the user so that our operators can alert on expiring certificates.

It has been identified that there is a memory accounting issue with this utility class, in that if we see the same certificate multiple times, we report that our cache is growing for each one. In reality however, though we may change the reference in our cache, the old value will be cleaned up, and memory should remain relatively low.

This PR both fixes the accounting bug, and adds a limit so that the client certificate cache can't negatively affect SQL operation.

Epic: none
Fixes: #151040
Release note: Fixes a memory accounting issue with the client certificate cache, where we were accidentally reporting multiple allocations for the same memory.

Release justification: Fixes a leak in memory tracking of client certificates, which can lead to the system failing queries.
