### PR TITLE
sql: add routine statement counters for tracking execution metrics

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -533,6 +533,166 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: The rate of this metric shows how frequently new connections are being established. This can be useful in determining if a high rate of incoming new connections is causing additional load on the server due to a misconfigured application.
       essential: true
+    - name: sql.routine.delete.count
+      exported_name: sql_routine_delete_count
+      labeled_name: 'sql.count{query_type: routine-delete}'
+      description: Number of SQL DELETE statements successfully executed within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.delete.count.internal
+      exported_name: sql_routine_delete_count_internal
+      labeled_name: 'sql.count{query_type: routine-delete, query_internal: true}'
+      description: Number of SQL DELETE statements successfully executed within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.delete.started.count
+      exported_name: sql_routine_delete_started_count
+      labeled_name: 'sql.count{query_type: routine-started-delete}'
+      description: Number of SQL DELETE statements started within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.delete.started.count.internal
+      exported_name: sql_routine_delete_started_count_internal
+      labeled_name: 'sql.count{query_type: routine-started-delete, query_internal: true}'
+      description: Number of SQL DELETE statements started within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.insert.count
+      exported_name: sql_routine_insert_count
+      labeled_name: 'sql.count{query_type: routine-insert}'
+      description: Number of SQL INSERT statements successfully executed within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.insert.count.internal
+      exported_name: sql_routine_insert_count_internal
+      labeled_name: 'sql.count{query_type: routine-insert, query_internal: true}'
+      description: Number of SQL INSERT statements successfully executed within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.insert.started.count
+      exported_name: sql_routine_insert_started_count
+      labeled_name: 'sql.count{query_type: routine-started-insert}'
+      description: Number of SQL INSERT statements started within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.insert.started.count.internal
+      exported_name: sql_routine_insert_started_count_internal
+      labeled_name: 'sql.count{query_type: routine-started-insert, query_internal: true}'
+      description: Number of SQL INSERT statements started within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.select.count
+      exported_name: sql_routine_select_count
+      labeled_name: 'sql.count{query_type: routine-select}'
+      description: Number of SQL SELECT statements successfully executed within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.select.count.internal
+      exported_name: sql_routine_select_count_internal
+      labeled_name: 'sql.count{query_type: routine-select, query_internal: true}'
+      description: Number of SQL SELECT statements successfully executed within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.select.started.count
+      exported_name: sql_routine_select_started_count
+      labeled_name: 'sql.count{query_type: routine-started-select}'
+      description: Number of SQL SELECT statements started within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.select.started.count.internal
+      exported_name: sql_routine_select_started_count_internal
+      labeled_name: 'sql.count{query_type: routine-started-select, query_internal: true}'
+      description: Number of SQL SELECT statements started within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.update.count
+      exported_name: sql_routine_update_count
+      labeled_name: 'sql.count{query_type: routine-update}'
+      description: Number of SQL UPDATE statements successfully executed within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.update.count.internal
+      exported_name: sql_routine_update_count_internal
+      labeled_name: 'sql.count{query_type: routine-update, query_internal: true}'
+      description: Number of SQL UPDATE statements successfully executed within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sql.routine.update.started.count
+      exported_name: sql_routine_update_started_count
+      labeled_name: 'sql.count{query_type: routine-started-update}'
+      description: Number of SQL UPDATE statements started within routine invocation
+      y_axis_label: SQL Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.
+      essential: true
+    - name: sql.routine.update.started.count.internal
+      exported_name: sql_routine_update_started_count_internal
+      labeled_name: 'sql.count{query_type: routine-started-update, query_internal: true}'
+      description: Number of SQL UPDATE statements started within routine invocation (internal queries)
+      y_axis_label: SQL Internal Statements
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
     - name: sql.select.count
       exported_name: sql_select_count
       labeled_name: 'sql.count{query_type: select}'

--- a/pkg/server/application_api/metrics_test.go
+++ b/pkg/server/application_api/metrics_test.go
@@ -8,6 +8,8 @@ package application_api_test
 import (
 	"bytes"
 	"context"
+	gosql "database/sql"
+	"fmt"
 	"strings"
 	"testing"
 
@@ -303,4 +305,449 @@ func TestSpanStatsResponse(t *testing.T) {
 	if a, e := int(responseSpanStats.RangeCount), initialRanges; a != e {
 		t.Errorf("expected %d ranges, found %d", e, a)
 	}
+}
+
+func confirmMetricCount(t *testing.T, db *gosql.DB, metricName string, expected int) {
+	var res gosql.NullInt64
+	if err := db.QueryRowContext(
+		context.Background(),
+		fmt.Sprintf("SELECT value FROM crdb_internal.node_metrics WHERE name = '%s'", metricName),
+	).Scan(&res); err != nil {
+		t.Fatalf("failed to query metric for %s: %v", metricName, err)
+	}
+	require.Equal(t, expected, int(res.Int64))
+}
+
+func TestStoreProcedureCallStatementMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.SystemLayer()
+	db := s.SQLConn(t)
+
+	var (
+		expectedStartedInsertCount = 0
+		expectedInsertCount        = 0
+		expectedStartedUpdateCount = 0
+		expectedUpdateCount        = 0
+		expectedStartedDeleteCount = 0
+		expectedDeleteCount        = 0
+		expectedStartedSelectCount = 0
+		expectedSelectCount        = 0
+	)
+
+	_, err := db.Exec(`		
+		CREATE TABLE tbl (id SERIAL PRIMARY KEY, t text UNIQUE);
+		INSERT INTO tbl (t) VALUES ('d');`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE OR REPLACE PROCEDURE inserttbl()
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+				INSERT INTO tbl (t) VALUES ('a');
+				COMMIT;
+				INSERT INTO tbl (t) VALUES ('b');
+				COMMIT;
+				INSERT INTO tbl (t) VALUES ('c');
+	     INSERT INTO tbl (t) VALUES ('d'); -- this will fail due to unique constraint.
+	     INSERT INTO tbl (t) VALUES ('z');
+		END;
+		$$;`)
+	require.NoError(t, err)
+
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// Only after the first call to inserttbl() do we expect to see the metrics.
+	_, err = db.Exec(`CALL inserttbl();`)
+	require.NotNil(t, err)
+
+	// The actual execution will halt at `INSERT INTO tbl (t) VALUES
+	// ('d');` due to violation of the unique constraint. So we expect 4
+	// started insert statements, but only 3 successful insert statements.
+	// The one after inserting 'd' will not be executed.
+	expectedStartedInsertCount += 4
+	expectedInsertCount += 3
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// This is to show that the metrics is globally aggregated across all calls of
+	// store procedures.
+	_, err = db.Exec(`
+			TRUNCATE tbl;
+			CALL inserttbl();
+	`)
+
+	require.NoError(t, err)
+
+	expectedStartedInsertCount += 5
+	expectedInsertCount += 5
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// Now we test the update, delete and select statements.
+	_, err = db.Exec(`
+			CREATE OR REPLACE PROCEDURE updatetbl()
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+					UPDATE tbl SET t = 'y' WHERE t = 'd';
+					DELETE FROM tbl WHERE t = 'b';
+					SELECT t FROM tbl WHERE t > 'a';
+					SELECT t FROM tbl; -- a select statement without filters.
+			END;
+			$$;
+			CALL updatetbl();`)
+	require.NoError(t, err)
+
+	expectedStartedUpdateCount++
+	expectedUpdateCount++
+	expectedStartedDeleteCount++
+	expectedDeleteCount++
+	expectedStartedSelectCount += 2
+	expectedSelectCount += 2
+	confirmMetricCount(t, db, "sql.routine.update.started.count", expectedStartedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.update.count", expectedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.delete.started.count", expectedStartedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.delete.count", expectedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedSelectCount)
+
+	// Now we test the nested procedure calls.
+	_, err = db.Exec(`
+			CREATE OR REPLACE PROCEDURE insertone()
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+					INSERT INTO tbl (t) VALUES ('x');
+			END;
+			$$;
+	
+			CREATE OR REPLACE PROCEDURE nested_insertone()
+			LANGUAGE plpgsql
+			AS $$
+			BEGIN
+					CALL insertone();
+			END;
+			$$;
+			CALL nested_insertone();`)
+	require.NoError(t, err)
+
+	expectedStartedInsertCount++
+	expectedInsertCount++
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// Test with SQL language SPs that perform all operations.
+	_, err = db.Exec(`
+		CREATE OR REPLACE PROCEDURE allops_sqllang()
+		LANGUAGE SQL
+		AS $$ 
+		DELETE FROM tbl WHERE t = 'x';
+		INSERT INTO tbl (t) VALUES ('x');
+		UPDATE tbl SET t = 'yy' WHERE t = 'x'; 
+		SELECT t FROM tbl; -- a select statement without filters.
+		SELECT t FROM tbl WHERE t > 'a';
+		$$;
+		CALL allops_sqllang();`)
+	require.NoError(t, err)
+
+	expectedStartedInsertCount++
+	expectedInsertCount++
+	expectedStartedUpdateCount++
+	expectedUpdateCount++
+	expectedStartedDeleteCount++
+	expectedDeleteCount++
+	expectedStartedSelectCount += 2
+	expectedSelectCount += 2
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.update.started.count", expectedStartedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.update.count", expectedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.delete.started.count", expectedStartedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.delete.count", expectedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedSelectCount)
+
+	// Test PLpgSQL with complex control structures.
+	_, err = db.Exec(`
+		CREATE OR REPLACE PROCEDURE complex_plpgsql()
+		LANGUAGE plpgsql
+		AS $$
+		DECLARE
+			counter INT := 0;
+			result TEXT;
+		BEGIN
+			counter := 5;
+		
+			-- IF statement with SQL inside
+			IF counter > 0 THEN
+				INSERT INTO tbl (t) VALUES ('if_branch');
+			ELSE
+				INSERT INTO tbl (t) VALUES ('else_branch');
+			END IF;
+		
+			-- WHILE loop with SQL inside
+			WHILE counter > 0 LOOP
+				INSERT INTO tbl (t) VALUES ('loop_' || counter);
+				counter := counter - 1;
+			END LOOP;
+		END;
+		$$;`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`CALL complex_plpgsql();`)
+	require.NoError(t, err)
+
+	// 6 = 1 from IF + 5 from WHILE loop.
+	expectedStartedInsertCount += 6
+	expectedInsertCount += 6
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+}
+
+func TestUDFStatementMetrics(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+	srv := serverutils.StartServerOnly(t, base.TestServerArgs{})
+	defer srv.Stopper().Stop(context.Background())
+	s := srv.SystemLayer()
+	db := s.SQLConn(t)
+
+	var (
+		expectedStartedInsertCount = 0
+		expectedInsertCount        = 0
+		expectedStartedUpdateCount = 0
+		expectedUpdateCount        = 0
+		expectedStartedDeleteCount = 0
+		expectedDeleteCount        = 0
+		expectedStartedSelectCount = 0
+		expectedSelectCount        = 0
+	)
+
+	_, err := db.Exec(`		
+		CREATE TABLE tbl (id SERIAL PRIMARY KEY, t text UNIQUE);
+		INSERT INTO tbl (t) VALUES ('d');`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION inserttbl() RETURNS TEXT
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+				INSERT INTO tbl (t) VALUES ('a');
+				INSERT INTO tbl (t) VALUES ('b');
+				INSERT INTO tbl (t) VALUES ('c');
+				INSERT INTO tbl (t) VALUES ('d'); -- this will fail due to unique constraint.
+				INSERT INTO tbl (t) VALUES ('z');
+				RETURN 'All inserts completed successfully';
+		EXCEPTION
+				WHEN unique_violation THEN
+						RETURN 'Unique constraint violation occurred';
+		END;
+		$$;`)
+	require.NoError(t, err)
+
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// Only after the first call to inserttbl() do we expect to see the metrics.
+	_, err = db.Exec(`SELECT inserttbl();`)
+	require.NoError(t, err)
+
+	// The actual execution will halt at `INSERT INTO tbl (t) VALUES
+	// ('d');` due to violation of the unique constraint. So we expect 4
+	// started insert statements, but only 3 successful insert statements.
+	// The one after inserting 'd' will not be executed.
+	expectedStartedInsertCount += 4
+	expectedInsertCount += 3
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// This is to show that the metrics is globally aggregated across all calls of
+	// store procedures.
+	_, err = db.Exec(`
+			TRUNCATE tbl;
+			SELECT inserttbl();
+	`)
+	require.NoError(t, err)
+
+	expectedStartedInsertCount += 5
+	expectedInsertCount += 5
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// Test the update, delete and select statements.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION updatetbl() RETURNS TEXT
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+				UPDATE tbl SET t = 'y' WHERE t = 'd';
+				DELETE FROM tbl WHERE t = 'b';
+				SELECT t FROM tbl WHERE t > 'a';
+				SELECT t FROM tbl; -- a select statement without filters.
+				RETURN 'All operations completed successfully';
+		END;
+		$$;
+		SELECT updatetbl();`)
+	require.NoError(t, err)
+
+	expectedStartedUpdateCount++
+	expectedUpdateCount++
+	expectedStartedDeleteCount++
+	expectedDeleteCount++
+	expectedStartedSelectCount += 2
+	expectedSelectCount += 2
+	confirmMetricCount(t, db, "sql.routine.update.started.count", expectedStartedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.update.count", expectedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.delete.started.count", expectedStartedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.delete.count", expectedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedSelectCount)
+
+	// Test the nested UDF calls.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION insertone() RETURNS TEXT
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+				INSERT INTO tbl (t) VALUES ('x');
+				RETURN 'Inserted value x';
+		END;
+		$$;
+	
+		CREATE OR REPLACE FUNCTION nested_insertone() RETURNS TEXT
+		LANGUAGE plpgsql
+		AS $$
+		BEGIN
+				SELECT insertone();
+				RETURN 'Nested insert completed';
+		END;
+		$$;
+		SELECT nested_insertone();`)
+	require.NoError(t, err)
+
+	expectedStartedInsertCount++
+	expectedInsertCount++
+	expectedStartedSelectCount++
+	expectedSelectCount++
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedSelectCount)
+
+	// Test with SQL language UDFs that perform all operations.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION allops_sqllang() RETURNS TEXT
+		LANGUAGE SQL
+		AS $$ 
+		DELETE FROM tbl WHERE t = 'x';
+		INSERT INTO tbl (t) VALUES ('x');
+		UPDATE tbl SET t = 'yy' WHERE t = 'x'; 
+		SELECT t FROM tbl; -- a select statement without filters.
+		SELECT t FROM tbl WHERE t > 'a';
+		SELECT 'All operations completed successfully';
+		$$;
+		SELECT allops_sqllang();`)
+
+	require.NoError(t, err)
+
+	expectedStartedInsertCount++
+	expectedInsertCount++
+	expectedStartedUpdateCount++
+	expectedUpdateCount++
+	expectedStartedDeleteCount++
+	expectedDeleteCount++
+	expectedStartedSelectCount += 3
+	expectedSelectCount += 3
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.update.started.count", expectedStartedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.update.count", expectedUpdateCount)
+	confirmMetricCount(t, db, "sql.routine.delete.started.count", expectedStartedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.delete.count", expectedDeleteCount)
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedSelectCount)
+
+	// Test that UDFs called from views increment statement metrics.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION selecttbl(text_val TEXT) RETURNS TEXT AS $$
+		BEGIN
+			SELECT t FROM tbl WHERE t = text_val;
+			RETURN text_val;
+		END;
+		$$ LANGUAGE plpgsql;
+	
+		-- Create a view that calls the UDF
+		CREATE OR REPLACE VIEW view_with_udf AS 
+		SELECT selecttbl('view_triggered_udf') AS result;
+`)
+	require.NoError(t, err)
+
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedStartedSelectCount)
+
+	_, err = db.Exec(`SELECT * FROM view_with_udf;`)
+	require.NoError(t, err)
+
+	expectedStartedSelectCount++
+	expectedSelectCount++
+	confirmMetricCount(t, db, "sql.routine.select.started.count", expectedStartedSelectCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedStartedSelectCount)
+
+	// Test complex PL/pgSQL with control structures.
+	_, err = db.Exec(`
+		CREATE OR REPLACE FUNCTION complex_plpgsql() RETURNS TEXT
+		LANGUAGE plpgsql
+		AS $$
+		DECLARE
+			counter INT := 0;
+			result TEXT;
+		BEGIN
+			counter := 5;
+		
+			-- IF statement with SQL inside.
+			IF counter > 0 THEN
+				INSERT INTO tbl (t) VALUES ('if_branch');
+			ELSE
+				INSERT INTO tbl (t) VALUES ('else_branch');
+			END IF;
+		
+			-- WHILE loop with SQL inside.
+			WHILE counter > 0 LOOP
+				INSERT INTO tbl (t) VALUES ('loop_' || counter);
+				counter := counter - 1;
+			END LOOP;
+			
+			RETURN 'Processing complete';
+		END;
+		$$;`)
+	require.NoError(t, err)
+
+	_, err = db.Exec(`SELECT complex_plpgsql();`)
+	require.NoError(t, err)
+
+	// 6 = 1 from IF + 5 from WHILE loop.
+	expectedStartedInsertCount += 6
+	expectedInsertCount += 6
+	confirmMetricCount(t, db, "sql.routine.insert.started.count", expectedStartedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+
+	// Test with inlined UDF calls.
+	_, err = db.Exec(`
+		TRUNCATE TABLE tbl;
+		CREATE OR REPLACE FUNCTION s1() RETURNS TEXT LANGUAGE SQL AS $$ SELECT 'z' $$;
+		CREATE FUNCTION ins1() RETURNS INT LANGUAGE SQL AS $$ INSERT INTO tbl (t) VALUES (s1()) RETURNING 1 $$;
+		SELECT ins1();
+`)
+	require.NoError(t, err)
+
+	expectedInsertCount += 1
+	expectedSelectCount += 1
+	confirmMetricCount(t, db, "sql.routine.insert.count", expectedInsertCount)
+	confirmMetricCount(t, db, "sql.routine.select.count", expectedSelectCount)
 }

--- a/pkg/sql/conn_executor.go
+++ b/pkg/sql/conn_executor.go
@@ -3804,34 +3804,36 @@ func bufferedWritesIsAllowedForIsolationLevel(
 func (ex *connExecutor) initEvalCtx(ctx context.Context, evalCtx *extendedEvalContext, p *planner) {
 	*evalCtx = extendedEvalContext{
 		Context: eval.Context{
-			Planner:                        p,
-			StreamManagerFactory:           p,
-			PrivilegedAccessor:             p,
-			SessionAccessor:                p,
-			JobExecContext:                 p,
-			ClientNoticeSender:             p,
-			Sequence:                       p,
-			Tenant:                         p,
-			Regions:                        p,
-			Gossip:                         p,
-			PreparedStatementState:         &ex.extraTxnState.prepStmtsNamespace,
-			SessionDataStack:               ex.sessionDataStack,
-			ReCache:                        ex.server.reCache,
-			ToCharFormatCache:              ex.server.toCharFormatCache,
-			SQLStatsController:             ex.server.persistedSQLStats,
-			SchemaTelemetryController:      ex.server.schemaTelemetryController,
-			IndexUsageStatsController:      ex.server.indexUsageStatsController,
-			ConsistencyChecker:             p.execCfg.ConsistencyChecker,
-			RangeProber:                    p.execCfg.RangeProber,
-			StmtDiagnosticsRequestInserter: ex.server.cfg.StmtDiagnosticsRecorder.InsertRequest,
-			CatalogBuiltins:                &p.evalCatalogBuiltins,
-			QueryCancelKey:                 ex.queryCancelKey,
-			DescIDGenerator:                ex.getDescIDGenerator(),
-			RangeStatsFetcher:              p.execCfg.RangeStatsFetcher,
-			JobsProfiler:                   p,
-			RNGFactory:                     &ex.rng.external,
-			ULIDEntropyFactory:             &ex.rng.ulidEntropy,
-			CidrLookup:                     p.execCfg.CidrLookup,
+			Planner:                          p,
+			StreamManagerFactory:             p,
+			PrivilegedAccessor:               p,
+			SessionAccessor:                  p,
+			JobExecContext:                   p,
+			ClientNoticeSender:               p,
+			Sequence:                         p,
+			Tenant:                           p,
+			Regions:                          p,
+			Gossip:                           p,
+			PreparedStatementState:           &ex.extraTxnState.prepStmtsNamespace,
+			SessionDataStack:                 ex.sessionDataStack,
+			ReCache:                          ex.server.reCache,
+			ToCharFormatCache:                ex.server.toCharFormatCache,
+			SQLStatsController:               ex.server.persistedSQLStats,
+			SchemaTelemetryController:        ex.server.schemaTelemetryController,
+			IndexUsageStatsController:        ex.server.indexUsageStatsController,
+			ConsistencyChecker:               p.execCfg.ConsistencyChecker,
+			RangeProber:                      p.execCfg.RangeProber,
+			StmtDiagnosticsRequestInserter:   ex.server.cfg.StmtDiagnosticsRecorder.InsertRequest,
+			CatalogBuiltins:                  &p.evalCatalogBuiltins,
+			QueryCancelKey:                   ex.queryCancelKey,
+			DescIDGenerator:                  ex.getDescIDGenerator(),
+			RangeStatsFetcher:                p.execCfg.RangeStatsFetcher,
+			JobsProfiler:                     p,
+			RNGFactory:                       &ex.rng.external,
+			ULIDEntropyFactory:               &ex.rng.ulidEntropy,
+			CidrLookup:                       p.execCfg.CidrLookup,
+			StartedRoutineStatementCounters:  ex.metrics.StartedStatementCounters.toRoutineStmtCounters(),
+			ExecutedRoutineStatementCounters: ex.metrics.ExecutedStatementCounters.toRoutineStmtCounters(),
 		},
 		Tracing:              &ex.sessionTracing,
 		MemMetrics:           &ex.memMetrics,
@@ -4605,8 +4607,15 @@ type StatementCounters struct {
 	UpdateCount telemetry.CounterWithAggMetric
 	InsertCount telemetry.CounterWithAggMetric
 	DeleteCount telemetry.CounterWithAggMetric
+
 	// CRUDQueryCount includes all 4 CRUD statements above.
 	CRUDQueryCount telemetry.CounterWithAggMetric
+
+	// Basic CRUD statements within the UDF/SP body.
+	RoutineSelectCount telemetry.CounterWithAggMetric
+	RoutineUpdateCount telemetry.CounterWithAggMetric
+	RoutineInsertCount telemetry.CounterWithAggMetric
+	RoutineDeleteCount telemetry.CounterWithAggMetric
 
 	// Transaction operations.
 	TxnBeginCount    telemetry.CounterWithAggMetric
@@ -4686,6 +4695,14 @@ func makeStartedStatementCounters(internal bool) StatementCounters {
 			getMetricMeta(MetaInsertStarted, internal)),
 		DeleteCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaDeleteStarted, internal)),
+		RoutineSelectCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineSelectStarted, internal)),
+		RoutineUpdateCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineUpdateStarted, internal)),
+		RoutineInsertCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineInsertStarted, internal)),
+		RoutineDeleteCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineDeleteStarted, internal)),
 		CRUDQueryCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaCRUDStarted, internal)),
 		DdlCount: telemetry.NewCounterWithMetric(
@@ -4739,6 +4756,14 @@ func makeExecutedStatementCounters(internal bool) StatementCounters {
 			getMetricMeta(MetaInsertExecuted, internal)),
 		DeleteCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaDeleteExecuted, internal)),
+		RoutineSelectCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineSelectExecuted, internal)),
+		RoutineUpdateCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineUpdateExecuted, internal)),
+		RoutineInsertCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineInsertExecuted, internal)),
+		RoutineDeleteCount: telemetry.NewCounterWithAggMetric(
+			getMetricMeta(MetaRoutineDeleteExecuted, internal)),
 		CRUDQueryCount: telemetry.NewCounterWithAggMetric(
 			getMetricMeta(MetaCRUDExecuted, internal)),
 		DdlCount: telemetry.NewCounterWithMetric(
@@ -4822,6 +4847,18 @@ func (sc *StatementCounters) incrementCount(ex *connExecutor, stmt tree.Statemen
 		} else {
 			sc.MiscCount.Inc()
 		}
+	}
+}
+
+// toRoutineStmtCounters converts the StatementCounters to a RoutineStatementCounters
+// so that it can be passed along eval ctx to the opt layer, avoiding
+// import cycle.
+func (sc *StatementCounters) toRoutineStmtCounters() eval.RoutineStatementCounters {
+	return eval.RoutineStatementCounters{
+		SelectCount: &sc.RoutineSelectCount,
+		UpdateCount: &sc.RoutineUpdateCount,
+		InsertCount: &sc.RoutineInsertCount,
+		DeleteCount: &sc.RoutineDeleteCount,
 	}
 }
 

--- a/pkg/sql/exec_util.go
+++ b/pkg/sql/exec_util.go
@@ -1397,6 +1397,95 @@ var (
 		Measurement: "SQL Statements",
 		Unit:        metric.Unit_COUNT,
 	}
+	MetaRoutineSelectStarted = metric.Metadata{
+		Name:         "sql.routine.select.started.count",
+		Help:         "Number of SQL SELECT statements started within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-started-select"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+	MetaRoutineUpdateStarted = metric.Metadata{
+		Name:         "sql.routine.update.started.count",
+		Help:         "Number of SQL UPDATE statements started within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-started-update"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+	MetaRoutineInsertStarted = metric.Metadata{
+		Name:         "sql.routine.insert.started.count",
+		Help:         "Number of SQL INSERT statements started within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-started-insert"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+	MetaRoutineDeleteStarted = metric.Metadata{
+		Name:         "sql.routine.delete.started.count",
+		Help:         "Number of SQL DELETE statements started within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-started-delete"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+
+	MetaRoutineSelectExecuted = metric.Metadata{
+		Name:         "sql.routine.select.count",
+		Help:         "Number of SQL SELECT statements successfully executed within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-select"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+	MetaRoutineUpdateExecuted = metric.Metadata{
+		Name:         "sql.routine.update.count",
+		Help:         "Number of SQL UPDATE statements successfully executed within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-update"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+	MetaRoutineInsertExecuted = metric.Metadata{
+		Name:         "sql.routine.insert.count",
+		Help:         "Number of SQL INSERT statements successfully executed within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-insert"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
+	MetaRoutineDeleteExecuted = metric.Metadata{
+		Name:         "sql.routine.delete.count",
+		Help:         "Number of SQL DELETE statements successfully executed within routine invocation",
+		Measurement:  "SQL Statements",
+		Unit:         metric.Unit_COUNT,
+		LabeledName:  "sql.count",
+		StaticLabels: metric.MakeLabelPairs(metric.LabelQueryType, "routine-delete"),
+		Essential:    true,
+		Category:     metric.Metadata_SQL,
+		HowToUse:     "This high-level metric reflects workload volume. Monitor this metric to identify abnormal application behavior or patterns over time. If abnormal patterns emerge, apply the metric's time range to the SQL Activity pages to investigate interesting outliers or patterns. For example, on the Transactions page and the Statements page, sort on the Execution Count column. To find problematic sessions, on the Sessions page, sort on the Transaction Count column. Find the sessions with high transaction counts and trace back to a user or application.",
+	}
 )
 
 func getMetricMeta(meta metric.Metadata, internal bool) metric.Metadata {

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3713,6 +3713,7 @@ func (b *Builder) buildCall(c *memo.CallExpr) (_ execPlan, outputCols colOrdMap,
 		udf.Def.Body,
 		udf.Def.BodyProps,
 		udf.Def.BodyStmts,
+		udf.Def.BodyTags,
 		false, /* allowOuterWithRefs */
 		nil,   /* wrapRootExpr */
 		0,     /* resultBufferID */

--- a/pkg/sql/opt/memo/expr.go
+++ b/pkg/sql/opt/memo/expr.go
@@ -746,6 +746,10 @@ type UDFDefinition struct {
 	// Body. It is only populated when verbose tracing is enabled.
 	BodyStmts []string
 
+	// BodyTags contains the type of each statement in Body, which is populated
+	// via `tree.Statement.StatementTag()`.
+	BodyTags []string
+
 	// FirstStmtOutput allows the result of the first body statement to be
 	// redirected. Only one of the options can be set. If one is set, there will
 	// be at least two body statements - the first with redirected output, and the

--- a/pkg/sql/opt/optbuilder/plpgsql.go
+++ b/pkg/sql/opt/optbuilder/plpgsql.go
@@ -678,7 +678,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			if b.options.insideDataSource && b.setReturnType.Family() == types.TupleFamily {
 				retNextScope = b.ob.expandRoutineTupleIntoCols(retNextScope)
 			}
-			b.appendBodyStmtFromScope(&retCon, retNextScope)
+			b.appendBodyStmtFromScope(&retCon, retNextScope, "" /* stmtTag */)
 			b.appendPlpgSQLStmts(&retCon, stmts[i+1:])
 			return b.callContinuation(&retCon, s)
 
@@ -720,7 +720,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			if !b.options.insideDataSource && b.setReturnType.Family() == types.TupleFamily {
 				retQueryScope = b.ob.combineRoutineColsIntoTuple(retQueryScope)
 			}
-			b.appendBodyStmtFromScope(&retCon, retQueryScope)
+			b.appendBodyStmtFromScope(&retCon, retQueryScope, t.SqlStmt.StatementTag())
 			b.appendPlpgSQLStmts(&retCon, stmts[i+1:])
 			return b.callContinuation(&retCon, s)
 
@@ -949,7 +949,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			// crdb_internal.plpgsql_raise builtin function.
 			con := b.makeContinuation("_stmt_raise")
 			con.def.Volatility = volatility.Volatile
-			b.appendBodyStmtFromScope(&con, b.buildPLpgSQLRaise(con.s, b.getRaiseArgs(con.s, t)))
+			b.appendBodyStmtFromScope(&con, b.buildPLpgSQLRaise(con.s, b.getRaiseArgs(con.s, t)), "" /* stmtTag */)
 			b.appendPlpgSQLStmts(&con, stmts[i+1:])
 			return b.callContinuation(&con, s)
 
@@ -970,7 +970,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			if len(t.Target) == 0 {
 				// When there is no INTO target, build the SQL statement into a body
 				// statement that is only executed for its side effects.
-				b.appendBodyStmtFromScope(&execCon, stmtScope)
+				b.appendBodyStmtFromScope(&execCon, stmtScope, t.SqlStmt.StatementTag())
 				b.appendPlpgSQLStmts(&execCon, stmts[i+1:])
 				return b.callContinuation(&execCon, s)
 			}
@@ -1028,7 +1028,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			intoScope = b.callContinuation(&retCon, intoScope)
 
 			// Step 3: call the INTO continuation from the parent scope.
-			b.appendBodyStmtFromScope(&execCon, intoScope)
+			b.appendBodyStmtFromScope(&execCon, intoScope, t.SqlStmt.StatementTag())
 			return b.callContinuation(&execCon, s)
 
 		case *ast.Open:
@@ -1068,7 +1068,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 				// Cursors with mutations are invalid.
 				panic(cursorMutationErr)
 			}
-			b.appendBodyStmtFromScope(&openCon, openScope)
+			b.appendBodyStmtFromScope(&openCon, openScope, query.StatementTag())
 			b.appendPlpgSQLStmts(&openCon, stmts[i+1:])
 
 			// Build a statement to generate a unique name for the cursor if one
@@ -1078,7 +1078,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			nameCon := b.makeContinuation("_gen_cursor_name")
 			nameCon.def.Volatility = volatility.Volatile
 			nameScope := b.buildCursorNameGen(&nameCon, t.CurVar)
-			b.appendBodyStmtFromScope(&nameCon, b.callContinuation(&openCon, nameScope))
+			b.appendBodyStmtFromScope(&nameCon, b.callContinuation(&openCon, nameScope), "" /* stmtTag */)
 			return b.callContinuation(&nameCon, s)
 
 		case *ast.Close:
@@ -1118,7 +1118,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			closeScope := closeCon.s.push()
 			b.ob.synthesizeColumn(closeScope, closeColName, types.Int, nil /* expr */, closeCall)
 			b.ob.constructProjectForScope(closeCon.s, closeScope)
-			b.appendBodyStmtFromScope(&closeCon, closeScope)
+			b.appendBodyStmtFromScope(&closeCon, closeScope, "" /* stmtTag */)
 			b.appendPlpgSQLStmts(&closeCon, stmts[i+1:])
 			return b.callContinuation(&closeCon, s)
 
@@ -1142,7 +1142,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			fetchCon.def.Volatility = volatility.Volatile
 			fetchScope := b.buildFetch(fetchCon.s, t)
 			if t.IsMove {
-				b.appendBodyStmtFromScope(&fetchCon, fetchScope)
+				b.appendBodyStmtFromScope(&fetchCon, fetchScope, "" /* stmtTag */)
 				b.appendPlpgSQLStmts(&fetchCon, stmts[i+1:])
 				return b.callContinuation(&fetchCon, s)
 			}
@@ -1173,7 +1173,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			intoScope = b.callContinuation(&retCon, intoScope)
 
 			// Add the built statement to the FETCH continuation.
-			b.appendBodyStmtFromScope(&fetchCon, intoScope)
+			b.appendBodyStmtFromScope(&fetchCon, intoScope, "" /* stmtTag */)
 			return b.callContinuation(&fetchCon, s)
 
 		case *ast.Null:
@@ -1275,7 +1275,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			if len(target) == 0 {
 				// When there is no INTO target, build the nested procedure call into a
 				// body statement that is only executed for its side effects.
-				b.appendBodyStmtFromScope(&callCon, callScope)
+				b.appendBodyStmtFromScope(&callCon, callScope, "" /* stmtTag */)
 				b.appendPlpgSQLStmts(&callCon, stmts[i+1:])
 				return b.callContinuation(&callCon, s)
 			}
@@ -1290,7 +1290,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			intoScope = b.callContinuation(&retCon, intoScope)
 
 			// Add the built statement to the CALL continuation.
-			b.appendBodyStmtFromScope(&callCon, intoScope)
+			b.appendBodyStmtFromScope(&callCon, intoScope, "" /* stmtTag */)
 			return b.callContinuation(&callCon, s)
 
 		case *ast.DoBlock:
@@ -1306,7 +1306,7 @@ func (b *plpgsqlBuilder) buildPLpgSQLStatements(stmts []ast.Statement, s *scope)
 			doCon := b.makeContinuation("_stmt_do")
 			doCon.def.Volatility = volatility.Volatile
 			bodyScope := b.ob.buildPLpgSQLDoBody(t)
-			b.appendBodyStmtFromScope(&doCon, bodyScope)
+			b.appendBodyStmtFromScope(&doCon, bodyScope, "" /* stmtTag */)
 			b.appendPlpgSQLStmts(&doCon, stmts[i+1:])
 			return b.callContinuation(&doCon, s)
 
@@ -1456,7 +1456,7 @@ func (b *plpgsqlBuilder) handleIntForLoop(
 	)
 	// Call recursively into the loop body continuation.
 	incScope = b.callContinuation(&loopCon, incScope)
-	b.appendBodyStmtFromScope(&incrementCon, incScope)
+	b.appendBodyStmtFromScope(&incrementCon, incScope, "" /* stmtTag */)
 
 	// Notably, we call the loop body continuation here, rather than the
 	// increment continuation, because the counter should not be incremented
@@ -2020,7 +2020,7 @@ func (b *plpgsqlBuilder) buildEndOfFunctionRaise(con *continuation) {
 		pgcode.RoutineExceptionFunctionExecutedNoReturnStatement.String(), /* code */
 	)
 	con.def.Volatility = volatility.Volatile
-	b.appendBodyStmtFromScope(con, b.buildPLpgSQLRaise(con.s, args))
+	b.appendBodyStmtFromScope(con, b.buildPLpgSQLRaise(con.s, args), "" /* stmtTag */)
 
 	// Build a dummy statement that returns NULL. It won't be executed, but
 	// ensures that the continuation routine's return type is correct.
@@ -2029,7 +2029,7 @@ func (b *plpgsqlBuilder) buildEndOfFunctionRaise(con *continuation) {
 	typedNull := b.ob.factory.ConstructNull(b.returnType)
 	b.ob.synthesizeColumn(eofScope, eofColName, b.returnType, nil /* expr */, typedNull)
 	b.ob.constructProjectForScope(con.s, eofScope)
-	b.appendBodyStmtFromScope(con, eofScope)
+	b.appendBodyStmtFromScope(con, eofScope, "" /* stmtTag */)
 }
 
 // addOneRowCheck handles INTO STRICT, where a SQL statement is required to
@@ -2279,7 +2279,9 @@ func (b *plpgsqlBuilder) makeContinuationWithTyp(
 // appendBodyStmtFromScope is separate from makeContinuation to allow recursive
 // routine definitions, which need to push the continuation before it is
 // finished. The separation also allows for appending multiple body statements.
-func (b *plpgsqlBuilder) appendBodyStmtFromScope(con *continuation, bodyScope *scope) {
+func (b *plpgsqlBuilder) appendBodyStmtFromScope(
+	con *continuation, bodyScope *scope, stmtTag string,
+) {
 	// Set the volatility of the continuation routine to the least restrictive
 	// volatility level in the Relational properties of the body statements.
 	bodyExpr := bodyScope.expr
@@ -2288,6 +2290,7 @@ func (b *plpgsqlBuilder) appendBodyStmtFromScope(con *continuation, bodyScope *s
 		con.def.Volatility = vol
 	}
 	con.def.Body = append(con.def.Body, bodyExpr)
+	con.def.BodyTags = append(con.def.BodyTags, stmtTag)
 	con.def.BodyProps = append(con.def.BodyProps, bodyScope.makePhysicalProps())
 }
 
@@ -2298,7 +2301,7 @@ func (b *plpgsqlBuilder) appendPlpgSQLStmts(con *continuation, stmts []ast.State
 	// Make sure to push s before constructing the continuation scope to ensure
 	// that the parameter columns are not projected.
 	continuationScope := b.buildPLpgSQLStatements(stmts, con.s.push())
-	b.appendBodyStmtFromScope(con, continuationScope)
+	b.appendBodyStmtFromScope(con, continuationScope, "" /* stmtTag */)
 }
 
 // callContinuation adds a column that projects the result of calling the

--- a/pkg/sql/opt/optbuilder/trigger.go
+++ b/pkg/sql/opt/optbuilder/trigger.go
@@ -846,6 +846,8 @@ func (b *Builder) buildTriggerFunction(
 	stmtScope := plBuilder.buildRootBlock(stmt.AST, triggerFuncScope, params)
 	udfDef.Body = []memo.RelExpr{stmtScope.expr}
 	udfDef.BodyProps = []*physical.Required{stmtScope.makePhysicalProps()}
+	// Placeholder that ensure the length of BodyTags is the same as Body.
+	udfDef.BodyTags = make([]string, 1)
 
 	return f.ConstructUDFCall(args, &memo.UDFCallPrivate{Def: udfDef}), resolvedDef
 }

--- a/pkg/sql/sem/eval/context.go
+++ b/pkg/sql/sem/eval/context.go
@@ -22,6 +22,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/kvserverbase"
 	"github.com/cockroachdb/cockroach/pkg/repstream/streampb"
 	"github.com/cockroachdb/cockroach/pkg/roachpb"
+	"github.com/cockroachdb/cockroach/pkg/server/telemetry"
 	"github.com/cockroachdb/cockroach/pkg/settings/cluster"
 	"github.com/cockroachdb/cockroach/pkg/sql/catalog/catpb"
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -311,6 +312,29 @@ type Context struct {
 
 	// CidrLookup is used to look up the tag name for a given IP address.
 	CidrLookup *cidr.Lookup
+
+	// StartedRoutineStatementCounters contains metrics for statements initiated by
+	// users when calling a UDF/SP. These metrics count user-initiated
+	// operations, regardless of success
+	StartedRoutineStatementCounters RoutineStatementCounters
+	// ExecutedStatementCounters contains metrics for successfully executed
+	// statements defined within the body of a UDF/SP.
+	ExecutedRoutineStatementCounters RoutineStatementCounters
+}
+
+// RoutineStatementCounters encapsulates metrics for tracking the execution
+// of different statement types defined within the body of a UDF or stored
+// procedure (SP).
+type RoutineStatementCounters struct {
+	// QueryCount includes all statements, and it is therefore the sum of
+	// all the below metrics.
+	QueryCount *telemetry.CounterWithMetric
+
+	// Basic CRUD statements.
+	SelectCount *telemetry.CounterWithAggMetric
+	UpdateCount *telemetry.CounterWithAggMetric
+	InsertCount *telemetry.CounterWithAggMetric
+	DeleteCount *telemetry.CounterWithAggMetric
 }
 
 // RNGFactory is a simple wrapper to preserve the RNG throughout the session.


### PR DESCRIPTION
Informs https://github.com/cockroachdb/cockroach/issues/151173

This commit introduces the following metrics for statements got executed via calling a store procedure or executing a routine:

- sql_routine_select_started_count
- sql_routine_update_started_count
- sql_routine_insert_started_count
- sql_routine_delete_started_count
- sql_routine_select_count
- sql_routine_update_count
- sql_routine_insert_count
- sql_routine_delete_count

The metrics with `started` are for statement that started execution, including those might error during execution. The ones without `started` are those successfully executed.

Like the existing counters for sql statements (e.g. sql_select_count), it increments before the changes is committed or aborted in an explicit transaction.

These counters are global, as in, calling different routines (i.e. UDF/SPs) will eventually aggregate to the same counter.

Release note (sql change): This commit introduces the following metrics for statements got executed via calling a store procedure: sql_routine_select_started_count, sql_routine_update_started_count,sql_routine_insert_started_count, sql_routine_delete_started_count,sql_routine_select_count,sql_routine_update_count,sql_routine_insert_count,sql_routine_delete_count.