### PR TITLE
cli(tsdump): introduce partial retries for tsdump Datadog upload

### DIFF
--- a/pkg/cli/debug.go
+++ b/pkg/cli/debug.go
@@ -1618,6 +1618,7 @@ func init() {
 	f.StringVar(&debugTimeSeriesDumpOpts.storeToNodeMapYAMLFile, "store-to-node-map-file", "", "yaml file path which contains the mapping of store ID to node ID for datadog upload.")
 	f.BoolVar(&debugTimeSeriesDumpOpts.dryRun, "dry-run", false, "run in dry-run mode without making any actual uploads")
 	f.IntVar(&debugTimeSeriesDumpOpts.noOfUploadWorkers, "upload-workers", 50, "number of workers to upload the time series data in parallel")
+	f.BoolVar(&debugTimeSeriesDumpOpts.retryFailedRequests, "retry-failed-requests", false, "retry previously failed requests from file")
 
 	f = debugSendKVBatchCmd.Flags()
 	f.StringVar(&debugSendKVBatchContext.traceFormat, "trace", debugSendKVBatchContext.traceFormat,

--- a/pkg/cli/testdata/tsdump_partial_upload_e2e
+++ b/pkg/cli/testdata/tsdump_partial_upload_e2e
@@ -1,0 +1,29 @@
+
+upload-datadog
+cr.node.admission.admitted.elastic-cpu,2025-05-26T08:32:00Z,1,1
+cr.node.sql.query.count,2021-01-01T00:00:00Z,1,100.5
+cr.node.sql.query.count,2021-01-01T00:00:10Z,1,102.3
+cr.store.rocksdb.block.cache.usage,2021-01-01T00:00:00Z,2,75.2
+----
+----
+{"series":[{"interval":10,"metric":"crdb.tsdump.admission.admitted.elastic-cpu","points":[{"timestamp":1748248320,"value":1}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}]}
+
+{"series":[{"interval":10,"metric":"crdb.tsdump.rocksdb.block.cache.usage","points":[{"timestamp":1609459200,"value":75.2}],"tags":["store:2","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}]}
+
+[{"ddsource":"tsdump_upload","ddtags":"cluster_type:SELF_HOSTED,cluster_label:test-cluster,cluster_id:test-cluster-id,zendesk_ticket:zd-test,org_name:test-org,user_name:test-user,upload_id:,upload_timestamp:2024-11-14 00:00:00,upload_year:2024,upload_month:11,upload_day:14,series_uploaded:4","dry_run":"false","duration":"0","estimated_cost":"0.000186986301369863","hostname":"hostname","message":"tsdump upload completed: uploaded 4 series overall","series_uploaded":"4","service":"tsdump_upload","success":"false"}]
+
+{"metric_series":[{"interval":10,"metric":"crdb.tsdump.sql.query.count","points":[{"timestamp":1609459200,"value":100.5}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}],"upload_id":"","timestamp":"2024-11-14T00:00:00Z","error":"409 Conflict"}
+{"metric_series":[{"interval":10,"metric":"crdb.tsdump.sql.query.count","points":[{"timestamp":1609459210,"value":102.3}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}],"upload_id":"","timestamp":"2024-11-14T00:00:00Z","error":"409 Conflict"}
+----
+----
+
+partial-upload
+{"metric_series":[{"interval":25,"metric":"crdb.tsdump.sql.query.count","points":[{"timestamp":1609459210,"value":102.3}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:test-cluster-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}],"upload_id":"test-cluster-20241114000000","timestamp":"2024-11-14T00:00:00Z","error":"409 Conflict"}
+{"metric_series":[{"interval":25,"metric":"crdb.tsdump.sql.query.count","points":[{"timestamp":1609459200,"value":100.5}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:test-cluster-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}],"upload_id":"test-cluster-20241114000000","timestamp":"2024-11-14T00:00:00Z","error":"409 Conflict"}
+----
+----
+{"series":[{"interval":25,"metric":"crdb.tsdump.sql.query.count","points":[{"timestamp":1609459210,"value":102.3}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:test-cluster-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}]}
+
+{"series":[{"interval":25,"metric":"crdb.tsdump.sql.query.count","points":[{"timestamp":1609459200,"value":100.5}],"tags":["node_id:1","cluster_type:SELF_HOSTED","cluster_label:test-cluster","cluster_id:test-cluster-id","zendesk_ticket:zd-test","org_name:test-org","user_name:test-user","upload_id:test-cluster-20241114000000","upload_timestamp:2024-11-14 00:00:00","upload_year:2024","upload_month:11","upload_day:14"],"type":0}]}
+----
+----

--- a/pkg/cli/tsdump_test.go
+++ b/pkg/cli/tsdump_test.go
@@ -74,6 +74,39 @@ func TestDebugTimeSeriesDumpCmd(t *testing.T) {
 		require.NoError(t, err)
 		require.NotEmpty(t, yamlContents)
 	})
+
+	t.Run("debug tsdump datadog upload with invalid upload workers", func(t *testing.T) {
+		// Create a temporary gob file for testing
+		tmpFile, err := os.CreateTemp("", "test_tsdump_*.gob")
+		require.NoError(t, err)
+		defer func(name string) {
+			err := os.Remove(name)
+			if err != nil {
+				t.Fatalf("failed to remove temporary file %s: %v", name, err)
+			}
+		}(tmpFile.Name())
+
+		// Test with upload workers > 100
+		out, _ := c.RunWithCapture(fmt.Sprintf(
+			"debug tsdump --format=datadog --dd-api-key=test-key --cluster-label=test --upload-workers=101 %s",
+			tmpFile.Name(),
+		))
+		require.Contains(t, out, "--upload-workers is set to an invalid value. please select a value which between 1 and 100.")
+
+		// Test with upload workers = 0
+		out, _ = c.RunWithCapture(fmt.Sprintf(
+			"debug tsdump --format=datadog --dd-api-key=test-key --cluster-label=test --upload-workers=0 %s",
+			tmpFile.Name(),
+		))
+		require.Contains(t, out, "--upload-workers is set to an invalid value. please select a value which between 1 and 100.")
+
+		// Test with negative upload workers
+		out, _ = c.RunWithCapture(fmt.Sprintf(
+			"debug tsdump --format=datadog --dd-api-key=test-key --cluster-label=test --upload-workers=-1 %s",
+			tmpFile.Name(),
+		))
+		require.Contains(t, out, "--upload-workers is set to an invalid value. please select a value which between 1 and 100.")
+	})
 }
 
 func TestMakeOpenMetricsWriter(t *testing.T) {
@@ -217,12 +250,13 @@ func TestTsDumpFormatsDataDriven(t *testing.T) {
 				debugTimeSeriesDumpOpts.organizationName = "test-org"
 				debugTimeSeriesDumpOpts.userName = "test-user"
 				debugTimeSeriesDumpOpts.noOfUploadWorkers = 50
+				debugTimeSeriesDumpOpts.retryFailedRequests = false
 				var series int
 				d.ScanArgs(t, "series-threshold", &series)
 				var ddwriter, err = makeDatadogWriter(
 					defaultDDSite, d.Cmd == "format-datadog-init", "api-key", series,
 					server.Listener.Addr().String(), debugTimeSeriesDumpOpts.noOfUploadWorkers,
-				)
+					debugTimeSeriesDumpOpts.retryFailedRequests)
 				require.NoError(t, err)
 
 				parseDDInput(t, d.Input, ddwriter)

--- a/pkg/cli/tsdump_upload.go
+++ b/pkg/cli/tsdump_upload.go
@@ -14,6 +14,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"path/filepath"
 	"sort"
 	"strconv"
 	"strings"
@@ -33,15 +34,10 @@ import (
 )
 
 const (
-	DatadogSeriesTypeUnknown = iota
-	DatadogSeriesTypeCounter
-	DatadogSeriesTypeRate
-	DatadogSeriesTypeGauge
-)
-const (
-	UploadStatusSuccess = "Success"
-	UploadStatusFailure = "Failed"
-	nodeKey             = "node_id"
+	UploadStatusSuccess        = "Success"
+	UploadStatusPartialSuccess = "Partial Success"
+	UploadStatusFailure        = "Failed"
+	nodeKey                    = "node_id"
 )
 
 var (
@@ -61,15 +57,31 @@ var (
 	zipFileSignature            = []byte{0x50, 0x4B, 0x03, 0x04}
 	logMessageFormat            = "tsdump upload to datadog is partially failed for metric: %s"
 	partialFailureMessageFormat = "The Tsdump upload to Datadog succeeded but %d metrics partially failed to upload." +
-		" These failures can be due to transient network errors. If any of these metrics are critical for your investigation," +
-		" please re-upload the Tsdump:\n%s\n"
-	datadogLogsURLFormat = "https://us5.datadoghq.com/logs?query=cluster_label:%s+upload_id:%s"
+		" These failures can be due to transient network errors.\nMetrics:\n%s\n" +
+		"If any of these metrics are critical for your investigation," +
+		" Failed requests have been saved to '%s'. You can retry uploading only the failed requests using the --retry-failed-requests flag\n"
+
+	datadogLogsURLFormat         = "https://us5.datadoghq.com/logs?query=cluster_label:%s+upload_id:%s"
+	failedRequestsFileNameFormat = "tsdump_failed_requests_%s.json"
 
 	translateMetricType = map[string]*datadogV2.MetricIntakeType{
 		"GAUGE":   datadogV2.METRICINTAKETYPE_GAUGE.Ptr(),
 		"COUNTER": datadogV2.METRICINTAKETYPE_COUNT.Ptr(),
 	}
 )
+
+// FailedRequest represents a failed metric upload request that can be retried
+type FailedRequest struct {
+	MetricSeries []datadogV2.MetricSeries `json:"metric_series"`
+	UploadID     string                   `json:"upload_id"`
+	Timestamp    time.Time                `json:"timestamp"`
+	Error        string                   `json:"error,omitempty"`
+}
+
+// FailedRequestsFile represents the structure of the failed requests file
+type FailedRequestsFile struct {
+	Requests []FailedRequest `json:"requests"`
+}
 
 var newTsdumpUploadID = func(uploadTime time.Time) string {
 	clusterTagValue := "cluster-debug"
@@ -97,6 +109,14 @@ type datadogWriter struct {
 	storeToNodeMap    map[string]string
 	metricTypeMap     map[string]string
 	noOfUploadWorkers int
+	// isPartialUploadOfFailedRequests indicates whether are we retrying failed requests
+	isPartialUploadOfFailedRequests bool
+	// failedRequestsFileName which captures failed requests.
+	failedRequestsFileName string
+	// fileMutex protects concurrent access to file which captures failed requests.
+	fileMutex syncutil.Mutex
+	// hasFailedRequestsInUpload tracks if any failed requests were saved during upload
+	hasFailedRequestsInUpload bool
 }
 
 func makeDatadogWriter(
@@ -106,6 +126,7 @@ func makeDatadogWriter(
 	threshold int,
 	hostNameOverride string,
 	noOfUploadWorkers int,
+	isPartialUploadOfFailedRequests bool,
 ) (*datadogWriter, error) {
 	currentTime := getCurrentTime()
 
@@ -151,17 +172,18 @@ func makeDatadogWriter(
 	}
 
 	return &datadogWriter{
-		datadogContext:    ctx,
-		apiClient:         apiClient,
-		apiKey:            apiKey,
-		uploadID:          newTsdumpUploadID(currentTime),
-		init:              init,
-		namePrefix:        "crdb.tsdump.", // Default pre-set prefix to distinguish these uploads.
-		threshold:         threshold,
-		uploadTime:        currentTime,
-		storeToNodeMap:    make(map[string]string),
-		metricTypeMap:     metricTypeMap,
-		noOfUploadWorkers: noOfUploadWorkers,
+		datadogContext:                  ctx,
+		apiClient:                       apiClient,
+		apiKey:                          apiKey,
+		uploadID:                        newTsdumpUploadID(currentTime),
+		init:                            init,
+		namePrefix:                      "crdb.tsdump.", // Default pre-set prefix to distinguish these uploads.
+		threshold:                       threshold,
+		uploadTime:                      currentTime,
+		storeToNodeMap:                  make(map[string]string),
+		metricTypeMap:                   metricTypeMap,
+		noOfUploadWorkers:               noOfUploadWorkers,
+		isPartialUploadOfFailedRequests: isPartialUploadOfFailedRequests,
 	}, nil
 }
 
@@ -238,6 +260,160 @@ func (d *datadogWriter) dump(kv *roachpb.KeyValue) (*datadogV2.MetricSeries, err
 	return series, nil
 }
 
+// saveFailedRequest saves a failed request to the failed requests file
+func (d *datadogWriter) saveFailedRequest(data []datadogV2.MetricSeries, err error) {
+	failedRequest := FailedRequest{
+		MetricSeries: data,
+		UploadID:     d.uploadID,
+		Timestamp:    getCurrentTime(),
+		Error:        err.Error(),
+	}
+
+	// Append to file using streaming JSON
+	if appendErr := d.appendFailedRequestToFile(failedRequest); appendErr != nil {
+		fmt.Printf("Warning: Failed to save failed request to file: %v\n", appendErr)
+		return
+	}
+
+	// mark that we have saved requests
+	sync.OnceFunc(func() {
+		d.hasFailedRequestsInUpload = true
+	})()
+
+}
+
+// appendFailedRequestToFile appends a single failed request to the file
+func (d *datadogWriter) appendFailedRequestToFile(request FailedRequest) error {
+	d.fileMutex.Lock()
+	defer d.fileMutex.Unlock()
+
+	fileName := d.failedRequestsFileName
+	file, err := os.OpenFile(fileName, os.O_CREATE|os.O_APPEND|os.O_WRONLY, 0644)
+	if err != nil {
+		return err
+	}
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			fmt.Printf("Warning: Failed to close failed requests file %s: %v\n", file.Name(), err)
+		}
+	}(file)
+
+	// Write each failed request as a single JSON line (JSONL format)
+	requestJSON, err := json.Marshal(request)
+	if err != nil {
+		return err
+	}
+
+	// Append newline to make it proper JSONL format
+	_, err = file.Write(append(requestJSON, '\n'))
+	return err
+}
+
+// streamFailedRequests streams failed requests from file to a channel without loading all into memory
+func streamFailedRequests(
+	filePath string, ch chan<- *FailedRequest, wg *sync.WaitGroup,
+) (int, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return 0, err
+	}
+	defer func(file *os.File) {
+		err := file.Close()
+		if err != nil {
+			fmt.Printf("failed to close file %s: %v\n", file.Name(), err)
+		}
+	}(file)
+
+	decoder := json.NewDecoder(file)
+	count := 0
+
+	for {
+		var request FailedRequest
+		err := decoder.Decode(&request)
+		if err == io.EOF {
+			break
+		}
+		if err != nil {
+			fmt.Printf("failed to parse failed request line: %v\n", err)
+			continue
+		}
+
+		// Add to wait group as soon as we read a valid request
+		wg.Add(1)
+		// Send request to channel for processing
+		ch <- &request
+		count++
+
+	}
+	return count, nil
+}
+
+// retryFailedRequests attempts to re-upload failed requests using streaming approach with channels
+func (d *datadogWriter) retryFailedRequests(fileName string) error {
+
+	// Create temporary file for requests which are still failing in re-upload.
+	tempFile := fileName + ".tmp"
+	d.failedRequestsFileName = tempFile
+
+	// Create channel for streaming requests
+	requestCh := make(chan *FailedRequest, 100)
+	defer close(requestCh)
+	var wg sync.WaitGroup
+
+	// State to track retry results
+	var retryState struct {
+		syncutil.Mutex
+		successCount int
+		failedCount  int
+	}
+
+	// Start workers to retry failed requests
+	for i := 0; i < d.noOfUploadWorkers; i++ {
+		go func() {
+			for failedReq := range requestCh {
+				_, err := d.emitDataDogMetrics(failedReq.MetricSeries)
+				func() {
+					retryState.Lock()
+					defer retryState.Unlock()
+					if err != nil {
+						retryState.failedCount++
+					} else {
+						retryState.successCount++
+					}
+				}()
+				wg.Done()
+			}
+		}()
+	}
+
+	_, err := streamFailedRequests(fileName, requestCh, &wg)
+	if err != nil {
+		fmt.Printf("error streaming failed requests: %v\n", err)
+	}
+
+	// Wait for all requests to be processed
+	wg.Wait()
+	fmt.Printf("\nretry completed: %d succeeded, %d still failed\n", retryState.successCount, retryState.failedCount)
+
+	// Replace original file with temp file if there are still failing requests
+	if d.hasFailedRequestsInUpload {
+		if err := os.Rename(tempFile, fileName); err != nil {
+			return fmt.Errorf("failed to update failed requests file: %w", err)
+		}
+		fmt.Printf("%d requests still failed and have been saved to %s\n", retryState.failedCount, fileName)
+		return nil
+	}
+
+	// All retries succeeded, remove the original failed requests file
+	if err := os.Remove(fileName); err != nil {
+		fmt.Printf("failed to remove failed requests file: %v\n", err)
+	} else {
+		fmt.Println("All retry requests succeeded. Failed requests file has been removed.")
+	}
+	return nil
+}
+
 func (d *datadogWriter) resolveMetricType(metricName string) *datadogV2.MetricIntakeType {
 	if !d.init {
 		// in this is not datadogInit command, we don't need to resolve the metric
@@ -280,8 +456,12 @@ func (d *datadogWriter) emitDataDogMetrics(data []datadogV2.MetricSeries) ([]str
 
 	emittedMetrics := make([]string, len(data))
 	for i := 0; i < len(data); i++ {
-		data[i].Tags = append(data[i].Tags, tags...)
-		data[i].Metric = d.namePrefix + data[i].Metric
+		// If we are retrying failed requests, we don't want to append prefix again to the metrics
+		// as initial upload has done that already.
+		if !d.isPartialUploadOfFailedRequests {
+			data[i].Tags = append(data[i].Tags, tags...)
+			data[i].Metric = d.namePrefix + data[i].Metric
+		}
 		emittedMetrics[i] = data[i].Metric
 	}
 
@@ -318,7 +498,13 @@ func (d *datadogWriter) emitDataDogMetrics(data []datadogV2.MetricSeries) ([]str
 		}
 	}()
 
-	return emittedMetrics, d.flush(data)
+	err := d.flush(data)
+	if err != nil {
+		// save failed request for potential retry.
+		d.saveFailedRequest(data, err)
+	}
+
+	return emittedMetrics, err
 }
 
 func getUploadTags(d *datadogWriter) []string {
@@ -388,6 +574,11 @@ func (d *datadogWriter) upload(fileName string) error {
 	if err != nil {
 		return err
 	}
+
+	// Extract directory from input fileName and attach it to failed requests filename
+	inputDir := filepath.Dir(fileName)
+	failedRequestsBaseName := fmt.Sprintf(failedRequestsFileNameFormat, d.uploadID)
+	d.failedRequestsFileName = filepath.Join(inputDir, failedRequestsBaseName)
 
 	if debugTimeSeriesDumpOpts.dryRun {
 		fmt.Println("Dry-run mode enabled. Not actually uploading data to Datadog.")
@@ -492,7 +683,9 @@ func (d *datadogWriter) upload(fileName string) error {
 	dashboardLink := fmt.Sprintf(datadogDashboardURLFormat, debugTimeSeriesDumpOpts.clusterLabel, d.uploadID, day, int(month), year, fromUnixTimestamp, toUnixTimestamp)
 
 	var uploadStatus string
-	if metricsUploadState.isSingleUploadSucceeded {
+	if metricsUploadState.isSingleUploadSucceeded && d.hasFailedRequestsInUpload {
+		uploadStatus = UploadStatusPartialSuccess
+	} else if metricsUploadState.isSingleUploadSucceeded {
 		uploadStatus = UploadStatusSuccess
 	} else {
 		uploadStatus = UploadStatusFailure
@@ -512,6 +705,8 @@ func (d *datadogWriter) upload(fileName string) error {
 	fmt.Printf("Estimated cost of this upload: $%.2f\n", estimatedCost)
 
 	tags := getUploadTags(d)
+	api := datadogV2.NewLogsApi(d.apiClient)
+
 	success := metricsUploadState.isSingleUploadSucceeded
 	if metricsUploadState.isSingleUploadSucceeded {
 		var isDatadogUploadFailed = false
@@ -520,6 +715,7 @@ func (d *datadogWriter) upload(fileName string) error {
 		})
 		if len(metricsUploadState.uploadFailedMetrics) != 0 {
 			success = false
+			// Print capture message if any failed requests were saved
 			fmt.Printf(partialFailureMessageFormat, len(metricsUploadState.uploadFailedMetrics), strings.Join(func() []string {
 				var failedMetricsList []string
 				index := 1
@@ -529,7 +725,7 @@ func (d *datadogWriter) upload(fileName string) error {
 					index++
 				}
 				return failedMetricsList
-			}(), "\n"))
+			}(), "\n"), d.failedRequestsFileName)
 
 			tags := strings.Join(tags, ",")
 			fmt.Println("\nPushing logs of metric upload failures to datadog...")
@@ -538,17 +734,18 @@ func (d *datadogWriter) upload(fileName string) error {
 				go func(metric string) {
 					logMessage := fmt.Sprintf(logMessageFormat, metric)
 
-					logEntryJSON, _ := json.Marshal(struct {
-						Message any    `json:"message,omitempty"`
-						Tags    string `json:"ddtags,omitempty"`
-						Source  string `json:"ddsource,omitempty"`
-					}{
-						Message: logMessage,
-						Tags:    tags,
-						Source:  "tsdump_upload",
+					hostName := getHostname()
+					_, _, err := api.SubmitLog(d.datadogContext, []datadogV2.HTTPLogItem{
+						{
+							Ddsource: datadog.PtrString("tsdump_upload"),
+							Ddtags:   datadog.PtrString(tags),
+							Message:  logMessage,
+							Service:  datadog.PtrString("tsdump_upload"),
+							Hostname: datadog.PtrString(hostName),
+						},
+					}, datadogV2.SubmitLogOptionalParameters{
+						ContentEncoding: datadogV2.CONTENTENCODING_GZIP.Ptr(),
 					})
-
-					_, err := uploadLogsToDatadog(logEntryJSON, d.apiKey, debugTimeSeriesDumpOpts.ddSite)
 					if err != nil {
 						markDatadogUploadFailedOnce()
 					}
@@ -571,8 +768,6 @@ func (d *datadogWriter) upload(fileName string) error {
 	}
 
 	eventTags := append(tags, makeDDTag("series_uploaded", strconv.Itoa(seriesUploaded)))
-
-	api := datadogV2.NewLogsApi(d.apiClient)
 	hostName := getHostname()
 	_, _, err = api.SubmitLog(d.datadogContext, []datadogV2.HTTPLogItem{
 		{

--- a/pkg/cli/tsdump_upload_test.go
+++ b/pkg/cli/tsdump_upload_test.go
@@ -11,9 +11,12 @@ import (
 	"encoding/gob"
 	"fmt"
 	"io"
+	"math/rand"
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
+	"regexp"
 	"strconv"
 	"strings"
 	"testing"
@@ -93,6 +96,126 @@ func TestTSDumpUploadE2E(t *testing.T) {
 			return ""
 		}
 	})
+}
+
+// TestTSDumpPartialUploadE2E tests the end-to-end functionality of generating failed uploads
+// in the file and re-upload the failed requests to Datadog.
+func TestTSDumpPartialUploadE2E(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	uploadTime := randomTimestamp()
+
+	defer testutils.TestingHook(&getCurrentTime, func() time.Time {
+		return time.Date(2024, 11, 14, 0, 0, 0, 0, time.UTC)
+	})()
+	defer testutils.TestingHook(&getHostname, func() string {
+		return "hostname"
+	})()
+
+	datadriven.RunTest(t, "testdata/tsdump_partial_upload_e2e", func(t *testing.T, d *datadriven.TestData) string {
+		var buf strings.Builder
+
+		debugTimeSeriesDumpOpts.clusterLabel = "test-cluster"
+		debugTimeSeriesDumpOpts.clusterID = "test-cluster-id"
+		debugTimeSeriesDumpOpts.zendeskTicket = "zd-test"
+		debugTimeSeriesDumpOpts.organizationName = "test-org"
+		debugTimeSeriesDumpOpts.userName = "test-user"
+		debugTimeSeriesDumpOpts.ddApiKey = "dd-api-key"
+		uploadID := newTsdumpUploadID(uploadTime)
+		defer testutils.TestingHook(&datadogSeriesThreshold, 1)()
+		defer testutils.TestingHook(&newUploadID, func(cluster string, time time.Time) string {
+			formattedTime := uploadTime.Format("20060102150405")
+			return strings.ToLower(
+				strings.ReplaceAll(
+					fmt.Sprintf("%s-%s", debugTimeSeriesDumpOpts.clusterLabel, formattedTime), " ", "-",
+				),
+			)
+		})()
+
+		c := NewCLITest(TestCLIParams{})
+		defer c.Cleanup()
+
+		switch d.Cmd {
+		case "upload-datadog":
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reader, err := gzip.NewReader(r.Body)
+				require.NoError(t, err)
+				body, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				if strings.Contains(string(body), "crdb.tsdump.sql.query.count") {
+					w.WriteHeader(http.StatusConflict)
+					return
+				}
+				fmt.Fprintln(&buf, trimNonDeterministicOutput(string(body), uploadID))
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer testutils.TestingHook(&hostNameOverride, server.Listener.Addr().String())()
+			defer server.Close()
+			dumpFilePath := generateMockTSDumpFromCSV(t, d.Input)
+
+			// Run the command
+			_, err := c.RunWithCapture(fmt.Sprintf(
+				`debug tsdump --format=datadog --dd-api-key="%s" --cluster-label=%s --upload-workers=1 %s`,
+				debugTimeSeriesDumpOpts.ddApiKey, debugTimeSeriesDumpOpts.clusterLabel, dumpFilePath,
+			))
+			require.NoError(t, err)
+
+			inputDir := filepath.Dir(dumpFilePath)
+			failedRequestsBaseName := fmt.Sprintf(failedRequestsFileNameFormat, uploadID)
+			fileContent := readFileContent(t, filepath.Join(inputDir, failedRequestsBaseName), uploadID)
+			fmt.Fprintln(&buf, fileContent)
+
+			return strings.TrimSpace(buf.String())
+
+		case "partial-upload":
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				reader, err := gzip.NewReader(r.Body)
+				require.NoError(t, err)
+				body, err := io.ReadAll(reader)
+				require.NoError(t, err)
+				fmt.Fprintln(&buf, string(body))
+				w.WriteHeader(http.StatusOK)
+			}))
+			defer testutils.TestingHook(&hostNameOverride, server.Listener.Addr().String())()
+			defer server.Close()
+
+			filePath := generateMockJSONFromInput(t, d.Input)
+			_, err := c.RunWithCapture(fmt.Sprintf(
+				`debug tsdump --format=datadog --dd-api-key="%s" --cluster-label=%s --upload-workers=1 --retry-failed-requests %s`,
+				debugTimeSeriesDumpOpts.ddApiKey, debugTimeSeriesDumpOpts.clusterLabel, filePath,
+			))
+			require.NoError(t, err)
+
+			return strings.TrimSpace(buf.String())
+
+		default:
+			t.Fatalf("unknown command: %s", d.Cmd)
+			return ""
+		}
+	})
+}
+
+func randomTimestamp() time.Time {
+	randomTime := rand.Int63n(time.Now().Unix())
+	randomNow := time.Unix(randomTime, 0)
+	return randomNow
+}
+
+// trimNonDeterministicOutput removes the upload ID from the output string.
+func trimNonDeterministicOutput(out, uploadID string) string {
+	re := regexp.MustCompile(uploadID)
+	out = re.ReplaceAllString(out, ``)
+	return out
+}
+
+func readFileContent(t *testing.T, fileName, uploadID string) string {
+	// Read the content of the file
+	content, err := os.ReadFile(fileName)
+	require.NoError(t, err)
+	t.Cleanup(func() {
+		require.NoError(t, os.Remove(fileName), "failed to remove temporary file")
+	})
+	return trimNonDeterministicOutput(string(content), uploadID)
 }
 
 // generateMockTSDumpFromCSV creates a mock tsdump file from CSV input string.
@@ -191,4 +314,28 @@ func createMockTimeSeriesKV(
 	}
 
 	return roachpb.KeyValue{Key: key, Value: roachValue}, nil
+}
+
+// generateMockJSONFromInput creates a mock JSON file from input data.
+// The input data is written directly to the JSON file.
+// This is useful for testing JSON file generation functionality.
+func generateMockJSONFromInput(t *testing.T, inputData string) string {
+	t.Helper()
+
+	// Create temporary file
+	tmpFile, err := os.CreateTemp("", "mock_json_*.json")
+	require.NoError(t, err)
+	defer tmpFile.Close()
+
+	// Write input data directly to the JSON file
+	for _, request := range strings.Split(inputData, "\n") {
+		_, err = tmpFile.Write([]byte(request + "\n"))
+		require.NoError(t, err)
+	}
+
+	// All retries are getting succeeded so command itself should remove the file.
+	t.Cleanup(func() {
+		require.Error(t, os.Remove(tmpFile.Name()), "file should not be removed as it is already removed in command")
+	})
+	return tmpFile.Name()
 }


### PR DESCRIPTION
Previously, tsdump datadog upload was all or nothing. This means that user has to retry the entire tsdump upload even if there is a single failure. This was inefficient because tsdump upload can take few hours to upload and most of upload requests would be redundant due to previous successful uploads. This patch adds the partial retries for the tsdump upload. If there are any failures during the upload then it captures failed requests in file with format `tsdump_failed_requests_{uploadID}.json`. User can retry the requests by providing the file path with `--retry-failed-requests` flag. If there are any failures during the retry then they will also get captured as part of same file. This patch also adds a cap of 100 on number of upload workers used during the Datadog upload.

Epic: CRDB-52093
Part of: CRDB-44836
Release note: None