### PR TITLE
release-25.2: kvcoord: deflake TestDistSenderReplicaStall

### DIFF
--- a/pkg/kv/kvclient/kvcoord/BUILD.bazel
+++ b/pkg/kv/kvclient/kvcoord/BUILD.bazel
@@ -220,6 +220,7 @@ go_test(
         "//pkg/testutils/testcluster",
         "//pkg/util",
         "//pkg/util/admission/admissionpb",
+        "//pkg/util/allstacks",
         "//pkg/util/caller",
         "//pkg/util/ctxgroup",
         "//pkg/util/encoding",


### PR DESCRIPTION
Backport 1/1 commits from #151680.

/cc @cockroachdb/release

---

Previously, the test would timeout after 30 seconds if it hasn't finished successfully. However, the 30 seconds countdown start from the beginning of the test, before creating the test cluster and running it. A few failures happened because the nodes took a long time in the CI to actually become up and running.

This commit deflakes the test by starting the 30 seconds countdown after test cluster is actually functional.

References: #151660

Release note: None

Release justification: Deflake test