### PR TITLE
integration: fix flaky TestInsightsIntegrationForContention

### DIFF
--- a/pkg/sql/sqlstats/insights/integration/BUILD.bazel
+++ b/pkg/sql/sqlstats/insights/integration/BUILD.bazel
@@ -26,6 +26,7 @@ go_test(
         "//pkg/util/log",
         "//pkg/util/timeutil",
         "//pkg/util/uuid",
+        "@com_github_cockroachdb_errors//:errors",
         "@com_github_stretchr_testify//require",
     ],
 )


### PR DESCRIPTION
This test has been seen to flake recently, due to the query on crdb_internal.node_transactions not returning any rows. To fix, it is now run within a testutils.SucceedSoon and will retry until it exists.

Fixes: #151125, #150555, #150139
Release note: None