### PR TITLE
sql/sqlstats/sslocal: fix BenchmarkSqlStatsDrain

### DIFF
--- a/pkg/sql/sqlstats/sslocal/sql_stats_test.go
+++ b/pkg/sql/sqlstats/sslocal/sql_stats_test.go
@@ -2053,12 +2053,12 @@ func BenchmarkSqlStatsDrain(b *testing.B) {
 	for _, bc := range benchCase {
 		b.Run(fmt.Sprintf("drainsql-%d", bc.statsCount), func(b *testing.B) {
 			for i := 0; i < b.N; i++ {
+				b.StopTimer()
 				sqlStats := createNewSqlStats()
 				populateSqlStats(b, sqlStats, bc.statsCount)
-				b.ResetTimer()
+				b.StartTimer()
 				sqlStats.DrainStats(ctx)
 			}
-
 		})
 	}
 }


### PR DESCRIPTION
Previously, this benchmark would reset the timer during the internal iteration loop `b.N`. This causes the internal go benchmark heuristics that try to achieve a running time of 1 second to never reach its goal, ultimately causing a timeout.

This change fixes the issue by rather using Start / Stop Timer to account for creating and populating stats.

Fixes: #151304

Epic: None
Release note: None