### PR TITLE
roachtest: improve obs in acceptance/gossip/restart

### DIFF
--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -358,7 +358,7 @@ func runGossipPeerings(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 func runGossipRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 	opts := option.DefaultStartOpts()
-	opts.RoachprodOpts.ExtraArgs = []string{"--vmodule=settings_watcher=1,watcher=1"}
+	opts.RoachprodOpts.ExtraArgs = []string{"--vmodule=*=1"}
 	c.Start(ctx, t.L(), opts, install.MakeClusterSettings())
 
 	// Repeatedly stop and restart a cluster and verify that we can perform basic

--- a/pkg/cmd/roachtest/tests/gossip.go
+++ b/pkg/cmd/roachtest/tests/gossip.go
@@ -357,7 +357,9 @@ func runGossipPeerings(ctx context.Context, t test.Test, c cluster.Cluster) {
 }
 
 func runGossipRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+	opts := option.DefaultStartOpts()
+	opts.RoachprodOpts.ExtraArgs = []string{"--vmodule=settings_watcher=1,watcher=1"}
+	c.Start(ctx, t.L(), opts, install.MakeClusterSettings())
 
 	// Repeatedly stop and restart a cluster and verify that we can perform basic
 	// operations. This is stressing the gossiping of the first range descriptor
@@ -377,7 +379,7 @@ func runGossipRestart(ctx context.Context, t test.Test, c cluster.Cluster) {
 		t.L().Printf("%d: restarting all nodes\n", i)
 		// Tell the httpClient our saved session cookies are no longer valid after a restart.
 		g.httpClient.ResetSession()
-		c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings())
+		c.Start(ctx, t.L(), opts, install.MakeClusterSettings())
 	}
 }
 

--- a/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
+++ b/pkg/kv/kvclient/rangefeed/rangefeedcache/watcher.go
@@ -312,6 +312,7 @@ func (s *Watcher[E]) Run(ctx context.Context) error {
 		rangefeed.WithDiff(s.withPrevValue),
 		rangefeed.WithRowTimestampInInitialScan(s.withRowTSInInitialScan),
 		rangefeed.WithOnInitialScanError(func(ctx context.Context, err error) (shouldFail bool) {
+			log.VInfof(ctx, 1, "initial scan error: %s", err)
 			// TODO(irfansharif): Consider if there are other errors which we
 			// want to treat as permanent. This was cargo culted from the
 			// settings watcher.

--- a/pkg/server/settingswatcher/settings_watcher.go
+++ b/pkg/server/settingswatcher/settings_watcher.go
@@ -185,6 +185,7 @@ func (s *SettingsWatcher) Start(ctx context.Context) error {
 		defer s.mu.Unlock()
 		s.mu.updater.ResetRemaining(ctx)
 		if !initialScan.done {
+			log.VInfof(ctx, 1, "initial settings scan complete")
 			initialScan.done = true
 			close(initialScan.ch)
 		}


### PR DESCRIPTION
In a test, we see occasional delays to propagate updated settings within 10s. This is right following a sequence of node restarts, so it makes sense that rangefeeds would be a little slow. This logging can potentially help.

Closes https://github.com/cockroachdb/cockroach/issues/151022.

Epic: none