### PR TITLE
roachtest: more patience in change-replicas/mixed-version

### DIFF
--- a/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_change_replicas.go
@@ -141,6 +141,9 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 		}
 
 		var rangeCount int
+		// We try for at least 80*9s = 12m to move replicas off of the node. The
+		// scanner interval defaults to 10 minutes, so we can't reliably expect
+		// this to go through much faster, though often it does.
 		for i := 0; i < 80; i++ {
 			err := h.QueryRow(r, `SELECT count(*) FROM `+
 				`[SHOW RANGES FROM TABLE test] WHERE $1::int = ANY(replicas)`, node).Scan(&rangeCount)
@@ -156,7 +159,7 @@ func runChangeReplicasMixedVersion(ctx context.Context, t test.Test, c cluster.C
 					return err
 				}
 			}
-			time.Sleep(3 * time.Second)
+			time.Sleep(9 * time.Second)
 		}
 		if rangeCount > 0 {
 			return errors.Errorf("n%d still has %d replicas", node, rangeCount)


### PR DESCRIPTION
When moving replicas off a node (via zone configs), we need to be prepared to
wait upwards of ten minutes (which is the default scanner interval, i.e. the
frequency with which a range is checked for relocation).

I'm still a little suspicious that there's more to this, given that I don't think this failed
as frequently. Still, we should give the test more time and then see what happens.

A next step, if this fails again, could be to add vmodule logging along the lines of
what's added here:

https://github.com/cockroachdb/cockroach/blob/5e50db71497755f774e4279ba9920441e3b3b46c/pkg/cmd/roachtest/tests/decommission.go#L1517-L1521

Should probably start with `replicate_queue=2,allocator=2,allocator_scorer=2`.

Fixes #150796.
Fixes #150677 (via the backport).
Fixes #149733 (via the backport).

Epic: none
