### PR TITLE
Add support for locality aware in compacted backup job

### DIFF
--- a/pkg/backup/compaction_dist.go
+++ b/pkg/backup/compaction_dist.go
@@ -226,17 +226,18 @@ func createCompactionCorePlacements(
 	for i := range corePlacements {
 		corePlacements[i].SQLInstanceID = sqlInstanceIDs[i]
 		corePlacements[i].Core.CompactBackups = &execinfrapb.CompactBackupsSpec{
-			JobID:       int64(jobID),
-			DefaultURI:  details.URI,
-			Destination: details.Destination,
-			Encryption:  details.EncryptionOptions,
-			StartTime:   details.StartTime,
-			EndTime:     details.EndTime,
-			ElideMode:   elideMode,
-			UserProto:   user.EncodeProto(),
-			Spans:       spansToCompact,
-			TargetSize:  targetSize,
-			MaxFiles:    maxFiles,
+			JobID:            int64(jobID),
+			DefaultURI:       details.URI,
+			Destination:      details.Destination,
+			Encryption:       details.EncryptionOptions,
+			StartTime:        details.StartTime,
+			EndTime:          details.EndTime,
+			ElideMode:        elideMode,
+			UserProto:        user.EncodeProto(),
+			Spans:            spansToCompact,
+			TargetSize:       targetSize,
+			MaxFiles:         maxFiles,
+			URIsByLocalityKV: details.URIsByLocalityKV,
 		}
 	}
 

--- a/pkg/sql/execinfrapb/processors_bulk_io.proto
+++ b/pkg/sql/execinfrapb/processors_bulk_io.proto
@@ -575,5 +575,6 @@ message CompactBackupsSpec {
 	// before the processors can load them.
 	optional int64 target_size = 11 [(gogoproto.nullable) = false];
 	optional int64 max_files = 12 [(gogoproto.nullable) = false];
+  map<string, string> uris_by_locality_kv = 13 [(gogoproto.customname) = "URIsByLocalityKV"];
 	// NEXT ID: 13.
 }


### PR DESCRIPTION
Previously, locality aware has being disabled in compact backup job. This change enable the compacted backup job has similar behavior to the regular backup job.

Fix: #149593

release note: backup compaction with locality awareness