### PR TITLE
release-25.2: colexec: fix column type when ConstNullOp is used

### DIFF
--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -2328,7 +2328,7 @@ func planProjectionOperators(
 		if datumType.Family() == types.UnknownFamily {
 			// We handle Unknown type by planning a special constant null
 			// operator.
-			return colexecbase.NewConstNullOp(allocator, input, resultIdx), nil
+			return colexecbase.NewConstNullOp(allocator, datumType, input, resultIdx), nil
 		}
 		constVal := colconv.GetDatumToPhysicalFn(datumType)(datum)
 		return colexecbase.NewConstOp(allocator, input, datumType, constVal, resultIdx)
@@ -2808,7 +2808,7 @@ func planProjectionExpr(
 			if !calledOnNullInput && right == tree.DNull {
 				// If the right is NULL and the operator is not called on NULL,
 				// simply project NULL.
-				op = colexecbase.NewConstNullOp(allocator, input, resultIdx)
+				op = colexecbase.NewConstNullOp(allocator, outputType, input, resultIdx)
 			} else if isCmpProjOp {
 				// Use optimized operators for special cases.
 				switch cmpProjOp.Symbol {

--- a/pkg/sql/colexec/colexecbase/const.eg.go
+++ b/pkg/sql/colexec/colexecbase/const.eg.go
@@ -583,12 +583,12 @@ func (c constDatumOp) Next() coldata.Batch {
 	return batch
 }
 
-// NewConstNullOp creates a new operator that produces a constant (untyped) NULL
-// value at index outputIdx.
+// NewConstNullOp creates a new operator that produces a constant NULL value at
+// index outputIdx. The column will be typed according to the passed in 't'.
 func NewConstNullOp(
-	allocator *colmem.Allocator, input colexecop.Operator, outputIdx int,
+	allocator *colmem.Allocator, t *types.T, input colexecop.Operator, outputIdx int,
 ) colexecop.Operator {
-	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Unknown, outputIdx)
+	input = colexecutils.NewVectorTypeEnforcer(allocator, input, t, outputIdx)
 	return &constNullOp{
 		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		outputIdx:      outputIdx,

--- a/pkg/sql/colexec/colexecbase/const_tmpl.go
+++ b/pkg/sql/colexec/colexecbase/const_tmpl.go
@@ -127,12 +127,12 @@ func (c const_TYPEOp) Next() coldata.Batch {
 // {{end}}
 // {{end}}
 
-// NewConstNullOp creates a new operator that produces a constant (untyped) NULL
-// value at index outputIdx.
+// NewConstNullOp creates a new operator that produces a constant NULL value at
+// index outputIdx. The column will be typed according to the passed in 't'.
 func NewConstNullOp(
-	allocator *colmem.Allocator, input colexecop.Operator, outputIdx int,
+	allocator *colmem.Allocator, t *types.T, input colexecop.Operator, outputIdx int,
 ) colexecop.Operator {
-	input = colexecutils.NewVectorTypeEnforcer(allocator, input, types.Unknown, outputIdx)
+	input = colexecutils.NewVectorTypeEnforcer(allocator, input, t, outputIdx)
 	return &constNullOp{
 		OneInputHelper: colexecop.MakeOneInputHelper(input),
 		outputIdx:      outputIdx,

--- a/pkg/sql/sem/eval/eval_test/BUILD.bazel
+++ b/pkg/sql/sem/eval/eval_test/BUILD.bazel
@@ -34,6 +34,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/randutil",
         "@com_github_cockroachdb_datadriven//:datadriven",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/sql/sem/eval/testdata/eval/boolean
+++ b/pkg/sql/sem/eval/testdata/eval/boolean
@@ -114,3 +114,10 @@ eval
 true OR (3 = 1)
 ----
 true
+
+# Regression test for incorrect typing of NULL column in the vectorized engine
+# (#151020).
+eval
+('foo' LIKE NULL) OR true
+----
+true


### PR DESCRIPTION
Backport 1/1 commits from #151093 on behalf of @yuzefovich.

----

In the vectorized engine, each projecting operator is responsible for appending its output vector to the batch. Previously, we had a bug in an edge case where we have a "typed" NULL constant vector. Namely, we would create the VectorTypeEnforcer helper with `types.Unknown`, yet we would include the actual type of the NULL column (by appending the actual output type to `typs` in `execplan.go`), which would lead to problems down the line. The fix is simple - use the actual type for the vector even if we're going to mark all values in it as NULL.

I struggled to come up with a scenario where we would hit this without disabling some folding optimizations, so the regression test added here disables the "always null" short-circuiting logic during type checking in test builds, via a testing knob.

Fixes: #151020.

Release note (bug fix): Previously, CockroachDB could encounter an internal error "trying to add a column of UNKNOWN type at ..." in rare cases when handling CASE or OR operations. The bug has been present since 20.2 version and is now fixed.

----

Release justification: low-risk bug fix.