### PR TITLE
roachtest: add startOpts.RoachprodOpts.SkipWaitForSQL

### DIFF
--- a/pkg/cmd/roachtest/cluster.go
+++ b/pkg/cmd/roachtest/cluster.go
@@ -2190,7 +2190,7 @@ func (c *clusterImpl) StartE(
 		}
 	}
 	// N.B. If `SkipInit` is set, we don't wait for SQL since node(s) may not join the cluster in any definite time.
-	if !startOpts.RoachprodOpts.SkipInit {
+	if !startOpts.RoachprodOpts.SkipInit && !startOpts.RoachprodOpts.SkipWaitForSQL {
 		// Wait for SQL to be ready on all nodes, for 'system' tenant, only.
 		for _, n := range nodes {
 			conn, err := c.ConnE(ctx, l, nodes[0], option.VirtualClusterName(install.SystemInterfaceName))

--- a/pkg/roachprod/install/cockroach.go
+++ b/pkg/roachprod/install/cockroach.go
@@ -127,6 +127,7 @@ type StartOpts struct {
 	// -- Options that apply only to StartDefault target --
 
 	SkipInit        bool
+	SkipWaitForSQL  bool
 	StoreCount      int
 	EncryptedStores bool
 	// WALFailover, if non-empty, configures the value to supply to the


### PR DESCRIPTION
Adds the `SkipWaitForSQL` bool to roachprod `StartOpts` to allow tests to skip waiting for the SQL connection to be ready when quorum can't be reached intentionally.

Closes: #141115

Release note: None