### PR TITLE
sql/ttl: refactor progress tracking behind interface for future checkpointing

### DIFF
--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "ttljob",
     srcs = [
+        "progress.go",
         "ttljob.go",
         "ttljob_metrics.go",
         "ttljob_processor.go",
@@ -66,6 +67,7 @@ go_test(
     size = "large",
     srcs = [
         "main_test.go",
+        "progress_test.go",
         "ttljob_internal_test.go",
         "ttljob_plans_test.go",
         "ttljob_processor_internal_test.go",

--- a/pkg/sql/ttl/ttljob/progress.go
+++ b/pkg/sql/ttl/ttljob/progress.go
@@ -1,0 +1,188 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ttljob
+
+import (
+	"context"
+	"math/rand"
+	"time"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
+	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
+	"github.com/cockroachdb/errors"
+	pbtypes "github.com/gogo/protobuf/types"
+)
+
+type progressTracker interface {
+	// initJobProgress writes the initial job progress to the job record with the correct
+	// span count determined after planning. This should be called after makePlan.
+	initJobProgress(ctx context.Context, jobSpanCount int64) error
+	// handleProgressUpdate handles incoming processor metadata and performs any necessary
+	// job updates. Each implementation determines how to handle the update (immediate vs deferred).
+	handleProgressUpdate(ctx context.Context, meta *execinfrapb.ProducerMetadata) error
+}
+
+// legacyProgressTracker tracks TTL job progress without span checkpointing.
+// Progress is computed by counting processed spans against the total span count.
+// Job restarts reset progress to 0%. Updates are gated to occur approximately
+// every 1% of spans processed and at least 60 seconds apart.
+type legacyProgressTracker struct {
+	job *jobs.Job
+
+	mu struct {
+		syncutil.Mutex
+		// lastUpdateTime is the wall time of the last job progress update.
+		// Used to gate how often we persist job progress in refreshJobProgress.
+		lastUpdateTime time.Time
+		// lastSpanCount is the number of spans processed as of the last persisted update.
+		lastSpanCount int64
+		// updateEvery determines how many spans must be processed before we persist a new update.
+		updateEvery int64
+		// updateEveryDuration is the minimum time that must pass before allowing another progress update.
+		updateEveryDuration time.Duration
+	}
+}
+
+var _ progressTracker = (*legacyProgressTracker)(nil)
+
+func newLegacyProgressTracker(job *jobs.Job) *legacyProgressTracker {
+	return &legacyProgressTracker{
+		job: job,
+	}
+}
+
+// setupUpdateFrequency configures the progress update frequency settings.
+// To avoid too many progress updates, especially if a lot of the spans don't
+// have expired rows, we will gate the updates to approximately every 1% of
+// spans processed, and at least 60 seconds apart with jitter.
+func (t *legacyProgressTracker) setupUpdateFrequency(jobSpanCount int64) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.mu.updateEvery = max(1, jobSpanCount/100)
+	t.mu.updateEveryDuration = 60*time.Second + time.Duration(rand.Int63n(10*1000))*time.Millisecond
+	t.mu.lastUpdateTime = timeutil.Now()
+	t.mu.lastSpanCount = 0
+}
+
+// initJobProgress implements the progressTracker interface.
+func (t *legacyProgressTracker) initJobProgress(ctx context.Context, jobSpanCount int64) error {
+	t.setupUpdateFrequency(jobSpanCount)
+
+	// Write initial progress to job record
+	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		rowLevelTTL := &jobspb.RowLevelTTLProgress{
+			JobTotalSpanCount:     jobSpanCount,
+			JobProcessedSpanCount: 0,
+		}
+
+		progress := &jobspb.Progress{
+			Details: &jobspb.Progress_RowLevelTTL{RowLevelTTL: rowLevelTTL},
+			Progress: &jobspb.Progress_FractionCompleted{
+				FractionCompleted: 0,
+			},
+		}
+		ju.UpdateProgress(progress)
+		return nil
+	})
+}
+
+// refreshJobProgress computes updated job progress from processor metadata.
+// It may return nil to skip immediate persistence, or a Progress to trigger an update.
+func (t *legacyProgressTracker) refreshJobProgress(
+	_ context.Context, md *jobs.JobMetadata, meta *execinfrapb.ProducerMetadata,
+) (*jobspb.Progress, error) {
+	if meta.BulkProcessorProgress == nil {
+		return nil, nil
+	}
+	var incomingProcProgress jobspb.RowLevelTTLProcessorProgress
+	if err := pbtypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &incomingProcProgress); err != nil {
+		return nil, errors.Wrapf(err, "unable to unmarshal ttl progress details")
+	}
+
+	orig := md.Progress.GetRowLevelTTL()
+	if orig == nil {
+		return nil, errors.New("job progress does not contain RowLevelTTL details")
+	}
+	rowLevelTTL := protoutil.Clone(orig).(*jobspb.RowLevelTTLProgress)
+
+	// Update or insert the incoming processor progress.
+	foundMatchingProcessor := false
+	for i := range rowLevelTTL.ProcessorProgresses {
+		if rowLevelTTL.ProcessorProgresses[i].ProcessorID == incomingProcProgress.ProcessorID {
+			rowLevelTTL.ProcessorProgresses[i] = incomingProcProgress
+			foundMatchingProcessor = true
+			break
+		}
+	}
+	if !foundMatchingProcessor {
+		rowLevelTTL.ProcessorProgresses = append(rowLevelTTL.ProcessorProgresses, incomingProcProgress)
+	}
+
+	// Recompute job level counters from scratch.
+	rowLevelTTL.JobDeletedRowCount = 0
+	rowLevelTTL.JobProcessedSpanCount = 0
+	totalSpanCount := int64(0)
+	for i := range rowLevelTTL.ProcessorProgresses {
+		pp := &rowLevelTTL.ProcessorProgresses[i]
+		rowLevelTTL.JobDeletedRowCount += pp.DeletedRowCount
+		rowLevelTTL.JobProcessedSpanCount += pp.ProcessedSpanCount
+		totalSpanCount += pp.TotalSpanCount
+	}
+
+	if totalSpanCount > rowLevelTTL.JobTotalSpanCount {
+		return nil, errors.Errorf(
+			"computed span total cannot exceed job total: computed=%d jobRecorded=%d",
+			totalSpanCount, rowLevelTTL.JobTotalSpanCount)
+	}
+
+	// Avoid the update if doing this too frequently.
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	processedDelta := rowLevelTTL.JobProcessedSpanCount - t.mu.lastSpanCount
+	processorComplete := incomingProcProgress.ProcessedSpanCount == incomingProcProgress.TotalSpanCount
+	firstProgressForProcessor := !foundMatchingProcessor
+
+	if !(processedDelta >= t.mu.updateEvery ||
+		timeutil.Since(t.mu.lastUpdateTime) >= t.mu.updateEveryDuration ||
+		processorComplete ||
+		firstProgressForProcessor) {
+		return nil, nil // Skip the update
+	}
+	t.mu.lastSpanCount = rowLevelTTL.JobProcessedSpanCount
+	t.mu.lastUpdateTime = timeutil.Now()
+
+	newProgress := &jobspb.Progress{
+		Details: &jobspb.Progress_RowLevelTTL{
+			RowLevelTTL: rowLevelTTL,
+		},
+		Progress: &jobspb.Progress_FractionCompleted{
+			FractionCompleted: float32(rowLevelTTL.JobProcessedSpanCount) /
+				float32(rowLevelTTL.JobTotalSpanCount),
+		},
+	}
+	return newProgress, nil
+}
+
+// handleProgressUpdate implements the progressTracker interface.
+func (t *legacyProgressTracker) handleProgressUpdate(
+	ctx context.Context, meta *execinfrapb.ProducerMetadata,
+) error {
+	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
+		progress, err := t.refreshJobProgress(ctx, &md, meta)
+		if err != nil {
+			return err
+		}
+		if progress != nil {
+			ju.UpdateProgress(progress)
+		}
+		return nil
+	})
+}

--- a/pkg/sql/ttl/ttljob/progress_test.go
+++ b/pkg/sql/ttl/ttljob/progress_test.go
@@ -1,0 +1,211 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ttljob
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/gogo/protobuf/types"
+	"github.com/stretchr/testify/require"
+)
+
+func makeFakeSpans(n int) []roachpb.Span {
+	spans := make([]roachpb.Span, n)
+	for i := 0; i < n; i++ {
+		start := roachpb.Key(fmt.Sprintf("k%03d", i))
+		end := roachpb.Key(fmt.Sprintf("k%03d", i+1))
+		spans[i] = roachpb.Span{Key: start, EndKey: end}
+	}
+	return spans
+}
+
+func createProgressMetadata(
+	t *testing.T,
+	processorID int32,
+	processedSpanCount int64,
+	deletedRowCount int64,
+	totalSpanCount int64,
+	completedSpans []roachpb.Span,
+) *execinfrapb.ProducerMetadata {
+	progressMsg := &jobspb.RowLevelTTLProcessorProgress{
+		ProcessorID:        processorID,
+		ProcessedSpanCount: processedSpanCount,
+		DeletedRowCount:    deletedRowCount,
+		TotalSpanCount:     totalSpanCount,
+	}
+	progressAny, err := types.MarshalAny(progressMsg)
+	if err != nil {
+		t.Fatalf("failed to marshal progress: %v", err)
+	}
+	return &execinfrapb.ProducerMetadata{
+		BulkProcessorProgress: &execinfrapb.RemoteProducerMetadata_BulkProcessorProgress{
+			CompletedSpans:  completedSpans,
+			ProgressDetails: *progressAny,
+		},
+	}
+}
+
+func TestLegacyProgressTrackerRefreshJobProgress(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	ctx := context.Background()
+
+	testCases := []struct {
+		name              string
+		jobTotalSpanCount int64
+		processorUpdates  []struct {
+			processorID        int32
+			processedSpanCount int64
+			deletedRowCount    int64
+			totalSpanCount     int64
+		}
+		expectedFraction       float32
+		expectedProcessedSpans int64
+		expectedDeletedRows    int64
+		expectedProcessorCount int
+		shouldError            bool
+	}{
+		{
+			name:              "empty metadata",
+			jobTotalSpanCount: 10,
+			processorUpdates:  nil,
+			expectedFraction:  0.0,
+		},
+		{
+			name:              "single processor progress",
+			jobTotalSpanCount: 10,
+			processorUpdates: []struct {
+				processorID        int32
+				processedSpanCount int64
+				deletedRowCount    int64
+				totalSpanCount     int64
+			}{
+				{processorID: 1, processedSpanCount: 3, deletedRowCount: 150, totalSpanCount: 10},
+			},
+			expectedFraction:       0.3, // 3/10
+			expectedProcessedSpans: 3,
+			expectedDeletedRows:    150,
+			expectedProcessorCount: 1,
+		},
+		{
+			name:              "multiple processors",
+			jobTotalSpanCount: 20,
+			processorUpdates: []struct {
+				processorID        int32
+				processedSpanCount int64
+				deletedRowCount    int64
+				totalSpanCount     int64
+			}{
+				{processorID: 1, processedSpanCount: 5, deletedRowCount: 100, totalSpanCount: 10},
+				{processorID: 2, processedSpanCount: 3, deletedRowCount: 75, totalSpanCount: 10},
+			},
+			expectedFraction:       0.4, // (5+3)/20
+			expectedProcessedSpans: 8,
+			expectedDeletedRows:    175,
+			expectedProcessorCount: 2,
+		},
+		{
+			name:              "processor update overwrites previous",
+			jobTotalSpanCount: 10,
+			processorUpdates: []struct {
+				processorID        int32
+				processedSpanCount int64
+				deletedRowCount    int64
+				totalSpanCount     int64
+			}{
+				{processorID: 1, processedSpanCount: 2, deletedRowCount: 50, totalSpanCount: 10},
+				{processorID: 1, processedSpanCount: 4, deletedRowCount: 100, totalSpanCount: 10}, // Same processor ID
+			},
+			expectedFraction:       0.4, // 4/10 (latest update)
+			expectedProcessedSpans: 4,
+			expectedDeletedRows:    100,
+			expectedProcessorCount: 1,
+		},
+		{
+			name:              "total span count exceeded",
+			jobTotalSpanCount: 5,
+			processorUpdates: []struct {
+				processorID        int32
+				processedSpanCount int64
+				deletedRowCount    int64
+				totalSpanCount     int64
+			}{
+				{processorID: 1, processedSpanCount: 3, deletedRowCount: 50, totalSpanCount: 10}, // totalSpanCount > jobTotalSpanCount
+			},
+			shouldError: true,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			progressUpdater := &legacyProgressTracker{}
+			progressUpdater.setupUpdateFrequency(tc.jobTotalSpanCount)
+
+			// Create initial progress
+			initialProgress := &jobspb.Progress{
+				Details: &jobspb.Progress_RowLevelTTL{
+					RowLevelTTL: &jobspb.RowLevelTTLProgress{
+						JobTotalSpanCount: tc.jobTotalSpanCount,
+					},
+				},
+				Progress: &jobspb.Progress_FractionCompleted{
+					FractionCompleted: 0,
+				},
+			}
+			md := jobs.JobMetadata{Progress: initialProgress}
+
+			var finalProgress *jobspb.Progress
+			var err error
+
+			if len(tc.processorUpdates) == 0 {
+				// Test with empty metadata.
+				emptyMetadata := &execinfrapb.ProducerMetadata{}
+				finalProgress, err = progressUpdater.refreshJobProgress(ctx, &md, emptyMetadata)
+				require.NoError(t, err)
+				require.Nil(t, finalProgress)
+				return
+			}
+
+			// Apply each processor update sequentially.
+			for _, update := range tc.processorUpdates {
+				metadata := createProgressMetadata(t, update.processorID, update.processedSpanCount,
+					update.deletedRowCount, update.totalSpanCount, makeFakeSpans(int(update.processedSpanCount)))
+
+				finalProgress, err = progressUpdater.refreshJobProgress(ctx, &md, metadata)
+				if tc.shouldError {
+					require.Error(t, err)
+					return
+				}
+				require.NoError(t, err)
+
+				// Update md.Progress for the next iteration.
+				if finalProgress != nil {
+					md.Progress = finalProgress
+				}
+			}
+
+			require.NotNil(t, finalProgress)
+
+			// Verify final results
+			require.InEpsilon(t, tc.expectedFraction, finalProgress.GetFractionCompleted(), 0.001)
+
+			ttlProgress := finalProgress.GetRowLevelTTL()
+			require.Equal(t, tc.jobTotalSpanCount, ttlProgress.JobTotalSpanCount)
+			require.Equal(t, tc.expectedProcessedSpans, ttlProgress.JobProcessedSpanCount)
+			require.Equal(t, tc.expectedDeletedRows, ttlProgress.JobDeletedRowCount)
+			require.Len(t, ttlProgress.ProcessorProgresses, tc.expectedProcessorCount)
+		})
+	}
+}

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -7,7 +7,6 @@ package ttljob
 
 import (
 	"context"
-	"math/rand"
 	"sync/atomic"
 	"time"
 
@@ -23,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/descs"
 	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
-	"github.com/cockroachdb/cockroach/pkg/sql/isql"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgerror"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
@@ -33,11 +31,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
-	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
-	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
-	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
 	"github.com/cockroachdb/errors"
-	pbtypes "github.com/gogo/protobuf/types"
 )
 
 var replanThreshold = settings.RegisterFloatSetting(
@@ -69,26 +63,14 @@ var replanStabilityWindow = settings.RegisterIntSetting(
 // nodes. DistSQL divides work into spans that each ttlProcessor scans in a
 // SELECT/DELETE loop.
 type rowLevelTTLResumer struct {
-	job          *jobs.Job
-	st           *cluster.Settings
-	physicalPlan *sql.PhysicalPlan
-	planCtx      *sql.PlanningCtx
+	job             *jobs.Job
+	st              *cluster.Settings
+	physicalPlan    *sql.PhysicalPlan
+	planCtx         *sql.PlanningCtx
+	progressTracker progressTracker
 
 	// consecutiveReplanDecisions tracks how many consecutive times replan was deemed necessary.
 	consecutiveReplanDecisions *atomic.Int64
-
-	mu struct {
-		syncutil.Mutex
-		// lastUpdateTime is the wall time of the last job progress update.
-		// Used to gate how often we persist job progress in refreshProgress.
-		lastUpdateTime time.Time
-		// lastSpanCount is the number of spans processed as of the last persisted update.
-		lastSpanCount int64
-		// updateEvery determines how many spans must be processed before we persist a new update.
-		updateEvery int64
-		// updateEveryDuration is the minimum time that must pass before allowing another progress update.
-		updateEveryDuration time.Duration
-	}
 }
 
 var _ jobs.Resumer = (*rowLevelTTLResumer)(nil)
@@ -204,6 +186,8 @@ func (t *rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (r
 
 	distSQLPlanner := jobExecCtx.DistSQLPlanner()
 
+	t.setupProgressTracking()
+
 	jobSpanCount := 0
 	makePlan := func(ctx context.Context, distSQLPlanner *sql.DistSQLPlanner) (*sql.PhysicalPlan, *sql.PlanningCtx, error) {
 		// We don't return the compatible nodes here since PartitionSpans will
@@ -292,13 +276,17 @@ func (t *rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (r
 		return err
 	}
 
-	if err := t.initProgressInJob(ctx, int64(jobSpanCount)); err != nil {
+	if err := t.progressTracker.initJobProgress(ctx, int64(jobSpanCount)); err != nil {
 		return err
 	}
 
 	metadataCallbackWriter := sql.NewMetadataOnlyMetadataCallbackWriter(
 		func(ctx context.Context, meta *execinfrapb.ProducerMetadata) error {
-			return t.refreshProgressInJob(ctx, meta)
+			// In mixed-version clusters (25.3 and earlier), TTL processors fall back to
+			// direct job table updates if any node in the cluster does not support
+			// coordinator-based progress reporting. In that case, no processors will emit
+			// progress metadata, so this callback will never be invoked.
+			return t.progressTracker.handleProgressUpdate(ctx, meta)
 		},
 	)
 
@@ -379,147 +367,9 @@ func (t *rowLevelTTLResumer) CollectProfile(_ context.Context, _ interface{}) er
 	return nil
 }
 
-// initProgressInJob initializes and persists the initial RowLevelTTL job progress state.
-// It computes throttling thresholds and writes an empty progress object to the job record.
-// This should be called once before job execution starts.
-func (t *rowLevelTTLResumer) initProgressInJob(ctx context.Context, jobSpanCount int64) error {
-	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, _ jobs.JobMetadata, ju *jobs.JobUpdater) error {
-		newProgress, err := t.initProgress(jobSpanCount)
-		if err != nil {
-			return err
-		}
-		ju.UpdateProgress(newProgress)
-		return nil
-	})
-}
-
-// refreshProgressInJob updates the job progress metadata based on input
-// from the last producer metadata received.
-//
-// In mixed-version clusters (25.3 and earlier), TTL processors fall back to
-// direct job table updates if any node in the cluster does not support
-// coordinator-based progress reporting. In that case, no processors will emit
-// progress metadata, so this callback will never be invoked.
-func (t *rowLevelTTLResumer) refreshProgressInJob(
-	ctx context.Context, meta *execinfrapb.ProducerMetadata,
-) error {
-	return t.job.NoTxn().Update(ctx, func(_ isql.Txn, md jobs.JobMetadata, ju *jobs.JobUpdater) error {
-		progress, err := t.refreshProgress(ctx, &md, meta)
-		if err != nil {
-			return err
-		}
-		if progress != nil {
-			ju.UpdateProgress(progress)
-		}
-		return nil
-	})
-}
-
-// initProgress initializes the RowLevelTTL job progress metadata, including
-// total span count and per-processor progress entries, based on the physical plan.
-// This should be called before the job starts execution.
-func (t *rowLevelTTLResumer) initProgress(jobSpanCount int64) (*jobspb.Progress, error) {
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	// To avoid too many progress updates, especially if a lot of the spans don't
-	// have expired rows, we will gate the updates to approximately every 1% of
-	// spans processed, and at least 60 seconds apart with jitter. This gating is
-	// done in refreshProgress.
-	t.mu.updateEvery = max(1, jobSpanCount/100)
-	t.mu.updateEveryDuration = 60*time.Second + time.Duration(rand.Int63n(10*1000))*time.Millisecond
-	t.mu.lastUpdateTime = timeutil.Now()
-	t.mu.lastSpanCount = 0
-
-	rowLevelTTL := &jobspb.RowLevelTTLProgress{
-		JobTotalSpanCount:     jobSpanCount,
-		JobProcessedSpanCount: 0,
-	}
-
-	progress := &jobspb.Progress{
-		Details: &jobspb.Progress_RowLevelTTL{RowLevelTTL: rowLevelTTL},
-		Progress: &jobspb.Progress_FractionCompleted{
-			FractionCompleted: 0,
-		},
-	}
-	return progress, nil
-}
-
-// refreshProgress ingests per-processor metadata pushed from TTL processors
-// and updates the job level progress. It recomputes total spans processed
-// and rows deleted, and sets the job level fraction completed.
-func (t *rowLevelTTLResumer) refreshProgress(
-	ctx context.Context, md *jobs.JobMetadata, meta *execinfrapb.ProducerMetadata,
-) (*jobspb.Progress, error) {
-	if meta.BulkProcessorProgress == nil {
-		return nil, nil
-	}
-	var incomingProcProgress jobspb.RowLevelTTLProcessorProgress
-	if err := pbtypes.UnmarshalAny(&meta.BulkProcessorProgress.ProgressDetails, &incomingProcProgress); err != nil {
-		return nil, errors.Wrapf(err, "unable to unmarshal ttl progress details")
-	}
-
-	orig := md.Progress.GetRowLevelTTL()
-	if orig == nil {
-		return nil, errors.New("job progress does not contain RowLevelTTL details")
-	}
-	rowLevelTTL := protoutil.Clone(orig).(*jobspb.RowLevelTTLProgress)
-
-	// Update or insert the incoming processor progress.
-	foundMatchingProcessor := false
-	for i := range rowLevelTTL.ProcessorProgresses {
-		if rowLevelTTL.ProcessorProgresses[i].ProcessorID == incomingProcProgress.ProcessorID {
-			rowLevelTTL.ProcessorProgresses[i] = incomingProcProgress
-			foundMatchingProcessor = true
-			break
-		}
-	}
-	if !foundMatchingProcessor {
-		rowLevelTTL.ProcessorProgresses = append(rowLevelTTL.ProcessorProgresses, incomingProcProgress)
-	}
-
-	// Recompute job level counters from scratch.
-	rowLevelTTL.JobDeletedRowCount = 0
-	rowLevelTTL.JobProcessedSpanCount = 0
-	totalSpanCount := int64(0)
-	for i := range rowLevelTTL.ProcessorProgresses {
-		pp := &rowLevelTTL.ProcessorProgresses[i]
-		rowLevelTTL.JobDeletedRowCount += pp.DeletedRowCount
-		rowLevelTTL.JobProcessedSpanCount += pp.ProcessedSpanCount
-		totalSpanCount += pp.TotalSpanCount
-	}
-
-	if totalSpanCount > rowLevelTTL.JobTotalSpanCount {
-		return nil, errors.Errorf(
-			"computed span total cannot exceed job total: computed=%d jobRecorded=%d",
-			totalSpanCount, rowLevelTTL.JobTotalSpanCount)
-	}
-
-	// Avoid the update if doing this too frequently.
-	t.mu.Lock()
-	defer t.mu.Unlock()
-	processedDelta := rowLevelTTL.JobProcessedSpanCount - t.mu.lastSpanCount
-	processorComplete := incomingProcProgress.ProcessedSpanCount == incomingProcProgress.TotalSpanCount
-	firstProgressForProcessor := !foundMatchingProcessor
-
-	if !(processedDelta >= t.mu.updateEvery ||
-		timeutil.Since(t.mu.lastUpdateTime) >= t.mu.updateEveryDuration ||
-		processorComplete ||
-		firstProgressForProcessor) {
-		return nil, nil // Skip the update
-	}
-	t.mu.lastSpanCount = rowLevelTTL.JobProcessedSpanCount
-	t.mu.lastUpdateTime = timeutil.Now()
-
-	newProgress := &jobspb.Progress{
-		Details: &jobspb.Progress_RowLevelTTL{
-			RowLevelTTL: rowLevelTTL,
-		},
-		Progress: &jobspb.Progress_FractionCompleted{
-			FractionCompleted: float32(rowLevelTTL.JobProcessedSpanCount) /
-				float32(rowLevelTTL.JobTotalSpanCount),
-		},
-	}
-	return newProgress, nil
+// setupProgressTracking sets up progress tracking for the TTL job.
+func (t *rowLevelTTLResumer) setupProgressTracking() {
+	t.progressTracker = newLegacyProgressTracker(t.job)
 }
 
 // replanDecider returns a function that determines whether a TTL job should be

--- a/pkg/sql/ttl/ttljob/ttljob_internal_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_internal_test.go
@@ -7,15 +7,11 @@ package ttljob
 
 import (
 	"context"
-	"fmt"
 	"sync/atomic"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/jobs"
-	"github.com/cockroachdb/cockroach/pkg/roachpb"
 	"github.com/cockroachdb/cockroach/pkg/sql"
-	"github.com/cockroachdb/cockroach/pkg/sql/execinfrapb"
 	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
@@ -27,135 +23,6 @@ import (
 // specifically part of the ttljob package to access non-exported functions and
 // structs. Hence, the name '_internal_' in the file to signify that it accesses
 // internal functions.
-
-func makeFakeSpans(n int) []roachpb.Span {
-	spans := make([]roachpb.Span, n)
-	for i := 0; i < n; i++ {
-		start := roachpb.Key(fmt.Sprintf("k%03d", i))
-		end := roachpb.Key(fmt.Sprintf("k%03d", i+1))
-		spans[i] = roachpb.Span{Key: start, EndKey: end}
-	}
-	return spans
-}
-
-func TestTTLProgressLifecycle(t *testing.T) {
-	defer leaktest.AfterTest(t)()
-	defer log.Scope(t).Close(t)
-
-	ctx := context.Background()
-
-	infra := &physicalplan.PhysicalInfrastructure{
-		Processors: []physicalplan.Processor{
-			{
-				SQLInstanceID: base.SQLInstanceID(11),
-				Spec: execinfrapb.ProcessorSpec{
-					ProcessorID: 1,
-					Core: execinfrapb.ProcessorCoreUnion{
-						Ttl: &execinfrapb.TTLSpec{
-							Spans: makeFakeSpans(100),
-						},
-					},
-				},
-			},
-			{
-				SQLInstanceID: base.SQLInstanceID(12),
-				Spec: execinfrapb.ProcessorSpec{
-					ProcessorID: 2,
-					Core: execinfrapb.ProcessorCoreUnion{
-						Ttl: &execinfrapb.TTLSpec{
-							Spans: makeFakeSpans(100),
-						},
-					},
-				},
-			},
-		},
-	}
-	physPlan := physicalplan.PhysicalPlan{
-		PhysicalInfrastructure: infra,
-	}
-	sqlPlan := sql.PhysicalPlan{
-		PhysicalPlan: physPlan,
-	}
-	resumer := rowLevelTTLResumer{
-		physicalPlan: &sqlPlan,
-	}
-
-	// Create two processors to match the IDs used in the physical plan
-	proc1 := mockProcessor(1, roachpb.NodeID(11), 100)
-	proc2 := mockProcessor(2, roachpb.NodeID(12), 100)
-	mockRowReceiver := metadataCache{}
-
-	// Step 1: initProgress
-	progress, err := resumer.initProgress(200)
-	require.NoError(t, err)
-	require.NotNil(t, progress)
-	require.Equal(t, float32(0), progress.GetFractionCompleted())
-	ttlProgress := progress.GetRowLevelTTL()
-	require.Equal(t, int64(200), ttlProgress.JobTotalSpanCount)
-	require.Zero(t, ttlProgress.JobProcessedSpanCount)
-	require.Zero(t, ttlProgress.JobDeletedRowCount)
-	require.Len(t, ttlProgress.ProcessorProgresses, 0)
-	md := jobs.JobMetadata{
-		Progress: progress,
-	}
-
-	// First refresh (processor 1 partial)
-	proc1.progressUpdater.OnSpanProcessed(50, 100)
-	err = proc1.progressUpdater.UpdateProgress(ctx, &mockRowReceiver)
-	require.NoError(t, err)
-	progress, err = resumer.refreshProgress(ctx, &md, mockRowReceiver.GetLatest())
-	require.NoError(t, err)
-	require.NotNil(t, progress)
-	md.Progress = progress
-
-	require.NoError(t, err)
-	require.InEpsilon(t, 0.25, progress.GetFractionCompleted(), 0.001)
-	ttlProgress = progress.GetRowLevelTTL()
-	require.Equal(t, int64(200), ttlProgress.JobTotalSpanCount)
-	require.Equal(t, int64(50), ttlProgress.JobProcessedSpanCount)
-	require.Equal(t, int64(100), ttlProgress.JobDeletedRowCount)
-	require.Len(t, ttlProgress.ProcessorProgresses, 1)
-
-	// Second refresh (processor 2 full)
-	proc2.progressUpdater.OnSpanProcessed(100, 400)
-	err = proc2.progressUpdater.UpdateProgress(ctx, &mockRowReceiver)
-	require.NoError(t, err)
-	progress, err = resumer.refreshProgress(ctx, &md, mockRowReceiver.GetLatest())
-	require.NoError(t, err)
-	require.NotNil(t, progress)
-	md.Progress = progress
-
-	require.NoError(t, err)
-	require.InEpsilon(t, 0.75, progress.GetFractionCompleted(), 0.001)
-	ttlProgress = progress.GetRowLevelTTL()
-	require.Equal(t, int64(200), ttlProgress.JobTotalSpanCount)
-	require.Equal(t, int64(150), ttlProgress.JobProcessedSpanCount)
-	require.Equal(t, int64(500), ttlProgress.JobDeletedRowCount)
-	require.Len(t, ttlProgress.ProcessorProgresses, 2)
-
-	// No update refresh (processor 1 empty)
-	err = proc1.progressUpdater.UpdateProgress(ctx, &mockRowReceiver) // No call to OnSpanProcessed
-	require.NoError(t, err)
-	progress, err = resumer.refreshProgress(ctx, &md, mockRowReceiver.GetLatest())
-	require.NoError(t, err)
-	require.Nil(t, progress)
-
-	// Final refresh (processor 1 remaining)
-	proc1.progressUpdater.OnSpanProcessed(50, 500)
-	err = proc1.progressUpdater.UpdateProgress(ctx, &mockRowReceiver)
-	require.NoError(t, err)
-	progress, err = resumer.refreshProgress(ctx, &md, mockRowReceiver.GetLatest())
-	require.NoError(t, err)
-	require.NotNil(t, progress)
-
-	require.NoError(t, err)
-	require.InEpsilon(t, 1, progress.GetFractionCompleted(), 0.001)
-	ttlProgress = progress.GetRowLevelTTL()
-	require.Equal(t, int64(200), ttlProgress.JobTotalSpanCount)
-	require.Equal(t, int64(200), ttlProgress.JobProcessedSpanCount)
-	require.Equal(t, int64(1000), ttlProgress.JobDeletedRowCount)
-	require.Len(t, ttlProgress.ProcessorProgresses, 2)
-}
 
 func TestReplanDecider(t *testing.T) {
 	defer leaktest.AfterTest(t)()


### PR DESCRIPTION
This change introduces a progressTracker interface to abstract how TTL job progress is tracked. The existing behavior is now encapsulated in a legacyProgressTracker implementation.

While TTL jobs could previously resume after interruption, they would always start from the beginning of the table, effectively discarding any partial progress. This refactor prepares for future support of span-level progress tracking, enabling jobs to resume from where they left off.

A follow-up change will add actual checkpointing support using this interface, allowing resumable TTL jobs to skip spans already processed.

This commit is scoped to the interface definition and refactoring of the current implementation under it.

Informs #140514

Release note: none