### PR TITLE
util/stop: update goroutine of span in Handle.Activate

### DIFF
--- a/pkg/util/stop/BUILD.bazel
+++ b/pkg/util/stop/BUILD.bazel
@@ -41,7 +41,9 @@ go_test(
         "//pkg/util/quotapool",
         "//pkg/util/syncutil",
         "//pkg/util/tracing",
+        "//pkg/util/tracing/tracingpb",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_petermattis_goid//:goid",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/util/stop/handle.go
+++ b/pkg/util/stop/handle.go
@@ -46,6 +46,10 @@ type ActiveHandle interface {
 func (hdl *Handle) Activate(ctx context.Context) ActiveHandle {
 	growstack.Grow() // see https://github.com/cockroachdb/cockroach/issues/130663
 
+	// Activate is called once we're inside the new goroutine.
+	if hdl.sp != nil {
+		hdl.sp.UpdateGoroutineIDToCurrent()
+	}
 	hdl.region = hdl.s.startRegion(ctx, hdl.taskName)
 	// NB: it's tempting for ergonomics to make `release` a method on `Handle` and
 	// to return `hdl.release` here, but that allocates.

--- a/pkg/util/stop/stopper_bench_test.go
+++ b/pkg/util/stop/stopper_bench_test.go
@@ -10,7 +10,9 @@ import (
 	"sync"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing"
 )
 
 func BenchmarkStopper(b *testing.B) {
@@ -19,52 +21,64 @@ func BenchmarkStopper(b *testing.B) {
 	s := NewStopper()
 	defer s.Stop(ctx)
 
-	opts := TaskOpts{
-		TaskName: "testTask",
-	}
+	tracer := tracing.NewTracer()
 
-	b.Run("RunTask", func(b *testing.B) {
-		b.ReportAllocs()
-		var wg sync.WaitGroup // for fairness
-		wg.Add(b.N)
-		for i := 0; i < b.N; i++ {
-			if err := s.RunTask(ctx, opts.TaskName, func(context.Context) { wg.Done() }); err != nil {
-				b.Fatal(err)
-			}
+	testutils.RunTrueAndFalse(b, "tracing", func(b *testing.B, tracingEnabled bool) {
+		ctx := context.Background()
+		opts := TaskOpts{
+			TaskName: "testTask",
 		}
-		wg.Wait() // noop
+		if tracingEnabled {
+			opts.SpanOpt = ChildSpan
+			sp := tracer.StartSpan("test span")
+			defer sp.Finish()
+			ctx = tracing.ContextWithSpan(ctx, sp)
+		}
+
+		b.Run("RunTask", func(b *testing.B) {
+			b.ReportAllocs()
+			var wg sync.WaitGroup // for fairness
+			wg.Add(b.N)
+			for i := 0; i < b.N; i++ {
+				if err := s.RunTask(ctx, opts.TaskName, func(context.Context) { wg.Done() }); err != nil {
+					b.Fatal(err)
+				}
+			}
+			wg.Wait() // noop
+		})
+
+		b.Run("AsyncTaskEx", func(b *testing.B) {
+			b.ReportAllocs()
+			var wg sync.WaitGroup
+			for i := 0; i < b.N; i++ {
+				wg.Add(1)
+				if err := s.RunAsyncTaskEx(ctx, opts, func(ctx context.Context) {
+					defer wg.Done()
+				}); err != nil {
+					b.Fatal(err)
+				}
+				wg.Wait()
+			}
+		})
+
+		hdlf := func(ctx context.Context, hdl *Handle, wg *sync.WaitGroup) {
+			defer hdl.Activate(ctx).Release(ctx)
+			defer wg.Done()
+		}
+
+		b.Run("Handle", func(b *testing.B) {
+			b.ReportAllocs()
+			var wg sync.WaitGroup
+			for i := 0; i < b.N; i++ {
+				ctx, hdl, err := s.GetHandle(ctx, opts)
+				if err != nil {
+					b.Fatal(err)
+				}
+				wg.Add(1)
+				go hdlf(ctx, hdl, &wg)
+				wg.Wait()
+			}
+		})
 	})
 
-	b.Run("AsyncTaskEx", func(b *testing.B) {
-		b.ReportAllocs()
-		var wg sync.WaitGroup
-		for i := 0; i < b.N; i++ {
-			wg.Add(1)
-			if err := s.RunAsyncTaskEx(ctx, opts, func(ctx context.Context) {
-				defer wg.Done()
-			}); err != nil {
-				b.Fatal(err)
-			}
-			wg.Wait()
-		}
-	})
-
-	hdlf := func(ctx context.Context, hdl *Handle, wg *sync.WaitGroup) {
-		defer hdl.Activate(ctx).Release(ctx)
-		defer wg.Done()
-	}
-
-	b.Run("Handle", func(b *testing.B) {
-		b.ReportAllocs()
-		var wg sync.WaitGroup
-		for i := 0; i < b.N; i++ {
-			ctx, hdl, err := s.GetHandle(ctx, opts)
-			if err != nil {
-				b.Fatal(err)
-			}
-			wg.Add(1)
-			go hdlf(ctx, hdl, &wg)
-			wg.Wait()
-		}
-	})
 }

--- a/pkg/util/stop/stopper_test.go
+++ b/pkg/util/stop/stopper_test.go
@@ -7,6 +7,7 @@ package stop_test
 
 import (
 	"context"
+	"fmt"
 	"runtime"
 	"sync"
 	"sync/atomic"
@@ -21,7 +22,9 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/stop"
 	"github.com/cockroachdb/cockroach/pkg/util/syncutil"
 	"github.com/cockroachdb/cockroach/pkg/util/tracing"
+	"github.com/cockroachdb/cockroach/pkg/util/tracing/tracingpb"
 	"github.com/cockroachdb/errors"
+	"github.com/petermattis/goid"
 	"github.com/stretchr/testify/require"
 )
 
@@ -741,4 +744,34 @@ func TestHandleWithoutActivateOrRelease(t *testing.T) {
 			(<-relCh).Release(ctx)
 		}
 	})
+}
+
+func TestHandleSetsGoroutineOnSpan(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	ctx := context.Background()
+
+	s := stop.NewStopper()
+	defer s.Stop(ctx)
+
+	tracer := tracing.NewTracer()
+	sp := tracer.StartSpan("test span")
+	sp.SetRecordingType(tracingpb.RecordingVerbose)
+	ctx = tracing.ContextWithSpan(ctx, sp)
+
+	ctx, hdl, err := s.GetHandle(ctx, stop.TaskOpts{
+		SpanOpt:  stop.ChildSpan,
+		TaskName: "async task",
+	})
+	require.NoError(t, err)
+
+	endCh := make(chan struct{})
+	var goroutineID int64
+	go func() {
+		defer hdl.Activate(ctx).Release(ctx)
+		goroutineID = goid.Get()
+		close(endCh)
+	}()
+	<-endCh
+	rec := sp.FinishAndGetRecording(tracingpb.RecordingVerbose)
+	require.Contains(t, rec.String(), fmt.Sprintf("gid:%d", goroutineID))
 }


### PR DESCRIPTION
The goroutine in the span of the Handle would be the goroutine of the
stopper, not the task, this change explicitly updates the goroutine ID
of the span when the handle is Activated.

```
❯ benchdiff ./pkg/util/stop -b -r 'BenchmarkStopper' -d "1000x" -c 30 --preview
old:  https://github.com/dhartunian/cockroach/commit/8dfc82dc036d33c7cd557b18b6d44a379b1e1aec util/stop: add tracing case to stopper benchmarks
new:  01429ca util/stop: update goroutine of span in `Handle.Act
args: benchdiff "./pkg/util/stop" "-b" "-r" "BenchmarkStopper" "-d" "1000x" "-c" "30" "--preview"

name                                  old time/op    new time/op    delta
Stopper/tracing=false/Handle-10         1.32µs ±12%    1.26µs ±12%  -4.47%  (p=0.003 n=29+30)
Stopper/tracing=false/RunTask-10        28.0ns ±13%    27.5ns ± 6%    ~     (p=0.284 n=29+26)
Stopper/tracing=false/AsyncTaskEx-10    1.42µs ±14%    1.38µs ±13%    ~     (p=0.081 n=30+30)
Stopper/tracing=true/RunTask-10         27.8ns ±11%    27.6ns ± 9%    ~     (p=0.814 n=27+28)
Stopper/tracing=true/AsyncTaskEx-10     1.87µs ±13%    1.82µs ±10%    ~     (p=0.186 n=30+30)
Stopper/tracing=true/Handle-10          1.72µs ± 8%    1.74µs ±10%    ~     (p=0.284 n=30+30)

name                                  old alloc/op   new alloc/op   delta
Stopper/tracing=false/AsyncTaskEx-10     75.0B ± 0%     74.6B ± 2%  -0.49%  (p=0.016 n=20+30)
Stopper/tracing=false/RunTask-10         0.00B          0.00B         ~     (all equal)
Stopper/tracing=false/Handle-10          50.0B ± 0%     50.0B ± 0%    ~     (all equal)
Stopper/tracing=true/RunTask-10          0.00B          0.00B         ~     (all equal)
Stopper/tracing=true/AsyncTaskEx-10       239B ± 1%      239B ± 1%    ~     (p=0.431 n=30+30)
Stopper/tracing=true/Handle-10            215B ± 1%      215B ± 1%    ~     (p=0.315 n=30+30)

name                                  old allocs/op  new allocs/op  delta
Stopper/tracing=false/RunTask-10          0.00           0.00         ~     (all equal)
Stopper/tracing=false/AsyncTaskEx-10      3.00 ± 0%      3.00 ± 0%    ~     (all equal)
Stopper/tracing=false/Handle-10           1.00 ± 0%      1.00 ± 0%    ~     (all equal)
Stopper/tracing=true/RunTask-10           0.00           0.00         ~     (all equal)
Stopper/tracing=true/AsyncTaskEx-10       4.00 ± 0%      4.00 ± 0%    ~     (all equal)
Stopper/tracing=true/Handle-10            2.00 ± 0%      2.00 ± 0%    ~     (all equal)
```

Epic: None
Release Note: None

----

util/stop: add tracing case to stopper benchmarks
This is helpful for measuring impact of changes when tracing is
enabled.

Epic: None
Release note: None