### PR TITLE
bench/rttanalysis: skip BenchmarkUseManyRoles

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",

--- a/pkg/bench/rttanalysis/create_alter_role_bench_test.go
+++ b/pkg/bench/rttanalysis/create_alter_role_bench_test.go
@@ -9,6 +9,8 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 )
 
 func BenchmarkCreateRole(b *testing.B) { reg.Run(b) }
@@ -63,7 +65,10 @@ func init() {
 
 // BenchmarkUseManyRoles is useful for testing the performance of the
 // role membership cache.
-func BenchmarkUseManyRoles(b *testing.B) { reg.Run(b) }
+func BenchmarkUseManyRoles(b *testing.B) {
+	skip.UnderShort(b, "skipping long benchmark")
+	reg.Run(b)
+}
 func init() {
 
 	createFunc := `


### PR DESCRIPTION
Previously, this benchmark was included in CI runs and would take more than 20 minutes to complete a single iteration (`--bench-time=1s --count=1`).

This is because the benchmark aims for a measured runtime of 1 second, but the unmeasured operations within each iteration take over 20 minutes combined to reach that target.

This change skips the benchmark in CI runs.

Fixes: #151303

Epic: None
Release note: None