### PR TITLE
kvcoord: deflake TestDistSenderReplicaStall

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_circuit_breaker_test.go
@@ -50,11 +50,7 @@ func TestDistSenderReplicaStall(t *testing.T) {
 	}
 
 	testutils.RunTrueAndFalse(t, "clientTimeout", func(t *testing.T, clientTimeout bool) {
-		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-		defer time.AfterFunc(29*time.Second, func() {
-			log.Errorf(ctx, "about to time out, all stacks:\n\n%s", allstacks.Get())
-		}).Stop()
-		defer cancel()
+		ctx := context.Background()
 
 		// The lease won't move unless we use expiration-based leases. We also
 		// speed up the test by reducing various intervals and timeouts.
@@ -88,6 +84,12 @@ func TestDistSenderReplicaStall(t *testing.T) {
 		key := tc.ScratchRange(t)
 		desc := tc.AddVotersOrFatal(t, key, tc.Targets(1, 2)...)
 		t.Logf("created %s", desc)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
+		defer time.AfterFunc(29*time.Second, func() {
+			log.Errorf(ctx, "about to time out, all stacks:\n\n%s", allstacks.Get())
+		}).Stop()
+		defer cancel()
 
 		// Move the lease to n3, and make sure everyone has applied it by
 		// replicating a write.


### PR DESCRIPTION
Previously, the test would timeout after 30 seconds if it hasn't finished successfully. However, the 30 seconds countdown start from the beginning of the test, before creating the test cluster and running it. A few failures happened because the nodes took a long time in the CI to actually become up and running.

This commit deflakes the test by starting the 30 seconds countdown after test cluster is actually functional.

References: #151660

Release note: None