### PR TITLE
release-24.3: changefeedccl: protobuf encoder randomized test for all types

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -330,6 +330,7 @@ go_test(
         "//pkg/util/intsets",
         "//pkg/util/ioctx",
         "//pkg/util/json",
+        "//pkg/util/keysutil",
         "//pkg/util/leaktest",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",

--- a/pkg/ccl/changefeedccl/helpers_test.go
+++ b/pkg/ccl/changefeedccl/helpers_test.go
@@ -1407,6 +1407,9 @@ func ChangefeedJobPermissionsTestSetup(t *testing.T, s TestServer) {
 		`GRANT CHANGEFEED ON table_a TO userWithSomeGrants`,
 
 		`CREATE USER regularUser`,
+
+		`CREATE USER viewClusterMetadataUser`,
+		`GRANT SYSTEM VIEWCLUSTERMETADATA TO viewClusterMetadataUser`,
 	)
 }
 

--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -7370,6 +7370,13 @@ CREATE TABLE crdb_internal.active_range_feeds (
   last_err STRING
 );`,
 	populate: func(ctx context.Context, p *planner, _ catalog.DatabaseDescriptor, addRow func(...tree.Datum) error) error {
+		privileged, err := p.HasPrivilege(ctx, syntheticprivilege.GlobalPrivilegeObject, privilege.VIEWCLUSTERMETADATA, p.User())
+		if err != nil {
+			return err
+		}
+		if !privileged {
+			return nil
+		}
 		return p.execCfg.DistSender.ForEachActiveRangeFeed(
 			func(rfCtx kvcoord.RangeFeedContext, rf kvcoord.PartialRangeFeed) error {
 				var lastEvent tree.Datum
@@ -9517,7 +9524,7 @@ CREATE TABLE crdb_internal.logical_replication_node_processors (
 	state STRING,
 	recv_time INTERVAL,
 	last_recv_time INTERVAL,
-	ingest_time INTERVAL, 
+	ingest_time INTERVAL,
 	flush_time INTERVAL,
 	flush_count INT,
 	flush_kvs INT,


### PR DESCRIPTION
Backport 1/2 commits from #150004.

/cc @cockroachdb/release

Release justification: minimal fix and test improvement

---

We recently added support for Protobuf encoding in changefeeds.
This test ensures that all types supported in CockroachDB are correctly
encoded and decoded using Protobuf.

fixes [#149797](https://github.com/cockroachdb/cockroach/issues/149797)
