### PR TITLE
tests,sqlsmith: skip st_snap in TestRandomSyntaxSQLSmith

### DIFF
--- a/pkg/internal/sqlsmith/relational.go
+++ b/pkg/internal/sqlsmith/relational.go
@@ -1790,12 +1790,19 @@ func (s *Smither) makeHaving(refs colRefs) *tree.Where {
 }
 
 func (s *Smither) isOrderable(typ *types.T) bool {
+	if typ.Family() == types.ArrayFamily {
+		typ = typ.ArrayContents()
+	}
+	if typ.Family() == types.RefCursorFamily || typ.Family() == types.JsonpathFamily {
+		// These types don't define an ordering function in PG.
+		return false
+	}
 	if s.postgres {
 		// PostGIS cannot order box2d types.
 		return typ.Family() != types.Box2DFamily
 	}
 	switch typ.Family() {
-	case types.TSQueryFamily, types.TSVectorFamily:
+	case types.TSQueryFamily, types.TSVectorFamily, types.PGVectorFamily:
 		// We can't order by these types - see #92165.
 		return false
 	default:

--- a/pkg/sql/tests/rsg_test.go
+++ b/pkg/sql/tests/rsg_test.go
@@ -758,6 +758,10 @@ func TestRandomSyntaxSQLSmith(t *testing.T) {
 		return err
 	}, func(ctx context.Context, db *verifyFormatDB, r *rsg.RSG) error {
 		s := smither.Generate()
+		if strings.Contains(s, "st_snap(") {
+			// TODO(#151103): unskip st_snap.
+			return nil
+		}
 		err := db.exec(t, ctx, s)
 		if c := (*crasher)(nil); errors.As(err, &c) {
 			if err := db.exec(t, ctx, "USE defaultdb"); err != nil {


### PR DESCRIPTION
There is a known issue with `st_snap` that causes a crash in geos, so we avoid generating a stmt with this builtin for now.

Additionally, I noticed some random stmts that always will hit an error because ORDER BY clause contains a type that doesn't define an ordering, so this commit also adjusts the sqlsmith generation for REFCURSOR, JSONPATH, and PGVECTOR (to match `ensureColumnOrderable`).

Informs: #151103
Fixes: #151580

Release note: None