### PR TITLE
sql: improve stmt bundles a bit

### DIFF
--- a/pkg/cli/statement_bundle.go
+++ b/pkg/cli/statement_bundle.go
@@ -179,6 +179,12 @@ func runBundleRecreate(cmd *cobra.Command, args []string) (resErr error) {
 		initStmts := strings.Split(strings.Join(lines, "\n"), "SET CLUSTER SETTING")
 		for i := 1; i < len(initStmts); i++ {
 			initStmts[i] = "SET CLUSTER SETTING " + initStmts[i]
+			if strings.Contains(initStmts[i], "cluster.preserve_downgrade_option") {
+				// This cluster setting can prevent the bundle from being
+				// recreated on a new enough binary, so we'll skip it.
+				initStmts = append(initStmts[:i], initStmts[i+1:]...)
+				i--
+			}
 		}
 		// All stmts before the first SET CLUSTER SETTING are SET stmts. We need
 		// to handle 'SET database = ' stmt separately if found - the target

--- a/pkg/sql/explain_bundle.go
+++ b/pkg/sql/explain_bundle.go
@@ -1132,7 +1132,9 @@ func (c *stmtEnvCollector) PrintSessionSettings(w io.Writer, sv *settings.Values
 		case "direct_columnar_scans_enabled":
 			// In test builds we might randomize some setting defaults, so
 			// we need to ignore them to make the tests deterministic.
-			skip = buildutil.CrdbTestBuild
+			if buildutil.CrdbTestBuild {
+				skip = true
+			}
 		case "role":
 			// If a role is set, we comment it out in env.sql. Otherwise, running
 			// 'debug sb recreate' will fail with a non-existent user/role error.


### PR DESCRIPTION
This commit addresses two minor issues around the stmt bundles:
- previously, we would always include the value of `direct_columnar_scans_enabled` session variable even when it's not changed from the default. This was a bug where we overrode the value of `skip` boolean based on whether crdb_test build tag was set.
- it also hardens `debug sb recreate` command to ignore `cluster.preserve_downgrade_option` if it's set - it has no effect on the execution, yet it can break recreation on a new enough binary.

Epic: None
Release note: None