### PR TITLE
sql: fix spelling of indexes

### DIFF
--- a/pkg/sql/backfill/index_backfiller_cols.go
+++ b/pkg/sql/backfill/index_backfiller_cols.go
@@ -18,7 +18,7 @@ import (
 // indexBackfiller and the information about which columns will need to
 // be evaluated during the backfill.
 type indexBackfillerCols struct {
-	// colIdxMap maps ColumnIDs to indices into desc.Columns and desc.Mutations.
+	// colIdxMap maps ColumnIDs to indexes into desc.Columns and desc.Mutations.
 	colIdxMap catalog.TableColMap
 
 	// cols are all writable (PUBLIC and WRITE_ONLY) columns in

--- a/pkg/sql/colexec/case.go
+++ b/pkg/sql/colexec/case.go
@@ -51,7 +51,7 @@ type caseOp struct {
 	//   scratch order = {4, 0, 2, 1, 5, 3}.
 	//
 	// It is guaranteed that after running all WHEN and ELSE arms, order will
-	// contain all tuple indices, and once that is the case, we simply need to
+	// contain all tuple indexes, and once that is the case, we simply need to
 	// copy the data out of the scratch into the output batch according to sel.
 	//
 	// Note that order doesn't satisfy the assumption of our normal selection
@@ -72,7 +72,7 @@ type caseOp struct {
 	// After running the ELSE arm projection:
 	//   scratch output = {-1, -1, -2, -2, 42, 42}
 	//   scratch order = {x, 4, 0, x, 2, 1, 5, x, 3}.
-	// Note that order has the length sufficient to support all indices
+	// Note that order has the length sufficient to support all indexes
 	// mentioned in the original selection vector and not selected elements will
 	// have garbage left in the corresponding positions in order.
 	//

--- a/pkg/sql/colexec/colbuilder/execplan.go
+++ b/pkg/sql/colexec/colbuilder/execplan.go
@@ -1524,7 +1524,7 @@ func NewColOperator(
 				// Set any nil values in the window frame to their default values.
 				wf.Frame = colexecwindow.NormalizeWindowFrame(wf.Frame)
 
-				// Copy the argument indices into a mutable slice.
+				// Copy the argument indexes into a mutable slice.
 				argIdxs := make([]int, len(wf.ArgsIdxs))
 				argTypes := make([]*types.T, len(wf.ArgsIdxs))
 				for i, idx := range wf.ArgsIdxs {

--- a/pkg/sql/colexec/colexecagg/aggregate_funcs.go
+++ b/pkg/sql/colexec/colexecagg/aggregate_funcs.go
@@ -87,7 +87,7 @@ type AggregateFunc interface {
 	SetOutput(vec *coldata.Vec)
 
 	// CurrentOutputIndex returns the current index in the output vector that
-	// the aggregate function is writing to. All indices < the index returned
+	// the aggregate function is writing to. All indexes < the index returned
 	// are finished aggregations for previous groups.
 	CurrentOutputIndex() int
 

--- a/pkg/sql/colexec/colexecdisk/external_sort.go
+++ b/pkg/sql/colexec/colexecdisk/external_sort.go
@@ -176,7 +176,7 @@ type externalSorter struct {
 	// currentPartitionIdx keeps track of the next available partition index.
 	currentPartitionIdx int
 	// currentPartitionIdxs is a slice of size maxNumberPartitions containing
-	// the mapping of all partitions to their corresponding partition indices.
+	// the mapping of all partitions to their corresponding partition indexes.
 	currentPartitionIdxs []int
 	// maxMerged is a slice of size maxNumberPartitions containing
 	// the mapping of all partitions to their maximum number of merges.
@@ -704,7 +704,7 @@ func (s *externalSorter) createMergerForPartitions(n int) *colexec.OrderedSynchr
 			sizes.WriteString(string(humanizeutil.IBytes(s.partitionsInfo.totalSize[partitionOrdinal])))
 		}
 		log.Infof(s.Ctx,
-			"external sorter is merging partitions with partition indices %v with counts [%s] and sizes [%s]",
+			"external sorter is merging partitions with partition indexes %v with counts [%s] and sizes [%s]",
 			s.currentPartitionIdxs[s.numPartitions-n:s.numPartitions], counts.String(), sizes.String(),
 		)
 	}

--- a/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
+++ b/pkg/sql/colexec/colexecdisk/hash_based_partitioner.go
@@ -55,12 +55,12 @@ const (
 	// hbpProcessNewPartitionUsingMain indicates that the operator should choose
 	// a partition index and process the corresponding partitions from all
 	// inputs using the "main" operator. We will only process the partitions if
-	// the partition fits into memory. If there are no partition indices that
+	// the partition fits into memory. If there are no partition indexes that
 	// the operator can process, it transitions into hbpRecursivePartitioning
-	// state. If there are no partition indices to process using the main
-	// operator, but there are indices to process using the "fallback" strategy,
+	// state. If there are no partition indexes to process using the main
+	// operator, but there are indexes to process using the "fallback" strategy,
 	// the operator transitions to hbpProcessNewPartitionUsingFallback state. If
-	// there are no partition indices left at all to process, the operator
+	// there are no partition indexes left at all to process, the operator
 	// transitions to hbpFinished state.
 	hbpProcessNewPartitionUsingMain
 	// hbpProcessingUsingMain indicates that the operator is currently
@@ -72,7 +72,7 @@ const (
 	hbpProcessingUsingMain
 	// hbpProcessNewPartitionUsingFallback indicates that the operator should
 	// choose a partition index to process using the "fallback" strategy. If
-	// there are no partition indices for this strategy left, the operator
+	// there are no partition indexes for this strategy left, the operator
 	// transitions to hbpFinished state.
 	hbpProcessNewPartitionUsingFallback
 	// hbpProcessingUsingFallback indicates that the operator is currently
@@ -142,13 +142,13 @@ type hashBasedPartitioner struct {
 	// numBuckets is the number of buckets that a partition is divided into.
 	numBuckets int
 	// partitionsToProcessUsingMain is a map from partitionIdx to a utility
-	// struct. This map contains all partition indices that need to be processed
+	// struct. This map contains all partition indexes that need to be processed
 	// using the in-memory "main" operator. If the partition is too big, it will
 	// be tried to be repartitioned; if during repartitioning the size doesn't
 	// decrease enough, it will be added to partitionsToProcessUsingFallback.
 	partitionsToProcessUsingMain map[int]*hbpPartitionInfo
-	// partitionsToProcessUsingFallback contains all partition indices that need
-	// to be processed using the "fallback" strategy. Partition indices will be
+	// partitionsToProcessUsingFallback contains all partition indexes that need
+	// to be processed using the "fallback" strategy. Partition indexes will be
 	// added into this map if recursive partitioning doesn't seem to make
 	// progress on partition' size reduction.
 	partitionsToProcessUsingFallback []int

--- a/pkg/sql/colexec/colexechash/hashtable.go
+++ b/pkg/sql/colexec/colexechash/hashtable.go
@@ -121,7 +121,7 @@ type hashTableProbeBuffer struct {
 	// HashTable.maxProbingBatchLength in size.                  //
 	///////////////////////////////////////////////////////////////
 
-	// ToCheck stores the indices of tuples from the probing batch for which we
+	// ToCheck stores the indexes of tuples from the probing batch for which we
 	// still want to keep traversing the hash chain trying to find equality
 	// matches.
 	//
@@ -251,7 +251,7 @@ type HashTable struct {
 	// Vals stores columns of the build source that are specified in colsToStore
 	// in the constructor. The ID of a tuple at any index of Vals is index + 1.
 	Vals *colexecutils.AppendOnlyBufferedBatch
-	// keyCols stores the indices of Vals which are used for equality
+	// keyCols stores the indexes of Vals which are used for equality
 	// comparison.
 	keyCols []uint32
 
@@ -330,8 +330,8 @@ func NewHashTable(
 	// colsToStore indicates the positions of columns to actually store in the
 	// hash table depending on the build mode:
 	// - all columns are stored in the full build mode
-	// - only columns with indices in keyCols are stored in the distinct build
-	// mode (columns with other indices will remain zero-capacity vectors in
+	// - only columns with indexes in keyCols are stored in the distinct build
+	// mode (columns with other indexes will remain zero-capacity vectors in
 	// Vals).
 	var colsToStore []int
 	switch buildMode {
@@ -908,11 +908,11 @@ func (ht *HashTable) CheckBuildForAggregation(
 // DistinctCheck determines if the current key in the ToCheckID bucket matches the
 // equality column key. If there is a match, then the key is removed from
 // ToCheck. If the bucket has reached the end, the key is rejected. The ToCheck
-// list is reconstructed to only hold the indices of the keyCols keys that have
+// list is reconstructed to only hold the indexes of the keyCols keys that have
 // not been found. The new length of ToCheck is returned by this function.
 func (ht *HashTable) DistinctCheck(nToCheck uint32, probeSel []int) uint32 {
 	ht.checkCols(ht.Keys, nToCheck, probeSel)
-	// Select the indices that differ and put them into ToCheck.
+	// Select the indexes that differ and put them into ToCheck.
 	nDiffers := uint32(0)
 	toCheckSlice := ht.ProbeScratch.ToCheck
 	_ = toCheckSlice[nToCheck-1]

--- a/pkg/sql/colexec/colexecjoin/crossjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/crossjoiner.go
@@ -297,7 +297,7 @@ func (c *crossJoiner) willEmit() int {
 	}
 }
 
-// setAllNulls sets all tuples in vecs with indices in [0, length) range to
+// setAllNulls sets all tuples in vecs with indexes in [0, length) range to
 // null.
 func setAllNulls(vecs []*coldata.Vec, length int) {
 	for i := range vecs {

--- a/pkg/sql/colexec/colexecjoin/hashjoiner.go
+++ b/pkg/sql/colexec/colexecjoin/hashjoiner.go
@@ -69,7 +69,7 @@ type HashJoinerSpec struct {
 }
 
 type hashJoinerSourceSpec struct {
-	// EqCols specify the indices of the source tables equality column during the
+	// EqCols specify the indexes of the source tables equality column during the
 	// hash join.
 	EqCols []uint32
 
@@ -109,14 +109,14 @@ type hashJoinerSourceSpec struct {
 //  2. In order to find the position of these key tuples in the hash table:
 //     - First find the first element in the bucket's linked list for each key tuple
 //     and store it in the ToCheckID array. Initialize the ToCheck array with the
-//     full sequence of input indices (0...batchSize - 1).
+//     full sequence of input indexes (0...batchSize - 1).
 //     - While ToCheck is not empty, each element in ToCheck represents a position
 //     of the key tuples for which the key has not yet been found in the hash
 //     table. Perform a multi-column equality check to see if the key columns
 //     match that of the build table's key columns at ToCheckID.
 //     - Update the differs array to store whether or not the probe's key tuple
 //     matched the corresponding build's key tuple.
-//     - Select the indices that differed and store them into ToCheck since they
+//     - Select the indexes that differed and store them into ToCheck since they
 //     need to be further processed.
 //     - For the differing tuples, find the next ID in that bucket of the hash table
 //     and put it into the ToCheckID array.
@@ -132,19 +132,19 @@ type hashJoinerSourceSpec struct {
 //  2. In order to find the position of these key tuples in the hash table:
 //     - First find the first element in the bucket's linked list for each key tuple
 //     and store it in the ToCheckID array. Initialize the ToCheck array with the
-//     full sequence of input indices (0...batchSize - 1).
+//     full sequence of input indexes (0...batchSize - 1).
 //     - While ToCheck is not empty, each element in ToCheck represents a position
 //     of the key tuples for which the key has not yet been visited by any prior
 //     probe. Perform a multi-column equality check to see if the key columns
 //     match that of the build table's key columns at ToCheckID.
 //     - Update the differs array to store whether or not the probe's key tuple
 //     matched the corresponding build's key tuple.
-//     - For the indices that did not differ, we can lazily update the HashTable's
+//     - For the indexes that did not differ, we can lazily update the HashTable's
 //     Same linked list to store a list of all identical keys starting at head.
 //     Once a key has been added to ht.Same, ht.Visited is set to true. For the
-//     indices that have never been visited, we want to continue checking this
+//     indexes that have never been visited, we want to continue checking this
 //     bucket for identical values by adding this key to ToCheck.
-//     - Select the indices that differed and store them into ToCheck since they
+//     - Select the indexes that differed and store them into ToCheck since they
 //     need to be further processed.
 //     - For the differing tuples, find the next ID in that bucket of the hash table
 //     and put it into the ToCheckID array.
@@ -190,7 +190,7 @@ type hashJoiner struct {
 
 	// probeState is used in hjProbing state.
 	probeState struct {
-		// buildIdx and probeIdx represents the matching row indices that are
+		// buildIdx and probeIdx represents the matching row indexes that are
 		// used to stitch together the join results.
 		buildIdx []int
 		probeIdx []int
@@ -535,7 +535,7 @@ func (hj *hashJoiner) exec() coldata.Batch {
 		hj.ht.ComputeBuckets(hj.probeState.buckets, hj.ht.Keys, batchSize, sel)
 
 		// Then, we initialize ToCheckID with the initial hash buckets and
-		// ToCheck with all applicable indices. Notably, only probing tuples
+		// ToCheck with all applicable indexes. Notably, only probing tuples
 		// that have hash matches are included into ToCheck whereas ToCheckID is
 		// correctly set for all tuples.
 		hj.ht.ProbeScratch.SetupLimitedSlices(batchSize)

--- a/pkg/sql/colexec/colexecjoin/mergejoiner.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner.go
@@ -75,8 +75,8 @@ import (
 //
 // We start of with reading first batches from both inputs (we store them in
 // mjProberState) and performing the probing step. We find that we have a single
-// group such that it contains rows with indices [0, 2) on the left and with
-// indices [0, 1) on the right. This group is fully contained within the batch
+// group such that it contains rows with indexes [0, 2) on the left and with
+// indexes [0, 1) on the right. This group is fully contained within the batch
 // (i.e. it is not a buffered group), so we'll be able to populate the cross
 // product during the build step. The last row with index 2 in the left batch
 // starts the left buffered group (we don't know yet whether the second batch
@@ -149,7 +149,7 @@ type mjState int
 
 const (
 	// mjEntry is the entry state of the merge joiner where all the batches and
-	// indices are properly set, regardless if Next was called the first time or
+	// indexes are properly set, regardless if Next was called the first time or
 	// the 1000th time. This state also routes into the correct state based on
 	// the prober state after setup.
 	mjEntry mjState = iota
@@ -266,7 +266,7 @@ type mjProberState struct {
 }
 
 type mergeJoinInput struct {
-	// eqCols specify the indices of the source table equality columns during the
+	// eqCols specify the indexes of the source table equality columns during the
 	// merge join.
 	eqCols []uint32
 
@@ -439,7 +439,7 @@ func NewMergeJoinOp(
 	}
 	for i := 0; i < numRightTypes; i++ {
 		// Merge joiner outputs all columns from both sides, and the columns
-		// from the right have indices in [numActualLeftTypes,
+		// from the right have indexes in [numActualLeftTypes,
 		// numActualLeftTypes + numActualRightTypes) range.
 		projection = append(projection, uint32(numActualLeftTypes+i))
 	}

--- a/pkg/sql/colexec/colexecjoin/mergejoiner_util.go
+++ b/pkg/sql/colexec/colexecjoin/mergejoiner_util.go
@@ -327,7 +327,7 @@ func (b *circularGroupsBuffer) addRightSemiGroup(curRIdx int, rRunLength int) {
 	b.advanceEnd()
 }
 
-// finishedCol is used to notify the circular buffer to update the indices
+// finishedCol is used to notify the circular buffer to update the indexes
 // representing the "window" of available values for the next column.
 func (b *circularGroupsBuffer) finishedCol() {
 	b.startIdx = b.nextColStartIdx

--- a/pkg/sql/colexec/colexectestutils/utils.go
+++ b/pkg/sql/colexec/colexectestutils/utils.go
@@ -936,15 +936,15 @@ func (s *opTestInput) Next() coldata.Batch {
 		for i := range s.selection {
 			s.selection[i] = i
 		}
-		// We have populated s.selection vector with possibly more indices than we
+		// We have populated s.selection vector with possibly more indexes than we
 		// have actual tuples for, so some "default" tuples will be introduced but
 		// will not be selected due to the length of the batch being equal to the
 		// number of actual tuples.
 		//
 		// To introduce an element of chaos in the testing process we shuffle the
 		// selection vector; however, in the real environment we expect that
-		// indices in the selection vector to be in ascending order, so we sort
-		// only those indices that correspond to the actual tuples. For example,
+		// indexes in the selection vector to be in ascending order, so we sort
+		// only those indexes that correspond to the actual tuples. For example,
 		// say we have 3 actual tuples, and after shuffling the selection vector
 		// is [200, 50, 100, ...], so we sort only those 3 values to get to
 		// [50, 100, 200, ...] in order to "scan" the selection vector in

--- a/pkg/sql/colexec/colexecutils/spilling_buffer.go
+++ b/pkg/sql/colexec/colexecutils/spilling_buffer.go
@@ -84,7 +84,7 @@ type SpillingBuffer struct {
 //
 // The column indexes that are passed as the last argument(s) are used to
 // determine which columns should be used from input batches during calls to
-// AppendTuples. If nil, columns at indices 0...len(inputTypes)-1 will be used.
+// AppendTuples. If nil, columns at indexes 0...len(inputTypes)-1 will be used.
 // Note that the given inputTypes slice defines the types of the columns that
 // will be stored, but the input batches may have a different schema when
 // colIdxs is not nil.

--- a/pkg/sql/colexec/colexecutils/utils.go
+++ b/pkg/sql/colexec/colexecutils/utils.go
@@ -37,7 +37,7 @@ func MakeWindowIntoBatch(
 		windowedBatch.SetSelection(true)
 		windowIntoSel := sel[startIdx:endIdx]
 		copy(windowedBatch.Selection(), windowIntoSel)
-		// We have to adjust the indices of our window based on the selection
+		// We have to adjust the indexes of our window based on the selection
 		// vector. The window needs to start from the zeroth tuple (even if it
 		// is not included in the selection vector) so that we don't have to
 		// shift the selection vector on the windowed batch.
@@ -196,7 +196,7 @@ func (b *AppendOnlyBufferedBatch) String() string {
 	return b.batch.String()
 }
 
-// AppendTuples is a helper method that appends all tuples with indices in range
+// AppendTuples is a helper method that appends all tuples with indexes in range
 // [startIdx, endIdx) from batch (paying attention to the selection vector)
 // into b. The newly allocated memory is registered with the allocator used to
 // create this AppendOnlyBufferedBatch.

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg.eg.go
@@ -56,12 +56,12 @@ type minMaxRemovableAggBase struct {
 	outputColIdx  int
 	framer        windowFramer
 
-	// A partial deque of indices into the current partition ordered by the value
-	// of the input column at each index. It contains only indices that are part
+	// A partial deque of indexes into the current partition ordered by the value
+	// of the input column at each index. It contains only indexes that are part
 	// of the current window frame. The first value in the queue is the index of
 	// the current value for the aggregation (NULL if empty). Under the
 	// simplifying assumption that the window frame has no exclusion clause, the
-	// queue does not need to contain any indices smaller than the best index -
+	// queue does not need to contain any indexes smaller than the best index -
 	// this keeps the queue small in many common cases.
 	queue minMaxQueue
 

--- a/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/min_max_removable_agg_tmpl.go
@@ -75,12 +75,12 @@ type minMaxRemovableAggBase struct {
 	outputColIdx  int
 	framer        windowFramer
 
-	// A partial deque of indices into the current partition ordered by the value
-	// of the input column at each index. It contains only indices that are part
+	// A partial deque of indexes into the current partition ordered by the value
+	// of the input column at each index. It contains only indexes that are part
 	// of the current window frame. The first value in the queue is the index of
 	// the current value for the aggregation (NULL if empty). Under the
 	// simplifying assumption that the window frame has no exclusion clause, the
-	// queue does not need to contain any indices smaller than the best index -
+	// queue does not need to contain any indexes smaller than the best index -
 	// this keeps the queue small in many common cases.
 	queue minMaxQueue
 

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler.eg.go
@@ -766,7 +766,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt16) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -913,7 +913,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt32) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1060,7 +1060,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInt64) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1207,7 +1207,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDecimal) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1344,7 +1344,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscFloat64) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1496,7 +1496,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscInterval) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1625,7 +1625,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDate) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1784,7 +1784,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscTimestamp) getIdx(ctx context.Contex
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -1928,7 +1928,7 @@ func (h *rangeHandlerOffsetPrecedingStartAscDatum) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2064,7 +2064,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt16) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2184,7 +2184,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt32) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2304,7 +2304,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInt64) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2424,7 +2424,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDecimal) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2534,7 +2534,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescFloat64) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2659,7 +2659,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescInterval) getIdx(ctx context.Contex
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2761,7 +2761,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDate) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -2893,7 +2893,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescTimestamp) getIdx(ctx context.Conte
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3010,7 +3010,7 @@ func (h *rangeHandlerOffsetPrecedingStartDescDatum) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3119,7 +3119,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt16) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3283,7 +3283,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt32) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3447,7 +3447,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInt64) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3611,7 +3611,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDecimal) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3765,7 +3765,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscFloat64) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -3934,7 +3934,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscInterval) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4080,7 +4080,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDate) getIdx(ctx context.Context, curr
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4256,7 +4256,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscTimestamp) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4417,7 +4417,7 @@ func (h *rangeHandlerOffsetPrecedingEndAscDatum) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4570,7 +4570,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt16) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4707,7 +4707,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt32) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4844,7 +4844,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInt64) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -4981,7 +4981,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDecimal) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5108,7 +5108,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescFloat64) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5250,7 +5250,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescInterval) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5369,7 +5369,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDate) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5518,7 +5518,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescTimestamp) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5652,7 +5652,7 @@ func (h *rangeHandlerOffsetPrecedingEndDescDatum) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5778,7 +5778,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt16) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -5925,7 +5925,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt32) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6072,7 +6072,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInt64) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6219,7 +6219,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDecimal) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6356,7 +6356,7 @@ func (h *rangeHandlerOffsetFollowingStartAscFloat64) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6508,7 +6508,7 @@ func (h *rangeHandlerOffsetFollowingStartAscInterval) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6637,7 +6637,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDate) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6796,7 +6796,7 @@ func (h *rangeHandlerOffsetFollowingStartAscTimestamp) getIdx(ctx context.Contex
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -6940,7 +6940,7 @@ func (h *rangeHandlerOffsetFollowingStartAscDatum) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7076,7 +7076,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt16) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7196,7 +7196,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt32) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7316,7 +7316,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInt64) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7436,7 +7436,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDecimal) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7546,7 +7546,7 @@ func (h *rangeHandlerOffsetFollowingStartDescFloat64) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7671,7 +7671,7 @@ func (h *rangeHandlerOffsetFollowingStartDescInterval) getIdx(ctx context.Contex
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7773,7 +7773,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDate) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -7905,7 +7905,7 @@ func (h *rangeHandlerOffsetFollowingStartDescTimestamp) getIdx(ctx context.Conte
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8022,7 +8022,7 @@ func (h *rangeHandlerOffsetFollowingStartDescDatum) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8131,7 +8131,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt16) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8295,7 +8295,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt32) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8459,7 +8459,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInt64) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8623,7 +8623,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDecimal) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8777,7 +8777,7 @@ func (h *rangeHandlerOffsetFollowingEndAscFloat64) getIdx(ctx context.Context, c
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -8946,7 +8946,7 @@ func (h *rangeHandlerOffsetFollowingEndAscInterval) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9092,7 +9092,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDate) getIdx(ctx context.Context, curr
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9268,7 +9268,7 @@ func (h *rangeHandlerOffsetFollowingEndAscTimestamp) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9429,7 +9429,7 @@ func (h *rangeHandlerOffsetFollowingEndAscDatum) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9582,7 +9582,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt16) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9719,7 +9719,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt32) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9856,7 +9856,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInt64) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -9993,7 +9993,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDecimal) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -10120,7 +10120,7 @@ func (h *rangeHandlerOffsetFollowingEndDescFloat64) getIdx(ctx context.Context, 
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -10262,7 +10262,7 @@ func (h *rangeHandlerOffsetFollowingEndDescInterval) getIdx(ctx context.Context,
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -10381,7 +10381,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDate) getIdx(ctx context.Context, cur
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -10530,7 +10530,7 @@ func (h *rangeHandlerOffsetFollowingEndDescTimestamp) getIdx(ctx context.Context
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.
@@ -10664,7 +10664,7 @@ func (h *rangeHandlerOffsetFollowingEndDescDatum) getIdx(ctx context.Context, cu
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.

--- a/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/range_offset_handler_tmpl.go
@@ -207,7 +207,7 @@ func (h *_OP_STRING) getIdx(ctx context.Context, currRow, lastIdx int) (idx int)
 
 	// When the order column is null, the offset is ignored. The start index is
 	// the first null value, and the end index is the end of the null group. All
-	// null rows have the same start and end indices.
+	// null rows have the same start and end indexes.
 	if vec.Nulls().MaybeHasNulls() && vec.Nulls().NullAt(vecIdx) {
 		// Since this function is only called for the first row of each peer group,
 		// this is the first null row.

--- a/pkg/sql/colexec/colexecwindow/window_framer.eg.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer.eg.go
@@ -24,7 +24,7 @@ type windowFramer interface {
 	// getColsToStore is called upon initialization of the windowFramer operators
 	// in order to add to the list of columns to store in the SpillingBuffer owned
 	// by the parent operator.
-	// getColsToStore adds column indices to the given list when the windowFramer
+	// getColsToStore adds column indexes to the given list when the windowFramer
 	// operator needs access to values in a column for each partition (for
 	// example, the peer groups column). If a column to be stored is already
 	// present in the list, a duplicate entry will not be created.
@@ -1155,7 +1155,7 @@ func (b *windowFramerBase) frameIntervals() []windowInterval {
 	return b.intervals
 }
 
-// getColsToStore appends to the given slice of column indices whatever columns
+// getColsToStore appends to the given slice of column indexes whatever columns
 // to which the window framer will need access. getColsToStore also remaps the
 // corresponding fields in the window framer to refer to ordinal positions
 // within the colsToStore slice rather than within the input batches.
@@ -1304,7 +1304,7 @@ func (b *windowFramerBase) handleOffsets(
 	}
 }
 
-// handleExcludeForNext updates the start and end indices for rows excluded by
+// handleExcludeForNext updates the start and end indexes for rows excluded by
 // the window frame's exclusion clause.
 func (b *windowFramerBase) handleExcludeForNext(ctx context.Context, currRowIsGroupStart bool) {
 	if b.excludeCurrRow() {
@@ -1316,7 +1316,7 @@ func (b *windowFramerBase) handleExcludeForNext(ctx context.Context, currRowIsGr
 		// actually exclude the current row, but that is handled later (by
 		// handleExcludeForFirstIdx, handleExcludeForLastIdx, etc.).
 		if currRowIsGroupStart {
-			// Only update the exclude indices upon entering a new peer group.
+			// Only update the exclude indexes upon entering a new peer group.
 			b.excludeStartIdx = b.excludeEndIdx
 			b.excludeEndIdx = b.incrementPeerGroup(ctx, b.excludeEndIdx, 1 /* groups */)
 		}
@@ -1427,7 +1427,7 @@ func getSlidingWindowIntervals(
 		// We need to find the set difference currIntervals \ prevIntervals (toAdd)
 		// and the set difference prevIntervals \ currIntervals (toRemove). To do
 		// this, take advantage of the fact that both sets of intervals are in
-		// ascending order, similar to merging sorted lists. Maintain indices into
+		// ascending order, similar to merging sorted lists. Maintain indexes into
 		// each list, and iterate whichever index has the 'smaller' interval
 		// (e.g. whichever ends first). The portions of the intervals that overlap
 		// are ignored, while those that don't are added to one of the 'toAdd' and

--- a/pkg/sql/colexec/colexecwindow/window_framer_tmpl.go
+++ b/pkg/sql/colexec/colexecwindow/window_framer_tmpl.go
@@ -44,7 +44,7 @@ type windowFramer interface {
 	// in order to add to the list of columns to store in the SpillingBuffer owned
 	// by the parent operator.
 	//
-	// getColsToStore adds column indices to the given list when the windowFramer
+	// getColsToStore adds column indexes to the given list when the windowFramer
 	// operator needs access to values in a column for each partition (for
 	// example, the peer groups column). If a column to be stored is already
 	// present in the list, a duplicate entry will not be created.
@@ -260,7 +260,7 @@ func (b *windowFramerBase) frameIntervals() []windowInterval {
 	return b.intervals
 }
 
-// getColsToStore appends to the given slice of column indices whatever columns
+// getColsToStore appends to the given slice of column indexes whatever columns
 // to which the window framer will need access. getColsToStore also remaps the
 // corresponding fields in the window framer to refer to ordinal positions
 // within the colsToStore slice rather than within the input batches.
@@ -409,7 +409,7 @@ func (b *windowFramerBase) handleOffsets(
 	}
 }
 
-// handleExcludeForNext updates the start and end indices for rows excluded by
+// handleExcludeForNext updates the start and end indexes for rows excluded by
 // the window frame's exclusion clause.
 func (b *windowFramerBase) handleExcludeForNext(ctx context.Context, currRowIsGroupStart bool) {
 	if b.excludeCurrRow() {
@@ -421,7 +421,7 @@ func (b *windowFramerBase) handleExcludeForNext(ctx context.Context, currRowIsGr
 		// actually exclude the current row, but that is handled later (by
 		// handleExcludeForFirstIdx, handleExcludeForLastIdx, etc.).
 		if currRowIsGroupStart {
-			// Only update the exclude indices upon entering a new peer group.
+			// Only update the exclude indexes upon entering a new peer group.
 			b.excludeStartIdx = b.excludeEndIdx
 			b.excludeEndIdx = b.incrementPeerGroup(ctx, b.excludeEndIdx, 1 /* groups */)
 		}
@@ -532,7 +532,7 @@ func getSlidingWindowIntervals(
 		// We need to find the set difference currIntervals \ prevIntervals (toAdd)
 		// and the set difference prevIntervals \ currIntervals (toRemove). To do
 		// this, take advantage of the fact that both sets of intervals are in
-		// ascending order, similar to merging sorted lists. Maintain indices into
+		// ascending order, similar to merging sorted lists. Maintain indexes into
 		// each list, and iterate whichever index has the 'smaller' interval
 		// (e.g. whichever ends first). The portions of the intervals that overlap
 		// are ignored, while those that don't are added to one of the 'toAdd' and

--- a/pkg/sql/colexec/hash_aggregator.eg.go
+++ b/pkg/sql/colexec/hash_aggregator.eg.go
@@ -13,7 +13,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// populateEqChains populates op.scratch.eqChains with indexes of tuples from b
 // that belong to the same groups. It returns the number of equality chains.
 // Passed-in sel is updated to include tuples that are "heads" of the
 // corresponding equality chains and op.ht.ProbeScratch.HashBuffer is adjusted
@@ -23,7 +23,7 @@ const _ = "template_populateEqChains"
 
 var zeroIntColumn = make([]int, coldata.MaxBatchSize)
 
-// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// populateEqChains populates op.scratch.eqChains with indexes of tuples from b
 // that belong to the same groups. It returns the number of equality chains as
 // well as a selection vector that contains "heads" of each of the chains. The
 // method assumes that op.ht.ProbeScratch.HeadID has been populated with keyIDs
@@ -86,7 +86,7 @@ func (op *hashAggregator) Next() coldata.Batch {
 	}
 }
 
-// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// populateEqChains populates op.scratch.eqChains with indexes of tuples from b
 // that belong to the same groups. It returns the number of equality chains.
 // Passed-in sel is updated to include tuples that are "heads" of the
 // corresponding equality chains and op.ht.ProbeScratch.HashBuffer is adjusted
@@ -138,7 +138,7 @@ func populateEqChains_true(
 	return eqChainsCount
 }
 
-// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// populateEqChains populates op.scratch.eqChains with indexes of tuples from b
 // that belong to the same groups. It returns the number of equality chains.
 // Passed-in sel is updated to include tuples that are "heads" of the
 // corresponding equality chains and op.ht.ProbeScratch.HashBuffer is adjusted

--- a/pkg/sql/colexec/hash_aggregator_tmpl.go
+++ b/pkg/sql/colexec/hash_aggregator_tmpl.go
@@ -14,7 +14,7 @@ import (
 	"github.com/cockroachdb/errors"
 )
 
-// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// populateEqChains populates op.scratch.eqChains with indexes of tuples from b
 // that belong to the same groups. It returns the number of equality chains.
 // Passed-in sel is updated to include tuples that are "heads" of the
 // corresponding equality chains and op.ht.ProbeScratch.HashBuffer is adjusted
@@ -80,7 +80,7 @@ func populateEqChains(
 
 var zeroIntColumn = make([]int, coldata.MaxBatchSize)
 
-// populateEqChains populates op.scratch.eqChains with indices of tuples from b
+// populateEqChains populates op.scratch.eqChains with indexes of tuples from b
 // that belong to the same groups. It returns the number of equality chains as
 // well as a selection vector that contains "heads" of each of the chains. The
 // method assumes that op.ht.ProbeScratch.HeadID has been populated with keyIDs

--- a/pkg/sql/colexec/ordered_aggregator.go
+++ b/pkg/sql/colexec/ordered_aggregator.go
@@ -72,7 +72,7 @@ const (
 // overflow values are copied to the start of the batch. Since the input batch
 // size is not necessarily the same as the output batch size, more than one copy
 // and return must be performed until the aggregator is in a state where its
-// functions are in a state where the output indices would not overflow the
+// functions are in a state where the output indexes would not overflow the
 // output batch if a worst case input batch is encountered (one where every
 // value is part of a new group).
 type orderedAggregator struct {

--- a/pkg/sql/colexec/ordered_synchronizer.eg.go
+++ b/pkg/sql/colexec/ordered_synchronizer.eg.go
@@ -46,14 +46,14 @@ type OrderedSynchronizer struct {
 
 	// inputBatches stores the current batch for each input.
 	inputBatches []coldata.Batch
-	// inputIndices stores the current index into each input batch.
-	inputIndices []int
+	// inputIndexes stores the current index into each input batch.
+	inputIndexes []int
 	// advanceMinBatch, if true, indicates that the minimum input (according to
 	// heap) needs to be advanced by one row. This advancement is delayed in
 	// order to not fetch the next batch from the input too eagerly.
 	advanceMinBatch bool
-	// heap is a min heap which stores indices into inputBatches. The "current
-	// value" of ith input batch is the tuple at inputIndices[i] position of
+	// heap is a min heap which stores indexes into inputBatches. The "current
+	// value" of ith input batch is the tuple at inputIndexes[i] position of
 	// inputBatches[i] batch. If an input is fully exhausted, it will be removed
 	// from heap.
 	heap []int
@@ -126,11 +126,11 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 			// Advance the minimum input batch, fetching a new batch if
 			// necessary.
 			minBatch := o.heap[0]
-			if o.inputIndices[minBatch]+1 < o.inputBatches[minBatch].Length() {
-				o.inputIndices[minBatch]++
+			if o.inputIndexes[minBatch]+1 < o.inputBatches[minBatch].Length() {
+				o.inputIndexes[minBatch]++
 			} else {
 				o.inputBatches[minBatch] = o.inputs[minBatch].Root.Next()
-				o.inputIndices[minBatch] = 0
+				o.inputIndexes[minBatch] = 0
 				o.updateComparators(minBatch)
 			}
 			if o.inputBatches[minBatch].Length() == 0 {
@@ -149,7 +149,7 @@ func (o *OrderedSynchronizer) Next() coldata.Batch {
 		minBatch := o.heap[0]
 		// Copy the min row into the output.
 		batch := o.inputBatches[minBatch]
-		srcRowIdx := o.inputIndices[minBatch]
+		srcRowIdx := o.inputIndexes[minBatch]
 		if sel := batch.Selection(); sel != nil {
 			srcRowIdx = sel[srcRowIdx]
 		}
@@ -286,7 +286,7 @@ func (o *OrderedSynchronizer) Init(ctx context.Context) {
 		return
 	}
 	o.Ctx, o.span = execinfra.ProcessorSpan(o.Ctx, o.flowCtx, "ordered sync", o.processorID)
-	o.inputIndices = make([]int, len(o.inputs))
+	o.inputIndexes = make([]int, len(o.inputs))
 	for i := range o.inputs {
 		o.inputs[i].Root.Init(o.Ctx)
 	}
@@ -327,8 +327,8 @@ func (o *OrderedSynchronizer) Close(context.Context) error {
 func (o *OrderedSynchronizer) compareRow(batchIdx1 int, batchIdx2 int) int {
 	batch1 := o.inputBatches[batchIdx1]
 	batch2 := o.inputBatches[batchIdx2]
-	valIdx1 := o.inputIndices[batchIdx1]
-	valIdx2 := o.inputIndices[batchIdx2]
+	valIdx1 := o.inputIndexes[batchIdx1]
+	valIdx2 := o.inputIndexes[batchIdx2]
 	if sel := batch1.Selection(); sel != nil {
 		valIdx1 = sel[valIdx1]
 	}

--- a/pkg/sql/colexec/sort.go
+++ b/pkg/sql/colexec/sort.go
@@ -441,7 +441,7 @@ func (p *sortOp) sort() {
 		} else {
 			omitNextPartitioning = false
 		}
-		// Convert the distinct vector into a selection vector - a vector of indices
+		// Convert the distinct vector into a selection vector - a vector of indexes
 		// that were true in the distinct vector.
 		sizeBefore := memsize.Int * int64(cap(p.scratch.partitions))
 		p.scratch.partitions = boolVecToSel(partitionsCol, p.scratch.partitions[:0])

--- a/pkg/sql/colexec/sort_chunks.go
+++ b/pkg/sql/colexec/sort_chunks.go
@@ -241,7 +241,7 @@ type chunker struct {
 	// partitionCol is a bool slice for partitioners' output to be ORed.
 	partitionCol []bool
 
-	// chunks contains the indices of the first tuples within different chunks
+	// chunks contains the indexes of the first tuples within different chunks
 	// found in the last read batch. Note: the first chunk might be a part of
 	// the chunk that is currently being buffered, and similarly the last chunk
 	// might include tuples from the batches to be read.

--- a/pkg/sql/colexec/sorttopk.eg.go
+++ b/pkg/sql/colexec/sorttopk.eg.go
@@ -37,7 +37,7 @@ const _ = "template_processGroupsInBatch"
 const _ = "template_processBatch"
 
 // spool reads in the entire input, always storing the top K rows it has seen so
-// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// far in o.topK. This is done by maintaining a max heap of indexes into o.topK.
 // Whenever we encounter a row which is smaller than the max row in the heap,
 // we replace the max with that row.
 //
@@ -54,7 +54,7 @@ const _ = "template_spool"
 const _ = "template_compareRow"
 
 // spool reads in the entire input, always storing the top K rows it has seen so
-// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// far in o.topK. This is done by maintaining a max heap of indexes into o.topK.
 // Whenever we encounter a row which is smaller than the max row in the heap,
 // we replace the max with that row.
 //
@@ -94,7 +94,7 @@ func (t *topKPartialOrderHeaper) Less(i, j int) bool {
 }
 
 // spool reads in the entire input, always storing the top K rows it has seen so
-// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// far in o.topK. This is done by maintaining a max heap of indexes into o.topK.
 // Whenever we encounter a row which is smaller than the max row in the heap,
 // we replace the max with that row.
 //
@@ -296,7 +296,7 @@ func spool_true(t *topKSorter) {
 }
 
 // spool reads in the entire input, always storing the top K rows it has seen so
-// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// far in o.topK. This is done by maintaining a max heap of indexes into o.topK.
 // Whenever we encounter a row which is smaller than the max row in the heap,
 // we replace the max with that row.
 //

--- a/pkg/sql/colexec/sorttopk.go
+++ b/pkg/sql/colexec/sorttopk.go
@@ -108,7 +108,7 @@ type topKSorter struct {
 	comparators []vecComparator
 	// topK stores the top K rows. It is not sorted internally.
 	topK *colexecutils.AppendOnlyBufferedBatch
-	// heap is a max heap which stores indices into topK.
+	// heap is a max heap which stores indexes into topK.
 	heap   []int
 	heaper heap.Interface
 	// sel is a selection vector which specifies an ordering on topK.

--- a/pkg/sql/colexec/sorttopk_tmpl.go
+++ b/pkg/sql/colexec/sorttopk_tmpl.go
@@ -97,7 +97,7 @@ func processBatch(
 }
 
 // spool reads in the entire input, always storing the top K rows it has seen so
-// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// far in o.topK. This is done by maintaining a max heap of indexes into o.topK.
 // Whenever we encounter a row which is smaller than the max row in the heap,
 // we replace the max with that row.
 //
@@ -238,7 +238,7 @@ func compareRow(
 }
 
 // spool reads in the entire input, always storing the top K rows it has seen so
-// far in o.topK. This is done by maintaining a max heap of indices into o.topK.
+// far in o.topK. This is done by maintaining a max heap of indexes into o.topK.
 // Whenever we encounter a row which is smaller than the max row in the heap,
 // we replace the max with that row.
 //

--- a/pkg/sql/colexec/substring.eg.go
+++ b/pkg/sql/colexec/substring.eg.go
@@ -157,7 +157,7 @@ func (s *substringInt64Int16Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -258,7 +258,7 @@ func (s *substringInt64Int32Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -359,7 +359,7 @@ func (s *substringInt64Int64Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -460,7 +460,7 @@ func (s *substringInt16Int16Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -561,7 +561,7 @@ func (s *substringInt16Int32Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -662,7 +662,7 @@ func (s *substringInt16Int64Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -763,7 +763,7 @@ func (s *substringInt32Int16Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -864,7 +864,7 @@ func (s *substringInt32Int32Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {
@@ -965,7 +965,7 @@ func (s *substringInt32Int64Operator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {

--- a/pkg/sql/colexec/substring_tmpl.go
+++ b/pkg/sql/colexec/substring_tmpl.go
@@ -157,7 +157,7 @@ func (s *substring_StartType_LengthTypeOperator) Next() coldata.Batch {
 
 				// If there is a rune that uses more than 1 byte in the substring or in
 				// the bytes leading up to the substring, then we must adjust the start
-				// and end indices to the rune boundaries. However, we have to test the
+				// and end indexes to the rune boundaries. However, we have to test the
 				// entire bytes slice instead of a subset, since RuneCount will treat an
 				// incomplete encoding as a single byte rune.
 				if utf8.RuneCount(bytes) != len(bytes) {

--- a/pkg/sql/colexec/values_differ.eg.go
+++ b/pkg/sql/colexec/values_differ.eg.go
@@ -27,7 +27,7 @@ var (
 	_ tree.AggType
 )
 
-// valuesDiffer takes in two ColVecs as well as values indices to check whether
+// valuesDiffer takes in two ColVecs as well as values indexes to check whether
 // the values differ. This function pays attention to NULLs.
 func valuesDiffer(
 	aColVec *coldata.Vec, aValueIdx int, bColVec *coldata.Vec, bValueIdx int, nullsAreDistinct bool,

--- a/pkg/sql/colexec/values_differ_tmpl.go
+++ b/pkg/sql/colexec/values_differ_tmpl.go
@@ -54,7 +54,7 @@ func _ASSIGN_NE(_, _, _, _, _, _ string) bool {
 
 // */}}
 
-// valuesDiffer takes in two ColVecs as well as values indices to check whether
+// valuesDiffer takes in two ColVecs as well as values indexes to check whether
 // the values differ. This function pays attention to NULLs.
 func valuesDiffer(
 	aColVec *coldata.Vec, aValueIdx int, bColVec *coldata.Vec, bValueIdx int, nullsAreDistinct bool,

--- a/pkg/sql/colflow/colrpc/inbox_test.go
+++ b/pkg/sql/colflow/colrpc/inbox_test.go
@@ -423,15 +423,15 @@ func TestInboxShutdown(t *testing.T) {
 						},
 					}
 
-					// goroutineIndices will be shuffled around to randomly change the order in
+					// goroutineIndexes will be shuffled around to randomly change the order in
 					// which the goroutines are spawned.
-					goroutineIndices := make([]int, len(goroutines))
-					for i := range goroutineIndices {
-						goroutineIndices[i] = i
+					goroutineIndexes := make([]int, len(goroutines))
+					for i := range goroutineIndexes {
+						goroutineIndexes[i] = i
 					}
-					rng.Shuffle(len(goroutineIndices), func(i, j int) { goroutineIndices[i], goroutineIndices[j] = goroutineIndices[j], goroutineIndices[i] })
+					rng.Shuffle(len(goroutineIndexes), func(i, j int) { goroutineIndexes[i], goroutineIndexes[j] = goroutineIndexes[j], goroutineIndexes[i] })
 					errChans := make([]chan error, 0, len(goroutines))
-					for _, i := range goroutineIndices {
+					for _, i := range goroutineIndexes {
 						errChans = append(errChans, goroutines[i].asyncOperation())
 					}
 
@@ -439,7 +439,7 @@ func TestInboxShutdown(t *testing.T) {
 						for err := <-errCh; err != nil; err = <-errCh {
 							if !testutils.IsError(err, "context canceled|artificial timeout") {
 								// Error to keep on draining errors but mark this test as failed.
-								t.Errorf("unexpected error %v from %s goroutine", err, goroutines[goroutineIndices[i]].name)
+								t.Errorf("unexpected error %v from %s goroutine", err, goroutines[goroutineIndexes[i]].name)
 							}
 						}
 					}

--- a/pkg/sql/colflow/routers.go
+++ b/pkg/sql/colflow/routers.go
@@ -424,7 +424,7 @@ type HashRouter struct {
 	// inputMetaInfo contains all of the meta components that the hash router
 	// is responsible for. Root field is exactly the same as OneInputNode.Input.
 	inputMetaInfo colexecargs.OpWithMetaInfo
-	// hashCols is a slice of indices of the columns used for hashing.
+	// hashCols is a slice of indexes of the columns used for hashing.
 	hashCols []uint32
 
 	// One output for each stream.

--- a/pkg/sql/colflow/routers_test.go
+++ b/pkg/sql/colflow/routers_test.go
@@ -165,7 +165,7 @@ func TestRouterOutputAddBatch(t *testing.T) {
 		inputBatchSize   int
 		outputBatchSize  int
 		blockedThreshold int
-		// selection determines which indices to add to the router output as well
+		// selection determines which indexes to add to the router output as well
 		// as how many elements from data are compared to the output.
 		selection []int
 		name      string

--- a/pkg/sql/colflow/vectorized_flow.go
+++ b/pkg/sql/colflow/vectorized_flow.go
@@ -595,7 +595,7 @@ type vectorizedFlowCreator struct {
 	// NB: must be accessed atomically.
 	numOutboxesDrained int32
 
-	// procIdxQueue is a queue of indices into processorSpecs (the argument to
+	// procIdxQueue is a queue of indexes into processorSpecs (the argument to
 	// setupFlow), for topologically ordered processing.
 	procIdxQueue []int
 	// opChains accumulates all operators that have no further outputs on the

--- a/pkg/sql/colmem/allocator.go
+++ b/pkg/sql/colmem/allocator.go
@@ -839,7 +839,7 @@ type SetAccountingHelper struct {
 	// fixed-length elements.
 	allFixedLength bool
 
-	// bytesLikeVecIdxs stores the indices of all bytes-like vectors.
+	// bytesLikeVecIdxs stores the indexes of all bytes-like vectors.
 	bytesLikeVecIdxs intsets.Fast
 	// bytesLikeVectors stores all actual bytes-like vectors. It is updated
 	// every time a new batch is allocated.
@@ -848,7 +848,7 @@ type SetAccountingHelper struct {
 	// that we have already accounted for.
 	prevBytesLikeTotalSize int64
 
-	// varSizeVecIdxs stores the indices of all vectors with variable sized
+	// varSizeVecIdxs stores the indexes of all vectors with variable sized
 	// values except for the bytes-like ones.
 	varSizeVecIdxs intsets.Fast
 	// decimalVecs and datumVecs store all decimal and datum-backed vectors,

--- a/pkg/sql/delete_preserving_index_test.go
+++ b/pkg/sql/delete_preserving_index_test.go
@@ -639,7 +639,7 @@ func TestMergeProcessor(t *testing.T) {
 			EvalCtx: &evalCtx,
 		}
 
-		// Here want to have different entries for the two indices, so we manipulate
+		// Here want to have different entries for the two indexes, so we manipulate
 		// the index to DELETE_ONLY when we don't want to write to it, and
 		// WRITE_ONLY when we write to it.
 		setUseDeletePreservingEncoding := func(b bool) func(*descpb.IndexDescriptor) error {

--- a/pkg/sql/distinct.go
+++ b/pkg/sql/distinct.go
@@ -16,12 +16,12 @@ import (
 type distinctNode struct {
 	singleInputPlanNode
 
-	// distinctOnColIdxs are the column indices of the child planNode and
+	// distinctOnColIdxs are the column indexes of the child planNode and
 	// is what defines the distinct key.
 	// For a normal DISTINCT (without the ON clause), distinctOnColIdxs
-	// contains all the column indices of the child planNode.
+	// contains all the column indexes of the child planNode.
 	// Otherwise, distinctOnColIdxs is a strict subset of the child
-	// planNode's column indices indicating which columns are specified in
+	// planNode's column indexes indicating which columns are specified in
 	// the DISTINCT ON (<exprs>) clause.
 	distinctOnColIdxs intsets.Fast
 

--- a/pkg/sql/distsql/columnar_operators_test.go
+++ b/pkg/sql/distsql/columnar_operators_test.go
@@ -229,7 +229,7 @@ func TestAggregatorAgainstProcessor(t *testing.T) {
 					}
 					// After all utility columns, we will have input columns for each
 					// of the aggregate functions. Here, we will set up the column
-					// indices, and the types will be generated below.
+					// indexes, and the types will be generated below.
 					numColsSoFar := numUtilityCols
 					for i := range aggregations {
 						numArguments := aggregateFuncToNumArguments[aggregations[i].Func]

--- a/pkg/sql/distsql_physical_planner.go
+++ b/pkg/sql/distsql_physical_planner.go
@@ -642,7 +642,7 @@ func checkSupportForPlanNode(
 			return cannotDistribute, err
 		}
 		rec := recLeft.compose(recRight)
-		if len(n.pred.leftEqualityIndices) > 0 {
+		if len(n.pred.leftEqualityIndexes) > 0 {
 			// We can partition both streams on the equality columns.
 			if n.estimatedLeftRowCount == 0 && n.estimatedRightRowCount == 0 {
 				log.VEventf(ctx, 2, "join (no stats) recommends plan distribution")
@@ -1209,7 +1209,7 @@ type PhysicalPlan struct {
 	physicalplan.PhysicalPlan
 
 	// PlanToStreamColMap maps planNode columns (see planColumns()) to columns in
-	// the result streams. These stream indices correspond to the streams
+	// the result streams. These stream indexes correspond to the streams
 	// referenced in ResultTypes.
 	//
 	// Note that in some cases, not all columns in the result streams are
@@ -2982,11 +2982,11 @@ func (dsp *DistSQLPlanner) planAggregators(
 
 			for _, finalInfo := range info.FinalStage {
 				// The input of the final aggregators is
-				// specified as the relative indices of the
+				// specified as the relative indexes of the
 				// local aggregation values. We need to map
-				// these to the corresponding absolute indices
+				// these to the corresponding absolute indexes
 				// in localAggs.
-				// argIdxs consists of the absolute indices
+				// argIdxs consists of the absolute indexes
 				// in localAggs.
 				argIdxs := make([]uint32, len(finalInfo.LocalIdxs))
 				for i, relIdx := range finalInfo.LocalIdxs {
@@ -3167,7 +3167,7 @@ func (dsp *DistSQLPlanner) planAggregators(
 						mappedIdxs[j] = int(finalIdxMap[finalIdx+j])
 					}
 					// Map the final aggregation values
-					// to their corresponding indices.
+					// to their corresponding indexes.
 					expr, err := info.FinalRendering(&h, mappedIdxs)
 					if err != nil {
 						return err
@@ -3945,8 +3945,8 @@ func (dsp *DistSQLPlanner) createPlanForJoin(
 	// We initialize these properties of the joiner. They will then be used to
 	// fill in the processor spec. See descriptions for HashJoinerSpec.
 	// Set up the equality columns and the merge ordering.
-	leftEqCols := eqCols(n.pred.leftEqualityIndices, leftMap)
-	rightEqCols := eqCols(n.pred.rightEqualityIndices, rightMap)
+	leftEqCols := eqCols(n.pred.leftEqualityIndexes, leftMap)
+	rightEqCols := eqCols(n.pred.rightEqualityIndexes, rightMap)
 	leftMergeOrd := distsqlOrdering(n.mergeJoinOrdering, leftEqCols)
 	rightMergeOrd := distsqlOrdering(n.mergeJoinOrdering, rightEqCols)
 

--- a/pkg/sql/distsql_plan_join.go
+++ b/pkg/sql/distsql_plan_join.go
@@ -29,7 +29,7 @@ type joinPlanningInfo struct {
 	onExpr              execinfrapb.Expression
 	post                execinfrapb.PostProcessSpec
 	joinToStreamColMap  []int
-	// leftEqCols and rightEqCols are the indices of equality columns. These
+	// leftEqCols and rightEqCols are the indexes of equality columns. These
 	// are only used when planning a hash join.
 	leftEqCols, rightEqCols             []uint32
 	leftEqColsAreKey, rightEqColsAreKey bool
@@ -157,13 +157,13 @@ func (h *joinPlanningHelper) remapOnExpr(
 }
 
 // eqCols produces a slice of ordinal references for the plan columns specified
-// in eqIndices using planToColMap.
-// That is: eqIndices contains a slice of plan column indexes and planToColMap
+// in eqIndexes using planToColMap.
+// That is: eqIndexes contains a slice of plan column indexes and planToColMap
 // maps the plan column indexes to the ordinal references (index of the
 // intermediate row produced).
-func eqCols(eqIndices []exec.NodeColumnOrdinal, planToColMap []int) []uint32 {
-	eqCols := make([]uint32, len(eqIndices))
-	for i, planCol := range eqIndices {
+func eqCols(eqIndexes []exec.NodeColumnOrdinal, planToColMap []int) []uint32 {
+	eqCols := make([]uint32, len(eqIndexes))
+	for i, planCol := range eqIndexes {
 		eqCols[i] = uint32(planToColMap[planCol])
 	}
 

--- a/pkg/sql/distsql_spec_exec_factory.go
+++ b/pkg/sql/distsql_spec_exec_factory.go
@@ -539,7 +539,7 @@ func (e *distSQLSpecExecFactory) ConstructMergeJoin(
 	leftEqColsAreKey, rightEqColsAreKey bool,
 	estimatedLeftRowCount, estimatedRightRowCount uint64,
 ) (exec.Node, error) {
-	leftEqCols, rightEqCols, mergeJoinOrdering, err := getEqualityIndicesAndMergeJoinOrdering(leftOrdering, rightOrdering)
+	leftEqCols, rightEqCols, mergeJoinOrdering, err := getEqualityIndexesAndMergeJoinOrdering(leftOrdering, rightOrdering)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/exec_factory_util.go
+++ b/pkg/sql/exec_factory_util.go
@@ -199,10 +199,10 @@ func getResultColumnsForSimpleProject(
 	return resultCols
 }
 
-func getEqualityIndicesAndMergeJoinOrdering(
+func getEqualityIndexesAndMergeJoinOrdering(
 	leftOrdering, rightOrdering colinfo.ColumnOrdering,
 ) (
-	leftEqualityIndices, rightEqualityIndices []exec.NodeColumnOrdinal,
+	leftEqualityIndexes, rightEqualityIndexes []exec.NodeColumnOrdinal,
 	mergeJoinOrdering colinfo.ColumnOrdering,
 	err error,
 ) {
@@ -212,23 +212,23 @@ func getEqualityIndicesAndMergeJoinOrdering(
 			"orderings from the left and right side must be the same non-zero length",
 		)
 	}
-	leftEqualityIndices = make([]exec.NodeColumnOrdinal, n)
-	rightEqualityIndices = make([]exec.NodeColumnOrdinal, n)
+	leftEqualityIndexes = make([]exec.NodeColumnOrdinal, n)
+	rightEqualityIndexes = make([]exec.NodeColumnOrdinal, n)
 	for i := 0; i < n; i++ {
 		leftColIdx, rightColIdx := leftOrdering[i].ColIdx, rightOrdering[i].ColIdx
-		leftEqualityIndices[i] = exec.NodeColumnOrdinal(leftColIdx)
-		rightEqualityIndices[i] = exec.NodeColumnOrdinal(rightColIdx)
+		leftEqualityIndexes[i] = exec.NodeColumnOrdinal(leftColIdx)
+		rightEqualityIndexes[i] = exec.NodeColumnOrdinal(rightColIdx)
 	}
 
 	mergeJoinOrdering = make(colinfo.ColumnOrdering, n)
 	for i := 0; i < n; i++ {
-		// The mergeJoinOrdering "columns" are equality column indices.  Because of
-		// the way we constructed the equality indices, the ordering will always be
+		// The mergeJoinOrdering "columns" are equality column indexes.  Because of
+		// the way we constructed the equality indexes, the ordering will always be
 		// 0,1,2,3..
 		mergeJoinOrdering[i].ColIdx = i
 		mergeJoinOrdering[i].Direction = leftOrdering[i].Direction
 	}
-	return leftEqualityIndices, rightEqualityIndices, mergeJoinOrdering, nil
+	return leftEqualityIndexes, rightEqualityIndexes, mergeJoinOrdering, nil
 }
 
 func getResultColumnsForGroupBy(

--- a/pkg/sql/execinfrapb/data.go
+++ b/pkg/sql/execinfrapb/data.go
@@ -43,7 +43,7 @@ func ConvertToSpecOrdering(columnOrdering colinfo.ColumnOrdering) Ordering {
 
 // ConvertToMappedSpecOrdering converts a colinfo.ColumnOrdering type
 // to an Ordering type (as defined in data.proto), using the column
-// indices contained in planToStreamColMap.
+// indexes contained in planToStreamColMap.
 func ConvertToMappedSpecOrdering(
 	columnOrdering colinfo.ColumnOrdering, planToStreamColMap []int,
 ) Ordering {

--- a/pkg/sql/execinfrapb/data.proto
+++ b/pkg/sql/execinfrapb/data.proto
@@ -47,7 +47,7 @@ message Expression {
   reserved 1;
 }
 
-// Ordering defines an order - specifically a list of column indices and
+// Ordering defines an order - specifically a list of column indexes and
 // directions. See colinfo.ColumnOrdering.
 message Ordering {
   option (gogoproto.equal) = true;

--- a/pkg/sql/execinfrapb/processors.proto
+++ b/pkg/sql/execinfrapb/processors.proto
@@ -43,7 +43,7 @@ import "gogoproto/gogo.proto";
 //
 // The core outputs rows of a certain schema to the post-processing stage. We
 // call this the "internal schema" (or "internal columns") and it differs for
-// each type of core. Column indices in a PostProcessSpec refers to these
+// each type of core. Column indexes in a PostProcessSpec refers to these
 // internal columns. Some columns may be unused by the post-processing stage;
 // processor implementations are internally optimized to not produce values for
 // such unneeded columns.

--- a/pkg/sql/execinfrapb/processors_sql.proto
+++ b/pkg/sql/execinfrapb/processors_sql.proto
@@ -1006,7 +1006,7 @@ message WindowerSpec {
   message WindowFn {
     // Func is which function to compute.
     optional Func func = 1 [(gogoproto.nullable) = false];
-    // ArgsIdxs contains indices of the columns that are arguments to the
+    // ArgsIdxs contains indexes of the columns that are arguments to the
     // window function.
     repeated uint32 argsIdxs = 7;
     // Ordering specifies in which order rows should be considered by this

--- a/pkg/sql/group.go
+++ b/pkg/sql/group.go
@@ -21,11 +21,11 @@ type groupNode struct {
 	// The schema for this groupNode.
 	columns colinfo.ResultColumns
 
-	// Indices of the group by columns in the source plan.
+	// Indexes of the group by columns in the source plan.
 	groupCols []exec.NodeColumnOrdinal
 
 	// Set when we have an input ordering on (a subset of) grouping columns. Only
-	// column indices in groupCols can appear in this ordering.
+	// column indexes in groupCols can appear in this ordering.
 	groupColOrdering colinfo.ColumnOrdering
 
 	// isScalar is set for "scalar groupby", where we want a result

--- a/pkg/sql/idxusage/local_index_usage_stats_test.go
+++ b/pkg/sql/idxusage/local_index_usage_stats_test.go
@@ -42,7 +42,7 @@ func TestIndexUsageStatisticsSubsystem(t *testing.T) {
 	ctx := context.Background()
 	stopper := stop.NewStopper()
 
-	indices := []roachpb.IndexUsageKey{
+	indexes := []roachpb.IndexUsageKey{
 		{
 			TableID: 1,
 			IndexID: 1,
@@ -59,47 +59,47 @@ func TestIndexUsageStatisticsSubsystem(t *testing.T) {
 
 	testInputs := []indexUse{
 		{
-			key:      indices[0],
+			key:      indexes[0],
 			usageTyp: readOp,
 		},
 		{
-			key:      indices[0],
+			key:      indexes[0],
 			usageTyp: readOp,
 		},
 		{
-			key:      indices[0],
+			key:      indexes[0],
 			usageTyp: writeOp,
 		},
 		{
-			key:      indices[1],
+			key:      indexes[1],
 			usageTyp: readOp,
 		},
 		{
-			key:      indices[1],
+			key:      indexes[1],
 			usageTyp: readOp,
 		},
 		{
-			key:      indices[2],
+			key:      indexes[2],
 			usageTyp: writeOp,
 		},
 		{
-			key:      indices[2],
+			key:      indexes[2],
 			usageTyp: writeOp,
 		},
 	}
 
 	expectedIndexUsage := map[roachpb.IndexUsageKey]roachpb.IndexUsageStatistics{
-		indices[0]: {
+		indexes[0]: {
 			TotalReadCount:  2,
 			LastRead:        timeutil.Now(),
 			TotalWriteCount: 1,
 			LastWrite:       timeutil.Now(),
 		},
-		indices[1]: {
+		indexes[1]: {
 			TotalReadCount: 2,
 			LastRead:       timeutil.Now(),
 		},
-		indices[2]: {
+		indexes[2]: {
 			TotalWriteCount: 2,
 			LastWrite:       timeutil.Now(),
 		},
@@ -118,7 +118,7 @@ func TestIndexUsageStatisticsSubsystem(t *testing.T) {
 
 	t.Run("point lookup", func(t *testing.T) {
 		actualEntryCount := 0
-		for _, index := range indices {
+		for _, index := range indexes {
 			stats := localIndexUsage.Get(index.TableID, index.IndexID)
 			require.NotNil(t, stats)
 

--- a/pkg/sql/index_join.go
+++ b/pkg/sql/index_join.go
@@ -30,7 +30,7 @@ type indexJoinNode struct {
 type indexJoinPlanningInfo struct {
 	fetch fetchPlanningInfo
 
-	// Indices of the PK columns in the input plan.
+	// Indexes of the PK columns in the input plan.
 	keyCols []exec.NodeColumnOrdinal
 
 	reqOrdering ReqOrdering

--- a/pkg/sql/join.go
+++ b/pkg/sql/join.go
@@ -23,9 +23,9 @@ type joinNode struct {
 	pred *joinPredicate
 
 	// mergeJoinOrdering is set if the left and right sides have similar ordering
-	// on the equality columns (or a subset of them). The column indices refer to
+	// on the equality columns (or a subset of them). The column indexes refer to
 	// equality columns: a ColIdx of i refers to left column
-	// pred.leftEqualityIndices[i] and right column pred.rightEqualityIndices[i].
+	// pred.leftEqualityIndexes[i] and right column pred.rightEqualityIndexes[i].
 	mergeJoinOrdering colinfo.ColumnOrdering
 
 	reqOrdering ReqOrdering

--- a/pkg/sql/join_predicate.go
+++ b/pkg/sql/join_predicate.go
@@ -33,17 +33,17 @@ type joinPredicate struct {
 	// operands.
 	numLeftCols, numRightCols int
 
-	// left/rightEqualityIndices give the position of equality columns
+	// left/rightEqualityIndexes give the position of equality columns
 	// on the left and right input row arrays, respectively.
 	// Only columns with the same left and right value types can be equality
 	// columns.
-	leftEqualityIndices  []exec.NodeColumnOrdinal
-	rightEqualityIndices []exec.NodeColumnOrdinal
+	leftEqualityIndexes  []exec.NodeColumnOrdinal
+	rightEqualityIndexes []exec.NodeColumnOrdinal
 
-	// The list of names for the columns listed in leftEqualityIndices.
+	// The list of names for the columns listed in leftEqualityIndexes.
 	// Used mainly for pretty-printing.
 	leftColNames tree.NameList
-	// The list of names for the columns listed in rightEqualityIndices.
+	// The list of names for the columns listed in rightEqualityIndexes.
 	// Used mainly for pretty-printing.
 	rightColNames tree.NameList
 

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -107,7 +107,7 @@ func sqlOrdering(ordering opt.Ordering, cols colOrdMap) (colinfo.ColumnOrdering,
 // builRelational builds a relational expression into an execPlan.
 //
 // outputCols is a map from opt.ColumnID to exec.NodeColumnOrdinal. It maps
-// columns in the output set of a relational expression to indices in the
+// columns in the output set of a relational expression to indexes in the
 // result columns of the exec.Node.
 //
 // The reason we need to keep track of this (instead of using just the

--- a/pkg/sql/opt/exec/factory.go
+++ b/pkg/sql/opt/exec/factory.go
@@ -255,7 +255,7 @@ type WindowInfo struct {
 	// in the same order as Exprs.
 	ArgIdxs [][]NodeColumnOrdinal
 
-	// FilterIdxs is the list of column indices to use as filters.
+	// FilterIdxs is the list of column indexes to use as filters.
 	FilterIdxs []int
 
 	// Partition is the set of input columns to partition on.

--- a/pkg/sql/opt/invertedidx/json_array.go
+++ b/pkg/sql/opt/invertedidx/json_array.go
@@ -669,7 +669,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValEqCondition(
 	// where arr is an ARRAY type tag used to indicate that the next key is
 	// part of an array, 1 is the table id, 2 is the inverted index id and
 	// pk is a primary key of a row in the table. Since the array
-	// elements do not have their respective indices stored in
+	// elements do not have their respective indexes stored in
 	// the encoding, the original filter needs to be applied after the initial
 	// scan.
 	for i := range keys {
@@ -759,7 +759,7 @@ func (j *jsonOrArrayFilterPlanner) extractJSONFetchValContainsCondition(
 	// where arr is an ARRAY type tag used to indicate that the next key is
 	// part of an array, 1 is the table id, 2 is the inverted index id and
 	// pk is a primary key of a row in the table. Since the array
-	// elements do not have their respective indices stored in
+	// elements do not have their respective indexes stored in
 	// the encoding, the original filter needs to be applied after the initial
 	// scan.
 	for i := range keys {

--- a/pkg/sql/opt/lookupjoin/constraint_builder.go
+++ b/pkg/sql/opt/lookupjoin/constraint_builder.go
@@ -536,7 +536,7 @@ func (b *ConstraintBuilder) findComputedColJoinEquality(
 // findJoinVariableRangeFilters attempts to find inequality constraints for the
 // given index column that reference input columns (not constants). If either
 // (or both) start and end bounds are found, findJoinVariableInequalityFilter
-// returns the corresponding filter indices.
+// returns the corresponding filter indexes.
 func (b *ConstraintBuilder) findJoinVariableRangeFilters(
 	rightCmp opt.ColList,
 	inequalityFilterOrds []int,

--- a/pkg/sql/opt/norm/groupby_funcs.go
+++ b/pkg/sql/opt/norm/groupby_funcs.go
@@ -351,7 +351,7 @@ func (c *CustomFuncs) MergeAggs(
 	innerAggs, outerAggs memo.AggregationsExpr, innerGroupingCols opt.ColSet,
 ) memo.AggregationsExpr {
 	// Create a mapping from the output ColumnIDs of the inner aggregates to their
-	// indices in innerAggs.
+	// indexes in innerAggs.
 	innerColsToAggs := map[opt.ColumnID]int{}
 	for i := range innerAggs {
 		innerColsToAggs[innerAggs[i].Col] = i

--- a/pkg/sql/opt/partition/locality.go
+++ b/pkg/sql/opt/partition/locality.go
@@ -54,7 +54,7 @@ type PrefixSorter struct {
 	EvalCtx *eval.Context
 	Entry   []Prefix
 
-	// A slice of indices of the last element of each equal-length group of
+	// A slice of indexes of the last element of each equal-length group of
 	// entries in the Entry array above. Used by Slice(i int)
 	idx []int
 

--- a/pkg/sql/opt/xform/coster.go
+++ b/pkg/sql/opt/xform/coster.go
@@ -1065,7 +1065,7 @@ func (c *coster) computeHashJoinCost(join memo.RelExpr) memo.Cost {
 	// pressure and the possibility of spilling to disk.
 	cost.Add(c.rowBufferCost(rightRowCount))
 
-	// Compute filter cost. Fetch the indices of the filters that will be used in
+	// Compute filter cost. Fetch the indexes of the filters that will be used in
 	// the join, since they will not add to the cost and should be skipped.
 	on := join.Child(2).(*memo.FiltersExpr)
 	leftCols := join.Child(0).(memo.RelExpr).Relational().OutputCols
@@ -1341,7 +1341,7 @@ func (c *coster) computeExprCost(expr opt.Expr) memo.Cost {
 // a filter. Callers of this function should add setupCost and multiply
 // perRowCost by the number of rows expected to be filtered.
 //
-// filtersToSkip identifies the indices of filters that should be skipped,
+// filtersToSkip identifies the indexes of filters that should be skipped,
 // because they do not add to the cost. This can happen when a condition still
 // exists in the filters even though it is handled by the join.
 func (c *coster) computeFiltersCost(

--- a/pkg/sql/opt/xform/join_order_builder.go
+++ b/pkg/sql/opt/xform/join_order_builder.go
@@ -1032,7 +1032,7 @@ func (jb *JoinOrderBuilder) allVertexes() vertexSet {
 	return vertexSet((1 << len(jb.vertexes)) - 1)
 }
 
-// allEdges returns an edgeSet that represents indices to all edges in the join
+// allEdges returns an edgeSet that represents indexes to all edges in the join
 // graph.
 func (jb *JoinOrderBuilder) allEdges() edgeSet {
 	allEdgeSet := edgeSet{}

--- a/pkg/sql/opt/xform/select_funcs.go
+++ b/pkg/sql/opt/xform/select_funcs.go
@@ -1499,7 +1499,7 @@ func (c *CustomFuncs) GenerateZigzagJoins(
 
 			if c.FiltersBoundBy(zigzagJoin.On, zigzagCols) {
 				// The ON condition refers only to the columns available in the zigzag
-				// indices.
+				// indexes.
 				indexJoin.On = memo.TrueFilter
 			} else {
 				// ON has some conditions that are bound by the columns in the index (at
@@ -1885,7 +1885,7 @@ func (c *CustomFuncs) GenerateInvertedIndexZigzagJoins(
 
 		if c.FiltersBoundBy(zigzagJoin.On, zigzagCols) {
 			// The ON condition refers only to the columns available in the zigzag
-			// indices.
+			// indexes.
 			indexJoin.On = memo.TrueFilter
 		} else {
 			// ON has some conditions that are bound by the columns in the index (at

--- a/pkg/sql/opt_exec_factory.go
+++ b/pkg/sql/opt_exec_factory.go
@@ -411,8 +411,8 @@ func (ef *execFactory) ConstructHashJoin(
 	pred := makePredicate(joinType, leftCols, rightCols, extraOnCond)
 
 	numEqCols := len(leftEqCols)
-	pred.leftEqualityIndices = leftEqCols
-	pred.rightEqualityIndices = rightEqCols
+	pred.leftEqualityIndexes = leftEqCols
+	pred.rightEqualityIndexes = rightEqCols
 	nameBuf := make(tree.NameList, 2*numEqCols)
 	pred.leftColNames = nameBuf[:numEqCols:numEqCols]
 	pred.rightColNames = nameBuf[numEqCols:]
@@ -462,7 +462,7 @@ func (ef *execFactory) ConstructMergeJoin(
 	pred.leftEqKey = leftEqColsAreKey
 	pred.rightEqKey = rightEqColsAreKey
 
-	pred.leftEqualityIndices, pred.rightEqualityIndices, node.mergeJoinOrdering, err = getEqualityIndicesAndMergeJoinOrdering(leftOrdering, rightOrdering)
+	pred.leftEqualityIndexes, pred.rightEqualityIndexes, node.mergeJoinOrdering, err = getEqualityIndexesAndMergeJoinOrdering(leftOrdering, rightOrdering)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/sql/physicalplan/aggregator_funcs.go
+++ b/pkg/sql/physicalplan/aggregator_funcs.go
@@ -16,7 +16,7 @@ import (
 
 // FinalStageInfo is a wrapper around an aggregation function performed
 // in the final stage of distributed aggregations that allows us to specify the
-// corresponding inputs from the local aggregations by their indices in the LocalStage.
+// corresponding inputs from the local aggregations by their indexes in the LocalStage.
 type FinalStageInfo struct {
 	Fn execinfrapb.AggregatorSpec_Func
 	// Specifies the ordered slice of outputs from local aggregations to propagate
@@ -49,7 +49,7 @@ type DistAggregationInfo struct {
 
 	// The final stage consists of one or more aggregations that take in an
 	// arbitrary number of inputs from the local stages. The inputs are ordered and
-	// mapped by the indices of the local aggregations in LocalStage (specified by
+	// mapped by the indexes of the local aggregations in LocalStage (specified by
 	// LocalIdxs).
 	FinalStage []FinalStageInfo
 
@@ -69,7 +69,7 @@ type DistAggregationInfo struct {
 	// Instead of defining a canonical non-typed expression and then tweaking it
 	// with visitors, we use a function that directly creates a typed expression
 	// on demand. The expression will refer to the final stage results using
-	// IndexedVars, with indices specified by varIdxs (1-1 mapping).
+	// IndexedVars, with indexes specified by varIdxs (1-1 mapping).
 	FinalRendering func(h *tree.IndexedVarHelper, varIdxs []int) (tree.TypedExpr, error)
 }
 

--- a/pkg/sql/physicalplan/aggregator_funcs_test.go
+++ b/pkg/sql/physicalplan/aggregator_funcs_test.go
@@ -172,7 +172,7 @@ func checkDistAggregationInfo(
 	numFinal := len(info.FinalStage)
 	for _, finalInfo := range info.FinalStage {
 		if len(finalInfo.LocalIdxs) == 0 {
-			t.Fatalf("final stage must specify input local indices: %#v", info)
+			t.Fatalf("final stage must specify input local indexes: %#v", info)
 		}
 		for _, localIdx := range finalInfo.LocalIdxs {
 			if localIdx >= uint32(numIntermediary) {
@@ -195,7 +195,7 @@ func checkDistAggregationInfo(
 	// The type(s) outputted by the final stage can be different than the
 	// input type (e.g. DECIMAL instead of INT).
 	finalOutputTypes := make([]*types.T, numFinal)
-	// Passed into FinalIndexing as the indices for the IndexedVars inputs
+	// Passed into FinalIndexing as the indexes for the IndexedVars inputs
 	// to the post processor.
 	varIdxs := make([]int, numFinal)
 	for i, finalInfo := range info.FinalStage {

--- a/pkg/sql/physicalplan/physical_plan.go
+++ b/pkg/sql/physicalplan/physical_plan.go
@@ -763,7 +763,7 @@ func (p *PhysicalPlan) AddRendering(
 	return nil
 }
 
-// reverseProjection remaps expression variable indices to refer to internal
+// reverseProjection remaps expression variable indexes to refer to internal
 // columns (i.e. before post-processing) of a processor instead of output
 // columns (i.e. after post-processing).
 //

--- a/pkg/sql/plan_names.go
+++ b/pkg/sql/plan_names.go
@@ -27,7 +27,7 @@ func nodeName(plan planNode) string {
 		if len(n.mergeJoinOrdering) > 0 {
 			return "merge join"
 		}
-		if len(n.pred.leftEqualityIndices) == 0 {
+		if len(n.pred.leftEqualityIndexes) == 0 {
 			return "cross join"
 		}
 		return "hash join"

--- a/pkg/sql/row/deleter.go
+++ b/pkg/sql/row/deleter.go
@@ -192,7 +192,7 @@ func (rd *Deleter) DeleteRow(
 		return err
 	}
 
-	// Delete the row from any secondary indices.
+	// Delete the row from any secondary indexes.
 	for i, index := range rd.Helper.Indexes {
 		// If the index ID exists in the set of indexes to ignore, do not
 		// attempt to delete from the index.

--- a/pkg/sql/row/row_converter.go
+++ b/pkg/sql/row/row_converter.go
@@ -231,7 +231,7 @@ type DatumRowConverter struct {
 
 	tableDesc catalog.TableDescriptor
 
-	// Tracks which column indices in the set of visible columns are part of the
+	// Tracks which column indexes in the set of visible columns are part of the
 	// user specified target columns. This can be used before populating Datums
 	// to filter out unwanted column data.
 	TargetColOrds intsets.Fast

--- a/pkg/sql/rowcontainer/hash_row_container.go
+++ b/pkg/sql/rowcontainer/hash_row_container.go
@@ -186,7 +186,7 @@ func storedEqColsToOrdering(storedEqCols columns) colinfo.ColumnOrdering {
 
 // HashMemRowContainer is an in-memory implementation of a HashRowContainer.
 // The rows are stored in an underlying MemRowContainer and an accompanying
-// map stores the mapping from equality column encodings to indices in the
+// map stores the mapping from equality column encodings to indexes in the
 // MemRowContainer corresponding to matching rows.
 // NOTE: Once a row is marked, adding more rows to the HashMemRowContainer
 // results in undefined behavior. It is not necessary to do otherwise for the
@@ -208,14 +208,14 @@ type HashMemRowContainer struct {
 	// HashMemRowContainer.
 	markMemoryReserved bool
 
-	// buckets contains the indices into MemRowContainer for a given group
+	// buckets contains the indexes into MemRowContainer for a given group
 	// key (which is the encoding of storedEqCols).
 	buckets map[string][]int
 	// bucketsAcc is the memory account for the buckets. The datums themselves
 	// are all in the MemRowContainer.
 	bucketsAcc mon.BoundAccount
 
-	// storedEqCols contains the indices of the columns of a row that are
+	// storedEqCols contains the indexes of the columns of a row that are
 	// encoded and used as a key into buckets when adding a row.
 	storedEqCols columns
 }
@@ -321,7 +321,7 @@ type hashMemRowBucketIterator struct {
 	scratchEncRow   rowenc.EncDatumRow
 	probeEqCols     columns
 	probeEqColTypes []*types.T
-	// rowIdxs are the indices of rows in the bucket.
+	// rowIdxs are the indexes of rows in the bucket.
 	rowIdxs []int
 	curIdx  int
 }

--- a/pkg/sql/rowcontainer/row_container.go
+++ b/pkg/sql/rowcontainer/row_container.go
@@ -697,7 +697,7 @@ func (f *DiskBackedRowContainer) SpillToDisk(ctx context.Context) error {
 
 // DiskBackedIndexedRowContainer is a wrapper around DiskBackedRowContainer
 // that adds an index to each row added in the order of addition of those rows
-// by storing an extra int column at the end of each row. These indices can be
+// by storing an extra int column at the end of each row. These indexes can be
 // thought of as ordinals of the rows.
 //
 // Note: although DiskRowContainer appends unique rowIDs to the keys that the
@@ -868,7 +868,7 @@ func (f *DiskBackedIndexedRowContainer) GetRow(
 		if f.idxRowIter > pos {
 			// The iterator has been advanced further than we need, so we need to
 			// start iterating from the beginning.
-			log.VEventf(ctx, 1, "rewinding: cache contains indices [%d, %d) but index %d requested", f.firstCachedRowPos, f.nextPosToCache, pos)
+			log.VEventf(ctx, 1, "rewinding: cache contains indexes [%d, %d) but index %d requested", f.firstCachedRowPos, f.nextPosToCache, pos)
 			f.idxRowIter = 0
 			f.diskRowIter.Rewind()
 			f.resetCache(ctx)

--- a/pkg/sql/rowcontainer/row_container_test.go
+++ b/pkg/sql/rowcontainer/row_container_test.go
@@ -801,7 +801,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 			storedTypes := make([]*types.T, len(typs)+1)
 			copy(storedTypes, typs)
-			// The container will add an extra int column for indices.
+			// The container will add an extra int column for indexes.
 			storedTypes[len(typs)] = types.OneIntCol[0]
 
 			func() {
@@ -842,7 +842,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 			}
 			storedTypes := make([]*types.T, len(typs)+1)
 			copy(storedTypes, typs)
-			// The container will add an extra int column for indices.
+			// The container will add an extra int column for indexes.
 			storedTypes[len(typs)] = types.OneIntCol[0]
 
 			func() {
@@ -876,7 +876,7 @@ func TestDiskBackedIndexedRowContainer(t *testing.T) {
 	})
 }
 
-// indexedRows are rows with the corresponding indices.
+// indexedRows are rows with the corresponding indexes.
 type indexedRows struct {
 	rows []IndexedRow
 }

--- a/pkg/sql/rowenc/index_encoding.go
+++ b/pkg/sql/rowenc/index_encoding.go
@@ -1724,7 +1724,7 @@ func writeColumnValues(
 }
 
 // EncodeSecondaryIndexes encodes key/values for the secondary indexes. colMap
-// maps descpb.ColumnIDs to indices in `values`. keyPrefixes is a slice that
+// maps descpb.ColumnIDs to indexes in `values`. keyPrefixes is a slice that
 // associates indexes to their key prefix; the caller can reuse this between
 // rows to save work from creating key prefixes. the indexes and keyPrefixes
 // slice should have the same ordering. secondaryIndexEntries is the return

--- a/pkg/sql/rowenc/index_encoding_test.go
+++ b/pkg/sql/rowenc/index_encoding_test.go
@@ -583,7 +583,7 @@ func TestEncodeContainingArrayInvertedIndexSpans(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		typ := randgen.RandArrayType(rng)
 
-		// We don't allow jsonpath indices.
+		// We don't allow jsonpath indexes.
 		if typ.ArrayContents().Family() == types.JsonpathFamily {
 			continue
 		}
@@ -980,7 +980,7 @@ func TestEncodeOverlapsArrayInvertedIndexSpans(t *testing.T) {
 	for i := 0; i < 100; i++ {
 		typ := randgen.RandArrayType(rng)
 
-		// We don't allow jsonpath indices.
+		// We don't allow jsonpath indexes.
 		if typ.ArrayContents().Family() == types.JsonpathFamily {
 			continue
 		}

--- a/pkg/sql/rowexec/aggregator_test.go
+++ b/pkg/sql/rowexec/aggregator_test.go
@@ -27,7 +27,7 @@ type aggTestSpec struct {
 	// The name of the aggregate function.
 	fname    string
 	distinct bool
-	// The column indices of the arguments to the function.
+	// The column indexes of the arguments to the function.
 	colIdx       []uint32
 	filterColIdx *uint32
 }

--- a/pkg/sql/rowexec/hashjoiner.go
+++ b/pkg/sql/rowexec/hashjoiner.go
@@ -51,7 +51,7 @@ const (
 type hashJoiner struct {
 	joinerBase
 
-	// eqCols contains the indices of the columns that are constrained to be
+	// eqCols contains the indexes of the columns that are constrained to be
 	// equal. Specifically column eqCols[0][i] on the left side must match the
 	// column eqCols[1][i] on the right side.
 	eqCols [2][]uint32

--- a/pkg/sql/rowexec/sample_aggregator.go
+++ b/pkg/sql/rowexec/sample_aggregator.go
@@ -58,7 +58,7 @@ type sampleAggregator struct {
 	sampledCols []descpb.ColumnID
 	sketches    []sketchInfo
 
-	// Input column indices for special columns.
+	// Input column indexes for special columns.
 	rankCol      int
 	sketchIdxCol int
 	numRowsCol   int

--- a/pkg/sql/rowexec/sampler.go
+++ b/pkg/sql/rowexec/sampler.go
@@ -57,7 +57,7 @@ type samplerProcessor struct {
 	invSr     map[uint32]*stats.SampleReservoir
 	invSketch map[uint32]*sketchInfo
 
-	// Output column indices for special columns.
+	// Output column indexes for special columns.
 	rankCol      int
 	sketchIdxCol int
 	numRowsCol   int

--- a/pkg/sql/rowexec/windower_test.go
+++ b/pkg/sql/rowexec/windower_test.go
@@ -110,7 +110,7 @@ func TestWindowerAccountingForResults(t *testing.T) {
 }
 
 type windowTestSpec struct {
-	// The column indices of PARTITION BY clause.
+	// The column indexes of PARTITION BY clause.
 	partitionBy []uint32
 	// Window function to be computed.
 	windowFn windowFnTestSpec

--- a/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
+++ b/pkg/sql/scheduledlogging/captured_index_usage_stats_test.go
@@ -146,7 +146,7 @@ func TestCaptureIndexUsageStats(t *testing.T) {
 	db.Exec(t, `CREATE TABLE "mIxEd-CaSe""woo☃"."sPe-CiAl✔" (num INT PRIMARY KEY, "HeLlO☀" char)`)
 	db.Exec(t, `CREATE TABLE "index"."index" (num INT PRIMARY KEY, "index" char)`)
 
-	// Create an index on each created table (each table now has two indices:
+	// Create an index on each created table (each table now has two indexes:
 	// primary and this one)
 	db.Exec(t, `CREATE INDEX ON test.test_table (letter)`)
 	db.Exec(t, `CREATE INDEX ON test2.test2_table (letter)`)

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -10953,7 +10953,7 @@ func regexpReplace(evalCtx *eval.Context, s, pattern, to, sqlFlags string) (tree
 					} else {
 						captureGroupNumber := int(to[i] - '0')
 						// regexpReplace expects references to "out-of-bounds"
-						// and empty (when the corresponding match indices
+						// and empty (when the corresponding match indexes
 						// are negative) capture groups to be ignored.
 						if matchIndexPos := 2 * captureGroupNumber; matchIndexPos < len(matchIndex) {
 							startPos := matchIndex[matchIndexPos]

--- a/pkg/sql/sem/builtins/window_frame_builtins.go
+++ b/pkg/sql/sem/builtins/window_frame_builtins.go
@@ -24,13 +24,13 @@ type indexedValue struct {
 	idx   int
 }
 
-// slidingWindow maintains a deque of values along with corresponding indices
+// slidingWindow maintains a deque of values along with corresponding indexes
 // based on cmp function:
 // for Min behavior, cmp = -a.Compare(b)
 // for Max behavior, cmp = a.Compare(b)
 //
 // It assumes that the frame bounds will never go back, i.e. non-decreasing
-// sequences of frame start and frame end indices.
+// sequences of frame start and frame end indexes.
 type slidingWindow struct {
 	values  ring.Buffer[*indexedValue]
 	evalCtx *eval.Context
@@ -67,7 +67,7 @@ func (sw *slidingWindow) add(ctx context.Context, iv *indexedValue) error {
 }
 
 // removeAllBefore removes all values from the beginning of the deque that have
-// indices smaller than given 'idx'. This operation corresponds to shifting the
+// indexes smaller than given 'idx'. This operation corresponds to shifting the
 // start of the frame up to 'idx'.
 func (sw *slidingWindow) removeAllBefore(idx int) {
 	for sw.values.Len() > 0 && sw.values.Get(0).idx < idx {
@@ -197,7 +197,7 @@ func (w *slidingWindowFunc) Close(context.Context, *eval.Context) {
 
 // slidingWindowSumFunc applies sliding window approach to summation over
 // a frame. It assumes that the frame bounds will never go back, i.e.
-// non-decreasing sequences of frame start and frame end indices.
+// non-decreasing sequences of frame start and frame end indexes.
 type slidingWindowSumFunc struct {
 	agg                eval.AggregateFunc // one of the four SumAggregates
 	prevStart, prevEnd int

--- a/pkg/sql/sem/eval/window_funcs.go
+++ b/pkg/sql/sem/eval/window_funcs.go
@@ -38,7 +38,7 @@ type WindowFunc interface {
 	Close(context.Context, *Context)
 }
 
-// IndexedRows are rows with the corresponding indices.
+// IndexedRows are rows with the corresponding indexes.
 type IndexedRows interface {
 	Len() int                                                // returns number of rows
 	GetRow(ctx context.Context, idx int) (IndexedRow, error) // returns a row at the given index or an error
@@ -48,14 +48,14 @@ type IndexedRows interface {
 type IndexedRow interface {
 	GetIdx() int                                         // returns index of the row
 	GetDatum(idx int) (tree.Datum, error)                // returns a datum at the given index
-	GetDatums(startIdx, endIdx int) (tree.Datums, error) // returns datums at indices [startIdx, endIdx)
+	GetDatums(startIdx, endIdx int) (tree.Datums, error) // returns datums at indexes [startIdx, endIdx)
 }
 
 // WindowFrameRun contains the runtime state of window frame during calculations.
 type WindowFrameRun struct {
 	// constant for all calls to WindowFunc.Add
 	Rows             IndexedRows
-	ArgsIdxs         []uint32          // indices of the arguments to the window function
+	ArgsIdxs         []uint32          // indexes of the arguments to the window function
 	Frame            *tree.WindowFrame // If non-nil, Frame represents the frame specification of this window. If nil, default frame is used.
 	StartBoundOffset tree.Datum
 	EndBoundOffset   tree.Datum
@@ -63,7 +63,7 @@ type WindowFrameRun struct {
 	OrdColIdx        int                // Column over which rows are ordered within the partition. It is only required in RANGE mode.
 	OrdDirection     encoding.Direction // Direction of the ordering over OrdColIdx.
 	PlusOp, MinusOp  *tree.BinOp        // Binary operators for addition and subtraction required only in RANGE mode.
-	PeerHelper       PeerGroupsIndicesHelper
+	PeerHelper       PeerGroupsIndexesHelper
 
 	// Any error that occurred within methods that cannot return an error (like
 	// within a closure that is passed into sort.Search()).

--- a/pkg/sql/sem/eval/window_funcs_test.go
+++ b/pkg/sql/sem/eval/window_funcs_test.go
@@ -343,7 +343,7 @@ func TestRangeMode(t *testing.T) {
 	}
 }
 
-// indexedRows are rows with the corresponding indices.
+// indexedRows are rows with the corresponding indexes.
 type indexedRows struct {
 	rows []indexedRow
 }

--- a/pkg/sql/sem/eval/window_funcs_util.go
+++ b/pkg/sql/sem/eval/window_funcs_util.go
@@ -11,7 +11,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/ring"
 )
 
-// PeerGroupChecker can check if a pair of row indices within a partition are
+// PeerGroupChecker can check if a pair of row indexes within a partition are
 // in the same peer group. It also returns an error if it occurs while checking
 // the peer groups.
 type PeerGroupChecker interface {
@@ -24,7 +24,7 @@ type peerGroup struct {
 	rowCount     int
 }
 
-// PeerGroupsIndicesHelper computes peer groups using the given
+// PeerGroupsIndexesHelper computes peer groups using the given
 // PeerGroupChecker. In ROWS and RANGE modes, it processes one peer group at
 // a time and stores information only about single peer group. In GROUPS mode,
 // it's behavior depends on the frame bounds; in the worst case, it stores
@@ -32,7 +32,7 @@ type peerGroup struct {
 // peer groups within the frame at any point and O is the maximum of two
 // offsets if we have OFFSET_FOLLOWING type of bound (both F and O are
 // upper-bounded by total number of peer groups).
-type PeerGroupsIndicesHelper struct {
+type PeerGroupsIndexesHelper struct {
 	groups               ring.Buffer[*peerGroup]
 	peerGrouper          PeerGroupChecker
 	headPeerGroupNum     int  // number of the peer group at the head of the queue
@@ -44,7 +44,7 @@ type PeerGroupsIndicesHelper struct {
 // Init computes all peer groups necessary to perform calculations of a window
 // function over the first row of the partition. It returns any error if it
 // occurs.
-func (p *PeerGroupsIndicesHelper) Init(wfr *WindowFrameRun, peerGrouper PeerGroupChecker) error {
+func (p *PeerGroupsIndexesHelper) Init(wfr *WindowFrameRun, peerGrouper PeerGroupChecker) error {
 	// We first reset the helper to reuse the same one for all partitions when
 	// computing a particular window function.
 	p.groups.Reset()
@@ -148,7 +148,7 @@ func (p *PeerGroupsIndicesHelper) Init(wfr *WindowFrameRun, peerGrouper PeerGrou
 // rows in wfr.CurRowPeerGroupNum peer group. If not all rows have been already
 // processed, it computes the next peer group. It returns any error if it
 // occurs.
-func (p *PeerGroupsIndicesHelper) Update(wfr *WindowFrameRun) error {
+func (p *PeerGroupsIndexesHelper) Update(wfr *WindowFrameRun) error {
 	if p.allPeerGroupsSkipped {
 		// No peer groups to process.
 		return nil
@@ -201,7 +201,7 @@ func (p *PeerGroupsIndicesHelper) Update(wfr *WindowFrameRun) error {
 
 // GetFirstPeerIdx returns index of the first peer within peer group of number
 // peerGroupNum (counting from 0).
-func (p *PeerGroupsIndicesHelper) GetFirstPeerIdx(peerGroupNum int) int {
+func (p *PeerGroupsIndexesHelper) GetFirstPeerIdx(peerGroupNum int) int {
 	posInBuffer := peerGroupNum - p.headPeerGroupNum
 	if posInBuffer < 0 || p.groups.Len() < posInBuffer {
 		panic("peerGroupNum out of bounds")
@@ -211,7 +211,7 @@ func (p *PeerGroupsIndicesHelper) GetFirstPeerIdx(peerGroupNum int) int {
 
 // GetRowCount returns the number of rows within peer group of number
 // peerGroupNum (counting from 0).
-func (p *PeerGroupsIndicesHelper) GetRowCount(peerGroupNum int) int {
+func (p *PeerGroupsIndexesHelper) GetRowCount(peerGroupNum int) int {
 	posInBuffer := peerGroupNum - p.headPeerGroupNum
 	if posInBuffer < 0 || p.groups.Len() < posInBuffer {
 		panic("peerGroupNum out of bounds")
@@ -220,7 +220,7 @@ func (p *PeerGroupsIndicesHelper) GetRowCount(peerGroupNum int) int {
 }
 
 // GetLastPeerGroupNum returns the number of the last peer group in the queue.
-func (p *PeerGroupsIndicesHelper) GetLastPeerGroupNum() int {
+func (p *PeerGroupsIndexesHelper) GetLastPeerGroupNum() int {
 	if p.groups.Len() == 0 {
 		panic("GetLastPeerGroupNum on empty RingBuffer")
 	}

--- a/pkg/sql/sem/tree/type_check.go
+++ b/pkg/sql/sem/tree/type_check.go
@@ -3180,12 +3180,12 @@ func typeCheckSameTypedTupleExprs(
 	// All expressions within tuples at the same indexes must be the same type.
 	resTypes := types.MakeLabeledTuple(make([]*types.T, firstLen), first.Labels)
 	sameTypeExprs := make([]Expr, 0, len(exprs))
-	// We will be skipping nulls, so we need to keep track at which indices in
+	// We will be skipping nulls, so we need to keep track at which indexes in
 	// exprs are the non-null tuples.
-	sameTypeExprsIndices := make([]int, 0, len(exprs))
+	sameTypeExprsIndexes := make([]int, 0, len(exprs))
 	for elemIdx := range first.Exprs {
 		sameTypeExprs = sameTypeExprs[:0]
-		sameTypeExprsIndices = sameTypeExprsIndices[:0]
+		sameTypeExprsIndexes = sameTypeExprsIndexes[:0]
 		for exprIdx, expr := range exprs {
 			// Skip expressions that are not Tuple expressions (e.g. NULLs or CastExpr).
 			// They are checked at the end of this function.
@@ -3193,7 +3193,7 @@ func typeCheckSameTypedTupleExprs(
 				continue
 			}
 			sameTypeExprs = append(sameTypeExprs, expr.(*Tuple).Exprs[elemIdx])
-			sameTypeExprsIndices = append(sameTypeExprsIndices, exprIdx)
+			sameTypeExprsIndexes = append(sameTypeExprsIndexes, exprIdx)
 		}
 		desiredElem := types.AnyElement
 		if len(desired.TupleContents()) > elemIdx {
@@ -3204,7 +3204,7 @@ func typeCheckSameTypedTupleExprs(
 			return nil, nil, pgerror.Wrapf(err, pgcode.DatatypeMismatch, "tuples %s are not the same type", Exprs(exprs))
 		}
 		for j, typedExpr := range typedSubExprs {
-			tupleIdx := sameTypeExprsIndices[j]
+			tupleIdx := sameTypeExprsIndexes[j]
 			exprs[tupleIdx].(*Tuple).Exprs[elemIdx] = typedExpr
 		}
 		resTypes.TupleContents()[elemIdx] = resType

--- a/pkg/sql/temporary_schema.go
+++ b/pkg/sql/temporary_schema.go
@@ -285,7 +285,7 @@ func cleanupTempSchemaObjects(
 		{"VIEW", views, nil},
 		{"TABLE", tables, nil},
 		// Drop sequences after tables, because then we reduce the amount of work
-		// that may be needed to drop indices.
+		// that may be needed to drop indexes.
 		{
 			"SEQUENCE",
 			sequences,

--- a/pkg/sql/ttl/ttljob/ttljob_plans_test.go
+++ b/pkg/sql/ttl/ttljob/ttljob_plans_test.go
@@ -151,7 +151,7 @@ func TestQueryPlansDataDriven(t *testing.T) {
 						query = strings.ReplaceAll(query, "'", "''")
 						query = strings.ReplaceAll(query, "$1", "'"+cutoff.String()+"'")
 						// Confusingly, all End bounds go before all Start
-						// bounds when assigning placeholder indices in the
+						// bounds when assigning placeholder indexes in the
 						// SelectQueryBuilder.
 						for i, d := range selectBounds.End {
 							query = strings.ReplaceAll(query, fmt.Sprintf("$%d", i+2), d.String())

--- a/pkg/sql/vecindex/cspann/index_test.go
+++ b/pkg/sql/vecindex/cspann/index_test.go
@@ -663,7 +663,7 @@ func (s *testState) BestCentroids(d *datadriven.TestData) string {
 		offsets[i] = i
 	}
 
-	// Sort indices by distance (argsort).
+	// Sort indexes by distance (argsort).
 	slices.SortFunc(offsets, func(a, b int) int {
 		if distances[a] < distances[b] {
 			return -1

--- a/pkg/sql/vecindex/vecstore/store.go
+++ b/pkg/sql/vecindex/vecstore/store.go
@@ -30,7 +30,7 @@ import (
 
 var moveFailedErr = errors.New("TryMoveVector failed to find source vector")
 
-// Store implements the cspann.Store interface for KV backed vector indices.
+// Store implements the cspann.Store interface for KV backed vector indexes.
 type Store struct {
 	db descs.DB // Used to generate new partition IDs
 	kv *kv.DB

--- a/pkg/sql/window.go
+++ b/pkg/sql/window.go
@@ -72,7 +72,7 @@ type windowFuncHolder struct {
 	expr *tree.FuncExpr
 	args []tree.Expr
 
-	argsIdxs     []uint32 // indices of the columns that are arguments to the window function
+	argsIdxs     []uint32 // indexes of the columns that are arguments to the window function
 	filterColIdx int      // optional index of filtering column, -1 if no filter
 	outputColIdx int      // index of the column that the output should be put into
 


### PR DESCRIPTION
Standardizes the spelling in the sql package for go and protobuf files.
Maybe there's room for a lint.

```
(i|I)ndices
$1ndexes

pkg/sql/**/*.go
pkg/sql/**/*.proto
```

Epic: none

Release note: None
