### PR TITLE
release-25.3: kvcoord: turn off buffering of replicated gets

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -55,7 +55,7 @@ var bufferedWritesGetTransformEnabled = settings.RegisterBoolSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.transformations.get.enabled",
 	"if enabled, locking get requests with replicated durability are transformed to unreplicated durability",
-	metamorphic.ConstantWithTestBool("kv.transaction.write_buffering.transformations.get.enabled", true /* defaultValue */),
+	metamorphic.ConstantWithTestBool("kv.transaction.write_buffering.transformations.get.enabled", false /* defaultValue */),
 )
 
 const defaultBufferSize = 1 << 22 // 4MB


### PR DESCRIPTION
This turns off buffering of replicated gets to be in line with the default for replicated scans.

Release note: None
Epic: none

Release justification: Avoid a correctness bug in transactions using buffered writes (default-off preview feature)