### PR TITLE
sql: add goroutine IDs to text trace output in logs

### DIFF
--- a/pkg/util/tracing/span_test.go
+++ b/pkg/util/tracing/span_test.go
@@ -145,10 +145,14 @@ func parseLine(s string) (traceLine, error) {
 	if match == nil {
 		return traceLine{}, errors.Newf("line doesn't match: %s", s)
 	}
+	text := match[3]
+	// Strip goroutine IDs from the text for test consistency
+	gidRe := regexp.MustCompile(` gid:\d+`)
+	text = string(gidRe.ReplaceAll([]byte(text), nil))
 	return traceLine{
 		timeSinceTraceStart: match[1],
 		timeSincePrev:       match[2],
-		text:                match[3],
+		text:                text,
 	}, nil
 }
 

--- a/pkg/util/tracing/test_utils.go
+++ b/pkg/util/tracing/test_utils.go
@@ -196,16 +196,22 @@ func checkRecordingWithRedact(t T, rec tracingpb.Recording, expected string, red
 		// 	 After  |  [operation]
 		re = regexp.MustCompile(`: .*]`)
 		rec = string(re.ReplaceAll([]byte(rec), []byte("]")))
-		// 5. Change all tabs to four spaces.
+		// 5. Strip out goroutine IDs from operation lines.
+		//
+		// 	 Before |  "=== operation:foo gid:123 _verbose:‹1›"
+		// 	 After  |  "=== operation:foo _verbose:‹1›"
+		re = regexp.MustCompile(` gid:\d+`)
+		rec = string(re.ReplaceAll([]byte(rec), nil))
+		// 6. Change all tabs to four spaces.
 		rec = strings.ReplaceAll(rec, "\t", "    ")
-		// 6. Compute the outermost indentation.
+		// 7. Compute the outermost indentation.
 		indent := strings.Repeat(" ", len(rec)-len(strings.TrimLeft(rec, " ")))
-		// 7. Outdent each line by that amount.
+		// 8. Outdent each line by that amount.
 		var lines []string
 		for _, line := range strings.Split(rec, "\n") {
 			lines = append(lines, strings.TrimPrefix(line, indent))
 		}
-		// 8. Stitch everything together.
+		// 9. Stitch everything together.
 		return strings.Join(lines, "\n")
 	}
 

--- a/pkg/util/tracing/tracingpb/recording.go
+++ b/pkg/util/tracing/tracingpb/recording.go
@@ -259,6 +259,10 @@ func (r Recording) visitSpan(sp RecordedSpan, depth int) []traceLogData {
 	sb.SafeString("=== operation:")
 	sb.SafeString(redact.SafeString(sp.Operation))
 
+	if sp.GoroutineID != 0 {
+		sb.Printf(" gid:%d", sp.GoroutineID)
+	}
+
 	for _, tg := range sp.TagGroups {
 		var prefix redact.RedactableString
 		if tg.Name != AnonymousTagGroupName {


### PR DESCRIPTION
when outputting a transaction trace in text format into the logs, we will now include the goroutine ID in the line with the operation like this:

```
=== operation:foo gid:123 <other tags>
```

Epic: None
Release note: None