### PR TITLE
bench/rttanalysis: skip BenchmarkShowGrants under short config

### DIFF
--- a/pkg/bench/rttanalysis/grant_revoke_role_bench_test.go
+++ b/pkg/bench/rttanalysis/grant_revoke_role_bench_test.go
@@ -5,7 +5,11 @@
 
 package rttanalysis
 
-import "testing"
+import (
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
+)
 
 func BenchmarkGrantRole(b *testing.B) { reg.Run(b) }
 func init() {
@@ -28,7 +32,11 @@ CREATE ROLE c;`,
 	})
 }
 
-func BenchmarkShowGrants(b *testing.B) { reg.Run(b) }
+func BenchmarkShowGrants(b *testing.B) {
+	skip.UnderShort(b, "skipping long benchmark")
+	reg.Run(b)
+}
+
 func init() {
 	reg.Register("ShowGrants", []RoundTripBenchTestCase{
 		{


### PR DESCRIPTION
Previously, this benchmark was included in CI runs and would take more than 20 minutes to complete a single iteration (--bench-time=1s --count=1).

This is because the benchmark aims for a measured runtime of 1 second, but the unmeasured operations within each iteration take over 20 minutes combined to reach that target.

This change skips the benchmark in CI runs.

Fixes: #151653

Release note: None