### PR TITLE
storage: fix pebbleFormatVersion handling of fence versions

### DIFF
--- a/pkg/clusterversion/cockroach_versions.go
+++ b/pkg/clusterversion/cockroach_versions.go
@@ -372,7 +372,7 @@ func SupportedPreviousReleases() []Key {
 func ListBetween(from, to roachpb.Version) []roachpb.Version {
 	var cvs []roachpb.Version
 	for k := Key(0); k < numKeys; k++ {
-		if v := k.Version(); from.Less(v) && v.LessEq(to) {
+		if v := k.Version(); from.Cmp(v) < 0 && v.Cmp(to) <= 0 {
 			cvs = append(cvs, v)
 		}
 	}

--- a/pkg/roachpb/version.go
+++ b/pkg/roachpb/version.go
@@ -6,6 +6,7 @@
 package roachpb
 
 import (
+	"cmp"
 	"fmt"
 	"regexp"
 	"strconv"
@@ -16,39 +17,33 @@ import (
 	"github.com/cockroachdb/redact"
 )
 
-// Less compares two Versions.
+// Cmp returns -1 if v < otherV, 0 if v == otherV, and 1 if v > otherV.
+func (v Version) Cmp(otherV Version) int {
+	if v.Major != otherV.Major {
+		return cmp.Compare(v.Major, otherV.Major)
+	}
+	if v.Minor != otherV.Minor {
+		return cmp.Compare(v.Minor, otherV.Minor)
+	}
+	if v.Patch != otherV.Patch {
+		return cmp.Compare(v.Patch, otherV.Patch)
+	}
+	return cmp.Compare(v.Internal, otherV.Internal)
+}
+
+// Less returns whether the receiver is less than the parameter.
 func (v Version) Less(otherV Version) bool {
-	if v.Major < otherV.Major {
-		return true
-	} else if v.Major > otherV.Major {
-		return false
-	}
-	if v.Minor < otherV.Minor {
-		return true
-	} else if v.Minor > otherV.Minor {
-		return false
-	}
-	if v.Patch < otherV.Patch {
-		return true
-	} else if v.Patch > otherV.Patch {
-		return false
-	}
-	if v.Internal < otherV.Internal {
-		return true
-	} else if v.Internal > otherV.Internal {
-		return false
-	}
-	return false
+	return v.Cmp(otherV) < 0
 }
 
 // LessEq returns whether the receiver is less than or equal to the parameter.
 func (v Version) LessEq(otherV Version) bool {
-	return v.Equal(otherV) || v.Less(otherV)
+	return v.Cmp(otherV) <= 0
 }
 
 // AtLeast returns true if the receiver is greater than or equal to the parameter.
 func (v Version) AtLeast(otherV Version) bool {
-	return !v.Less(otherV)
+	return v.Cmp(otherV) >= 0
 }
 
 // String implements the fmt.Stringer interface. The result is of the form

--- a/pkg/storage/pebble.go
+++ b/pkg/storage/pebble.go
@@ -513,12 +513,6 @@ var MVCCMerger = &pebble.Merger{
 
 const mvccWallTimeIntervalCollector = "MVCCTimeInterval"
 
-// MinimumSupportedFormatVersion is the version that provides features that the
-// Cockroach code relies on unconditionally (like range keys). New stores are by
-// default created with this version. It should correspond to the minimum
-// supported binary version.
-const MinimumSupportedFormatVersion = pebble.FormatTableFormatV6
-
 // DefaultPebbleOptions returns the default pebble options.
 func DefaultPebbleOptions() *pebble.Options {
 	opts := &pebble.Options{

--- a/pkg/storage/pebble_test.go
+++ b/pkg/storage/pebble_test.go
@@ -1601,6 +1601,22 @@ func TestMinimumSupportedFormatVersion(t *testing.T) {
 		"MinimumSupportedFormatVersion must match the format version for %s", clusterversion.MinSupported)
 }
 
+func TestPebbleFormatVersion(t *testing.T) {
+	latestKey := pebbleFormatVersionKeys[0]
+	latestVersion := latestKey.Version()
+	latestFmv := pebbleFormatVersionMap[latestKey]
+
+	require.Equal(t, pebbleFormatVersion(latestVersion), latestFmv)
+	v := latestVersion
+	v.Minor++
+	require.Equal(t, pebbleFormatVersion(latestVersion), latestFmv)
+
+	// The fence version should use the previous format version. Advancing to a
+	// fence version is intended to be a no-op (see upgrademanager package for
+	// more information).
+	require.Less(t, pebbleFormatVersion(latestVersion.FenceVersion()), latestFmv)
+}
+
 // delayFS injects a delay on each read.
 type delayFS struct {
 	vfs.FS

--- a/pkg/upgrade/upgrademanager/manager.go
+++ b/pkg/upgrade/upgrademanager/manager.go
@@ -838,7 +838,7 @@ func (m *Manager) listBetween(from roachpb.Version, to roachpb.Version) []roachp
 		result := m.knobs.ListBetweenOverride(from, to)
 		// Sanity check result to catch invalid overrides.
 		for _, v := range result {
-			if v.LessEq(from) || to.Less(v) {
+			if !(from.Cmp(v) < 0 && v.Cmp(to) <= 0) {
 				panic(fmt.Sprintf("ListBetweenOverride(%s, %s) returned invalid version %s", from, to, v))
 			}
 		}


### PR DESCRIPTION
#### roachpb: add Version.Cmp method

Add a `Version.Cmp()` method that is more natural to use than
`Less/LessEq/AtLeast` and can also be used for things like
`slices.Sort`.

Epic: none
Release note: None

#### storage: fix pebbleFormatVersion handling of fence versions

Currently `pebbleFormatVersion` changes the pebble format as soon as
we hit the fence version of the key in the `pebbleFormatVersionMap`.
This is incorrect - advancing to a fence version must be a no-op;
fence versions are used strictly for detecting an older binary node
joining the cluster right as we are in the process of advancing to the
fence version.

In practice, this fix only makes a difference if a newer pebble format
is associated with the first internal version added by a newer binary
(`Vxx_y_Start` for GA-to-GA upgrades).

Epic: none
Release note: None