### PR TITLE
backupsink: increase test size to large

### DIFF
--- a/pkg/backup/backupsink/BUILD.bazel
+++ b/pkg/backup/backupsink/BUILD.bazel
@@ -32,6 +32,7 @@ go_library(
 
 go_test(
     name = "backupsink_test",
+    size = "large",
     srcs = [
         "file_sst_sink_test.go",
         "sst_sink_key_writer_test.go",


### PR DESCRIPTION
The test allocates a relatively large buffers and we have seen periodic ooms as a result.

Release note: None
Informs: #145892
Informs: #150623
Informs: #151665
Informs: #151032