### PR TITLE
changefeedccl: write new ResolvedTables protobuf to job_info

### DIFF
--- a/pkg/ccl/changefeedccl/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/BUILD.bazel
@@ -8,6 +8,7 @@ go_library(
         "batching_sink.go",
         "changefeed.go",
         "changefeed_dist.go",
+        "changefeed_job_info.go",
         "changefeed_processors.go",
         "changefeed_stmt.go",
         "compression.go",
@@ -197,6 +198,7 @@ go_test(
     srcs = [
         "alter_changefeed_test.go",
         "changefeed_dist_test.go",
+        "changefeed_job_info_test.go",
         "changefeed_stmt_test.go",
         "changefeed_test.go",
         "csv_test.go",

--- a/pkg/ccl/changefeedccl/changefeed_job_info.go
+++ b/pkg/ccl/changefeedccl/changefeed_job_info.go
@@ -1,0 +1,68 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"strings"
+
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/jobs/jobspb"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/util/protoutil"
+	"github.com/cockroachdb/errors"
+)
+
+// Filename prefix/extension for all changefeed-related job info files.
+const (
+	jobInfoFilenamePrefix    = "~changefeed/"
+	jobInfoFilenameExtension = ".binpb"
+)
+
+const (
+	// resolvedTablesFilename: ~changefeed/resolved_tables.binpb
+	resolvedTablesFilename = jobInfoFilenamePrefix + "resolved_tables" + jobInfoFilenameExtension
+)
+
+// writeChangefeedJobInfo writes a changefeed job info protobuf to the
+// job_info table. A changefeed-specific filename is required.
+func writeChangefeedJobInfo(
+	ctx context.Context, filename string, info protoutil.Message, txn isql.Txn, jobID jobspb.JobID,
+) error {
+	if !strings.HasPrefix(filename, jobInfoFilenamePrefix) {
+		return errors.AssertionFailedf("filename %q must start with prefix %q", filename, jobInfoFilenamePrefix)
+	}
+	if !strings.HasSuffix(filename, jobInfoFilenameExtension) {
+		return errors.AssertionFailedf("filename %q must end with extension %q", filename, jobInfoFilenameExtension)
+	}
+	data, err := protoutil.Marshal(info)
+	if err != nil {
+		return errors.Wrapf(err, "error marshaling %s for job %d", filename, jobID)
+	}
+	return jobs.WriteChunkedFileToJobInfo(ctx, filename, data, txn, jobID)
+}
+
+// readChangefeedJobInfo reads a changefeed job info protobuf from the
+// job_info table. A changefeed-specific filename is required.
+// TODO(#148119): Use this function to read.
+func readChangefeedJobInfo(
+	ctx context.Context, filename string, info protoutil.Message, txn isql.Txn, jobID jobspb.JobID,
+) error {
+	if !strings.HasPrefix(filename, jobInfoFilenamePrefix) {
+		return errors.AssertionFailedf("filename %q must start with prefix %q", filename, jobInfoFilenamePrefix)
+	}
+	if !strings.HasSuffix(filename, jobInfoFilenameExtension) {
+		return errors.AssertionFailedf("filename %q must end with extension %q", filename, jobInfoFilenameExtension)
+	}
+	data, err := jobs.ReadChunkedFileToJobInfo(ctx, filename, txn, jobID)
+	if err != nil {
+		return err
+	}
+	if err := protoutil.Unmarshal(data, info); err != nil {
+		return errors.Wrapf(err, "error unmarshaling %s for job %d", filename, jobID)
+	}
+	return nil
+}

--- a/pkg/ccl/changefeedccl/changefeed_job_info_test.go
+++ b/pkg/ccl/changefeedccl/changefeed_job_info_test.go
@@ -1,0 +1,63 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedccl
+
+import (
+	"context"
+	"testing"
+
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/cdctest"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedbase"
+	"github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedpb"
+	"github.com/cockroachdb/cockroach/pkg/jobs"
+	"github.com/cockroachdb/cockroach/pkg/sql"
+	"github.com/cockroachdb/cockroach/pkg/sql/isql"
+	"github.com/cockroachdb/cockroach/pkg/testutils/sqlutils"
+	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/cockroachdb/cockroach/pkg/util/log"
+	"github.com/stretchr/testify/require"
+)
+
+func TestChangefeedJobInfoResolvedTables(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+	defer log.Scope(t).Close(t)
+
+	testFn := func(t *testing.T, s TestServer, f cdctest.TestFeedFactory) {
+		ctx := context.Background()
+		sqlDB := sqlutils.MakeSQLRunner(s.DB)
+
+		// Make sure per-table tracking is enabled.
+		changefeedbase.TrackPerTableProgress.Override(ctx, &s.Server.ClusterSettings().SV, true)
+
+		sqlDB.Exec(t, `CREATE TABLE foo (a INT PRIMARY KEY, b STRING)`)
+		sqlDB.Exec(t, `CREATE TABLE bar (x INT PRIMARY KEY, y STRING)`)
+		feed := feed(t, f, `CREATE CHANGEFEED FOR foo, bar`)
+		defer closeFeed(t, feed)
+
+		sqlDB.Exec(t, `INSERT INTO foo VALUES (1, 'one')`)
+		sqlDB.Exec(t, `INSERT INTO bar VALUES (10, 'ten')`)
+		assertPayloads(t, feed, []string{
+			`foo: [1]->{"after": {"a": 1, "b": "one"}}`,
+			`bar: [10]->{"after": {"x": 10, "y": "ten"}}`,
+		})
+
+		// The ResolvedTables message should be persisted to the job_info table
+		// at the same time as the highwater being set.
+		enterpriseFeed := feed.(cdctest.EnterpriseTestFeed)
+		waitForHighwater(t, enterpriseFeed, s.Server.JobRegistry().(*jobs.Registry))
+
+		// Make sure the ResolvedTables message was persisted and can be decoded.
+		var resolvedTables changefeedpb.ResolvedTables
+		execCfg := s.Server.ExecutorConfig().(sql.ExecutorConfig)
+		err := execCfg.InternalDB.Txn(ctx, func(ctx context.Context, txn isql.Txn) error {
+			return readChangefeedJobInfo(ctx, resolvedTablesFilename, &resolvedTables, txn, enterpriseFeed.JobID())
+		})
+		require.NoError(t, err)
+		require.Len(t, resolvedTables.Tables, 2)
+	}
+
+	cdcTest(t, testFn, feedTestEnterpriseSinks)
+}

--- a/pkg/ccl/changefeedccl/changefeedpb/BUILD.bazel
+++ b/pkg/ccl/changefeedccl/changefeedpb/BUILD.bazel
@@ -4,9 +4,17 @@ load("@io_bazel_rules_go//proto:def.bzl", "go_proto_library")
 
 proto_library(
     name = "changefeedpb_proto",
-    srcs = ["scheduled_changefeed.proto"],
+    srcs = [
+        "changefeed.proto",
+        "scheduled_changefeed.proto",
+    ],
     strip_import_prefix = "/pkg",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs/jobspb:jobspb_proto",
+        "//pkg/util/hlc:hlc_proto",
+        "@com_github_gogo_protobuf//gogoproto:gogo_proto",
+    ],
 )
 
 go_proto_library(
@@ -15,16 +23,25 @@ go_proto_library(
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedpb",
     proto = ":changefeedpb_proto",
     visibility = ["//visibility:public"],
+    deps = [
+        "//pkg/jobs/jobspb",
+        "//pkg/util/hlc",
+        "@com_github_gogo_protobuf//gogoproto",
+    ],
 )
 
 go_library(
     name = "changefeedpb",
-    srcs = ["marshal.go"],
+    srcs = [
+        "changefeed.go",
+        "marshal.go",
+    ],
     embed = [":changefeedpb_go_proto"],
     importpath = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedpb",
     visibility = ["//visibility:public"],
     deps = [
         "//pkg/cloud",
+        "//pkg/sql/catalog/descpb",
         "//pkg/sql/parser",
         "//pkg/sql/sem/tree",
         "@com_github_cockroachdb_errors//:errors",

--- a/pkg/ccl/changefeedccl/changefeedpb/changefeed.go
+++ b/pkg/ccl/changefeedccl/changefeedpb/changefeed.go
@@ -1,0 +1,8 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+package changefeedpb
+
+import _ "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb" // Needed for changefeed.proto.

--- a/pkg/ccl/changefeedccl/changefeedpb/changefeed.proto
+++ b/pkg/ccl/changefeedccl/changefeedpb/changefeed.proto
@@ -1,0 +1,23 @@
+// Copyright 2025 The Cockroach Authors.
+//
+// Use of this software is governed by the CockroachDB Software License
+// included in the /LICENSE file.
+
+syntax = "proto3";
+package cockroach.ccl.changefeedccl;
+option go_package = "github.com/cockroachdb/cockroach/pkg/ccl/changefeedccl/changefeedpb";
+
+import "gogoproto/gogo.proto";
+import "jobs/jobspb/jobs.proto";
+import "util/hlc/timestamp.proto";
+
+// ResolvedTables contains per-table resolved timestamp information.
+message ResolvedTables {
+  map<uint32, util.hlc.Timestamp> tables = 1 [
+    (gogoproto.castkey) = "github.com/cockroachdb/cockroach/pkg/sql/catalog/descpb.ID",
+    (gogoproto.nullable) = false
+  ];
+
+  // TODO(#148124): Write to this field for aggregator-to-frontier messages.
+  cockroach.sql.jobs.jobspb.ResolvedSpan.BoundaryType boundary_type = 2;
+}


### PR DESCRIPTION
This patch introduces a new `ResolvedTables` protobuf, which is used
used to store per-table resolved timestamps. When per-table progress
tracking is on, a `ResolvedTables` message will be marshaled and
persisted to the `system.job_info` table whenever the changefeed's
highwater is updated.

This patch also adds some helper functions to standardize the filenames
used for changefeed job info files.

Fixes #148118

Release note: None