### PR TITLE
sql: prep migration of sql_perf logging channels

### DIFF
--- a/docs/generated/eventlog.md
+++ b/docs/generated/eventlog.md
@@ -2771,6 +2771,11 @@ Note: these events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.
 
+In version 26.1, these events will be moved to the `SQL_EXEC` channel.
+To test compatability before this, set the cluster setting
+`log.channel_compatibility_mode.enabled` to false. This will send the
+events to `SQL_EXEC` instead of `SQL_PERF`.
+
 Events in this category are logged to the `SQL_PERF` channel.
 
 
@@ -2900,6 +2905,11 @@ SQL statements.
 Note: these events are not written to `system.eventlog`, even
 when the cluster setting `system.eventlog.enabled` is set. They
 are only emitted via external logging.
+
+In version 26.1, these events will be moved to the `SQL_EXEC` channel.
+To test compatability before this, set the cluster setting
+`log.channel_compatibility_mode.enabled` to false. This will send the
+events to `SQL_EXEC` instead of `SQL_INTERNAL_PERF`.
 
 Events in this category are logged to the `SQL_INTERNAL_PERF` channel.
 

--- a/pkg/sql/conn_executor_exec.go
+++ b/pkg/sql/conn_executor_exec.go
@@ -3345,7 +3345,10 @@ func (ex *connExecutor) handleTxnRowsGuardrails(
 					CommonTxnRowsLimitDetails: commonTxnRowsLimitDetails,
 				}
 			}
-			log.StructuredEvent(ctx, severity.INFO, event)
+			migrator := log.NewStructuredEventMigrator(func() bool {
+				return log.ShouldMigrateEvent(ex.planner.ExecCfg().SV())
+			}, logpb.Channel_SQL_EXEC)
+			migrator.StructuredEvent(ctx, severity.INFO, event)
 			logCounter.Inc(1)
 		}
 	}

--- a/pkg/sql/event_log_test.go
+++ b/pkg/sql/event_log_test.go
@@ -22,7 +22,6 @@ import (
 	"github.com/cockroachdb/cockroach/pkg/util/log"
 	"github.com/cockroachdb/cockroach/pkg/util/log/channel"
 	"github.com/cockroachdb/cockroach/pkg/util/log/eventpb"
-	"github.com/cockroachdb/cockroach/pkg/util/log/logconfig"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logpb"
 	"github.com/cockroachdb/cockroach/pkg/util/log/logtestutils"
 	"github.com/cockroachdb/cockroach/pkg/util/timeutil"
@@ -458,14 +457,14 @@ func TestPerfLogging(t *testing.T) {
 		{
 			query:       `INSERT INTO t(i) VALUES (6)`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `INSERT INTO t(i) VALUES (7), (8), (9)`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -473,7 +472,7 @@ func TestPerfLogging(t *testing.T) {
 			setup:       `INSERT INTO t(i) VALUES (-1), (-2), (-3)`,
 			query:       `UPDATE t SET i = i - 10 WHERE i < 0`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"UPDATE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"UPDATE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -482,7 +481,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `COMMIT`,
 			query:       `INSERT INTO t(i) VALUES (10); INSERT INTO t(i) VALUES (11), (12);`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -491,14 +490,14 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `RESET transaction_rows_written_log`,
 			query:       `INSERT INTO t(i) VALUES (13), (14)`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `INSERT INTO t(i) VALUES (15), (16), (17), (18)`,
 			errRe:       `pq: txn has written 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -507,14 +506,14 @@ func TestPerfLogging(t *testing.T) {
 			// We now have 4 negative values in the table t.
 			query:       `DELETE FROM t WHERE i < 0`,
 			errRe:       `pq: txn has written 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"DELETE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"DELETE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `UPSERT INTO t(i) VALUES (-2), (-3), (-4), (-5)`,
 			errRe:       `pq: txn has written 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"UPSERT INTO.*","TxnID":".*","SessionID":".*","NumRows":4`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"UPSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*","NumRows":4`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -523,7 +522,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `ROLLBACK`,
 			query:       `INSERT INTO t(i) VALUES (15), (16), (17); INSERT INTO t(i) VALUES (18);`,
 			errRe:       `pq: txn has written 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*","NumRows":3`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*","NumRows":3`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -532,21 +531,21 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `RESET transaction_rows_written_err`,
 			query:       `INSERT INTO t(i) VALUES (15), (16)`,
 			errRe:       `pq: txn has written 2 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"INSERT INTO.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `SELECT * FROM t WHERE i = 6`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i = ‹6›","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i = ‹6›","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `SELECT * FROM t WHERE i IN (6, 7, 8)`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹6›, ‹7›, ‹8›\)","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*,"NumRows":3`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹6›, ‹7›, ‹8›\)","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*,"NumRows":3`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -555,7 +554,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `COMMIT`,
 			query:       `SELECT * FROM t WHERE i = 6; SELECT * FROM t WHERE i = 7; SELECT * FROM t WHERE i = 8;`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i = ‹8›","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*,"NumRows":3`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i = ‹8›","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*,"NumRows":3`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -564,14 +563,14 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `RESET transaction_rows_read_log`,
 			query:       `SELECT * FROM t WHERE i IN (6, 7)`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹6›, ‹7›\)","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*,"NumRows":2`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹6›, ‹7›\)","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*,"NumRows":2`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `SELECT * FROM t WHERE i IN (6, 7, 8, 9)`,
 			errRe:       `pq: txn has read 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹6›, ‹7›, ‹8›, ‹9›\)","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*,"NumRows":4`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹6›, ‹7›, ‹8›, ‹9›\)","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*,"NumRows":4`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -580,7 +579,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `ROLLBACK`,
 			query:       `SELECT * FROM t WHERE i IN (6, 7); SELECT * FROM t WHERE i IN (8, 9)`,
 			errRe:       `pq: txn has read 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹8›, ‹9›\)","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*,"NumRows":4`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i IN \(‹8›, ‹9›\)","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*,"NumRows":4`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -589,7 +588,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `RESET transaction_rows_read_err`,
 			query:       `SELECT * FROM t WHERE i = 6 OR i = 7`,
 			errRe:       `pq: txn has read 2 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i = ‹6› OR ‹i› = ‹7›","Tag":"SELECT","User":"root","TxnID":.*,"SessionID":.*`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"SELECT \* FROM .*\.t WHERE i = ‹6› OR ‹i› = ‹7›","Tag":"SELECT","User":"root","TxnReadTimestamp":.*,"TxnID":.*,"SessionID":.*`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
@@ -600,7 +599,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `SET transaction_rows_written_log = 2; SET transaction_rows_written_err = 3;`,
 			query:       `UPDATE t SET i = i - 10 WHERE i < 0`,
 			errRe:       `pq: txn has read 4 rows, which is above the limit: TxnID .* SessionID .*`,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"UPDATE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"UPDATE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: true,
 			channel:     channel.SQL_PERF,
 		},
@@ -608,7 +607,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `DROP TABLE t_copy`,
 			query:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"CREATE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"CREATE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
@@ -616,7 +615,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `DROP TABLE t_copy`,
 			query:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"CREATE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"CREATE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
@@ -624,7 +623,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `DROP TABLE t_copy`,
 			query:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"CREATE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"CREATE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
@@ -632,7 +631,7 @@ func TestPerfLogging(t *testing.T) {
 			cleanup:     `DROP TABLE t_copy`,
 			query:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"CREATE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"CREATE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
@@ -640,7 +639,7 @@ func TestPerfLogging(t *testing.T) {
 			setup:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			query:       `DROP TABLE t_copy`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"DROP.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"DROP.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
@@ -648,7 +647,7 @@ func TestPerfLogging(t *testing.T) {
 			setup:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			query:       `DROP TABLE t_copy`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"DROP.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"DROP.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
@@ -656,7 +655,7 @@ func TestPerfLogging(t *testing.T) {
 			setup:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			query:       `DROP TABLE t_copy`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_written_limit","Statement":"DROP.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_written_limit","Statement":"DROP.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
@@ -664,21 +663,21 @@ func TestPerfLogging(t *testing.T) {
 			setup:       `CREATE TABLE t_copy (i PRIMARY KEY) AS SELECT i FROM t`,
 			query:       `DROP TABLE t_copy`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"DROP.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"DROP.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
 		{
 			query:       `ANALYZE t`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"ANALYZE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"ANALYZE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_PERF,
 		},
 		{
 			query:       `ANALYZE t`,
 			errRe:       ``,
-			logRe:       `"EventType":"txn_rows_read_limit","Statement":"ANALYZE.*","TxnID":".*","SessionID":".*"`,
+			logRe:       `"EventType":"txn_rows_read_limit","Statement":"ANALYZE.*","TxnReadTimestamp":.*,"TxnID":".*","SessionID":".*"`,
 			logExpected: false,
 			channel:     channel.SQL_INTERNAL_PERF,
 		},
@@ -701,25 +700,26 @@ func TestPerfLogging(t *testing.T) {
 	// Make file sinks for the SQL perf logs.
 	sc := log.ScopeWithoutShowLogs(t)
 	defer sc.Close(t)
-	log.TestingResetActive()
-	cfg := logconfig.DefaultConfig()
-	auditable := true
-	cfg.Sinks.FileGroups = map[string]*logconfig.FileSinkConfig{
-		"sql-slow": {
-			FileDefaults: logconfig.FileDefaults{
-				CommonSinkConfig: logconfig.CommonSinkConfig{Auditable: &auditable},
-			},
-			Channels: logconfig.SelectChannels(channel.SQL_PERF, channel.SQL_INTERNAL_PERF),
+
+	logSpy := logtestutils.NewStructuredLogSpy(
+		t,
+		[]logpb.Channel{logpb.Channel_SQL_PERF, logpb.Channel_SQL_INTERNAL_PERF, logpb.Channel_SQL_EXEC},
+		[]string{
+			"txn_rows_written_limit",
+			"txn_rows_written_limit_internal",
+			"txn_rows_read_limit",
+			"txn_rows_read_limit_internal",
+			"large_row",
+			"large_row_internal",
+			"slow_query",
+			"slow_query_internal",
 		},
-	}
-	dir := sc.GetDirectory()
-	if err := cfg.Validate(&dir); err != nil {
-		t.Fatal(err)
-	}
-	cleanup, err := log.ApplyConfig(cfg, nil /* fileSinkMetricsForDir */, nil /* fatalOnLogStall */)
-	if err != nil {
-		t.Fatal(err)
-	}
+		func(entry logpb.Entry) (logpb.Entry, error) {
+			entry.Message = entry.Message[entry.StructuredStart:entry.StructuredEnd]
+			return entry, nil
+		},
+	)
+	cleanup := log.InterceptWith(ctx, logSpy)
 	defer cleanup()
 
 	// Start a SQL server.
@@ -727,7 +727,7 @@ func TestPerfLogging(t *testing.T) {
 	defer s.Stopper().Stop(context.Background())
 	// TODO(fqazi): Enable with MVCC back filler support, since max_row_size is
 	// not properly enforced right now.
-	_, err = sqlDB.Exec("SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer='off'")
+	_, err := sqlDB.Exec("SET CLUSTER SETTING sql.defaults.use_declarative_schema_changer='off'")
 	require.NoError(t, err)
 	_, err = sqlDB.Exec("SET use_declarative_schema_changer='off'")
 	require.NoError(t, err)
@@ -759,20 +759,24 @@ func TestPerfLogging(t *testing.T) {
 			t.Log("FOUND")
 		}
 		t.Log(tc.query)
-		start := timeutil.Now().UnixNano()
 		if tc.errRe != "" {
 			db.ExpectErr(t, tc.errRe, tc.query)
 		} else {
 			db.Exec(t, tc.query)
 		}
 
+		expectedChannel := tc.channel
+		if !log.ChannelCompatibilityModeEnabled.Get(&s.ClusterSettings().SV) {
+			expectedChannel = logpb.Channel_SQL_EXEC
+		}
+
 		var logRe = regexp.MustCompile(tc.logRe)
-		log.FlushFiles()
-		entries, err := log.FetchEntriesFromFiles(
-			start, math.MaxInt64, 1000, logRe, log.WithMarkedSensitiveData,
-		)
-		if err != nil {
-			t.Fatal(err)
+		events := logSpy.GetUnreadLogs(expectedChannel)
+		var entries []logpb.Entry
+		for _, e := range events {
+			if logRe.Match([]byte(e.Message)) {
+				entries = append(entries, e)
+			}
 		}
 		for _, l := range entries {
 			log.Infof(context.Background(), "%s", l.Message)
@@ -787,15 +791,6 @@ func TestPerfLogging(t *testing.T) {
 				"%v log messages for query `%s` matching `%s`, expected %s",
 				len(entries), tc.query, tc.logRe, expected,
 			))
-		}
-
-		for _, entry := range entries {
-			t.Log(entry)
-			if entry.Channel != tc.channel {
-				t.Fatal(errors.Newf(
-					"log message on channel %v, expected channel %v: %v", entry.Channel, tc.channel, entry,
-				))
-			}
 		}
 
 		if tc.cleanup != "" {

--- a/pkg/util/log/eventpb/sql_audit_events.proto
+++ b/pkg/util/log/eventpb/sql_audit_events.proto
@@ -86,6 +86,10 @@ message RoleBasedAuditEvent {
   string role = 4 [(gogoproto.jsontag) = ",omitempty"];
 }
 
+// TODO (#151948): Update channel from SQL_PERF to SQL_EXEC once the
+// `log.channel_compatibility_mode.enabled` cluster setting is set to false
+// by default and cluster setting is set for removal.
+
 // Category: SQL Slow Query Log
 // Channel: SQL_PERF
 //
@@ -95,6 +99,10 @@ message RoleBasedAuditEvent {
 // when the cluster setting `system.eventlog.enabled` is set. They
 // are only emitted via external logging.
 //
+// In version 26.1, these events will be moved to the `SQL_EXEC` channel.
+// To test compatability before this, set the cluster setting
+// `log.channel_compatibility_mode.enabled` to false. This will send the
+// events to `SQL_EXEC` instead of `SQL_PERF`.
 
 // SlowQuery is recorded when a query triggers the "slow query" condition.
 //
@@ -163,6 +171,10 @@ message TxnRowsReadLimit {
   CommonTxnRowsLimitDetails info = 3 [(gogoproto.nullable) = false, (gogoproto.jsontag) = "", (gogoproto.embed) = true];
 }
 
+// TODO (#151948): Update channel from SQL_INTERNAL_PERF to SQL_EXEC once the
+// `log.channel_compatibility_mode.enabled` cluster setting is set to false
+// by default and cluster setting is set for removal.
+
 // Category: SQL Slow Query Log (Internal)
 // Channel: SQL_INTERNAL_PERF
 //
@@ -173,6 +185,11 @@ message TxnRowsReadLimit {
 // Note: these events are not written to `system.eventlog`, even
 // when the cluster setting `system.eventlog.enabled` is set. They
 // are only emitted via external logging.
+//
+// In version 26.1, these events will be moved to the `SQL_EXEC` channel.
+// To test compatability before this, set the cluster setting
+// `log.channel_compatibility_mode.enabled` to false. This will send the
+// events to `SQL_EXEC` instead of `SQL_INTERNAL_PERF`.
 
 // SlowQueryInternal is recorded when a query triggers the "slow query" condition,
 // and the cluster setting `sql.log.slow_query.internal_queries.enabled` is


### PR DESCRIPTION
In v26.1, sql perf events will be moved from the SQL_PERF and
SQL_INTERNAL_PERF logging channel to the SQL_EXEC logging
channel.

This commit gates this migration under the cluster setting:
`log.channel_compatibility_mode.enabled` and will log these events
to the SQL_EXEC channel if this setting is set to false. Users can
set this setting to false in their clusters to validate, test, and
identify potential downstream impacts to their logging setups and
pipelines.

Epic: [CRDB-53410](https://cockroachlabs.atlassian.net/browse/CRDB-53410)
Part of: [CRDB-53412](https://cockroachlabs.atlassian.net/browse/CRDB-53412)
Release note (ops change): sql perf events will be moved to the
SQL_EXEC channel in 26.1. In order to test the impact of these
changes, users can set the setting:
`log.channel_compatibility_mode.enabled` to false. Note that this
will cause these logs to start logging in the SQL_EXEC channel so
this shouldn't be tested in a production environment.

----
Note: This is a stacked PR, only the last commit needs to be reviewed