### PR TITLE
release-25.3: sql: fix DROP USER to detect default privilege dependencies

### DIFF
--- a/pkg/sql/catalog/catpb/privilege.proto
+++ b/pkg/sql/catalog/catpb/privilege.proto
@@ -62,6 +62,8 @@ message DefaultPrivilegesForRole {
     // for the role causes it to "own" default privileges as it is no longer
     // the "default" case and the role cannot be dropped until the default case
     // is met.
+    // Note: if adding any public_has_* fields in the future, be sure to update
+    // checking of these default privileges in addDependentPrivileges.
     optional bool public_has_usage_on_types = 4 [(gogoproto.nullable) = false];
     optional bool role_has_all_privileges_on_tables = 5 [(gogoproto.nullable) = false];
     optional bool role_has_all_privileges_on_sequences = 6 [(gogoproto.nullable) = false];

--- a/pkg/sql/drop_role.go
+++ b/pkg/sql/drop_role.go
@@ -563,16 +563,40 @@ func accumulateDependentDefaultPrivileges(
 			role.ForAllRoles = true
 		}
 		for object, defaultPrivs := range defaultPrivilegesForRole.DefaultPrivilegesPerObject {
-			addDependentPrivileges(object, defaultPrivs, role, userNames, dbName, schemaName)
+			addDependentPrivileges(object, defaultPrivs, role, defaultPrivilegesForRole.GetExplicitRole(),
+				userNames, dbName, schemaName)
 		}
 		return nil
 	})
 }
 
+// addDependentPrivileges checks if a specific default privilege creates dependencies
+// that would prevent dropping any of the target roles.
+//
+// This function examines one default privilege rule and determines if:
+//  1. The role that created the default privilege is being dropped (creator dependency).
+//  2. Any roles that were granted privileges by this default privilege are being
+//     dropped (grantee dependency).
+//
+// Parameters:
+//   - object: The type of database object this default privilege applies to
+//     (e.g., privilege.Tables, privilege.Sequences, privilege.Routines, etc.).
+//   - defaultPrivs: The privilege descriptor containing the actual privilege
+//     grants/revokes for this specific default privilege rule.
+//   - role: The role information for who created this default privilege rule.
+//     Contains either a specific role (role.Role) or indicates it applies to all roles
+//     (role.ForAllRoles)
+//   - explicitRole: This is passed in if the default privilege is for a specific role.
+//   - userNames: Map of roles being dropped -> their accumulated dependency objects.
+//     Used both for lookup (is this role being dropped?) and for recording dependencies.
+//   - dbName: Name of the database where this default privilege is defined.
+//   - schemaName: Name of the schema where this default privilege is defined,
+//     or empty string if this is a database-level default privilege.
 func addDependentPrivileges(
 	object privilege.TargetObjectType,
 	defaultPrivs catpb.PrivilegeDescriptor,
 	role catpb.DefaultPrivilegesRole,
+	explicitRole *catpb.DefaultPrivilegesForRole_ExplicitRole,
 	userNames map[username.SQLUsername][]objectAndType,
 	dbName string,
 	schemaName string,
@@ -587,6 +611,10 @@ func addDependentPrivileges(
 		objectType = "types"
 	case privilege.Schemas:
 		objectType = "schemas"
+	case privilege.Routines:
+		objectType = "routines"
+	default:
+		objectType = object.String()
 	}
 
 	inSchemaMsg := ""
@@ -597,6 +625,8 @@ func addDependentPrivileges(
 	createHint := func(
 		role catpb.DefaultPrivilegesRole,
 		grantee username.SQLUsername,
+		isRevoke bool,
+		privilegeKind privilege.Kind,
 	) string {
 
 		roleString := "ALL ROLES"
@@ -604,15 +634,25 @@ func addDependentPrivileges(
 			roleString = fmt.Sprintf("ROLE %s", role.Role.SQLIdentifier())
 		}
 
-		return fmt.Sprintf("USE %s; ALTER DEFAULT PRIVILEGES FOR %s%s REVOKE ALL ON %s FROM %s;",
-			dbName, roleString, strings.ToUpper(inSchemaMsg), strings.ToUpper(object.String()), grantee.SQLIdentifier())
+		var action, targetKeyword string
+		if isRevoke {
+			action = "REVOKE"
+			targetKeyword = "FROM"
+		} else {
+			action = "GRANT"
+			targetKeyword = "TO"
+		}
+
+		return fmt.Sprintf("USE %s; ALTER DEFAULT PRIVILEGES FOR %s%s %s %s ON %s %s %s;",
+			dbName, roleString, strings.ToUpper(inSchemaMsg), action, string(privilegeKind.DisplayName()),
+			strings.ToUpper(object.String()), targetKeyword, grantee.SQLIdentifier())
 	}
 
 	for _, privs := range defaultPrivs.Users {
 		grantee := privs.User()
 		if !role.ForAllRoles {
 			if _, ok := userNames[role.Role]; ok {
-				hint := createHint(role, grantee)
+				hint := createHint(role, grantee, true /* isRevoke */, privilege.ALL)
 				userNames[role.Role] = append(userNames[role.Role],
 					objectAndType{
 						IsDefaultPrivilege: true,
@@ -625,7 +665,7 @@ func addDependentPrivileges(
 			}
 		}
 		if _, ok := userNames[grantee]; ok {
-			hint := createHint(role, grantee)
+			hint := createHint(role, grantee, true /* isRevoke */, privilege.ALL)
 			var err error
 			if role.ForAllRoles {
 				err = errors.Newf(
@@ -643,6 +683,32 @@ func addDependentPrivileges(
 					IsDefaultPrivilege: true,
 					ErrorMessage:       errors.WithHint(err, hint),
 				})
+		}
+	}
+
+	// New roles grant EXECUTE on functions and USAGE on types by default. If any
+	// of those two were revoked, the privilege needs to be granted again to
+	// remove any dependencies.
+	if explicitRole != nil {
+		if _, ok := userNames[role.Role]; ok {
+			var hint string
+			if !explicitRole.PublicHasUsageOnTypes && object == privilege.Types {
+				hint = createHint(role, username.PublicRoleName(), false /* isRevoke */, privilege.USAGE)
+			}
+			if !explicitRole.PublicHasExecuteOnFunctions && object == privilege.Routines {
+				hint = createHint(role, username.PublicRoleName(), false /* isRevoke */, privilege.EXECUTE)
+			}
+			if hint != "" {
+				userNames[role.Role] = append(userNames[role.Role],
+					objectAndType{
+						IsDefaultPrivilege: true,
+						ErrorMessage: errors.WithHint(
+							errors.Newf(
+								"owner of default privileges that revokes privileges of %s from public in database %s%s",
+								objectType, dbName, inSchemaMsg,
+							), hint),
+					})
+			}
 		}
 	}
 }

--- a/pkg/sql/logictest/testdata/logic_test/drop_user
+++ b/pkg/sql/logictest/testdata/logic_test/drop_user
@@ -215,3 +215,78 @@ statement error role schema_owner cannot be dropped because some objects depend 
 DROP ROLE schema_owner
 
 subtest end
+
+# Regression test for #150543. Ensure that DROP USER is blocked when role has
+# default privileges. 
+subtest default_privileges_dependency
+
+statement ok
+CREATE USER default_priv_user
+
+# Create default privileges with REVOKE. Target routines and types initially. These undo
+# the implicitly created default privileges for new roles.
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user REVOKE EXECUTE ON ROUTINES FROM public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user REVOKE USAGE ON TYPES FROM public
+
+# The next threes REVOKE's are essentially no-op since they don't change anything
+# as nothing was implicitly granted for them.
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user REVOKE USAGE ON SEQUENCES FROM public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user REVOKE ALL ON TABLES FROM public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user REVOKE ALL ON SCHEMAS FROM public
+
+statement error role default_priv_user cannot be dropped because some objects depend on it\nowner of default privileges that revokes privileges of routines from public in database test\nowner of default privileges that revokes privileges of types from public in database test\nHINT: USE test; ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user GRANT EXECUTE ON ROUTINES TO public;\nUSE test; ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user GRANT USAGE ON TYPES TO public;
+DROP USER default_priv_user
+
+# Test with GRANT case 
+statement ok
+CREATE USER default_priv_user2
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 GRANT ALL ON TABLES TO public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 GRANT ALL ON SCHEMAS TO public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 GRANT USAGE ON SEQUENCES TO public
+
+statement error role default_priv_user2 cannot be dropped because some objects depend on it\nowner of default privileges on new relations belonging to role default_priv_user2 in database test\nowner of default privileges on new schemas belonging to role default_priv_user2 in database test\nowner of default privileges on new sequences belonging to role default_priv_user2 in database test\nHINT: USE test; ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 REVOKE ALL ON TABLES FROM public;\nUSE test; ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 REVOKE ALL ON SCHEMAS FROM public;\nUSE test; ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 REVOKE ALL ON SEQUENCES FROM public;
+DROP USER default_priv_user2
+
+# Clean up for successful drop
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user GRANT EXECUTE ON FUNCTIONS TO public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user GRANT USAGE ON TYPES TO public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 REVOKE ALL ON TABLES FROM public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 REVOKE ALL ON SCHEMAS FROM public
+
+statement ok
+ALTER DEFAULT PRIVILEGES FOR ROLE default_priv_user2 REVOKE USAGE ON SEQUENCES FROM public
+
+statement ok
+DROP USER default_priv_user
+
+statement ok
+DROP USER default_priv_user2
+
+# Ensure there are no invalid objects left around. This was how the issue was
+# found prior to #150543.
+query TTTT
+SELECT database_name, schema_name, obj_name, error FROM crdb_internal.invalid_objects;
+----
+
+subtest end

--- a/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_owned_by.go
+++ b/pkg/sql/schemachanger/scbuild/internal/scbuildstmt/drop_owned_by.go
@@ -101,6 +101,8 @@ func DropOwnedBy(b BuildCtx, n *tree.DropOwnedBy) {
 		}
 	})
 
+	// TODO(151425): we should cleanup default privileges for the user too like postgres
+
 	b.IncrementSubWorkID()
 	b.IncrementDropOwnedByCounter()
 


### PR DESCRIPTION
Backport 1/1 commits from #151472 on behalf of @spilchen.

----

Prior to this fix, DROP USER would succeed even when a role had created default privilege rules, leaving orphaned default privilege entries that referenced non-existent roles.

The issue occurred because the dependency detection logic only checked for roles that had privileges granted to them, but missed the case where a role was the creator of default privileges through REVOKE operations. When default privileges are created with REVOKE (e.g., "ALTER DEFAULT PRIVILEGES FOR ROLE user REVOKE EXECUTE ON ROUTINES FROM public"), the grantee list becomes empty, so the original logic didn't detect the dependency.

This fix adds explicit detection of creator dependencies for default privileges, ensuring that roles cannot be dropped if they own default privilege rules.

Fixes #150543.

Release note (bug fix): Fixed DROP USER succeeding when a role owned default privileges, which could leave invalid privilege entries in the system.

Epic: None

----

Release justification: fix a bug that can cause a database descriptor to enter an invalid state