### PR TITLE
changefeedccl: add envelope type to encoder benchmarks

### DIFF
--- a/pkg/ccl/changefeedccl/encoder_test.go
+++ b/pkg/ccl/changefeedccl/encoder_test.go
@@ -1029,12 +1029,15 @@ func BenchmarkEncoders(b *testing.B) {
 				b.Logf("column types: %v, keys: %v", colTypes, colTypes[:numKeyCols])
 
 				if tc.benchEncodeKey {
-					b.Run(fmt.Sprintf("encodeKey/%dcols", numKeyCols),
-						func(b *testing.B) {
-							opts := changefeedbase.EncodingOptions{Format: tc.format}
-							bench(b, encodeKey, opts, updatedRows, prevRows)
-						},
-					)
+					testutils.RunValues(b, "envelope", tc.envelopes,
+						func(t *testing.B, envelope changefeedbase.EnvelopeType) {
+							b.Run(fmt.Sprintf("encodeKey/%dcols/envelope=%s", numKeyCols, envelope),
+								func(b *testing.B) {
+									opts := changefeedbase.EncodingOptions{Format: tc.format, Envelope: envelope}
+									bench(b, encodeKey, opts, updatedRows, prevRows)
+								},
+							)
+						})
 				}
 
 				for _, envelope := range tc.envelopes {


### PR DESCRIPTION
Previously some tests in BenchmarkEncoders did not pass through an envelope type, which caused the json encoder to fail. This PR adds an envelope type based on the test case. It also adds the envelope type to the benchmark name, which should be fine since this benchmark has not worked in awhile.

Epic: none
Fixes: #151301

Release note: none