### PR TITLE
allkeywords: replace switch with map in GetKeywordID

### DIFF
--- a/pkg/sql/lexbase/allkeywords/main.go
+++ b/pkg/sql/lexbase/allkeywords/main.go
@@ -107,18 +107,21 @@ var KeywordNames = []string{
 {{end -}}
 }
 
+var keywordID = map[string]int32{
+{{range . -}}
+	"{{.Keyword}}": {{.Ident}},
+{{end -}}
+}
+
 // GetKeywordID returns the lex id of the SQL keyword k or IDENT if k is
 // not a keyword.
+//
+//gcassert:inline
 func GetKeywordID(k string) int32 {
-	// The previous implementation generated a map that did a string ->
-	// id lookup. Various ideas were benchmarked and the implementation below
-	// was the fastest of those, between 3% and 10% faster (at parsing, so the
-	// scanning speedup is even more) than the map implementation.
-	switch k {
-	{{range . -}}
-	case "{{.Keyword}}": return {{.Ident}}
-	{{end -}}
-	default: return IDENT
+	id, ok := keywordID[k]
+	if !ok {
+		return IDENT
 	}
+	return id
 }
 `

--- a/pkg/testutils/lint/gcassert_paths.txt
+++ b/pkg/testutils/lint/gcassert_paths.txt
@@ -23,7 +23,9 @@ sql/colexec/colexecspan
 sql/colexec/colexecwindow
 sql/colfetcher
 sql/execinfrapb
+sql/lexbase
 sql/opt
+sql/plpgsql/parser/lexbase
 sql/row
 sql/sem/tree
 storage
@@ -33,6 +35,7 @@ util
 util/admission
 util/hlc
 util/intsets
+util/jsonpath/parser/lexbase
 util/mon
 util/num32
 util/vector

--- a/pkg/testutils/lint/lint_test.go
+++ b/pkg/testutils/lint/lint_test.go
@@ -2396,6 +2396,7 @@ func TestLint(t *testing.T) {
 				filter,
 				stream.GrepNot("sql/colexec/execgen/cmd/execgen/*"),
 				stream.GrepNot("sql/colexec/execgen/testdata/*"),
+				stream.GrepNot("sql/lexbase/allkeywords/main.go"),
 				stream.GrepNot("testutils/lint/lint_test.go"),
 			), func(s string) {
 				// s here is of the form


### PR DESCRIPTION
Long time ago in 74f630cc48078b3d9638814e8de9db7455df960b we switched the implementation of keyword ID lookup in lexer from the map to a large generated switch. At that time it was more performant, but with the new swiss table implementation of hash maps in Go I was curious to see whether the map approach is now faster, and it turns out to be so, so this commit switches back to the map lookup.

```
name                   old time/op    new time/op    delta
Parse/simple-8           12.4µs ± 0%    12.1µs ± 0%  -2.05%  (p=0.000 n=8+9)
Parse/string-8           18.2µs ± 0%    18.0µs ± 0%  -1.24%  (p=0.000 n=10+9)
Parse/tpcc-delivery-8    25.0µs ± 0%    24.5µs ± 0%  -1.73%  (p=0.000 n=10+10)
Parse/account-8          32.9µs ± 0%    32.2µs ± 0%  -2.14%  (p=0.000 n=10+10)

name                   old alloc/op   new alloc/op   delta
Parse/simple-8           3.56kB ± 0%    3.56kB ± 0%    ~     (all equal)
Parse/string-8           3.83kB ± 0%    3.83kB ± 0%    ~     (all equal)
Parse/tpcc-delivery-8    6.14kB ± 0%    6.14kB ± 0%    ~     (all equal)
Parse/account-8          11.2kB ± 0%    11.2kB ± 0%    ~     (all equal)

name                   old allocs/op  new allocs/op  delta
Parse/simple-8             22.0 ± 0%      22.0 ± 0%    ~     (all equal)
Parse/string-8             26.0 ± 0%      26.0 ± 0%    ~     (all equal)
Parse/tpcc-delivery-8      41.0 ± 0%      41.0 ± 0%    ~     (all equal)
Parse/account-8            75.0 ± 0%      75.0 ± 0%    ~     (all equal)
```

Epic: None
Release note: None