### PR TITLE
sql: de-flake TestUpsertFastPath due to write buffer max size

### DIFF
--- a/pkg/sql/upsert_test.go
+++ b/pkg/sql/upsert_test.go
@@ -89,6 +89,12 @@ func TestUpsertFastPath(t *testing.T) {
 		sqlDB := sqlutils.MakeSQLRunner(conn)
 		sqlDB.Exec(t, `CREATE DATABASE d`)
 		sqlDB.Exec(t, `CREATE TABLE d.kv (k INT PRIMARY KEY, v INT)`)
+		if bufferedWritesEnabled {
+			// The buffer size can be changed metamoprhically, and if it happens
+			// to be too small (200B or less), then the txn will flush the
+			// buffer, resulting in different KV requests.
+			sqlDB.Exec(t, `SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size = '250B';`)
+		}
 
 		// This should hit the fast path.
 		atomic.StoreUint64(&gets, 0)


### PR DESCRIPTION
When the txn write buffer size is too small, we'll flush it, violating the test expectations. Ensure a lower bound on the buffer size.

Fixes: #150632.
Release note: None