### PR TITLE
release-25.3: make and publish: tag staging repo early in process

### DIFF
--- a/build/teamcity/internal/release/process/make-and-publish-build-start.sh
+++ b/build/teamcity/internal/release/process/make-and-publish-build-start.sh
@@ -1,0 +1,45 @@
+#!/usr/bin/env bash
+
+# Copyright 2022 The Cockroach Authors.
+#
+# Use of this software is governed by the CockroachDB Software License
+# included in the /LICENSE file.
+
+
+set -euo pipefail
+
+# This script can be skipped for dry run and customized builds.
+is_customized_build="$(echo "$TC_BUILD_BRANCH" | grep -Eo "^custombuild-" || echo "")"
+if [[ -n "${DRY_RUN:-}" ]] || [[ -n "${is_customized_build}" ]]; then
+  echo "Skipping for dry run or customized build."
+  exit 0
+fi
+
+dir="$(dirname $(dirname $(dirname $(dirname $(dirname "${0}")))))"
+source "$dir/release/teamcity-support.sh"
+
+github_ssh_key="${GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY:?GITHUB_COCKROACH_TEAMCITY_PRIVATE_SSH_KEY must be specified}"
+metadata_gcs_bucket="cockroach-release-qualification-prod"
+metadata_google_credentials="$GCS_CREDENTIALS_PROD"
+build_name="$(git describe --tags --dirty --match=v[0-9]* 2> /dev/null || git rev-parse --short HEAD;)"
+
+configure_git_ssh_key
+git tag "${build_name}"
+git_wrapped push ssh://git@github.com/cockroachlabs/release-staging.git "${build_name}"
+
+# Publish build metadata to a stable location.
+timestamp=$(date -u +"%Y-%m-%dT%H:%M:%SZ")
+metadata_file="artifacts/metadata.json"
+mkdir -p artifacts
+cat > "$metadata_file" << EOF
+{
+  "sha": "$BUILD_VCS_NUMBER",
+  "timestamp": "$timestamp",
+  "tag": "$build_name"
+}
+EOF
+# Run jq to pretty print and validate JSON
+jq . "$metadata_file"
+google_credentials=$metadata_google_credentials log_into_gcloud
+gsutil cp "$metadata_file" "gs://$metadata_gcs_bucket/builds/$BUILD_VCS_NUMBER.json"
+echo "Published to https://storage.googleapis.com/$metadata_gcs_bucket/builds/$BUILD_VCS_NUMBER.json"


### PR DESCRIPTION
Backport 1/1 commits from #148443.

/cc @cockroachdb/release

---

Currently, the “Make and Publish Build” process creates a staging tag and pushes it to the staging repository only after all builds and tests have been completed. This approach delays the initiation of the “Build and Sign Cockroach Release” build. In optimal scenarios, “Make and Publish Build” can take over 30 minutes to finish, and any flaky tests can reset this timer.

In urgent situations where fixes need to be deployed quickly, we want to initiate the release process without waiting for “Make and Publish Build” to complete. It’s important to note that the built binaries are merely staged and not published at this stage.

To enhance efficiency, we can shift the tagging process to the beginning of the “Make and Publish Build.” This adjustment will allow us to commence building release binaries without being hindered by the blocking build jobs. Furthermore, we should publish the metadata.json file immediately after tagging to avoid delaying the Pick SHA process.


Release note: none
Fixes: RE-958

Release justification: not a part of the product
