### PR TITLE
fprint all rts

### DIFF
--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -3,6 +3,7 @@ load("@io_bazel_rules_go//go:def.bzl", "go_library", "go_test")
 go_library(
     name = "cdctest",
     srcs = [
+        "consumer.go",
         "mock_webhook_sink.go",
         "nemeses.go",
         "row.go",
@@ -37,13 +38,18 @@ go_library(
         "//pkg/util/hlc",
         "//pkg/util/json",
         "//pkg/util/log",
+        "//pkg/util/parquet",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
         "@com_github_cockroachdb_errors//:errors",
+        "@com_github_ibm_sarama//:sarama",
         "@com_github_klauspost_compress//zstd",
         "@com_github_lib_pq//oid",
         "@com_github_linkedin_goavro_v2//:goavro",
         "@com_github_stretchr_testify//require",
+        "@com_google_cloud_go_storage//:storage",
+        "@org_golang_google_api//iterator",
+        "@org_golang_x_sync//errgroup",
     ],
 )
 

--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -41,7 +41,7 @@ go_library(
         "//pkg/util/parquet",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
-        "@com_github_cockroachdb_apd//:apd",
+        "@com_github_cockroachdb_apd_v3//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_ibm_sarama//:sarama",
         "@com_github_klauspost_compress//zstd",

--- a/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/cdctest/BUILD.bazel
@@ -41,6 +41,7 @@ go_library(
         "//pkg/util/parquet",
         "//pkg/util/syncutil",
         "//pkg/util/timeutil",
+        "@com_github_cockroachdb_apd//:apd",
         "@com_github_cockroachdb_errors//:errors",
         "@com_github_ibm_sarama//:sarama",
         "@com_github_klauspost_compress//zstd",

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -315,7 +315,6 @@ func ConsumeAndValidate(ctx context.Context, consumer Consumer, validator Valida
 					return errors.Newf("validator failed: %v", failures)
 				}
 			} else {
-				fmt.Printf("C+A: NoteRow: %+v\n", msg)
 				if err := validator.NoteRow(msg.Partition, msg.Key, msg.Value, msg.Updated, msg.Topic); err != nil {
 					fmt.Printf("C+A: NoteRow failed: %v\n", err)
 					return err

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -1,0 +1,137 @@
+package cdctest
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/IBM/sarama"
+	"github.com/cockroachdb/cockroach/pkg/util/hlc"
+	"golang.org/x/sync/errgroup"
+)
+
+type ConsumerMessage struct {
+	Topic     string
+	Partition string
+	Resolved  hlc.Timestamp
+	Updated   hlc.Timestamp
+	Key       string
+	Value     string
+}
+
+type Consumer interface {
+	Start(ctx context.Context) error
+	Output() <-chan *ConsumerMessage
+}
+
+type kafkaConsumer struct {
+	uri                string
+	topic              string
+	partitions         []string
+	consumer           sarama.Consumer
+	partitionConsumers map[int32]sarama.PartitionConsumer
+	output             chan *ConsumerMessage
+}
+
+func NewKafkaConsumer(ctx context.Context, uri, topic string) (*kafkaConsumer, error) {
+	config := sarama.NewConfig()
+	config.Consumer.Fetch.Default = 1000012
+	consumer, err := sarama.NewConsumer([]string{uri}, config)
+	if err != nil {
+		return nil, err
+	}
+
+	parts, err := consumer.Partitions(topic)
+	if err != nil {
+		return nil, err
+	}
+	partitions := make([]string, len(parts))
+	for i, partition := range parts {
+		partitions[i] = strconv.Itoa(int(partition))
+	}
+
+	partitionConsumers := make(map[int32]sarama.PartitionConsumer, len(parts))
+	for _, partition := range parts {
+		pc, err := consumer.ConsumePartition(topic, partition, sarama.OffsetOldest)
+		if err != nil {
+			return nil, err
+		}
+		partitionConsumers[partition] = pc
+	}
+
+	return &kafkaConsumer{
+		uri:                uri,
+		topic:              topic,
+		partitions:         partitions,
+		consumer:           consumer,
+		partitionConsumers: partitionConsumers,
+		output:             make(chan *ConsumerMessage),
+	}, nil
+}
+
+func (c *kafkaConsumer) Start(ctx context.Context) error {
+	defer close(c.output)
+
+	partConsumerOutputs := make([]<-chan *sarama.ConsumerMessage, len(c.partitionConsumers))
+	for i, partition := range c.partitionConsumers {
+		partConsumerOutputs[i] = partition.Messages()
+	}
+	return fanIn(ctx, partConsumerOutputs, c.output, func(msg *sarama.ConsumerMessage) *ConsumerMessage {
+		return &ConsumerMessage{
+			Topic:     c.topic,
+			Partition: strconv.Itoa(int(msg.Partition)),
+			Key:       string(msg.Key),
+			Value:     string(msg.Value),
+		}
+	})
+}
+
+func (c *kafkaConsumer) Output() <-chan *ConsumerMessage {
+	return c.output
+}
+
+
+// TODO: other consumers
+// - [ ] cloud storage (sinkURI = `experimental-gs://cockroach-tmp/roachtest/` + ts + "?AUTH=implicit)
+// - [ ] webhook (need a webhook server that buffers data to disk and can replay it back)
+// - any others are a bonus
+
+func fanIn[I, O any](ctx context.Context, inputs []<-chan I, output chan<- O, f func(I) O) error {
+	wg, ctx := errgroup.WithContext(ctx)
+	for _, input := range inputs {
+		input := input
+		wg.Go(func() error {
+			for msg := range input {
+				select {
+				case <-ctx.Done():
+					return ctx.Err()
+				case output <- f(msg):
+				}
+			}
+			return nil
+		})
+	}
+	return wg.Wait()
+}
+
+func ConsumeAndValidate(ctx context.Context, consumer Consumer, validator Validator) error {
+	msgs := consumer.Output()
+	eg, ctx := errgroup.WithContext(ctx)
+	eg.Go(func() error {
+		return consumer.Start(ctx)
+	})
+	eg.Go(func() error {
+		for msg := range msgs {
+			if msg.Resolved.IsSet() {
+				if err := validator.NoteResolved(msg.Partition, msg.Resolved); err != nil {
+					return err
+				}
+			} else {
+				if err := validator.NoteRow(msg.Partition, msg.Key, msg.Value, msg.Updated, msg.Topic); err != nil {
+					return err
+				}
+			}
+		}
+		return nil
+	})
+	return eg.Wait()
+}

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -133,7 +133,7 @@ func NewCloudStorageConsumer(ctx context.Context, uri string, format string) (*c
 		return nil, err
 	}
 	bucket := gcs.Bucket(parsedURI.Host)
-	return &cloudStorageConsumer{gcs: gcs, bucket: bucket, prefix: parsedURI.Path, format: format}, nil
+	return &cloudStorageConsumer{gcs: gcs, bucket: bucket, prefix: parsedURI.Path, format: format, output: make(chan *ConsumerMessage)}, nil
 }
 
 func (c *cloudStorageConsumer) Start(ctx context.Context) error {

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -16,7 +16,7 @@ import (
 
 	"cloud.google.com/go/storage"
 	"github.com/IBM/sarama"
-	"github.com/cockroachdb/apd"
+	"github.com/cockroachdb/apd/v3"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/parquet"
 	"github.com/cockroachdb/errors"
@@ -440,5 +440,5 @@ func parseTimeToHLC(s string) (hlc.Timestamp, error) {
 	if err != nil {
 		return hlc.Timestamp{}, err
 	}
-	return ts
+	return ts, nil
 }

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -195,17 +195,17 @@ func (c *cloudStorageConsumer) Start(ctx context.Context) error {
 
 		fmt.Printf("Parsed filename: %s; topic=%s; resolved=%s\n", nextFile, topic, resolved)
 
-		if topic != c.topic {
-			fmt.Printf("Skipping file: %s (topic=%s != %s)\n", nextFile, topic, c.topic)
-			continue
-		}
-
 		if resolved.IsSet() {
 			select {
 			case <-ctx.Done():
 				return ctx.Err()
 			case c.output <- &ConsumerMessage{Resolved: resolved}:
 			}
+			continue
+		}
+
+		if topic != c.topic {
+			fmt.Printf("Skipping file: %s (topic=%s != %s)\n", nextFile, topic, c.topic)
 			continue
 		}
 
@@ -311,6 +311,7 @@ func ConsumeAndValidate(ctx context.Context, consumer Consumer, validator Valida
 					return errors.Newf("validator failed: %v", failures)
 				}
 			} else {
+				// bro so slowwwww
 				if err := validator.NoteRow(msg.Partition, msg.Key, msg.Value, msg.Updated, msg.Topic); err != nil {
 					fmt.Printf("C+A: NoteRow failed: %v\n", err)
 					return err

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -187,10 +187,13 @@ func (c *cloudStorageConsumer) Start(ctx context.Context) error {
 				Updated:   updated,
 			}
 		}
+		if err := scanner.Err(); err != nil {
+			return err
+		}
+
+		// Mark the file as seen.
+		seenFiles[nextFile] = struct{}{}
 	}
-
-	// we need to read the files in order and then emit the messages in order
-
 	return nil
 }
 

--- a/pkg/ccl/changefeedccl/cdctest/consumer.go
+++ b/pkg/ccl/changefeedccl/cdctest/consumer.go
@@ -202,7 +202,6 @@ func (c *cloudStorageConsumer) Output() <-chan *ConsumerMessage {
 }
 
 // TODO: other consumers
-// - [ ] cloud storage (sinkURI = `experimental-gs://cockroach-tmp/roachtest/` + ts + "?AUTH=implicit)
 // - [ ] webhook (need a webhook server that buffers data to disk and can replay it back)
 // - any others are a bonus
 

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -137,10 +137,6 @@ func (v *orderValidator) GetValuesForKeyBelowTimestamp(
 func (v *orderValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	defer func(start time.Time) {
-		fmt.Printf("ordervalidator: NoteRow took %s\n", time.Since(start))
-	}(time.Now())
-
 	if prev, ok := v.partitionForKey[key]; ok && prev != partition {
 		v.failures = append(v.failures, fmt.Sprintf(
 			`key [%s] received on two partitions: %s and %s`, key, prev, partition,
@@ -231,10 +227,6 @@ func NewBeforeAfterValidator(sqlDB *gosql.DB, table string, diff bool) (Validato
 func (v *beforeAfterValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	defer func(start time.Time) {
-		fmt.Printf("beforeaftervalidator: NoteRow took %s\n", time.Since(start))
-	}(time.Now())
-
 	keyJSON, err := json.ParseJSON(key)
 	if err != nil {
 		return err
@@ -387,10 +379,6 @@ func NewMvccTimestampValidator() Validator {
 func (v *mvccTimestampValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	defer func(start time.Time) {
-		fmt.Printf("mvccvalidator: NoteRow took %s\n", time.Since(start))
-	}(time.Now())
-
 	valueJSON, err := json.ParseJSON(value)
 	if err != nil {
 		return err
@@ -461,10 +449,6 @@ func NewKeyInValueValidator(sqlDB *gosql.DB, table string) (Validator, error) {
 func (v *keyInValueValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	defer func(start time.Time) {
-		fmt.Printf("keyinvaluevalidator: NoteRow took %s\n", time.Since(start))
-	}(time.Now())
-
 	keyJSON, err := json.ParseJSON(key)
 	if err != nil {
 		return err
@@ -527,10 +511,6 @@ func NewTopicValidator(table string, fullTableName bool) Validator {
 func (v *topicValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	defer func(start time.Time) {
-		fmt.Printf("topicvalidator: NoteRow took %s\n", time.Since(start))
-	}(time.Now())
-
 	if v.fullTableName {
 		if topic != fmt.Sprintf(`d.public.%s`, v.table) {
 			v.failures = append(v.failures, fmt.Sprintf(
@@ -983,10 +963,6 @@ type Validators []Validator
 func (vs Validators) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	defer func(start time.Time) {
-		fmt.Printf("Validators.NoteRow took %s\n", time.Since(start))
-	}(time.Now())
-
 	for _, v := range vs {
 		if err := v.NoteRow(partition, key, value, updated, topic); err != nil {
 			return err

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -645,6 +645,8 @@ func (v *FingerprintValidator) DBFunc(
 func (v *FingerprintValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
+	fmt.Printf("NoteRow: partition=%s key=%s value=%s updated=%s topic=%s\n", partition, key, value, updated, topic)
+
 	if v.firstRowTimestamp.IsEmpty() || updated.Less(v.firstRowTimestamp) {
 		v.firstRowTimestamp = updated
 	}

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -1061,7 +1061,7 @@ func fetchPrimaryKeyCols(sqlDB *gosql.DB, tableStr string) ([]string, error) {
 		SELECT column_name
 		FROM %sinformation_schema.key_column_usage
 		WHERE table_name=$1
-			AND constraint_name=($1||'_pkey')
+			AND constraint_name like '%%_pkey'
 		ORDER BY ordinal_position`, db),
 		table,
 	)

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -645,8 +645,6 @@ func (v *FingerprintValidator) DBFunc(
 func (v *FingerprintValidator) NoteRow(
 	partition, key, value string, updated hlc.Timestamp, topic string,
 ) error {
-	fmt.Printf("NoteRow: partition=%s key=%s value=%s updated=%s topic=%s\n", partition, key, value, updated, topic)
-
 	if v.firstRowTimestamp.IsEmpty() || updated.Less(v.firstRowTimestamp) {
 		v.firstRowTimestamp = updated
 	}

--- a/pkg/ccl/changefeedccl/cdctest/validator.go
+++ b/pkg/ccl/changefeedccl/cdctest/validator.go
@@ -915,7 +915,9 @@ func (v *FingerprintValidator) NoteResolved(partition string, resolved hlc.Times
 
 		// If any updates have exactly the same timestamp, we have to apply them all
 		// before fingerprinting.
+		// TODO: why do we need to fingerprint after every apply? why can't we just fingerprint after draining the buffer?
 		if len(v.buffer) == 0 || v.buffer[0].updated != row.updated {
+			fmt.Printf("fprintvalidator: fingerprinting at %s (len(v.buffer): %d)\n", row.updated, len(v.buffer))
 			lastFingerprintedAt = row.updated
 			if err := v.fingerprint(row.updated); err != nil {
 				return err

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2115,8 +2115,8 @@ func registerCDC(r registry.Registry) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
-			// TODO: more warehouses once fprintval doesnt require initial_scan=on
-			ct.runTPCCWorkload(tpccArgs{warehouses: 1, duration: "30m"})
+			// 100 warehouses was too much (fingerprint method was taking a minute)
+			ct.runTPCCWorkload(tpccArgs{warehouses: 10, duration: "30m"})
 
 			feed := ct.newChangefeed(feedArgs{
 				sinkType: kafkaSink,
@@ -2127,8 +2127,7 @@ func registerCDC(r registry.Registry) {
 				opts: map[string]string{"initial_scan": "'no'"},
 			})
 			ct.runFeedLatencyVerifier(feed, latencyTargets{
-				initialScanLatency: 3 * time.Minute,
-				steadyLatency:      10 * time.Minute,
+				steadyLatency: 10 * time.Minute,
 			})
 			ct.waitForWorkload()
 		},

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -608,6 +608,7 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 		// choose a random table to fingerprint
 		rng := entropy{Rand: globalRand}
 		table := args.targets[rng.Intn(len(args.targets))]
+		table = "tpcc.order_line" // DBG
 
 		if _, err := db.Exec(`CREATE TABLE fprint (LIKE ` + table + ` INCLUDING ALL)`); err != nil {
 			ct.t.Fatalf("failed to create fingerprint table: %s", err)

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -635,6 +635,11 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 
 		valdtr := cdctest.NewCountValidator(validators)
 
+		format := "json"
+		if f, ok := feedOptions["format"]; ok {
+			format = f
+		}
+
 		// start consumer
 		var consumer cdctest.Consumer
 		switch args.sinkType {
@@ -644,7 +649,7 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 				ct.t.Fatalf("failed to create kafka consumer: %s", err)
 			}
 		case cloudStorageSink:
-			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI)
+			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI, format)
 			if err != nil {
 				ct.t.Fatalf("failed to create cloud storage consumer: %s", err)
 			}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -622,10 +622,13 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 
 		var baV cdctest.Validator
 		if _, ok := feedOptions["diff"]; ok {
-			baV, err = cdctest.NewBeforeAfterValidator(db, table, true)
-			if err != nil {
-				ct.t.Fatalf("failed to create before after validator: %s", err)
-			}
+			// TODO: before after validator is too slowwwwww
+			// also the bug i fixed in him seems real. is it??
+
+			// baV, err = cdctest.NewBeforeAfterValidator(db, table, true)
+			// if err != nil {
+			// 	ct.t.Fatalf("failed to create before after validator: %s", err)
+			// }
 		}
 
 		validators := cdctest.Validators{

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -43,9 +43,12 @@ import (
 	msktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/aws/aws-sdk-go/aws"
 	awslog "github.com/aws/smithy-go/logging"
+	"github.com/cockroachdb/cockroach/pkg/base"
+	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/grafana"
@@ -59,6 +62,7 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	roachprodaws "github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
+	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -643,7 +647,12 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 			if err != nil {
 				ct.t.Fatalf("failed to create kafka consumer: %s", err)
 			}
-
+		case cloudStorageSink:
+			}
+			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI)
+			if err != nil {
+				ct.t.Fatalf("failed to create cloud storage consumer: %s", err)
+			}
 		}
 		// TODO(xxx): start it on another node for less test runner load
 		ct.mon.Go(func(ctx context.Context) error {

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -601,7 +601,7 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 		logger:         ct.logger,
 	}
 
-	ct.t.Status(fmt.Sprintf("created changefeed %s with jobID %d", cj.Label(), jobID))
+	ct.t.Status(fmt.Sprintf("created changefeed %s with jobID %d, opts=%+v", cj.Label(), jobID, feedOptions))
 
 	// start fingerprint validator for everyone unless they opt out
 	if !args.noAutoValidate {
@@ -662,6 +662,7 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 			ct.t.Status(fmt.Sprintf("created cloud storage consumer for %s", table))
 		}
 		// TODO(xxx): start it on another node for less test runner load
+		// TODO: handle initial scans better (no resolved or updated, validate on feed completion)
 		ct.mon.Go(func(ctx context.Context) error {
 			return cdctest.ConsumeAndValidate(ctx, consumer, valdtr)
 		})

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -2131,7 +2131,7 @@ func registerCDC(r registry.Registry) {
 
 			// HERE
 			// 100 warehouses was too much (fingerprint method was taking a minute)
-			ct.runTPCCWorkload(tpccArgs{warehouses: 10, duration: "30m"})
+			ct.runTPCCWorkload(tpccArgs{warehouses: 100, duration: "30m"})
 
 			feed := ct.newChangefeed(feedArgs{
 				sinkType: kafkaSink,

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -642,17 +642,19 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 			format = f
 		}
 
+		// TODO: other workloads / better
+		topic := strings.TrimPrefix(table, "tpcc.")
 		// start consumer
 		var consumer cdctest.Consumer
 		switch args.sinkType {
 		case kafkaSink:
-			consumer, err = cdctest.NewKafkaConsumer(ct.ctx, sinkURI, table)
+			consumer, err = cdctest.NewKafkaConsumer(ct.ctx, sinkURI, topic)
 			if err != nil {
 				ct.t.Fatalf("failed to create kafka consumer: %s", err)
 			}
 			ct.t.Status(fmt.Sprintf("created kafka consumer for %s", table))
 		case cloudStorageSink:
-			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI, table, format)
+			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI, topic, format)
 			if err != nil {
 				ct.t.Fatalf("failed to create cloud storage consumer: %s", err)
 			}

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -567,15 +567,16 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 	} else {
 		feedOptions["resolved"] = ""
 	}
-	if !args.noAutoValidate {
-		feedOptions["updated"] = ""
-	}
 
 	for option, value := range args.opts {
 		feedOptions[option] = value
 		if option == "initial_scan_only" || (option == "initial_scan" && value == "'only'") {
 			delete(feedOptions, "resolved")
 		}
+	}
+
+	if !args.noAutoValidate && feedOptions["initial_scan"] != "'only'" {
+		feedOptions["updated"] = ""
 	}
 
 	ct.t.Status(fmt.Sprintf(

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -687,6 +687,8 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 			ct.t.Fatalf("failed to create fingerprint validator: %s", err)
 		}
 
+		fprintV.CoarseGrainedChecks = true // DBG
+
 		var baV cdctest.Validator
 		if _, ok := feedOptions["diff"]; ok {
 			// TODO: before after validator is too slowwwwww
@@ -2115,6 +2117,7 @@ func registerCDC(r registry.Registry) {
 			ct := newCDCTester(ctx, t, c)
 			defer ct.Close()
 
+			// HERE
 			// 100 warehouses was too much (fingerprint method was taking a minute)
 			ct.runTPCCWorkload(tpccArgs{warehouses: 10, duration: "30m"})
 

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -609,8 +609,11 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 		rng := entropy{Rand: globalRand}
 		table := args.targets[rng.Intn(len(args.targets))]
 
-		if _, err := db.Exec(`CREATE TABLE fprint AS TABLE ` + table + ` WITH NO DATA`); err != nil {
+		if _, err := db.Exec(`CREATE TABLE fprint AS TABLE ` + table); err != nil {
 			ct.t.Fatalf("failed to create fingerprint table: %s", err)
+		}
+		if _, err := db.Exec(`TRUNCATE TABLE fprint`); err != nil {
+			ct.t.Fatalf("failed to truncate fingerprint table: %s", err)
 		}
 
 		partitions := []string{""} // unless kafka..? TODO: get these from somewhere

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -43,12 +43,9 @@ import (
 	msktypes "github.com/aws/aws-sdk-go-v2/service/kafka/types"
 	"github.com/aws/aws-sdk-go/aws"
 	awslog "github.com/aws/smithy-go/logging"
-	"github.com/cockroachdb/cockroach/pkg/base"
-	"github.com/cockroachdb/cockroach/pkg/blobs"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
 	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
-	"github.com/cockroachdb/cockroach/pkg/cloud"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/cluster"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/clusterstats"
 	"github.com/cockroachdb/cockroach/pkg/cmd/roachtest/grafana"
@@ -62,7 +59,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/roachprod/prometheus"
 	"github.com/cockroachdb/cockroach/pkg/roachprod/vm"
 	roachprodaws "github.com/cockroachdb/cockroach/pkg/roachprod/vm/aws"
-	"github.com/cockroachdb/cockroach/pkg/security/username"
 	"github.com/cockroachdb/cockroach/pkg/testutils"
 	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
 	"github.com/cockroachdb/cockroach/pkg/util/retry"
@@ -648,7 +644,6 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 				ct.t.Fatalf("failed to create kafka consumer: %s", err)
 			}
 		case cloudStorageSink:
-			}
 			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI)
 			if err != nil {
 				ct.t.Fatalf("failed to create cloud storage consumer: %s", err)

--- a/pkg/cmd/roachtest/tests/cdc.go
+++ b/pkg/cmd/roachtest/tests/cdc.go
@@ -648,16 +648,19 @@ func (ct *cdcTester) newChangefeed(args feedArgs) changefeedJob {
 			if err != nil {
 				ct.t.Fatalf("failed to create kafka consumer: %s", err)
 			}
+			ct.t.Status(fmt.Sprintf("created kafka consumer for %s", table))
 		case cloudStorageSink:
 			consumer, err = cdctest.NewCloudStorageConsumer(ct.ctx, sinkURI, format)
 			if err != nil {
 				ct.t.Fatalf("failed to create cloud storage consumer: %s", err)
 			}
+			ct.t.Status(fmt.Sprintf("created cloud storage consumer for %s", table))
 		}
 		// TODO(xxx): start it on another node for less test runner load
 		ct.mon.Go(func(ctx context.Context) error {
 			return cdctest.ConsumeAndValidate(ctx, consumer, valdtr)
 		})
+		ct.t.Status(fmt.Sprintf("started consume+validate for %s", table))
 	}
 
 	return cj

--- a/pkg/sql/sem/builtins/fixed_oids.go
+++ b/pkg/sql/sem/builtins/fixed_oids.go
@@ -2753,6 +2753,8 @@ var builtinOidsArray = []string{
 	2790: `any_in(input: anyelement) -> any`,
 	2791: `trigger_out(trigger: trigger) -> bytes`,
 	2792: `trigger_in(input: anyelement) -> trigger`,
+	2793: `crdb_internal.fingerprint(span: bytes[], start_time: decimal, all_revisions: bool, stripped: bool) -> int`,
+	2794: `crdb_internal.fingerprint(span: bytes[], start_time: timestamptz, all_revisions: bool, stripped: bool) -> int`,
 }
 
 var builtinOidsBySignature map[string]oid.Oid


### PR DESCRIPTION
- **roachprod: update gc job image**
- **roachtest: Test message too large error formatting for kafka v2 sinks**
- **roachprod: gc ibm cloud**
- **authors: add chenbh to authors**
- **failureinjection: add disk stall cycle option**
- **roachtestutil: disk stall Unstall returns error**
- **kvnemesis: first step towards a fuzzed KVNemesis**
- **stats: improve handling of some expected errors**
- **kvserver: add basic FlushLockTable request**
- **kvnemesis: add FlushLockTableOperation**
- **util: support max duration in retry loop**
- **roachtest: capture metrics for index backfill in schemachange/bulkingest**
- **roachprod: fix race condition in ui/spinner**
- **logictest: fix user logictest for provisioning gating validation**
- **kvcoord: remove elision of buffered revisions on mid txn flush**
- **changefeedccl: limit bank transfers in TestCatchupScanOrdering**
- **backup: create tests for simulating backup compactions**
- **jobs: make GC of old jobs txn'l**
- **sql: skip vtable for control ALL X JOBS**
- **jobs: add stub implementation of inspect job**
- **sql: support starting inspect job from SCRUB**
- **sql: add logic tests for inspect job via SCRUB**
- **sql: add unit test for SCRUB job execution semantics**
- **opentelemetry: add raftlog size metrics**
- **changefeedccl: fix split_column_families changefeeds**
- **cli: debug zip captures execution traces from every node**
- **sql: allow EXPLAIN of mutations in read-only transactions**
- **tracing: fix tests for simple flight recorder**
- **bazel: refine `is_dev_s390x` condition**
- **go.mod: bump Pebble to 20e2cbcd70de**
- **kvserver: make snapshot builder type**
- **kvserver: make helper for SST creation**
- **kvserver: make rewriteRaftState a method**
- **kvserver: make clearSubsumedReplicaDiskData a method**
- **server: new endpoint to expose node termination safety status**
- **kvcoord: optimize allocations in BenchmarkTxnWriteBuffer**
- **kvcoord: optimize the initial allocation of bufferedWrite.vals**
- **kvserver: store cleared spans in the builder struct**
- **kvserver: wrap snapshot SST creations**
- **sql,schemachanger: add remaining handling for routine references in views**
- **sql: support referencing a routine from a view query**
- **workload_generator: parse DDLs and build schema structs for debug-zip workloads**
- **pkg/cli: Enhance TSV parsing in zip_upload_table_dumps**
- **rpc: replace dead link with reference**
- **mmaprototype: land code from #142138**
- **kvserver: mma -> mmaprototype**
- **mmaprototype: add doc.go**
- **mmaprototype: fix SafeValue lint**
- **kvserver: move SST wrapper to SSTStorageScratch**
- **spanrecv: squash WriteSST method**
- **kvserver: pass context into write functor**
- **kvserver: rm unnecessary parameter**
- **sql: update SHOW users/roles to support provisioned users**
- **roachtest: increase backupRestoreRoundTrip split_queue verbosity**
- **roachtest: deflake splits/load/ycsb/e**
- **vecindex: add TryMoveVector method to Store interface**
- **cspann: add utils.ReplaceWithLast helper function**
- **cspann: move level searcher init code to Init method**
- **cspann: add BestCentroids vector index test**
- **cspann: enhance SearchSet**
- **cspann: move vectors from sibling partitions during split**
- **cspann: do not duplicate vectors to avoid an empty partition**
- **cli: improve debug.zip transaction_contention_events query**
- **roachtest: Skip flaky endpoint and fix retry logic for db-console/endpoints**
- **tests: fix set_liveness doc**
- **gen: add MultiLoad**
- **asim: add queue settings**
- **build: add new Nightly Stress Extra pipeline script**
- **crdb_internal: make system_jobs a view**
- **roachtest: use leader leases by default in perturbation tests**
- **roachprod: fix target inverse secure flag**
- **opt: refactor NormalizeLikeAny**
- **opt/optgen: compile string and integer literals as Go values**
- **roachtest: print remaining replicas in change-replicas**
- **changefeedccl: add CHANGEFEED privilege to DB and Schema privileges**
- **roachtest: fail on bad table lookup when fingerprinting fixtures**
- **storage: enable multilevel compactions by default with a cluster setting**
- **roachprod: create node stability helpers**
- **failure-injection: use DB connection pools**
- **failure-injection: wait for replication and rebalancing**
- **failureinjection: skip log stalled smoke test check**
- **backup: move retry loop to entire download phase**
- **sql: add CITEXT column data type**
- **opt: normalize `x LIKE '%'` to `x IS NOT NULL`**
- **profiler: add environment variable to enable continuous profiling**
- **opt: enable optimizer_prefer_bounded_cardinality by default**
- **jsonpath: allow case insensitivity for keyword idents**
- **sql: use has_system_privilege instead of has_admin_role in view def**
- **logictest: deflake partial_stats**
- **util/admission: clarify context cancellation**
- **sqlccl: log cancelled stmts in TestExplainGist**
- **asim: add replica_placement, min_key, max_key**
- **tests: add and use scanMustExist**
- **history: also print sum, not just stddev**
- **asim: remove extra newline**
- **asim: move NewStateWith* helpers into separate file**
- **asim: remove unused keyspace from BaseRanges and rand framework**
- **asim: fix under-replication in rand testing**
- **asim: remove unused keyspace for rand testing**
- **asim: sue DefaultSpanConfigWithRF in more places**
- **asim: simplify logic in history.ShowRecordedValueAt**
- **sql: prevent auth failure when no roles are granted during sync**
- **workload_generator: convert parsed DDL schemas into generator-ready YAML format**
- **pkg/cli: Implement redaction validation and user confirmation for debug zip uploads**
- **build: add crdb_bench flag**
- **dev: add crdb_bench flag to dev bench**
- **sql: allow testing override for schema_locked for benchmarks**
- **build: add crdb_bench flag to microbenchmark build support**
- **asim: remove replica_weights and lease_weights**
- **asim: add "print" command to output initial cluster state**
- **asim: add replica_placement option to gen_ranges**
- **asim: refactor the code to use rebalancing snapshot rate**
- **asim: add time.Second to snapshot rate delay calculation**
- **asim: change defaultRebalancingSnapshotRate to 32MiB/s**
- **asim: use << 20 instead of 1024*1024**
- **asim: fix bug with missing ticket in controller**
- **asim: remove unused return value in checkPendingTicket**
- **asim: add SetSimulationSettings as a mutation event**
- **asim: add ChangeReplicasOp as an operation**
- **asim: support store_byte_capacity option with gen_cluster**
- **asim: support region and nodes_per_region with gen_cluster**
- **asim: integrate cluster setting properly**
- **asim: fix snapshot rate delay integer division**
- **kvserver: skip TestFlowControlRaftMembership{,RemoveSelf}V2 under duress**
- **roachtest: skip many perturbation tests**
- **roachtest: increase the load and estimate max warehouses for TPCC bench**
- **state: add TestReplicaPlacement**
- **state: rename ParseStoreWeights -> ParseReplicaPlacement**
- **state: improve ReplicaPlacement parsing and stringer**
- **testdata: rm example_replica_placement**
- **perf: faster allocator on sysbench settings**
- **codeowners: move ownership of tenantcostclient/server to sql queries**
- **structlogging: clean up hot ranges logger startup procedure**
- **changefeedccl: gate Kafka v2 message too large error detail behind cluster setting**
- **catalog: make DescriptorType unredactable**
- **db-console: change the name of the "Hot Ranges" page to "Top Ranges"**
- **multiregionccl: skip TestMultiRegionTenantRegions under duress**
- **logictest: add back assertion that was rewritten accidentally**
- **roachtest: fix hibernate nightly test**
- **kvserver: do not write truncated state during evaluation**
- **sql: don't throw errors for skipped auto stats jobs**
- **util: add envAlwaysKeepTestLogsEnabled**
- **sql/inspect: introduce new INSPECT processor into DistSQL flow**
- **opt: convert parameterized lookup joins to placeholder scans**
- **cli/debug: strip comments in statement bundle env.sql file**
- **roachtest: Fix JSON configuration file for db-console/endpoints**
- **roachtest: create backup fixtures for azure**
- **roachtest: add schemachange/bulkingest variant for ADD COLUMN**
- **clusterversion: move to 25.4 version**
- **schemachanger: generate deprules for 25.4**
- **go.mod: bump Pebble to a370be5e7e50**
- **asim: remove unused range usage info**
- **asim: support request_cpu_per_access and raft_cpu_per_write**
- **asim: add impact from request_cpu_per_access and raft_cpu_per_write**
- **asim: add store capacity cpu stats  to storemetrics**
- **asim: removes redundant size assignment**
- **asim: add a comment for RangeUsageInfo.WritesPerSecond**
- **asim: account for follower replica load**
- **asim: add range info String method**
- **roachpb: add proto changes for StoreCapacity**
- **roachpb: add proto changes for NodeCapacity**
- **asim: add write bytes per sec to capacity & range usage**
- **asim: support node_cpu_rate_capacity with gen_cluster**
- **asim: add comments for datadriven**
- **db-console: add analytics to hot ranges page**
- **sql: add security_invoker feature flag and grammar support**
- **opt: fix sysbench-update-non-index benchmark**
- **storage: avoid value retrieval of sys keys during ComputeStats**
- **tests: add missing RaftCPUPerWrite**
- **roachpb: rm a test**
- **roachpb: improve a comment**
- **asim: include WriteBytesPerSecond in StoreMetrics**
- **asim: fix argument passing in BasicLoad.Generate**
- **ui: fix bug where "Drop Unused Index" recommendations are not populated on... ... Schema Insights**
- **sql: default sql.stats.error_on_concurrent_create_stats.enabled to false**
- **sql,externalconn: add ALTER EXTERNAL CONNECTION Parser**
- **kvserver: add more logging to TestProcessSplitAfterRightHandSideHasBeenRemoved**
- **sql/inspect: introduce interface for INSPECT check infrastructure**
- **asim: add .txt ending**
- **jobs: update hot ranges logger details**
- **vecindex: improve vector reranking**
- **storage: aggressively separate values in range ID keyspace**
- **structlogging: fix hot ranges logging job exit mechanism**
- **asim: add replace = true to example_splitting**
- **asim: add comment for BasicCluster.info**
- **sql/inspect: implement INSPECT processor stub**
- **roachtest: separate panic node step into panic step and restart step**
- **metric: Report aggregate metric when no child metrics are present**
- **backup: fix download job progress tracker ctx awareness**
- **distsql: fix recently introduced leak of CancelFunc**
- **e2e: Fix db console cypress tests after "Top Ranges" name change**
- **sql: add backfill validation for entries written by BulkAdder**
- **sql,eventpb: log structured event for REFRESH MATERIALIZED VIEW**
- **ui: refactor schema insights to remove redux and sagas**
- **sql: validate trigger backreferences in table descriptors**
- **tenantcostclient: fix leak of CancelFunc**
- **asim: don't run simulations under duress**
- **structlogging: skip hot range logging exit test**
- **changefeedccl: rename TableID to DescID**
- **changefeedccl: modify changefeed job payload to support db-level changefeeds**
- **roachprod: fix ServiceDescriptor error handling**
- **ui: fix text overflow on job details page**
- **testutils/lint: add a linter to prohibit ignoring cancel func**
- **roachtest: return non-zero exit code from roachtest pipeline if GitHub issue creation fails**
- **util: update comment for retry**
- **structlogging: fix flaky hot range job test**
- **sql/ttl: centralize row-level TTL progress updates at coordinator**
- **restore: add secondary retry policy to restore**
- **storage: remove seekVersion's next-before-seek optimization**
- **settings: support enum cluster setting validation**
- **kvserver: add LBRebalancingMultiMetric**
- **go.mod: bump Pebble to 837c19b81bab**
- **asim: fix shorter than expected replica change delay**
- **sql: use correct context in recursive CTE iterations**
- **logictest: extend a few EXPLAIN tests a bit**
- **execbuilder: add "average lookup ratio" parallelization heuristic for lookup joins**
- **sql: de-flake TestDistSQLReceiverReportsContention/contention=false**
- **kvserver: port over relevant kvserver and allocator integration files**
- **backup/rewrite: handle UDF references from views when restoring**
- **asim: correct data driven input command for example_fullfisk**
- **kvserver: track write bytes per sec properly**
- **asim: fix inconsistent range state**
- **asim: introduce NodeCapacityProvider**
- **asim: move store pool to be at the node level**
- **asim: introduce MMAllocator at node level**
- **asim: remove unused storepool field from store**
- **asim: use cluster setting for some non-simulation settings**
- **asim: panic if ticket not found in store rebalancer**
- **asim: pass node id to queues for logging**
- **asim: add AllocatorSync to asim node**
- **asim: integrate mma store rebalancer**
- **asim: add AllocatorSync to asim queues**
- **kvserver: add storage.disk.{read,write}-max.iops**
- **crosscluster/physical: fix status after init scan complete**
- **sql: standardize retryable spelling**
- **storage: refactor computeStatsForIterWithVisitors**
- **quantize: recompute norm when centroid is updated**
- **schemachanger: implement ALTER COLUMN [SET | DROP] ON UPDATE in declarative**
- **schemachanger: add builder and planner tests for DEFAULT / ON UPDATE**
- **sql: standardize error message for ON UPDATE expressions**
- **clusterversion: remove obs TODO_Delete_V25_2 versions**
- **quantize: set zero dot product for centroid data vector**
- **cspann: use correct metric for assigning vectors during split**
- **roachtest: actually fail TPCC bench if reached max warehouses**
- **roachtest: increase restore timeouts for fingerprinting**
- **restore: delete comments after failed or cancelled cluster restore**
- **crosscluster/physical: persist standby poller progress**
- **gceworker.sh: update default worker image**
- **roachtest: add PostValidationAll**
- **asim: use roachpb.ReplicationTarget for AllocationTransferLeaseOp**
- **changefeedccl: emit warning when `resolved` or `min_checkpoint_frequency` is set too low**
- **sql: ensure that index backfill monitor is closed in error case**
- **ui: remove standby poller job progress bar**
- **kvstorage: revise CreateUninitializedReplica plan**
- **kvstorage: revise applySnapshot plan**
- **kvstorage: revise DestroyReplica plan**
- **roachtest: run c2c/kv0 with zipfian distribution**
- **scripts: add basic pcr setup/admin wrapper**
- **asim: pass false to ReplicaChangeDelayFn for AllocationTransferLeaseOp**
- **asim: correctly update queue.next in pushReplicateChange**
- **asim: pass simulator.Replica instead to pushReplicateChange**
- **asim: pass state changer directly to pushReplicateChange**
- **asim: integrate allocatorsync with lease and replicate queue properly**
- **asim: pass queue names for logging**
- **asim: remove setting from store**
- **asim: add rebalance_objective and delay for rebalance_mode**
- **asim: check for LBRebalancingMultiMetric in ShouldRebalanceStore**
- **kvpb: avoid over redaction of prev_err field**
- **roachtest: add schema change workload to all pcr read from standby roachtests**
- **roachtest: ignore testInsertWithManyToOne in hibernate test**
- **changefeedccl: support for constant headers for webhook and kafka sinks**
- **changefeedccl: remove extra characters from topic names**
- **roachtest: fix check for npm being installed**
- **build: cherry-pick golang#62086 onto cockroach-go1.23.7**
- **release: add linux-s390x support**
- **nightlies: run `TestDataDriven` once under `cockroach_nightly_extra_stress_impl.sh`**
- **asim: add `skip_under_ci` for some tests in `pkg/kv/kvserver/asim/tests`**
- **asim: add leaktest, log.Scope defer stmt for TestDataDriven**
- **backup: increase max duration for restore fast fail tests**
- **sql: include write buffering info to EXPLAIN ANALYZE top level**
- **changefeedccl: fix test assertion in TestNoStopAfterNonTargetColumnDrop**
- **vecbench: download dataset as separate files**
- **ccl/oidcccl: increase client timeout to fix flaky test**
- **roachtest: fix nil team loader**
- **asim: use cluster setting LBRebalancingMode directly**
- **mmaprototypehelpers: skip mma coordination when mma is disabled**
- **release: GPG signing for custom releases**
- **sql: block DROP NOT NULL on generated identity columns**
- **roachtests/allocation_bench: improve logging in runAllocationBench**
- **gss/psql: update golang version and dependencies**
- **asim: add more data driven tests**
- **roachtest: validate number of tables in database for fingerprinting**
- **Update THIRD-PARTY-NOTICES.txt**
- **storage: disable value separation by default**
- **sql/schemachanger: properly discard zone configs for sequences**
- **logictest: add more entries in the json_tab in inverted_join_json_array**
- **Reapply "sql,log: add new txn_timestamp filed to CommonSqlEventDetails"**
- **server: fixes test flaps due to drains timing out**
- **mmaprototype: improve multi-dimensional rebalancing logic**
- **mmaprototype: canShedAndAddLoad must not make target overloadUrgent**
- **mmaprototype: reduce minWriteBandwidthGranularity to 128KiB**
- **mmaprototype: when ignoreHigherThanLoadThreshold is set, extend beyond first equivalence class in sortTargetCandidateSetAndPick**
- **mmaprototype: fix bug in sortTargetCandidateSetAndPick**
- **sql,externalconn: add ALTER EXTERNAL CONNECTION implmentation**
- **changefeedccl: fix TestNoBackfillAfterNonTargetColumnDrop**
- **backup: reset retry counter for download job when progress is detected**
- **kvstorage: fix CreateUninitializedReplica comment**
- **sql: use friendly schema changes status messages**
- **sql: restrict ALTER user password for provisioned users**
- **roachtest/pg_regress: accept recent diffs**
- **sql: add storage param for region column inference**
- **sql: implement new storage param in the schema changer**
- **opt: take exclusive locks for foreign key cascades under read-committed**
- **sql: disable vector index backfill in the legacy schema changer**
- **ci: copy roachtest perf artifact to designated (blob) path**
- **gossip: fix pending callbacks not dropping to zero**
- **sql,builtins: add nil-check for functions that use evalCtx.Regions**
- **opt: add support for region column inference to catalog and test catalog**
- **workload_generator: introduce Generator interface and concrete generator types**
- **crosscluster: fixup a few typos**
- **kvserver: use FullReplicaID in creation stack**
- **roachpb: move FullReplicaID type in**
- **kv: remove some tautological conditionals**
- **sql/execinfrapb: extracting export proto**
- **sql/export: add header row option to export csv**
- **asim: fix load_distribution_movement_disabled_enable_later**
- **kv/bulk: compute accurate stats in StreamSSTBatcher**
- **admission: move some grant coordinators to their own source file**
- **kvserver/rangefeed: remove kv.rangefeed.mux_stream_send.latency histogram**
- **changefeedccl: add protobuf encoder support for Kafka with envelope=bare**
- **sql: populate estimated_last_login_time for all authenticating users**
- **opt: implement region-column inference**
- **sql: restrict admin inheritance for specific role options**
- **bulk: avoid leaking sst writers**
- **logical: coalesce updates in crud writer**
- **sql: fix CITEXT formatting panic**
- **tabledesc: allow TTL storage params to be set to 0**
- **distsql: harden recent memory leak fix**
- **sql: INVERTED JOIN acceleration for json {?, ?&, ?|} array and array && array**
- **opt: optimizer_min_row_count to 1 by default**
- **kvserver/load: add NodeCapacityProvider**
- **kvserver: plumb nodeCapacityProvider**
- **catalog/replication: make system.privileges a view too**
- **backup: fix race condition in starting compaction job**
- **builtins: fix `pg_collation_for` for CITEXT**
- **util/parquet,sql: clean up DOidWrapper handling a bit**
- **cli(debug.zip): improve tsdump upload speed**
- **kvserver: drop RemoveReplica opts parameter**
- **kvserver: inline the static opts in RemoveReplica**
- **kvserver: drop removeReplicaRaftMuLocked opts**
- **kvserver: squash RemoveOptions sanity check**
- **kvserver: clean up postDestroyRaftMuLocked**
- **kvserver,rangefeed: enable bulk value delivery**
- **kvserver: pass NodeCapacityProviderConfig to NewNodeCapacityProvider**
- **server: crlfmt**
- **server: make knobs handling a little more compact**
- **release: add support for s390x in custom release signing script**
- **roachtest: fix nodejs install helper function**
- **valueside: fix missing support for CITEXT**
- **catalog: allow offline descriptors for type hydrations**
- **admission: split TestGranterBasic into two tests**
- **sql: fix super region placement in 3-region database with secondary region**
- **bazelbuilder: add `s390x` support**
- **roachtest: unblock rust-postgres test case fixed by #22463**
- **sql/explain: ignore all 'unsafe' settings in test**
- **kv/bulk: add debug setting to discard SSTs**
- **crosscluster/producer: add debug setting to drop all data**
- **changefeedccl: support resolved option with protobuf format**
- **changefeedccl: fix ALTER CHANGEFEED max PTS age bug**
- **kvcoord: disallow pipelining while write buffering is enabled**
- **kvcoord: allow write buffer to re-enable pipelining**
- **roachtest: add flaky test cases to ruby-pg ignoreList**
- **upgradeccl: ensure multiple releases for TestTenantUpgradeFailure test**
- **build: update `builder` docker image**
- **workload/tpcds: remove remaining queries that can't be parsed**
- **gssapiccl: revert "link with `keyutils` on `s390x`"**
- **geos: update GEOS to 3.12.3**
- **roachtest: bump upgrade timeout in jobs/mixed-version**
- **opt: add tests for tpc-ds**
- **bazel: don't `lintonbuild` in `ci` configuration**
- **asim: add node id for simulator replica**
- **kvserver: pass ReplicationTarget for TransferLease**
- **teamcity: add `s390x` unit tests build configuration**
- **kvcoord: minor txnWriteBuffer refactor**
- **kvcoord: make write buffer options metamorphic**
- **kvcoord: rename a few tests**
- **cli(debug.zip): upload profiles from node subdirectories**
- **roachprod: limit max concurrent hosts in flight**
- **kvserver: takes write and ingested bytes for recordRequestWriteBytes**
- **kvserver: record follower write bytes in replica load**
- **kvserver: record follower write bytes during recordStatsOnCommit**
- **kvserver: rename numWriteBytes to numWriteAndIngestedBytes**
- **rpc: authorize DRPC method endpoints for tenants for split Internal service**
- **provisioning: add usability counters for enabling ldap provisioning**
- ****workload: add main orchestrator `workload.go` for end-to-end data generation****
- **ccl/cdc: change when drop column is detected in schema feed**
- **restore: mark pebble corruption errors on backup file reads as failures**
- **roachtest: elide 'estimated_last_login_time' in system.users fingerprint**
- **catalog/lease: add memory monitoring for lease manager**
- **go.mod: bump Pebble to 273e26653683**
- **sql,settings: add sensitive, reportable to cluster_settings VTable**
- **cli: updates redaction policy for cluster settings in debug zip**
- **asim: plot initial values only if nonzero**
- **changefeedccl: protobuf support envelope=wrapped with kafka This change adds support for wrapped envelopes for changefeeds in protobuf format.**
- **vecbench: update vecbench and vecann to handle segmented datasets**
- **pkg/util/log: reducing allocs in otlp sink**
- **kvcoord: make GetRequest transforms configurable**
- **workload/schemachange: don't use CITEXT in mixed version cluster**
- **roachprod: make port expanders work with virtual clusters**
- **teamcity: add `s390x-test-failure` label for relevant unit test failures**
- **sniffarg: simplify**
- **sniffarg: support bool**
- **storage: re-enable value separation by default, metamorphically**
- **restore: fast fail unsupported online restore with range keys**
- **util/log: fix data race in (*StructuredLogSpy).Intercept**
- **util/log: dedup some code by providing FromLogEntry**
- **status: add sys.host.net.send.tcp.{fast_,}retrans_segs**
- **asim: rename a variable**
- **asim: plot charts using gonum/plot**
- **asim: don't mistake png files for test files**
- **sql/stats: prevent stats collection in read-only tenants**
- **kv: clean up 25.1 gates**
- **asim: add .txt suffix to testdata files**
- **gossip: pass OrigStamp as part of gossip callback**
- **sql: remove citext from versions previous to 25.3**
- **workload: trim down crdb_internal.create_statements.txt test fixture**
- **tenantcostserver: give default tokens for testing**
- **cli: update --database and --url flag help text for virtual clusters**
- **pgwire,provisioning,jwtauthccl: support user provisioning in jwt authentication**
- **roachtest: turn off backups in admission-control/multitenant-fairness**
- **roachtest: fix cdc/message-too-large-error**
- **Add a roachtest command to list operations**
- **crosscluster: clean up some metrics**
- **pkg/util/log: add metrics to otlp sink**
- **authors: add sanjay.pandey@cockroachlabs.com to authors**
- **pkg/util/log: add http mode to otlp sink**
- **oidcccl, server: add role synchronisation for DB Console OIDC logins**
- **release: add support for no-telemetry build for FIPS**
- **changefeedccl: add sink backpressure time metric**
- **server: plumb AC pacer support into UA servers**
- **release: add linux-amd64-fips to GPG signing script**
- **pgwire: decouple jwt authentication and authorization logic**
- **kvserver/rangefeed: make bulk delivery setting a size limit**
- **kvserver/rangefeed: enable bulk delivery by default**
- **opt: deflake fk_read_committed**
- **sql: fix spelling of committed**
- **pgwire,provisioning: align JWT auth logging and telemetry with LDAP**
- **workload: add SQL generation and placeholder‐rewriting utilities**
- **roachtest/large-schema-benchmark: improve import init performance**
- **dev-inf: add CLAUDE.md guidance for AI development**
- **teamcity: fix extra labels logic**
- **asim: address a TODO**
- **cmd/dev: remove warning about two year old change**
- **asim: run no_rand tests in parallel**
- **opt: add additional read-committed fk cascade testing**
- **asim: move plots to `testdata/generated`**
- **drtprod: PUA changes for v25.2**
- **drtprod: remote cloud CLI processes terminated**
- **drtprod: artifacts dependencies on remote**
- **drtprod: generate tpcc run server side support**
- **drtprod: 300-node TPCC bench**
- **kvserver: skip TestFlowControlAdmissionPostSplitMergeV2 under duress**
- **authors: add Shreyas KM to authors**
- **workload: enable workload_generator to run SQL workloads with init artifacts**
- **sql: allow DB owner to set session var defaults in database**
- **server: skip TestCheckRestartSafe tests**
- **sql: harden stmt bundle building code a bit**
- **sql: fix entries for I/O functions in pg_type**
- **workload: allow bank workload to run for multiple tables**
- **ui: show tenant dropdown in insecure mode when multiple tenants exist**
- **storage: use AssertionFailedf for panics**
- **CLAUDE: use verbose output in filtered tests**
- **backup: deflake TestScheduleChainingWithDatabaseExpansion**
- **storage/disk: deflake TestMonitorManager_monitorDisks**
- **storage/disk: use context cancellation to stop monitoring**
- **opt: address minor test nits from a recent change**
- **changefeedccl: add helper to detect changefeed errors**
- **go.mod: bump Pebble to e2a0f833e83b**
- **changefeedccl: add pts management performance benchmark**
- **sqlccl: bump engflow worker size**
- **logictest: make one query in `show_ranges` deterministic**
- **mmaprototype: remove unused loadTracker**
- **changefeedccl: add Protobuf vs JSON encoder benchmarks**
- **asim: port over some trivial commits from prototype**
- **crosscluster/physical: send recompute stats requests on range key flush**
- **span: clean up test code after llrb frontier deletion**
- **sql: cleanup descriptor helper**
- **backup: deflake some chaining tests**
- **workload: add simple CHECK constraint support and bit/bytes generators**
- **sql/ttl: improve TTL replan decision logic**
- **roachprod: gc ibm clusters with no tags**
- **roachtest: don't specify virtual cluster in debug zips**
- **auditloggingccl: fix TestReducedAuditConfig**
- **roachtest: deflake activerecord**
- **orchestration: released CockroachDB version v25.2.3. Next version: v25.2.4**
- **roachtest: fix test failed message**
- **server: change sort order of local hot ranges to descending**
- **kv/bulk: pace bulk SST generation/addition with elastic AC**
- **sql/importer: pace import processing with elastic AC**
- **sql/rowexec: pace index backfill processing with elastic AC**
- **contention: Increase RetryBudgetForMissingResult**
- **workload/schemachanger: fix trigger function generation**
- **mmaprototype: remove unused lint suppression**
- **roachtest/pg_regress: adjust the runner a bit**
- **kvnemesis: add user priority**
- **kvcoord,concurrency: enable buffered writes by default**
- **roachtest: restrict rebalance/by-load/*/mixed-version to v25.1+**
- **changefeedccl: support rangefeed bulk delivery**
- **build: update goid dependency**
- **changefeedccl: protobuf encoder randomized test for all types**
- **kvserver: add MMARangeLoad**
- **kvserver: add mmaRangeMessageNeeded**
- **kvserver: add more methods to mmaRangeMessageNeeded**
- **kvserver: add store.MakeStoreLeaseholderMsg**
- **kvserver: add mmaStoreRebalancer**
- **kvserver: plumb mmaStoreRebalancer**
- **kvserver: use RegisterCallback for mma**
- **kvserver: rm mma_store_rebalancer_test.go**
- **kvserver: simplify r.mmaRangeMessageNeeded**
- **kvserver: address s.mmaStoreRebalancer start**
- **kvserver: delete mmaStore interface**
- **kvserver: move mma replica related methods to its own files**
- **kvserver: add to mmaReplica**
- **kvserver: rename to constructMMAUpdate**
- **kvserver: add mmaLeaseholderReplica**
- **kvserver: refactor for mmaRangeLoad**
- **kvserver: add mmaStore**
- **kvserver: add replicaToApplyChanges interface**
- **kvserver: refactor constructMMAUpdate**
- **kvserver: fix Replica nil check in mmaStoreRebalancer**
- **kvserver: refactor mmaStoreRebalancer.rebalance**
- **kvserver: fix linter failure on line length**
- **kvserver: minor cleanup**
- **kvserver: renames Conf and Populated in RangeMsg**
- **kvserver: use errors package**
- **kvserver: fix nil check with GetReplicaIfExists**
- **kvserver: pass RaftStatus() result to constructMMAUpdate**
- **kvserver: replace mmaFullRangeMessageNeeded with mmaSpanConfigIsUpToDate**
- **kvserver: fix locking in mma_replica_store**
- **kv: minor cleanup**
- **kvserver: add a todo comment on raftSparseStatusRLocked**
- **pgwire: limit concurrent updates to last_login_time**
- **backup: fix external storage error propagation**
- **sql/pgwire: use a single query to update last_login_time**
- **execbuilder: fix test flake in show_trace**
- ***: upgrade to Go 1.24.5**
- **roachtest/ttl: fix TTL restart test flakiness**
- **tree: fix CREATE TABLE format for ON COMMIT option**
- **randgen: use hidden rowid column in columnFamilyMutator**
- **sqlstats: rename sslocal.New to NewSQLStats**
- **sqlstats: rename sqlStats field to persistedSQLStats**
- **sqlstats: rename localStatsProvider to localSQLStats**
- **sqlstats: rename statsProvider field to persistedSQLStats**
- **kvstorage: introduce WAG encoding**
- **server: skip TestCheckRestartSafe under duress**
- **roachprod: update gc image**
- **sql/tests: avoid trigger I/O functions in random syntax test**
- **k8s: fix python3 compatibility issue for multi-region setup**
- **kvserver: return an assertion error instead of panic**
- **vfsutil: add CopyRecursive**
- **kvserver: dump memFS on test failure**
- **security: fix memory accounting issue in client certificate cache**
- **kvserver: rename constructMMAUpdate to constructRangeMsgReplicas**
- **kvserver: clean up comments**
- **sql/pgwire: avoid frequent updates to last_login_time**
- **pgwire: use defer to unlock lastLoginUpdater mutex**
- **psql: delete unnecessary `toolchain` line**
- **colexec: fix column type when ConstNullOp is used**
- **asim: fix dd output**
- **backupinfo: fix error handling in desciter**
- **sql: fix a crash with `crdb_internal.execute_internally` in an edge case**
- **roachtest: bump min version for db-console/mixed-version-endpoints roachtest**
- **pgwire: protect lastUpdateCache with a mutex**
- **generated: (mostly) ignore via .gitignore**
- **sniffarg: unconditionally convert to double-dash args**
- **CLAUDE: add details and adjust directions for dev workflow**
- **security: address a couple of nits in a recent change**
- **cli: explicitly set disallow_full_table_scans for debug.zips**
- **drtprod: add wait_before and wait_after yaml support**
- **asim: temporarily disable some commands**
- **asim: error in eval when no ranges configured**
- **asim: add a (dummy) mode**
- **asim: collect a slice of events**
- **asim: address a TODO**
- **asim: unify two code paths**
- **asim: modes -> configurations**
- **asim: introduce configuration mma-only**
- **asim: generate all plots**
- **asim: rename a variable**
- **asim: "handle" two errors**
- **asim: investigate charts using a single-page app**
- **asim: opt into metrics summaries**
- **asim: remove plot**
- **asim: add and adopt eval configs**
- **asim: merge two tests**
- **asim: fix a one-off**
- **asim: print nicer name**
- **asim: rework a test**
- **asim: delete load_distribution_movement_disabled.txt**
- **asim: warn against likely accidental load or capacity**
- **asim: consolidate example_skewed_cpu_even_ranges_mma tests**
- **asim: consolidate onto mma_skewed_cpu_skewed_write.txt**
- **asim: remove print**
- **asim: do not reset log tags**
- **asim: better log tag**
- **asim: extend example_skewed_cpu_even_ranges_mma by 10m**
- **asim: remove errant raft_cpu_per_write**
- **asim: revert accidental change to write workload**
- **asim: correct workload usage approximation**
- **asim: remove some unused fields**
- **asim: don't swallow warning about unrealistic node capacity**
- **asim: regenerate files**
- **clusterversion: move WriteInitialTruncStateBeforeSplitApplication to 25.4**
- **orchestration: released CockroachDB version v25.2.4. Next version: v25.2.5**
- **admission: replace GrantCoordinator with storeGrantCoordinator**
- **integration: fix flaky TestInsightsIntegrationForContention**
- **github: add @cockroachdb/kv-distribution to relevant files**
- **kvserver: update store pool for `leasequeue.process`**
- **kv/rangefeed: filter and test internal rangefeed registry**
- **authors: add <dodeca12> to authors**
- **roachprod: roundrobin ibm clusters between two regions**
- **all: reduce usage of `tenant 2` as an application tenant from tests**
- **wip**
- **wip**
- **wip**
- **w**
- **gcs**
- **p**
- **badparquet**
- **wip**
- **com**
- **wip**
- **wip**
- **wadawd**
- **wip**
- **cawed**
- **wip**
- **wip**
- **ts**
- **b**
- **wip**
- **wip**
- **wip**
- **cloud storage seems to be working**
- **kafka**
- **wip**
- **wip**
- **wip**
- **wip**
- **shutdown**
- **100**
- **use other fingerprint method**
- **split and scatter (SLOWWWW)**
- **rm start ts cause its unsupported**
