### PR TITLE
stmtdiagnostics: de-flake TestDiagnosticsRequest

### DIFF
--- a/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
+++ b/pkg/sql/stmtdiagnostics/statement_diagnostics_test.go
@@ -481,9 +481,10 @@ func TestDiagnosticsRequest(t *testing.T) {
 		runner.Exec(t, "INSERT INTO large VALUES (1);")
 		runner.Exec(t, "INSERT INTO large SELECT 2 FROM generate_series(1, 100);")
 		runner.Exec(t, "ANALYZE large;")
+		runner.Exec(t, "SET optimizer_min_row_count = 0;")
 
 		// query1 results in scan + lookup join whereas query2 does two scans +
-		// merge join.
+		// merge join (after adjusting optimizer_min_row_count).
 		const (
 			fprint = `SELECT v FROM small INNER JOIN large ON (k = v) AND (k = _)`
 			query1 = "SELECT v FROM small INNER JOIN large ON k = v AND k = 0;"


### PR DESCRIPTION
"plan-gist matching/anti-match" test case needs to have a query that has different plans depending on the values of the placeholders. With the recent bump of the default value of `optimizer_min_row_count` to 1 what used to be two different plans (scan + lookup join vs two scans + merge join) became effectively the same (two scans + merge join), resulting in a rare flake. This is now fixed by reseting the session variable to the old value for the test.

Fixes: #151344.

Release note: None