### PR TITLE
sql: Add DefaultValue field to SetClusterSettings event

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -634,6 +634,7 @@ An event of type `set_cluster_setting` is recorded when a cluster setting is cha
 |--|--|--|
 | `SettingName` | The name of the affected cluster setting. | no |
 | `Value` | The new value of the cluster setting. | yes |
+| `DefaultValue` | The current default value of the cluster setting. | yes |
 
 
 #### Common fields

--- a/pkg/sql/logictest/testdata/logic_test/event_log
+++ b/pkg/sql/logictest/testdata/logic_test/event_log
@@ -482,12 +482,12 @@ AND info NOT LIKE '%sql.testing%'
 AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
-1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "node", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
-1  {"EventType": "set_cluster_setting", "SettingName": "feature.vector_index.enabled", "Statement": "SET CLUSTER SETTING \"feature.vector_index.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "sql.vecindex.deterministic_fixups.enabled", "Statement": "SET CLUSTER SETTING \"sql.vecindex.deterministic_fixups.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
-1  {"EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}
+1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "DefaultValue": "true", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "node", "Value": "true"}
+1  {"DefaultValue": "-10s", "EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
+1  {"DefaultValue": "false", "EventType": "set_cluster_setting", "SettingName": "feature.vector_index.enabled", "Statement": "SET CLUSTER SETTING \"feature.vector_index.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
+1  {"DefaultValue": "false", "EventType": "set_cluster_setting", "SettingName": "sql.vecindex.deterministic_fixups.enabled", "Statement": "SET CLUSTER SETTING \"sql.vecindex.deterministic_fixups.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
+1  {"DefaultValue": "true", "EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = false", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "false"}
+1  {"DefaultValue": "true", "EventType": "set_cluster_setting", "SettingName": "kv.allocator.load_based_lease_rebalancing.enabled", "Statement": "SET CLUSTER SETTING \"kv.allocator.load_based_lease_rebalancing.enabled\" = DEFAULT", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "DEFAULT"}
 1  {"EventType": "set_cluster_setting", "PlaceholderValues": ["'some string'"], "SettingName": "cluster.label", "Statement": "SET CLUSTER SETTING \"cluster.label\" = $1", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "'some string'"}
 
 onlyif config 3node-tenant-default-configs
@@ -503,10 +503,10 @@ AND info NOT LIKE '%sql.testing%'
 AND info NOT LIKE '%sql.stats%'
 ORDER BY "timestamp", info
 ----
-1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "node", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
-1  {"EventType": "set_cluster_setting", "SettingName": "feature.vector_index.enabled", "Statement": "SET CLUSTER SETTING \"feature.vector_index.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
-1  {"EventType": "set_cluster_setting", "SettingName": "sql.vecindex.deterministic_fixups.enabled", "Statement": "SET CLUSTER SETTING \"sql.vecindex.deterministic_fixups.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
+1  {"ApplicationName": "$ internal-optInToDiagnosticsStatReporting", "DefaultValue": "true", "EventType": "set_cluster_setting", "SettingName": "diagnostics.reporting.enabled", "Statement": "SET CLUSTER SETTING \"diagnostics.reporting.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "node", "Value": "true"}
+1  {"DefaultValue": "-10s", "EventType": "set_cluster_setting", "SettingName": "sql.crdb_internal.table_row_statistics.as_of_time", "Statement": "SET CLUSTER SETTING \"sql.crdb_internal.table_row_statistics.as_of_time\" = e'-1\\u00B5s'", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "-00:00:00.000001"}
+1  {"DefaultValue": "false", "EventType": "set_cluster_setting", "SettingName": "feature.vector_index.enabled", "Statement": "SET CLUSTER SETTING \"feature.vector_index.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
+1  {"DefaultValue": "false", "EventType": "set_cluster_setting", "SettingName": "sql.vecindex.deterministic_fixups.enabled", "Statement": "SET CLUSTER SETTING \"sql.vecindex.deterministic_fixups.enabled\" = true", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "true"}
 1  {"EventType": "set_cluster_setting", "PlaceholderValues": ["'some string'"], "SettingName": "cluster.label", "Statement": "SET CLUSTER SETTING \"cluster.label\" = $1", "Tag": "SET CLUSTER SETTING", "User": "root", "Value": "'some string'"}
 
 # Set and unset zone configs

--- a/pkg/sql/set_cluster_setting.go
+++ b/pkg/sql/set_cluster_setting.go
@@ -464,8 +464,9 @@ func writeSettingInternal(
 		return logFn(ctx,
 			0, /* no target */
 			&eventpb.SetClusterSetting{
-				SettingName: string(name),
-				Value:       reportedValue,
+				SettingName:  string(name),
+				Value:        reportedValue,
+				DefaultValue: setting.DefaultString(),
 			})
 	}(); err != nil {
 		return "", err

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -5747,6 +5747,18 @@ func (m *SetClusterSetting) AppendJSONFields(printComma bool, b redact.Redactabl
 		b = append(b, '"')
 	}
 
+	if m.DefaultValue != "" {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"DefaultValue\":\""...)
+		b = append(b, redact.StartMarker()...)
+		b = redact.RedactableBytes(jsonbytes.EncodeString([]byte(b), string(redact.EscapeMarkers([]byte(m.DefaultValue)))))
+		b = append(b, redact.EndMarker()...)
+		b = append(b, '"')
+	}
+
 	return printComma, b
 }
 

--- a/pkg/util/log/eventpb/misc_sql_events.proto
+++ b/pkg/util/log/eventpb/misc_sql_events.proto
@@ -33,6 +33,8 @@ message SetClusterSetting {
   string setting_name = 3 [(gogoproto.jsontag) = ",omitempty", (gogoproto.moretags) = "redact:\"nonsensitive\""];
   // The new value of the cluster setting.
   string value = 4 [(gogoproto.jsontag) = ",omitempty"];
+  // The current default value of the cluster setting.
+  string default_value = 5 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 


### PR DESCRIPTION
encodes the current default value of a cluster setting when a cluster setting has changed. This is primarily being added to help with debugging when it is unclear what the default setting value may have been at the time of updating the setting.

Epic: CRDB-52093
Part of: https://cockroachlabs.atlassian.net/browse/CRDB-50883
Release note: None