### PR TITLE
security: address a couple of nits in a recent change

### DIFF
--- a/pkg/security/certificate_manager.go
+++ b/pkg/security/certificate_manager.go
@@ -198,9 +198,9 @@ func (cm *CertificateManager) RegisterSignalHandler(
 	})
 }
 
-var CertCacheMemLimit = settings.RegisterIntSetting(
-	settings.SystemVisible,
-	"security.clienc_cert.cache_memory_limit",
+var certCacheMemLimit = settings.RegisterByteSizeSetting(
+	settings.ApplicationLevel,
+	"security.client_cert.cache_memory_limit",
 	"memory limit for the client certificate expiration cache",
 	1<<29, // 512MiB
 )
@@ -214,7 +214,7 @@ func (cm *CertificateManager) RegisterExpirationCache(
 	parentMon *mon.BytesMonitor,
 	st *cluster.Settings,
 ) error {
-	limit := CertCacheMemLimit.Get(&st.SV)
+	limit := certCacheMemLimit.Get(&st.SV)
 	m := mon.NewMonitorInheritWithLimit(mon.MakeName("client-expiration-caches"), limit, parentMon, true /* longLiving */)
 	acc := m.MakeConcurrentBoundAccount()
 	m.StartNoReserved(ctx, parentMon)

--- a/pkg/security/clientcert/cert_expiry_cache.go
+++ b/pkg/security/clientcert/cert_expiry_cache.go
@@ -99,7 +99,7 @@ func (c *Cache) Upsert(ctx context.Context, user string, serial string, newExpir
 	if _, ok := c.cache[user]; !ok {
 		err := c.account.Grow(ctx, 2*GaugeSize)
 		if err != nil {
-			log.Ops.Warningf(ctx, "no memory available to cache cert expiry: %v", err)
+			log.Warningf(ctx, "no memory available to cache cert expiry: %v", err)
 			return
 		}
 		c.cache[user] = map[string]certInfo{}


### PR DESCRIPTION
I don't see why we would make the cluster setting a SystemVisible given that it affects every tenant and seems ok to be allowed for a tenant to change. Also there was a typo in the setting name as well as we should've registered the setting as ByteSize (which gives non-negative int validation). Additionally, unify the logging channels used for the error message (both will now go to DEV).

Touches: #151041.

Epic: None
Release note: None