### PR TITLE
release-25.3: roachtest: bump min version for db-console/mixed-version-endpoints roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/db_console_endpoints.go
+++ b/pkg/cmd/roachtest/tests/db_console_endpoints.go
@@ -110,10 +110,8 @@ func registerDBConsoleEndpointsMixedVersion(r registry.Registry) {
 func runDBConsoleMixedVersion(ctx context.Context, t test.Test, c cluster.Cluster) {
 	mvt := mixedversion.NewTest(ctx, t, t.L(), c,
 		c.CRDBNodes(),
-		// We test only upgrades from 23.2 in this test because it uses
-		// the `workload init` command, which is only supported
-		// reliably multi-tenant mode starting from that version.
-		mixedversion.MinimumSupportedVersion("v23.2.0"),
+		// In 24.3 new endpoints were added to /api/v2 server.
+		mixedversion.MinimumSupportedVersion("v24.3.0"),
 	)
 
 	mvt.InMixedVersion("test db console endpoints", func(ctx context.Context, l *logger.Logger, rng *rand.Rand, h *mixedversion.Helper) error {


### PR DESCRIPTION
Backport 1/1 commits from #151163.

/cc @cockroachdb/release

---

Previously the mixed version roachtest would fail whenever test plans included versions of crdb < 24.3. This was because a handful of /api/v2 endpoints were added in 24.3 (and not backported), and so they would return 404s in the test on versions prior.

This commit bumps the min version to 24.3.0.

Fixes: #150601, #148875, #149866
Release note: None


Release justification: test-only change