### PR TITLE
roachprod: default to secure clusters unless GCE cockroach-ephemeral

### DIFF
--- a/pkg/cmd/drt-run/BUILD.bazel
+++ b/pkg/cmd/drt-run/BUILD.bazel
@@ -18,6 +18,7 @@ go_library(
         "//pkg/cmd/roachtest/registry",
         "//pkg/cmd/roachtest/spec",
         "//pkg/roachprod",
+        "//pkg/roachprod/install",
         "//pkg/roachprod/logger",
         "//pkg/util/randutil",
         "//pkg/util/syncutil",

--- a/pkg/cmd/drt-run/workloads.go
+++ b/pkg/cmd/drt-run/workloads.go
@@ -14,6 +14,7 @@ import (
 	"sync"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 	"github.com/cockroachdb/errors"
 	"github.com/cockroachdb/logtags"
@@ -45,7 +46,7 @@ func (w *workloadRunner) runWorkloadStep(
 		return
 	}
 	pgUrl, err := roachprod.PgURL(ctx, l, w.config.ClusterName, w.config.CertsDir, roachprod.PGURLOptions{
-		Secure:   w.config.CertsDir != "",
+		Secure:   install.SimpleSecureOption(w.config.CertsDir != ""),
 		External: true,
 	})
 	if err != nil {

--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor.go
@@ -283,7 +283,7 @@ func setupAndExecute(
 ) error {
 	logger := config.Logger
 	// Move the drtprod binary to /usr/bin to ensure it is available system-wide on the cluster.
-	err := roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+	err := roachprodRun(ctx, logger, monitorClusterName, "", "", install.SimpleSecureOption(true),
 		os.Stdout, os.Stderr,
 		[]string{fmt.Sprintf("sudo cp %s /usr/bin", drtprodLocation)},
 		install.RunOptions{FailOption: install.FailSlow})
@@ -293,7 +293,7 @@ func setupAndExecute(
 
 	// Enable linger for the default user, so that the cloud subprocess is not
 	// killed when the user logs out.
-	err = roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+	err = roachprodRun(ctx, logger, monitorClusterName, "", "", install.SimpleSecureOption(true),
 		os.Stdout, os.Stderr,
 		[]string{fmt.Sprintf("sudo loginctl enable-linger %s", config.SharedUser)},
 		install.RunOptions{FailOption: install.FailSlow})
@@ -318,7 +318,7 @@ func setupAndExecute(
 	}
 
 	// Run the systemd command on the remote cluster.
-	return roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+	return roachprodRun(ctx, logger, monitorClusterName, "", "", install.SimpleSecureOption(true),
 		os.Stdout, os.Stderr,
 		[]string{executeArgs},
 		install.RunOptions{FailOption: install.FailSlow})
@@ -340,7 +340,7 @@ func uploadAllDependentFiles(
 			if strings.Contains(fl, "/") {
 				dirLocation := filepath.Dir(fl)
 				// Use roachprod to create the directory on the remote.
-				err := roachprodRun(ctx, logger, monitorClusterName, "", "", true,
+				err := roachprodRun(ctx, logger, monitorClusterName, "", "", install.SimpleSecureOption(true),
 					os.Stdout, os.Stderr,
 					[]string{fmt.Sprintf("mkdir -p %s", dirLocation)},
 					install.RunOptions{FailOption: install.FailSlow})

--- a/pkg/cmd/drtprod/cli/commands/yamlprocessor_test.go
+++ b/pkg/cmd/drtprod/cli/commands/yamlprocessor_test.go
@@ -254,7 +254,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			require.Equal(t, "test-monitor", clusterName)
 			if strings.HasPrefix(cmdArray[0], "mkdir -p") {
@@ -284,7 +284,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			require.Equal(t, "test-monitor", clusterName)
 			return nil
@@ -311,7 +311,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			if strings.HasPrefix(cmdArray[0], "sudo cp") {
 				return fmt.Errorf("move command failed")
@@ -342,7 +342,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			runCmdsLock.Lock()
 			defer runCmdsLock.Unlock()
@@ -375,7 +375,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			require.Equal(t, "test-monitor", clusterName)
 			if strings.HasPrefix(cmdArray[0], "sudo systemd-run") {
@@ -409,7 +409,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			require.Equal(t, "test-monitor", clusterName)
 			runCmdsLock.Lock()
@@ -483,7 +483,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			require.Equal(t, "test-monitor", clusterName)
 			runCmdsLock.Lock()
@@ -553,7 +553,7 @@ environment:
 			return nil
 		}
 		roachprodRun = func(ctx context.Context, l *logger.Logger, clusterName,
-			SSHOptions, processTag string, secure bool, stdout, stderr io.Writer,
+			SSHOptions, processTag string, secure install.SecureOption, stdout, stderr io.Writer,
 			cmdArray []string, options install.RunOptions) error {
 			require.Equal(t, "test-monitor", clusterName)
 			runCmdsLock.Lock()

--- a/pkg/cmd/roachprod-microbench/cluster/execute.go
+++ b/pkg/cmd/roachprod-microbench/cluster/execute.go
@@ -57,7 +57,7 @@ type RemoteExecutionFunc func(
 	ctx context.Context,
 	l *logger.Logger,
 	clusterName, SSHOptions, processTag string,
-	secure bool,
+	secure install.SecureOption,
 	cmdArray []string,
 	options install.RunOptions,
 ) ([]install.RunResultDetails, error)
@@ -156,7 +156,7 @@ func remoteWorker(
 
 			runResult, err := execFunc(
 				cmdCtx, log, clusterNode, "" /* SSHOptions */, "", /* processTag */
-				false /* secure */, command.Args, runOptions,
+				install.SimpleSecureOption(false), command.Args, runOptions,
 			)
 			duration := timeutil.Since(start)
 

--- a/pkg/cmd/roachprod-microbench/cluster/executor_test.go
+++ b/pkg/cmd/roachprod-microbench/cluster/executor_test.go
@@ -69,7 +69,7 @@ func TestExecutionScheduling(t *testing.T) {
 				ctx context.Context,
 				l *logger.Logger,
 				clusterName, SSHOptions, processTag string,
-				secure bool,
+				secure install.SecureOption,
 				cmdArray []string,
 				options install.RunOptions,
 			) ([]install.RunResultDetails, error) {
@@ -168,7 +168,7 @@ func TestCancelGroupsBeforeExecution(t *testing.T) {
 		ctx context.Context,
 		l *logger.Logger,
 		clusterName, SSHOptions, processTag string,
-		secure bool,
+		secure install.SecureOption,
 		cmdArray []string,
 		options install.RunOptions,
 	) ([]install.RunResultDetails, error) {
@@ -226,7 +226,7 @@ func TestCancelGroupsInFlight(t *testing.T) {
 		ctx context.Context,
 		l *logger.Logger,
 		clusterName, SSHOptions, processTag string,
-		secure bool,
+		secure install.SecureOption,
 		cmdArray []string,
 		options install.RunOptions,
 	) ([]install.RunResultDetails, error) {

--- a/pkg/cmd/roachprod-microbench/executor.go
+++ b/pkg/cmd/roachprod-microbench/executor.go
@@ -252,7 +252,7 @@ func (e *executor) listBenchmarks(
 // cluster by inspecting the given remote directory.
 func (e *executor) listRemotePackages(log *logger.Logger, dir string) ([]string, error) {
 	ctx := context.Background()
-	results, err := roachprod.RunWithDetails(ctx, log, e.cluster, "", "", false,
+	results, err := roachprod.RunWithDetails(ctx, log, e.cluster, "", "", install.SimpleSecureOption(false),
 		[]string{"find", dir, "-name", "run.sh"}, install.WithNodes(install.Nodes{1}))
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachprod-microbench/roachprod_util.go
+++ b/pkg/cmd/roachprod-microbench/roachprod_util.go
@@ -26,7 +26,7 @@ func InitRoachprod() {
 func RoachprodRun(clusterName string, l *logger.Logger, cmdArray []string) error {
 	// Execute the roachprod command with the provided context, logger, cluster name, and options.
 	return roachprod.Run(
-		context.Background(), l, clusterName, "", "", false,
+		context.Background(), l, clusterName, "", "", install.SimpleSecureOption(false),
 		os.Stdout, os.Stderr, cmdArray, install.DefaultRunOptions(),
 	)
 }

--- a/pkg/cmd/roachprod-stress/main.go
+++ b/pkg/cmd/roachprod-stress/main.go
@@ -135,7 +135,7 @@ func roundToSeconds(d time.Duration) time.Duration {
 
 func roachprodRun(clusterName string, cmdArray []string) error {
 	return roachprod.Run(
-		context.Background(), l, clusterName, "", "", false,
+		context.Background(), l, clusterName, "", "", install.SimpleSecureOption(false),
 		os.Stdout, os.Stderr, cmdArray, install.DefaultRunOptions(),
 	)
 }

--- a/pkg/cmd/roachprod/cli/commands.go
+++ b/pkg/cmd/roachprod/cli/commands.go
@@ -736,7 +736,7 @@ cluster setting will be set to its value.
 			clusterSettingsOpts := []install.ClusterSettingOption{
 				install.TagOption(tag),
 				install.PGUrlCertsDirOption(pgurlCertsDir),
-				install.SecureOption(isSecure),
+				isSecure,
 				install.UseTreeDistOption(useTreeDist),
 				install.EnvOption(nodeEnv),
 				install.NumRacksOption(numRacks),
@@ -773,7 +773,7 @@ Note that if the cluster is started in insecure mode, set the insecure mode here
 		Args: cobra.ExactArgs(1),
 		Run: Wrap(func(cmd *cobra.Command, args []string) error {
 			clusterSettingsOpts := []install.ClusterSettingOption{
-				install.SecureOption(isSecure),
+				isSecure,
 			}
 			return roachprod.UpdateTargets(context.Background(), config.Logger, args[0], clusterSettingsOpts...)
 		}),
@@ -857,7 +857,7 @@ environment variables to the cockroach process.
 			clusterSettingsOpts := []install.ClusterSettingOption{
 				install.TagOption(tag),
 				install.PGUrlCertsDirOption(pgurlCertsDir),
-				install.SecureOption(isSecure),
+				isSecure,
 				install.UseTreeDistOption(useTreeDist),
 				install.EnvOption(nodeEnv),
 				install.NumRacksOption(numRacks),
@@ -1723,7 +1723,7 @@ roachprod grafana-annotation grafana.testeng.crdb.io example-annotation-event --
 				return errors.Newf("Too many arguments for --time-range, expected 1 or 2, got: %d", len(grafanaTimeRange))
 			}
 
-			return roachprod.AddGrafanaAnnotation(context.Background(), args[0] /* host */, isSecure, req)
+			return roachprod.AddGrafanaAnnotation(context.Background(), args[0] /* host */, isSecure.DefaultSecure, req)
 		}),
 	}
 	initGrafanaAnnotationCmdFlags(grafanaAnnotationCmd)

--- a/pkg/cmd/roachprod/cli/flags.go
+++ b/pkg/cmd/roachprod/cli/flags.go
@@ -47,9 +47,9 @@ var (
 	listJSON              bool
 	listMine              bool
 	listPattern           string
-	isSecure              bool // Set based on the values passed to --secure and --insecure
-	secure                = false
-	insecure              = envutil.EnvOrDefaultBool("COCKROACH_ROACHPROD_INSECURE", true)
+	isSecure              install.ComplexSecureOption // Set based on the values passed to --secure and --insecure
+	secure                = true
+	insecure              = envutil.EnvOrDefaultBool("COCKROACH_ROACHPROD_INSECURE", false)
 	virtualClusterName    string
 	sqlInstance           int
 	extraSSHOptions       = ""

--- a/pkg/cmd/roachprod/cli/util.go
+++ b/pkg/cmd/roachprod/cli/util.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	rperrors "github.com/cockroachdb/cockroach/pkg/roachprod/errors"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm/gce"
 	"github.com/cockroachdb/errors"
@@ -127,20 +128,23 @@ func Wrap(f func(cmd *cobra.Command, args []string) error) func(cmd *cobra.Comma
 	}
 }
 
-func isSecureCluster(cmd *cobra.Command) (bool, error) {
+func isSecureCluster(cmd *cobra.Command) (install.ComplexSecureOption, error) {
 	hasSecureFlag := cmd.Flags().Changed("secure")
 	hasInsecureFlag := cmd.Flags().Changed("insecure")
 
 	switch {
 	case hasSecureFlag && hasInsecureFlag:
 		// Disallow passing both flags, even if they are consistent.
-		return false, fmt.Errorf("cannot pass both --secure and --insecure flags")
+		return install.ComplexSecureOption{}, fmt.Errorf("cannot pass both --secure and --insecure flags")
 
 	case hasSecureFlag:
-		return secure, nil
+		return install.ComplexSecureOption{ForcedSecure: true}, nil
+
+	case hasInsecureFlag:
+		return install.ComplexSecureOption{ForcedInsecure: true}, nil
 
 	default:
-		return !insecure, nil
+		return install.ComplexSecureOption{DefaultSecure: !insecure}, nil
 	}
 }
 

--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -1390,7 +1390,7 @@ func (c *clusterImpl) FetchDebugZip(
 			pgURLOpts := roachprod.PGURLOptions{
 				// `cockroach debug zip` does not support non root authentication.
 				Auth:   install.AuthRootCert,
-				Secure: c.IsSecure(),
+				Secure: install.SimpleSecureOption(c.IsSecure()),
 			}
 			// Use roachprod.PgURL directly as we want to bypass the default virtual cluster
 			// logic. The debug zip command already handles fetching all virtual clusters by passing
@@ -2116,7 +2116,7 @@ func (c *clusterImpl) configureClusterSettingOptions(
 	return []install.ClusterSettingOption{
 		install.TagOption(settings.Tag),
 		install.PGUrlCertsDirOption(settings.PGUrlCertsDir),
-		install.SecureOption(settings.Secure),
+		install.SimpleSecureOption(settings.Secure),
 		install.UseTreeDistOption(settings.UseTreeDist),
 		install.EnvOption(settings.Env),
 		install.NumRacksOption(settings.NumRacks),
@@ -2310,7 +2310,7 @@ func (c *clusterImpl) StopServiceForVirtualClusterE(
 	}
 
 	return roachprod.StopServiceForVirtualCluster(
-		ctx, l, c.MakeNodes(nodes), c.IsSecure(), stopOpts.RoachprodOpts,
+		ctx, l, c.MakeNodes(nodes), install.SimpleSecureOption(c.IsSecure()), stopOpts.RoachprodOpts,
 	)
 }
 
@@ -2521,7 +2521,7 @@ func (c *clusterImpl) RunE(ctx context.Context, options install.RunOptions, args
 		DefaultVirtualCluster: c.defaultVirtualCluster,
 	}
 	if err := roachprod.Run(
-		ctx, l, c.MakeNodes(nodes), "", "", c.IsSecure(),
+		ctx, l, c.MakeNodes(nodes), "", "", install.SimpleSecureOption(c.IsSecure()),
 		l.Stdout, l.Stderr, args, options.WithExpanderConfig(expanderCfg).WithLogExpandedCommand(),
 	); err != nil {
 		if err := ctx.Err(); err != nil {
@@ -2592,7 +2592,9 @@ func (c *clusterImpl) RunWithDetails(
 	}
 	results, err := roachprod.RunWithDetails(
 		ctx, l, c.MakeNodes(nodes), "" /* SSHOptions */, "", /* processTag */
-		c.IsSecure(), args, options.WithExpanderConfig(expanderCfg).WithLogExpandedCommand(),
+		install.SimpleSecureOption(c.IsSecure()),
+		args,
+		options.WithExpanderConfig(expanderCfg).WithLogExpandedCommand(),
 	)
 
 	var logFileFull string
@@ -2674,7 +2676,7 @@ func (c *clusterImpl) PopulateEtcHosts(ctx context.Context, l *logger.Logger) er
 func (c *clusterImpl) pgURLErr(
 	ctx context.Context, l *logger.Logger, nodes option.NodeListOption, opts roachprod.PGURLOptions,
 ) ([]string, error) {
-	opts.Secure = c.IsSecure()
+	opts.Secure = install.SimpleSecureOption(c.IsSecure())
 
 	// Use CockroachNodeCertsDir if it's an internal url with access to the node.
 	certsDir := install.CockroachNodeCertsDir
@@ -2784,7 +2786,8 @@ func (c *clusterImpl) SQLPorts(
 	sqlInstance int,
 ) ([]int, error) {
 	return roachprod.SQLPorts(
-		ctx, l, c.MakeNodes(nodes), c.IsSecure(), c.virtualCluster(tenant), sqlInstance,
+		ctx, l, c.MakeNodes(nodes), install.SimpleSecureOption(c.IsSecure()),
+		c.virtualCluster(tenant), sqlInstance,
 	)
 }
 
@@ -2796,7 +2799,8 @@ func (c *clusterImpl) AdminUIPorts(
 	sqlInstance int,
 ) ([]int, error) {
 	return roachprod.AdminPorts(
-		ctx, l, c.MakeNodes(nodes), c.IsSecure(), c.virtualCluster(tenant), sqlInstance,
+		ctx, l, c.MakeNodes(nodes), install.SimpleSecureOption(c.IsSecure()),
+		c.virtualCluster(tenant), sqlInstance,
 	)
 }
 
@@ -2830,7 +2834,7 @@ func (c *clusterImpl) adminUIAddr(
 		"", /* path */
 		external,
 		false,
-		false,
+		install.SimpleSecureOption(false),
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/cmd/roachtest/dynamic_cluster.go
+++ b/pkg/cmd/roachtest/dynamic_cluster.go
@@ -9,6 +9,7 @@ import (
 	"context"
 
 	"github.com/cockroachdb/cockroach/pkg/roachprod"
+	"github.com/cockroachdb/cockroach/pkg/roachprod/install"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/logger"
 )
 
@@ -18,7 +19,7 @@ type dynamicClusterImpl struct {
 
 // Grow adds nodes to the cluster.
 func (c *clusterImpl) Grow(ctx context.Context, l *logger.Logger, nodeCount int) error {
-	err := roachprod.Grow(ctx, l, c.name, c.IsSecure(), nodeCount)
+	err := roachprod.Grow(ctx, l, c.name, install.SimpleSecureOption(c.IsSecure()), nodeCount)
 	if err != nil {
 		return err
 	}

--- a/pkg/cmd/roachtest/tests/activerecord.go
+++ b/pkg/cmd/roachtest/tests/activerecord.go
@@ -46,7 +46,7 @@ func registerActiveRecord(r registry.Registry) {
 		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// Activerecord uses root user with ssl disabled.
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/awsdms.go
+++ b/pkg/cmd/roachtest/tests/awsdms.go
@@ -560,7 +560,7 @@ func setupCockroachDBCluster(
 ) func(context.Context, *logger.Logger) error {
 	return func(_ context.Context, l *logger.Logger) error {
 		l.Printf("setting up cockroach")
-		settings := install.MakeClusterSettings(install.SecureOption(false))
+		settings := install.MakeClusterSettings(install.SimpleSecureOption(false))
 		c.Start(ctx, l, option.DefaultStartOpts(), settings, c.All())
 
 		db := c.Conn(ctx, l, 1)

--- a/pkg/cmd/roachtest/tests/buffered_logging.go
+++ b/pkg/cmd/roachtest/tests/buffered_logging.go
@@ -75,7 +75,7 @@ func registerBufferedLogging(r registry.Registry) {
 			install.CockroachNodeCertsDir, /* certsDir */
 			roachprod.PGURLOptions{
 				External: false,
-				Secure:   true,
+				Secure:   install.SimpleSecureOption(true),
 			})
 		require.NoError(t, err)
 		workloadPGURLs := make([]string, len(secureUrls))

--- a/pkg/cmd/roachtest/tests/cluster_init.go
+++ b/pkg/cmd/roachtest/tests/cluster_init.go
@@ -46,7 +46,7 @@ func runClusterInit(ctx context.Context, t test.Test, c cluster.Cluster) {
 
 	// Start the cluster in insecure mode to allow it to test both
 	// authenticated and unauthenticated code paths.
-	settings := install.MakeClusterSettings(install.SecureOption(false))
+	settings := install.MakeClusterSettings(install.SimpleSecureOption(false))
 
 	for _, initNode := range []int{2, 1} {
 		c.Wipe(ctx)

--- a/pkg/cmd/roachtest/tests/gopg.go
+++ b/pkg/cmd/roachtest/tests/gopg.go
@@ -55,7 +55,7 @@ func registerGopg(r registry.Registry) {
 		// upgrade support to that version and enable secure mode.
 		c.Start(
 			ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB),
-			install.MakeClusterSettings(install.SecureOption(false)),
+			install.MakeClusterSettings(install.SimpleSecureOption(false)),
 		)
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -92,7 +92,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// Hibernate uses a hardcoded connection string with ssl disabled.
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 
 		if opt.dbSetupFunc != nil {
 			opt.dbSetupFunc(ctx, t, c)

--- a/pkg/cmd/roachtest/tests/jasyncsql.go
+++ b/pkg/cmd/roachtest/tests/jasyncsql.go
@@ -30,7 +30,7 @@ func registerJasyncSQL(r registry.Registry) {
 		// TODO(darrylwong): If the above issue is addressed we can enable secure mode
 		c.Start(
 			ctx, t.L(), option.NewStartOpts(sqlClientsInMemoryDB),
-			install.MakeClusterSettings(install.SecureOption(false)),
+			install.MakeClusterSettings(install.SimpleSecureOption(false)),
 		)
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])

--- a/pkg/cmd/roachtest/tests/liquibase.go
+++ b/pkg/cmd/roachtest/tests/liquibase.go
@@ -34,7 +34,7 @@ func registerLiquibase(r registry.Registry) {
 		startOpts := option.DefaultStartOpts()
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// TODO(darrylwong): if https://github.com/liquibase/liquibase-test-harness/pull/724 is merged, enable secure mode
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/mixed_version_backup.go
+++ b/pkg/cmd/roachtest/tests/mixed_version_backup.go
@@ -2696,7 +2696,7 @@ func (u *CommonTestUtils) resetCluster(
 	}
 
 	cockroachPath := clusterupgrade.CockroachPathForVersion(u.t, version)
-	settings = append(settings, install.BinaryOption(cockroachPath), install.SecureOption(true))
+	settings = append(settings, install.BinaryOption(cockroachPath), install.SimpleSecureOption(true))
 	return clusterupgrade.StartWithSettings(
 		ctx, l, u.cluster, u.roachNodes, option.NewStartOpts(opts...), settings...,
 	)

--- a/pkg/cmd/roachtest/tests/multi_region_system_database.go
+++ b/pkg/cmd/roachtest/tests/multi_region_system_database.go
@@ -38,7 +38,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 				return r[0] + "-" + r[1]
 			}
 			t.Status("starting cluster")
-			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(false)))
+			c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SimpleSecureOption(false)))
 			conn := c.Conn(ctx, t.L(), 1)
 			defer conn.Close()
 
@@ -65,7 +65,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 				c.Stop(ctx, t.L(), option.NewStopOpts(option.Graceful(shutdownGracePeriod)), c.Node(i))
 				t.WorkerStatus("start")
 				startOpts := option.DefaultStartOpts()
-				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.Node(i))
+				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.Node(i))
 			}
 
 			// Check system.lease table to ensure that region information for each node is correct
@@ -116,7 +116,7 @@ func registerMultiRegionSystemDatabase(r registry.Registry) {
 
 				t.WorkerStatus("start")
 				startOpts := option.DefaultStartOpts()
-				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.Node(i))
+				c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.Node(i))
 			}
 		},
 	})

--- a/pkg/cmd/roachtest/tests/network.go
+++ b/pkg/cmd/roachtest/tests/network.go
@@ -338,7 +338,7 @@ func runClientNetworkConnectionTimeout(ctx context.Context, t test.Test, c clust
 	grp.Go(func(ctx context.Context, l *logger.Logger) error {
 		urls, err := roachprod.PgURL(ctx, l, c.MakeNodes(c.Node(1)), certsDir, roachprod.PGURLOptions{
 			External: true,
-			Secure:   true,
+			Secure:   install.SimpleSecureOption(true),
 		})
 		if err != nil {
 			return err

--- a/pkg/cmd/roachtest/tests/pg_regress.go
+++ b/pkg/cmd/roachtest/tests/pg_regress.go
@@ -33,7 +33,7 @@ func initPGRegress(ctx context.Context, t test.Test, c cluster.Cluster) {
 	node := c.Node(1)
 	t.Status("setting up cockroach")
 	// pg_regress does not support ssl connections.
-	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SecureOption(false)), c.All())
+	c.Start(ctx, t.L(), option.DefaultStartOpts(), install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 
 	db, err := c.ConnE(ctx, t.L(), node[0])
 	if err != nil {

--- a/pkg/cmd/roachtest/tests/restore.go
+++ b/pkg/cmd/roachtest/tests/restore.go
@@ -784,7 +784,7 @@ func makeRestoreDriver(
 
 func (rd *restoreDriver) defaultClusterSettings() []install.ClusterSettingOption {
 	return []install.ClusterSettingOption{
-		install.SecureOption(false),
+		install.SimpleSecureOption(false),
 	}
 }
 

--- a/pkg/cmd/roachtest/tests/ruby_pg.go
+++ b/pkg/cmd/roachtest/tests/ruby_pg.go
@@ -56,7 +56,7 @@ func registerRubyPG(r registry.Registry) {
 		startOpts.RoachprodOpts.SQLPort = config.DefaultSQLPort
 		// TODO(darrylwong): ruby-pg is currently being updated to run on Ubuntu 22.04.
 		// Once complete, fix up ruby_pg_helpers to accept a tls connection.
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/rust_postgres.go
+++ b/pkg/cmd/roachtest/tests/rust_postgres.go
@@ -34,7 +34,7 @@ func registerRustPostgres(r registry.Registry) {
 		// the environment, which means we can't pass it ssl connection details
 		// and must run the cluster in insecure mode.
 		// See: https://github.com/sfackler/rust-postgres/issues/654
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 		db := c.Conn(ctx, t.L(), 1)
 		_, err := db.Exec("create user postgres with createdb createlogin createrole cancelquery")
 		if err != nil {

--- a/pkg/cmd/roachtest/tests/sequelize.go
+++ b/pkg/cmd/roachtest/tests/sequelize.go
@@ -39,7 +39,7 @@ func registerSequelize(r registry.Registry) {
 		t.Status("setting up cockroach")
 		startOpts := option.NewStartOpts(sqlClientsInMemoryDB)
 		roachtestutil.SetDefaultSQLPort(c, &startOpts.RoachprodOpts)
-		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SecureOption(false)), c.All())
+		c.Start(ctx, t.L(), startOpts, install.MakeClusterSettings(install.SimpleSecureOption(false)), c.All())
 
 		version, err := fetchCockroachVersion(ctx, t.L(), c, node[0])
 		if err != nil {

--- a/pkg/roachprod/failureinjection/failures/failure.go
+++ b/pkg/roachprod/failureinjection/failures/failure.go
@@ -90,7 +90,11 @@ func makeGenericFailure(
 	clusterName string, l *logger.Logger, clusterOpts ClusterOptions, failureModeName string,
 ) (*GenericFailure, error) {
 	connectionInfo := clusterOpts.ConnectionInfo
-	c, err := roachprod.GetClusterFromCache(l, clusterName, install.SecureOption(connectionInfo.secure))
+	c, err := roachprod.GetClusterFromCache(
+		l,
+		clusterName,
+		install.SimpleSecureOption(connectionInfo.secure),
+	)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/roachprod/install/cluster_synced.go
+++ b/pkg/roachprod/install/cluster_synced.go
@@ -119,6 +119,14 @@ func NewSyncedCluster(
 		return nil, err
 	}
 	c.Nodes = nodes
+
+	if c.ClusterSettings.secureFlagsOpt != nil {
+		err = c.ClusterSettings.secureFlagsOpt.overrideBasedOnClusterSettings(c)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	return c, nil
 }
 

--- a/pkg/roachprod/multitenant.go
+++ b/pkg/roachprod/multitenant.go
@@ -53,9 +53,13 @@ func StartServiceForVirtualCluster(
 
 // StopServiceForVirtualCluster stops SQL instance processes on the virtualCluster given.
 func StopServiceForVirtualCluster(
-	ctx context.Context, l *logger.Logger, clusterName string, secure bool, stopOpts StopOpts,
+	ctx context.Context,
+	l *logger.Logger,
+	clusterName string,
+	secure install.SecureOption,
+	stopOpts StopOpts,
 ) error {
-	c, err := newCluster(l, clusterName, install.SecureOption(secure))
+	c, err := newCluster(l, clusterName, secure)
 	if err != nil {
 		return err
 	}

--- a/pkg/roachprod/vm/gce/gcloud.go
+++ b/pkg/roachprod/vm/gce/gcloud.go
@@ -64,6 +64,8 @@ const (
 	VolumeTypeBoot VolumeType = "boot"
 	// VolumeTypeStandard represents an attached persistent disk.
 	VolumeTypePersistent VolumeType = "persistent"
+
+	DefaultProjectID = "cockroach-ephemeral"
 )
 
 var (
@@ -74,7 +76,7 @@ var (
 
 func initGCEProjectDefaults() {
 	defaultDefaultProject = config.EnvOrDefaultString(
-		"ROACHPROD_GCE_DEFAULT_PROJECT", "cockroach-ephemeral",
+		"ROACHPROD_GCE_DEFAULT_PROJECT", DefaultProjectID,
 	)
 	defaultMetadataProject = config.EnvOrDefaultString(
 		"ROACHPROD_GCE_METADATA_PROJECT",


### PR DESCRIPTION
Since #147737, to ease testing for engineering teams, roachprod defaults to insecure clusters. This change has led to security impact for other entities at CRL.

This patch brings smart selection of secure vs. insecure cluster depending on the Cloud project the cluster is provisionned in. If the cluster is provisionned in the engineering's ephemeral GCP project, it will default to insecure, while all other configurations will default to secure.

In order to achieve that, and because this depends on the cluster's configuration that is not available at the CLI package level, the CLI now keeps track of the user's arguments (--secure, --insecure, default) and passes the information to the roachprod library.

Epic: none
Release note: None