### PR TITLE
release-25.3: compose: deflake TestComposeCompare

### DIFF
--- a/pkg/compose/compare/compare/compare_test.go
+++ b/pkg/compose/compare/compare/compare_test.go
@@ -93,7 +93,7 @@ func TestCompare(t *testing.T) {
 						randgen.ForeignKeyMutator,
 						randgen.ColumnFamilyMutator,
 						randgen.IndexStoringMutator,
-						randgen.PartialIndexMutator,
+						randgen.DupPartialIndexMutator,
 					},
 				},
 			},


### PR DESCRIPTION
Backport 1/1 commits from #151549 on behalf of @fqazi.

----

Previously, the compose test had a mutation that added partial indexes to random indexes. This could cause unique indexes to become unusable for foreign keys, an issue that was being incorrectly ignored in the schema changer. A recent change fixed this bug, which now causes these scenarios to fail correctly. To address this, this patch modifies the mutator inside compose to only add partial indexes on new, duplicate indexes so that original unique constraints are not lost.

Fixes: #150817
Fixes: #149565

Release note: None

----

Release justification: test only change