### PR TITLE
workflows: remove EOL 25.1 from update_releases.yaml

### DIFF
--- a/.github/workflows/update_releases.yaml
+++ b/.github/workflows/update_releases.yaml
@@ -30,7 +30,6 @@ jobs:
           - "release-23.2"
           - "release-24.1"
           - "release-24.3"
-          - "release-25.1"
           - "release-25.2"
           - "release-25.3"
     name: Update pkg/testutils/release/cockroach_releases.yaml on ${{ matrix.branch }}


### PR DESCRIPTION
Epic: None
Release note: None
Release justification: release-process only change