### PR TITLE
server: fix potential nil pointer when starting flight recorder

### DIFF
--- a/pkg/server/env_sampler.go
+++ b/pkg/server/env_sampler.go
@@ -161,10 +161,11 @@ func startSampleEnvironment(
 	simpleFlightRecorder, err := goexectrace.NewFlightRecorder(cfg.st, 10*time.Second, cfg.executionTraceDirName)
 	if err != nil {
 		log.Warningf(ctx, "failed to initialize flight recorder: %v", err)
-	}
-	err = simpleFlightRecorder.Start(ctx, cfg.stopper)
-	if err != nil {
-		log.Warningf(ctx, "failed to start flight recorder: %v", err)
+	} else {
+		err = simpleFlightRecorder.Start(ctx, cfg.stopper)
+		if err != nil {
+			log.Warningf(ctx, "failed to start flight recorder: %v", err)
+		}
 	}
 
 	return cfg.stopper.RunAsyncTaskEx(ctx,


### PR DESCRIPTION
When the flightt recorder constructor returns an error in `NewFlightRecorder`, we should make sure not to call `Start`.

Epic: None
Release note: None