### PR TITLE
keyside: temporarily don't return assertion error for LTREE

### DIFF
--- a/pkg/sql/rowenc/keyside/encode.go
+++ b/pkg/sql/rowenc/keyside/encode.go
@@ -183,6 +183,11 @@ func Encode(b []byte, val tree.Datum, dir encoding.Direction) ([]byte, error) {
 		return encodeJSONKey(b, t, dir)
 	}
 	if buildutil.CrdbTestBuild {
+		if _, isLTree := val.(*tree.DLTree); isLTree {
+			// TODO(paulniziolek): remove this exception once key encoding is
+			// added.
+			return nil, errors.Newf("LTREE key encoding is not implemented yet")
+		}
 		return nil, errors.AssertionFailedf("unable to encode table key: %T", val)
 	}
 	return nil, errors.Errorf("unable to encode table key: %T", val)


### PR DESCRIPTION
We merged new LTREE datum type only with value encoding, yet this type can be key-encodable (but that is not implemented). In such case, in test builds we return an assertion error for missing key encoding, and many of our tests fail if they see an assertion error. To silence this expected failure mode we add an exception for LTREE to result in a regular error for now, which I think should cover most test failures we've seen.

Fixes: #151614.
Fixes: #151659.

Release note: None