### PR TITLE
catalog/lease: fix hang on range feed restart

### DIFF
--- a/pkg/sql/catalog/lease/lease_test.go
+++ b/pkg/sql/catalog/lease/lease_test.go
@@ -3189,7 +3189,8 @@ func TestAmbiguousResultIsRetried(t *testing.T) {
 func TestLeaseDescriptorRangeFeedFailure(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 	defer log.Scope(t).Close(t)
-	skip.UnderDuress(t)
+	// Too slow for execution under race.
+	skip.UnderRace(t)
 
 	settings := cluster.MakeTestingClusterSettings()
 	ctx := context.Background()


### PR DESCRIPTION
Previously, the test was hanging because the lease manager mutex was held while closing the range feed. While a real failure would likely occur in the middle of a range feed callback during a restart, the synthetic scenario in this test made a hang possible. To avoid this, the lease manager lock is now released before closing the range feed.

Fixes: #150679
Fixes: #151088

Release note: None