### PR TITLE
release-25.3: rowexec: fix JoinReader benchmarks

### DIFF
--- a/pkg/sql/rowexec/joinreader_test.go
+++ b/pkg/sql/rowexec/joinreader_test.go
@@ -1814,8 +1814,9 @@ func benchmarkJoinReader(b *testing.B, bc JRBenchConfig) {
 
 								spec := execinfrapb.JoinReaderSpec{
 									FetchSpec:           fetchSpec,
-									LookupColumnsAreKey: parallel,
+									LookupColumnsAreKey: parallel && columnDef.matchesPerLookupRow == 1,
 									MaintainOrdering:    reqOrdering,
+									Parallelize:         parallel,
 								}
 								if lookupExpr {
 									// @1 is the column in the input, @2 is the only fetched column.
@@ -2026,9 +2027,10 @@ func BenchmarkJoinReaderLookupStress(b *testing.B) {
 				b.Fatal(err)
 			}
 			spec := execinfrapb.JoinReaderSpec{
-				FetchSpec: fetchSpec,
-				LookupColumnsAreKey:/*parallel=*/ true,
-				MaintainOrdering:/*reqOrdering=*/ false,
+				FetchSpec:           fetchSpec,
+				LookupColumnsAreKey: true,
+				MaintainOrdering:    false,
+				Parallelize:         true,
 			}
 			lookupExprString := "@1 = @2"
 			for i := 0; i < numExprs; i++ {


### PR DESCRIPTION
Backport 1/1 commits from #151578 on behalf of @yuzefovich.

----

We recently added an assertion that the lookup join with "equality columns are key" property never fetches more than one lookup row for each input row. In a couple of existing benchmarks this fact was violated, so this commit fixes the issue. Namely, previously we set it to indicate that we want cross-range parallelism, but now we actually have a separate boolean on the processor spec, which makes the fix simple.

Fixes: #151296.
Fixes: #151299.

Release note: None

----

Release justification: test-only change.