### PR TITLE
storage, kvpb: add more separated value iteration stats to ScanStats

### DIFF
--- a/pkg/kv/kvpb/api.go
+++ b/pkg/kv/kvpb/api.go
@@ -2494,10 +2494,14 @@ func (s *ScanStats) SafeFormat(w redact.SafePrinter, _ rune) {
 		humanizeCount(s.NumReverseScans),
 	)
 	if s.SeparatedPointCount != 0 {
-		w.Printf(" separated: (count: %s, bytes: %s, bytes-fetched: %s)",
+		w.Printf(" separated: (count: %s, bytes: %s, bytes-fetched: %s, "+
+			"count-fetched: %s, reader-cache-misses: %s)",
 			humanizeCount(s.SeparatedPointCount),
 			humanizeutil.IBytes(int64(s.SeparatedPointValueBytes)),
-			humanizeutil.IBytes(int64(s.SeparatedPointValueBytesFetched)))
+			humanizeutil.IBytes(int64(s.SeparatedPointValueBytesFetched)),
+			humanizeCount(s.SeparatedPointValueCountFetched),
+			humanizeCount(s.SeparatedPointValueReaderCacheMisses),
+		)
 	}
 }
 

--- a/pkg/kv/kvpb/api.proto
+++ b/pkg/kv/kvpb/api.proto
@@ -3901,6 +3901,8 @@ message ScanStats {
   uint64 separated_point_count = 14;
   uint64 separated_point_value_bytes = 15;
   uint64 separated_point_value_bytes_fetched = 16;
+  uint64 separated_point_value_count_fetched = 23;
+  uint64 separated_point_value_reader_cache_misses = 24;
   google.protobuf.Duration block_read_duration = 20 [(gogoproto.nullable) = false,
     (gogoproto.stdduration) = true];
 

--- a/pkg/sql/execstats/stats.go
+++ b/pkg/sql/execstats/stats.go
@@ -137,6 +137,8 @@ func (l *ScanStatsListener) Notify(event tracing.Structured) tracing.EventConsum
 	l.mu.ScanStats.separatedPointCount += ss.SeparatedPointCount
 	l.mu.ScanStats.separatedPointValueBytes += ss.SeparatedPointValueBytes
 	l.mu.ScanStats.separatedPointValueBytesFetched += ss.SeparatedPointValueBytesFetched
+	l.mu.ScanStats.separatedPointValueCountFetched += ss.SeparatedPointValueCountFetched
+	l.mu.ScanStats.separatedPointValueReaderCacheMisses += ss.SeparatedPointValueReaderCacheMisses
 	l.mu.ScanStats.numGets += ss.NumGets
 	l.mu.ScanStats.numScans += ss.NumScans
 	l.mu.ScanStats.numReverseScans += ss.NumReverseScans
@@ -196,22 +198,24 @@ type ScanStats struct {
 	numInterfaceSeeks uint64
 	// numInternalSeeks is the number of times that MVCC seek was invoked
 	// internally, including to step over internal, uncompacted Pebble versions.
-	numInternalSeeks                uint64
-	blockBytes                      uint64
-	blockBytesInCache               uint64
-	keyBytes                        uint64
-	valueBytes                      uint64
-	pointCount                      uint64
-	pointsCoveredByRangeTombstones  uint64
-	rangeKeyCount                   uint64
-	rangeKeyContainedPoints         uint64
-	rangeKeySkippedPoints           uint64
-	separatedPointCount             uint64
-	separatedPointValueBytes        uint64
-	separatedPointValueBytesFetched uint64
-	numGets                         uint64
-	numScans                        uint64
-	numReverseScans                 uint64
+	numInternalSeeks                     uint64
+	blockBytes                           uint64
+	blockBytesInCache                    uint64
+	keyBytes                             uint64
+	valueBytes                           uint64
+	pointCount                           uint64
+	pointsCoveredByRangeTombstones       uint64
+	rangeKeyCount                        uint64
+	rangeKeyContainedPoints              uint64
+	rangeKeySkippedPoints                uint64
+	separatedPointCount                  uint64
+	separatedPointValueBytes             uint64
+	separatedPointValueBytesFetched      uint64
+	separatedPointValueCountFetched      uint64
+	separatedPointValueReaderCacheMisses uint64
+	numGets                              uint64
+	numScans                             uint64
+	numReverseScans                      uint64
 	// nodeIDs stores the ordered list of all KV nodes that were used to
 	// evaluate the KV requests.
 	nodeIDs []int32

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -4410,6 +4410,8 @@ func recordIteratorStats(iter iteratorWithStats, scanStats *kvpb.ScanStats) {
 	scanStats.SeparatedPointCount += stats.InternalStats.SeparatedPointValue.Count
 	scanStats.SeparatedPointValueBytes += stats.InternalStats.SeparatedPointValue.ValueBytes
 	scanStats.SeparatedPointValueBytesFetched += stats.InternalStats.SeparatedPointValue.ValueBytesFetched
+	scanStats.SeparatedPointValueCountFetched += stats.InternalStats.SeparatedPointValue.CountFetched
+	scanStats.SeparatedPointValueReaderCacheMisses += stats.InternalStats.SeparatedPointValue.ReaderCacheMisses
 	scanStats.BlockReadDuration += blockReads.BlockReadDuration
 }
 


### PR DESCRIPTION
This patch adds two more stats to `kvpb.ScanStats` regarding value retrieval of separated values during iteration: `SeparatedPointValueCountFetched` and `SeparatedPointValueReaderCacheMisses`. We follow the pattern with existing stats for separated value iteration to add these in for traces.

Epic: none
Fixes: #149422

Release note: None