### PR TITLE
roachprod: bump gc job

### DIFF
--- a/pkg/roachprod/k8s/roachprod-gc.yaml
+++ b/pkg/roachprod/k8s/roachprod-gc.yaml
@@ -31,7 +31,7 @@ spec:
         spec:
           containers:
             - name: roachprod-gc-cronjob
-              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:add1f523468
+              image: gcr.io/cockroach-dev-inf/cockroachlabs/roachprod:c3e379f7f51
               args:
                 - gc
                 - --gce-project=cockroach-ephemeral,cockroach-roachstress


### PR DESCRIPTION
This patch bumps the roachprod GC job to include #151319.

Epic: none
Release note: None