### PR TITLE
settings: set MinPasswordLength to 14 for FIPS builds

### DIFF
--- a/pkg/ccl/securityccl/fipsccl/fipscclbase/BUILD.bazel
+++ b/pkg/ccl/securityccl/fipsccl/fipscclbase/BUILD.bazel
@@ -5,6 +5,7 @@ go_library(
     srcs = [
         "build_boring.go",  # keep
         "build_noboring.go",
+        "consts.go",
     ],
     cgo = True,
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/securityccl/fipsccl/fipscclbase",

--- a/pkg/ccl/securityccl/fipsccl/fipscclbase/consts.go
+++ b/pkg/ccl/securityccl/fipsccl/fipscclbase/consts.go
@@ -1,0 +1,9 @@
+// Copyright 2023 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package fipscclbase
+
+// FIPSMinPasswordLength is the minimum length of a password in FIPS 140-3 mode.
+const FIPSMinPasswordLength = 14

--- a/pkg/cli/clisqlclient/BUILD.bazel
+++ b/pkg/cli/clisqlclient/BUILD.bazel
@@ -22,6 +22,7 @@ go_library(
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/build",
+        "//pkg/ccl/securityccl/fipsccl/fipscclbase",
         "//pkg/cli/clicfg",
         "//pkg/cli/clierror",
         "//pkg/security/pprompt",

--- a/pkg/cli/clisqlclient/conn.go
+++ b/pkg/cli/clisqlclient/conn.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/cockroachdb/cockroach-go/v2/crdb"
 	"github.com/cockroachdb/cockroach/pkg/build"
+	"github.com/cockroachdb/cockroach/pkg/ccl/securityccl/fipsccl/fipscclbase"
 	"github.com/cockroachdb/cockroach/pkg/cli/clierror"
 	"github.com/cockroachdb/cockroach/pkg/security/pprompt"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -43,7 +44,7 @@ type sqlConn struct {
 	conn         *pgx.Conn
 	reconnecting bool
 
-	// passwordMissing is true iff the url is missing a password.
+	// passwordMissing is true if the url is missing a password.
 	passwordMissing bool
 
 	// alwaysInferResultTypes is true iff the client should always use the
@@ -182,6 +183,10 @@ func (c *sqlConn) EnsureConn(ctx context.Context) error {
 	base, err := pgx.ParseConfig(c.url)
 	if err != nil {
 		return wrapConnError(err)
+	}
+	// Under FIPS 140-3 mode, the password must be at least 14 characters long.
+	if fipscclbase.IsFIPSReady() && !c.passwordMissing && len(base.Password) < fipscclbase.FIPSMinPasswordLength {
+		return errors.Newf("password must be at least %d characters long", fipscclbase.FIPSMinPasswordLength)
 	}
 	// Add a notice handler - re-use the cliOutputError function in this case.
 	base.OnNotice = func(_ *pgconn.PgConn, notice *pgconn.Notice) {
@@ -768,6 +773,10 @@ func (c *sqlConn) fillPassword() error {
 	pwd, err := pprompt.PromptForPassword("" /* prompt */)
 	if err != nil {
 		return err
+	}
+	// Under FIPS 140-3 mode, the password must be at least 14 characters long.
+	if fipscclbase.IsFIPSReady() && len(pwd) < fipscclbase.FIPSMinPasswordLength {
+		return errors.Newf("password must be at least %d characters long", fipscclbase.FIPSMinPasswordLength)
 	}
 	connURL.User = url.UserPassword(connURL.User.Username(), pwd)
 	c.url = connURL.String()

--- a/pkg/cli/interactive_tests/test_demo.tcl
+++ b/pkg/cli/interactive_tests/test_demo.tcl
@@ -169,11 +169,11 @@ eexpect eof
 end_test
 
 start_test "Check that the user can override the password."
-set ::env(COCKROACH_DEMO_PASSWORD) "hunter2"
+set ::env(COCKROACH_DEMO_PASSWORD) "hunter2hunter2hunter2hunter2"
 spawn $argv demo --no-line-editor --insecure=false --no-example-database --log-dir=logs
 eexpect "Connection parameters"
 eexpect "(sql)"
-eexpect "postgresql://demo:hunter2@"
+eexpect "postgresql://demo:hunter2hunter2hunter2hunter2@"
 eexpect "defaultdb>"
 send_eof
 eexpect eof

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -751,7 +751,7 @@ const (
 	AuthRootCert
 
 	DefaultUser     = "roachprod"
-	DefaultPassword = "cockroachdb"
+	DefaultPassword = "cockroachpassword"
 
 	DefaultAuthModeEnv = "ROACHPROD_DEFAULT_AUTH_MODE"
 )


### PR DESCRIPTION
Previously, the minimum password length was 1 character. For FIPS 140-3 builds, if short passwords are allowed, this leads to server crashes when a short password is used. Under the hood, the FIPS implementation panics if a password is shorter than 14 characters. This aligns with the NIST recommendation that HMAC should have a key length of at least 112 bits, which translates to 14 ASCII characters.

This change sets the default minimum password length to 14 characters for FIPS builds.

Additionally, `cockroach demo` has been updated to ensure that the password length for the demo user is at least the minimum password length.

Epic: none
Release note (security update): Strengthened password policy controls for FIPS 140‑3 builds. The minimum allowed password length is now set to 14 characters (112 bits of entropy) in FIPS-compliant builds. This prevents crashes caused by shorter passwords, aligning with NIST key-length recommendations