### PR TITLE
release-25.3: colexecerror: improve BenchmarkSQLCatchVectorizedRuntimeError

### DIFF
--- a/pkg/sql/colexecerror/error_test.go
+++ b/pkg/sql/colexecerror/error_test.go
@@ -184,7 +184,7 @@ func BenchmarkSQLCatchVectorizedRuntimeError(b *testing.B) {
 	// crdb_test-build behavior.
 	defer colexecerror.ProductionBehaviorForTests()()
 
-	for _, parallelism := range []int{1, 20, 50} {
+	for _, parallelism := range []int{1, 8, 32} {
 		numConns := runtime.GOMAXPROCS(0) * parallelism
 		b.Run(fmt.Sprintf("conns=%d", numConns), func(b *testing.B) {
 			for _, tc := range cases {
@@ -209,6 +209,7 @@ func BenchmarkSQLCatchVectorizedRuntimeError(b *testing.B) {
 						var conn *gosql.DB
 						select {
 						case conn = <-conns:
+							defer conn.Close()
 						default:
 							b.Fatal("not enough warm connections")
 						}


### PR DESCRIPTION
Backport 1/1 commits from #151447 on behalf of @yuzefovich.

----

Previously, this benchmark when run with `conns=50` parameter would often hit errors seemingly due to port exhaustion. This was the case since the benchmark opens a ton of connections, but they would only be closed on the server shutdown. This commit fixes that issue by explicitly closing the connection from each worker goroutine once the worker is done with it.

Additionally, it reduces the conns parameters from 20 and 50 to 8 and 32 in order to speed up the benchmark overall (total time on gceworker went down from 375s to 231s).

Fixes: #124021.
Fixes: #151297.

Release note: None

----

Release justification: test-only change.