### PR TITLE
roachtest: deflake hibernate timeouts

### DIFF
--- a/pkg/cmd/roachtest/tests/hibernate.go
+++ b/pkg/cmd/roachtest/tests/hibernate.go
@@ -251,7 +251,7 @@ func registerHibernate(r registry.Registry, opt hibernateOptions) {
 		NativeLibs:       registry.LibGEOS,
 		CompatibleClouds: registry.AllExceptAWS,
 		Suites:           registry.Suites(registry.Nightly, registry.ORM),
-		Timeout:          4 * time.Hour,
+		Timeout:          5 * time.Hour,
 		Run: func(ctx context.Context, t test.Test, c cluster.Cluster) {
 			runHibernate(ctx, t, c)
 		},


### PR DESCRIPTION
This patch increases the timeout to avoid hitting spurious failures when the test takes too long.

fixes https://github.com/cockroachdb/cockroach/issues/151591
fixes https://github.com/cockroachdb/cockroach/issues/151711
Release note: None