### PR TITLE
[tiered prototype] storage: plumb TieringAttribute through roachpb.Value and enginepb.MVCCValueHeader

### DIFF
--- a/pkg/roachpb/data.proto
+++ b/pkg/roachpb/data.proto
@@ -87,6 +87,12 @@ message Value {
   bytes raw_bytes = 1;
   // Timestamp of value.
   util.hlc.Timestamp timestamp = 2 [(gogoproto.nullable) = false];
+
+  // Tiering attribute is used to populate the corresponding field in
+  // MVCCValueHeader.
+  // TODO(radu): prototype the alternative of encoding the tiering attribute
+  // directly into raw_bytes, as an optional header with a special tag.
+  uint64 tiering_attribute = 3;
 }
 
 // KeyValue is a pair of Key and Value for returned Key/Value pairs

--- a/pkg/storage/enginepb/mvcc3.proto
+++ b/pkg/storage/enginepb/mvcc3.proto
@@ -217,7 +217,12 @@ message MVCCValueHeader {
     (gogoproto.omitempty) = true,
     (gogoproto.casttype) = "github.com/cockroachdb/cockroach/pkg/util/hlc.Timestamp"];
 
-   // NextID = 7.
+  // Tiering attribute is used when tiering is enabled at the storage layer. It
+  // associates each KV with a uint64 value (typically derived from a timestamp)
+  // in a way that is easily decodable from the storage layer.
+  uint64 tiering_attribute = 7;
+
+  // NextID = 8.
 }
 
 // MVCCStatsDelta is convertible to MVCCStats, but uses signed variable width

--- a/pkg/storage/mvcc.go
+++ b/pkg/storage/mvcc.go
@@ -2706,6 +2706,7 @@ func mvccPutInternal(
 	versionValue.OmitInRangefeeds = opts.OmitInRangefeeds
 	versionValue.ImportEpoch = opts.ImportEpoch
 	versionValue.OriginID = opts.OriginID
+	versionValue.TieringAttribute = value.TieringAttribute
 	if opts.OriginTimestamp.IsSet() {
 		versionValue.OriginTimestamp = opts.OriginTimestamp
 	}

--- a/pkg/storage/mvcc_value.go
+++ b/pkg/storage/mvcc_value.go
@@ -328,6 +328,17 @@ func DecodeMVCCValueAndErr(buf []byte, err error) (MVCCValue, error) {
 	return DecodeMVCCValue(buf)
 }
 
+func DecodeTieringAttributeFromMVCCValue(buf []byte) (uint64, error) {
+	if _, ok, err := tryDecodeSimpleMVCCValue(buf); ok || err != nil {
+		return 0, err
+	}
+	v, err := decodeExtendedMVCCValue(buf, true)
+	if err != nil {
+		return 0, err
+	}
+	return v.TieringAttribute, nil
+}
+
 // Static error definitions, to permit inlining.
 var errMVCCValueMissingTag = errors.Errorf("invalid encoded mvcc value, missing tag")
 var errMVCCValueMissingHeader = errors.Errorf("invalid encoded mvcc value, missing header")

--- a/pkg/storage/mvcc_value_test.go
+++ b/pkg/storage/mvcc_value_test.go
@@ -287,6 +287,23 @@ func TestDecodeMVCCValueErrors(t *testing.T) {
 	}
 }
 
+func TestDecodeTieringAttributeFromMVCCValue(t *testing.T) {
+	var v MVCCValue
+	enc, err := EncodeMVCCValue(v)
+	require.NoError(t, err)
+	tieringAttr, err := DecodeTieringAttributeFromMVCCValue(enc)
+	require.NoError(t, err)
+	assert.Equal(t, tieringAttr, uint64(0))
+
+	v.TieringAttribute = 123
+	v.Value.RawBytes = []byte{1, 2, 3}
+	enc, err = EncodeMVCCValue(v)
+	require.NoError(t, err)
+	tieringAttr, err = DecodeTieringAttributeFromMVCCValue(enc)
+	require.NoError(t, err)
+	assert.Equal(t, tieringAttr, uint64(123))
+}
+
 func mvccValueBenchmarkConfigs() (
 	headers map[string]enginepb.MVCCValueHeader,
 	values map[string]roachpb.Value,


### PR DESCRIPTION
This is an initial attempt. We will want to investigate encoding the tiering attribute directly into the value bytes, as a system column or using a new `roachpb.ValueType` sentinel tag.