### PR TITLE
netutil: Add ReadHeaderTimeout to http servers

### DIFF
--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -86,7 +86,8 @@ func MakeHTTPServer(
 					delete(activeConns, conn)
 				}
 			},
-			ErrorLog: httpLogger,
+			ErrorLog:          httpLogger,
+			ReadHeaderTimeout: 5 * time.Second,
 		},
 	}
 


### PR DESCRIPTION
The DB Console only expects simple GETs/POSTs/PUTs. It is a best practice to then include a read header timeout.

Epic: none
Release note: None