### PR TITLE
opt: estimate worst-case selectivity of placeholder equalities

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain_redact
@@ -697,7 +697,7 @@ upsert bc
 query T
 EXPLAIN (OPT, MEMO, REDACT) INSERT INTO bc SELECT a::float + 1 FROM a ON CONFLICT (b) DO UPDATE SET b = bc.b + 100
 ----
-memo (optimized, ~36KB, required=[presentation: info:25] [distribution: test])
+memo (optimized, ~37KB, required=[presentation: info:25] [distribution: test])
  ├── G1: (explain G2 [distribution: test])
  │    └── [presentation: info:25] [distribution: test]
  │         ├── best: (explain G2="[distribution: test]" [distribution: test])
@@ -2497,7 +2497,7 @@ project
 query T
 EXPLAIN (OPT, MEMO, REDACT) SELECT * FROM bc JOIN f ON b = f + 1
 ----
-memo (optimized, ~28KB, required=[presentation: info:14] [distribution: test])
+memo (optimized, ~29KB, required=[presentation: info:14] [distribution: test])
  ├── G1: (explain G2 [presentation: b:1,c:2,f:7] [distribution: test])
  │    └── [presentation: info:14] [distribution: test]
  │         ├── best: (explain G2="[presentation: b:1,c:2,f:7] [distribution: test]" [presentation: b:1,c:2,f:7] [distribution: test])

--- a/pkg/sql/opt/memo/expr_format.go
+++ b/pkg/sql/opt/memo/expr_format.go
@@ -885,11 +885,19 @@ func (f *ExprFmtCtx) formatRelational(e RelExpr, tp treeprinter.Node) {
 		if relational.HasPlaceholder {
 			writeFlag("has-placeholder")
 		}
+		if p, ok := e.Private().(*JoinPrivate); ok {
+			if !p.ParameterizedCols.Empty() {
+				tp.Childf("parameterized columns: %s", p.ParameterizedCols)
+			}
+		}
 		if lookupJoin, ok := e.(*LookupJoinExpr); ok {
 			// For lookup joins, indicate whether reverse scans are required to
 			// satisfy the ordering.
 			if lookupJoinMustUseReverseScans(md, lookupJoin, &required.Ordering) {
 				writeFlag("reverse-scans")
+			}
+			if !lookupJoin.ParameterizedCols.Empty() {
+				tp.Childf("parameterized columns: %s", lookupJoin.ParameterizedCols)
 			}
 		}
 

--- a/pkg/sql/opt/memo/testdata/stats/generic
+++ b/pkg/sql/opt/memo/testdata/stats/generic
@@ -2,9 +2,14 @@ exec-ddl
 CREATE TABLE t (
   k INT PRIMARY KEY,
   i INT,
-  s STRING
+  s STRING,
+  INDEX (i)
 )
 ----
+
+# ------------------------
+# Tests without Histograms
+# ------------------------
 
 exec-ddl
 ALTER TABLE t INJECT STATISTICS '[
@@ -162,6 +167,298 @@ select
  ├── scan t
  │    ├── columns: k:1(int!null) i:2(int) s:3(string)
  │    ├── stats: [rows=10000, distinct(1)=10000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── (i:2 = $1) OR (s:3 = $2) [type=bool, outer=(2,3)]
+
+# ---------------------
+# Tests with Histograms
+# ---------------------
+
+exec-ddl
+ALTER TABLE t INJECT STATISTICS '[
+  {
+    "columns": ["k"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 1000
+  },
+  {
+    "columns": ["i"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 41,
+    "null_count": 30,
+    "avg_size": 2,
+    "histo_col_type": "int",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "0"},
+      {"num_eq": 10, "num_range": 90, "distinct_range": 9, "upper_bound": "100"},
+      {"num_eq": 10, "num_range": 180, "distinct_range": 9, "upper_bound": "200"},
+      {"num_eq": 20, "num_range": 270, "distinct_range": 9, "upper_bound": "300"},
+      {"num_eq": 30, "num_range": 360, "distinct_range": 9, "upper_bound": "400"}
+    ]
+  },
+  {
+    "columns": ["s"],
+    "created_at": "2018-01-01 1:00:00.00000+00:00",
+    "row_count": 1000,
+    "distinct_count": 20,
+    "avg_size": 3,
+    "histo_col_type": "string",
+    "histo_buckets": [
+      {"num_eq": 0, "num_range": 0, "distinct_range": 0, "upper_bound": "apple"},
+      {"num_eq": 300, "num_range": 100, "distinct_range": 9, "upper_bound": "banana"},
+      {"num_eq": 500, "num_range": 100, "distinct_range": 9, "upper_bound": "cherry"}
+    ]
+  }
+]'
+----
+
+norm
+SELECT * FROM t WHERE k = $1
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string)
+ ├── cardinality: [0 - 1]
+ ├── has-placeholder
+ ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ ├── key: ()
+ ├── fd: ()-->(1-3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── k:1 = $1 [type=bool, outer=(1), constraints=(/1: (/NULL - ]), fd=()-->(1)]
+
+# The row count of the filter is the max frequency of i's histogram.
+norm
+SELECT * FROM t WHERE i = $1
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=30, distinct(2)=1, null(2)=0]
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=41, null(2)=30]
+ │    │   histogram(2)=  0   30   0  0  90  10   180  10   270  20   360  30
+ │    │                <--- NULL --- 0 ---- 100 ----- 200 ----- 300 ----- 400
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 = $1 [type=bool, outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+
+# Similar case as above, but with opt to ensure the correct row counts are used
+# for new memo groups.
+opt
+SELECT k FROM t WHERE i = $1
+----
+project
+ ├── columns: k:1(int!null)
+ ├── has-placeholder
+ ├── stats: [rows=30]
+ ├── key: (1)
+ └── placeholder-scan t@t_i_idx
+      ├── columns: k:1(int!null) i:2(int!null)
+      ├── has-placeholder
+      ├── stats: [rows=30, distinct(2)=1, null(2)=0]
+      ├── key: (1)
+      ├── fd: ()-->(2)
+      └── span
+           └── $1 [type=int]
+
+# Similar case as above, but with opt to ensure the correct row counts are used
+# for new memo groups.
+opt
+SELECT * FROM t WHERE i = $1
+----
+project
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=30, distinct(2)=1, null(2)=0]
+ ├── key: (1)
+ ├── fd: ()-->(2), (1)-->(3)
+ └── inner-join (lookup t)
+      ├── columns: k:1(int!null) i:2(int!null) s:3(string) "$1":6(int!null)
+      ├── key columns: [1] = [1]
+      ├── lookup columns are key
+      ├── has-placeholder
+      ├── stats: [rows=30, distinct(2)=1, null(2)=0, distinct(6)=1, null(6)=0]
+      ├── key: (1)
+      ├── fd: ()-->(2,6), (1)-->(3), (2)==(6), (6)==(2)
+      ├── inner-join (lookup t@t_i_idx)
+      │    ├── columns: k:1(int!null) i:2(int!null) "$1":6(int!null)
+      │    ├── flags: disallow merge join
+      │    ├── key columns: [6] = [2]
+      │    ├── parameterized columns: (6)
+      │    ├── has-placeholder
+      │    ├── stats: [rows=30, distinct(2)=1, null(2)=0, distinct(6)=1, null(6)=0]
+      │    ├── key: (1)
+      │    ├── fd: ()-->(2,6), (2)==(6), (6)==(2)
+      │    ├── values
+      │    │    ├── columns: "$1":6(int)
+      │    │    ├── cardinality: [1 - 1]
+      │    │    ├── has-placeholder
+      │    │    ├── stats: [rows=1, distinct(6)=1, null(6)=0]
+      │    │    ├── key: ()
+      │    │    ├── fd: ()-->(6)
+      │    │    └── ($1,) [type=tuple{int}]
+      │    └── filters (true)
+      └── filters (true)
+
+# The row count of the filter is the max frequency of s's histogram.
+norm
+SELECT * FROM t WHERE $1 = s
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string!null)
+ ├── has-placeholder
+ ├── stats: [rows=500, distinct(3)=1, null(3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(3), (1)-->(2)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(3)=20, null(3)=0]
+ │    │   histogram(3)=  0     0     100    300     100    500
+ │    │                <--- 'apple' ----- 'banana' ----- 'cherry'
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── s:3 = $1 [type=bool, outer=(3), constraints=(/3: (/NULL - ]), fd=()-->(3)]
+
+# Similar case to the previous one, but with a join on a values expression to
+# mimic a parameterized join of a generic query plan.
+# TODO(mgartner): The row count of the inner-join should be 500, because that is
+# the maximum frequency of s. It is currently 50 because the v.s is not marked
+# as a "parameterized column", which only happens during the
+# GenerateParameterizedJoin exploration rule. I think we can address this by
+# including paramterized columns in logical properties and propagating them
+# upward.
+norm
+SELECT * FROM (VALUES ($1::STRING)) v(s) JOIN t ON t.s = v.s
+----
+inner-join (hash)
+ ├── columns: s:1(string!null) k:2(int!null) i:3(int) s:4(string!null)
+ ├── multiplicity: left-rows(zero-or-more), right-rows(zero-or-one)
+ ├── has-placeholder
+ ├── stats: [rows=50, distinct(1)=1, null(1)=0, distinct(4)=1, null(4)=0]
+ ├── key: (2)
+ ├── fd: ()-->(1,4), (2)-->(3), (1)==(4), (4)==(1)
+ ├── values
+ │    ├── columns: column1:1(string)
+ │    ├── cardinality: [1 - 1]
+ │    ├── has-placeholder
+ │    ├── stats: [rows=1, distinct(1)=1, null(1)=0]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1)
+ │    └── ($1,) [type=tuple{string}]
+ ├── scan t
+ │    ├── columns: k:2(int!null) i:3(int) s:4(string)
+ │    ├── stats: [rows=1000, distinct(4)=20, null(4)=0]
+ │    │   histogram(4)=  0     0     100    300     100    500
+ │    │                <--- 'apple' ----- 'banana' ----- 'cherry'
+ │    ├── key: (2)
+ │    └── fd: (2)-->(3,4)
+ └── filters
+      └── s:4 = column1:1 [type=bool, outer=(1,4), constraints=(/1: (/NULL - ]; /4: (/NULL - ]), fd=(1)==(4), (4)==(1)]
+
+# The row count of the filter is based on the product of selectivities from the
+# max frequencies of i's and s's histograms.
+norm
+SELECT * FROM t WHERE i = $1 AND s = $2
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string!null)
+ ├── has-placeholder
+ ├── stats: [rows=15, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(2,3)=1, null(2,3)=0]
+ ├── key: (1)
+ ├── fd: ()-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=41, null(2)=30, distinct(3)=20, null(3)=0, distinct(2,3)=820, null(2,3)=0]
+ │    │   histogram(2)=  0   30   0  0  90  10   180  10   270  20   360  30
+ │    │                <--- NULL --- 0 ---- 100 ----- 200 ----- 300 ----- 400
+ │    │   histogram(3)=  0     0     100    300     100    500
+ │    │                <--- 'apple' ----- 'banana' ----- 'cherry'
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      ├── i:2 = $1 [type=bool, outer=(2), constraints=(/2: (/NULL - ]), fd=()-->(2)]
+      └── s:3 = $2 [type=bool, outer=(3), constraints=(/3: (/NULL - ]), fd=()-->(3)]
+
+norm
+SELECT * FROM t WHERE i > $1
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=323.333, distinct(2)=41, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=41, null(2)=30]
+ │    │   histogram(2)=  0   30   0  0  90  10   180  10   270  20   360  30
+ │    │                <--- NULL --- 0 ---- 100 ----- 200 ----- 300 ----- 400
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 > $1 [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+
+norm
+SELECT * FROM t WHERE i = $1 OR i = $2
+----
+select
+ ├── columns: k:1(int!null) i:2(int!null) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=323.333, distinct(2)=41, null(2)=0]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0, distinct(2)=41, null(2)=30]
+ │    │   histogram(2)=  0   30   0  0  90  10   180  10   270  20   360  30
+ │    │                <--- NULL --- 0 ---- 100 ----- 200 ----- 300 ----- 400
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── (i:2 = $1) OR (i:2 = $2) [type=bool, outer=(2), constraints=(/2: (/NULL - ])]
+
+norm
+SELECT * FROM t WHERE i IN ($1, $2, $3)
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=333.333]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2,3)
+ └── filters
+      └── i:2 IN ($1, $2, $3) [type=bool, outer=(2)]
+
+norm
+SELECT * FROM t WHERE i = $1 OR s = $2
+----
+select
+ ├── columns: k:1(int!null) i:2(int) s:3(string)
+ ├── has-placeholder
+ ├── stats: [rows=333.333]
+ ├── key: (1)
+ ├── fd: (1)-->(2,3)
+ ├── scan t
+ │    ├── columns: k:1(int!null) i:2(int) s:3(string)
+ │    ├── stats: [rows=1000, distinct(1)=1000, null(1)=0]
  │    ├── key: (1)
  │    └── fd: (1)-->(2,3)
  └── filters

--- a/pkg/sql/opt/ops/relational.opt
+++ b/pkg/sql/opt/ops/relational.opt
@@ -307,6 +307,11 @@ define JoinPrivate {
     # SkipReorderJoins indicates whether the ReorderJoins rule should match this
     # join.
     SkipReorderJoins bool
+
+    # ParameterizedCols is the set of columns that are equivalent to placeholder
+    # values. These columns are typically created when exploring parameterized
+    # joins for generic query plans.
+    ParameterizedCols ColSet
 }
 
 # IndexJoin represents an inner join between an input expression and a primary

--- a/pkg/sql/opt/props/selectivity.go
+++ b/pkg/sql/opt/props/selectivity.go
@@ -89,10 +89,16 @@ func (s *Selectivity) Divide(other Selectivity) {
 
 // MinSelectivity returns the smaller value of two selectivities.
 func MinSelectivity(a, b Selectivity) Selectivity {
-	if a.selectivity < b.selectivity {
-		return a
+	return Selectivity{
+		selectivity: min(a.selectivity, b.selectivity),
 	}
-	return b
+}
+
+// MinSelectivity3 returns the smallest value of three selectivities.
+func MinSelectivity3(a, b, c Selectivity) Selectivity {
+	return Selectivity{
+		selectivity: min(a.selectivity, b.selectivity, c.selectivity),
+	}
 }
 
 // MaxSelectivity returns the larger value of two selectivities.

--- a/pkg/sql/opt/xform/generic_funcs.go
+++ b/pkg/sql/opt/xform/generic_funcs.go
@@ -37,7 +37,7 @@ func (c *CustomFuncs) HasPlaceholdersOrStableExprs(e memo.RelExpr) bool {
 // placeholders or stable expressions, ok=false is returned.
 func (c *CustomFuncs) GenerateParameterizedJoinValuesAndFilters(
 	filters memo.FiltersExpr,
-) (values memo.RelExpr, newFilters memo.FiltersExpr, ok bool) {
+) (values memo.RelExpr, newFilters memo.FiltersExpr, parameterizedCols opt.ColSet, ok bool) {
 	var exprs memo.ScalarListExpr
 	var cols opt.ColList
 	placeholderCols := make(map[tree.PlaceholderIdx]opt.ColumnID)
@@ -59,6 +59,7 @@ func (c *CustomFuncs) GenerateParameterizedJoinValuesAndFilters(
 			placeholderCols[idx] = col
 			exprs = append(exprs, t)
 			cols = append(cols, col)
+			parameterizedCols.Add(col)
 			return c.e.f.ConstructVariable(col)
 
 		case *memo.FunctionExpr:
@@ -71,6 +72,7 @@ func (c *CustomFuncs) GenerateParameterizedJoinValuesAndFilters(
 				col := c.e.f.Metadata().AddColumn("", t.DataType())
 				exprs = append(exprs, t)
 				cols = append(cols, col)
+				parameterizedCols.Add(col)
 				return c.e.f.ConstructVariable(col)
 			}
 		}
@@ -98,7 +100,7 @@ func (c *CustomFuncs) GenerateParameterizedJoinValuesAndFilters(
 	// If no placeholders or stable expressions were replaced, there is nothing
 	// to do.
 	if len(exprs) == 0 {
-		return nil, nil, false
+		return nil, nil, opt.ColSet{}, false
 	}
 
 	// Create the Values expression with one row and one column for each
@@ -114,15 +116,16 @@ func (c *CustomFuncs) GenerateParameterizedJoinValuesAndFilters(
 		ID:   c.e.f.Metadata().NextUniqueID(),
 	})
 
-	return values, newFilters, true
+	return values, newFilters, parameterizedCols, true
 }
 
 // ParameterizedJoinPrivate returns JoinPrivate that disabled join reordering and
 // merge join exploration.
-func (c *CustomFuncs) ParameterizedJoinPrivate() *memo.JoinPrivate {
+func (c *CustomFuncs) ParameterizedJoinPrivate(parameterizedCols opt.ColSet) *memo.JoinPrivate {
 	return &memo.JoinPrivate{
-		Flags:            memo.DisallowMergeJoin,
-		SkipReorderJoins: true,
+		Flags:             memo.DisallowMergeJoin,
+		ParameterizedCols: parameterizedCols,
+		SkipReorderJoins:  true,
 	}
 }
 

--- a/pkg/sql/opt/xform/rules/generic.opt
+++ b/pkg/sql/opt/xform/rules/generic.opt
@@ -38,6 +38,7 @@
             (
                 $values
                 $newFilters
+                $parameterizedCols
                 $ok
             ):(GenerateParameterizedJoinValuesAndFilters
                 $filters
@@ -51,7 +52,7 @@
         $values
         $scan
         $newFilters
-        (ParameterizedJoinPrivate)
+        (ParameterizedJoinPrivate $parameterizedCols)
     )
     []
     (OutputCols (Root))

--- a/pkg/sql/opt/xform/testdata/coster/placeholder-scan
+++ b/pkg/sql/opt/xform/testdata/coster/placeholder-scan
@@ -367,6 +367,7 @@ project
            ├── lookup expression
            │    └── filters
            │         └── a:2 > "$1":7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+           ├── parameterized columns: (7,8)
            ├── has-placeholder
            ├── stats: [rows=11111.1, distinct(2)=100, null(2)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
            ├── cost: 68690.7277
@@ -500,7 +501,7 @@ project
       ├── key columns: [1] = [1]
       ├── lookup columns are key
       ├── has-placeholder
-      ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+      ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(2,3)=1, null(2,3)=0]
       ├── cost: 36.19
       ├── cost-flags: unbounded-cardinality
       ├── key: (1)
@@ -509,8 +510,9 @@ project
       │    ├── columns: k:1!null a:2!null b:3!null "$1":7!null "$2":8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [7 8] = [2 3]
+      │    ├── parameterized columns: (7,8)
       │    ├── has-placeholder
-      │    ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+      │    ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(2,3)=1, null(2,3)=0]
       │    ├── cost: 26.11
       │    ├── cost-flags: unbounded-cardinality
       │    ├── key: (1)
@@ -1014,6 +1016,7 @@ project
            ├── lookup expression
            │    └── filters
            │         └── a:2 > "$1":7 [outer=(2,7), constraints=(/2: (/NULL - ]; /7: (/NULL - ])]
+           ├── parameterized columns: (7,8)
            ├── has-placeholder
            ├── stats: [rows=11111.1, distinct(2)=100, null(2)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
            ├── cost: 67857.3943
@@ -1163,7 +1166,7 @@ project
       ├── key columns: [1] = [1]
       ├── lookup columns are key
       ├── has-placeholder
-      ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+      ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(2,3)=1, null(2,3)=0]
       ├── cost: 36.145
       ├── cost-flags: unbounded-cardinality
       ├── key: (1)
@@ -1172,8 +1175,9 @@ project
       │    ├── columns: k:1!null a:2!null b:3!null "$1":7!null "$2":8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [7 8] = [2 3]
+      │    ├── parameterized columns: (7,8)
       │    ├── has-placeholder
-      │    ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0]
+      │    ├── stats: [rows=1, distinct(2)=1, null(2)=0, distinct(3)=1, null(3)=0, distinct(7)=1, null(7)=0, distinct(8)=1, null(8)=0, distinct(2,3)=1, null(2,3)=0]
       │    ├── cost: 26.08
       │    ├── cost-flags: unbounded-cardinality
       │    ├── key: (1)

--- a/pkg/sql/opt/xform/testdata/external/nova
+++ b/pkg/sql/opt/xform/testdata/external/nova
@@ -220,6 +220,7 @@ project
       │    │    │    │    │    │         │    ├── key columns: [37] = [7]
       │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── parameterized columns: (37)
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
       │    │    │    │    │    │         │    ├── fd: ()-->(1,7,37), (7)==(37), (37)==(7)
@@ -790,6 +791,7 @@ project
       │    │    │    │    │    │         │    ├── key columns: [43 42] = [2 13]
       │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── parameterized columns: (42,43)
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
       │    │    │    │    │    │         │    ├── fd: ()-->(1,2,13,42,43), (2)==(43), (43)==(2), (13)==(42), (42)==(13)
@@ -926,6 +928,7 @@ project
       │    │    │    │    │    │         ├── key columns: [42] = [1]
       │    │    │    │    │    │         ├── lookup columns are key
       │    │    │    │    │    │         ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         ├── parameterized columns: (42,43)
       │    │    │    │    │    │         ├── has-placeholder
       │    │    │    │    │    │         ├── key: ()
       │    │    │    │    │    │         ├── fd: ()-->(1-16,42,43), (1)==(42), (42)==(1), (13)==(43), (43)==(13)
@@ -1068,6 +1071,7 @@ project
       │    │    │    │    │    │         │    ├── key columns: [37] = [2]
       │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── parameterized columns: (37)
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
       │    │    │    │    │    │         │    ├── fd: ()-->(1,2,37), (2)==(37), (37)==(2)
@@ -1200,6 +1204,7 @@ project
       │    │    │    │    │    │         │    ├── key columns: [37] = [7]
       │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── parameterized columns: (37)
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
       │    │    │    │    │    │         │    ├── fd: ()-->(1,7,37), (7)==(37), (37)==(7)
@@ -1628,6 +1633,7 @@ project
       │    │    │    │    │    │         │    ├── key columns: [43 42] = [7 13]
       │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── parameterized columns: (42,43)
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
       │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,42,43), (7)==(43), (43)==(7), (13)==(42), (42)==(13)
@@ -2331,6 +2337,7 @@ project
       │    │    │    │    │    │         │    ├── key columns: [43 42] = [7 13]
       │    │    │    │    │    │         │    ├── lookup columns are key
       │    │    │    │    │    │         │    ├── cardinality: [0 - 1]
+      │    │    │    │    │    │         │    ├── parameterized columns: (42,43)
       │    │    │    │    │    │         │    ├── has-placeholder
       │    │    │    │    │    │         │    ├── key: ()
       │    │    │    │    │    │         │    ├── fd: ()-->(1,7,13,42,43), (7)==(43), (43)==(7), (13)==(42), (42)==(13)

--- a/pkg/sql/opt/xform/testdata/rules/generic
+++ b/pkg/sql/opt/xform/testdata/rules/generic
@@ -116,6 +116,7 @@ project
       │    ├── columns: k:1!null i:2!null s:3!null b:4!null "$1":8!null "$2":9!null "$3":10!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8 9 10] = [2 3 4]
+      │    ├── parameterized columns: (8-10)
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2-4,8-10), (2)==(8), (8)==(2), (3)==(9), (9)==(3), (4)==(10), (10)==(4)
@@ -151,6 +152,7 @@ project
       ├── key columns: [8] = [1]
       ├── lookup columns are key
       ├── cardinality: [0 - 1]
+      ├── parameterized columns: (8)
       ├── has-placeholder
       ├── key: ()
       ├── fd: ()-->(1-5,8), (1)==(2,8), (2)==(1,8), (8)==(1,2)
@@ -185,6 +187,7 @@ project
       │    ├── columns: k:1!null i:2!null t:5 "$1":8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8] = [2]
+      │    ├── parameterized columns: (8)
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2,8), (1)-->(5), (2)==(8), (8)==(2)
@@ -279,6 +282,7 @@ project
       │    ├── columns: k:1!null t:5!null "$1":8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8] = [5]
+      │    ├── parameterized columns: (8)
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(5,8), (5)==(8), (8)==(5)
@@ -335,6 +339,7 @@ project
       │    ├── columns: k:1!null i:2!null t:5!null "$1":8!null "$2":9!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8 9] = [2 5]
+      │    ├── parameterized columns: (8,9)
       │    ├── has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2,5,8,9), (2)==(8), (8)==(2), (5)==(9), (9)==(5)
@@ -389,6 +394,7 @@ project
            │    ├── key columns: [8 9] = [3 1]
            │    ├── lookup columns are key
            │    ├── cardinality: [0 - 1]
+           │    ├── parameterized columns: (8,9)
            │    ├── has-placeholder
            │    ├── key: ()
            │    ├── fd: ()-->(1,3,8,9), (3)==(8), (8)==(3), (1)==(9), (9)==(1)
@@ -425,6 +431,7 @@ project
       │    ├── key columns: [8 9] = [3 1]
       │    ├── lookup columns are key
       │    ├── cardinality: [0 - 1]
+      │    ├── parameterized columns: (8,9)
       │    ├── has-placeholder
       │    ├── key: ()
       │    ├── fd: ()-->(1,3,8,9), (3)==(8), (8)==(3), (1)==(9), (9)==(1)
@@ -456,14 +463,14 @@ project
  ├── columns: k:1!null
  ├── stable
  ├── stats: [rows=330]
- ├── cost: 50.975
+ ├── cost: 51.1800002
  ├── cost-flags: unbounded-cardinality
  ├── key: (1)
  └── project
       ├── columns: k:1!null t:5!null
       ├── stable
       ├── stats: [rows=330, distinct(5)=100, null(5)=0]
-      ├── cost: 47.655
+      ├── cost: 47.8600002
       ├── cost-flags: unbounded-cardinality
       ├── key: (1)
       ├── fd: ()-->(5)
@@ -471,9 +478,10 @@ project
            ├── columns: k:1!null t:5!null column8:8!null
            ├── flags: disallow merge join
            ├── key columns: [8] = [5]
+           ├── parameterized columns: (8)
            ├── stable
-           ├── stats: [rows=9.9, distinct(5)=1, null(5)=0, distinct(8)=1, null(8)=0]
-           ├── cost: 44.335
+           ├── stats: [rows=10, distinct(5)=1, null(5)=0, distinct(8)=1, null(8)=0]
+           ├── cost: 44.5400002
            ├── cost-flags: unbounded-cardinality
            ├── key: (1)
            ├── fd: ()-->(5,8), (5)==(8), (8)==(5)
@@ -507,6 +515,7 @@ project
       │    ├── columns: k:1!null t:5!null column8:8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8] = [5]
+      │    ├── parameterized columns: (8)
       │    ├── stable
       │    ├── key: (1)
       │    ├── fd: ()-->(5,8), (5)==(8), (8)==(5)
@@ -555,6 +564,7 @@ project
       │    ├── columns: k:1!null i:2!null t:5!null "$1":8!null column9:9!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8 9] = [2 5]
+      │    ├── parameterized columns: (8,9)
       │    ├── stable, has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2,5,8,9), (2)==(8), (8)==(2), (5)==(9), (9)==(5)
@@ -590,6 +600,7 @@ project
       │    │    └── filters
       │    │         ├── t:5 > column9:9 [outer=(5,9), constraints=(/5: (/NULL - ]; /9: (/NULL - ])]
       │    │         └── "$1":8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      │    ├── parameterized columns: (8,9)
       │    ├── stable, has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2,8,9), (1)-->(5), (2)==(8), (8)==(2)
@@ -627,6 +638,7 @@ project
            │    ├── columns: k:1!null i:2!null t:5!null "$1":8!null column9:9 "$2":10 column11:11!null
            │    ├── flags: disallow merge join
            │    ├── key columns: [8 11] = [2 5]
+           │    ├── parameterized columns: (8-10)
            │    ├── stable, has-placeholder
            │    ├── key: (1)
            │    ├── fd: ()-->(2,5,8-11), (2)==(8), (8)==(2), (5)==(11), (11)==(5)
@@ -672,6 +684,7 @@ project
            │    ├── columns: k:1!null i:2!null t:5!null "$1":8!null column9:9 column10:10!null
            │    ├── flags: disallow merge join
            │    ├── key columns: [8 10] = [2 5]
+           │    ├── parameterized columns: (8,9)
            │    ├── stable, has-placeholder
            │    ├── key: (1)
            │    ├── fd: ()-->(2,5,8-10), (2)==(8), (8)==(2), (5)==(10), (10)==(5)
@@ -732,6 +745,7 @@ project
       │    ├── columns: k:1!null i:2!null s:3!null b:4 "$1":8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8] = [2]
+      │    ├── parameterized columns: (8)
       │    ├── stable, has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2,3,8), (1)-->(4), (2)==(8), (8)==(2)
@@ -768,6 +782,7 @@ project
       │    ├── columns: k:1!null i:2!null s:3!null b:4 "$1":8!null
       │    ├── flags: disallow merge join
       │    ├── key columns: [8] = [2]
+      │    ├── parameterized columns: (8)
       │    ├── stable, has-placeholder
       │    ├── key: (1)
       │    ├── fd: ()-->(2,3,8), (1)-->(4), (2)==(8), (8)==(2)

--- a/pkg/sql/opt/xform/testdata/rules/groupby
+++ b/pkg/sql/opt/xform/testdata/rules/groupby
@@ -2298,7 +2298,7 @@ memo (optimized, ~6KB, required=[presentation: u:2,v:3,w:4] [ordering: +4])
 memo
 SELECT (SELECT w FROM kuvw WHERE v=1 AND x=u) FROM xyz ORDER BY x+1, x
 ----
-memo (optimized, ~27KB, required=[presentation: w:12] [ordering: +13,+1])
+memo (optimized, ~28KB, required=[presentation: w:12] [ordering: +13,+1])
  ├── G1: (project G2 G3 x)
  │    ├── [presentation: w:12] [ordering: +13,+1]
  │    │    ├── best: (sort G1)
@@ -2422,7 +2422,7 @@ memo (optimized, ~29KB, required=[])
 memo
 INSERT INTO xyz SELECT v, w, 1.0 FROM kuvw ON CONFLICT (x) DO UPDATE SET z=2.0
 ----
-memo (optimized, ~29KB, required=[])
+memo (optimized, ~30KB, required=[])
  ├── G1: (upsert G2 G3 G4 xyz)
  │    └── []
  │         ├── best: (upsert G2 G3 G4 xyz)

--- a/pkg/sql/opt/xform/testdata/rules/join
+++ b/pkg/sql/opt/xform/testdata/rules/join
@@ -235,7 +235,7 @@ inner-join (merge)
 memo expect=ReorderJoins
 SELECT * FROM abc, stu, xyz WHERE abc.a=stu.s AND stu.s=xyz.x
 ----
-memo (optimized, ~48KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
+memo (optimized, ~50KB, required=[presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (merge-join G2 G3 G10 inner-join,+1,+7) (merge-join G3 G2 G10 inner-join,+7,+1) (lookup-join G3 G10 abc@ab,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G5 G6 G10 inner-join,+7,+12) (merge-join G6 G5 G10 inner-join,+12,+7) (lookup-join G6 G10 stu,keyCols=[12],outCols=(1-3,7-9,12-14)) (merge-join G8 G9 G10 inner-join,+7,+12) (lookup-join G8 G10 xyz@xy,keyCols=[7],outCols=(1-3,7-9,12-14)) (merge-join G9 G8 G10 inner-join,+12,+7)
  │    └── [presentation: a:1,b:2,c:3,s:7,t:8,u:9,x:12,y:13,z:14]
  │         ├── best: (merge-join G5="[ordering: +7]" G6="[ordering: +(1|12)]" G10 inner-join,+7,+12)
@@ -343,7 +343,7 @@ SELECT *
 FROM stu, abc, xyz, pqr
 WHERE u = a AND a = x AND x = p
 ----
-memo (optimized, ~42KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
+memo (optimized, ~43KB, required=[presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+3,+6) (merge-join G3 G2 G5 inner-join,+6,+3) (lookup-join G3 G5 stu@uts,keyCols=[6],outCols=(1-3,6-8,12-14,18-22))
  │    └── [presentation: s:1,t:2,u:3,a:6,b:7,c:8,x:12,y:13,z:14,p:18,q:19,r:20,s:21,t:22]
  │         ├── best: (merge-join G2="[ordering: +3]" G3="[ordering: +(6|12|18)]" G5 inner-join,+3,+6)
@@ -1277,7 +1277,7 @@ memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
 memo expect=ReorderJoins
 SELECT * FROM abc FULL OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (full-join G2 G3 G4) (full-join G3 G2 G4) (merge-join G2 G3 G5 full-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (full-join G2 G3 G4)
@@ -1363,7 +1363,7 @@ full-join (hash)
 memo expect-not=ReorderJoins
 SELECT * FROM abc INNER LOOKUP JOIN xyz ON a=x
 ----
-memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~14KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9))
@@ -1446,7 +1446,7 @@ New expression 1 of 1:
 memo
 SELECT * FROM abc LEFT OUTER JOIN xyz ON a=z
 ----
-memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~13KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (left-join G2 G3 G4) (right-join G3 G2 G4) (merge-join G2 G3 G5 left-join,+1,+9)
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (left-join G2 G3 G4)
@@ -1827,7 +1827,7 @@ inner-join (merge)
 memo
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~17KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (merge-join G2 G3 G5 inner-join,+1,+7) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (merge-join G3 G2 G5 inner-join,+7,+1) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (merge-join G3="[ordering: +7]" G2="[ordering: +1]" G5 inner-join,+7,+1)
@@ -1878,7 +1878,7 @@ memo (optimized, ~12KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
 memo set=(optimizer_merge_joins_enabled=false) expect-not=GenerateMergeJoins
 SELECT * FROM abc JOIN xyz ON a=x
 ----
-memo (optimized, ~15KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
+memo (optimized, ~16KB, required=[presentation: a:1,b:2,c:3,x:7,y:8,z:9])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (lookup-join G2 G5 xyz@xy,keyCols=[1],outCols=(1-3,7-9)) (lookup-join G3 G5 abc@ab,keyCols=[7],outCols=(1-3,7-9))
  │    └── [presentation: a:1,b:2,c:3,x:7,y:8,z:9]
  │         ├── best: (inner-join G3 G2 G4)
@@ -7305,7 +7305,7 @@ WHERE n.name = 'Upper West Side'
 OR n.name = 'Upper East Side'
 GROUP BY n.name, n.geom
 ----
-memo (optimized, ~38KB, required=[presentation: name:16,popn_per_sqkm:22])
+memo (optimized, ~39KB, required=[presentation: name:16,popn_per_sqkm:22])
  ├── G1: (project G2 G3 name)
  │    └── [presentation: name:16,popn_per_sqkm:22]
  │         ├── best: (project G2 G3 name)

--- a/pkg/sql/opt/xform/testdata/rules/join_order
+++ b/pkg/sql/opt/xform/testdata/rules/join_order
@@ -360,7 +360,7 @@ memo (optimized, ~25KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:
 memo set=reorder_joins_limit=2
 SELECT * FROM bx, cy, abc WHERE a = 1 AND abc.b = bx.b AND abc.c = cy.c
 ----
-memo (optimized, ~37KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
+memo (optimized, ~38KB, required=[presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (merge-join G2 G3 G8 inner-join,+1,+10) (merge-join G3 G2 G8 inner-join,+10,+1) (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12)) (merge-join G5 G6 G8 inner-join,+5,+11) (merge-join G6 G5 G8 inner-join,+11,+5) (lookup-join G6 G8 cy,keyCols=[11],outCols=(1,2,5,6,9-12))
  │    └── [presentation: b:1,x:2,c:5,y:6,a:9,b:10,c:11,d:12]
  │         ├── best: (lookup-join G3 G8 bx,keyCols=[10],outCols=(1,2,5,6,9-12))
@@ -527,7 +527,7 @@ inner-join (cross)
 memo set=reorder_joins_limit=0
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~32KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~33KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (merge-join G2 G3 G5 inner-join,+2,+6)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G2 G3 G4)
@@ -593,7 +593,7 @@ memo (optimized, ~32KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:
 memo set=reorder_joins_limit=3
 SELECT * FROM bx, cy, dz, abc WHERE x = y AND y = z AND z = a
 ----
-memo (optimized, ~69KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
+memo (optimized, ~74KB, required=[presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16])
  ├── G1: (inner-join G2 G3 G4) (inner-join G3 G2 G4) (inner-join G5 G6 G7) (inner-join G6 G5 G7) (inner-join G8 G9 G7) (inner-join G9 G8 G7) (inner-join G10 G11 G12) (inner-join G11 G10 G12) (inner-join G13 G14 G12) (inner-join G14 G13 G12) (inner-join G15 G16 G12) (inner-join G16 G15 G12) (inner-join G17 G18 G12) (inner-join G18 G17 G12) (merge-join G3 G2 G19 inner-join,+6,+2) (merge-join G6 G5 G19 inner-join,+10,+6) (merge-join G9 G8 G19 inner-join,+10,+6) (merge-join G11 G10 G19 inner-join,+13,+10) (merge-join G14 G13 G19 inner-join,+13,+10) (merge-join G16 G15 G19 inner-join,+13,+10) (lookup-join G17 G19 abc,keyCols=[10],outCols=(1,2,5,6,9,10,13-16)) (merge-join G18 G17 G19 inner-join,+13,+10)
  │    └── [presentation: b:1,x:2,c:5,y:6,d:9,z:10,a:13,b:14,c:15,d:16]
  │         ├── best: (inner-join G3 G2 G4)
@@ -2785,7 +2785,7 @@ SELECT (
 )
   FROM table80901_1 AS tab_42921;
 ----
-memo (optimized, ~73KB, required=[presentation: ?column?:50])
+memo (optimized, ~76KB, required=[presentation: ?column?:50])
  ├── G1: (project G2 G3)
  │    └── [presentation: ?column?:50]
  │         ├── best: (project G2 G3)
@@ -3642,7 +3642,7 @@ CREATE TABLE t146507 (
 memo disable=(SimplifySameVarEqualities,PushFilterIntoJoinLeft,HoistUnboundFilterFromExistsSubquery)
 SELECT a FROM t146507 AS t WHERE b IN (SELECT t.b FROM t146507 AS t2)
 ----
-memo (optimized, ~23KB, required=[presentation: a:1])
+memo (optimized, ~24KB, required=[presentation: a:1])
  ├── G1: (project G2 G3 a)
  │    └── [presentation: a:1]
  │         ├── best: (project G2 G3 a)

--- a/pkg/sql/opt/xform/testdata/rules/select
+++ b/pkg/sql/opt/xform/testdata/rules/select
@@ -9818,7 +9818,7 @@ select
 memo
 SELECT p,q,r,s FROM pqr WHERE q = 1 AND r = 1 AND s = 'foo'
 ----
-memo (optimized, ~42KB, required=[presentation: p:1,q:2,r:3,s:4])
+memo (optimized, ~43KB, required=[presentation: p:1,q:2,r:3,s:4])
  ├── G1: (select G2 G3) (select G4 G5) (select G6 G7) (select G8 G9) (select G10 G9) (lookup-join G11 G12 pqr,keyCols=[1],outCols=(1-4)) (zigzag-join G3 pqr@q pqr@s) (zigzag-join G3 pqr@q pqr@rs) (lookup-join G13 G9 pqr,keyCols=[1],outCols=(1-4))
  │    └── [presentation: p:1,q:2,r:3,s:4]
  │         ├── best: (zigzag-join G3 pqr@q pqr@s)
@@ -12003,7 +12003,7 @@ JOIN t61795 AS t2 ON t1.c = t1.b AND t1.b = t2.b
 WHERE t1.a = 10 OR t2.b != abs(t2.b)
 ORDER BY t1.b ASC
 ----
-memo (optimized, ~37KB, required=[presentation: a:1] [ordering: +2])
+memo (optimized, ~38KB, required=[presentation: a:1] [ordering: +2])
  ├── G1: (project G2 G3 a b)
  │    ├── [presentation: a:1] [ordering: +2]
  │    │    ├── best: (sort G1)


### PR DESCRIPTION
Previously, we calculated the selectivity of placeholder equality
filters, e.g., `x = $1`, using the distinct count of a column and total
row count. This represented an average-case selectivity.

Now, we instead estimate the worst-case selectivity using the maximum
frequency of the histogram of the constrained column. This helps avoid
choosing a generic query plan under `plan_cache_mode=auto` that performs
poorly for heavy-hitter placeholder values.

Fixes #151373
Informs #148703

Release note (performance improvement): The cost of generic query plans
is now calculated based on worst-case selectivities for placeholder
equalities (e.g., x = $1). This reduces the chance of suboptimal generic
query plans being chosen when `plan_cache_mode=auto`.
