### PR TITLE
[dnm] prototype: add tcp_rtt and tcp_rtt_var metrics for DRPC

### DIFF
--- a/pkg/rpc/BUILD.bazel
+++ b/pkg/rpc/BUILD.bazel
@@ -17,6 +17,7 @@ go_library(
         "errors.go",
         "grpc.go",
         "heartbeat.go",
+        "instrumented_conn.go",
         "keepalive.go",
         "metrics.go",
         "peer.go",

--- a/pkg/rpc/instrumented_conn.go
+++ b/pkg/rpc/instrumented_conn.go
@@ -1,0 +1,46 @@
+package rpc
+
+import (
+	"net"
+
+	"github.com/cockroachdb/cockroach/pkg/util/sysutil"
+	"storj.io/drpc/drpcmigrate"
+)
+
+type InstrumentedConn struct {
+	net.Conn
+	metrics *tcpMetrics
+	onClose func() error
+}
+
+func getTCPConn(conn net.Conn) *net.TCPConn {
+	switch c := conn.(type) {
+	case *net.TCPConn:
+		return c
+	case *drpcmigrate.HeaderConn:
+		return getTCPConn(c.Conn)
+	default:
+		return nil
+	}
+}
+
+func (c *InstrumentedConn) UpdateMetrics() {
+	tcpConn := getTCPConn(c.Conn)
+	if tcpConn == nil {
+		return
+	}
+	rttInfo, ok := sysutil.GetRTTInfo(tcpConn)
+	if !ok {
+		return
+	}
+	c.metrics.TCPRTT.Update(rttInfo.RTT.Nanoseconds())
+	c.metrics.TCPRTTVar.Update(rttInfo.RTTVar.Nanoseconds())
+}
+
+func (c *InstrumentedConn) Close() error {
+	// we use the underlying connection for idempotency
+	if err := c.Conn.Close(); err != nil {
+		return err
+	}
+	return c.onClose()
+}

--- a/pkg/server/drpc_test.go
+++ b/pkg/server/drpc_test.go
@@ -8,6 +8,7 @@ package server_test
 import (
 	"context"
 	"crypto/tls"
+	"net"
 	"testing"
 
 	"github.com/cockroachdb/cockroach/pkg/base"
@@ -248,7 +249,8 @@ func TestDialDRPC_InterceptorsAreSet(t *testing.T) {
 			return mockStreamInterceptor
 		},
 	}
-	getConn := rpc.DialDRPC(rpcCtx)
+	onNetworkDial := func(conn net.Conn) net.Conn { return conn }
+	getConn := rpc.DialDRPC(rpcCtx, onNetworkDial)
 	conn, err := getConn(ctx, rpcAddr, rpcbase.DefaultClass)
 	require.NoError(t, err)
 	defer func() { require.NoError(t, conn.Close()) }()


### PR DESCRIPTION
Prototype.

Previously, we added observability into the TCP connections backing each gRPC
channel. The implementation was based on the fact that gRPC employs HTTP/2,
allowing it to multiplex multiple streams over a single TCP connection, so we
stored a single tcpConn on for each "peer". Here, "peer" is defined the tuple
(nodeID, remoteAddr, connectionClass).

Unlike gRPC, DRPC internally maintains a pool of TCP connection for each logical
DRPC channel because it does not employ HTTP/2 and thus cannot multiplex
concurrent streams over a single TCP connection. So, for a "peer", we have a
pool of TCP connections.

The lifecycle of the connections in this pool is as follows:
- On each RPC invokation, we check if there's an available connection in our
  pool to serve our request.
    - if so, we use it
    - if not, we dial a new TCP connection
- Upon completion of the RPC, we return the connection to the pool and schedule
  it to close after `defaultDRPCConnIdleTimeout`.

To manage the open TCP connections backing a peeer, we hook into this lifecycle.

Like the previous gRPC implementation, when we use a callback to the network
dial function to add a newly created TCP connection to a map on peer.

Additionally, within this callback, we wrap the original `net.Conn` in a custom
struct `InstrumentedConn` which embeds `net.Conn`. We override the `Close`
method to remove our connection from the peer map after calling the underlying
conn's `Close` func.

This allows us to maintain an up-to-date snapshot of all live TCP connections
within the pool backing a "peer" connection.

As such, we can periodically update metrics for each of these TCP connections.

---

Further discussion is needed to determine how exactly these metrics should be
exposed.

In it's current state, this prototype exposes metrics for each TCP connection.
This involved modifying the child metric keying mechanism to additionally use
the connection's local address, which is unique for each TCP connection.

However, the metrics we care about for these TCP connections are obtained via a
syscall, which is synchronous and incurs high overhead. Since we have many
more TCP connections now (preliminary testing showed ~10 per class vs. 1 for
gRPC), it will probably be prohibitively expensive to proceed with this design.
<img width="2322" height="1798" alt="Screenshot 2025-08-08 at 4 49 25 PM" src="https://github.com/user-attachments/assets/5cfdf114-d616-48a5-ba99-4021ce3c6c5f" />
<img width="2722" height="1528" alt="Screenshot 2025-08-08 at 4 55 31 PM" src="https://github.com/user-attachments/assets/96d3316f-c5ef-4656-9743-997f9e115139" />

So, that leaves us with one option: sampling a connection from the pool.

Initially, we thought that connections are fungible, i.e., sampling any
connection from the pool would roughly be the same.

The fact that some connections are dormant in the pool while others may be
receiving lots of traffic makes it so that an individual connection's RTT might
not be representative of the pool's RTT.

Although, at a macro-level, they seem to be decently representative.

See [this dashboard](https://grafana.testeng.crdb.io/d/deuck6zx2jgg0c/tcp-rtt-v2?orgId=1&var-DS_PROMETHEUS=v9Zz2K6nz&var-cluster=michaelxu-granular-metrics&var-filters=node_id%7C%3D%7C1&var-filters=remote_node_id%7C%3D%7C3&from=1754695483103&to=1754704559093).
<img width="3066" height="1936" alt="Screenshot 2025-08-12 at 1 28 38 PM" src="https://github.com/user-attachments/assets/d24eac17-cf2a-4651-a507-b4dd545dc2d0" />

Additionally, I can imagine that having the source of the metric dynamically
change might be really confusing for someone reading the graph.

Part of: https://github.com/cockroachdb/cockroach/issues/149959
Release note: None