### PR TITLE
release-23.2: kv: include tracing for split QueryIntent requests

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender.go
@@ -1253,38 +1253,46 @@ func (ds *DistSender) divideAndSendParallelCommit(
 	qiBatchIdx := batchIdx + 1
 	qiResponseCh := make(chan response, 1)
 
-	runTask := ds.rpcContext.Stopper.RunAsyncTask
+	runTask := ds.rpcContext.Stopper.RunAsyncTaskEx
 	if ds.disableParallelBatches {
-		runTask = ds.rpcContext.Stopper.RunTask
-	}
-	if err := runTask(ctx, "kv.DistSender: sending pre-commit query intents", func(ctx context.Context) {
-		log.VEvent(ctx, 3, "sending split out pre-commit QueryIntent batch")
-		// Map response index to the original un-swapped batch index.
-		// Remember that we moved the last QueryIntent in this batch
-		// from swapIdx to the end.
-		//
-		// From the example above:
-		//  Before:    [put qi(1) put del qi(2) qi(3) qi(4) et]
-		//  Separated: [put qi(1) put del et] [qi(3) qi(4) qi(2)]
-		//
-		//  qiBa.Requests = [qi(3) qi(4) qi(2)]
-		//  swapIdx       = 4
-		//  positions     = [5 6 4]
-		//
-		positions := make([]int, len(qiBa.Requests))
-		positions[len(positions)-1] = swapIdx
-		for i := range positions[:len(positions)-1] {
-			positions[i] = swapIdx + 1 + i
+		// NB: Construct a function signature that matches Stopper.RunAsyncTaskEx to
+		// avoid some code duplication.
+		runTask = func(ctx context.Context, opts stop.TaskOpts, fn func(ctx context.Context)) error {
+			return ds.rpcContext.Stopper.RunTask(ctx, opts.TaskName, fn)
 		}
+	}
+	if err := runTask(ctx,
+		stop.TaskOpts{
+			TaskName: "kv.DistSender: sending pre-commit query intents",
+			SpanOpt:  stop.ChildSpan,
+		},
+		func(ctx context.Context) {
+			log.VEvent(ctx, 3, "sending split out pre-commit QueryIntent batch")
+			// Map response index to the original un-swapped batch index.
+			// Remember that we moved the last QueryIntent in this batch
+			// from swapIdx to the end.
+			//
+			// From the example above:
+			//  Before:    [put qi(1) put del qi(2) qi(3) qi(4) et]
+			//  Separated: [put qi(1) put del et] [qi(3) qi(4) qi(2)]
+			//
+			//  qiBa.Requests = [qi(3) qi(4) qi(2)]
+			//  swapIdx       = 4
+			//  positions     = [5 6 4]
+			//
+			positions := make([]int, len(qiBa.Requests))
+			positions[len(positions)-1] = swapIdx
+			for i := range positions[:len(positions)-1] {
+				positions[i] = swapIdx + 1 + i
+			}
 
-		// Send the batch with withCommit=true since it will be inflight
-		// concurrently with the EndTxn batch below.
-		reply, pErr := ds.divideAndSendBatchToRanges(ctx, qiBa, qiRS, qiIsReverse, true /* withCommit */, qiBatchIdx)
-		qiResponseCh <- response{reply: reply, positions: positions, pErr: pErr}
-	}); err != nil {
+			// Send the batch with withCommit=true since it will be inflight
+			// concurrently with the EndTxn batch below.
+			reply, pErr := ds.divideAndSendBatchToRanges(ctx, qiBa, qiRS, qiIsReverse, true /* withCommit */, qiBatchIdx)
+			qiResponseCh <- response{reply: reply, positions: positions, pErr: pErr}
+		}); err != nil {
 		return nil, kvpb.NewError(err)
 	}
-
 	// Adjust the original batch request to ignore the pre-commit
 	// QueryIntent requests. Make sure to determine the request's
 	// new key span.

--- a/pkg/kv/kvclient/kvcoord/txn_test.go
+++ b/pkg/kv/kvclient/kvcoord/txn_test.go
@@ -9,6 +9,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"regexp"
 	"testing"
 	"time"
 
@@ -25,15 +26,19 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/tscache"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/storage/enginepb"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/kvclientutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/localtestcluster"
 	"github.com/cockroachdb/cockroach/pkg/testutils/serverutils"
+	"github.com/cockroachdb/cockroach/pkg/testutils/testcluster"
 	"github.com/cockroachdb/cockroach/pkg/util/admission/admissionpb"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
 	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
 	"github.com/stretchr/testify/require"
 )
@@ -1444,4 +1449,48 @@ func TestTxnUpdateFromTxnRecordDoesNotOverwriteFields(t *testing.T) {
 
 	// OmitInRangefeeds is still true.
 	require.True(t, txn.GetOmitInRangefeeds())
+}
+
+// TestTxnTracesSplitQueryIntents verifies that the split out QueryIntent
+// requests are captured in the verbose tracing of a transaction.
+func TestTxnTracesSplitQueryIntents(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	st := cluster.MakeTestingClusterSettings()
+	tc := testcluster.StartTestCluster(t, 1, base.TestClusterArgs{
+		ServerArgs: base.TestServerArgs{
+			Settings: st,
+		},
+	})
+	ctx := context.Background()
+	defer tc.Stopper().Stop(ctx)
+
+	db := tc.Server(0).DB()
+
+	tracer := tracing.NewTracer()
+	traceCtx, sp := tracer.StartSpanCtx(context.Background(), "test-txn", tracing.WithRecording(tracingpb.RecordingVerbose))
+
+	if err := db.Txn(traceCtx, func(ctx context.Context, txn *kv.Txn) error {
+		if err := txn.CPut(ctx, "a", "val", nil); err != nil {
+			return err
+		}
+		if err := txn.Put(ctx, "c", "d"); err != nil {
+			return err
+		}
+		return nil
+	}); err != nil {
+		t.Fatal(err)
+	}
+	collectedSpans := sp.FinishAndGetRecording(tracingpb.RecordingVerbose)
+	dump := collectedSpans.String()
+	// dump:
+	//    0.275ms      0.171ms    sending split out pre-commit QueryIntent batch
+	found, err := regexp.MatchString(
+		// The (?s) makes "." match \n. This makes the test resilient to other log
+		// lines being interspersed.
+		`.*sending split out pre-commit QueryIntent batch`,
+		dump)
+	require.NoError(t, err)
+	require.True(t, found, "didn't match: %s", dump)
 }

--- a/pkg/sql/opt/exec/execbuilder/testdata/show_trace
+++ b/pkg/sql/opt/exec/execbuilder/testdata/show_trace
@@ -35,6 +35,7 @@ SELECT $$
     FROM [SHOW KV TRACE FOR SESSION]
    WHERE message NOT LIKE '%Z/%'
          AND operation NOT LIKE 'kv.DistSender: sending partial batch%'
+         AND operation NOT LIKE 'kv.DistSender: sending pre-commit query intents%'
          AND message NOT SIMILAR TO '%(PushTxn|ResolveIntent|SystemConfigSpan)%'
          AND tag NOT LIKE '%intExec=%'
          AND tag NOT LIKE '%scExec%'

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -913,6 +913,7 @@ SET tracing = on,kv,results; UPSERT INTO t.kv(k, v) VALUES (2,3); SET tracing = 
 query TT
 SELECT operation, message FROM [SHOW KV TRACE FOR SESSION]
  WHERE operation != 'dist sender send' AND operation != 'kv.DistSender: sending partial batch'
+  AND operation NOT LIKE 'kv.DistSender: sending pre-commit query intents%'
 ----
 colbatchscan  Scan /Table/120/1/2/0
 count         CPut /Table/120/1/2/0 -> /TUPLE/2:2:Int/3


### PR DESCRIPTION
Backport 1/1 commits from #151367.

/cc @cockroachdb/release

---

When performing a parallel commit, we split out QueryIntent requests for previously pipelined writes that need to be verified as part of the parallel commit into their own batches. These are then run in parallel with the EndTxn batch. Previously, we were missing tracing for these, as we weren't using the correct SpanOpt. This is now fixed.

Epic: none

Release note: None
