### PR TITLE
roachtest: Skip rangelog endpoint in db-console/endpoints roachtest

### DIFF
--- a/pkg/cmd/roachtest/tests/db-console/admin_endpoints.json
+++ b/pkg/cmd/roachtest/tests/db-console/admin_endpoints.json
@@ -82,7 +82,8 @@
     },
     {
       "url": "/_admin/v1/rangelog/{range_id}",
-      "method": "GET"
+      "method": "GET",
+      "skip": "https://github.com/cockroachdb/cockroach/issues/149866#issuecomment-3161313828"
     },
     {
       "url": "/_admin/v1/data_distribution",


### PR DESCRIPTION
This commit skips the rangelog endpoint on the admin server. This failure mode is described in https://github.com/cockroachdb/cockroach/issues/149866#issuecomment-3161313828

Part of: #149866
Release note: None