### PR TITLE
server: expose Go soft memory limit as a metric

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -522,6 +522,7 @@ An event of type `runtime_stats` is recorded every 10 seconds as server health m
 | `GCRunCount` | The total number of GC runs. | no |
 | `NetHostRecvBytes` | The bytes received on all network interfaces since this process started. | no |
 | `NetHostSendBytes` | The bytes sent on all network interfaces since this process started. | no |
+| `GoLimitBytes` | The soft Go memory limit in bytes. | no |
 
 
 #### Common fields

--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -10366,6 +10366,14 @@ layers:
       unit: BYTES
       aggregation: AVG
       derivative: NONE
+    - name: sys.go.limitbytes
+      exported_name: sys_go_limitbytes
+      description: Go soft memory limit
+      y_axis_label: Memory
+      type: GAUGE
+      unit: BYTES
+      aggregation: AVG
+      derivative: NONE
     - name: sys.go.pause.other.ns
       exported_name: sys_go_pause_other_ns
       description: Estimated non-GC-related total pause time

--- a/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
+++ b/pkg/roachprod/opentelemetry/cockroachdb_metrics.go
@@ -2044,6 +2044,7 @@ var cockroachdbMetrics = map[string]string{
 	"sys_go_heap_heapfragmentbytes":                               "sys.go.heap.heapfragmentbytes",
 	"sys_go_heap_heapreleasedbytes":                               "sys.go.heap.heapreleasedbytes",
 	"sys_go_heap_heapreservedbytes":                               "sys.go.heap.heapreservedbytes",
+	"sys_go_limitbytes":                                           "sys.go.limitbytes",
 	"sys_go_pause_other_ns":                                       "sys.go.pause.other.ns",
 	"sys_go_stack_systembytes":                                    "sys.go.stack.systembytes",
 	"sys_go_stop_other_ns":                                        "sys.go.stop.other.ns",

--- a/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
+++ b/pkg/ui/workspaces/db-console/src/views/cluster/containers/nodeGraphs/dashboards/runtime.tsx
@@ -51,6 +51,8 @@ export default function (props: GraphDashboardProps) {
             <dd>Memory allocated by the Go layer</dd>
             <dt>Go Total</dt>
             <dd>Total memory managed by the Go layer</dd>
+            <dt>Go Limit</dt>
+            <dd>Go soft memory limit</dd>
             <dt>C Allocated</dt>
             <dd>Memory allocated by the C layer</dd>
             <dt>C Total</dt>
@@ -64,6 +66,7 @@ export default function (props: GraphDashboardProps) {
         <Metric name="cr.node.sys.rss" title="Total memory (RSS)" />
         <Metric name="cr.node.sys.go.allocbytes" title="Go Allocated" />
         <Metric name="cr.node.sys.go.totalbytes" title="Go Total" />
+        <Metric name="cr.node.sys.go.limitbytes" title="Go Limit" />
         <Metric name="cr.node.sys.cgo.allocbytes" title="CGo Allocated" />
         <Metric name="cr.node.sys.cgo.totalbytes" title="CGo Total" />
       </Axis>

--- a/pkg/util/log/eventpb/health_events.proto
+++ b/pkg/util/log/eventpb/health_events.proto
@@ -59,6 +59,8 @@ message RuntimeStats {
   uint64 net_host_recv_bytes = 18 [(gogoproto.jsontag) = ",omitempty"];
   // The bytes sent on all network interfaces since this process started.
   uint64 net_host_send_bytes = 19 [(gogoproto.jsontag) = ",omitempty"];
+  // The soft Go memory limit in bytes.
+  uint64 go_limit_bytes = 20 [(gogoproto.jsontag) = ",omitempty"];
 }
 
 // HotRangesStats

--- a/pkg/util/log/eventpb/json_encode_generated.go
+++ b/pkg/util/log/eventpb/json_encode_generated.go
@@ -4548,6 +4548,15 @@ func (m *RuntimeStats) AppendJSONFields(printComma bool, b redact.RedactableByte
 		b = strconv.AppendUint(b, uint64(m.NetHostSendBytes), 10)
 	}
 
+	if m.GoLimitBytes != 0 {
+		if printComma {
+			b = append(b, ',')
+		}
+		printComma = true
+		b = append(b, "\"GoLimitBytes\":"...)
+		b = strconv.AppendUint(b, uint64(m.GoLimitBytes), 10)
+	}
+
 	return printComma, b
 }
 


### PR DESCRIPTION
If the Go memory usage gets close to the soft memory limit,
performance can plummet because the GC has to run constantly.

This commit adds a metric showing the soft memory limit, so it's easy
to see when the Go total and alloc graphs get close to that.

Epic: none
Release note: None