### PR TITLE
release-25.2: sql/ttl: improve TTL replan decision logic

### DIFF
--- a/pkg/cmd/roachtest/tests/ttl_restart.go
+++ b/pkg/cmd/roachtest/tests/ttl_restart.go
@@ -53,6 +53,11 @@ const jobCheckSQL = `
   ORDER BY created DESC LIMIT 1
 `
 
+const (
+	maxRetryAttempts = 5
+	ttlJobWaitTime   = 8 * time.Minute
+)
+
 type ttlJobInfo struct {
 	JobID          int
 	CoordinatorID  int
@@ -88,112 +93,80 @@ func runTTLRestart(ctx context.Context, t test.Test, c cluster.Cluster, numResta
 		db := c.Conn(ctx, t.L(), 1)
 		defer db.Close()
 
-		t.Status("create the table")
-		setup := []string{
-			// Speed up the test by doing the replan check often and with a low threshold.
-			"SET CLUSTER SETTING sql.ttl.replan_flow_frequency = '15s'",
-			"SET CLUSTER SETTING sql.ttl.replan_flow_threshold = '0.1'",
-			// Disable the stability window to ensure immediate replanning on node changes.
-			"SET CLUSTER SETTING sql.ttl.replan_stability_window = 1",
-			// Add additional logging to help debug the test on failure.
-			"SET CLUSTER SETTING server.debug.default_vmodule = 'ttljob_processor=1,distsql_plan_bulk=1'",
-			// Create the schema to be used in the test
-			"CREATE DATABASE IF NOT EXISTS ttldb",
-			"CREATE TABLE IF NOT EXISTS ttldb.tab1 (pk INT8 NOT NULL PRIMARY KEY, ts TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP)",
-		}
-		for _, stmt := range setup {
-			if _, err := db.ExecContext(ctx, stmt); err != nil {
-				return errors.Wrapf(err, "error with statement: %s", stmt)
-			}
+		// Determine how many nodes we need TTL activity on based on restart scenario
+		requiredTTLNodes := 3 // Default for numRestartNodes=1
+		if numRestartNodes == 2 {
+			requiredTTLNodes = 2
 		}
 
-		t.Status("add manual splits so that ranges are distributed evenly across the cluster")
-		if _, err := db.ExecContext(ctx, "ALTER TABLE ttldb.tab1 SPLIT AT VALUES (6000), (12000)"); err != nil {
-			return errors.Wrapf(err, "error adding manual splits")
-		}
-
-		t.Status("insert data")
-		if _, err := db.ExecContext(ctx, "INSERT INTO ttldb.tab1 (pk) SELECT generate_series(1, 18000)"); err != nil {
-			return errors.Wrapf(err, "error ingesting data")
-		}
-
-		t.Status("relocate ranges to distribute across nodes")
-		// Moving ranges is put under a SucceedsSoon to account for errors like:
-		// "lease target replica not found in RangeDescriptor"
-		testutils.SucceedsSoon(t, func() error { return distributeLeases(ctx, t, db) })
-		leases, err := gatherLeaseDistribution(ctx, t, db)
-		if err != nil {
-			return errors.Wrapf(err, "error gathering lease distribution")
-		}
-		showLeaseDistribution(t, leases)
-
-		t.Status("enable TTL")
-		ts := db.QueryRowContext(ctx, "SELECT EXTRACT(HOUR FROM now() + INTERVAL '2 minutes') AS hour, EXTRACT(MINUTE FROM now() + INTERVAL '2 minutes') AS minute")
-		var hour, minute int
-		if err := ts.Scan(&hour, &minute); err != nil {
-			return errors.Wrapf(err, "error generating cron expression")
-		}
-		ttlCronExpression := fmt.Sprintf("%d %d * * *", minute, hour)
-		t.L().Printf("using a cron expression of '%s'", ttlCronExpression)
-		ttlJobSettingSQL := fmt.Sprintf(`ALTER TABLE ttldb.tab1
-			SET (ttl_expiration_expression = $$(ts::timestamptz + '1 minutes')$$,
-           ttl_select_batch_size=100,
-           ttl_delete_batch_size=100,
-           ttl_select_rate_limit=100,
-           ttl_job_cron='%s')`,
-			ttlCronExpression)
-		if _, err := db.ExecContext(ctx, ttlJobSettingSQL); err != nil {
-			return errors.Wrapf(err, "error setting TTL attributes")
-		}
-
-		t.Status("wait for the TTL job to start")
 		var jobInfo ttlJobInfo
-		waitForTTLJob := func() error {
-			var err error
-			jobInfo, err = findRunningJob(ctx, t, c, db, nil,
-				false /* expectJobRestart */, false /* allowJobSucceeded */)
-			return err
-		}
-		// The ttl job is scheduled to run in about 2 minutes. Wait for a little
-		// while longer to give the job system enough time to start the job in case
-		// the system is slow.
-		testutils.SucceedsWithin(t, waitForTTLJob, 8*time.Minute)
-		t.L().Printf("TTL job (ID %d) is running at node %d", jobInfo.JobID, jobInfo.CoordinatorID)
-		// Reset the connection so that we query from the coordinator as this is the
-		// only node that will stay up.
-		if err := db.Close(); err != nil {
-			return errors.Wrapf(err, "error closing connection")
-		}
-		db = c.Conn(ctx, t.L(), jobInfo.CoordinatorID)
+		var ttlNodes map[int]struct{}
 
-		t.Status("wait for TTL deletions to start happening")
-		// Take baseline once and reuse it for all progress checks
-		baseline, err := takeProgressBaseline(ctx, t, db)
-		if err != nil {
-			return errors.Wrapf(err, "error taking TTL progress baseline")
-		}
-		waitForTTLProgressAcrossAllNodes := func() error {
-			if err := checkTTLProgressAgainstBaseline(ctx, db, baseline); err != nil {
-				return errors.Wrapf(err, "error waiting for TTL progress after restart")
+		// Retry loop: attempt to setup table and get proper TTL distribution
+		for attempt := 1; attempt <= maxRetryAttempts; attempt++ {
+			if attempt > 1 {
+				t.L().Printf("Attempt %d/%d: Retrying table setup due to insufficient TTL distribution", attempt, maxRetryAttempts)
 			}
-			return nil
+
+			// Setup table and data
+			if err := setupTableAndData(ctx, t, db); err != nil {
+				return err
+			}
+
+			// Enable TTL and wait for job to start
+			var err error
+			jobInfo, err = enableTTLAndWaitForJob(ctx, t, c, db)
+			if err != nil {
+				return err
+			}
+
+			// Reset the connection so that we query from the coordinator as this is the
+			// only node that will stay up.
+			if err := db.Close(); err != nil {
+				return errors.Wrapf(err, "error closing connection")
+			}
+			db = c.Conn(ctx, t.L(), jobInfo.CoordinatorID)
+
+			t.Status("check TTL activity distribution across nodes")
+			err = testutils.SucceedsWithinError(func() error {
+				var err error
+				ttlNodes, err = findNodesWithJobLogs(ctx, t, c, jobInfo.JobID)
+				if err != nil {
+					return err
+				}
+				if len(ttlNodes) < requiredTTLNodes {
+					return errors.Newf("TTL activity found on only %d nodes (need %d)", len(ttlNodes), requiredTTLNodes)
+				}
+				return nil
+			}, 1*time.Minute)
+
+			if err == nil {
+				// Success! TTL is distributed across enough nodes
+				t.L().Printf("TTL job %d found on nodes: %v", jobInfo.JobID, ttlNodes)
+				break
+			}
+
+			// Handle the error
+			if ttlNodes != nil && len(ttlNodes) < requiredTTLNodes {
+				t.L().Printf("Attempt %d/%d: TTL job %d found on nodes: %v", attempt, maxRetryAttempts, jobInfo.JobID, ttlNodes)
+				t.L().Printf("Attempt %d/%d: TTL activity found on only %d nodes (need %d)", attempt, maxRetryAttempts, len(ttlNodes), requiredTTLNodes)
+
+				if attempt == maxRetryAttempts {
+					// Final attempt failed - exit successfully as current behavior
+					t.L().Printf("After %d attempts, TTL activity found on only %d nodes (need %d for restart test). Test completed successfully.", maxRetryAttempts, len(ttlNodes), requiredTTLNodes)
+					return nil
+				}
+				// Continue to next attempt
+				continue
+			}
+
+			// Other error that's not related to TTL distribution
+			return errors.Wrapf(err, "error waiting for TTL activity distribution")
 		}
-		testutils.SucceedsWithin(t, waitForTTLProgressAcrossAllNodes, 1*time.Minute)
 
 		t.Status("stop non-coordinator nodes")
 		nonCoordinatorCount := c.Spec().NodeCount - 1
 		stoppingAllNonCoordinators := numRestartNodes == nonCoordinatorCount
-		var ttlNodes map[int]struct{}
-		if !stoppingAllNonCoordinators {
-			// We need to stop a node that actually executed part of the TTL job.
-			// Relying on SQL isn't fully reliable due to potential cache staleness.
-			// Instead, we scan cockroach.log files for known TTL job log markers to
-			// identify nodes that were truly involved in the job execution.
-			ttlNodes, err = findNodesWithJobLogs(ctx, t, c, jobInfo.JobID)
-			if err != nil {
-				return errors.Wrapf(err, "error finding nodes with job logs")
-			}
-		}
 		stoppedNodes := make([]int, 0)
 		for node := 1; node <= c.Spec().NodeCount && len(stoppedNodes) < numRestartNodes; node++ {
 			if node == jobInfo.CoordinatorID {
@@ -214,6 +187,7 @@ func runTTLRestart(ctx context.Context, t test.Test, c cluster.Cluster, numResta
 
 		// If we haven't lost quorum, then the TTL job should restart and continue
 		// working before restarting the down nodes.
+		var err error
 		if numRestartNodes <= c.Spec().NodeCount/2 {
 			t.Status("ensure TTL job restarts")
 			testutils.SucceedsWithin(t, func() error {
@@ -315,108 +289,6 @@ func distributeLeases(ctx context.Context, t test.Test, db *gosql.DB) error {
 	}
 	return nil
 
-}
-
-// takeProgressBaseline captures the initial key counts for each range and its leaseholder.
-// This baseline will be used later to check if TTL progress is being made.
-func takeProgressBaseline(
-	ctx context.Context, t test.Test, db *gosql.DB,
-) (map[int]map[int]int, error) {
-	query := `
-		WITH r AS (
-			SHOW RANGES FROM TABLE ttldb.tab1 WITH DETAILS
-		)
-		SELECT
-		  range_id,
-			lease_holder,
-			count(*) AS key_count
-		FROM
-			r,
-			LATERAL crdb_internal.list_sql_keys_in_range(range_id)
-		GROUP BY
-		  range_id,
-			lease_holder
-		ORDER BY
-		  range_id`
-
-	// Map of leaseholder -> rangeID -> keyCount
-	baseline := make(map[int]map[int]int)
-
-	rows, err := db.QueryContext(ctx, query)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var rangeID, leaseHolder, keyCount int
-		if err := rows.Scan(&rangeID, &leaseHolder, &keyCount); err != nil {
-			return nil, err
-		}
-		if _, ok := baseline[leaseHolder]; !ok {
-			baseline[leaseHolder] = make(map[int]int)
-		}
-		baseline[leaseHolder][rangeID] = keyCount
-	}
-
-	return baseline, nil
-}
-
-// checkTTLProgressAgainstBaseline checks if each leaseholder has made progress
-// on at least one of their original ranges compared to the provided baseline.
-func checkTTLProgressAgainstBaseline(
-	ctx context.Context, db *gosql.DB, baseline map[int]map[int]int,
-) error {
-	query := `
-		WITH r AS (
-			SHOW RANGES FROM TABLE ttldb.tab1 WITH DETAILS
-		)
-		SELECT
-		  range_id,
-			lease_holder,
-			count(*) AS key_count
-		FROM
-			r,
-			LATERAL crdb_internal.list_sql_keys_in_range(range_id)
-		GROUP BY
-		  range_id,
-			lease_holder
-		ORDER BY
-		  range_id`
-
-	current := make(map[int]int) // rangeID -> keyCount
-
-	rows, err := db.QueryContext(ctx, query)
-	if err != nil {
-		return err
-	}
-	defer rows.Close()
-
-	for rows.Next() {
-		var rangeID, leaseHolder, keyCount int
-		if err := rows.Scan(&rangeID, &leaseHolder, &keyCount); err != nil {
-			return err
-		}
-		current[rangeID] = keyCount
-	}
-
-	for leaseHolder, ranges := range baseline {
-		madeProgress := false
-		for rangeID, oldCount := range ranges {
-			newCount, ok := current[rangeID]
-			if !ok {
-				return errors.Newf("range %d (from leaseholder %d) not found in follow-up check", rangeID, leaseHolder)
-			}
-			if newCount < oldCount {
-				madeProgress = true
-			}
-		}
-		if !madeProgress {
-			return errors.Newf("leaseholder %d made no progress on any of their original ranges", leaseHolder)
-		}
-	}
-
-	return nil
 }
 
 // findRunningJob checks the current state of the TTL job and returns metadata
@@ -526,7 +398,96 @@ func findNodesWithJobLogs(
 		nodeList = append(nodeList, node)
 	}
 	sort.Ints(nodeList)
-	t.L().Printf("TTL job %d found on nodes: %v", jobID, nodeList)
 
 	return nodesWithJob, nil
+}
+
+// setupTableAndData creates the ttldb database and tab1 table, inserts data,
+// and distributes ranges across nodes. This function can be called multiple
+// times to recreate the table for retry scenarios.
+func setupTableAndData(ctx context.Context, t test.Test, db *gosql.DB) error {
+	t.Status("create/recreate the table")
+	setup := []string{
+		// Speed up the test by doing the replan check often and with a low threshold.
+		"SET CLUSTER SETTING sql.ttl.replan_flow_frequency = '15s'",
+		"SET CLUSTER SETTING sql.ttl.replan_flow_threshold = '0.1'",
+		// Disable the stability window to ensure immediate replanning on node changes.
+		"SET CLUSTER SETTING sql.ttl.replan_stability_window = 1",
+		// Add additional logging to help debug the test on failure.
+		"SET CLUSTER SETTING server.debug.default_vmodule = 'ttljob_processor=1,distsql_plan_bulk=1'",
+		// Drop existing table if it exists
+		"DROP TABLE IF EXISTS ttldb.tab1",
+		// Create the schema to be used in the test
+		"CREATE DATABASE IF NOT EXISTS ttldb",
+		"CREATE TABLE IF NOT EXISTS ttldb.tab1 (pk INT8 NOT NULL PRIMARY KEY, ts TIMESTAMP NOT NULL DEFAULT now():::TIMESTAMP)",
+	}
+	for _, stmt := range setup {
+		if _, err := db.ExecContext(ctx, stmt); err != nil {
+			return errors.Wrapf(err, "error with statement: %s", stmt)
+		}
+	}
+
+	t.Status("add manual splits so that ranges are distributed evenly across the cluster")
+	if _, err := db.ExecContext(ctx, "ALTER TABLE ttldb.tab1 SPLIT AT VALUES (6000), (12000)"); err != nil {
+		return errors.Wrapf(err, "error adding manual splits")
+	}
+
+	t.Status("insert data")
+	if _, err := db.ExecContext(ctx, "INSERT INTO ttldb.tab1 (pk) SELECT generate_series(1, 18000)"); err != nil {
+		return errors.Wrapf(err, "error ingesting data")
+	}
+
+	t.Status("relocate ranges to distribute across nodes")
+	// Moving ranges is put under a SucceedsSoon to account for errors like:
+	// "lease target replica not found in RangeDescriptor"
+	testutils.SucceedsSoon(t, func() error { return distributeLeases(ctx, t, db) })
+	leases, err := gatherLeaseDistribution(ctx, t, db)
+	if err != nil {
+		return errors.Wrapf(err, "error gathering lease distribution")
+	}
+	showLeaseDistribution(t, leases)
+
+	return nil
+}
+
+// enableTTLAndWaitForJob enables TTL on the table with a cron expression
+// set to run in about 2 minutes, then waits for the job to start.
+func enableTTLAndWaitForJob(
+	ctx context.Context, t test.Test, c cluster.Cluster, db *gosql.DB,
+) (ttlJobInfo, error) {
+	var jobInfo ttlJobInfo
+
+	t.Status("enable TTL")
+	ts := db.QueryRowContext(ctx, "SELECT EXTRACT(HOUR FROM now() + INTERVAL '2 minutes') AS hour, EXTRACT(MINUTE FROM now() + INTERVAL '2 minutes') AS minute")
+	var hour, minute int
+	if err := ts.Scan(&hour, &minute); err != nil {
+		return jobInfo, errors.Wrapf(err, "error generating cron expression")
+	}
+	ttlCronExpression := fmt.Sprintf("%d %d * * *", minute, hour)
+	t.L().Printf("using a cron expression of '%s'", ttlCronExpression)
+	ttlJobSettingSQL := fmt.Sprintf(`ALTER TABLE ttldb.tab1
+		SET (ttl_expiration_expression = $$(ts::timestamptz + '1 minutes')$$,
+          ttl_select_batch_size=100,
+          ttl_delete_batch_size=100,
+          ttl_select_rate_limit=100,
+          ttl_job_cron='%s')`,
+		ttlCronExpression)
+	if _, err := db.ExecContext(ctx, ttlJobSettingSQL); err != nil {
+		return jobInfo, errors.Wrapf(err, "error setting TTL attributes")
+	}
+
+	t.Status("wait for the TTL job to start")
+	waitForTTLJob := func() error {
+		var err error
+		jobInfo, err = findRunningJob(ctx, t, c, db, nil,
+			false /* expectJobRestart */, false /* allowJobSucceeded */)
+		return err
+	}
+	// The ttl job is scheduled to run in about 2 minutes. Wait for a little
+	// while longer to give the job system enough time to start the job in case
+	// the system is slow.
+	testutils.SucceedsWithin(t, waitForTTLJob, ttlJobWaitTime)
+	t.L().Printf("TTL job (ID %d) is running at node %d", jobInfo.JobID, jobInfo.CoordinatorID)
+
+	return jobInfo, nil
 }

--- a/pkg/sql/ttl/ttljob/BUILD.bazel
+++ b/pkg/sql/ttl/ttljob/BUILD.bazel
@@ -63,6 +63,7 @@ go_test(
     size = "large",
     srcs = [
         "main_test.go",
+        "ttljob_internal_test.go",
         "ttljob_plans_test.go",
         "ttljob_processor_internal_test.go",
         "ttljob_processor_test.go",
@@ -100,6 +101,7 @@ go_test(
         "//pkg/sql/isql",
         "//pkg/sql/lexbase",
         "//pkg/sql/parser",
+        "//pkg/sql/physicalplan",
         "//pkg/sql/randgen",
         "//pkg/sql/rowenc",
         "//pkg/sql/sem/eval",

--- a/pkg/sql/ttl/ttljob/ttljob.go
+++ b/pkg/sql/ttl/ttljob/ttljob.go
@@ -7,6 +7,7 @@ package ttljob
 
 import (
 	"context"
+	"sync/atomic"
 	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -50,6 +51,14 @@ var replanFrequency = settings.RegisterDurationSetting(
 	settings.PositiveDuration,
 )
 
+var replanStabilityWindow = settings.RegisterIntSetting(
+	settings.ApplicationLevel,
+	"sql.ttl.replan_stability_window",
+	"number of consecutive replan evaluations required before triggering a replan; set to 1 to disable stability window",
+	2,
+	settings.PositiveInt,
+)
+
 // rowLevelTTLResumer implements the TTL job. The job can run on any node, but
 // the job node distributes SELECT/DELETE work via DistSQL to ttlProcessor
 // nodes. DistSQL divides work into spans that each ttlProcessor scans in a
@@ -57,6 +66,9 @@ var replanFrequency = settings.RegisterDurationSetting(
 type rowLevelTTLResumer struct {
 	job *jobs.Job
 	st  *cluster.Settings
+
+	// consecutiveReplanDecisions tracks how many consecutive times replan was deemed necessary.
+	consecutiveReplanDecisions *atomic.Int64
 }
 
 var _ jobs.Resumer = (*rowLevelTTLResumer)(nil)
@@ -283,7 +295,10 @@ func (t rowLevelTTLResumer) Resume(ctx context.Context, execCtx interface{}) (re
 	// the TTL job to utilize those nodes for parallel work.
 	replanChecker, cancelReplanner := sql.PhysicalPlanChangeChecker(
 		ctx, physicalPlan, makePlan, jobExecCtx,
-		sql.ReplanOnChangedFraction(func() float64 { return replanThreshold.Get(&execCfg.Settings.SV) }),
+		replanDecider(t.consecutiveReplanDecisions,
+			func() int64 { return replanStabilityWindow.Get(&execCfg.Settings.SV) },
+			func() float64 { return replanThreshold.Get(&execCfg.Settings.SV) },
+		),
 		func() time.Duration { return replanFrequency.Get(&execCfg.Settings.SV) },
 	)
 
@@ -351,11 +366,91 @@ func (t rowLevelTTLResumer) CollectProfile(_ context.Context, _ interface{}) err
 	return nil
 }
 
+// replanDecider returns a function that determines whether a TTL job should be
+// replanned based on changes in the physical execution plan. It compares the
+// old and new plans to detect node availability changes and decides if the
+// benefit of replanning (better parallelization) outweighs the cost of
+// restarting the job. It implements a stability window to avoid replanning
+// due to transient changes.
+func replanDecider(
+	consecutiveReplanDecisions *atomic.Int64,
+	stabilityWindowFn func() int64,
+	thresholdFn func() float64,
+) sql.PlanChangeDecision {
+	return func(ctx context.Context, oldPlan, newPlan *sql.PhysicalPlan) bool {
+		changed, growth := detectNodeAvailabilityChanges(oldPlan, newPlan)
+		threshold := thresholdFn()
+		shouldReplan := threshold != 0.0 && growth > threshold
+
+		stabilityWindow := stabilityWindowFn()
+
+		var currentDecisions int64
+		if shouldReplan {
+			currentDecisions = consecutiveReplanDecisions.Add(1)
+		} else {
+			consecutiveReplanDecisions.Store(0)
+			currentDecisions = 0
+		}
+
+		// If stability window is 1, replan immediately. Otherwise, require
+		// consecutive decisions to meet the window threshold.
+		replan := currentDecisions >= stabilityWindow
+
+		// Reset the counter when we decide to replan, since the job will restart
+		if replan {
+			consecutiveReplanDecisions.Store(0)
+		}
+
+		if shouldReplan || growth > 0.1 || log.V(1) {
+			log.Infof(ctx, "Re-planning would add or alter flows on %d nodes / %.2f, threshold %.2f, consecutive decisions %d/%d, replan %v",
+				changed, growth, threshold, currentDecisions, stabilityWindow, replan)
+		}
+
+		return replan
+	}
+}
+
+// detectNodeAvailabilityChanges analyzes differences between two physical plans
+// to determine if nodes have become unavailable. It returns the number of nodes
+// that are no longer available and the fraction of the original plan affected.
+//
+// The function focuses on detecting when nodes from the original plan are missing
+// from the new plan, which typically indicates node failures. When nodes fail,
+// their work gets redistributed to remaining nodes, making a job restart
+// beneficial for better parallelization. We ignore newly added nodes since
+// continuing the current job on existing nodes is usually more efficient than
+// restarting to incorporate new capacity.
+func detectNodeAvailabilityChanges(before, after *sql.PhysicalPlan) (int, float64) {
+	var changed int
+	beforeSpecs, beforeCleanup := before.GenerateFlowSpecs()
+	defer beforeCleanup(beforeSpecs)
+	afterSpecs, afterCleanup := after.GenerateFlowSpecs()
+	defer afterCleanup(afterSpecs)
+
+	// Count nodes from the original plan that are no longer present in the new plan.
+	// We only check nodes in beforeSpecs because we specifically want to detect
+	// when nodes that were doing work are no longer available, which typically
+	// indicates beneficial restart scenarios (node failures where work can be
+	// redistributed more efficiently).
+	for n := range beforeSpecs {
+		if _, ok := afterSpecs[n]; !ok {
+			changed++
+		}
+	}
+
+	var frac float64
+	if changed > 0 {
+		frac = float64(changed) / float64(len(beforeSpecs))
+	}
+	return changed, frac
+}
+
 func init() {
 	jobs.RegisterConstructor(jobspb.TypeRowLevelTTL, func(job *jobs.Job, settings *cluster.Settings) jobs.Resumer {
 		return &rowLevelTTLResumer{
-			job: job,
-			st:  settings,
+			job:                        job,
+			st:                         settings,
+			consecutiveReplanDecisions: &atomic.Int64{},
 		}
 	}, jobs.UsesTenantCostControl)
 }

--- a/pkg/sql/ttl/ttljob/ttljob_internal_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_internal_test.go
@@ -1,0 +1,214 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package ttljob
+
+import (
+	"context"
+	"sync/atomic"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/physicalplan"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+// NOTE: This test is for functions in ttljob.go. We already have
+// ttljob_test.go, but that is part of the ttljob_test package. This test is
+// specifically part of the ttljob package to access non-exported functions and
+// structs. Hence, the name '_internal_' in the file to signify that it accesses
+// internal functions.
+
+func TestReplanDecider(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		desc         string
+		beforeNodes  []base.SQLInstanceID
+		afterNodes   []base.SQLInstanceID
+		threshold    float64
+		expectReplan bool
+	}{
+		{
+			desc:         "nodes don't change",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3},
+			afterNodes:   []base.SQLInstanceID{1, 2, 3},
+			threshold:    0.1,
+			expectReplan: false,
+		},
+		{
+			desc:         "one node is shutdown",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3},
+			afterNodes:   []base.SQLInstanceID{1, 3},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+		{
+			desc:         "one node is brought online",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3},
+			afterNodes:   []base.SQLInstanceID{1, 2, 3, 4},
+			threshold:    0.1,
+			expectReplan: false,
+		},
+		{
+			desc:         "one node is replaced",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3},
+			afterNodes:   []base.SQLInstanceID{1, 2, 4},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+		{
+			desc:         "multiple nodes shutdown",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3, 4, 5},
+			afterNodes:   []base.SQLInstanceID{1, 3},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+		{
+			desc:         "all nodes replaced",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3},
+			afterNodes:   []base.SQLInstanceID{4, 5, 6},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+		{
+			desc:         "threshold boundary: exactly at threshold",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			afterNodes:   []base.SQLInstanceID{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			threshold:    0.1,
+			expectReplan: false,
+		},
+		{
+			desc:         "threshold boundary: just above threshold",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3, 4, 5, 6, 7, 8, 9},
+			afterNodes:   []base.SQLInstanceID{1, 2, 3, 4, 5, 6, 7, 8},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+		{
+			desc:         "threshold disabled",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3},
+			afterNodes:   []base.SQLInstanceID{1, 2},
+			threshold:    0.0,
+			expectReplan: false,
+		},
+		{
+			desc:         "large scale: many nodes lost",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15, 16, 17, 18, 19, 20},
+			afterNodes:   []base.SQLInstanceID{1, 2, 3, 4, 5, 6, 7, 8, 9, 10},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+		{
+			desc:         "mixed scenario: nodes added and removed",
+			beforeNodes:  []base.SQLInstanceID{1, 2, 3, 4, 5},
+			afterNodes:   []base.SQLInstanceID{1, 3, 5, 6, 7, 8},
+			threshold:    0.1,
+			expectReplan: true,
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			// Create atomic counter and set stability window to 1 for immediate replan (current behavior)
+			consecutiveReplanDecisions := &atomic.Int64{}
+			decider := replanDecider(consecutiveReplanDecisions, func() int64 { return 1 }, func() float64 { return testCase.threshold })
+			ctx := context.Background()
+			oldPlan := &sql.PhysicalPlan{}
+			oldPlan.PhysicalInfrastructure = &physicalplan.PhysicalInfrastructure{Processors: nil}
+			for _, nodeID := range testCase.beforeNodes {
+				oldPlan.Processors = append(oldPlan.Processors, physicalplan.Processor{SQLInstanceID: nodeID})
+			}
+			newPlan := &sql.PhysicalPlan{}
+			newPlan.PhysicalInfrastructure = &physicalplan.PhysicalInfrastructure{Processors: nil}
+			for _, nodeID := range testCase.afterNodes {
+				newPlan.Processors = append(newPlan.Processors, physicalplan.Processor{SQLInstanceID: nodeID})
+			}
+			replan := decider(ctx, oldPlan, newPlan)
+			require.Equal(t, testCase.expectReplan, replan)
+		})
+	}
+}
+
+func TestReplanDeciderStabilityWindow(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testCases := []struct {
+		desc            string
+		stabilityWindow int64
+		threshold       float64
+		planChanges     [][]base.SQLInstanceID // sequence of plan changes
+		expectedReplans []bool                 // expected replan decision for each change
+	}{
+		{
+			desc:            "stability window 1 - immediate replan",
+			stabilityWindow: 1,
+			threshold:       0.1,
+			planChanges:     [][]base.SQLInstanceID{{2, 3}, {2, 4}, {3, 4}},
+			expectedReplans: []bool{true, true, true},
+		},
+		{
+			desc:            "stability window 2 - requires consecutive decisions",
+			stabilityWindow: 2,
+			threshold:       0.1,
+			planChanges:     [][]base.SQLInstanceID{{2, 3}, {2, 4}, {1, 2, 3}},
+			expectedReplans: []bool{false, true, false}, // first false, second true (meets window), third false (reset)
+		},
+		{
+			desc:            "stability window 2 - interrupted sequence",
+			stabilityWindow: 2,
+			threshold:       0.1,
+			planChanges:     [][]base.SQLInstanceID{{2, 3}, {1, 2, 3}, {2, 4}, {3, 4}},
+			expectedReplans: []bool{false, false, false, true}, // interrupted, then consecutive
+		},
+		{
+			desc:            "stability window 3 - three consecutive needed",
+			stabilityWindow: 3,
+			threshold:       0.1,
+			planChanges:     [][]base.SQLInstanceID{{2, 3}, {2, 4}, {3, 4}, {1, 2, 3}},
+			expectedReplans: []bool{false, false, true, false}, // third one triggers replan
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.desc, func(t *testing.T) {
+			consecutiveReplanDecisions := &atomic.Int64{}
+			decider := replanDecider(
+				consecutiveReplanDecisions,
+				func() int64 { return testCase.stabilityWindow },
+				func() float64 { return testCase.threshold },
+			)
+			ctx := context.Background()
+
+			// Use initial plan with nodes 1,2,3
+			initialPlan := &sql.PhysicalPlan{}
+			initialPlan.PhysicalInfrastructure = &physicalplan.PhysicalInfrastructure{Processors: nil}
+			for _, nodeID := range []base.SQLInstanceID{1, 2, 3} {
+				initialPlan.Processors = append(initialPlan.Processors, physicalplan.Processor{SQLInstanceID: nodeID})
+			}
+
+			for i, nodes := range testCase.planChanges {
+				newPlan := &sql.PhysicalPlan{}
+				newPlan.PhysicalInfrastructure = &physicalplan.PhysicalInfrastructure{Processors: nil}
+				for _, nodeID := range nodes {
+					newPlan.Processors = append(newPlan.Processors, physicalplan.Processor{SQLInstanceID: nodeID})
+				}
+
+				replan := decider(ctx, initialPlan, newPlan)
+				if replan != testCase.expectedReplans[i] {
+					t.Errorf("step %d: expected replan=%v, got %v (consecutive count: %d)", i, testCase.expectedReplans[i], replan, consecutiveReplanDecisions.Load())
+				}
+
+				// Update initial plan for next iteration to maintain state
+				initialPlan = newPlan
+			}
+		})
+	}
+}


### PR DESCRIPTION
Backport:
  * 1/1 commits from "sql/ttl: improve TTL replan decision logic" (#150771)
  * 1/1 commits from "roachtest/ttl: fix TTL restart test flakiness" (#151063)
  * 1/1 commits from "roachtest/ttl-restart: make test robust to lease placement variability" (#151323)

Please see individual PRs for details.

/cc @cockroachdb/release

Release justification: bug fix that was hit by a customer