### PR TITLE
roachprod: roundrobin ibm clusters between two regions

### DIFF
--- a/pkg/roachprod/vm/ibm/provider.go
+++ b/pkg/roachprod/vm/ibm/provider.go
@@ -72,7 +72,7 @@ var (
 // The default region used for non-geo clusters.
 // Leave this field empty to randomize the region for non-geo clusters.
 // This could be useful in case of quota issues in the default region.
-const defaultRegionForNonGeoClusters = "ca-tor"
+const defaultRegionForNonGeoClusters = ""
 
 var (
 	// defaultZones is the list of availability zones agreed upon with IBM.


### PR DESCRIPTION
Even though, we have two available regions to provision IBM clusters into, they were being provisioned only in ca-tor by default (unless a specific region was requested). This tends to lead to quota issues when spawning a lot of cluster during roachtests.

Unless a region is specifically requested, this PR round robins clusters between the two available regions.

Epic: CRDB-8035
Release note: None