### PR TITLE
kvserver: add observability (logging & metrics) for decomissioning nudger

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -15384,6 +15384,30 @@ layers:
       unit: COUNT
       aggregation: AVG
       derivative: NONE
+    - name: ranges.decommissioning.nudger.enqueue.attempts
+      exported_name: ranges_decommissioning_nudger_enqueue_attempts
+      description: Number of attempts to enqueue a range for decommissioning by the decommissioning nudger
+      y_axis_label: Ranges
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: ranges.decommissioning.nudger.enqueue.failure
+      exported_name: ranges_decommissioning_nudger_enqueue_failure
+      description: Number of failed enqueues of a range for decommissioning by the decommissioning nudger
+      y_axis_label: Ranges
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: ranges.decommissioning.nudger.enqueue.success
+      exported_name: ranges_decommissioning_nudger_enqueue_success
+      description: Number of successful enqueues of a range for decommissioning by the decommissioning nudger
+      y_axis_label: Ranges
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: ranges.overreplicated
       exported_name: ranges_overreplicated
       description: Number of ranges with more live replicas than the replication target

--- a/pkg/kv/kvserver/metrics.go
+++ b/pkg/kv/kvserver/metrics.go
@@ -171,6 +171,26 @@ var (
 		Unit:        metric.Unit_COUNT,
 	}
 
+	// Decommissioning nudger metrics.
+	metaDecommissioningNudgerEnqueueAttempts = metric.Metadata{
+		Name:        "ranges.decommissioning.nudger.enqueue.attempts",
+		Help:        "Number of attempts to enqueue a range for decommissioning by the decommissioning nudger",
+		Measurement: "Ranges",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaDecommissioningNudgerEnqueueSuccess = metric.Metadata{
+		Name:        "ranges.decommissioning.nudger.enqueue.success",
+		Help:        "Number of successful enqueues of a range for decommissioning by the decommissioning nudger",
+		Measurement: "Ranges",
+		Unit:        metric.Unit_COUNT,
+	}
+	metaDecommissioningNudgerEnqueueFailure = metric.Metadata{
+		Name:        "ranges.decommissioning.nudger.enqueue.failure",
+		Help:        "Number of failed enqueues of a range for decommissioning by the decommissioning nudger",
+		Measurement: "Ranges",
+		Unit:        metric.Unit_COUNT,
+	}
+
 	// Lease request metrics.
 	metaLeaseRequestSuccessCount = metric.Metadata{
 		Name:        "leases.success",
@@ -2861,6 +2881,11 @@ type StoreMetrics struct {
 	DecommissioningRangeCount       *metric.Gauge
 	RangeClosedTimestampPolicyCount [ctpb.MAX_CLOSED_TIMESTAMP_POLICY]*metric.Gauge
 
+	// Decommissioning nudger metrics.
+	DecommissioningNudgerEnqueueAttempts *metric.Counter
+	DecommissioningNudgerEnqueueSuccess  *metric.Counter
+	DecommissioningNudgerEnqueueFailure  *metric.Counter
+
 	// Lease request metrics for successful and failed lease requests. These
 	// count proposals (i.e. it does not matter how many replicas apply the
 	// lease).
@@ -3578,6 +3603,11 @@ func newStoreMetrics(histogramWindow time.Duration) *StoreMetrics {
 		OverReplicatedRangeCount:        metric.NewGauge(metaOverReplicatedRangeCount),
 		DecommissioningRangeCount:       metric.NewGauge(metaDecommissioningRangeCount),
 		RangeClosedTimestampPolicyCount: makePolicyRefresherMetrics(),
+
+		// Decommissioning nudger metrics.
+		DecommissioningNudgerEnqueueAttempts: metric.NewCounter(metaDecommissioningNudgerEnqueueAttempts),
+		DecommissioningNudgerEnqueueSuccess:  metric.NewCounter(metaDecommissioningNudgerEnqueueSuccess),
+		DecommissioningNudgerEnqueueFailure:  metric.NewCounter(metaDecommissioningNudgerEnqueueFailure),
 
 		// Lease request metrics.
 		LeaseRequestSuccessCount: metric.NewCounter(metaLeaseRequestSuccessCount),

--- a/pkg/kv/kvserver/replicate_queue_test.go
+++ b/pkg/kv/kvserver/replicate_queue_test.go
@@ -2477,7 +2477,18 @@ func TestReplicateQueueDecommissionScannerDisabled(t *testing.T) {
 	// decommissioning replica is noticed via maybeEnqueueProblemRange.
 	scratchKey := tc.ScratchRange(t)
 	tc.AddVotersOrFatal(t, scratchKey, tc.Target(decommissioningSrvIdx))
+
+	// Get the initial metric values before enabling the replicate queue
+	initialAttempts := getDecommissioningNudgerMetricValue(t, tc, "attempts")
+	initialSuccesses := getDecommissioningNudgerMetricValue(t, tc, "success")
+	initialFailures := getDecommissioningNudgerMetricValue(t, tc, "failure")
+
+	t.Logf("Initial metric values - Attempts: %d, Successes: %d, Failures: %d",
+		initialAttempts, initialSuccesses, initialFailures)
+
 	tc.ToggleReplicateQueues(true /* active */)
+
+	// Wait for the replica to be removed and verify metrics were incremented.
 	testutils.SucceedsSoon(t, func() error {
 		var descs []*roachpb.RangeDescriptor
 		tc.GetFirstStoreFromServer(t, decommissioningSrvIdx).VisitReplicas(func(r *kvserver.Replica) bool {
@@ -2489,4 +2500,51 @@ func TestReplicateQueueDecommissionScannerDisabled(t *testing.T) {
 		}
 		return nil
 	})
+
+	// Verify that the decommissioning nudger metrics were incremented.
+	finalAttempts := getDecommissioningNudgerMetricValue(t, tc, "attempts")
+	finalSuccesses := getDecommissioningNudgerMetricValue(t, tc, "success")
+	finalFailures := getDecommissioningNudgerMetricValue(t, tc, "failure")
+
+	// Verify that decommissioning nudger attemps succeed.
+	require.Equal(t, finalAttempts, finalSuccesses, "expected all decommissioning nudger enqueue attempts to succeed")
+
+	// Verify that attempts were incremented (at least one attempt should have been made).
+	require.Greater(t, finalAttempts, initialAttempts,
+		"expected decommissioning nudger enqueue attempts to be incremented")
+
+	// Verify that successes were incremented (at least one success should have occurred).
+	require.Greater(t, finalSuccesses, initialSuccesses,
+		"expected decommissioning nudger enqueue successes to be incremented")
+
+	t.Logf("decommissioning nudger enqueue failures increased by %d",
+		finalFailures-initialFailures)
+}
+
+// getDecommissioningNudgerMetricValue retrieves the value of a specific decommissioning
+// nudger metric from the test cluster. It aggregates the values across all stores.
+func getDecommissioningNudgerMetricValue(
+	t *testing.T, tc *testcluster.TestCluster, metricType string,
+) int64 {
+	var total int64
+
+	for i := 0; i < tc.NumServers(); i++ {
+		store := tc.GetFirstStoreFromServer(t, i)
+		var value int64
+
+		switch metricType {
+		case "attempts":
+			value = store.Metrics().DecommissioningNudgerEnqueueAttempts.Count()
+		case "success":
+			value = store.Metrics().DecommissioningNudgerEnqueueSuccess.Count()
+		case "failure":
+			value = store.Metrics().DecommissioningNudgerEnqueueFailure.Count()
+		default:
+			t.Fatalf("Unknown metric type: %s", metricType)
+		}
+
+		total += value
+	}
+
+	return total
 }


### PR DESCRIPTION
Adds logging & metrics for decommissioning nudger to ensure its proper workflow. 

#### Testing:
```sh
$ ./dev test pkg/kv/kvserver -f TestReplicateQueueDecommissionScannerDisabled -v --show-logs --stream-output 
# should show the following output
 replicate_queue_test.go:2509: Final metric values - Attempts: 1, Successes: 1, Failures: 0
```

Fixes #148090
Epic: None