### PR TITLE
kvserver: remove `ApplyImpact` from `AllocationOp`

### DIFF
--- a/pkg/kv/kvserver/lease_queue.go
+++ b/pkg/kv/kvserver/lease_queue.go
@@ -140,12 +140,6 @@ func (lq *leaseQueue) process(
 			return false, errors.Wrapf(err, "%s: unable to transfer lease to s%d", repl, transferOp.Target)
 		}
 
-		// TODO(wenyihu6): Initially, change.Op.ApplyImpact was used here. This was
-		// a problem since AllocationTransferLeaseOp.ApplyImpact was left
-		// unimplemented. We should either implement
-		// AllocationTransferLeaseOp.ApplyImpact correctly or remove the use of
-		// ApplyImpact entirely. The replicate queue does not have this issue since
-		// it uses rq.TransferLease, which updates the local store pool directly.
 		lq.storePool.UpdateLocalStoresAfterLeaseTransfer(
 			transferOp.Source.StoreID, transferOp.Target.StoreID, transferOp.Usage)
 	}


### PR DESCRIPTION
Epic: CRDB-25222
Release note: none

---

**kvserver: update local store pool directly with AllocationChangeReplicasOp**

Previously, `change.Op.ApplyImpact` was used to update the replicateQueue's
local store pool state after a successful change replica call to reflect the
result of applying the operation. But in practice only
`AllocationChangeReplicasOp` used it - other ops update the store pool directly.
This commit updates `AllocationChangeReplicasOp` to also update the local store
pool directly after a successful `repl.changeReplicasImpl`.

In a follow-up, we'll remove `ApplyImpact` from the `AllocationOp` interface
entirely, since it adds an unnecessary layer of indirection without providing
much value.

---

**kvserver: remove `ApplyImpact` from `AllocationOp`**

This commit removes `ApplyImpact` from the `AllocationOp` interface entirely,
since it adds an unnecessary layer of indirection without providing much value.
