### PR TITLE
kvserver: two possible changes to fix interactions between RC and SI

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/repro151663
+++ b/pkg/ccl/logictestccl/testdata/logic_test/repro151663
@@ -1,0 +1,87 @@
+statement ok
+CREATE TABLE parent_150282 (
+  p INT PRIMARY KEY,
+  i INT,
+  j INT,
+  INDEX (i),
+  INDEX (j),
+  FAMILY (p, i, j)
+);
+
+statement ok
+CREATE TABLE child_150282 (
+  c INT PRIMARY KEY,
+  p INT REFERENCES parent_150282 (p) ON DELETE CASCADE ON UPDATE CASCADE,
+  INDEX (p),
+  FAMILY (c, p)
+);
+
+statement ok
+GRANT ALL ON TABLE parent_150282 TO testuser;
+
+statement ok
+GRANT ALL ON TABLE child_150282 TO testuser;
+
+statement ok
+INSERT INTO parent_150282 VALUES (1, 2, 3);
+
+user root
+
+# statement ok
+# SET kv_transaction_buffered_writes_enabled = off
+
+# statement ok
+# SET tracing = on
+
+statement ok
+BEGIN TRANSACTION ISOLATION LEVEL READ COMMITTED
+
+statement ok
+SELECT 1;
+
+statement async fk_delete
+WITH sleep AS (SELECT pg_sleep(1)) DELETE FROM parent_150282@parent_150282_i_idx WHERE i = 2;
+
+user testuser
+
+# statement ok
+# SET kv_transaction_buffered_writes_enabled = off
+
+# statement ok
+# SET tracing = on
+
+statement async fkinsert error pgcode 23503 pq: insert on table "child_150282" violates foreign key constraint "child_150282_p_fkey"
+INSERT INTO child_150282 VALUES (4, 1);
+
+user root
+
+awaitstatement fk_delete
+
+statement ok
+COMMIT;
+
+# statement ok
+# SET tracing = off
+
+# query TTT nosort
+# SELECT timestamp, tag, message FROM [SHOW TRACE FOR SESSION]
+# ----
+
+user testuser
+
+awaitstatement fkinsert
+
+# statement ok
+# SET tracing = off
+
+query III
+SELECT * FROM parent_150282;
+----
+
+query II
+SELECT * FROM child_150282;
+----
+
+# query TTT nosort
+# SELECT timestamp, tag, message FROM [SHOW TRACE FOR SESSION]
+# ----

--- a/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/3node-tenant/generated_test.go
@@ -2759,6 +2759,13 @@ func TestTenantLogic_zone_config(
 	runLogicTest(t, "zone_config")
 }
 
+func TestTenantLogicCCL_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestTenantLogicCCL_cluster_locks_tenant(
 	t *testing.T,
 ) {
@@ -2939,6 +2946,13 @@ func TestTenantLogicCCL_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestTenantLogicCCL_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestTenantLogicCCL_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 36,
+    shard_count = 38,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-disk/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -241,6 +248,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 36,
+    shard_count = 38,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist-vec-off/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -241,6 +248,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/fakedist/BUILD.bazel
@@ -12,7 +12,7 @@ go_test(
         "//build/toolchains:is_heavy": {"test.Pool": "heavy"},
         "//conditions:default": {"test.Pool": "large"},
     }),
-    shard_count = 37,
+    shard_count = 39,
     tags = ["cpu:2"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/fakedist/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -248,6 +255,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 34,
+    shard_count = 36,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-legacy-schema-changer/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -234,6 +241,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 33,
+    shard_count = 35,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.2/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_fips_ready(
 	t *testing.T,
 ) {
@@ -220,6 +227,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.3/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.3/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 36,
+    shard_count = 38,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-mixed-25.3/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-mixed-25.3/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -241,6 +248,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-read-committed/generated_test.go
@@ -2736,6 +2736,13 @@ func TestReadCommittedLogic_zone_config_system_tenant(
 	runLogicTest(t, "zone_config_system_tenant")
 }
 
+func TestReadCommittedLogicCCL_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestReadCommittedLogicCCL_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -2902,6 +2909,13 @@ func TestReadCommittedLogicCCL_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestReadCommittedLogicCCL_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestReadCommittedLogicCCL_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-repeatable-read/generated_test.go
@@ -2722,6 +2722,13 @@ func TestRepeatableReadLogic_zone_config_system_tenant(
 	runLogicTest(t, "zone_config_system_tenant")
 }
 
+func TestRepeatableReadLogicCCL_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestRepeatableReadLogicCCL_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -2888,6 +2895,13 @@ func TestRepeatableReadLogicCCL_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestRepeatableReadLogicCCL_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestRepeatableReadLogicCCL_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/BUILD.bazel
@@ -9,7 +9,7 @@ go_test(
         "//pkg/ccl/logictestccl:testdata",  # keep
     ],
     exec_properties = {"test.Pool": "large"},
-    shard_count = 36,
+    shard_count = 38,
     tags = ["cpu:1"],
     deps = [
         "//pkg/base",

--- a/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local-vec-off/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_buffered_writes_lock_loss(
 	t *testing.T,
 ) {
@@ -241,6 +248,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_schema_change_in_txn(

--- a/pkg/ccl/logictestccl/tests/local/generated_test.go
+++ b/pkg/ccl/logictestccl/tests/local/generated_test.go
@@ -75,6 +75,13 @@ func TestLogic_tmp(t *testing.T) {
 	logictest.RunLogicTests(t, logictest.TestServerArgs{}, configIdx, glob)
 }
 
+func TestCCLLogic_2tmp(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "2tmp")
+}
+
 func TestCCLLogic_as_of(
 	t *testing.T,
 ) {
@@ -332,6 +339,13 @@ func TestCCLLogic_refcursor(
 ) {
 	defer leaktest.AfterTest(t)()
 	runCCLLogicTest(t, "refcursor")
+}
+
+func TestCCLLogic_repro151663(
+	t *testing.T,
+) {
+	defer leaktest.AfterTest(t)()
+	runCCLLogicTest(t, "repro151663")
 }
 
 func TestCCLLogic_restore(

--- a/pkg/kv/kvserver/batcheval/BUILD.bazel
+++ b/pkg/kv/kvserver/batcheval/BUILD.bazel
@@ -65,6 +65,7 @@ go_library(
         "//pkg/kv/kvserver/abortspan",
         "//pkg/kv/kvserver/batcheval/result",
         "//pkg/kv/kvserver/concurrency",
+        "//pkg/kv/kvserver/concurrency/isolation",
         "//pkg/kv/kvserver/concurrency/lock",
         "//pkg/kv/kvserver/gc",
         "//pkg/kv/kvserver/intentresolver",

--- a/pkg/kv/kvserver/replica_write.go
+++ b/pkg/kv/kvserver/replica_write.go
@@ -173,7 +173,11 @@ func (r *Replica) executeWriteBatch(
 			}
 		}()
 	}
-	log.Event(ctx, "applied timestamp cache")
+	if ba.Txn != nil {
+		log.Eventf(ctx, "applied timestamp cache at wts %s", ba.Txn.WriteTimestamp)
+	} else {
+		log.Eventf(ctx, "applied timestamp cache at ts %s", ba.Timestamp)
+	}
 
 	// Checking the context just before proposing can help avoid ambiguous errors.
 	if err := ctx.Err(); err != nil {

--- a/pkg/sql/insert_fast_path.go
+++ b/pkg/sql/insert_fast_path.go
@@ -8,6 +8,7 @@ package sql
 import (
 	"context"
 	"sync"
+	"time"
 
 	"github.com/cockroachdb/cockroach/pkg/kv/kvpb"
 	"github.com/cockroachdb/cockroach/pkg/kv/kvserver/concurrency/lock"
@@ -519,6 +520,11 @@ func (n *insertFastPathNode) BatchedNext(params runParams) (bool, error) {
 			return false, err
 		}
 	}
+
+	if n.run.ti.ri.Helper.TableDesc.GetName() == "child_150282" {
+		time.Sleep(2 * time.Second)
+	}
+
 	n.run.ti.setRowsWrittenLimit(params.extendedEvalCtx.SessionData())
 	if err := n.run.ti.finalize(params.ctx); err != nil {
 		return false, err


### PR DESCRIPTION
1. when updating the timestamp cache, use the write timestamp for locked reads

2. disallow PushTxn requests on non-serializable transactions

Informs: #151663

Release note: None