### PR TITLE
util: add ApplyPermutation utility

### DIFF
--- a/pkg/util/slices.go
+++ b/pkg/util/slices.go
@@ -136,3 +136,26 @@ func Reduce[T any, U any](collection []T, fn func(acc U, el T, idx int) U, init 
 	}
 	return acc
 }
+
+// ApplyPermutation applies a permutation of indices to a slice via its swap
+// function.
+func ApplyPermutation(indices []int, swap func(i, j int)) {
+	n := len(indices)
+	visited := make([]bool, n)
+
+	for i := range n {
+		if visited[i] || indices[i] == i {
+			continue
+		}
+
+		j := i
+		for !visited[j] {
+			visited[j] = true
+			k := indices[j]
+			if k != i {
+				swap(j, k)
+			}
+			j = k
+		}
+	}
+}

--- a/pkg/util/slices_test.go
+++ b/pkg/util/slices_test.go
@@ -203,3 +203,53 @@ func TestReduce(t *testing.T) {
 		}, 0))
 	})
 }
+
+func TestApplyPermutation(t *testing.T) {
+	testcases := []struct {
+		name        string
+		input       []any
+		permutation []int
+		expected    []any
+	}{
+		{
+			name:        "empty input",
+			input:       []any{},
+			permutation: []int{},
+			expected:    []any{},
+		},
+		{
+			name:        "single element",
+			input:       []any{"a"},
+			permutation: []int{0},
+			expected:    []any{"a"},
+		},
+		{
+			name:        "reversal",
+			input:       []any{"a", "b", "c", "d"},
+			permutation: []int{3, 2, 1, 0},
+			expected:    []any{"d", "c", "b", "a"},
+		},
+		{
+			name:        "simple swaps, no cycles",
+			input:       []any{"a", "b", "c", "d"},
+			permutation: []int{1, 0, 3, 2},
+			expected:    []any{"b", "a", "d", "c"},
+		},
+		{
+			name:        "permutation with cycles",
+			input:       []any{"a", "b", "c", "d", "e"},
+			permutation: []int{4, 0, 1, 3, 2},
+			expected:    []any{"e", "a", "b", "d", "c"},
+		},
+	}
+
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			ApplyPermutation(tc.permutation, func(i, j int) {
+				tc.input[i], tc.input[j] = tc.input[j], tc.input[i]
+			})
+			require.Equal(t, tc.expected, tc.input)
+		})
+	}
+
+}


### PR DESCRIPTION
This commit adds the ApplyPermutation utility function, which allows you to sort a slice to match a certain permutation of indices.

Epic: None

Release note: None