### PR TITLE
kvcoord: include destination node ID in mux rangefeed recv errors

### DIFF
--- a/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
+++ b/pkg/kv/kvclient/kvcoord/dist_sender_mux_rangefeed.go
@@ -457,7 +457,7 @@ func (m *rangefeedMuxer) receiveEventsFromNode(
 	for {
 		event, err := receiver.Recv()
 		if err != nil {
-			return err
+			return errors.Wrapf(err, "receiving from node %d", ms.nodeID)
 		}
 
 		active := ms.lookupStream(event.StreamID)


### PR DESCRIPTION
Previously, when mux rangefeed connections encountered gRPC recv errors,
the error messages did not include the destination node ID, making it
difficult to troubleshoot which node was causing connection issues.

This change wraps mux rangefeed recv errors with the destination node ID
information in the `receiveEventsFromNode` function.

Fixes #149926

Release note: None

🤖 Generated with [Claude Code](https://claude.ai/code)