### PR TITLE
storage: use latest supported table format when writing SSTs

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -372,7 +372,7 @@ func SupportedPreviousReleases() []Key {
 func ListBetween(from, to roachpb.Version) []roachpb.Version {
 	var cvs []roachpb.Version
 	for k := Key(0); k < numKeys; k++ {
-		if v := k.Version(); from.Less(v) && v.LessEq(to) {
+		if v := k.Version(); from.Cmp(v) < 0 && v.Cmp(to) <= 0 {
 			cvs = append(cvs, v)
 		}
 	}

--- a/pkg/clusterversion/cockroach_versions_test.go
+++ b/pkg/clusterversion/cockroach_versions_test.go
@@ -143,8 +143,9 @@ func TestClusterVersionPrettyPrint(t *testing.T) {
 		{cv(20, 1, 0, 4), "20.1-upgrading-to-20.2-step-004"},
 		{cv(20, 2, 0, 7), "20.2-upgrading-to-21.1-step-007(fence)"},
 		{cv(20, 2, 0, 4), "20.2-upgrading-to-21.1-step-004"},
-		{cv(22, 2, 1, 5), "22.2-upgrading-to-23.1-step-005(fence)"},
-		{cv(22, 2, 1, 4), "22.2-upgrading-to-23.1-step-004"},
+		{cv(22, 2, 1, 5), "22.2-upgrading-to-23.1-step-005(fence)"}, {cv(22, 2, 1, 4), "22.2-upgrading-to-23.1-step-004"},
+		{cv(24, 2, 0, 0), "24.2"},
+		{cv(24, 2, 0, 0).FenceVersion(), "24.2-upgrading-final-step(fence)"},
 	}
 	for _, test := range tests {
 		if actual := test.cv.PrettyPrint().StripMarkers(); actual != test.exp {

--- a/pkg/kv/kvserver/kvstorage/snaprecv/testdata/echotest/TestMultiSSTWriterInitSST_interesting=false
+++ b/pkg/kv/kvserver/kvstorage/snaprecv/testdata/echotest/TestMultiSSTWriterInitSST_interesting=false
@@ -3,7 +3,7 @@
 echo
 ----
 >> finishing msstw
->> sstSize=4752 estDataSize=126
+>> sstSize=4881 estDataSize=126
 >> sst0:
 rangedel: /Local/RangeID/100/{r""-s""}
 rangekeydel: /Local/RangeID/100/{r""-s""}

--- a/pkg/kv/kvserver/kvstorage/snaprecv/testdata/echotest/TestMultiSSTWriterInitSST_interesting=true
+++ b/pkg/kv/kvserver/kvstorage/snaprecv/testdata/echotest/TestMultiSSTWriterInitSST_interesting=true
@@ -5,11 +5,11 @@ echo
 >> rangekeyset [/Local/RangeID/100/r/AbortSpan/"00000000-0000-0000-0000-000000000000"-/Local/RangeID/100/r/AbortSpan/"6ba7b810-9dad-11d1-80b4-00c04fd430c8")
 >> sstSize=0 estDataSize=94
 >> rangekeyset [/Local/Range"d"/RangeDescriptor-/Local/Range"f"/RangeDescriptor)
->> sstSize=1154 estDataSize=403
+>> sstSize=1178 estDataSize=403
 >> rangekeyset ["e"-"f")
->> sstSize=4244 estDataSize=581
+>> sstSize=4324 estDataSize=581
 >> finishing msstw
->> sstSize=5222 estDataSize=585
+>> sstSize=5320 estDataSize=585
 >> sst0:
 rangedel: /Local/RangeID/100/r{""-/AbortSpan/"00000000-0000-0000-0000-000000000000"}
 rangedel: /Local/RangeID/100/r/AbortSpan/"{00000000-0000-0000-0000-000000000000"-6ba7b810-9dad-11d1-80b4-00c04fd430c8"}

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -6,6 +6,7 @@
 package roachpb
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -16,39 +17,33 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// Less compares two Versions.
+// Cmp returns -1 if v < otherV, 0 if v == otherV, and 1 if v > otherV.
+func (v Version) Cmp(otherV Version) int {
+	if v.Major != otherV.Major {
+		return cmp.Compare(v.Major, otherV.Major)
+	}
+	if v.Minor != otherV.Minor {
+		return cmp.Compare(v.Minor, otherV.Minor)
+	}
+	if v.Patch != otherV.Patch {
+		return cmp.Compare(v.Patch, otherV.Patch)
+	}
+	return cmp.Compare(v.Internal, otherV.Internal)
+}
+
+// Less returns whether the receiver is less than the parameter.
 func (v Version) Less(otherV Version) bool {
-	if v.Major < otherV.Major {
-		return true
-	} else if v.Major > otherV.Major {
-		return false
-	}
-	if v.Minor < otherV.Minor {
-		return true
-	} else if v.Minor > otherV.Minor {
-		return false
-	}
-	if v.Patch < otherV.Patch {
-		return true
-	} else if v.Patch > otherV.Patch {
-		return false
-	}
-	if v.Internal < otherV.Internal {
-		return true
-	} else if v.Internal > otherV.Internal {
-		return false
-	}
-	return false
+	return v.Cmp(otherV) < 0
 }
 
 // LessEq returns whether the receiver is less than or equal to the parameter.
 func (v Version) LessEq(otherV Version) bool {
-	return v.Equal(otherV) || v.Less(otherV)
+	return v.Cmp(otherV) <= 0
 }
 
 // AtLeast returns true if the receiver is greater than or equal to the parameter.
 func (v Version) AtLeast(otherV Version) bool {
-	return !v.Less(otherV)
+	return v.Cmp(otherV) >= 0
 }
 
 // String implements the fmt.Stringer interface. The result is of the form

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -2348,9 +2348,60 @@ func pebbleFormatVersion(clusterVersion roachpb.Version) pebble.FormatMajorVersi
 	// that is not newer than clusterVersion.
 	for _, k := range pebbleFormatVersionKeys {
 		// We switch to using a new format as soon as we reach the fence version.
-		// Note that at this point, the cluster might contain a node with an older
-		// binary; but this node's local Pebble format should not affect other nodes.
+		//
+		// This allows us to guarantee that all nodes in the cluster are using the
+		// new format when the cluster version is k.Version(); see
+		// minPebbleFormatVersionInCluster.
+		//
+		// Note that at this point, other nodes in the cluster might not be at the
+		// fence version yet. But this node's local Pebble format change does not
+		// affect other nodes, as long as minPebbleFormatVersionInCluster still
+		// returns the old format (which it does for the fence version).
 		if clusterVersion.Cmp(k.Version().FenceVersion()) >= 0 {
+			return pebbleFormatVersionMap[k]
+		}
+	}
+	// This should never happen in production. But we tolerate tests creating
+	// imaginary older versions; we must still use the earliest supported
+	// format.
+	return MinimumSupportedFormatVersion
+}
+
+// minPebbleFormatVersionInCluster returns the minimum pebble format version
+// supported by any node in the cluster.
+func minPebbleFormatVersionInCluster(clusterVersion roachpb.Version) pebble.FormatMajorVersion {
+	// Say clusterVersion is exactly the version for a key in
+	// pebbleFormatVersionMap. All nodes in the cluster are guaranteed to be at
+	// least at the corresponding fence version, which means they already upgraded
+	// the pebble format version (see pebbleFormatVersion()).
+	for _, k := range pebbleFormatVersionKeys {
+		// Nodes switch to using the new format as soon as we reach the fence
+		// version (k.Version().FenceVersion()). If we are at the non-fence version
+		// (k.Version()), we are guaranteed that all nodes in the cluster are at the
+		// fence version (at least), which means they have already upgraded their
+		// stores.
+		//
+		// -- More details about how this happens --
+		//
+		// Say that pebbleFormatVersionMap defines a new Pebble format version 31 at
+		// cluster version 24.3-6. Then pebbleFormatVersion() returns 31 for the
+		// first time at cluster version 24.3-5(fence);
+		// minPebbleFormatVersionInCluster() returns 31 for the first time at
+		// cluster version 24.3-6.
+		//
+		// The upgrade manager bumps the cluster version on all nodes for each
+		// version, including the fence version 24.3-5(fence), using
+		// upgrademanager.bumpClusterVersion(). The latter issues RPCs to all nodes
+		// to upgrade their version, which includes bumping the Pebble format to 31,
+		// via server.bumpClusterVersion() which invokes
+		// kvstorage.WriteClusterVersionToEngines(). The
+		// upgrademanager.bumpClusterVersion() code also detects any node joins that
+		// raced with the operation and retries until the cluster stabilizes. This
+		// guarantees that before the upgrade process to 25.3-6 starts, all nodes in
+		// the cluster are at version 25.3-5(fence); and thus all stores have been
+		// ratcheted to Pebble format 31 and are ready to accept sstables in the new
+		// format, which can happen as soon as any node is upgraded to 25.3-6.
+		if clusterVersion.Cmp(k.Version()) >= 0 {
 			return pebbleFormatVersionMap[k]
 		}
 	}

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1609,15 +1609,46 @@ func TestPebbleFormatVersion(t *testing.T) {
 	latestFmv := pebbleFormatVersionMap[latestKey]
 
 	require.Equal(t, pebbleFormatVersion(latestVersion), latestFmv)
+	require.Equal(t, minPebbleFormatVersionInCluster(latestVersion), latestFmv)
 
 	// We upgrade the pebble format as soon as we reach the fence version.
 	require.Equal(t, pebbleFormatVersion(latestVersion.FenceVersion()), latestFmv)
+	// But at the fence version, we don't have a guarantee that all nodes have
+	// upgraded.
+	require.Less(t, minPebbleFormatVersionInCluster(latestVersion.FenceVersion()), latestFmv)
 
 	require.Less(t, pebbleFormatVersion((latestKey - 1).Version()), latestFmv)
+	require.Less(t, minPebbleFormatVersionInCluster((latestKey - 1).Version()), latestFmv)
 
 	v := latestVersion
 	v.Minor++
 	require.Equal(t, pebbleFormatVersion(latestVersion), latestFmv)
+	require.Equal(t, minPebbleFormatVersionInCluster(latestVersion), latestFmv)
+
+	require.Equal(t, pebbleFormatVersion(clusterversion.MinSupported.Version()), MinimumSupportedFormatVersion)
+	require.Equal(t, minPebbleFormatVersionInCluster(clusterversion.MinSupported.Version()), MinimumSupportedFormatVersion)
+
+	// Gather all possible versions since MinSupported.
+	var versions []roachpb.Version
+	for k := clusterversion.MinSupported + 1; k <= clusterversion.Latest; k++ {
+		versions = append(versions, k.Version().FenceVersion(), k.Version())
+	}
+
+	prevFMV := MinimumSupportedFormatVersion
+	for i, v := range versions {
+		fmv := pebbleFormatVersion(v)
+		if fmv != prevFMV {
+			require.True(t, v.IsFence())
+			// minPebbleFormatVersionInCluster() should return the previous format.
+			require.Equal(t, prevFMV, minPebbleFormatVersionInCluster(v))
+			// For the next version, minPebbleFormatVersionInCluster() should return
+			// the new format.
+			require.Equal(t, fmv, minPebbleFormatVersionInCluster(versions[i+1]))
+		} else {
+			require.Equal(t, fmv, minPebbleFormatVersionInCluster(v))
+		}
+		prevFMV = fmv
+	}
 }
 
 // delayFS injects a delay on each read.

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1601,6 +1601,25 @@ func TestMinimumSupportedFormatVersion(t *testing.T) {
 		"MinimumSupportedFormatVersion must match the format version for %s", clusterversion.MinSupported)
 }
 
+func TestPebbleFormatVersion(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	latestKey := pebbleFormatVersionKeys[0]
+	latestVersion := latestKey.Version()
+	latestFmv := pebbleFormatVersionMap[latestKey]
+
+	require.Equal(t, pebbleFormatVersion(latestVersion), latestFmv)
+
+	// We upgrade the pebble format as soon as we reach the fence version.
+	require.Equal(t, pebbleFormatVersion(latestVersion.FenceVersion()), latestFmv)
+
+	require.Less(t, pebbleFormatVersion((latestKey - 1).Version()), latestFmv)
+
+	v := latestVersion
+	v.Minor++
+	require.Equal(t, pebbleFormatVersion(latestVersion), latestFmv)
+}
+
 // delayFS injects a delay on each read.
 type delayFS struct {
 	vfs.FS

--- a/pkg/storage/sst_writer.go
+++ b/pkg/storage/sst_writer.go
@@ -82,9 +82,7 @@ func (*noopFinishAbort) Abort() {}
 // also used when constructing sstables for backups (because these sstables may
 // ultimately be ingested during online restore).
 func MakeIngestionWriterOptions(ctx context.Context, cs *cluster.Settings) sstable.WriterOptions {
-	// TODO(jackson): Tie the table format to the cluster version using
-	// FormatMajorVersion.MaxTableFormat.
-	format := sstable.TableFormatPebblev5
+	format := minPebbleFormatVersionInCluster(cs.Version.ActiveVersion(ctx).Version).MaxTableFormat()
 
 	opts := DefaultPebbleOptions().MakeWriterOptions(0, format)
 	// By default, compress with the algorithm used for L6 in a Pebble store.
@@ -119,9 +117,7 @@ func makeSSTRewriteOptions(
 // scanned and their keys inserted into new sstables (NB: constructed using
 // MakeIngestionSSTWriter) that ultimately are uploaded to object storage.
 func MakeTransportSSTWriter(ctx context.Context, cs *cluster.Settings, f io.Writer) SSTWriter {
-	// TODO(jackson): Tie the table format to the cluster version using
-	// FormatMajorVersion.MaxTableFormat.
-	format := sstable.TableFormatPebblev5
+	format := minPebbleFormatVersionInCluster(cs.Version.ActiveVersion(ctx).Version).MaxTableFormat()
 
 	opts := DefaultPebbleOptions().MakeWriterOptions(0, format)
 

--- a/pkg/storage/sst_writer_test.go
+++ b/pkg/storage/sst_writer_test.go
@@ -90,7 +90,7 @@ func TestMakeIngestionWriterOptions(t *testing.T) {
 				return st
 			}(),
 			want: want{
-				format:             sstable.TableFormatPebblev5,
+				format:             sstable.TableFormatPebblev7,
 				disableValueBlocks: false,
 			},
 		},
@@ -102,7 +102,7 @@ func TestMakeIngestionWriterOptions(t *testing.T) {
 				return st
 			}(),
 			want: want{
-				format:             sstable.TableFormatPebblev5,
+				format:             sstable.TableFormatPebblev7,
 				disableValueBlocks: true,
 			},
 		},

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -838,7 +838,7 @@ func (m *Manager) listBetween(from roachpb.Version, to roachpb.Version) []roachp
 		result := m.knobs.ListBetweenOverride(from, to)
 		// Sanity check result to catch invalid overrides.
 		for _, v := range result {
-			if v.LessEq(from) || to.Less(v) {
+			if !(from.Cmp(v) < 0 && v.Cmp(to) <= 0) {
 				panic(fmt.Sprintf("ListBetweenOverride(%s, %s) returned invalid version %s", from, to, v))
 			}
 		}


### PR DESCRIPTION
Fixes #151085

#### roachpv: add Version.Cmp method

Add a `Version.Cmp()` method that is more natural to use than
`Less/LessEq/AtLeast` and can also be used for things like
`slices.Sort`.

Epic: none
Release note: None

#### storage: clarify pebbleFormatVersion and add a test

Epic: none
Release note: None

#### storage: use latest supported table format when writing SSTs

When CRDB is writing SSTs (for ingestion or transport), it is using a
fixed table format version. We improve this to use the latest version
guaranteed to be supported by all nodes in the cluster (based on the
current cluster version).

During upgrade, the Pebble format is bumped at fence versions (e.g.
24.3-7) which guarantees that all nodes are using that version at the
non-fence version (e.g. 24.3-8).

Epic: none
Release note: None