### PR TITLE
sql: fix "rows affected" for deleteRange with multiple column families

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -603,3 +603,24 @@ statement error pgcode 42803 sum\(\): aggregate functions are not allowed in ORD
 DELETE FROM t108166 ORDER BY COALESCE(sum(a), 1) LIMIT 1;
 
 subtest end
+
+# Regression test for double-counting some rows for "rows affected" statistic in
+# deleteRange when a single SQL row is deleted via different KV batches.
+subtest regression_151505
+
+statement ok
+CREATE TABLE t (
+  k INT PRIMARY KEY,
+  c INT,
+  FAMILY (k),
+  FAMILY (c)
+);
+
+statement ok
+INSERT INTO t SELECT i, NULL FROM generate_series(1, 599) AS g(i);
+INSERT INTO t VALUES (600, 2);
+
+statement count 600
+DELETE FROM t WHERE k > 0 AND k < 1000;
+
+subtest end


### PR DESCRIPTION
In 807c1f21c8f6ad05834b5fc44ab91915c6092fc4 we began paginating DelRange requests that are used by the deleteRangeNode. Namely, we now delete at most 600 keys via a single BatchRequest. That change introduced a minor bug that when we have multiple column families AND the pagination stops in the middle of a SQL row, then we would count that row twice for the purposes of "rows affected" counter. This bug is now fixed by maintaining the row prefix across BatchRequests.

Fixes: #151505.

Release note (bug fix): CockroachDB could previously elevate the number of rows deleted on table with multiple column families in some cases. The bug has been present since 19.2 version and is now fixed. Note that the data was deleted correctly, just "rows affected" number was wrong.