### PR TITLE
sniffarg: unconditionally convert to double-dash args

### DIFF
--- a/pkg/testutils/sniffarg/sniffarg_test.go
+++ b/pkg/testutils/sniffarg/sniffarg_test.go
@@ -46,3 +46,18 @@ func TestDo(t *testing.T) {
 	assert.Zero(t, notFound)
 
 }
+
+func TestDoBoolUnknownSingleDashFlag(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	// This is a regression test: in the past, `-show-logs` would trigger pflag to
+	// output the help and return an error, due to the `-h` shorthand in
+	// `-show-logs`.
+
+	args := []string{
+		"-show-logs", "-rewrite",
+	}
+	var rewrite bool
+	require.NoError(t, Do(args, "rewrite", &rewrite))
+	require.True(t, rewrite)
+}


### PR DESCRIPTION
The old code was being dumb while trying to be too clever - it tried to do only the minimal amount of rewriting, but really should've just rewritten all the flags to `--format` instead.

Found during #150847.

Epic: CRDB-25222