### PR TITLE
storage: add blocks loaded histogram for mvcc gets

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10736,6 +10736,14 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric reports the number of a node's LSM compactions. If the number of compactions remains elevated while the LSM health does not improve, compactions are not keeping up with the workload. If the condition persists for an extended period, the cluster will initially exhibit performance issues that will eventually escalate into stability issues.
       essential: true
+    - name: storage.mvcc.get.blocks_loaded
+      exported_name: storage_mvcc_get_blocks_loaded
+      description: Number of blocks loaded per MVCC get operation
+      y_axis_label: Block Loads
+      type: HISTOGRAM
+      unit: COUNT
+      aggregation: AVG
+      derivative: NONE
     - name: storage.wal.fsync.latency
       exported_name: storage_wal_fsync_latency
       description: The write ahead log fsync latency

--- a/pkg/kv/kvserver/spanset/batch.go
+++ b/pkg/kv/kvserver/spanset/batch.go
@@ -518,6 +518,11 @@ func (s spanSetReader) PinEngineStateForIterators(readCategory fs.ReadCategory) 
 	return s.r.PinEngineStateForIterators(readCategory)
 }
 
+// RecordMVCCGetBlocksLoaded implements the storage.Reader interface.
+func (s spanSetReader) RecordMVCCGetBlocksLoaded(blockLoads int64) {
+	s.r.RecordMVCCGetBlocksLoaded(blockLoads)
+}
+
 type spanSetWriter struct {
 	w     storage.Writer
 	spans *SpanSet
@@ -836,6 +841,11 @@ func (s spanSetBatch) PutInternalPointKey(key *pebble.InternalKey, value []byte)
 
 func (s spanSetBatch) ClearRawEncodedRange(start, end []byte) error {
 	return s.b.ClearRawEncodedRange(start, end)
+}
+
+// RecordMVCCGetBlocksLoaded implements the storage.Reader interface.
+func (s spanSetBatch) RecordMVCCGetBlocksLoaded(blockLoads int64) {
+	s.b.RecordMVCCGetBlocksLoaded(blockLoads)
 }
 
 // NewBatch returns a storage.Batch that asserts access of the underlying

--- a/pkg/kv/kvserver/store.go
+++ b/pkg/kv/kvserver/store.go
@@ -3805,6 +3805,10 @@ func (s *Store) ComputeMetricsPeriodically(
 			prevMetrics.WALFsyncLatency, m.LogWriter.FsyncLatency, s.metrics.FsyncLatency); err != nil {
 			return m, err
 		}
+		if err := updateWindowedHistogram(
+			prevMetrics.MVCCGetBlocksLoaded, m.MVCCGetBlockLoadsCumulative, s.metrics.MVCCGetBlocksLoadedHistogram); err != nil {
+			return m, err
+		}
 		if m.WAL.Failover.FailoverWriteAndSyncLatency != nil {
 			if err := updateWindowedHistogram(prevMetrics.WALFailoverWriteAndSyncLatency,
 				m.WAL.Failover.FailoverWriteAndSyncLatency, s.metrics.WALFailoverWriteAndSyncLatency); err != nil {

--- a/pkg/storage/BUILD.bazel
+++ b/pkg/storage/BUILD.bazel
@@ -83,6 +83,7 @@ go_library(
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
         "//pkg/util/metamorphic",
+        "//pkg/util/metric",
         "//pkg/util/mon",
         "//pkg/util/protoutil",
         "//pkg/util/syncutil",
@@ -111,6 +112,7 @@ go_library(
         "@com_github_dustin_go_humanize//:go-humanize",
         "@com_github_elastic_gosigar//:gosigar",
         "@com_github_gogo_protobuf//proto",
+        "@com_github_prometheus_client_golang//prometheus",
         "@com_github_prometheus_client_model//go",
     ],
 )

--- a/pkg/storage/pebble_batch.go
+++ b/pkg/storage/pebble_batch.go
@@ -451,6 +451,13 @@ func (wb *writeBatch) ShouldWriteLocalTimestamps(ctx context.Context) bool {
 	return wb.shouldWriteLocalTimestamps
 }
 
+// RecordMVCCGetBlocksLoaded implements the Reader interface.
+func (wb *writeBatch) RecordMVCCGetBlocksLoaded(blockLoads int64) {
+	if wb.parent != nil {
+		wb.parent.RecordMVCCGetBlocksLoaded(blockLoads)
+	}
+}
+
 // Close implements the WriteBatch interface.
 func (wb *writeBatch) Close() {
 	wb.close()
@@ -722,6 +729,13 @@ func (p *pebbleBatch) PinEngineStateForIterators(readCategory fs.ReadCategory) e
 		// just created it, so cloning it would just be overhead.
 	}
 	return nil
+}
+
+// RecordMVCCGetBlocksLoaded implements the Reader interface.
+func (p *pebbleBatch) RecordMVCCGetBlocksLoaded(blockLoads int64) {
+	if p.parent != nil {
+		p.parent.RecordMVCCGetBlocksLoaded(blockLoads)
+	}
 }
 
 // ClearMVCCIteratorRange implements the Batch interface.


### PR DESCRIPTION
Add a histogram metric for the number of blocks loaded for an mvcc get
operation.

Closes: cockroachdb/pebble#5015