### PR TITLE
sql: fix TestRelocateNonVoters flake by speeding up allocator intervals

### DIFF
--- a/pkg/sql/BUILD.bazel
+++ b/pkg/sql/BUILD.bazel
@@ -810,6 +810,7 @@ go_test(
         "//pkg/kv/kvclient/rangefeed",
         "//pkg/kv/kvpb",
         "//pkg/kv/kvserver",
+        "//pkg/kv/kvserver/allocator",
         "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/kvserverbase",
         "//pkg/kv/kvserver/protectedts",

--- a/pkg/sql/multitenant_admin_function_test.go
+++ b/pkg/sql/multitenant_admin_function_test.go
@@ -13,10 +13,12 @@ import (
 	"strconv"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
 	"github.com/cockroachdb/cockroach/pkg/config/zonepb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver"
+	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/allocator"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/multitenant/tenantcapabilitiespb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
@@ -58,6 +60,13 @@ func createTestClusterArgs(ctx context.Context, numReplicas, numVoters int32) ba
 	clusterSettings := cluster.MakeTestingClusterSettings()
 	kvserverbase.LoadBasedRebalancingMode.Override(ctx, &clusterSettings.SV, kvserverbase.LBRebalancingOff)
 	kvserverbase.MergeQueueEnabled.Override(ctx, &clusterSettings.SV, false)
+
+	// Set allocator intervals to scan faster to help with recovery from race
+	// conditions between allocator and manual relocate operations.
+	allocator.LoadBasedRebalanceInterval.Override(ctx, &clusterSettings.SV, 100*time.Millisecond)
+	kvserver.MinLeaseTransferInterval.Override(ctx, &clusterSettings.SV, 100*time.Millisecond)
+	kvserver.MinIOOverloadLeaseShedInterval.Override(ctx, &clusterSettings.SV, 100*time.Millisecond)
+
 	return base.TestClusterArgs{
 		ServerArgs: base.TestServerArgs{
 			Settings: clusterSettings,


### PR DESCRIPTION
The test was failing due to race conditions between allocator operations and manual relocate commands. Set allocator intervals to 100ms to allow faster recovery from inconsistent replica states.

Fixes #150993

Release note: None

Epic: None