### PR TITLE
mixedversion: don't mark shared process tenant availability in monitor

### DIFF
--- a/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
+++ b/pkg/cmd/roachtest/roachtestutil/mixedversion/steps.go
@@ -903,7 +903,7 @@ func (s networkPartitionInjectStep) Run(
 	ctx context.Context, l *logger.Logger, _ *rand.Rand, h *Helper,
 ) error {
 	h.runner.monitor.ExpectProcessDead(s.targetNode)
-	if h.Tenant != nil {
+	if h.DeploymentMode() == SeparateProcessDeployment {
 		opt := option.VirtualClusterName(h.Tenant.Descriptor.Name)
 		h.runner.monitor.ExpectProcessDead(s.targetNode, opt)
 	}
@@ -958,7 +958,7 @@ func (s networkPartitionRecoveryStep) Run(
 	}
 
 	h.runner.monitor.ExpectProcessAlive(s.targetNode)
-	if h.Tenant != nil {
+	if h.DeploymentMode() == SeparateProcessDeployment {
 		opt := option.VirtualClusterName(h.Tenant.Descriptor.Name)
 		h.runner.monitor.ExpectProcessAlive(s.targetNode, opt)
 	}


### PR DESCRIPTION
The monitor does not support monitoring shared process tenants in isolation, i.e. it can only monitor both system and the secondary shared process.

However, the mixed version framework was reporting availability of shared process tenants to the monitor. This broke an assumption that the monitor makes that any registered process is either the system tenant or a separate process tenant. This would cause the monitor to mistakenly believe there was a running separate process tenant.

Fixes: https://github.com/cockroachdb/cockroach/issues/151450