### PR TITLE
roachtest: fix tpcc/large-schema-benchmark load bug

### DIFF
--- a/pkg/workload/tpcc/tpcc_multi_db.go
+++ b/pkg/workload/tpcc/tpcc_multi_db.go
@@ -447,7 +447,7 @@ func (t *tpccMultiDB) Hooks() workload.Hooks {
 				if _, err := conn.ExecContext(ctx, "USE $1", dbName.Catalog()); err != nil {
 					return err
 				}
-				if _, err := db.ExecContext(ctx, fmt.Sprintf("SET search_path = %s", dbName.Schema())); err != nil {
+				if _, err := conn.ExecContext(ctx, fmt.Sprintf("SET search_path = %s", dbName.Schema())); err != nil {
 					return err
 				}
 				return t.tpcc.postLoadImpl(ctx, conn)


### PR DESCRIPTION
Previously, changes to optimize the post load process for the large schema benchmark had a bug where the search_path was being updated incorrectly on the connection pool. The code was intended to updated the search_path on the connection on the go routines. This patch fixes the incorrect behavior.

Fixes: #151285
Fixes: #151284
Fixes: #151283

Release note: None