### PR TITLE
sql: use indexes spelling in show columns

### DIFF
--- a/pkg/sql/delegate/show_table.go
+++ b/pkg/sql/delegate/show_table.go
@@ -193,7 +193,7 @@ SELECT
     is_nullable::BOOL,
     column_default,
     generation_expression,
-    IF(inames[1] IS NULL, ARRAY[]:::STRING[], inames) AS indices,
+    IF(inames[1] IS NULL, ARRAY[]:::STRING[], inames) AS indexes,
     is_hidden::BOOL`
 
 	if n.WithComment {

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -24,7 +24,7 @@ ALTER TABLE t ALTER s TYPE STRING, ALTER sl TYPE STRING(6), ALTER ts TYPE TIMEST
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM t
 ----
-column_name  data_type    is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type    is_nullable  column_default  generation_expression  indexes   is_hidden
 s            STRING       true         NULL            ·                      {t_pkey}  false
 sl           STRING(6)    true         NULL            ·                      {t_pkey}  false
 t            TIME         true         NULL            ·                      {t_pkey}  false
@@ -123,7 +123,7 @@ CREATE TABLE t (a INT)
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM t
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 a            INT8       true         NULL            ·                      {t_pkey}  false
 rowid        INT8       false        unique_rowid()  ·                      {t_pkey}  true
 
@@ -133,7 +133,7 @@ ALTER TABLE t ALTER a TYPE INTEGER
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM t
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 a            INT8       true         NULL            ·                      {t_pkey}  false
 rowid        INT8       false        unique_rowid()  ·                      {t_pkey}  true
 

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -23,7 +23,7 @@ ALTER TABLE t ADD b INT
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM t
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices           is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes           is_hidden
 a            INT8       false        NULL            ·                      {t_f_idx,t_pkey}  false
 f            INT8       true         NULL            ·                      {t_f_idx,t_pkey}  false
 b            INT8       true         NULL            ·                      {t_pkey}          false
@@ -526,7 +526,7 @@ ALTER TABLE tt ADD t DECIMAL UNIQUE DEFAULT 4.0
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM tt
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices                      is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes                      is_hidden
 a            INT8       false        NULL            ·                      {tt_pkey,tt_s_key,tt_t_key}  false
 q            DECIMAL    false        NULL            ·                      {tt_pkey}                    false
 r            DECIMAL    true         NULL            ·                      {tt_pkey}                    false
@@ -546,7 +546,7 @@ ALTER TABLE add_default ALTER COLUMN b SET DEFAULT 42
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM add_default
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices             is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes             is_hidden
 a            INT8       false        NULL            ·                      {add_default_pkey}  false
 b            INT8       false        42              ·                      {add_default_pkey}  false
 
@@ -704,7 +704,7 @@ ALTER TABLE add_default SET (schema_locked=true)
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM add_default
 ----
-column_name  data_type  is_nullable  column_default           generation_expression  indices             is_hidden
+column_name  data_type  is_nullable  column_default           generation_expression  indexes             is_hidden
 a            INT8       false        NULL                     ·                      {add_default_pkey}  false
 b            INT8       true         NULL                     ·                      {add_default_pkey}  false
 c            TIMESTAMP  true         current_timestamp()      ·                      {add_default_pkey}  false
@@ -766,7 +766,7 @@ user root
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM privs
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices       is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes       is_hidden
 a            INT8       false        NULL            ·                      {privs_pkey}  false
 b            INT8       true         NULL            ·                      {privs_pkey}  false
 
@@ -784,7 +784,7 @@ ALTER TABLE privs ADD CONSTRAINT foo UNIQUE (b)
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM privs
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices           is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes           is_hidden
 a            INT8       false        NULL            ·                      {foo,privs_pkey}  false
 b            INT8       true         NULL            ·                      {foo,privs_pkey}  false
 c            INT8       true         NULL            ·                      {privs_pkey}      false
@@ -4644,7 +4644,7 @@ alter table roach add column serial_id SERIAL;
 query TTBTTTB colnames,rowsort
 show columns from roach;
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices       is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes       is_hidden
 id           INT8       true         NULL            ·                      {roach_pkey}  false
 rowid        INT8       false        unique_rowid()  ·                      {roach_pkey}  true
 serial_id    INT8       false        unique_rowid()  ·                      {roach_pkey}  false

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -162,7 +162,7 @@ x  CREATE TABLE public.x (
 query TTBTTTB colnames
 SELECT * FROM  [SHOW COLUMNS FROM x] ORDER BY column_name
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 a            INT8       true         3               ·                      {x_pkey}  false
 b            INT8       true         7               ·                      {x_pkey}  false
 c            INT8       true         NULL            a                      {x_pkey}  false

--- a/pkg/sql/logictest/testdata/logic_test/default
+++ b/pkg/sql/logictest/testdata/logic_test/default
@@ -30,7 +30,7 @@ CREATE TABLE t (
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM t
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 a            INT8       false        42              ·                      {t_pkey}  false
 b            TIMESTAMP  true         now()           ·                      {t_pkey}  false
 c            FLOAT8     true         random()        ·                      {t_pkey}  false
@@ -42,7 +42,7 @@ COMMENT ON COLUMN t.a IS 'a'
 query TTBTTTBT colnames,rowsort
 SHOW COLUMNS FROM t WITH COMMENT
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden  comment
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden  comment
 a            INT8       false        42              ·                      {t_pkey}  false      a
 b            TIMESTAMP  true         now()           ·                      {t_pkey}  false      NULL
 c            FLOAT8     true         random()        ·                      {t_pkey}  false      NULL
@@ -132,7 +132,7 @@ UPDATE v SET (a, c) = (DEFAULT, DEFAULT)
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM v
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 a            INT8       false        NULL            ·                      {v_pkey}  false
 b            TIMESTAMP  true         NULL            ·                      {v_pkey}  false
 c            INT8       true         NULL            ·                      {v_pkey}  false

--- a/pkg/sql/logictest/testdata/logic_test/expression_index
+++ b/pkg/sql/logictest/testdata/logic_test/expression_index
@@ -99,7 +99,7 @@ CREATE TABLE public.t (
 query TTBTTTB colnames
 SELECT * FROM [SHOW COLUMNS FROM t] ORDER BY column_name
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices                                                           is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes                                                           is_hidden
 a            INT8       true         NULL            ·                      {t_pkey,t_vec}                                                    false
 b            INT8       true         NULL            ·                      {t_b_j_a_asc,t_pkey}                                              false
 c            STRING     true         NULL            ·                      {t_pkey}                                                          false

--- a/pkg/sql/logictest/testdata/logic_test/information_schema
+++ b/pkg/sql/logictest/testdata/logic_test/information_schema
@@ -336,7 +336,7 @@ information_schema.tables  CREATE TABLE information_schema.tables (
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM information_schema.tables
 ----
-column_name         data_type  is_nullable  column_default  generation_expression  indices  is_hidden
+column_name         data_type  is_nullable  column_default  generation_expression  indexes  is_hidden
 table_catalog       STRING     false        NULL            ·                      {}       false
 table_schema        STRING     false        NULL            ·                      {}       false
 table_name          STRING     false        NULL            ·                      {}       false
@@ -3385,7 +3385,7 @@ DROP DATABASE other_db CASCADE
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM information_schema.column_privileges
 ----
-column_name     data_type  is_nullable  column_default  generation_expression  indices  is_hidden
+column_name     data_type  is_nullable  column_default  generation_expression  indexes  is_hidden
 grantor         STRING     true         NULL            ·                      {}       false
 grantee         STRING     false        NULL            ·                      {}       false
 table_catalog   STRING     false        NULL            ·                      {}       false
@@ -3400,7 +3400,7 @@ is_grantable    STRING     true         NULL            ·                      
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM information_schema.routines
 ----
-column_name                          data_type    is_nullable  column_default  generation_expression  indices  is_hidden
+column_name                          data_type    is_nullable  column_default  generation_expression  indexes  is_hidden
 specific_catalog                     STRING       true         NULL            ·                      {}       false
 specific_schema                      STRING       true         NULL            ·                      {}       false
 specific_name                        STRING       true         NULL            ·                      {}       false
@@ -3495,7 +3495,7 @@ test              pg_catalog       pg_get_functiondef_2035  test             pg_
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM information_schema.parameters
 ----
-column_name               data_type  is_nullable  column_default  generation_expression  indices  is_hidden
+column_name               data_type  is_nullable  column_default  generation_expression  indexes  is_hidden
 specific_catalog          STRING     true         NULL            ·                      {}       false
 specific_schema           STRING     true         NULL            ·                      {}       false
 specific_name             STRING     true         NULL            ·                      {}       false
@@ -4808,7 +4808,7 @@ CREATE TYPE u AS (ufoo int, ubar int);
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM information_schema.user_defined_types
 ----
-column_name                 data_type  is_nullable  column_default  generation_expression  indices  is_hidden
+column_name                 data_type  is_nullable  column_default  generation_expression  indexes  is_hidden
 user_defined_type_catalog   STRING     true         NULL            ·                      {}       false
 user_defined_type_schema    STRING     true         NULL            ·                      {}       false
 user_defined_type_name      STRING     true         NULL            ·                      {}       false
@@ -4857,7 +4857,7 @@ subtest attributes
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM information_schema.attributes
 ----
-column_name                     data_type  is_nullable  column_default  generation_expression  indices  is_hidden
+column_name                     data_type  is_nullable  column_default  generation_expression  indexes  is_hidden
 udt_catalog                     STRING     true         NULL            ·                      {}       false
 udt_schema                      STRING     true         NULL            ·                      {}       false
 udt_name                        STRING     true         NULL            ·                      {}       false

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -319,7 +319,7 @@ pg_catalog.pg_namespace  CREATE TABLE pg_catalog.pg_namespace (
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM pg_catalog.pg_namespace
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices  is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes  is_hidden
 oid          OID        true         NULL            ·                      {}       false
 nspname      NAME       false        NULL            ·                      {}       false
 nspowner     OID        true         NULL            ·                      {}       false
@@ -2922,7 +2922,7 @@ datid  datname  pid  usesysid  usename  application_name  client_addr  client_ho
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM pg_catalog.pg_stat_activity
 ----
-column_name       data_type    is_nullable  column_default  generation_expression  indices  is_hidden
+column_name       data_type    is_nullable  column_default  generation_expression  indexes  is_hidden
 datid             OID          true         NULL            ·                      {}       false
 datname           NAME         true         NULL            ·                      {}       false
 pid               INT8         true         NULL            ·                      {}       false

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -115,7 +115,7 @@ CREATE TABLE d (
 query TTBTTTB colnames
 SHOW COLUMNS FROM d
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 id           INT8       false        NULL            ·                      {d_pkey}  false
 
 statement ok
@@ -126,7 +126,7 @@ CREATE TABLE e (
 query TTBTTTB colnames
 SHOW COLUMNS FROM e
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 id           INT8       false        NULL            ·                      {e_pkey}  false
 
 statement ok
@@ -140,7 +140,7 @@ CREATE TABLE f (
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM f
 ----
-column_name  data_type  is_nullable  column_default  generation_expression  indices   is_hidden
+column_name  data_type  is_nullable  column_default  generation_expression  indexes   is_hidden
 a            INT8       false        NULL            ·                      {f_pkey}  false
 b            INT8       false        NULL            ·                      {f_pkey}  false
 c            INT8       false        NULL            ·                      {f_pkey}  false
@@ -191,7 +191,7 @@ CREATE TABLE test.users (
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM test.users
 ----
-column_name  data_type     is_nullable  column_default  generation_expression  indices               is_hidden
+column_name  data_type     is_nullable  column_default  generation_expression  indexes               is_hidden
 id           INT8          false        NULL            ·                      {bar,foo,users_pkey}  false
 name         VARCHAR       false        NULL            ·                      {bar,foo,users_pkey}  false
 title        VARCHAR       true         NULL            ·                      {users_pkey}          false
@@ -446,7 +446,7 @@ CREATE TABLE alltypes (
 query TTBTTTB colnames,rowsort
 SHOW COLUMNS FROM alltypes
 ----
-column_name       data_type     is_nullable  column_default  generation_expression  indices          is_hidden
+column_name       data_type     is_nullable  column_default  generation_expression  indexes          is_hidden
 cbigint           INT8          true         NULL            ·                      {alltypes_pkey}  false
 cbigserial        INT8          false        unique_rowid()  ·                      {alltypes_pkey}  false
 cblob             BYTES         true         NULL            ·                      {alltypes_pkey}  false

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -591,7 +591,7 @@ distribution: local
 vectorized: true
 ·
 • sort
-│ order: +ordinal_position,+column_name,+crdb_sql_type,+is_nullable,+column_default,+generation_expression,+indices,+is_hidden
+│ order: +ordinal_position,+column_name,+crdb_sql_type,+is_nullable,+column_default,+generation_expression,+indexes,+is_hidden
 │
 └── • render
     │


### PR DESCRIPTION
Release note (sql change): The `SHOW COLUMNS` command now uses the
conventional spelling for "indexes".

Epic: none