### PR TITLE
sql/importer: recover panics in workloads

### DIFF
--- a/pkg/sql/importer/BUILD.bazel
+++ b/pkg/sql/importer/BUILD.bazel
@@ -100,6 +100,7 @@ go_library(
         "//pkg/util/ioctx",
         "//pkg/util/log",
         "//pkg/util/log/eventpb",
+        "//pkg/util/log/logcrash",
         "//pkg/util/log/logutil",
         "//pkg/util/metamorphic",
         "//pkg/util/protoutil",

--- a/pkg/sql/importer/read_import_workload.go
+++ b/pkg/sql/importer/read_import_workload.go
@@ -28,6 +28,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/sql/types"
 	"github.com/cockroachdb/cockroach/pkg/util/bufalloc"
 	"github.com/cockroachdb/cockroach/pkg/util/ctxgroup"
+	"github.com/cockroachdb/cockroach/pkg/util/log/logcrash"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil/pgdate"
 	"github.com/cockroachdb/cockroach/pkg/workload"
 	"github.com/cockroachdb/errors"
@@ -186,7 +187,12 @@ func (w *workloadReader) readFiles(
 	}
 
 	for _, wc := range wcs {
-		if err := ctxgroup.GroupWorkers(ctx, w.parallelism, func(ctx context.Context, _ int) error {
+		if err := ctxgroup.GroupWorkers(ctx, w.parallelism, func(ctx context.Context, _ int) (retErr error) {
+			defer func() {
+				if r := recover(); r != nil {
+					retErr = errors.CombineErrors(logcrash.PanicAsError(1, r), retErr)
+				}
+			}()
 			evalCtx := w.evalCtx.Copy()
 			return wc.Worker(ctx, evalCtx, w.semaCtx)
 		}); err != nil {


### PR DESCRIPTION
Several of these workload generators are written for testing purposes, and testing code can sometimes be missing bounds checks or extra validaton. However when we use them in the main process as IMPORT sources, any crashes in them do not just crash a standalone workload utility, but previously would crash the whole cockroach process. Instead, any panics in the workload generator are now recovered and converted to an import error.

Release note: none.
Epic: none.