### PR TITLE
release-25.3: sctest: decrease sampling rate for random BACKUPs

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -107,7 +107,7 @@ var runAllBackups = flag.Bool(
 	"if true, run all backups instead of a random subset",
 )
 
-const skipRate = .5
+const skipRate = .6
 
 func maybeRandomlySkip(t *testing.T) {
 	if !*runAllBackups && rand.Float64() < skipRate {


### PR DESCRIPTION
Backport 1/1 commits from #151356.

/cc @cockroachdb/release

---

We are seeing more package timeouts in this test, so to speed up the test, we will take fewer random BACKUPs.

fixes https://github.com/cockroachdb/cockroach/issues/149852
fixes https://github.com/cockroachdb/cockroach/issues/149391
fixes https://github.com/cockroachdb/cockroach/issues/149539

Release note: None

Release justification: test only change
