### PR TITLE
bench/rttanalysis: skip BenchmarkSystemDatabaseQueries

### DIFF
--- a/pkg/bench/rttanalysis/BUILD.bazel
+++ b/pkg/bench/rttanalysis/BUILD.bazel
@@ -67,6 +67,7 @@ go_test(
         "//pkg/server/serverpb",
         "//pkg/testutils/pgurlutils",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/testutils/testcluster",
         "//pkg/util/protoutil",
         "//pkg/util/randutil",

--- a/pkg/bench/rttanalysis/system_bench_test.go
+++ b/pkg/bench/rttanalysis/system_bench_test.go
@@ -5,9 +5,17 @@
 
 package rttanalysis
 
-import "testing"
+import (
+	"testing"
 
-func BenchmarkSystemDatabaseQueries(b *testing.B) { reg.Run(b) }
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+)
+
+func BenchmarkSystemDatabaseQueries(b *testing.B) {
+	skip.UnderShort(b, "skipping long benchmark")
+	reg.Run(b)
+}
+
 func init() {
 	reg.Register("SystemDatabaseQueries", []RoundTripBenchTestCase{
 		// This query performs 1-2 lookups: getting the descriptor ID by Name, then


### PR DESCRIPTION
Previously, this benchmark was included in CI runs and would take more than 20 minutes to complete a single iteration (--bench-time=1s --count=1).

This is because the benchmark aims for a measured runtime of 1 second, but the unmeasured operations within each iteration take over 20 minutes combined to reach that target.

This change skips the benchmark in CI runs.

Fixes: #151298

Epic: None
Release note: None