### PR TITLE
sql: reduce batch sizes for span stats and table metadata

### DIFF
--- a/pkg/sql/sem/builtins/generator_builtins.go
+++ b/pkg/sql/sem/builtins/generator_builtins.go
@@ -68,7 +68,7 @@ func init() {
 	}
 }
 
-const DefaultSpanStatsSpanLimit = 1000
+const DefaultSpanStatsSpanLimit = 25
 
 // SpanStatsBatchLimit registers the maximum number of spans allowed in a
 // span stats request payload.

--- a/pkg/sql/tablemetadatacache/cluster_settings.go
+++ b/pkg/sql/tablemetadatacache/cluster_settings.go
@@ -15,7 +15,7 @@ const (
 	defaultDataValidDuration = time.Minute * 20
 	// defaultTableBatchSize is the number of tables to fetch in a
 	// single batch from the system tables.
-	defaultTableBatchSize = 20
+	defaultTableBatchSize = 5
 )
 
 var AutomaticCacheUpdatesEnabledSetting = settings.RegisterBoolSetting(


### PR DESCRIPTION
Previously, we would use batches of 1000 for span stats requests and 20 tables at a time for table metadata. On very large clusters this can cause visible load spikes that interfere with workload.

For now, this change reduces the number of tables per batch to 5 and the number of span stats per request to 25 in order to reduce pressure on large clusters.

Resolves: #147760

Epic: None
Release note: None