### PR TITLE
release-25.3: netutil: Add ReadHeaderTimeout to http servers

### DIFF
--- a/pkg/util/netutil/net.go
+++ b/pkg/util/netutil/net.go
@@ -86,7 +86,8 @@ func MakeHTTPServer(
 					delete(activeConns, conn)
 				}
 			},
-			ErrorLog: httpLogger,
+			ErrorLog:          httpLogger,
+			ReadHeaderTimeout: 5 * time.Second,
 		},
 	}
 


### PR DESCRIPTION
Backport 1/1 commits from #151542 on behalf of @alyshanjahani-crl.

----

The DB Console only expects simple GETs/POSTs/PUTs. It is a best practice to then include a read header timeout.

Epic: none
Release note: None

----

Release justification: