### PR TITLE
kvcoord: set a 1KB minimum write buffer for buffered writes

### DIFF
--- a/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
+++ b/pkg/kv/kvclient/kvcoord/txn_interceptor_write_buffer.go
@@ -59,6 +59,7 @@ var bufferedWritesGetTransformEnabled = settings.RegisterBoolSetting(
 )
 
 const defaultBufferSize = 1 << 22 // 4MB
+const minBufferSize = 1 << 10     // 1KB -- below this, some logic tests start to fail
 var bufferedWritesMaxBufferSize = settings.RegisterByteSizeSetting(
 	settings.ApplicationLevel,
 	"kv.transaction.write_buffering.max_buffer_size",
@@ -66,10 +67,10 @@ var bufferedWritesMaxBufferSize = settings.RegisterByteSizeSetting(
 		"buffer that will be used to buffer transactional writes per-transaction",
 	int64(metamorphic.ConstantWithTestRange("kv.transaction.write_buffering.max_buffer_size",
 		defaultBufferSize, // default
-		1,                 // min
+		minBufferSize,     // min
 		defaultBufferSize, // max
 	)),
-	settings.NonNegativeInt,
+	settings.ByteSizeWithMinimum(minBufferSize),
 	settings.WithPublic,
 )
 

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -603,7 +603,7 @@ INSERT INTO t7 VALUES (5,1)
 user testuser
 
 statement ok
-SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size='1'
+SET CLUSTER SETTING kv.transaction.write_buffering.max_buffer_size='1KiB'
 
 user root
 


### PR DESCRIPTION
When the buffer size gets too small, logic tests start to fail just because the tracing looks different.

Fixes: #151725
Release note (sql change): The minimum buffer size for buffered writes is now 1KiB.