### PR TITLE
roachprod: ibm delete clusters

### DIFF
--- a/pkg/roachprod/vm/ibm/provider.go
+++ b/pkg/roachprod/vm/ibm/provider.go
@@ -551,7 +551,7 @@ func (p *Provider) DeleteCluster(l *logger.Logger, name string) error {
 	// roachprod and cluster tags, but will also fallback to searching via the
 	// instance name to ensure all instances are properly deleted.
 	query := fmt.Sprintf(
-		`(tags:"%s:true AND %s:%s") OR (NOT (tags:"%s:true") AND name:%s-*)`,
+		`(tags:"%s:true" AND tags:"%s:%s") OR (NOT (tags:"%s:true") AND name:%s-*)`,
 		vm.TagRoachprod, vm.TagCluster, name,
 		vm.TagRoachprod, name,
 	)


### PR DESCRIPTION
Starting in #150873, the IBM API query to list instances for deletion got more complex and this made the previously working shorthand `tags:"k1:v1 AND k2:v2"` ineffective.

This patches the query to the fully written format `(tags:"k1:v1" AND tags:"k2:v2")`.

Epic: none
Release note: None