### PR TITLE
sql: add transaction instrumentation helper

### DIFF
--- a/pkg/server/statement_diagnostics_requests.go
+++ b/pkg/server/statement_diagnostics_requests.go
@@ -94,6 +94,8 @@ func (s *statusServer) CreateStatementDiagnosticsReport(
 		req.ExpiresAfter,
 		req.Redacted,
 		username,
+		// TODO(davidh): add flag to request payload and thread through.
+		false,
 	)
 	if err != nil {
 		return nil, err

--- a/pkg/server/status.go
+++ b/pkg/server/status.go
@@ -559,6 +559,7 @@ type StmtDiagnosticsRequester interface {
 		expiresAfter time.Duration,
 		redacted bool,
 		username string,
+		includeTxn bool,
 	) error
 	// CancelRequest updates an entry in system.statement_diagnostics_requests
 	// for tracing a query with the given fingerprint to be expired (thus,

--- a/pkg/sql/sem/builtins/builtins.go
+++ b/pkg/sql/sem/builtins/builtins.go
@@ -12262,6 +12262,8 @@ argument is true, then the bundle will be redacted`
 				expiresAfter,
 				redacted,
 				username,
+				// TODO(davidh): Wire this up to new bundle arg.
+				false, /* includeTxn */
 			); err != nil {
 				return nil, err
 			}

--- a/pkg/sql/sem/eval/deps.go
+++ b/pkg/sql/sem/eval/deps.go
@@ -760,6 +760,7 @@ type StmtDiagnosticsRequestInsertFunc func(
 	expiresAfter time.Duration,
 	redacted bool,
 	username string,
+	includeTxn bool,
 ) error
 
 // AsOfSystemTime represents the result from the evaluation of AS OF SYSTEM TIME


### PR DESCRIPTION
Previously, the `instrumentationhelper` was created to help collect
statement diagnostic bundles during execution. This commit adds a
`txnInstrumentationHelper` struct which will help gather transaction
diagnostic bundles.

The transaction diagnostic bundle consists of a transaction-level
trace and collects the individual statement bundle zips into a
transaction-level zip file.

The transaction trace is saved in Jaeger JSON format, and the
individual statement bundle zips are collected by numbering them in
order of execution, and using their AST "tag" as the name to prevent
complications with converting fingerprints to filenames.

This commit adds the `txnInstrumentationHelper` to the `connExecutor`
and adds some placeholders for future commits to wire up the
collection triggers and zip file persistence to SQL.

Epic: CRDB-53541
Resolves: CRDB-53542
Release note: None