### PR TITLE
roachtest: revert disable network partition

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/mutators.go
@@ -501,9 +501,7 @@ type networkPartitionMutator struct{}
 func (m networkPartitionMutator) Name() string { return failures.IPTablesNetworkPartitionName }
 
 func (m networkPartitionMutator) Probability() float64 {
-	// Temporarily set to 0 while we investigate a better way to handle
-	// intersecting failures.
-	return 0
+	return 0.3
 }
 
 func (m networkPartitionMutator) Generate(


### PR DESCRIPTION
This reverts commit 08d1e046aa251121004b7ce64c073452a27dc3d2, reversing changes made to e390312ca0fe9ed4001766e57fd4887f10adf5d0.

Epic: none

Release note: none