### PR TITLE
release-25.1: kv: include tracing for split QueryIntent requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1500,35 +1500,44 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	qiBatchIdx := batchIdx + 1
 	qiResponseCh := make(chan response, 1)
 
-	runTask := ds.stopper.RunAsyncTask
+	runTask := ds.stopper.RunAsyncTaskEx
 	if ds.disableParallelBatches {
-		runTask = ds.stopper.RunTask
-	}
-	if err := runTask(ctx, "kv.DistSender: sending pre-commit query intents", func(ctx context.Context) {
-		log.VEvent(ctx, 3, "sending split out pre-commit QueryIntent batch")
-		// Map response index to the original un-swapped batch index.
-		// Remember that we moved the last QueryIntent in this batch
-		// from swapIdx to the end.
-		//
-		// From the example above:
-		//  Before:    [put qi(1) put del qi(2) qi(3) qi(4) et]
-		//  Separated: [put qi(1) put del et] [qi(3) qi(4) qi(2)]
-		//
-		//  qiBa.Requests = [qi(3) qi(4) qi(2)]
-		//  swapIdx       = 4
-		//  positions     = [5 6 4]
-		//
-		positions := make([]int, len(qiBa.Requests))
-		positions[len(positions)-1] = swapIdx
-		for i := range positions[:len(positions)-1] {
-			positions[i] = swapIdx + 1 + i
+		// NB: Construct a function signature that matches Stopper.RunAsyncTaskEx to
+		// avoid some code duplication.
+		runTask = func(ctx context.Context, opts stop.TaskOpts, fn func(ctx context.Context)) error {
+			return ds.stopper.RunTask(ctx, opts.TaskName, fn)
 		}
+	}
+	if err := runTask(ctx,
+		stop.TaskOpts{
+			TaskName: "kv.DistSender: sending pre-commit query intents",
+			SpanOpt:  stop.ChildSpan,
+		},
+		func(ctx context.Context) {
+			log.VEvent(ctx, 3, "sending split out pre-commit QueryIntent batch")
+			// Map response index to the original un-swapped batch index.
+			// Remember that we moved the last QueryIntent in this batch
+			// from swapIdx to the end.
+			//
+			// From the example above:
+			//  Before:    [put qi(1) put del qi(2) qi(3) qi(4) et]
+			//  Separated: [put qi(1) put del et] [qi(3) qi(4) qi(2)]
+			//
+			//  qiBa.Requests = [qi(3) qi(4) qi(2)]
+			//  swapIdx       = 4
+			//  positions     = [5 6 4]
+			//
+			positions := make([]int, len(qiBa.Requests))
+			positions[len(positions)-1] = swapIdx
+			for i := range positions[:len(positions)-1] {
+				positions[i] = swapIdx + 1 + i
+			}
 
-		// Send the batch with withCommit=true since it will be inflight
-		// concurrently with the EndTxn batch below.
-		reply, pErr := ds.divideAndSendBatchToRanges(ctx, qiBa, qiRS, qiIsReverse, true /* withCommit */, qiBatchIdx)
-		qiResponseCh <- response{reply: reply, positions: positions, pErr: pErr}
-	}); err != nil {
+			// Send the batch with withCommit=true since it will be inflight
+			// concurrently with the EndTxn batch below.
+			reply, pErr := ds.divideAndSendBatchToRanges(ctx, qiBa, qiRS, qiIsReverse, true /* withCommit */, qiBatchIdx)
+			qiResponseCh <- response{reply: reply, positions: positions, pErr: pErr}
+		}); err != nil {
 		return nil, kvpb.NewError(err)
 	}
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -35,6 +35,7 @@ SELECT $$
     FROM [SHOW KV TRACE FOR SESSION]
    WHERE message NOT LIKE '%Z/%'
          AND operation NOT LIKE 'kv.DistSender: sending partial batch%'
+         AND operation NOT LIKE 'kv.DistSender: sending pre-commit query intents%'
          AND message NOT SIMILAR TO '%(PushTxn|ResolveIntent|SystemConfigSpan)%'
          AND tag NOT LIKE '%intExec=%'
          AND tag NOT LIKE '%scExec%'

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1069,6 +1069,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
+  AND operation NOT LIKE 'kv.DistSender: sending pre-commit query intents%'
 ----
 colbatchscan  Scan /Table/120/1/2/0 lock Exclusive (Block, Unreplicated)
 count         CPut /Table/120/1/2/0 -> /TUPLE/2:2:Int/3


### PR DESCRIPTION
Backport 1/1 commits from #151367.

/cc @cockroachdb/release

---

When performing a parallel commit, we split out QueryIntent requests for previously pipelined writes that need to be verified as part of the parallel commit into their own batches. These are then run in parallel with the EndTxn batch. Previously, we were missing tracing for these, as we weren't using the correct SpanOpt. This is now fixed.

Epic: none

Release note: None
