### PR TITLE
sql: add ltree value encoding tests

### DIFF
--- a/pkg/sql/randgen/datum.go
+++ b/pkg/sql/randgen/datum.go
@@ -316,25 +316,7 @@ func RandDatumWithNullChance(
 	case types.OidFamily:
 		return tree.NewDOidWithType(oid.Oid(rng.Uint32()), typ)
 	case types.LTreeFamily:
-		length := rng.Intn(10)
-		if length == 1 && rng.Intn(4) == 0 {
-			return tree.NewDLTree(ltree.Empty)
-		}
-		labels := make([]string, length)
-		for i := range labels {
-			// Labels cannot be empty.
-			labelLen := rng.Intn(9) + 1
-			p := make([]byte, labelLen)
-			for j := range p {
-				p[j] = charSet[rng.Intn(len(charSet))]
-			}
-			labels[i] = string(p)
-		}
-		l, err := tree.ParseDLTree(strings.Join(labels, ltree.PathSeparator))
-		if err != nil {
-			return nil
-		}
-		return l
+		return tree.NewDLTree(ltree.RandLTree(rng))
 	case types.UnknownFamily:
 		return tree.DNull
 	case types.ArrayFamily:

--- a/pkg/util/encoding/encoding.go
+++ b/pkg/util/encoding/encoding.go
@@ -3644,6 +3644,13 @@ func PrettyPrintValueEncoded(b []byte) ([]byte, string, error) {
 		var s string
 		b, s, err = PrettyPrintTupleValueEncoded(b)
 		return b, s, err
+	case LTree:
+		var l ltree.T
+		b, l, err = DecodeLTreeValue(b)
+		if err != nil {
+			return b, "", err
+		}
+		return b, l.String(), nil
 	default:
 		return b, "", errors.Errorf("unknown type %s", typ)
 	}

--- a/pkg/util/encoding/encoding_test.go
+++ b/pkg/util/encoding/encoding_test.go
@@ -1725,6 +1725,10 @@ func (rd randData) ipAddr() ipaddr.IPAddr {
 	return ipaddr.RandIPAddr(rd.Rand)
 }
 
+func (rd randData) ltree() ltree.T {
+	return ltree.RandLTree(rd.Rand)
+}
+
 func BenchmarkEncodeUint32(b *testing.B) {
 	rng, _ := randutil.NewTestRand()
 
@@ -2251,6 +2255,25 @@ func TestValueEncodeDecodeDuration(t *testing.T) {
 	}
 }
 
+func TestValueEncodeDecodeLTree(t *testing.T) {
+	rng, seed := randutil.NewTestRand()
+	rd := randData{rng}
+	tests := make([]ltree.T, 1000)
+	for i := range tests {
+		tests[i] = rd.ltree()
+	}
+	for _, test := range tests {
+		buf := EncodeLTreeValue(nil, NoColumnID, test)
+		_, x, err := DecodeLTreeValue(buf)
+		if err != nil {
+			t.Fatal(err)
+		}
+		if x.Compare(test) != 0 {
+			t.Errorf("seed %d: expected %s got %s", seed, test.String(), x.String())
+		}
+	}
+}
+
 func BenchmarkEncodeNonsortingVarint(b *testing.B) {
 	bytes := make([]byte, 0, b.N*MaxNonsortingVarintLen)
 	rng, _ := randutil.NewTestRand()
@@ -2456,6 +2479,9 @@ func randValueEncode(rd randData, buf []byte, colID uint32, typ Type) ([]byte, i
 	case IPAddr:
 		x := rd.ipAddr()
 		return EncodeIPAddrValue(buf, colID, x), x, true
+	case LTree:
+		x := rd.ltree()
+		return EncodeLTreeValue(buf, colID, x), x, true
 	default:
 		return buf, nil, false
 	}
@@ -2611,6 +2637,8 @@ func TestValueEncodingRand(t *testing.T) {
 			buf, decoded, err = DecodeBitArrayValue(buf)
 		case IPAddr:
 			buf, decoded, err = DecodeIPAddrValue(buf)
+		case LTree:
+			buf, decoded, err = DecodeLTreeValue(buf)
 		default:
 			err = errors.Errorf("unknown type %s", typ)
 		}
@@ -2639,6 +2667,12 @@ func TestValueEncodingRand(t *testing.T) {
 			d := decoded.(bitarray.BitArray)
 			val := value.(bitarray.BitArray)
 			if bitarray.Compare(d, val) != 0 {
+				t.Fatalf("seed %d: %s got %v expected %v", seed, typ, decoded, value)
+			}
+		case LTree:
+			d := decoded.(ltree.T)
+			val := value.(ltree.T)
+			if d.Compare(val) != 0 {
 				t.Fatalf("seed %d: %s got %v expected %v", seed, typ, decoded, value)
 			}
 		default:

--- a/pkg/util/ltree/ltree.go
+++ b/pkg/util/ltree/ltree.go
@@ -7,6 +7,7 @@ package ltree
 
 import (
 	"bytes"
+	"math/rand"
 	"strings"
 
 	"github.com/cockroachdb/cockroach/pkg/sql/pgwire/pgcode"
@@ -142,6 +143,25 @@ func (lt T) Copy() T {
 	copiedLabels := make([]string, lt.Len())
 	copy(copiedLabels, lt.path)
 	return T{path: copiedLabels}
+}
+
+func RandLTree(rng *rand.Rand) T {
+	charSet := "-0123456789ABCDEFGHIJKLMNOPQRSTUVWXYZ_abcdefghijklmnopqrstuvwxyz"
+	length := rng.Intn(10)
+	if length == 0 {
+		return Empty
+	}
+	labels := make([]string, length)
+	for i := range labels {
+		// Labels cannot be empty.
+		labelLen := rng.Intn(9) + 1
+		p := make([]byte, labelLen)
+		for j := range p {
+			p[j] = charSet[rng.Intn(len(charSet))]
+		}
+		labels[i] = string(p)
+	}
+	return T{path: labels}
 }
 
 // validateLabel checks if a label is valid and returns an error if it is not,


### PR DESCRIPTION
#### sql: add ltree value encoding tests

This was forgotten when we first implemented the ltree datum.

Epic: None
Fixes: None

Release note: None