### PR TITLE
types: add a .Canonical method to types

### DIFF
--- a/pkg/sql/randgen/types_test.go
+++ b/pkg/sql/randgen/types_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/randutil"
 	"github.com/cockroachdb/errors"
 )
 
@@ -48,5 +49,29 @@ loop:
 			s += fmt.Sprintf("%s (%d) ", types.Family_name[int32(f)], f)
 		}
 		t.Fatal(errors.Errorf("%s", s))
+	}
+}
+
+func TestCanonical(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	rng, _ := randutil.NewTestRand()
+	for range 1000 {
+		typ := RandType(rng)
+
+		if !typ.Canonical().Equivalent(typ.WithoutTypeModifiers()) {
+			t.Errorf("fail: canonical type of %+v should be equivalent to the type without modifiers", typ)
+		}
+
+		datum := RandDatum(rng, typ, false)
+		datumTyp := datum.ResolvedType()
+		if !datumTyp.Equivalent(typ.Canonical()) {
+			t.Errorf("fail: canonical type of %+v is %+v and the datum's type is %+v", typ, typ.Canonical(), datumTyp)
+		}
+
+		if datumTyp.Oid() != typ.Canonical().Oid() {
+			t.Errorf("fail type %+v: canonical type oid %d does not match the datum's (%+v) oid %+v",
+				typ, typ.Canonical().Oid(), datum, datumTyp.Oid())
+		}
 	}
 }

--- a/pkg/sql/types/BUILD.bazel
+++ b/pkg/sql/types/BUILD.bazel
@@ -38,6 +38,7 @@ go_test(
     name = "types_test",
     size = "small",
     srcs = [
+        "canonical_test.go",
         "types_test.go",
         "types_text_marshal_test.go",
     ],

--- a/pkg/sql/types/canonical_test.go
+++ b/pkg/sql/types/canonical_test.go
@@ -1,0 +1,486 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package types
+
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/geo/geopb"
+	"github.com/lib/pq/oid"
+)
+
+func TestCanonical(t *testing.T) {
+	testCases := []struct {
+		name      string
+		inputType *T
+		expected  *T
+	}{
+		// BoolFamily
+		{
+			name:      "Bool",
+			inputType: Bool,
+			expected:  Bool,
+		},
+
+		// IntFamily - all int types should map to canonical Int
+		{
+			name:      "Int (canonical)",
+			inputType: Int,
+			expected:  Int,
+		},
+		{
+			name:      "Int4",
+			inputType: Int4,
+			expected:  Int,
+		},
+		{
+			name:      "Int2",
+			inputType: Int2,
+			expected:  Int,
+		},
+
+		// FloatFamily - all float types should map to canonical Float
+		{
+			name:      "Float (canonical)",
+			inputType: Float,
+			expected:  Float,
+		},
+		{
+			name:      "Float4",
+			inputType: Float4,
+			expected:  Float,
+		},
+
+		// DecimalFamily
+		{
+			name:      "Decimal (canonical)",
+			inputType: Decimal,
+			expected:  Decimal,
+		},
+		{
+			name:      "Decimal with precision",
+			inputType: MakeDecimal(10, 3),
+			expected:  Decimal,
+		},
+
+		// DateFamily
+		{
+			name:      "Date",
+			inputType: Date,
+			expected:  Date,
+		},
+
+		// TimestampFamily
+		{
+			name:      "Timestamp (canonical)",
+			inputType: Timestamp,
+			expected:  Timestamp,
+		},
+		{
+			name:      "Timestamp with precision",
+			inputType: MakeTimestamp(3),
+			expected:  Timestamp,
+		},
+
+		// IntervalFamily
+		{
+			name:      "Interval (canonical)",
+			inputType: Interval,
+			expected:  Interval,
+		},
+		{
+			name:      "Interval with precision",
+			inputType: MakeInterval(IntervalTypeMetadata{Precision: 3, PrecisionIsSet: true}),
+			expected:  Interval,
+		},
+
+		// StringFamily and CollatedStringFamily - both map to canonical String
+		{
+			name:      "String (canonical)",
+			inputType: String,
+			expected:  String,
+		},
+		{
+			name:      "VarChar",
+			inputType: VarChar,
+			expected:  String,
+		},
+		{
+			name:      "String with width",
+			inputType: MakeString(20),
+			expected:  String,
+		},
+		{
+			name:      "VarChar with width",
+			inputType: MakeVarChar(20),
+			expected:  String,
+		},
+		{
+			name:      "BPChar",
+			inputType: BPChar,
+			expected:  String,
+		},
+		{
+			name:      "Char with width",
+			inputType: MakeChar(20),
+			expected:  String,
+		},
+		{
+			name:      "QChar",
+			inputType: QChar,
+			expected:  String,
+		},
+		{
+			name:      "Name",
+			inputType: Name,
+			expected:  Name,
+		},
+		{
+			name:      "CollatedString",
+			inputType: MakeCollatedString(String, "en"),
+			expected:  MakeCollatedString(String, "en"),
+		},
+		{
+			name:      "CollatedString VarChar",
+			inputType: MakeCollatedString(VarChar, "de"),
+			expected:  MakeCollatedString(String, "de"),
+		},
+		{
+			name:      "CIText",
+			inputType: CIText,
+			expected:  CIText,
+		},
+
+		// BytesFamily
+		{
+			name:      "Bytes",
+			inputType: Bytes,
+			expected:  Bytes,
+		},
+
+		// TimestampTZFamily
+		{
+			name:      "TimestampTZ (canonical)",
+			inputType: TimestampTZ,
+			expected:  TimestampTZ,
+		},
+		{
+			name:      "TimestampTZ with precision",
+			inputType: MakeTimestampTZ(3),
+			expected:  TimestampTZ,
+		},
+
+		// OidFamily - each type in this family is its own canonical type
+		{
+			name:      "Oid",
+			inputType: Oid,
+			expected:  Oid,
+		},
+		{
+			name:      "RegClass",
+			inputType: RegClass,
+			expected:  RegClass,
+		},
+		{
+			name:      "RegNamespace",
+			inputType: RegNamespace,
+			expected:  RegNamespace,
+		},
+		{
+			name:      "RegProc",
+			inputType: RegProc,
+			expected:  RegProc,
+		},
+		{
+			name:      "RegProcedure",
+			inputType: RegProcedure,
+			expected:  RegProcedure,
+		},
+		{
+			name:      "RegRole",
+			inputType: RegRole,
+			expected:  RegRole,
+		},
+		{
+			name:      "RegType",
+			inputType: RegType,
+			expected:  RegType,
+		},
+
+		// UnknownFamily
+		{
+			name:      "Unknown",
+			inputType: Unknown,
+			expected:  Unknown,
+		},
+
+		// UuidFamily
+		{
+			name:      "Uuid",
+			inputType: Uuid,
+			expected:  Uuid,
+		},
+
+		// INetFamily
+		{
+			name:      "INet",
+			inputType: INet,
+			expected:  INet,
+		},
+
+		// TimeFamily
+		{
+			name:      "Time (canonical)",
+			inputType: Time,
+			expected:  Time,
+		},
+		{
+			name:      "Time with precision",
+			inputType: MakeTime(3),
+			expected:  Time,
+		},
+
+		// JsonFamily - note that Json and Jsonb both map to Jsonb
+		{
+			name:      "Jsonb (canonical)",
+			inputType: Jsonb,
+			expected:  Jsonb,
+		},
+		{
+			name:      "Json",
+			inputType: Json,
+			expected:  Jsonb,
+		},
+
+		// TimeTZFamily
+		{
+			name:      "TimeTZ (canonical)",
+			inputType: TimeTZ,
+			expected:  TimeTZ,
+		},
+		{
+			name:      "TimeTZ with precision",
+			inputType: MakeTimeTZ(3),
+			expected:  TimeTZ,
+		},
+
+		// BitFamily
+		{
+			name:      "VarBit (canonical)",
+			inputType: VarBit,
+			expected:  VarBit,
+		},
+		{
+			name:      "Bit",
+			inputType: MakeBit(1),
+			expected:  VarBit,
+		},
+		{
+			name:      "VarBit with width",
+			inputType: MakeVarBit(20),
+			expected:  VarBit,
+		},
+
+		// GeometryFamily
+		{
+			name:      "Geometry (canonical)",
+			inputType: Geometry,
+			expected:  Geometry,
+		},
+		{
+			name:      "Geometry with shape and SRID",
+			inputType: MakeGeometry(geopb.ShapeType_Point, 4326),
+			expected:  Geometry,
+		},
+
+		// GeographyFamily
+		{
+			name:      "Geography (canonical)",
+			inputType: Geography,
+			expected:  Geography,
+		},
+		{
+			name:      "Geography with shape and SRID",
+			inputType: MakeGeography(geopb.ShapeType_Point, 4326),
+			expected:  Geography,
+		},
+
+		// Box2DFamily
+		{
+			name:      "Box2D",
+			inputType: Box2D,
+			expected:  Box2D,
+		},
+
+		// VoidFamily
+		{
+			name:      "Void",
+			inputType: Void,
+			expected:  Void,
+		},
+
+		// EncodedKeyFamily
+		{
+			name:      "EncodedKey",
+			inputType: EncodedKey,
+			expected:  EncodedKey,
+		},
+
+		// TSQueryFamily
+		{
+			name:      "TSQuery",
+			inputType: TSQuery,
+			expected:  TSQuery,
+		},
+
+		// TSVectorFamily
+		{
+			name:      "TSVector",
+			inputType: TSVector,
+			expected:  TSVector,
+		},
+
+		// PGLSNFamily
+		{
+			name:      "PGLSN",
+			inputType: PGLSN,
+			expected:  PGLSN,
+		},
+
+		// RefCursorFamily
+		{
+			name:      "RefCursor",
+			inputType: RefCursor,
+			expected:  RefCursor,
+		},
+
+		// PGVectorFamily
+		{
+			name:      "PGVector (canonical)",
+			inputType: PGVector,
+			expected:  PGVector,
+		},
+		{
+			name:      "PGVector with dimensions",
+			inputType: MakePGVector(128),
+			expected:  PGVector,
+		},
+
+		// TriggerFamily
+		{
+			name:      "Trigger",
+			inputType: Trigger,
+			expected:  Trigger,
+		},
+
+		// JsonpathFamily
+		{
+			name:      "Jsonpath",
+			inputType: Jsonpath,
+			expected:  Jsonpath,
+		},
+
+		// AnyFamily
+		{
+			name:      "Any",
+			inputType: Any,
+			expected:  Any,
+		},
+		{
+			name:      "AnyElement",
+			inputType: AnyElement,
+			expected:  Any,
+		},
+
+		// ArrayFamily - these types are canonical (return themselves)
+		{
+			name:      "IntArray",
+			inputType: IntArray,
+			expected:  IntArray,
+		},
+		{
+			name:      "StringArray",
+			inputType: StringArray,
+			expected:  StringArray,
+		},
+		{
+			name:      "Array of custom type",
+			inputType: MakeArray(MakeDecimal(10, 3)),
+			expected:  MakeArray(MakeDecimal(10, 3)),
+		},
+
+		// TupleFamily - these types are canonical (return themselves)
+		{
+			name:      "EmptyTuple",
+			inputType: EmptyTuple,
+			expected:  EmptyTuple,
+		},
+		{
+			name:      "Tuple with contents",
+			inputType: MakeTuple([]*T{Int, String}),
+			expected:  MakeTuple([]*T{Int, String}),
+		},
+		{
+			name:      "Labeled tuple",
+			inputType: MakeLabeledTuple([]*T{Int, String}, []string{"a", "b"}),
+			expected:  MakeLabeledTuple([]*T{Int, String}, []string{"a", "b"}),
+		},
+
+		// EnumFamily - these types are canonical (return themselves)
+		{
+			name:      "Enum",
+			inputType: MakeEnum(100, 101),
+			expected:  MakeEnum(100, 101),
+		},
+		{
+			name:      "AnyEnum",
+			inputType: AnyEnum,
+			expected:  AnyEnum,
+		},
+
+		// LTreeFamily
+		{
+			name:      "LTree",
+			inputType: LTree,
+			expected:  LTree,
+		},
+
+		// Composite Type
+		{
+			name:      "CompositeType",
+			inputType: NewCompositeType(1001, 1002, []*T{Int, String}, []string{"a", "b"}),
+			expected:  NewCompositeType(1001, 1002, []*T{Int, String}, []string{"a", "b"}),
+		},
+
+		// Unknown family type that should map to Unknown
+		{
+			name: "Unrecognized family defaults to Unknown",
+			inputType: &T{InternalType: InternalType{
+				Family: Family(9999), // Non-existent family
+				Oid:    oid.T_unknown,
+				Locale: &emptyLocale,
+			}},
+			expected: Unknown,
+		},
+	}
+
+	for _, tc := range testCases {
+		t.Run(tc.name, func(t *testing.T) {
+			canonical := tc.inputType.Canonical()
+
+			// Check that the canonical type is the expected one
+			if !canonical.Identical(tc.expected) {
+				t.Errorf("Canonical() = %v, expected %v", canonical.DebugString(), tc.expected.DebugString())
+			}
+
+			// Check that applying Canonical to the result is idempotent
+			canonicalTwice := canonical.Canonical()
+			if !canonical.Identical(canonicalTwice) {
+				t.Errorf("Canonical() is not idempotent: %v != %v", canonical.DebugString(), canonicalTwice.DebugString())
+			}
+		})
+	}
+}

--- a/pkg/sql/types/types.go
+++ b/pkg/sql/types/types.go
@@ -205,6 +205,104 @@ func (t *T) CopyForHydrate() *T {
 	return &newT
 }
 
+// Canonical returns the canonical type for this type. A type's canonical type
+// is the type of the datum used to represent instances of the type in the SQL
+// engine. Types with the same canonical type share an in-memory datum
+// representation. If you have a datum of a type T, then `datum.ResolvedType`
+// will be T.Canonical().
+//
+// There are a few special cases for Canonical:
+// 1. Arrays, Enums, UDT, and DOid datums have an attached type. For these
+// types the canonical type is the identity function.
+// 2. Collated strings share DCollatedString datum, but the type of the datum
+// depends on the collation order.
+// 3. There are a few unusual types that use DOIdWrapper. Which carries type
+// information with it.
+func (t *T) Canonical() *T {
+	switch t.Family() {
+	case BoolFamily:
+		return Bool
+	case IntFamily:
+		return Int
+	case FloatFamily:
+		return Float
+	case DecimalFamily:
+		return Decimal
+	case DateFamily:
+		return Date
+	case TimestampFamily:
+		return Timestamp
+	case IntervalFamily:
+		return Interval
+	case StringFamily:
+		if t.Oid() == oid.T_name {
+			// Name uses StringFamily and DOidWrapper
+			return Name
+		}
+		return String
+	case BytesFamily:
+		return Bytes
+	case TimestampTZFamily:
+		return TimestampTZ
+	case UnknownFamily:
+		return Unknown
+	case UuidFamily:
+		return Uuid
+	case INetFamily:
+		return INet
+	case TimeFamily:
+		return Time
+	case JsonFamily:
+		return Jsonb
+	case TimeTZFamily:
+		return TimeTZ
+	case BitFamily:
+		return VarBit
+	case GeometryFamily:
+		return Geometry
+	case GeographyFamily:
+		return Geography
+	case Box2DFamily:
+		return Box2D
+	case VoidFamily:
+		return Void
+	case EncodedKeyFamily:
+		return EncodedKey
+	case TSQueryFamily:
+		return TSQuery
+	case TSVectorFamily:
+		return TSVector
+	case PGLSNFamily:
+		return PGLSN
+	case RefCursorFamily:
+		// NOTE: RefCursorFamily is a little weird in that it has its own type
+		// family and it is implemeneted as a DOidWrapper around a DString.
+		return RefCursor
+	case PGVectorFamily:
+		return PGVector
+	case TriggerFamily:
+		return Trigger
+	case JsonpathFamily:
+		return Jsonpath
+	case LTreeFamily:
+		return LTree
+	case AnyFamily:
+		return Any
+	case CollatedStringFamily:
+		if t.Oid() == oidext.T_citext {
+			// CIText uses the CollatedStringFamily and the DOIdWrapper.
+			return t
+		}
+		return MakeCollatedString(String, *t.InternalType.Locale)
+	case ArrayFamily, TupleFamily, EnumFamily, OidFamily:
+		// Datums for these types have types attached to the datum instance, so
+		// every type in the family is canonical.
+		return t
+	default:
+		return Unknown
+	}
+}
+
 // UserDefinedTypeMetadata contains metadata needed for runtime
 // operations on user defined types. The metadata must be read only.
 type UserDefinedTypeMetadata struct {


### PR DESCRIPTION
This adds a `.Canonical` method to types. This will be used by LDR to
determine which type should be used as the parameter type when creating
prepared statements to replicate arbitrary types.

Canonical is needed because decoding a KV from the source cluster and
querying a local row will return datums that match the canonical type.
So we need a generic way to know the decoded Canonical type of all
types.

Release note: none
Part of: https://github.com/cockroachdb/cockroach/issues/148310