### PR TITLE
opt: eliminate barrier expressions at the root

### DIFF
--- a/pkg/sql/opt/norm/testdata/rules/barrier
+++ b/pkg/sql/opt/norm/testdata/rules/barrier
@@ -6,9 +6,9 @@ CREATE TABLE xy (x INT PRIMARY KEY, y INT);
 # EliminateRedundantBarrier
 # --------------------------------------------------
 
-# TODO(sql-queries): for simplicity, we should eliminate the barrier expression
-# at the root in this case. It serves no purpose because the filters were able
-# to permeate it.
+# NOTE: Barriers at the root are eliminated by optbuilder, not a normalization
+# rule. exprnorm bypasses optbuilder, so the root barrier remains in the output
+# of this test case.
 exprnorm expect=EliminateRedundantBarrier
 (Barrier
   (Barrier

--- a/pkg/sql/opt/norm/testdata/rules/join
+++ b/pkg/sql/opt/norm/testdata/rules/join
@@ -4623,26 +4623,98 @@ project
 norm expect=PushLeakproofJoinIntoPermeableBarrierRight
 SELECT * FROM rls t1 INNER JOIN rls t2 ON t1.y = 20 AND t1.x = t2.x;
 ----
-barrier
+inner-join (hash)
  ├── columns: x:1!null y:2!null alice_has_access:3!null x:6!null y:7 alice_has_access:8!null
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  ├── key: (6)
  ├── fd: ()-->(2,3,7,8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+ ├── select
+ │    ├── columns: x:1!null y:2!null alice_has_access:3!null
+ │    ├── key: (1)
+ │    ├── fd: ()-->(2,3)
+ │    ├── scan rls
+ │    │    ├── columns: x:1!null y:2 alice_has_access:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ │         └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
+ ├── select
+ │    ├── columns: x:6!null y:7 alice_has_access:8!null
+ │    ├── key: (6)
+ │    ├── fd: ()-->(8), (6)-->(7)
+ │    ├── scan rls
+ │    │    ├── columns: x:6!null y:7 alice_has_access:8
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7,8)
+ │    └── filters
+ │         └── alice_has_access:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+ └── filters
+      └── x:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+norm expect=PushLeakproofJoinIntoPermeableBarrierLeft
+SELECT * FROM rls t1 INNER JOIN rls t2 ON t2.y = 20 AND t1.x = t2.x;
+----
+inner-join (hash)
+ ├── columns: x:1!null y:2 alice_has_access:3!null x:6!null y:7!null alice_has_access:8!null
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ ├── key: (6)
+ ├── fd: ()-->(2,3,7,8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+ ├── select
+ │    ├── columns: x:1!null y:2 alice_has_access:3!null
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
+ │    ├── scan rls
+ │    │    ├── columns: x:1!null y:2 alice_has_access:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ ├── select
+ │    ├── columns: x:6!null y:7!null alice_has_access:8!null
+ │    ├── key: (6)
+ │    ├── fd: ()-->(7,8)
+ │    ├── scan rls
+ │    │    ├── columns: x:6!null y:7 alice_has_access:8
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7,8)
+ │    └── filters
+ │         ├── alice_has_access:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
+ │         └── y:7 = 20 [outer=(7), constraints=(/7: [/20 - /20]; tight), fd=()-->(7)]
+ └── filters
+      └── x:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+
+
+# Test for PushLeakproofJoinIntoPermeableBarrierLeft using InnerJoinApply.
+norm expect=PushLeakproofJoinIntoPermeableBarrierLeft
+SELECT *
+FROM rls AS outer_rls
+JOIN LATERAL (
+    SELECT y
+    FROM rls AS inner_rls
+    WHERE inner_rls.x = outer_rls.x AND alice_has_access
+) AS filtered_rls
+ON outer_rls.y = filtered_rls.y;
+----
+project
+ ├── columns: x:1!null y:2!null alice_has_access:3!null y:7!null
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2,7), (2)==(7), (7)==(2)
  └── inner-join (hash)
-      ├── columns: x:1!null y:2!null alice_has_access:3!null x:6!null y:7 alice_has_access:8!null
+      ├── columns: x:1!null y:2!null alice_has_access:3!null x:6!null y:7!null alice_has_access:8!null
       ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
       ├── key: (6)
-      ├── fd: ()-->(2,3,7,8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
+      ├── fd: ()-->(3,8), (1)-->(2), (6)-->(7), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
       ├── select
-      │    ├── columns: x:1!null y:2!null alice_has_access:3!null
+      │    ├── columns: x:1!null y:2 alice_has_access:3!null
       │    ├── key: (1)
-      │    ├── fd: ()-->(2,3)
+      │    ├── fd: ()-->(3), (1)-->(2)
       │    ├── scan rls
       │    │    ├── columns: x:1!null y:2 alice_has_access:3
       │    │    ├── key: (1)
       │    │    └── fd: (1)-->(2,3)
       │    └── filters
-      │         ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      │         └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
+      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
       ├── select
       │    ├── columns: x:6!null y:7 alice_has_access:8!null
       │    ├── key: (6)
@@ -4654,94 +4726,10 @@ barrier
       │    └── filters
       │         └── alice_has_access:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
       └── filters
-           └── x:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           ├── x:6 = x:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+           └── y:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
-norm expect=PushLeakproofJoinIntoPermeableBarrierLeft
-SELECT * FROM rls t1 INNER JOIN rls t2 ON t2.y = 20 AND t1.x = t2.x;
-----
-barrier
- ├── columns: x:1!null y:2 alice_has_access:3!null x:6!null y:7!null alice_has_access:8!null
- ├── key: (6)
- ├── fd: ()-->(2,3,7,8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
- └── inner-join (hash)
-      ├── columns: x:1!null y:2 alice_has_access:3!null x:6!null y:7!null alice_has_access:8!null
-      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
-      ├── key: (6)
-      ├── fd: ()-->(2,3,7,8), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
-      ├── select
-      │    ├── columns: x:1!null y:2 alice_has_access:3!null
-      │    ├── key: (1)
-      │    ├── fd: ()-->(3), (1)-->(2)
-      │    ├── scan rls
-      │    │    ├── columns: x:1!null y:2 alice_has_access:3
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2,3)
-      │    └── filters
-      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      ├── select
-      │    ├── columns: x:6!null y:7!null alice_has_access:8!null
-      │    ├── key: (6)
-      │    ├── fd: ()-->(7,8)
-      │    ├── scan rls
-      │    │    ├── columns: x:6!null y:7 alice_has_access:8
-      │    │    ├── key: (6)
-      │    │    └── fd: (6)-->(7,8)
-      │    └── filters
-      │         ├── alice_has_access:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
-      │         └── y:7 = 20 [outer=(7), constraints=(/7: [/20 - /20]; tight), fd=()-->(7)]
-      └── filters
-           └── x:1 = x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-
-
-# Test for PushLeakproofJoinIntoPermeableBarrierLeft using InnerJoinApply
-norm expect=PushLeakproofJoinIntoPermeableBarrierLeft
-SELECT *
-FROM rls AS outer_rls
-JOIN LATERAL (
-    SELECT y
-    FROM rls AS inner_rls
-    WHERE inner_rls.x = outer_rls.x AND alice_has_access
-) AS filtered_rls
-ON outer_rls.y = filtered_rls.y;
-----
-barrier
- ├── columns: x:1!null y:2!null alice_has_access:3!null y:7!null
- ├── key: (1)
- ├── fd: ()-->(3), (1)-->(2,7), (2)==(7), (7)==(2)
- └── project
-      ├── columns: x:1!null y:2!null alice_has_access:3!null y:7!null
-      ├── key: (1)
-      ├── fd: ()-->(3), (1)-->(2,7), (2)==(7), (7)==(2)
-      └── inner-join (hash)
-           ├── columns: x:1!null y:2!null alice_has_access:3!null x:6!null y:7!null alice_has_access:8!null
-           ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
-           ├── key: (6)
-           ├── fd: ()-->(3,8), (1)-->(2), (6)-->(7), (1)==(6), (6)==(1), (2)==(7), (7)==(2), (3)==(8), (8)==(3)
-           ├── select
-           │    ├── columns: x:1!null y:2 alice_has_access:3!null
-           │    ├── key: (1)
-           │    ├── fd: ()-->(3), (1)-->(2)
-           │    ├── scan rls
-           │    │    ├── columns: x:1!null y:2 alice_has_access:3
-           │    │    ├── key: (1)
-           │    │    └── fd: (1)-->(2,3)
-           │    └── filters
-           │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-           ├── select
-           │    ├── columns: x:6!null y:7 alice_has_access:8!null
-           │    ├── key: (6)
-           │    ├── fd: ()-->(8), (6)-->(7)
-           │    ├── scan rls
-           │    │    ├── columns: x:6!null y:7 alice_has_access:8
-           │    │    ├── key: (6)
-           │    │    └── fd: (6)-->(7,8)
-           │    └── filters
-           │         └── alice_has_access:8 [outer=(8), constraints=(/8: [/true - /true]; tight), fd=()-->(8)]
-           └── filters
-                ├── x:6 = x:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-                └── y:2 = y:7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
-
-# Try a semi-join to ensure barrier bubbles up above the join
+# Try a semi-join to ensure barrier bubbles up above the join.
 norm expect=PushLeakproofFiltersIntoPermeableBarrier
 SELECT *
 FROM rls
@@ -4750,34 +4738,29 @@ WHERE EXISTS (
     WHERE v.x = rls.x AND v.y = rls.y
 );
 ----
-barrier
+semi-join (hash)
  ├── columns: x:1!null y:2 alice_has_access:3!null
  ├── cardinality: [0 - 2]
  ├── key: (1)
  ├── fd: ()-->(3), (1)-->(2)
- └── semi-join (hash)
-      ├── columns: x:1!null y:2 alice_has_access:3!null
-      ├── cardinality: [0 - 2]
-      ├── key: (1)
-      ├── fd: ()-->(3), (1)-->(2)
-      ├── select
-      │    ├── columns: x:1!null y:2 alice_has_access:3!null
-      │    ├── key: (1)
-      │    ├── fd: ()-->(3), (1)-->(2)
-      │    ├── scan rls
-      │    │    ├── columns: x:1!null y:2 alice_has_access:3
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2,3)
-      │    └── filters
-      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      ├── values
-      │    ├── columns: column1:6!null column2:7!null
-      │    ├── cardinality: [2 - 2]
-      │    ├── (1, 2)
-      │    └── (3, 4)
-      └── filters
-           ├── column1:6 = x:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
-           └── column2:7 = y:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
+ ├── select
+ │    ├── columns: x:1!null y:2 alice_has_access:3!null
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
+ │    ├── scan rls
+ │    │    ├── columns: x:1!null y:2 alice_has_access:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ ├── values
+ │    ├── columns: column1:6!null column2:7!null
+ │    ├── cardinality: [2 - 2]
+ │    ├── (1, 2)
+ │    └── (3, 4)
+ └── filters
+      ├── column1:6 = x:1 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+      └── column2:7 = y:2 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ]), fd=(2)==(7), (7)==(2)]
 
 # Use of leakproof and non-leakproof functions on either side of joins.
 #
@@ -4785,37 +4768,33 @@ barrier
 norm disable=InlineUDF expect=PushLeakproofJoinIntoPermeableBarrierLeft
 SELECT * FROM rls, b WHERE rls.x = b.x AND leakproof_fn(b.y);
 ----
-barrier
+inner-join (hash)
  ├── columns: x:1!null y:2 alice_has_access:3!null x:6!null y:7
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  ├── key: (6)
  ├── fd: ()-->(3), (1)-->(2), (6)-->(7), (1)==(6), (6)==(1)
- └── inner-join (hash)
-      ├── columns: rls.x:1!null rls.y:2 alice_has_access:3!null b.x:6!null b.y:7
-      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
-      ├── key: (6)
-      ├── fd: ()-->(3), (1)-->(2), (6)-->(7), (1)==(6), (6)==(1)
-      ├── select
-      │    ├── columns: rls.x:1!null rls.y:2 alice_has_access:3!null
-      │    ├── key: (1)
-      │    ├── fd: ()-->(3), (1)-->(2)
-      │    ├── scan rls
-      │    │    ├── columns: rls.x:1!null rls.y:2 alice_has_access:3
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2,3)
-      │    └── filters
-      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      ├── select
-      │    ├── columns: b.x:6!null b.y:7
-      │    ├── key: (6)
-      │    ├── fd: (6)-->(7)
-      │    ├── scan b
-      │    │    ├── columns: b.x:6!null b.y:7
-      │    │    ├── key: (6)
-      │    │    └── fd: (6)-->(7)
-      │    └── filters
-      │         └── leakproof_fn(b.y:7) [outer=(7), udf]
-      └── filters
-           └── rls.x:1 = b.x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ ├── select
+ │    ├── columns: rls.x:1!null rls.y:2 alice_has_access:3!null
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
+ │    ├── scan rls
+ │    │    ├── columns: rls.x:1!null rls.y:2 alice_has_access:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ ├── select
+ │    ├── columns: b.x:6!null b.y:7
+ │    ├── key: (6)
+ │    ├── fd: (6)-->(7)
+ │    ├── scan b
+ │    │    ├── columns: b.x:6!null b.y:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── leakproof_fn(b.y:7) [outer=(7), udf]
+ └── filters
+      └── rls.x:1 = b.x:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
 
 # 2. Right side uses non-leakproof function. Everything else with the query is the same as 1.
 norm disable=InlineUDF expect=PushLeakproofJoinIntoPermeableBarrierLeft
@@ -4863,37 +4842,33 @@ project
 norm disable=InlineUDF expect=PushLeakproofJoinIntoPermeableBarrierRight
 SELECT * FROM b, rls WHERE b.x = rls.x AND leakproof_fn(b.y);
 ----
-barrier
+inner-join (hash)
  ├── columns: x:1!null y:2 x:5!null y:6 alice_has_access:7!null
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
  ├── key: (5)
  ├── fd: ()-->(7), (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
- └── inner-join (hash)
-      ├── columns: b.x:1!null b.y:2 rls.x:5!null rls.y:6 alice_has_access:7!null
-      ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
-      ├── key: (5)
-      ├── fd: ()-->(7), (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
-      ├── select
-      │    ├── columns: b.x:1!null b.y:2
-      │    ├── key: (1)
-      │    ├── fd: (1)-->(2)
-      │    ├── scan b
-      │    │    ├── columns: b.x:1!null b.y:2
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2)
-      │    └── filters
-      │         └── leakproof_fn(b.y:2) [outer=(2), udf]
-      ├── select
-      │    ├── columns: rls.x:5!null rls.y:6 alice_has_access:7!null
-      │    ├── key: (5)
-      │    ├── fd: ()-->(7), (5)-->(6)
-      │    ├── scan rls
-      │    │    ├── columns: rls.x:5!null rls.y:6 alice_has_access:7
-      │    │    ├── key: (5)
-      │    │    └── fd: (5)-->(6,7)
-      │    └── filters
-      │         └── alice_has_access:7 [outer=(7), constraints=(/7: [/true - /true]; tight), fd=()-->(7)]
-      └── filters
-           └── b.x:1 = rls.x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ ├── select
+ │    ├── columns: b.x:1!null b.y:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan b
+ │    │    ├── columns: b.x:1!null b.y:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── filters
+ │         └── leakproof_fn(b.y:2) [outer=(2), udf]
+ ├── select
+ │    ├── columns: rls.x:5!null rls.y:6 alice_has_access:7!null
+ │    ├── key: (5)
+ │    ├── fd: ()-->(7), (5)-->(6)
+ │    ├── scan rls
+ │    │    ├── columns: rls.x:5!null rls.y:6 alice_has_access:7
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6,7)
+ │    └── filters
+ │         └── alice_has_access:7 [outer=(7), constraints=(/7: [/true - /true]; tight), fd=()-->(7)]
+ └── filters
+      └── b.x:1 = rls.x:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # 4. Left side uses non-leakproof function. Otherwise the query is the same as 3.
 norm disable=InlineUDF expect=PushLeakproofJoinIntoPermeableBarrierRight

--- a/pkg/sql/opt/norm/testdata/rules/project
+++ b/pkg/sql/opt/norm/testdata/rules/project
@@ -2055,19 +2055,17 @@ SET ROLE alice;
 norm expect=PushLeakproofProjectionsIntoPermeableBarrier
 SELECT CASE WHEN y = 20 THEN 10 ELSE 0 END FROM rls
 ----
-barrier
+project
  ├── columns: case:6
- └── project
-      ├── columns: case:6
-      ├── select
-      │    ├── columns: y:2 alice_has_access:3!null
-      │    ├── fd: ()-->(3)
-      │    ├── scan rls
-      │    │    └── columns: y:2 alice_has_access:3
-      │    └── filters
-      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      └── projections
-           └── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]
+ ├── select
+ │    ├── columns: y:2 alice_has_access:3!null
+ │    ├── fd: ()-->(3)
+ │    ├── scan rls
+ │    │    └── columns: y:2 alice_has_access:3
+ │    └── filters
+ │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ └── projections
+      └── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]
 
 # Only some expressions in projection are leakproof
 norm expect-not=PushLeakproofProjectionsIntoPermeableBarrier
@@ -2122,23 +2120,19 @@ project
 norm expect=PushLeakproofProjectionsIntoPermeableBarrier
 SELECT x, y, CASE WHEN y = 20 THEN 10 ELSE 0 END FROM rls
 ----
-barrier
+project
  ├── columns: x:1!null y:2 case:6
  ├── key: (1)
  ├── fd: (1)-->(2), (2)-->(6)
- └── project
-      ├── columns: case:6 x:1!null y:2
-      ├── key: (1)
-      ├── fd: (1)-->(2), (2)-->(6)
-      ├── select
-      │    ├── columns: x:1!null y:2 alice_has_access:3!null
-      │    ├── key: (1)
-      │    ├── fd: ()-->(3), (1)-->(2)
-      │    ├── scan rls
-      │    │    ├── columns: x:1!null y:2 alice_has_access:3
-      │    │    ├── key: (1)
-      │    │    └── fd: (1)-->(2,3)
-      │    └── filters
-      │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-      └── projections
-           └── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]
+ ├── select
+ │    ├── columns: x:1!null y:2 alice_has_access:3!null
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
+ │    ├── scan rls
+ │    │    ├── columns: x:1!null y:2 alice_has_access:3
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── filters
+ │         └── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+ └── projections
+      └── CASE WHEN y:2 = 20 THEN 10 ELSE 0 END [as=case:6, outer=(2)]

--- a/pkg/sql/opt/norm/testdata/rules/select
+++ b/pkg/sql/opt/norm/testdata/rules/select
@@ -2689,21 +2689,17 @@ project
 norm expect=PushLeakproofFiltersIntoPermeableBarrier
 SELECT * FROM rls WHERE y = 20;
 ----
-barrier
+select
  ├── columns: x:1!null y:2!null alice_has_access:3!null
  ├── key: (1)
  ├── fd: ()-->(2,3)
- └── select
-      ├── columns: x:1!null y:2!null alice_has_access:3!null
-      ├── key: (1)
-      ├── fd: ()-->(2,3)
-      ├── scan rls
-      │    ├── columns: x:1!null y:2 alice_has_access:3
-      │    ├── key: (1)
-      │    └── fd: (1)-->(2,3)
-      └── filters
-           ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
-           └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
+ ├── scan rls
+ │    ├── columns: x:1!null y:2 alice_has_access:3
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      ├── alice_has_access:3 [outer=(3), constraints=(/3: [/true - /true]; tight), fd=()-->(3)]
+      └── y:2 = 20 [outer=(2), constraints=(/2: [/20 - /20]; tight), fd=()-->(2)]
 
 # --------------------------------------------------
 # NormalizeLikeAny

--- a/pkg/sql/opt/optbuilder/testdata/row_level_security
+++ b/pkg/sql/opt/optbuilder/testdata/row_level_security
@@ -2110,15 +2110,13 @@ CREATE POLICY p1 ON ob USING (user_has_access);
 norm
 SELECT * FROM ob WHERE y = 20;
 ----
-barrier
+select
  ├── columns: x:1!null y:2!null user_has_access:3!null
- └── select
-      ├── columns: x:1!null y:2!null user_has_access:3!null
-      ├── scan ob
-      │    └── columns: x:1!null y:2 user_has_access:3
-      └── filters
-           ├── user_has_access:3
-           └── y:2 = 20
+ ├── scan ob
+ │    └── columns: x:1!null y:2 user_has_access:3
+ └── filters
+      ├── user_has_access:3
+      └── y:2 = 20
 
 # Barrier needed. Try to expose with a division by zero error.
 norm

--- a/pkg/sql/opt/xform/testdata/placeholder-fast-path/rls
+++ b/pkg/sql/opt/xform/testdata/placeholder-fast-path/rls
@@ -1,0 +1,96 @@
+exec-ddl
+CREATE TABLE t (
+  a INT PRIMARY KEY,
+  b INT,
+  c INT,
+  d INT,
+  INDEX (b),
+  INDEX (d, c)
+)
+----
+
+# The fast path is conditional on having a small estimated row count. Inject
+# statistics so that we don't have to worry about this aspect in tests.
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["a"],
+    "created_at": "2018-05-01 1:00:00.00000+00:00",
+    "row_count": 10,
+    "distinct_count": 10
+  }
+]'
+----
+
+exec-ddl
+CREATE ROLE alice
+----
+
+exec-ddl
+CREATE ROLE bob
+----
+
+exec-ddl
+CREATE POLICY select_policy_alice
+ON t
+FOR SELECT
+TO alice
+USING (true)
+----
+
+exec-ddl
+CREATE POLICY select_policy_bob
+ON t
+FOR SELECT
+TO bob
+USING (d = 0)
+----
+
+exec-ddl
+ALTER TABLE t ENABLE ROW LEVEL SECURITY
+----
+
+exec-ddl
+SET ROLE alice
+----
+
+placeholder-fast-path
+SELECT a FROM t WHERE b = $1
+----
+placeholder-scan t@t_b_idx
+ ├── columns: a:1!null
+ ├── has-placeholder
+ ├── stats: [rows=9.9]
+ ├── key: (1)
+ └── span
+      └── $1
+
+# The index on (d, c) cannot be used because d is not constrained by the query
+# nor the policy.
+placeholder-fast-path
+SELECT a FROM t WHERE c = $1
+----
+no fast path
+
+exec-ddl
+SET ROLE bob
+----
+
+# The fast path cannot be used because there is an additional filter on d that
+# is not pushed into an index constraint.
+placeholder-fast-path
+SELECT a FROM t WHERE b = $1
+----
+no fast path
+
+placeholder-fast-path
+SELECT a FROM t WHERE c = $1
+----
+placeholder-scan t@t_d_c_idx
+ ├── columns: a:1!null
+ ├── has-placeholder
+ ├── stats: [rows=9.801]
+ ├── key: (1)
+ └── span
+      ├── 0
+      └── $1


### PR DESCRIPTION
`BarrierExpr`s are now eliminated at the root of the expression tree.
These barriers are typically pulled up the expression tree by
normalization rules. At the root, they are useless, as their purpose is
an optimization barrier which prevents filters from being pushed into
their input. These barriers also prevented the placeholder-fast path
from applying, incurring extra overhead for queries on RLS tables.

Barrier elimination occurs in `optbuilder` when building the canonical
plan. It cannot be codified as a normalization rule because the
`Construct...` functions have no concept of a root expression when they
are invoked. The tree is built bottom-up so the root expression is only
known by callers, when all other expressions have been built. Barrier
expressions are never added nor pulled up the tree during exploration,
so removing a barrier at the root in the canonical plan should be
sufficient in eliminating a barriers at the root in all optimized plans.

Fixes #149694

Release note (performance improvement): Some types of simple queries
that query a table with RLS enabled are now more efficiently executed.
