### PR TITLE
bazel: enable remote build on mesolite from linux

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -147,17 +147,16 @@ build:engflowbase --remote_upload_local_results=false
 build:engflowbase --remote_download_toplevel
 build:engflowbase --test_env=GO_TEST_WRAP_TESTV=1
 build:engflowbase --config=lintonbuild
+build:engflowbase --remote_cache=grpcs://mesolite.cluster.engflow.com
+build:engflowbase --remote_executor=grpcs://mesolite.cluster.engflow.com
+build:engflowbase --bes_backend=grpcs://mesolite.cluster.engflow.com
 test:engflowbase --test_env=REMOTE_EXEC=1
 test:engflowbase --test_env=GOTRACEBACK=all
 build:engflow --config=engflowbase
-build:engflow --remote_cache=grpcs://tanzanite.cluster.engflow.com
-build:engflow --remote_executor=grpcs://tanzanite.cluster.engflow.com
-build:engflow --bes_backend=grpcs://tanzanite.cluster.engflow.com
-build:engflow --bes_results_url=https://tanzanite.cluster.engflow.com/invocation/
+build:engflow --bes_results_url=https://mesolite.cluster.engflow.com/invocations/private
+build:engflow --remote_instance_name=private
+build:engflow --bes_instance_name=private
 build:engflowpublic --config=engflowbase
-build:engflowpublic --remote_cache=grpcs://mesolite.cluster.engflow.com
-build:engflowpublic --remote_executor=grpcs://mesolite.cluster.engflow.com
-build:engflowpublic --bes_backend=grpcs://mesolite.cluster.engflow.com
 build:engflowpublic --bes_results_url=https://mesolite.cluster.engflow.com/invocation/
 
 try-import %workspace%/.bazelrc.user

--- a/dev
+++ b/dev
@@ -8,7 +8,7 @@ fi
 set -euo pipefail
 
 # Bump this counter to force rebuilding `dev` on all machines.
-DEV_VERSION=112
+DEV_VERSION=113
 
 THIS_DIR=$(cd "$(dirname "$0")" && pwd)
 BINARY_DIR=$THIS_DIR/bin/dev-versions

--- a/pkg/cmd/dev/doctor.go
+++ b/pkg/cmd/dev/doctor.go
@@ -30,7 +30,7 @@ const (
 	// doctorStatusVersion is the current "version" of the status checks
 	// performed by `dev doctor``. Increasing it will force doctor to be re-run
 	// before other dev commands can be run.
-	doctorStatusVersion = 11
+	doctorStatusVersion = 12
 
 	noCacheFlag     = "no-cache"
 	interactiveFlag = "interactive"
@@ -276,8 +276,15 @@ Make sure one of the following lines is in the file %s/.bazelrc.user:
 			if d.checkUsingConfig(cfg.workspace, "dev") {
 				return "In --remote mode, you cannot use the `dev` build configuration."
 			}
-			if !d.checkLinePresenceInBazelRcUser(cfg.workspace, "build:engflow --jobs=200") {
-				return fmt.Sprintf("Make sure the following line is in %s/.bazelrc.user: build:engflow --jobs=200", cfg.workspace)
+			requiredLines := []string{
+				"build:engflow --jobs=200",
+				"build:engflow --credential_helper=mesolite.cluster.engflow.com=engflow_auth",
+				"build:engflow --remote_execution_priority=-1",
+			}
+			for _, line := range requiredLines {
+				if !d.checkLinePresenceInBazelRcUser(cfg.workspace, line) {
+					return fmt.Sprintf("Make sure the following line is in %s/.bazelrc.user: %s", cfg.workspace, line)
+				}
 			}
 			return ""
 		},
@@ -304,13 +311,19 @@ Make sure one of the following lines is in the file %s/.bazelrc.user:
 					return err
 				}
 			}
-			if !d.checkLinePresenceInBazelRcUser(cfg.workspace, "build:engflow --jobs=200") {
-				err := d.addLineToBazelRcUser(cfg.workspace, "build:engflow --jobs=200")
-				if err != nil {
-					return err
+			requiredLines := []string{
+				"build:engflow --jobs=200",
+				"build:engflow --credential_helper=mesolite.cluster.engflow.com=engflow_auth",
+				"build:engflow --remote_execution_priority=-1",
+			}
+			for _, line := range requiredLines {
+				if !d.checkLinePresenceInBazelRcUser(cfg.workspace, line) {
+					err := d.addLineToBazelRcUser(cfg.workspace, line)
+					if err != nil {
+						return err
+					}
 				}
 			}
-
 			return nil
 		},
 		remoteOnly: true,
@@ -359,13 +372,16 @@ slightly slower and introduce a noticeable delay in first-time build setup.`
 		},
 	},
 	{
-		name: "engflow_certificates",
+		name: "engflow_auth",
 		check: func(d *dev, ctx context.Context, cfg doctorConfig) string {
-			if !d.checkLinePresenceInBazelRcUser(cfg.workspace, "build:engflow --tls_client_certificate=") {
-				return fmt.Sprintf("Must specify the --tls_client_certificate to use for EngFlow builds in %s/.bazelrc.user. This is a line of the form: `build:engflow --tls_client_certificate=/path/to/file`.", cfg.workspace)
+			if !d.checkFileExistsUnderHomedir(".config/engflow_auth/tokens/mesolite.cluster.engflow.com") {
+				return "Make sure you've installed engflow_auth (https://github.com/EngFlow/auth), added it to your PATH, and login using `engflow_auth login -store=file https://mesolite.cluster.engflow.com`."
 			}
-			if !d.checkLinePresenceInBazelRcUser(cfg.workspace, "build:engflow --tls_client_key=") {
-				return fmt.Sprintf("Must specify the --tls_client_key to use for EngFlow builds in %s/.bazelrc.user. This is a line of the form: `build:engflow --tls_client_key=/path/to/file`.", cfg.workspace)
+			if d.checkLinePresenceInBazelRcUser(cfg.workspace, "build:engflow --tls_client_certificate=") {
+				return fmt.Sprintf("Please remove the --tls_client_certificate line from %s/.bazelrc.user. It is no longer necessary when using engflow_auth.", cfg.workspace)
+			}
+			if d.checkLinePresenceInBazelRcUser(cfg.workspace, "build:engflow --tls_client_key=") {
+				return fmt.Sprintf("Please remove the --tls_client_key line from %s/.bazelrc.user. It is no longer necessary when using engflow_auth.", cfg.workspace)
 			}
 			return ""
 		},
@@ -923,4 +939,19 @@ func (d *dev) removeAllPrefixesInFile(filename, prefixToRemove string) error {
 	outStr := out.String()
 	outStr = strings.TrimSpace(outStr) + "\n"
 	return d.os.WriteFile(filename, outStr)
+}
+
+// checkFileExistsUnderHomedir checks whether the given file or path is present
+// under the home directory. If it is, this function returns true. Otherwise,
+// it returns false.
+func (d *dev) checkFileExistsUnderHomedir(expectedFile string) bool {
+	homeDir, err := os.UserHomeDir()
+	if err != nil {
+		return false
+	}
+	exists, err := d.os.Exists(filepath.Join(homeDir, expectedFile))
+	if err != nil {
+		return false
+	}
+	return exists
 }

--- a/pkg/cmd/dev/io/os/os.go
+++ b/pkg/cmd/dev/io/os/os.go
@@ -296,6 +296,26 @@ func (o *OS) IsDir(dirname string) (bool, error) {
 	return strconv.ParseBool(strings.TrimSpace(output))
 }
 
+// Exists wraps around os.Stat, which returns the os.FileInfo of the named
+// path. Exists returns true if and only if it exists. If there is an error,
+// it will return false and the error.
+func (o *OS) Exists(filename string) (bool, error) {
+	command := fmt.Sprintf("cat %s", filename)
+	if !o.knobs.silent {
+		o.logger.Print(command)
+	}
+
+	output, _ := o.Next(command, func() (output string, err error) {
+		_, err = os.Stat(filename)
+		exists := !errors.Is(err, fs.ErrNotExist)
+		if exists && err != nil {
+			return "false", err
+		}
+		return strconv.FormatBool(exists), nil
+	})
+	return strconv.ParseBool(strings.TrimSpace(output))
+}
+
 // ReadFile wraps around os.ReadFile, reading a file from disk and
 // returning the contents.
 func (o *OS) ReadFile(filename string) (string, error) {


### PR DESCRIPTION
We are merging EngFlow clusters. This transitions to using the mesolite cluster for running remote builds from gceworkers.

Part of: DEVINF-1489
Release note: None