### PR TITLE
sql: gate access to crdb_internal tables based on session var

### DIFF
--- a/pkg/sql/crdb_internal.go
+++ b/pkg/sql/crdb_internal.go
@@ -235,29 +235,29 @@ var crdbInternal = virtualSchema{
 	validWithNoDatabaseContext: true,
 }
 
-// SupportedVTables are the crdb_internal tables that are "supported" for real
+// SupportedCRDBInternal are the crdb_internal tables that are "supported" for real
 // customer use in production for legacy reasons. Avoid adding to this list if
 // possible and prefer to add new customer-facing tables that should be public
 // under the non-"internal" namespace of information_schema.
-var SupportedVTables = map[string]struct{}{
-	`"".crdb_internal.cluster_contended_indexes`:     {},
-	`"".crdb_internal.cluster_contended_keys`:        {},
-	`"".crdb_internal.cluster_contended_tables`:      {},
-	`"".crdb_internal.cluster_contention_events`:     {},
-	`"".crdb_internal.cluster_locks`:                 {},
-	`"".crdb_internal.cluster_queries`:               {},
-	`"".crdb_internal.cluster_sessions`:              {},
-	`"".crdb_internal.cluster_transactions`:          {},
-	`"".crdb_internal.index_usage_statistics`:        {},
-	`"".crdb_internal.statement_statistics`:          {},
-	`"".crdb_internal.transaction_contention_events`: {},
-	`"".crdb_internal.transaction_statistics`:        {},
-	`"".crdb_internal.zones`:                         {},
+var SupportedCRDBInternalTables = map[string]struct{}{
+	`cluster_contended_indexes`:     {},
+	`cluster_contended_keys`:        {},
+	`cluster_contended_tables`:      {},
+	`cluster_contention_events`:     {},
+	`cluster_locks`:                 {},
+	`cluster_queries`:               {},
+	`cluster_sessions`:              {},
+	`cluster_transactions`:          {},
+	`index_usage_statistics`:        {},
+	`statement_statistics`:          {},
+	`transaction_contention_events`: {},
+	`transaction_statistics`:        {},
+	`zones`:                         {},
 }
 
 // Note that this map is currently unused but serves to document which vtables
 // are expected to be used in production setting.
-var _ = SupportedVTables
+var _ = SupportedCRDBInternalTables
 
 var crdbInternalBuildInfoTable = virtualSchemaTable{
 	comment: `detailed identification strings (RAM, local node only)`,


### PR DESCRIPTION
The epic below outlines a set of work to prevent users from unauthorized
access to what we deem unsafe internals. These unsafe internals lie
mostly in the crdb_internal schema and the system database. This PR
makes it so that crdb_internal access is limited to a slim set of
"allowed" internal objects.

Fixes: #151803
Epic: CRDB-24527
Release note (ops change): restricts access to all but allowed list of internal
tables in the crdb_internal schema if the session variable
`allow_unsafe_internals` is set to true, or if the caller is internal.