### PR TITLE
release-25.3: status: add sys.host.net.send.tcp.retrans_segs (and friends)

### DIFF
--- a/docs/generated/metrics/metrics.yaml
+++ b/docs/generated/metrics/metrics.yaml
@@ -9837,6 +9837,86 @@ layers:
       derivative: NON_NEGATIVE_DERIVATIVE
       how_to_use: This metric measures the length of time, in seconds, that the CockroachDB process has been running. Monitor this metric to detect events such as node restarts, which may require investigation or intervention.
       essential: true
+  - name: NETWORKING
+    metrics:
+    - name: sys.host.net.send.tcp.fast_retrans_segs
+      exported_name: sys_host_net_send_tcp_fast_retrans_segs
+      description: |-
+        Segments retransmitted due to the fast retransmission mechanism in TCP.
+        Fast retransmissions occur when the sender learns that intermediate segments have been lost.
+      y_axis_label: Segments
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sys.host.net.send.tcp.loss_probes
+      exported_name: sys_host_net_send_tcp_loss_probes
+      description: |2-
+
+        Number of TCP tail loss probes sent. Loss probes are an optimization to detect
+        loss of the last packet earlier than the retransmission timer, and can indicate
+        network issues. Tail loss probes are aggressive, so the base rate is often nonzero
+        even in healthy networks.
+      y_axis_label: Probes
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sys.host.net.send.tcp.retrans_segs
+      exported_name: sys_host_net_send_tcp_retrans_segs
+      description: |2
+
+        The number of TCP segments retransmitted across all network interfaces.
+        This can indicate packet loss occurring in the network. However, it can
+        also be caused by recipient nodes not consuming packets in a timely manner,
+        or the local node overflowing its outgoing buffers, for example due to overload.
+
+        Retransmissions also occur in the absence of problems, as modern TCP stacks
+        err on the side of aggressively retransmitting segments.
+
+        The linux tool 'ss -i' can show the Linux kernel's smoothed view of round-trip
+        latency and variance on a per-connection basis.  Additionally, 'netstat -s'
+        shows all TCP counters maintained by the kernel.
+      y_axis_label: Segments
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+      how_to_use: |2
+
+        Phase changes, especially when occurring on groups of nodes, can indicate packet
+        loss in the network or a slow consumer of packets. On slow consumers, the
+        'sys.host.net.rcvd.drop' metric may be elevated; on overloaded senders, it
+        is worth checking the 'sys.host.net.send.drop' metric.
+        Additionally, the 'sys.host.net.send.tcp.*' may provide more insight into the
+        specific type of retransmission.
+      essential: true
+    - name: sys.host.net.send.tcp.slow_start_retrans
+      exported_name: sys_host_net_send_tcp_slow_start_retrans
+      description: |2
+
+        Number of TCP retransmissions in slow start. This can indicate that the network
+        is unable to support the initial fast ramp-up in window size, and can be a sign
+        of packet loss or congestion.
+      y_axis_label: Segments
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
+    - name: sys.host.net.send.tcp_timeouts
+      exported_name: sys_host_net_send_tcp_timeouts
+      description: |2
+
+        Number of TCP retransmission timeouts. These typically imply that a packet has
+        not been acknowledged within at least 200ms.  Modern TCP stacks use
+        optimizations such as fast retransmissions and loss probes to avoid hitting
+        retransmission timeouts. Anecdotally, they still occasionally present themselves
+        even in supposedly healthy cloud environments.
+      y_axis_label: Timeouts
+      type: COUNTER
+      unit: COUNT
+      aggregation: AVG
+      derivative: NON_NEGATIVE_DERIVATIVE
   - name: UNSET
     metrics:
     - name: build.timestamp

--- a/pkg/server/status/BUILD.bazel
+++ b/pkg/server/status/BUILD.bazel
@@ -157,6 +157,7 @@ go_test(
         "//pkg/settings/cluster",
         "//pkg/sql/sem/catconstants",
         "//pkg/testutils/serverutils",
+        "//pkg/testutils/skip",
         "//pkg/ts/tspb",
         "//pkg/ts/tsutil",
         "//pkg/util/hlc",
@@ -171,6 +172,7 @@ go_test(
         "@com_github_prometheus_client_model//go",
         "@com_github_prometheus_common//expfmt",
         "@com_github_shirou_gopsutil_v3//net",
+        "@com_github_stretchr_testify//assert",
         "@com_github_stretchr_testify//require",
     ],
 )

--- a/pkg/server/status/runtime_test.go
+++ b/pkg/server/status/runtime_test.go
@@ -9,12 +9,16 @@ import (
 	"context"
 	"math"
 	"reflect"
+	"runtime"
 	"runtime/metrics"
 	"testing"
 
+	"github.com/cockroachdb/cockroach/pkg/testutils/skip"
 	"github.com/cockroachdb/cockroach/pkg/util/hlc"
 	"github.com/cockroachdb/cockroach/pkg/util/leaktest"
+	"github.com/kr/pretty"
 	"github.com/shirou/gopsutil/v3/net"
+	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 )
 
@@ -134,35 +138,47 @@ func TestSubtractDiskCounters(t *testing.T) {
 func TestSubtractNetCounters(t *testing.T) {
 	defer leaktest.AfterTest(t)()
 
-	from := net.IOCountersStat{
-		PacketsRecv: 3,
-		BytesRecv:   3,
-		Errin:       2,
-		Dropin:      2,
-		BytesSent:   3,
-		PacketsSent: 3,
-		Errout:      2,
-		Dropout:     2,
+	from := netCounters{
+		IOCounters: net.IOCountersStat{
+			PacketsRecv: 3,
+			BytesRecv:   3,
+			Errin:       2,
+			Dropin:      2,
+			BytesSent:   3,
+			PacketsSent: 3,
+			Errout:      2,
+			Dropout:     2,
+		},
+		TCPRetransSegs: 12,
+		TCPFastRetrans: 10,
 	}
-	sub := net.IOCountersStat{
-		PacketsRecv: 1,
-		BytesRecv:   1,
-		Errin:       1,
-		Dropin:      1,
-		BytesSent:   1,
-		PacketsSent: 1,
-		Errout:      1,
-		Dropout:     1,
+	sub := netCounters{
+		IOCounters: net.IOCountersStat{
+			PacketsRecv: 1,
+			BytesRecv:   1,
+			Errin:       1,
+			Dropin:      1,
+			BytesSent:   1,
+			PacketsSent: 1,
+			Errout:      1,
+			Dropout:     1,
+		},
+		TCPRetransSegs: 9,
+		TCPFastRetrans: 4,
 	}
-	expected := net.IOCountersStat{
-		BytesRecv:   2,
-		PacketsRecv: 2,
-		Dropin:      1,
-		Errin:       1,
-		BytesSent:   2,
-		PacketsSent: 2,
-		Errout:      1,
-		Dropout:     1,
+	expected := netCounters{
+		IOCounters: net.IOCountersStat{
+			BytesRecv:   2,
+			PacketsRecv: 2,
+			Dropin:      1,
+			Errin:       1,
+			BytesSent:   2,
+			PacketsSent: 2,
+			Errout:      1,
+			Dropout:     1,
+		},
+		TCPRetransSegs: 3,
+		TCPFastRetrans: 6,
 	}
 	subtractNetworkCounters(&from, sub)
 	if !reflect.DeepEqual(from, expected) {
@@ -209,4 +225,99 @@ func TestSampleEnvironment(t *testing.T) {
 	s.SampleEnvironment(ctx, cgoStats)
 
 	require.GreaterOrEqual(t, s.HostCPUCombinedPercentNorm.Value(), s.CPUCombinedPercentNorm.Value())
+}
+
+func TestNetworkStatsLinux(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	if runtime.GOOS != "linux" {
+		skip.IgnoreLint(t, "network stats only supported on linux")
+	}
+
+	nc, err := getSummedNetStats(context.Background())
+	require.NoError(t, err)
+	// Verify that we don't see -1 for TCPRetransSegs, which would indicate that
+	// the RetransSegs metric is not supported on this linux system.
+	require.LessOrEqual(t, int64(0), nc.TCPRetransSegs)
+	require.LessOrEqual(t, int64(0), nc.TCPFastRetrans)
+}
+
+// A real file grabbed from a linux system under 10% packet loss.
+const procNetStat = `
+TcpExt: SyncookiesSent SyncookiesRecv SyncookiesFailed EmbryonicRsts PruneCalled RcvPruned OfoPruned OutOfWindowIcmps LockDroppedIcmps ArpFilter TW TWRecycled TWKilled PAWSActive PAWSEstab DelayedACKs DelayedACKLocked DelayedACKLost ListenOverflows ListenDrops TCPHPHits TCPPureAcks TCPHPAcks TCPRenoRecovery TCPSackRecovery TCPSACKReneging TCPSACKReorder TCPRenoReorder TCPTSReorder TCPFullUndo TCPPartialUndo TCPDSACKUndo TCPLossUndo TCPLostRetransmit TCPRenoFailures TCPSackFailures TCPLossFailures TCPFastRetrans TCPSlowStartRetrans TCPTimeouts TCPLossProbes TCPLossProbeRecovery TCPRenoRecoveryFail TCPSackRecoveryFail TCPRcvCollapsed TCPBacklogCoalesce TCPDSACKOldSent TCPDSACKOfoSent TCPDSACKRecv TCPDSACKOfoRecv TCPAbortOnData TCPAbortOnClose TCPAbortOnMemory TCPAbortOnTimeout TCPAbortOnLinger TCPAbortFailed TCPMemoryPressures TCPMemoryPressuresChrono TCPSACKDiscard TCPDSACKIgnoredOld TCPDSACKIgnoredNoUndo TCPSpuriousRTOs TCPMD5NotFound TCPMD5Unexpected TCPMD5Failure TCPSackShifted TCPSackMerged TCPSackShiftFallback TCPBacklogDrop PFMemallocDrop TCPMinTTLDrop TCPDeferAcceptDrop IPReversePathFilter TCPTimeWaitOverflow TCPReqQFullDoCookies TCPReqQFullDrop TCPRetransFail TCPRcvCoalesce TCPOFOQueue TCPOFODrop TCPOFOMerge TCPChallengeACK TCPSYNChallenge TCPFastOpenActive TCPFastOpenActiveFail TCPFastOpenPassive TCPFastOpenPassiveFail TCPFastOpenListenOverflow TCPFastOpenCookieReqd TCPFastOpenBlackhole TCPSpuriousRtxHostQueues BusyPollRxPackets TCPAutoCorking TCPFromZeroWindowAdv TCPToZeroWindowAdv TCPWantZeroWindowAdv TCPSynRetrans TCPOrigDataSent TCPHystartTrainDetect TCPHystartTrainCwnd TCPHystartDelayDetect TCPHystartDelayCwnd TCPACKSkippedSynRecv TCPACKSkippedPAWS TCPACKSkippedSeq TCPACKSkippedFinWait2 TCPACKSkippedTimeWait TCPACKSkippedChallenge TCPWinProbe TCPKeepAlive TCPMTUPFail TCPMTUPSuccess TCPDelivered TCPDeliveredCE TCPAckCompressed TCPZeroWindowDrop TCPRcvQDrop TCPWqueueTooBig TCPFastOpenPassiveAltKey TcpTimeoutRehash TcpDuplicateDataRehash TCPDSACKRecvSegs TCPDSACKIgnoredDubious TCPMigrateReqSuccess TCPMigrateReqFailure TCPPLBRehash
+TcpExt: 0 0 0 99 0 0 0 5 0 0 4156 0 0 0 2 392423 218 4330 0 2 8462987 6021614 28236625 0 82 0 1532 1 51 13 23 34 581 194 0 1 2 2379 15 870 4552 262 0 0 0 183582 4322 1 4786 0 48 40 0 86 0 0 0 0 0 0 3938 0 0 0 0 728 1437 3775 0 0 0 0 0 0 0 0 5 24433719 86 0 1 0 0 0 0 0 0 0 0 0 2 0 24910503 11 11 43 70 160859949 243 18791 3 1074 6 1 1169 0 0 0 0 18437 0 0 160868740 0 0 0 0 0 0 844 36 4848 0 0 0 0
+IpExt: InNoRoutes InTruncatedPkts InMcastPkts OutMcastPkts InBcastPkts OutBcastPkts InOctets OutOctets InMcastOctets OutMcastOctets InBcastOctets OutBcastOctets InCsumErrors InNoECTPkts InECT1Pkts InECT0Pkts InCEPkts ReasmOverlaps
+IpExt: 0 0 0 0 0 0 374286811874 177053817186 0 0 0 0 0 106137015 0 0 0 0
+MPTcpExt: MPCapableSYNRX MPCapableSYNTX MPCapableSYNACKRX MPCapableACKRX MPCapableFallbackACK MPCapableFallbackSYNACK MPFallbackTokenInit MPTCPRetrans MPJoinNoTokenFound MPJoinSynRx MPJoinSynAckRx MPJoinSynAckHMacFailure MPJoinAckRx MPJoinAckHMacFailure DSSNotMatching InfiniteMapTx InfiniteMapRx DSSNoMatchTCP DataCsumErr OFOQueueTail OFOQueue OFOMerge NoDSSInWindow DuplicateData AddAddr AddAddrTx AddAddrTxDrop EchoAdd EchoAddTx EchoAddTxDrop PortAdd AddAddrDrop MPJoinPortSynRx MPJoinPortSynAckRx MPJoinPortAckRx MismatchPortSynRx MismatchPortAckRx RmAddr RmAddrDrop RmAddrTx RmAddrTxDrop RmSubflow MPPrioTx MPPrioRx MPFailTx MPFailRx MPFastcloseTx MPFastcloseRx MPRstTx MPRstRx RcvPruned SubflowStale SubflowRecover SndWndShared RcvWndShared RcvWndConflictUpdate RcvWndConflict
+MPTcpExt: 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0 0
+`
+
+func TestNetworkStatsFixture(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	{
+		orig := mockableMaybeReadProcStatFile
+		mockableMaybeReadProcStatFile = func(ctx context.Context, protocol, path string) (map[string]int64, error) {
+			require.Equal(t, "TcpExt", protocol)
+			return parseProcStatFile(ctx, protocol, []byte(procNetStat))
+		}
+		defer func() { mockableMaybeReadProcStatFile = orig }()
+	}
+
+	ctx := context.Background()
+	nc, err := getSummedNetStats(ctx)
+	require.NoError(t, err)
+	nc.IOCounters = net.IOCountersStat{}
+	nc.TCPRetransSegs = -1 // comes from gops, only works on linux, so override
+	exp := netCounters{
+		TCPRetransSegs:      -1, // not tested here
+		TCPFastRetrans:      2379,
+		TCPTimeouts:         870,
+		TCPSlowStartRetrans: 15,
+		TCPLossProbes:       4552,
+	}
+	require.Equal(t, exp, nc, "%s", pretty.Diff(exp, nc))
+}
+
+func TestParseProcStatFile(t *testing.T) {
+	defer leaktest.AfterTest(t)()
+
+	ctx := context.Background()
+
+	t.Run("success", func(t *testing.T) {
+		stats, err := parseProcStatFile(ctx, "TcpExt", []byte(procNetStat))
+		require.NoError(t, err)
+		require.NotNil(t, stats)
+		t.Log(stats)
+		assert.Zero(t, stats["SynCookiesSent"])
+		assert.Equal(t, int64(2379), stats["TCPFastRetrans"])
+		assert.Equal(t, int64(194), stats["TCPLostRetransmit"])
+		assert.Zero(t, stats["InOctets"]) // since protocol != IpExt
+	})
+
+	t.Run("protocol-not-found", func(t *testing.T) {
+		stats, err := parseProcStatFile(ctx, "UdpExt", []byte(procNetStat))
+		require.NoError(t, err)
+		require.Nil(t, stats)
+	})
+
+	t.Run("malformed-mismatch", func(t *testing.T) {
+		badData := `
+TcpExt: a b
+TcpExt: 1
+`
+		_, err := parseProcStatFile(ctx, "TcpExt", []byte(badData))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "mismatch between headers and values")
+	})
+
+	t.Run("malformed-parse-err", func(t *testing.T) {
+		badData := `
+TcpExt: a
+TcpExt: b
+`
+		_, err := parseProcStatFile(ctx, "TcpExt", []byte(badData))
+		require.Error(t, err)
+		require.Contains(t, err.Error(), "could not parse value")
+	})
 }


### PR DESCRIPTION
Backport 1/1 commits from #149928.

/cc @cockroachdb/release

---

`retrans_segs` tracks TCP segments retransmitted for any reason. Please refer
to the help text of the metric, the (internal) [talk], and the excellent
[post by Arthur Chiao].

[talk]: https://cockroachlabs.slack.com/archives/C05B1BPMJLE/p1752780299376659
[post by Arthur Chiao]: http://arthurchiao.art/blog/tcp-retransmission-may-be-misleading/

A number of additional metrics have been added. They all have in common that
they break up the retrans_segs metric, i.e. they can possibly allow us to dig
deeper.

These metrics are parsed from /proc/net/netstat (and /proc/net/snmp, via
`gops`), so they're only supported on linux. When not supported, these
counters will remain at a value of -1.

Fixes https://github.com/cockroachdb/cockroach/issues/149598.

Epic: none
Release note: the `sys.host.net.send.tcp.retrans_segs` metric has been added, alongside a number of additional TCP metrics. These can be useful to diagnose network issues.

Release justification: add more network observability to older versions