### PR TITLE
sql/tests: for now skip st_snap in TestRandomSyntaxFunctions

### DIFF
--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -435,6 +435,9 @@ func TestRandomSyntaxFunctions(t *testing.T) {
 					"crdb_internal.fingerprint":
 					// Skipped due to long execution time.
 					continue
+				case "st_snap":
+					// TODO(#151103): unskip st_snap.
+					continue
 				}
 				_, variations := builtinsregistry.GetBuiltinProperties(name)
 				for _, builtin := range variations {


### PR DESCRIPTION
There appears to be a regression with geos bump from 3.11 to 3.12. It's not fixed in 3.13 either (latest stable available release), so until we fix it proper, skip `st_snap` function.

Informs: #151103.
Epic: None

Release note: None