### PR TITLE
sctestbackupccl: deflake schemachanger tests during BACKUP

### DIFF
--- a/pkg/sql/schemachanger/sctest/backup.go
+++ b/pkg/sql/schemachanger/sctest/backup.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"sync/atomic"
 	"testing"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/clusterversion"
 	"github.com/cockroachdb/cockroach/pkg/sql/parser"
@@ -194,6 +195,7 @@ func backupSuccess(t *testing.T, factory TestServerFactory, cs CumulativeTestCas
 	runfn := func(s serverutils.TestServerInterface, db *gosql.DB) {
 		dbForBackup.Store(db)
 		tdb := sqlutils.MakeSQLRunner(db)
+		tdb.SucceedsSoonDuration = 5 * time.Minute
 
 		// Setup the test cluster.
 		tdb.Exec(t, "CREATE DATABASE backups")


### PR DESCRIPTION
Increase the timeout for waiting for a schema change to complete, which can take a longer time if there are concurrent backups.

fixes https://github.com/cockroachdb/cockroach/issues/151469
fixes https://github.com/cockroachdb/cockroach/issues/150842
Release note: None