### PR TITLE
release-25.3: kvserver: do not write truncated state during evaluation

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -220,6 +220,12 @@ const (
 
 	V25_3_AddHotRangeLoggerJob
 
+	// V25_3_WriteInitialTruncStateBeforeSplitApplication is the version above
+	// which we write the initial truncated state before applying a split. By
+	// extension, we no longer need to replicate the truncated state when
+	// constructing the split write batch.
+	V25_3_WriteInitialTruncStateBeforeSplitApplication
+
 	// V25_3 is CockroachDB v25.3. It's used for all v25.3.x patch releases.
 	V25_3
 
@@ -282,6 +288,8 @@ var versionTable = [numKeys]roachpb.Version{
 	V25_3_AddEstimatedLastLoginTime: {Major: 25, Minor: 2, Internal: 6},
 
 	V25_3_AddHotRangeLoggerJob: {Major: 25, Minor: 2, Internal: 8},
+
+	V25_3_WriteInitialTruncStateBeforeSplitApplication: {Major: 25, Minor: 2, Internal: 10},
 
 	V25_3: {Major: 25, Minor: 3, Internal: 0},
 

--- a/pkg/kv/kvserver/BUILD.bazel
+++ b/pkg/kv/kvserver/BUILD.bazel
@@ -577,6 +577,7 @@ go_test(
         "@org_golang_google_grpc//:grpc",
         "@org_golang_google_grpc//metadata",
         "@org_golang_x_exp//maps",
+        "@org_golang_x_exp//slices",
         "@org_golang_x_sync//errgroup",
         "@org_golang_x_sync//syncmap",
     ],

--- a/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
+++ b/pkg/kv/kvserver/batcheval/cmd_end_transaction_test.go
@@ -2232,13 +2232,14 @@ func TestSplitTriggerWritesInitialReplicaState(t *testing.T) {
 	require.NoError(t, err)
 	require.NotNil(t, loadedGCHint)
 	require.Equal(t, gcHint, *loadedGCHint)
-	expTruncState := kvserverpb.RaftTruncatedState{
-		Term:  stateloader.RaftInitialLogTerm,
-		Index: stateloader.RaftInitialLogIndex,
-	}
+
+	// The split trigger doesn't write the initial truncated state for the RHS
+	// as it isn't part of the range's applied state.
+	expTruncState := kvserverpb.RaftTruncatedState{}
 	loadedTruncState, err := slRight.LoadRaftTruncatedState(ctx, batch)
 	require.NoError(t, err)
 	require.Equal(t, expTruncState, loadedTruncState)
+
 	loadedVersion, err := slRight.LoadVersion(ctx, batch)
 	require.NoError(t, err)
 	require.Equal(t, version, loadedVersion)

--- a/pkg/kv/kvserver/stateloader/initial.go
+++ b/pkg/kv/kvserver/stateloader/initial.go
@@ -107,8 +107,10 @@ func WriteInitialReplicaState(
 	return newMS, nil
 }
 
-// WriteInitialTruncState writes the initial RaftTruncatedState.
-// TODO(arulajmani): remove this.
+// WriteInitialTruncState writes the initial truncated state.
+//
+// TODO(arul): this can be removed once no longer call this from the split
+// evaluation path.
 func WriteInitialTruncState(ctx context.Context, w storage.Writer, rangeID roachpb.RangeID) error {
 	return logstore.NewStateLoader(rangeID).SetRaftTruncatedState(ctx, w,
 		&kvserverpb.RaftTruncatedState{

--- a/pkg/kv/kvserver/store_split.go
+++ b/pkg/kv/kvserver/store_split.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvstorage"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/load"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/stateloader"
@@ -131,11 +132,22 @@ func splitPreApply(
 	}
 
 	// The RHS replica exists and is uninitialized. We are initializing it here.
-	// Update the raft HardState with the new Commit index (taken from the applied
-	// state in the write batch), and use existing or default Term and Vote. This
-	// is the common case.
+	// This is the common case.
+	//
+	// Update the raft HardState with the new Commit index (taken from the
+	// applied state in the write batch), and use existing[*] or default Term
+	// and Vote. Also write the initial RaftTruncatedState.
+	//
+	// [*] Note that uninitialized replicas may cast votes, and if they have, we
+	// can't load the default Term and Vote values.
 	rsl := stateloader.Make(split.RightDesc.RangeID)
 	if err := rsl.SynthesizeRaftState(ctx, readWriter); err != nil {
+		log.Fatalf(ctx, "%v", err)
+	}
+	if err := rsl.SetRaftTruncatedState(ctx, readWriter, &kvserverpb.RaftTruncatedState{
+		Index: stateloader.RaftInitialLogIndex,
+		Term:  stateloader.RaftInitialLogTerm,
+	}); err != nil {
 		log.Fatalf(ctx, "%v", err)
 	}
 	// Persist the closed timestamp.

--- a/pkg/kv/kvserver/store_test.go
+++ b/pkg/kv/kvserver/store_test.go
@@ -72,6 +72,7 @@ import (
 	"github.com/cockroachdb/redact"
 	"github.com/kr/pretty"
 	"github.com/stretchr/testify/require"
+	"golang.org/x/exp/slices"
 	"golang.org/x/sync/errgroup"
 )
 
@@ -4131,6 +4132,77 @@ func TestStoreGetOrCreateReplicaWritesRaftReplicaID(t *testing.T) {
 		ctx, tc.store.StateEngine())
 	require.NoError(t, err)
 	require.Equal(t, kvserverpb.RaftReplicaID{ReplicaID: 7}, replicaID)
+}
+
+// TestSplitPreApplyInitializesTruncatedState ensures that the Raft truncated
+// state for the RHS is correctly initialized when calling splitPreApply.
+func TestSplitPreApplyInitializesTruncatedState(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+	manual := timeutil.NewManualTime(timeutil.Unix(0, 10))
+	clock := hlc.NewClockForTesting(manual)
+
+	db := storage.NewDefaultInMemForTesting()
+	defer db.Close()
+	batch := db.NewBatch()
+	defer batch.Close()
+
+	startKey := roachpb.Key("0000")
+	endKey := roachpb.Key("9999")
+	desc := roachpb.RangeDescriptor{
+		RangeID:  99,
+		StartKey: roachpb.RKey(startKey),
+		EndKey:   roachpb.RKey(endKey),
+	}
+	desc.AddReplica(1, 1, roachpb.VOTER_FULL)
+
+	sl := stateloader.Make(desc.RangeID)
+	// Write the range state that will be consulted and copied during the split.
+	lease := roachpb.Lease{
+		Replica:       desc.InternalReplicas[0],
+		Term:          10,
+		MinExpiration: hlc.Timestamp{WallTime: 100},
+	}
+	err := sl.SetLease(ctx, batch, nil, lease)
+	require.NoError(t, err)
+
+	// Set up the store and LHS replica.
+	cfg := TestStoreConfig(clock)
+	stopper := stop.NewStopper()
+	defer stopper.Stop(ctx)
+	store := createTestStoreWithConfig(ctx, t, stopper, testStoreOpts{}, &cfg)
+	lhsRepl := createReplica(store, desc.RangeID, desc.StartKey, desc.EndKey)
+
+	// Construct the split trigger.
+	splitKey := roachpb.RKey("5555")
+	leftDesc, rightDesc := desc, desc
+	leftDesc.EndKey = splitKey
+	rightDesc.RangeID++
+	rightDesc.StartKey = splitKey
+	rightDesc.InternalReplicas = slices.Clone(leftDesc.InternalReplicas)
+	rightDesc.InternalReplicas[0].ReplicaID++
+
+	// Create an uninitialized replica for the RHS. splitPreApply expects this.
+	_, _, err = store.getOrCreateReplica(
+		ctx, rightDesc.RangeID, rightDesc.InternalReplicas[0].ReplicaID, &rightDesc.InternalReplicas[0],
+	)
+	require.NoError(t, err)
+
+	split := roachpb.SplitTrigger{
+		LeftDesc:  leftDesc,
+		RightDesc: rightDesc,
+	}
+
+	splitPreApply(ctx, lhsRepl, batch, split, nil)
+
+	// Verify that the RHS truncated state is initialized as expected.
+	rsl := stateloader.Make(rightDesc.RangeID)
+	truncState, err := rsl.LoadRaftTruncatedState(ctx, batch)
+	require.NoError(t, err)
+	require.Equal(t, stateloader.RaftInitialLogIndex, int(truncState.Index))
+	require.Equal(t, stateloader.RaftInitialLogTerm, int(truncState.Term))
 }
 
 func BenchmarkStoreGetReplica(b *testing.B) {


### PR DESCRIPTION
Backport 1/1 commits from #149620.

/cc @cockroachdb/release

---

This moves writing the truncated state from evaluation to splitPreApply, which is run locally on each store before the write batch constructed as part of the split is applied. This means we no longer replicate state that nominally belongs to the raft engine.

Closes #144540
Release note: None

Release justification: version gate that should make it to the release