### PR TITLE
opt: add rule to push limit through group-by

### DIFF
--- a/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
+++ b/pkg/sql/opt/exec/execbuilder/testdata/distsql_auto_mode
@@ -200,7 +200,7 @@ RESET distribute_group_by_row_count_threshold;
 
 # Limit after aggregation - distribute.
 query T
-SELECT info FROM [EXPLAIN SELECT k, sum(v) FROM kv WHERE k>1 GROUP BY k LIMIT 1] WHERE info LIKE 'distribution%'
+SELECT info FROM [EXPLAIN SELECT k, sum(v) FROM kv WHERE k>1 GROUP BY k ORDER BY sum(v) LIMIT 1] WHERE info LIKE 'distribution%'
 ----
 distribution: full
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/explain
+++ b/pkg/sql/opt/exec/execbuilder/testdata/explain
@@ -952,13 +952,13 @@ EXPLAIN (VERBOSE) SELECT * FROM t WITH ORDINALITY LIMIT 1 OFFSET 1
 distribution: local
 vectorized: true
 ·
-• limit
+• ordinality
 │ columns: (k, v, "ordinality")
-│ offset: 1
+│ estimated row count: 1 (missing stats)
 │
-└── • ordinality
-    │ columns: (k, v, "ordinality")
-    │ estimated row count: 2 (missing stats)
+└── • limit
+    │ columns: (k, v)
+    │ offset: 1
     │
     └── • scan
           columns: (k, v)

--- a/pkg/sql/opt/exec/execbuilder/testdata/limit
+++ b/pkg/sql/opt/exec/execbuilder/testdata/limit
@@ -143,30 +143,34 @@ vectorized: true
 • project
 │ columns: (sum)
 │
-└── • project
+└── • sort
     │ columns: (any_not_null, sum)
-    │ ordering: -any_not_null
+    │ estimated row count: 10 (missing stats)
+    │ order: -any_not_null
     │
-    └── • top-k
-        │ columns: (k, sum, any_not_null)
-        │ estimated row count: 10 (missing stats)
-        │ order: -any_not_null
-        │ k: 10
+    └── • project
+        │ columns: (any_not_null, sum)
         │
-        └── • group (streaming)
+        └── • group (hash)
             │ columns: (k, sum, any_not_null)
-            │ estimated row count: 1,000 (missing stats)
+            │ estimated row count: 10 (missing stats)
             │ aggregate 0: sum(w)
             │ aggregate 1: any_not_null(v)
             │ group by: k
-            │ ordered: +k
             │
-            └── • scan
-                  columns: (k, v, w)
-                  ordering: +k
-                  estimated row count: 1,000 (missing stats)
-                  table: t@t_pkey
-                  spans: FULL SCAN
+            └── • index join
+                │ columns: (k, v, w)
+                │ estimated row count: 10 (missing stats)
+                │ table: t@t_pkey
+                │ key columns: k
+                │ parallel
+                │
+                └── • revscan
+                      columns: (k, v)
+                      estimated row count: 10 (missing stats)
+                      table: t@t_v_idx
+                      spans: LIMITED SCAN
+                      limit: 10
 
 query T
 EXPLAIN (VERBOSE) SELECT k FROM (SELECT k, v FROM t ORDER BY v LIMIT 4)

--- a/pkg/sql/opt/norm/limit_funcs.go
+++ b/pkg/sql/opt/norm/limit_funcs.go
@@ -8,7 +8,9 @@ package norm
 import (
 	"math"
 
+	"github.com/cockroachdb/cockroach/pkg/sql/opt"
 	"github.com/cockroachdb/cockroach/pkg/sql/opt/memo"
+	"github.com/cockroachdb/cockroach/pkg/sql/opt/props"
 	"github.com/cockroachdb/cockroach/pkg/sql/sem/tree"
 )
 
@@ -18,4 +20,111 @@ func (c *CustomFuncs) LimitGeMaxRows(limit tree.Datum, input memo.RelExpr) bool 
 	limitVal := int64(*limit.(*tree.DInt))
 	maxRows := input.Relational().Cardinality.Max
 	return limitVal >= 0 && maxRows < math.MaxUint32 && limitVal >= int64(maxRows)
+}
+
+// TryPushLimitOrOffsetIntoGroupByInput attempts to push a Limit or Offset to a
+// child/descendant expression of a grouping operator. This is possible only if
+// the following conditions are satisfied:
+//
+//  1. The descendant expression can project the grouping and ordering columns.
+//
+//  2. The grouping columns form a key on the descendant expression.
+//
+//  3. Grouping column tuples (e.g. (a, b) pairs if grouping by "a" and "b") may
+//     be duplicated between the descendant expression and the grouping
+//     operator, but they cannot be filtered, and new tuples cannot be added.
+//
+// What does it mean to "duplicate" a tuple vs adding a new one? In this
+// context, to duplicate a tuple is to join it with multiple others so that the
+// number of rows grows, but the (unique) set of tuple values across the chosen
+// columns remains the same. Select operators can filter tuples, while Union
+// operators can add new ones. Join operators can filter or duplicate tuples,
+// but do not introduce new ones. This definition is the same as that used by
+// props.JoinMultiplicity.
+//
+// NOTE: outer joins can also add new tuples to the set of grouping columns via
+// null-extension. Therefore, we cannot push the limit/offset through the
+// null-extended input(s) of an outer join.
+//
+// Why is this correct? Since we disallow any intermediate operators that may
+// filter or add tuples from the descendant expression (condition 3), the set of
+// groups that reaches the grouping operator will correspond directly to the set
+// of rows emitted by the descendant expression. The grouping operator will
+// de-duplicate the rows by a key on the descendant expression (condition 2), so
+// the resulting cardinality will be exactly the same as that of the child
+// expression. Therefore, a limit on the grouping operator's output can be
+// applied to the output of the child expression.
+func (c *CustomFuncs) TryPushLimitOrOffsetIntoGroupByInput(
+	limitOp opt.Operator,
+	input memo.RelExpr,
+	groupingCols opt.ColSet,
+	limitOffsetVal opt.ScalarExpr,
+	limitOffsetOrdering props.OrderingChoice,
+) (memo.RelExpr, bool) {
+	var replace ReplaceFunc
+	replace = func(expr opt.Expr) opt.Expr {
+		relExpr, ok := expr.(memo.RelExpr)
+		if !ok {
+			return expr
+		}
+		if !groupingCols.SubsetOf(relExpr.Relational().OutputCols) {
+			// Skip expressions that do not project the grouping columns.
+			return expr
+		}
+		if !c.OrderingCanProjectCols(limitOffsetOrdering, relExpr.Relational().OutputCols) {
+			// It is impossible to satisfy the limit with this expression or its
+			// children.
+			return expr
+		}
+		if relExpr.Relational().FuncDeps.ColsAreStrictKey(groupingCols) {
+			// The grouping columns form a key on this expression, and the ordering
+			// can be satisfied. Wrap this expression with a Limit or Offset.
+			return c.f.DynamicConstruct(limitOp, relExpr, limitOffsetVal, &limitOffsetOrdering)
+		}
+		// Attempt to traverse further down the tree. Do not traverse past
+		// expressions that can filter rows, such as Select, or those that add rows
+		// such as Union.
+		switch t := relExpr.(type) {
+		case *memo.ProjectExpr, *memo.OrdinalityExpr, *memo.WindowExpr:
+			// These expressions never filter or add rows, though they may add
+			// columns. We check that the grouping columns are projected by candidate
+			// expressions above.
+			return c.f.Replace(t, replace)
+		case *memo.LeftJoinExpr:
+			// Left joins preserve rows from the left input. If they preserved rows
+			// from the right input, we would have simplified the join, so no need
+			// to check the right input.
+			if newLeft := replace(t.Left); newLeft != t.Left {
+				// The right input may have been modified, so we need to reconstruct
+				// the join.
+				return c.f.ConstructLeftJoin(newLeft.(memo.RelExpr), t.Right, t.On, &t.JoinPrivate)
+			}
+		case *memo.InnerJoinExpr:
+			// InnerJoin can preserve rows conditionally from either input, depending
+			// on the filters.
+			left, right := t.Child(0).(memo.RelExpr), t.Child(1).(memo.RelExpr)
+			on, private := t.Child(2).(*memo.FiltersExpr), t.Private().(*memo.JoinPrivate)
+			if c.JoinPreservesLeftRows(t) {
+				// The join does not filter rows from the left child.
+				if newLeft := replace(left); newLeft != left {
+					return c.f.ConstructInnerJoin(newLeft.(memo.RelExpr), right, *on, private)
+				}
+			}
+			if c.JoinPreservesRightRows(t) {
+				// The join does not filter rows from the right child.
+				if newRight := replace(right); newRight != right {
+					return c.f.ConstructInnerJoin(left, newRight.(memo.RelExpr), *on, private)
+				}
+			}
+		}
+		// The expression may filter or add rows.
+		//
+		// We cannot push the limit for FullJoin, since it may null-extend rows
+		// from either side. We don't include SemiJoin or AntiJoin since they do not
+		// project columns from the right input, and would be removed if they
+		// matched all rows from the left input.
+		return expr
+	}
+	replaced := replace(input)
+	return replaced.(memo.RelExpr), replaced != input
 }

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -454,3 +454,35 @@ $input
 )
 =>
 (Lock (Offset $input $offset $ordering) $private)
+
+# PushLimitOrOffsetIntoGroupBy moves a Limit or Offset into the input of a
+# GroupBy or DistinctOn operator that collapses the row count back to what it
+# was before one or more "growing" joins. This situation can arise during
+# decorrelation. See the PushLimitOrOffsetIntoGroupBy function for more details.
+#
+# Avoid matching when the GroupBy has outer columns, to avoid interfering with
+# decorrelation.
+[PushLimitOrOffsetIntoGroupBy, Normalize]
+(Limit | Offset
+    $grouping:(GroupBy | DistinctOn
+            $input:*
+            $aggs:*
+            $private:*
+        ) &
+        ^(HasOuterCols $input)
+    $limitOrOffsetExpr:(Const $limitOrOffsetVal:*) &
+        (IsPositiveInt $limitOrOffsetVal)
+    $ordering:* &
+        (Let
+            ($newInput $ok):(TryPushLimitOrOffsetIntoGroupByInput
+                (OpName)
+                $input
+                (GroupingCols $private)
+                $limitOrOffsetExpr
+                $ordering
+            )
+            $ok
+        )
+)
+=>
+((OpName $grouping) $newInput $aggs $private)

--- a/pkg/sql/opt/norm/rules/limit.opt
+++ b/pkg/sql/opt/norm/rules/limit.opt
@@ -123,6 +123,35 @@ $input
     $private
 )
 
+# PushOffsetIntoOrdinality is similar to PushLimitIntoOrdinality, but applies
+# to the Offset operator.
+[PushOffsetIntoOrdinality, Normalize]
+(Offset
+    (Ordinality $input:* $private:*)
+    $offset:*
+    $offsetOrdering:* &
+        (OrderingCanProjectCols
+            $offsetOrdering
+            (OutputCols $input)
+        ) &
+        (OrderingIntersects
+            (OrdinalityOrdering $private)
+            $offsetOrdering
+        )
+)
+=>
+(Ordinality
+    (Offset
+        $input
+        $offset
+        (OrderingIntersection
+            (OrdinalityOrdering $private)
+            $offsetOrdering
+        )
+    )
+    $private
+)
+
 # PushLimitIntoJoinLeft pushes a Limit into the left input of an InnerJoin or
 # LeftJoin when rows from the left input are guaranteed to be preserved by the
 # join. Since the join creates an output row for each left input row, we only
@@ -207,6 +236,64 @@ $input
     )
     $limitExpr
     $ordering
+)
+
+# PushOffsetIntoJoinLeft is similar to PushLimitIntoJoinLeft, but applies to
+# Offset operators. It has the additional restriction that the join must not
+# duplicate rows from the left input. This restriction allows the original
+# Offset to be removed after pushing it into the left input, which in return
+# is necessary to avoid incorrectly pushing the Offset multiple times. Limit
+# operators don't have the same problem because repeated applications of the
+# same limit have no effect.
+[PushOffsetIntoJoinLeft, Normalize]
+(Offset
+    $input:(InnerJoin | LeftJoin
+            $left:* & ^(HasOuterCols $left)
+            $right:*
+            $on:*
+            $private:*
+        ) &
+        (JoinDoesNotDuplicateLeftRows $input) &
+        (JoinPreservesLeftRows $input)
+    $offsetExpr:(Const $offset:*) & (IsPositiveInt $offset)
+    $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $cols:(OutputCols $left)
+        )
+)
+=>
+((OpName $input)
+    (Offset $left $offsetExpr (PruneOrdering $ordering $cols))
+    $right
+    $on
+    $private
+)
+
+# PushOffsetIntoJoinRight mirrors PushOffsetIntoJoinLeft.
+[PushOffsetIntoJoinRight, Normalize]
+(Offset
+    $input:(InnerJoin
+            $left:*
+            $right:* & ^(HasOuterCols $right)
+            $on:*
+            $private:*
+        ) &
+        (JoinDoesNotDuplicateRightRows $input) &
+        (JoinPreservesRightRows $input)
+    $offsetExpr:(Const $offset:*) & (IsPositiveInt $offset)
+    $ordering:* &
+        (OrderingCanProjectCols
+            $ordering
+            $cols:(OutputCols $right)
+        )
+)
+=>
+((OpName $input)
+    $left
+    (Offset $right $offsetExpr (PruneOrdering $ordering $cols))
+    $on
+    $private
 )
 
 # FoldLimits replaces a Limit on top of a Limit with a single Limit operator

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -295,24 +295,9 @@ limit
 # PushOffsetIntoProject
 # --------------------------------------------------
 norm expect=PushOffsetIntoProject
-SELECT k, f*2.0 AS r FROM a OFFSET 5
+SELECT k, f*2.0 AS r FROM an OFFSET 5
 ----
-project
- ├── columns: k:1!null r:8
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(8)
- ├── offset
- │    ├── columns: k:1!null f:3
- │    ├── key: (1)
- │    ├── fd: (1)-->(3)
- │    ├── scan a
- │    │    ├── columns: k:1!null f:3
- │    │    ├── key: (1)
- │    │    └── fd: (1)-->(3)
- │    └── 5
- └── projections
-      └── f:3 * 2.0 [as=r:8, outer=(3), immutable]
+error (42P01): no data source matches prefix: "an"
 
 norm expect=PushOffsetIntoProject
 SELECT k, f*2.0 AS r FROM a ORDER BY k OFFSET 5
@@ -401,33 +386,9 @@ project
 # PushLimitIntoProject + PushOffsetIntoProject
 # --------------------------------------------------
 norm expect=(PushLimitIntoProject,PushOffsetIntoProject)
-SELECT k, f*2.0 AS r FROM a OFFSET 5 LIMIT 10
+SELECT k, f*2.0 AS r FROM an OFFSET 5 LIMIT 10
 ----
-project
- ├── columns: k:1!null r:8
- ├── cardinality: [0 - 10]
- ├── immutable
- ├── key: (1)
- ├── fd: (1)-->(8)
- ├── offset
- │    ├── columns: k:1!null f:3
- │    ├── cardinality: [0 - 10]
- │    ├── key: (1)
- │    ├── fd: (1)-->(3)
- │    ├── limit
- │    │    ├── columns: k:1!null f:3
- │    │    ├── cardinality: [0 - 15]
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(3)
- │    │    ├── scan a
- │    │    │    ├── columns: k:1!null f:3
- │    │    │    ├── key: (1)
- │    │    │    ├── fd: (1)-->(3)
- │    │    │    └── limit hint: 15.00
- │    │    └── 15
- │    └── 5
- └── projections
-      └── f:3 * 2.0 [as=r:8, outer=(3), immutable]
+error (42P01): no data source matches prefix: "an"
 
 norm expect=(PushLimitIntoProject,PushOffsetIntoProject)
 SELECT f, f+1.1 AS r FROM (SELECT f, i FROM a GROUP BY f, i) a ORDER BY f OFFSET 5 LIMIT 10
@@ -493,25 +454,9 @@ offset
  └── 10
 
 norm expect=(PushLimitIntoOffset)
-SELECT k, i FROM a OFFSET 10 LIMIT 10
+SELECT k, i FROM an OFFSET 10 LIMIT 10
 ----
-offset
- ├── columns: k:1!null i:2
- ├── cardinality: [0 - 10]
- ├── key: (1)
- ├── fd: (1)-->(2)
- ├── limit
- │    ├── columns: k:1!null i:2
- │    ├── cardinality: [0 - 20]
- │    ├── key: (1)
- │    ├── fd: (1)-->(2)
- │    ├── scan a
- │    │    ├── columns: k:1!null i:2
- │    │    ├── key: (1)
- │    │    ├── fd: (1)-->(2)
- │    │    └── limit hint: 20.00
- │    └── 20
- └── 10
+error (42P01): no data source matches prefix: "an"
 
 # Limit can be pushed into the ordering if they have the same ordering.
 norm expect=PushLimitIntoOffset
@@ -597,6 +542,10 @@ limit
  │    │    └── limit hint: 18446744073709551616.00
  │    └── 9223372036854775807
  └── 9223372036854775807
+
+# --------------------------------------------------
+# PushLimitIntoOrdinality
+# --------------------------------------------------
 
 norm expect=PushLimitIntoOrdinality
 SELECT * FROM (SELECT * FROM a ORDER BY k) WITH ORDINALITY LIMIT 10
@@ -735,6 +684,195 @@ limit
  │         ├── fd: (1)-->(2-5)
  │         └── limit hint: 10.00
  └── 10
+
+# --------------------------------------------------
+# PushOffsetIntoOrdinality
+# --------------------------------------------------
+
+norm expect=PushOffsetIntoOrdinality
+SELECT * FROM (SELECT * FROM a ORDER BY k) WITH ORDINALITY OFFSET 10
+----
+ordinality
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ └── offset
+      ├── columns: k:1!null i:2 f:3 s:4 j:5
+      ├── internal-ordering: +1
+      ├── key: (1)
+      ├── fd: (1)-->(2-5)
+      ├── ordering: +1
+      ├── scan a
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5)
+      │    └── ordering: +1
+      └── 10
+
+norm expect=PushOffsetIntoOrdinality
+SELECT * FROM (SELECT * FROM a ORDER BY k) WITH ORDINALITY LIMIT 10 OFFSET 10
+----
+ordinality
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ └── offset
+      ├── columns: k:1!null i:2 f:3 s:4 j:5
+      ├── internal-ordering: +1
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2-5)
+      ├── ordering: +1
+      ├── limit
+      │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    ├── internal-ordering: +1
+      │    ├── cardinality: [0 - 20]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5)
+      │    ├── ordering: +1
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-5)
+      │    │    ├── ordering: +1
+      │    │    └── limit hint: 20.00
+      │    └── 20
+      └── 10
+
+norm expect=PushOffsetIntoOrdinality
+SELECT * FROM a WITH ORDINALITY ORDER BY k LIMIT 10 OFFSET 5
+----
+sort
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ ├── ordering: +1
+ └── ordinality
+      ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+      └── offset
+           ├── columns: k:1!null i:2 f:3 s:4 j:5
+           ├── internal-ordering: +1
+           ├── cardinality: [0 - 10]
+           ├── key: (1)
+           ├── fd: (1)-->(2-5)
+           ├── limit
+           │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+           │    ├── internal-ordering: +1
+           │    ├── cardinality: [0 - 15]
+           │    ├── key: (1)
+           │    ├── fd: (1)-->(2-5)
+           │    ├── ordering: +1
+           │    ├── scan a
+           │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+           │    │    ├── key: (1)
+           │    │    ├── fd: (1)-->(2-5)
+           │    │    ├── ordering: +1
+           │    │    └── limit hint: 15.00
+           │    └── 15
+           └── 5
+
+norm expect=PushOffsetIntoOrdinality
+SELECT * FROM (SELECT * FROM a WHERE i=f ORDER BY i, s) WITH ORDINALITY ORDER BY f LIMIT 10 OFFSET 3
+----
+ordinality
+ ├── columns: k:1!null i:2!null f:3!null s:4 j:5 ordinality:8!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8), (8)-->(1-5), (2)==(3), (3)==(2)
+ ├── ordering: +(2|3) [actual: +2]
+ └── offset
+      ├── columns: k:1!null i:2!null f:3!null s:4 j:5
+      ├── internal-ordering: +(2|3),+4
+      ├── cardinality: [0 - 10]
+      ├── key: (1)
+      ├── fd: (1)-->(2-5), (2)==(3), (3)==(2)
+      ├── ordering: +(2|3),+4 [actual: +2,+4]
+      ├── limit
+      │    ├── columns: k:1!null i:2!null f:3!null s:4 j:5
+      │    ├── internal-ordering: +(2|3),+4
+      │    ├── cardinality: [0 - 13]
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2-5), (2)==(3), (3)==(2)
+      │    ├── ordering: +(2|3),+4 [actual: +2,+4]
+      │    ├── sort
+      │    │    ├── columns: k:1!null i:2!null f:3!null s:4 j:5
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2-5), (2)==(3), (3)==(2)
+      │    │    ├── ordering: +(2|3),+4 [actual: +2,+4]
+      │    │    ├── limit hint: 13.00
+      │    │    └── select
+      │    │         ├── columns: k:1!null i:2!null f:3!null s:4 j:5
+      │    │         ├── key: (1)
+      │    │         ├── fd: (1)-->(2-5), (2)==(3), (3)==(2)
+      │    │         ├── scan a
+      │    │         │    ├── columns: k:1!null i:2 f:3 s:4 j:5
+      │    │         │    ├── key: (1)
+      │    │         │    └── fd: (1)-->(2-5)
+      │    │         └── filters
+      │    │              └── i:2 = f:3 [outer=(2,3), constraints=(/2: (/NULL - ]; /3: (/NULL - ]), fd=(2)==(3), (3)==(2)]
+      │    └── 13
+      └── 3
+
+norm expect-not=PushOffsetIntoOrdinality
+SELECT * FROM (SELECT * FROM a ORDER BY k) WITH ORDINALITY ORDER BY i OFFSET 10
+----
+offset
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ ├── internal-ordering: +2
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ ├── ordering: +2
+ ├── sort
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ │    ├── ordering: +2
+ │    └── ordinality
+ │         ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ │         └── scan a
+ │              ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │              ├── key: (1)
+ │              ├── fd: (1)-->(2-5)
+ │              └── ordering: +1
+ └── 10
+
+norm expect-not=PushOffsetIntoOrdinality
+SELECT * FROM (SELECT * FROM a WITH ORDINALITY) ORDER BY ordinality LIMIT 10 OFFSET 5
+----
+offset
+ ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ ├── internal-ordering: +8
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ ├── ordering: +8
+ ├── limit
+ │    ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ │    ├── internal-ordering: +8
+ │    ├── cardinality: [0 - 15]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ │    ├── ordering: +8
+ │    ├── ordinality
+ │    │    ├── columns: k:1!null i:2 f:3 s:4 j:5 ordinality:8!null
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-5,8), (8)-->(1-5)
+ │    │    ├── ordering: +8
+ │    │    ├── limit hint: 15.00
+ │    │    └── scan a
+ │    │         ├── columns: k:1!null i:2 f:3 s:4 j:5
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2-5)
+ │    │         └── limit hint: 15.00
+ │    └── 15
+ └── 5
 
 # ------------------------------------------------
 # PushLimitIntoJoinLeft and PushLimitIntoJoinRight
@@ -1248,6 +1386,543 @@ limit
  │    └── filters
  │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
  └── 10
+
+# ------------------------------------------------
+# PushOffsetIntoJoinLeft and PushOffsetIntoJoinRight
+# ------------------------------------------------
+
+# InnerJoin case.
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM kvr_fk INNER JOIN uv ON r = u OFFSET 10
+----
+inner-join (hash)
+ ├── columns: k:1!null v:2 r:3!null u:6!null v:7
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (6)-->(7), (3)==(6), (6)==(3)
+ ├── offset
+ │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── scan kvr_fk
+ │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2,3)
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:6!null uv.v:7
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── r:3 = u:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
+# LeftJoin case.
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u OFFSET 10
+----
+left-join (hash)
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── offset
+ │    ├── columns: a:1!null b:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:5!null v:6
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6)
+ └── filters
+      └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+
+# InnerJoin case for PushOffsetIntoJoinRight.
+norm expect=PushOffsetIntoJoinRight
+SELECT * FROM uv INNER JOIN kvr_fk ON u = r OFFSET 10
+----
+inner-join (hash)
+ ├── columns: u:1!null v:2 k:5!null v:6 r:7!null
+ ├── multiplicity: left-rows(zero-or-more), right-rows(exactly-one)
+ ├── key: (5)
+ ├── fd: (1)-->(2), (5)-->(6,7), (1)==(7), (7)==(1)
+ ├── scan uv
+ │    ├── columns: u:1!null uv.v:2
+ │    ├── key: (1)
+ │    └── fd: (1)-->(2)
+ ├── offset
+ │    ├── columns: k:5!null kvr_fk.v:6 r:7!null
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(6,7)
+ │    ├── scan kvr_fk
+ │    │    ├── columns: k:5!null kvr_fk.v:6 r:7!null
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6,7)
+ │    └── 10
+ └── filters
+      └── u:1 = r:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+
+# Ordering can be pushed down.
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY an OFFSET 10
+----
+error (42703): column "an" does not exist
+
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY b OFFSET 10
+----
+sort
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── ordering: +2
+ └── left-join (hash)
+      ├── columns: a:1!null b:2 u:5 v:6
+      ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+      ├── key: (1)
+      ├── fd: (1)-->(2,5,6), (5)-->(6)
+      ├── offset
+      │    ├── columns: a:1!null b:2
+      │    ├── internal-ordering: +2
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2)
+      │    ├── sort
+      │    │    ├── columns: a:1!null b:2
+      │    │    ├── key: (1)
+      │    │    ├── fd: (1)-->(2)
+      │    │    ├── ordering: +2
+      │    │    └── scan ab
+      │    │         ├── columns: a:1!null b:2
+      │    │         ├── key: (1)
+      │    │         └── fd: (1)-->(2)
+      │    └── 10
+      ├── scan uv
+      │    ├── columns: u:5!null v:6
+      │    ├── key: (5)
+      │    └── fd: (5)-->(6)
+      └── filters
+           └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+
+# Ordering on u is not equivalent to ordering on a because of NULLs; it cannot
+# be pushed down.
+norm expect-not=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY u OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── internal-ordering: +5
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── ordering: +5
+ ├── sort
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │    ├── ordering: +5
+ │    └── left-join (hash)
+ │         ├── columns: a:1!null b:2 u:5 v:6
+ │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │         ├── scan ab
+ │         │    ├── columns: a:1!null b:2
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         ├── scan uv
+ │         │    ├── columns: u:5!null v:6
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6)
+ │         └── filters
+ │              └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
+# Ordering cannot be pushed down.
+norm expect-not=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY v OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── internal-ordering: +6
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── ordering: +6
+ ├── sort
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │    ├── ordering: +6
+ │    └── left-join (hash)
+ │         ├── columns: a:1!null b:2 u:5 v:6
+ │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │         ├── scan ab
+ │         │    ├── columns: a:1!null b:2
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         ├── scan uv
+ │         │    ├── columns: u:5!null v:6
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6)
+ │         └── filters
+ │              └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
+norm expect-not=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON b = v ORDER BY a, v OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── internal-ordering: +1,+6
+ ├── key: (1,5)
+ ├── fd: (1)-->(2), (5)-->(6)
+ ├── ordering: +1,+6
+ ├── sort
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── key: (1,5)
+ │    ├── fd: (1)-->(2), (5)-->(6)
+ │    ├── ordering: +1,+6
+ │    └── left-join (hash)
+ │         ├── columns: a:1!null b:2 u:5 v:6
+ │         ├── key: (1,5)
+ │         ├── fd: (1)-->(2), (5)-->(6)
+ │         ├── scan ab
+ │         │    ├── columns: a:1!null b:2
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         ├── scan uv
+ │         │    ├── columns: u:5!null v:6
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6)
+ │         └── filters
+ │              └── b:2 = v:6 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+ └── 10
+
+norm expect-not=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u ORDER BY u, b OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── internal-ordering: +5,+2
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── ordering: +5,+2
+ ├── sort
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │    ├── ordering: +5,+2
+ │    └── left-join (hash)
+ │         ├── columns: a:1!null b:2 u:5 v:6
+ │         ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │         ├── scan ab
+ │         │    ├── columns: a:1!null b:2
+ │         │    ├── key: (1)
+ │         │    └── fd: (1)-->(2)
+ │         ├── scan uv
+ │         │    ├── columns: u:5!null v:6
+ │         │    ├── key: (5)
+ │         │    └── fd: (5)-->(6)
+ │         └── filters
+ │              └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
+# Difference with PushLimitIntoJoinLeft: rule fires even if the input's
+# cardinality is less than the offset.
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM (SELECT * FROM ab OFFSET 5) LEFT JOIN uv ON a = u OFFSET 10
+----
+left-join (hash)
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── offset
+ │    ├── columns: a:1!null b:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── offset
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan ab
+ │    │    │    ├── columns: a:1!null b:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── 5
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:5!null v:6
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6)
+ └── filters
+      └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM (SELECT * FROM ab OFFSET 20) LEFT JOIN uv ON a = u OFFSET 10
+----
+left-join (hash)
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── offset
+ │    ├── columns: a:1!null b:2
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── offset
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan ab
+ │    │    │    ├── columns: a:1!null b:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── 20
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:5!null v:6
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6)
+ └── filters
+      └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+
+# Push the offset if both sides of an inner join have identical equality filters
+# on FK equality columns.
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM kvr_fk INNER JOIN uv ON r = u WHERE r = 5 OFFSET 10
+----
+inner-join (hash)
+ ├── columns: k:1!null v:2 r:3!null u:6!null v:7
+ ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: ()-->(3,6,7), (1)-->(2), (3)==(6), (6)==(3)
+ ├── offset
+ │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    ├── key: (1)
+ │    ├── fd: ()-->(3), (1)-->(2)
+ │    ├── select
+ │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    ├── key: (1)
+ │    │    ├── fd: ()-->(3), (1)-->(2)
+ │    │    ├── scan kvr_fk
+ │    │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    └── filters
+ │    │         └── r:3 = 5 [outer=(3), constraints=(/3: [/5 - /5]; tight), fd=()-->(3)]
+ │    └── 10
+ ├── select
+ │    ├── columns: u:6!null uv.v:7
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(6,7)
+ │    ├── scan uv
+ │    │    ├── columns: u:6!null uv.v:7
+ │    │    ├── key: (6)
+ │    │    └── fd: (6)-->(7)
+ │    └── filters
+ │         └── u:6 = 5 [outer=(6), constraints=(/6: [/5 - /5]; tight), fd=()-->(6)]
+ └── filters
+      └── r:3 = u:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
+# Don't push negative offsets (or we would enter an infinite loop).
+norm expect-not=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u OFFSET -1
+----
+offset
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── left-join (hash)
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,5,6), (5)-->(6)
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan uv
+ │    │    ├── columns: u:5!null v:6
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── -1
+
+# Don't push offsets into an inner join that may not preserve rows.
+norm expect-not=(PushOffsetIntoJoinLeft,PushOffsetIntoJoinRight)
+SELECT * FROM ab INNER JOIN uv ON a = u OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2 u:5!null v:6
+ ├── key: (5)
+ ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
+ ├── inner-join (hash)
+ │    ├── columns: a:1!null b:2 u:5!null v:6
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    ├── key: (5)
+ │    ├── fd: (1)-->(2), (5)-->(6), (1)==(5), (5)==(1)
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan uv
+ │    │    ├── columns: u:5!null v:6
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
+# Don't push an offset into the right side of a LeftJoin.
+norm expect-not=PushOffsetIntoJoinRight
+SELECT * FROM uv LEFT JOIN kvr_fk ON u = r OFFSET 10
+----
+offset
+ ├── columns: u:1!null v:2 k:5 v:6 r:7
+ ├── key: (1,5)
+ ├── fd: (1)-->(2), (5)-->(6,7)
+ ├── left-join (hash)
+ │    ├── columns: u:1!null uv.v:2 k:5 kvr_fk.v:6 r:7
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(exactly-one)
+ │    ├── key: (1,5)
+ │    ├── fd: (1)-->(2), (5)-->(6,7)
+ │    ├── scan uv
+ │    │    ├── columns: u:1!null uv.v:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan kvr_fk
+ │    │    ├── columns: k:5!null kvr_fk.v:6 r:7!null
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6,7)
+ │    └── filters
+ │         └── u:1 = r:7 [outer=(1,7), constraints=(/1: (/NULL - ]; /7: (/NULL - ]), fd=(1)==(7), (7)==(1)]
+ └── 10
+
+# Don't push an offset into either side of a FullJoin.
+norm expect-not=(PushOffsetIntoJoinLeft,PushOffsetIntoJoinRight)
+SELECT * FROM ab FULL JOIN uv ON a = u OFFSET 10
+----
+offset
+ ├── columns: a:1 b:2 u:5 v:6
+ ├── key: (1,5)
+ ├── fd: (1)-->(2), (5)-->(6)
+ ├── full-join (hash)
+ │    ├── columns: a:1 b:2 u:5 v:6
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(exactly-one)
+ │    ├── key: (1,5)
+ │    ├── fd: (1)-->(2), (5)-->(6)
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan uv
+ │    │    ├── columns: u:5!null v:6
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
+ └── 10
+
+# Don't push an offset if the join duplicates input rows.
+norm expect-not=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = v OFFSET 10
+----
+offset
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── key: (1,5)
+ ├── fd: (1)-->(2), (5)-->(6)
+ ├── left-join (hash)
+ │    ├── columns: a:1!null b:2 u:5 v:6
+ │    ├── multiplicity: left-rows(one-or-more), right-rows(zero-or-one)
+ │    ├── key: (1,5)
+ │    ├── fd: (1)-->(2), (5)-->(6)
+ │    ├── scan ab
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── key: (1)
+ │    │    └── fd: (1)-->(2)
+ │    ├── scan uv
+ │    │    ├── columns: u:5!null v:6
+ │    │    ├── key: (5)
+ │    │    └── fd: (5)-->(6)
+ │    └── filters
+ │         └── a:1 = v:6 [outer=(1,6), constraints=(/1: (/NULL - ]; /6: (/NULL - ]), fd=(1)==(6), (6)==(1)]
+ └── 10
+
+# Case with limit + offset.
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM kvr_fk INNER JOIN uv ON r = u LIMIT 10 OFFSET 10
+----
+inner-join (hash)
+ ├── columns: k:1!null v:2 r:3!null u:6!null v:7
+ ├── cardinality: [0 - 10]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ ├── key: (1)
+ ├── fd: (1)-->(2,3), (6)-->(7), (3)==(6), (6)==(3)
+ ├── offset
+ │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3)
+ │    ├── limit
+ │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    ├── cardinality: [0 - 20]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan kvr_fk
+ │    │    │    ├── columns: k:1!null kvr_fk.v:2 r:3!null
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    └── limit hint: 20.00
+ │    │    └── 20
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:6!null uv.v:7
+ │    ├── key: (6)
+ │    └── fd: (6)-->(7)
+ └── filters
+      └── r:3 = u:6 [outer=(3,6), constraints=(/3: (/NULL - ]; /6: (/NULL - ]), fd=(3)==(6), (6)==(3)]
+
+norm expect=PushOffsetIntoJoinLeft
+SELECT * FROM ab LEFT JOIN uv ON a = u LIMIT 5 OFFSET 10
+----
+left-join (hash)
+ ├── columns: a:1!null b:2 u:5 v:6
+ ├── cardinality: [0 - 5]
+ ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-one)
+ ├── key: (1)
+ ├── fd: (1)-->(2,5,6), (5)-->(6)
+ ├── offset
+ │    ├── columns: a:1!null b:2
+ │    ├── cardinality: [0 - 5]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2)
+ │    ├── limit
+ │    │    ├── columns: a:1!null b:2
+ │    │    ├── cardinality: [0 - 15]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan ab
+ │    │    │    ├── columns: a:1!null b:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    └── limit hint: 15.00
+ │    │    └── 15
+ │    └── 10
+ ├── scan uv
+ │    ├── columns: u:5!null v:6
+ │    ├── key: (5)
+ │    └── fd: (5)-->(6)
+ └── filters
+      └── a:1 = u:5 [outer=(1,5), constraints=(/1: (/NULL - ]; /5: (/NULL - ]), fd=(1)==(5), (5)==(1)]
 
 # ----------
 # FoldLimits

--- a/pkg/sql/opt/norm/testdata/rules/limit
+++ b/pkg/sql/opt/norm/testdata/rules/limit
@@ -2501,3 +2501,1180 @@ offset
  │              ├── key: (1)
  │              └── fd: (1)-->(3)
  └── 1
+
+# --------------------------------------------------
+# PushLimitOrOffsetIntoGroupBy
+# --------------------------------------------------
+
+# Basic case: push limit into a GroupBy with an aggregation where grouping
+# columns form a key and there's a growing join between scan and group by.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a LEFT JOIN b ON i = y) GROUP BY k LIMIT 10
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── left-join (hash)
+ │    ├── columns: k:1!null i:2 y:9
+ │    ├── fd: (1)-->(2)
+ │    ├── limit
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── cardinality: [0 - 10]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    └── limit hint: 10.00
+ │    │    └── 10
+ │    ├── scan b
+ │    │    └── columns: y:9
+ │    └── filters
+ │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# DistinctOn case.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT DISTINCT ON (k) * FROM (SELECT k, i, y FROM a LEFT JOIN b ON i = y) LIMIT 5
+----
+distinct-on
+ ├── columns: k:1!null i:2 y:9
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(2,9)
+ ├── left-join (hash)
+ │    ├── columns: k:1!null i:2 y:9
+ │    ├── fd: (1)-->(2)
+ │    ├── limit
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── cardinality: [0 - 5]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    └── limit hint: 5.00
+ │    │    └── 5
+ │    ├── scan b
+ │    │    └── columns: y:9
+ │    └── filters
+ │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── aggregations
+      ├── first-agg [as=i:2, outer=(2)]
+      │    └── i:2
+      └── first-agg [as=y:9, outer=(9)]
+           └── y:9
+
+# Offset case.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a LEFT JOIN b ON i = y) GROUP BY k OFFSET 10
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── left-join (hash)
+ │    ├── columns: k:1!null i:2 y:9
+ │    ├── fd: (1)-->(2)
+ │    ├── offset
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    └── 10
+ │    ├── scan b
+ │    │    └── columns: y:9
+ │    └── filters
+ │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# Cases with a non-duplicating join that maintains the key. The join may filter
+# rows, so the limit has to remain on top of it.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) GROUP BY k LIMIT 10
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── limit
+ │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    │    ├── limit hint: 10.00
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── key: (8)
+ │    │    │    └── fd: (8)-->(9)
+ │    │    └── filters
+ │    │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    └── 10
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# DistinctOn case. Note that the DistinctOn ends up being eliminated.
+norm
+SELECT DISTINCT k FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) LIMIT 5
+----
+project
+ ├── columns: k:1!null
+ ├── cardinality: [0 - 5]
+ ├── key: (1)
+ └── limit
+      ├── columns: k:1!null i:2!null x:8!null
+      ├── cardinality: [0 - 5]
+      ├── key: (1)
+      ├── fd: (1)-->(2), (2)==(8), (8)==(2)
+      ├── inner-join (hash)
+      │    ├── columns: k:1!null i:2!null x:8!null
+      │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+      │    ├── key: (1)
+      │    ├── fd: (1)-->(2), (2)==(8), (8)==(2)
+      │    ├── limit hint: 5.00
+      │    ├── scan a
+      │    │    ├── columns: k:1!null i:2
+      │    │    ├── key: (1)
+      │    │    └── fd: (1)-->(2)
+      │    ├── scan b
+      │    │    ├── columns: x:8!null
+      │    │    └── key: (8)
+      │    └── filters
+      │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+      └── 5
+
+# Case with offset.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) GROUP BY k LIMIT 10 OFFSET 5
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 10]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── offset
+ │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    ├── cardinality: [0 - 10]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    ├── limit
+ │    │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    │    ├── cardinality: [0 - 15]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    │    │    ├── limit hint: 15.00
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    ├── scan b
+ │    │    │    │    ├── columns: x:8!null y:9
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    └── filters
+ │    │    │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    │    └── 15
+ │    └── 5
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# Case with empty grouping columns.
+norm expect=PushLimitOrOffsetIntoGroupBy disable=EliminateLimit
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x AND k = 1) GROUP BY k LIMIT 10
+----
+group-by (streaming)
+ ├── columns: k:1!null sum:12
+ ├── cardinality: [0 - 1]
+ ├── key: ()
+ ├── fd: ()-->(1,12)
+ ├── limit
+ │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    ├── cardinality: [0 - 1]
+ │    ├── key: ()
+ │    ├── fd: ()-->(1,2,8,9), (2)==(8), (8)==(2)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    │    ├── cardinality: [0 - 1]
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-one)
+ │    │    ├── key: ()
+ │    │    ├── fd: ()-->(1,2,8,9), (2)==(8), (8)==(2)
+ │    │    ├── limit hint: 10.00
+ │    │    ├── select
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(1,2)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    └── filters
+ │    │    │         └── k:1 = 1 [outer=(1), constraints=(/1: [/1 - /1]; tight), fd=()-->(1)]
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── key: (8)
+ │    │    │    └── fd: (8)-->(9)
+ │    │    └── filters
+ │    │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    └── 10
+ └── aggregations
+      ├── sum [as=sum:12, outer=(9)]
+      │    └── y:9
+      └── const-agg [as=k:1, outer=(1)]
+           └── k:1
+
+# Push limit through FK joins.
+exec-ddl
+CREATE TABLE p1 (id1 INT PRIMARY KEY, val1 INT)
+----
+
+exec-ddl
+CREATE TABLE p2 (id2 INT PRIMARY KEY, val2 INT)
+----
+
+exec-ddl
+CREATE TABLE child (
+  k INT PRIMARY KEY,
+  val INT,
+  ref1 INT NOT NULL REFERENCES p1 (id1),
+  ref2 INT NOT NULL REFERENCES p2 (id2)
+)
+----
+
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(val), sum(val1)
+FROM child
+INNER JOIN p1 ON id1 = ref1
+GROUP BY k
+LIMIT 3
+----
+group-by (hash)
+ ├── columns: k:1!null sum:11 sum:12
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 3]
+ ├── key: (1)
+ ├── fd: (1)-->(11,12)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null val:2 ref1:3!null id1:7!null val1:8
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3), (7)-->(8), (3)==(7), (7)==(3)
+ │    ├── limit
+ │    │    ├── columns: k:1!null val:2 ref1:3!null
+ │    │    ├── cardinality: [0 - 3]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3)
+ │    │    ├── scan child
+ │    │    │    ├── columns: k:1!null val:2 ref1:3!null
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2,3)
+ │    │    │    └── limit hint: 3.00
+ │    │    └── 3
+ │    ├── scan p1
+ │    │    ├── columns: id1:7!null val1:8
+ │    │    ├── key: (7)
+ │    │    └── fd: (7)-->(8)
+ │    └── filters
+ │         └── id1:7 = ref1:3 [outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+ └── aggregations
+      ├── sum [as=sum:11, outer=(2)]
+      │    └── val:2
+      └── sum [as=sum:12, outer=(8)]
+           └── val1:8
+
+# Case with two joins.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(val), sum(val1), sum(val2)
+FROM child
+INNER JOIN p1 ON id1 = ref1
+INNER JOIN p2 ON id2 = ref2
+GROUP BY k
+LIMIT 3
+----
+group-by (hash)
+ ├── columns: k:1!null sum:15 sum:16 sum:17
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 3]
+ ├── key: (1)
+ ├── fd: (1)-->(15-17)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null id1:7!null val1:8 id2:11!null val2:12
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (7)-->(8), (11)-->(12), (3)==(7), (7)==(3), (4)==(11), (11)==(4)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null id1:7!null val1:8
+ │    │    ├── cardinality: [0 - 3]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4), (7)-->(8), (3)==(7), (7)==(3)
+ │    │    ├── limit
+ │    │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null
+ │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2-4)
+ │    │    │    ├── scan child
+ │    │    │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2-4)
+ │    │    │    │    └── limit hint: 3.00
+ │    │    │    └── 3
+ │    │    ├── scan p1
+ │    │    │    ├── columns: id1:7!null val1:8
+ │    │    │    ├── key: (7)
+ │    │    │    └── fd: (7)-->(8)
+ │    │    └── filters
+ │    │         └── id1:7 = ref1:3 [outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+ │    ├── scan p2
+ │    │    ├── columns: id2:11!null val2:12
+ │    │    ├── key: (11)
+ │    │    └── fd: (11)-->(12)
+ │    └── filters
+ │         └── id2:11 = ref2:4 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+ └── aggregations
+      ├── sum [as=sum:15, outer=(2)]
+      │    └── val:2
+      ├── sum [as=sum:16, outer=(8)]
+      │    └── val1:8
+      └── sum [as=sum:17, outer=(12)]
+           └── val2:12
+
+# Offset case.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(val), sum(val1), sum(val2)
+FROM child
+INNER JOIN p1 ON id1 = ref1
+INNER JOIN p2 ON id2 = ref2
+GROUP BY k
+LIMIT 3 OFFSET 5
+----
+group-by (hash)
+ ├── columns: k:1!null sum:15 sum:16 sum:17
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 3]
+ ├── key: (1)
+ ├── fd: (1)-->(15-17)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null id1:7!null val1:8 id2:11!null val2:12
+ │    ├── cardinality: [0 - 3]
+ │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2-4), (7)-->(8), (11)-->(12), (3)==(7), (7)==(3), (4)==(11), (11)==(4)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null id1:7!null val1:8
+ │    │    ├── cardinality: [0 - 3]
+ │    │    ├── multiplicity: left-rows(exactly-one), right-rows(zero-or-more)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2-4), (7)-->(8), (3)==(7), (7)==(3)
+ │    │    ├── offset
+ │    │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null
+ │    │    │    ├── cardinality: [0 - 3]
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2-4)
+ │    │    │    ├── limit
+ │    │    │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null
+ │    │    │    │    ├── cardinality: [0 - 8]
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2-4)
+ │    │    │    │    ├── scan child
+ │    │    │    │    │    ├── columns: k:1!null val:2 ref1:3!null ref2:4!null
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: (1)-->(2-4)
+ │    │    │    │    │    └── limit hint: 8.00
+ │    │    │    │    └── 8
+ │    │    │    └── 5
+ │    │    ├── scan p1
+ │    │    │    ├── columns: id1:7!null val1:8
+ │    │    │    ├── key: (7)
+ │    │    │    └── fd: (7)-->(8)
+ │    │    └── filters
+ │    │         └── id1:7 = ref1:3 [outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+ │    ├── scan p2
+ │    │    ├── columns: id2:11!null val2:12
+ │    │    ├── key: (11)
+ │    │    └── fd: (11)-->(12)
+ │    └── filters
+ │         └── id2:11 = ref2:4 [outer=(4,11), constraints=(/4: (/NULL - ]; /11: (/NULL - ]), fd=(4)==(11), (11)==(4)]
+ └── aggregations
+      ├── sum [as=sum:15, outer=(2)]
+      │    └── val:2
+      ├── sum [as=sum:16, outer=(8)]
+      │    └── val1:8
+      └── sum [as=sum:17, outer=(12)]
+           └── val2:12
+
+# A filter may prevent matches despite the foreign key, preventing limit
+# push-down below the join.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(val), sum(val1)
+FROM child
+INNER JOIN p1 ON id1 = ref1 AND val1 > 10
+GROUP BY k
+LIMIT 3
+----
+group-by (hash)
+ ├── columns: k:1!null sum:11 sum:12!null
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 3]
+ ├── key: (1)
+ ├── fd: (1)-->(11,12)
+ ├── limit
+ │    ├── columns: k:1!null val:2 ref1:3!null id1:7!null val1:8!null
+ │    ├── cardinality: [0 - 3]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,3), (7)-->(8), (3)==(7), (7)==(3)
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1!null val:2 ref1:3!null id1:7!null val1:8!null
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,3), (7)-->(8), (3)==(7), (7)==(3)
+ │    │    ├── limit hint: 3.00
+ │    │    ├── scan child
+ │    │    │    ├── columns: k:1!null val:2 ref1:3!null
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2,3)
+ │    │    ├── select
+ │    │    │    ├── columns: id1:7!null val1:8!null
+ │    │    │    ├── key: (7)
+ │    │    │    ├── fd: (7)-->(8)
+ │    │    │    ├── scan p1
+ │    │    │    │    ├── columns: id1:7!null val1:8
+ │    │    │    │    ├── key: (7)
+ │    │    │    │    └── fd: (7)-->(8)
+ │    │    │    └── filters
+ │    │    │         └── val1:8 > 10 [outer=(8), constraints=(/8: [/11 - ]; tight)]
+ │    │    └── filters
+ │    │         └── id1:7 = ref1:3 [outer=(3,7), constraints=(/3: (/NULL - ]; /7: (/NULL - ]), fd=(3)==(7), (7)==(3)]
+ │    └── 3
+ └── aggregations
+      ├── sum [as=sum:11, outer=(2)]
+      │    └── val:2
+      └── sum [as=sum:12, outer=(8)]
+           └── val1:8
+
+# Case with Project operator between join and group by - should still work.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(computed) FROM (SELECT k, i*2 as computed FROM a LEFT JOIN b ON i = y) GROUP BY k LIMIT 7 OFFSET 3
+----
+group-by (hash)
+ ├── columns: k:1!null sum:13
+ ├── grouping columns: k:1!null
+ ├── immutable
+ ├── key: (1)
+ ├── fd: (1)-->(13)
+ ├── project
+ │    ├── columns: computed:12 k:1!null
+ │    ├── immutable
+ │    ├── fd: (1)-->(12)
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1!null i:2 y:9
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── offset
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── cardinality: [0 - 7]
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    ├── limit
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── cardinality: [0 - 10]
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: (1)-->(2)
+ │    │    │    │    │    └── limit hint: 10.00
+ │    │    │    │    └── 10
+ │    │    │    └── 3
+ │    │    ├── scan b
+ │    │    │    └── columns: y:9
+ │    │    └── filters
+ │    │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    └── projections
+ │         └── i:2 * 2 [as=computed:12, outer=(2), immutable]
+ └── aggregations
+      └── sum [as=sum:13, outer=(12)]
+           └── computed:12
+
+# Case with Ordinality operator between join and group by - should still work.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(ordinality) FROM (SELECT k, ordinality FROM a WITH ORDINALITY LEFT JOIN b ON i = y) GROUP BY k LIMIT 7 OFFSET 3
+----
+group-by (hash)
+ ├── columns: k:1!null sum:13!null
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(13)
+ ├── left-join (hash)
+ │    ├── columns: k:1!null i:2 ordinality:8!null y:10
+ │    ├── fd: (1)-->(2,8), (8)-->(1,2)
+ │    ├── ordinality
+ │    │    ├── columns: k:1!null i:2 ordinality:8!null
+ │    │    ├── cardinality: [0 - 7]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,8), (8)-->(1,2)
+ │    │    └── offset
+ │    │         ├── columns: k:1!null i:2
+ │    │         ├── cardinality: [0 - 7]
+ │    │         ├── key: (1)
+ │    │         ├── fd: (1)-->(2)
+ │    │         ├── limit
+ │    │         │    ├── columns: k:1!null i:2
+ │    │         │    ├── cardinality: [0 - 10]
+ │    │         │    ├── key: (1)
+ │    │         │    ├── fd: (1)-->(2)
+ │    │         │    ├── scan a
+ │    │         │    │    ├── columns: k:1!null i:2
+ │    │         │    │    ├── key: (1)
+ │    │         │    │    ├── fd: (1)-->(2)
+ │    │         │    │    └── limit hint: 10.00
+ │    │         │    └── 10
+ │    │         └── 3
+ │    ├── scan b
+ │    │    └── columns: y:10
+ │    └── filters
+ │         └── i:2 = y:10 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ └── aggregations
+      └── sum [as=sum:13, outer=(8)]
+           └── ordinality:8
+
+# Case with Window operator between join and group by - should still work.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(computed) FROM (SELECT k, row_number() OVER () as computed FROM a LEFT JOIN b ON i = y) GROUP BY k LIMIT 7 OFFSET 3
+----
+group-by (hash)
+ ├── columns: k:1!null sum:13
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(13)
+ ├── window partition=()
+ │    ├── columns: k:1!null i:2 y:9 row_number:12
+ │    ├── fd: (1)-->(2)
+ │    ├── left-join (hash)
+ │    │    ├── columns: k:1!null i:2 y:9
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── offset
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── cardinality: [0 - 7]
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    ├── limit
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── cardinality: [0 - 10]
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2)
+ │    │    │    │    ├── scan a
+ │    │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    │    ├── key: (1)
+ │    │    │    │    │    ├── fd: (1)-->(2)
+ │    │    │    │    │    └── limit hint: 10.00
+ │    │    │    │    └── 10
+ │    │    │    └── 3
+ │    │    ├── scan b
+ │    │    │    └── columns: y:9
+ │    │    └── filters
+ │    │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    └── windows
+ │         └── row-number [as=row_number:12]
+ └── aggregations
+      └── sum [as=sum:13, outer=(12)]
+           └── row_number:12
+
+# Case with a Select - the limit is pushed to the filter, but not below it.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a LEFT JOIN b ON i = y WHERE k > 10) GROUP BY k LIMIT 6
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── left-join (hash)
+ │    ├── columns: k:1!null i:2 y:9
+ │    ├── fd: (1)-->(2)
+ │    ├── limit
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── cardinality: [0 - 6]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── select
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    ├── limit hint: 6.00
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    ├── fd: (1)-->(2)
+ │    │    │    │    └── limit hint: 18.00
+ │    │    │    └── filters
+ │    │    │         └── k:1 > 10 [outer=(1), constraints=(/1: [/11 - ]; tight)]
+ │    │    └── 6
+ │    ├── scan b
+ │    │    └── columns: y:9
+ │    └── filters
+ │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# Offset case.
+norm expect=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a LEFT JOIN b ON i = y WHERE k > 10) GROUP BY k OFFSET 6
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── left-join (hash)
+ │    ├── columns: k:1!null i:2 y:9
+ │    ├── fd: (1)-->(2)
+ │    ├── offset
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── select
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    └── filters
+ │    │    │         └── k:1 > 10 [outer=(1), constraints=(/1: [/11 - ]; tight)]
+ │    │    └── 6
+ │    ├── scan b
+ │    │    └── columns: y:9
+ │    └── filters
+ │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# No-op Limit case for ScalarGroupBy.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) LIMIT 1
+----
+scalar-group-by
+ ├── columns: sum:12
+ ├── cardinality: [1 - 1]
+ ├── key: ()
+ ├── fd: ()-->(12)
+ ├── inner-join (hash)
+ │    ├── columns: i:2!null x:8!null y:9
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    ├── fd: (8)-->(9), (2)==(8), (8)==(2)
+ │    ├── scan a
+ │    │    └── columns: i:2
+ │    ├── scan b
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# No-op Offset case for ScalarGroupBy.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) OFFSET 1
+----
+values
+ ├── columns: sum:12!null
+ ├── cardinality: [0 - 0]
+ ├── key: ()
+ └── fd: ()-->(12)
+
+# Don't match when grouping columns don't form a key in the input.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT i, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) GROUP BY i LIMIT 5 OFFSET 1
+----
+offset
+ ├── columns: i:2!null sum:12
+ ├── cardinality: [0 - 5]
+ ├── key: (2)
+ ├── fd: (2)-->(12)
+ ├── limit
+ │    ├── columns: i:2!null sum:12
+ │    ├── cardinality: [0 - 6]
+ │    ├── key: (2)
+ │    ├── fd: (2)-->(12)
+ │    ├── group-by (hash)
+ │    │    ├── columns: i:2!null sum:12
+ │    │    ├── grouping columns: i:2!null
+ │    │    ├── key: (2)
+ │    │    ├── fd: (2)-->(12)
+ │    │    ├── limit hint: 6.00
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: i:2!null x:8!null y:9
+ │    │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    │    ├── fd: (8)-->(9), (2)==(8), (8)==(2)
+ │    │    │    ├── scan a
+ │    │    │    │    └── columns: i:2
+ │    │    │    ├── scan b
+ │    │    │    │    ├── columns: x:8!null y:9
+ │    │    │    │    ├── key: (8)
+ │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    └── filters
+ │    │    │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    │    └── aggregations
+ │    │         └── sum [as=sum:12, outer=(9)]
+ │    │              └── y:9
+ │    └── 6
+ └── 1
+
+# Don't match when input has outer columns (avoid interfering with decorrelation).
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, (SELECT sum(y) FROM b WHERE x = i GROUP BY x LIMIT 1) FROM a LIMIT 3
+----
+project
+ ├── columns: k:1!null sum:13
+ ├── cardinality: [0 - 3]
+ ├── key: (1)
+ ├── fd: (1)-->(13)
+ ├── limit
+ │    ├── columns: k:1!null i:2 sum:12
+ │    ├── cardinality: [0 - 3]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2,12)
+ │    ├── left-join-apply
+ │    │    ├── columns: k:1!null i:2 sum:12
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2,12)
+ │    │    ├── limit hint: 3.00
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    ├── group-by (streaming)
+ │    │    │    ├── columns: sum:12
+ │    │    │    ├── outer: (2)
+ │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    ├── key: ()
+ │    │    │    ├── fd: ()-->(12)
+ │    │    │    ├── select
+ │    │    │    │    ├── columns: x:8!null y:9
+ │    │    │    │    ├── outer: (2)
+ │    │    │    │    ├── cardinality: [0 - 1]
+ │    │    │    │    ├── key: ()
+ │    │    │    │    ├── fd: ()-->(8,9)
+ │    │    │    │    ├── scan b
+ │    │    │    │    │    ├── columns: x:8!null y:9
+ │    │    │    │    │    ├── key: (8)
+ │    │    │    │    │    └── fd: (8)-->(9)
+ │    │    │    │    └── filters
+ │    │    │    │         └── x:8 = i:2 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    │    │    └── aggregations
+ │    │    │         └── sum [as=sum:12, outer=(9)]
+ │    │    │              └── y:9
+ │    │    └── filters (true)
+ │    └── 3
+ └── projections
+      └── sum:12 [as=sum:13, outer=(12)]
+
+# Don't match when limit >= max rows of input (would be eliminated by EliminateLimit).
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM (SELECT * FROM a LIMIT 5) t INNER JOIN b ON i = x) GROUP BY k LIMIT 10
+----
+group-by (hash)
+ ├── columns: k:1!null sum:12
+ ├── grouping columns: k:1!null
+ ├── cardinality: [0 - 5]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── inner-join (hash)
+ │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    ├── cardinality: [0 - 5]
+ │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    ├── limit
+ │    │    ├── columns: k:1!null i:2
+ │    │    ├── cardinality: [0 - 5]
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    └── limit hint: 5.00
+ │    │    └── 5
+ │    ├── scan b
+ │    │    ├── columns: x:8!null y:9
+ │    │    ├── key: (8)
+ │    │    └── fd: (8)-->(9)
+ │    └── filters
+ │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ └── aggregations
+      └── sum [as=sum:12, outer=(9)]
+           └── y:9
+
+# Don't match when limit ordering can't be satisfied by input columns.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) GROUP BY k ORDER BY sum(y) LIMIT 4
+----
+limit
+ ├── columns: k:1!null sum:12
+ ├── internal-ordering: +12
+ ├── cardinality: [0 - 4]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── ordering: +12
+ ├── sort
+ │    ├── columns: k:1!null sum:12
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(12)
+ │    ├── ordering: +12
+ │    ├── limit hint: 4.00
+ │    └── group-by (hash)
+ │         ├── columns: k:1!null sum:12
+ │         ├── grouping columns: k:1!null
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(12)
+ │         ├── inner-join (hash)
+ │         │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │         │    ├── scan a
+ │         │    │    ├── columns: k:1!null i:2
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(2)
+ │         │    ├── scan b
+ │         │    │    ├── columns: x:8!null y:9
+ │         │    │    ├── key: (8)
+ │         │    │    └── fd: (8)-->(9)
+ │         │    └── filters
+ │         │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │         └── aggregations
+ │              └── sum [as=sum:12, outer=(9)]
+ │                   └── y:9
+ └── 4
+
+# Offset case.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) GROUP BY k ORDER BY sum(y) LIMIT 4
+----
+limit
+ ├── columns: k:1!null sum:12
+ ├── internal-ordering: +12
+ ├── cardinality: [0 - 4]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── ordering: +12
+ ├── sort
+ │    ├── columns: k:1!null sum:12
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(12)
+ │    ├── ordering: +12
+ │    ├── limit hint: 4.00
+ │    └── group-by (hash)
+ │         ├── columns: k:1!null sum:12
+ │         ├── grouping columns: k:1!null
+ │         ├── key: (1)
+ │         ├── fd: (1)-->(12)
+ │         ├── inner-join (hash)
+ │         │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │         │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │         │    ├── key: (1)
+ │         │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │         │    ├── scan a
+ │         │    │    ├── columns: k:1!null i:2
+ │         │    │    ├── key: (1)
+ │         │    │    └── fd: (1)-->(2)
+ │         │    ├── scan b
+ │         │    │    ├── columns: x:8!null y:9
+ │         │    │    ├── key: (8)
+ │         │    │    └── fd: (8)-->(9)
+ │         │    └── filters
+ │         │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │         └── aggregations
+ │              └── sum [as=sum:12, outer=(9)]
+ │                   └── y:9
+ └── 4
+
+# Don't match when the input of the group-by can filter rows.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = y) GROUP BY k LIMIT 6 OFFSET 2
+----
+offset
+ ├── columns: k:1!null sum:12!null
+ ├── cardinality: [0 - 6]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── limit
+ │    ├── columns: k:1!null sum:12!null
+ │    ├── cardinality: [0 - 8]
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(12)
+ │    ├── group-by (hash)
+ │    │    ├── columns: k:1!null sum:12!null
+ │    │    ├── grouping columns: k:1!null
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(12)
+ │    │    ├── limit hint: 8.00
+ │    │    ├── inner-join (hash)
+ │    │    │    ├── columns: k:1!null i:2!null y:9!null
+ │    │    │    ├── fd: (1)-->(2), (2)==(9), (9)==(2)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    ├── scan b
+ │    │    │    │    └── columns: y:9
+ │    │    │    └── filters
+ │    │    │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    │    └── aggregations
+ │    │         └── sum [as=sum:12, outer=(9)]
+ │    │              └── y:9
+ │    └── 8
+ └── 2
+
+# Don't match when the input of the group-by can add rows.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(i) FROM (SELECT k, i FROM a UNION (SELECT x, y FROM b)) GROUP BY k LIMIT 6 OFFSET 6
+----
+offset
+ ├── columns: k:12!null sum:14
+ ├── cardinality: [0 - 6]
+ ├── key: (12)
+ ├── fd: (12)-->(14)
+ ├── limit
+ │    ├── columns: k:12!null sum:14
+ │    ├── cardinality: [0 - 12]
+ │    ├── key: (12)
+ │    ├── fd: (12)-->(14)
+ │    ├── group-by (hash)
+ │    │    ├── columns: k:12!null sum:14
+ │    │    ├── grouping columns: k:12!null
+ │    │    ├── key: (12)
+ │    │    ├── fd: (12)-->(14)
+ │    │    ├── limit hint: 12.00
+ │    │    ├── union
+ │    │    │    ├── columns: k:12!null i:13
+ │    │    │    ├── left columns: a.k:1 a.i:2
+ │    │    │    ├── right columns: x:8 y:9
+ │    │    │    ├── key: (12,13)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: a.k:1!null a.i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    └── scan b
+ │    │    │         ├── columns: x:8!null y:9
+ │    │    │         ├── key: (8)
+ │    │    │         └── fd: (8)-->(9)
+ │    │    └── aggregations
+ │    │         └── sum [as=sum:14, outer=(13)]
+ │    │              └── i:13
+ │    └── 12
+ └── 6
+
+# Don't match with negative limit.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a INNER JOIN b ON i = x) GROUP BY k LIMIT -1
+----
+limit
+ ├── columns: k:1!null sum:12
+ ├── cardinality: [0 - 0]
+ ├── immutable
+ ├── key: ()
+ ├── fd: ()-->(1,12)
+ ├── group-by (hash)
+ │    ├── columns: k:1!null sum:12
+ │    ├── grouping columns: k:1!null
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(12)
+ │    ├── limit hint: 1.00
+ │    ├── inner-join (hash)
+ │    │    ├── columns: k:1!null i:2!null x:8!null y:9
+ │    │    ├── multiplicity: left-rows(zero-or-one), right-rows(zero-or-more)
+ │    │    ├── key: (1)
+ │    │    ├── fd: (1)-->(2), (8)-->(9), (2)==(8), (8)==(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    ├── scan b
+ │    │    │    ├── columns: x:8!null y:9
+ │    │    │    ├── key: (8)
+ │    │    │    └── fd: (8)-->(9)
+ │    │    └── filters
+ │    │         └── i:2 = x:8 [outer=(2,8), constraints=(/2: (/NULL - ]; /8: (/NULL - ]), fd=(2)==(8), (8)==(2)]
+ │    └── aggregations
+ │         └── sum [as=sum:12, outer=(9)]
+ │              └── y:9
+ └── -1
+
+# No-op because grouping by a projected column.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k_proj, sum(y) FROM (SELECT k * 1000 AS k_proj, i, y FROM a LEFT JOIN b ON i = y) GROUP BY k_proj LIMIT 10
+----
+limit
+ ├── columns: k_proj:12!null sum:13
+ ├── cardinality: [0 - 10]
+ ├── immutable
+ ├── key: (12)
+ ├── fd: (12)-->(13)
+ ├── group-by (hash)
+ │    ├── columns: k_proj:12!null sum:13
+ │    ├── grouping columns: k_proj:12!null
+ │    ├── immutable
+ │    ├── key: (12)
+ │    ├── fd: (12)-->(13)
+ │    ├── limit hint: 10.00
+ │    ├── project
+ │    │    ├── columns: k_proj:12!null y:9
+ │    │    ├── immutable
+ │    │    ├── left-join (hash)
+ │    │    │    ├── columns: k:1!null i:2 y:9
+ │    │    │    ├── fd: (1)-->(2)
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    ├── scan b
+ │    │    │    │    └── columns: y:9
+ │    │    │    └── filters
+ │    │    │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    │    └── projections
+ │    │         └── k:1 * 1000 [as=k_proj:12, outer=(1), immutable]
+ │    └── aggregations
+ │         └── sum [as=sum:13, outer=(9)]
+ │              └── y:9
+ └── 10
+
+# No-op case with grouping on a projected column under the join.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k_proj, sum(y) FROM (SELECT k_proj, i, y FROM (SELECT *, k * 1000 AS k_proj FROM a) LEFT JOIN b ON i = y) GROUP BY k_proj LIMIT 10
+----
+limit
+ ├── columns: k_proj:8!null sum:13
+ ├── cardinality: [0 - 10]
+ ├── immutable
+ ├── key: (8)
+ ├── fd: (8)-->(13)
+ ├── group-by (hash)
+ │    ├── columns: k_proj:8!null sum:13
+ │    ├── grouping columns: k_proj:8!null
+ │    ├── immutable
+ │    ├── key: (8)
+ │    ├── fd: (8)-->(13)
+ │    ├── limit hint: 10.00
+ │    ├── left-join (hash)
+ │    │    ├── columns: i:2 k_proj:8!null y:10
+ │    │    ├── immutable
+ │    │    ├── project
+ │    │    │    ├── columns: k_proj:8!null i:2
+ │    │    │    ├── immutable
+ │    │    │    ├── scan a
+ │    │    │    │    ├── columns: k:1!null i:2
+ │    │    │    │    ├── key: (1)
+ │    │    │    │    └── fd: (1)-->(2)
+ │    │    │    └── projections
+ │    │    │         └── k:1 * 1000 [as=k_proj:8, outer=(1), immutable]
+ │    │    ├── scan b
+ │    │    │    └── columns: y:10
+ │    │    └── filters
+ │    │         └── i:2 = y:10 [outer=(2,10), constraints=(/2: (/NULL - ]; /10: (/NULL - ]), fd=(2)==(10), (10)==(2)]
+ │    └── aggregations
+ │         └── sum [as=sum:13, outer=(10)]
+ │              └── y:10
+ └── 10
+
+# Do not push into the right input of a LeftJoin.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM b LEFT JOIN a ON i = y) GROUP BY k LIMIT 5
+----
+limit
+ ├── columns: k:5 sum:12
+ ├── cardinality: [0 - 5]
+ ├── key: (5)
+ ├── fd: (5)-->(12)
+ ├── group-by (hash)
+ │    ├── columns: k:5 sum:12
+ │    ├── grouping columns: k:5
+ │    ├── key: (5)
+ │    ├── fd: (5)-->(12)
+ │    ├── limit hint: 5.00
+ │    ├── left-join (hash)
+ │    │    ├── columns: y:2 k:5 i:6
+ │    │    ├── fd: (5)-->(6)
+ │    │    ├── scan b
+ │    │    │    └── columns: y:2
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:5!null i:6
+ │    │    │    ├── key: (5)
+ │    │    │    └── fd: (5)-->(6)
+ │    │    └── filters
+ │    │         └── i:6 = y:2 [outer=(2,6), constraints=(/2: (/NULL - ]; /6: (/NULL - ]), fd=(2)==(6), (6)==(2)]
+ │    └── aggregations
+ │         └── sum [as=sum:12, outer=(2)]
+ │              └── y:2
+ └── 5
+
+# Do not push into either input of a FullJoin.
+norm expect-not=PushLimitOrOffsetIntoGroupBy
+SELECT k, sum(y) FROM (SELECT k, i, y FROM a FULL JOIN b ON i = y) GROUP BY k LIMIT 5
+----
+limit
+ ├── columns: k:1 sum:12
+ ├── cardinality: [0 - 5]
+ ├── key: (1)
+ ├── fd: (1)-->(12)
+ ├── group-by (hash)
+ │    ├── columns: k:1 sum:12
+ │    ├── grouping columns: k:1
+ │    ├── key: (1)
+ │    ├── fd: (1)-->(12)
+ │    ├── limit hint: 5.00
+ │    ├── full-join (hash)
+ │    │    ├── columns: k:1 i:2 y:9
+ │    │    ├── fd: (1)-->(2)
+ │    │    ├── scan a
+ │    │    │    ├── columns: k:1!null i:2
+ │    │    │    ├── key: (1)
+ │    │    │    └── fd: (1)-->(2)
+ │    │    ├── scan b
+ │    │    │    └── columns: y:9
+ │    │    └── filters
+ │    │         └── i:2 = y:9 [outer=(2,9), constraints=(/2: (/NULL - ]; /9: (/NULL - ]), fd=(2)==(9), (9)==(2)]
+ │    └── aggregations
+ │         └── sum [as=sum:12, outer=(9)]
+ │              └── y:9
+ └── 5

--- a/pkg/sql/opt/xform/testdata/external/trading
+++ b/pkg/sql/opt/xform/testdata/external/trading
@@ -794,122 +794,126 @@ WHERE (Name, SetName, Number) > ('Shock', '7E', 248)
 ORDER BY Name, SetName, Number
 LIMIT 50
 ----
-project
+sort
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:11!null sellprice:12!null desiredinventory:14!null actualinventory:15!null version:17!null discount:13!null maxinventory:16!null twodaysales:31
- ├── cardinality: [0 - 50]
  ├── immutable
- ├── stats: [rows=50]
+ ├── stats: [rows=49.9764]
  ├── key: (17,31)
  ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
  ├── ordering: +2,+4,+5
- ├── limit
- │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:30
- │    ├── internal-ordering: +2,+4,+5
- │    ├── cardinality: [0 - 50]
- │    ├── immutable
- │    ├── stats: [rows=50]
- │    ├── key: (10)
- │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,30), (17)-->(10-16), (1)==(10), (10)==(1)
- │    ├── ordering: +2,+4,+5
- │    ├── group-by (partial streaming)
- │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:30
- │    │    ├── grouping columns: name:2!null setname:4 number:5!null cardsinfo.cardid:10!null
- │    │    ├── internal-ordering: +2,+4,+5 opt(9)
- │    │    ├── immutable
- │    │    ├── stats: [rows=29618.5, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
- │    │    ├── key: (10)
- │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,30), (17)-->(10-16), (1)==(10), (10)==(1)
- │    │    ├── ordering: +2,+4,+5
- │    │    ├── limit hint: 50.00
- │    │    ├── left-join (lookup transactiondetails@detailscardidindex)
- │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null transactiondetails.dealerid:20 isbuy:21 transactiondate:22 transactiondetails.cardid:23 quantity:24
- │    │    │    ├── lookup expression
- │    │    │    │    └── filters
- │    │    │    │         ├── (transactiondate:22 >= '2020-02-28 00:00:00+00') AND (transactiondate:22 <= '2020-03-01 00:00:00+00') [outer=(22), constraints=(/22: [/'2020-02-28 00:00:00+00' - /'2020-03-01 00:00:00+00']; tight)]
- │    │    │    │         ├── "lookup_join_const_col_@20":38 = transactiondetails.dealerid:20 [outer=(20,38), constraints=(/20: (/NULL - ]; /38: (/NULL - ]), fd=(20)==(38), (38)==(20)]
- │    │    │    │         ├── "lookup_join_const_col_@21":39 = isbuy:21 [outer=(21,39), constraints=(/21: (/NULL - ]; /39: (/NULL - ]), fd=(21)==(39), (39)==(21)]
- │    │    │    │         └── id:1 = transactiondetails.cardid:23 [outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
- │    │    │    ├── immutable
- │    │    │    ├── stats: [rows=519622, distinct(10)=19000, null(10)=0, distinct(23)=19000, null(23)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
- │    │    │    ├── key: (10,22-24)
- │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (10,22-24)-->(20,21), (1)==(10), (10)==(1)
- │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
- │    │    │    ├── limit hint: 877.19
- │    │    │    ├── project
- │    │    │    │    ├── columns: "lookup_join_const_col_@20":38!null "lookup_join_const_col_@21":39!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
- │    │    │    │    ├── immutable
- │    │    │    │    ├── stats: [rows=29618.5]
- │    │    │    │    ├── key: (10)
- │    │    │    │    ├── fd: ()-->(9,38,39), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
- │    │    │    │    ├── ordering: +2,+4,+5 opt(9,38,39) [actual: +2,+4,+5]
- │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    ├── inner-join (lookup cardsinfo)
- │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
- │    │    │    │    │    ├── key columns: [32 1] = [9 10]
- │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── stats: [rows=29618.5, distinct(1)=19000, null(1)=0, distinct(10)=19000, null(10)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
- │    │    │    │    │    ├── key: (10)
- │    │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
- │    │    │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
- │    │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@9":32!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
- │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    ├── stats: [rows=19000]
- │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    ├── fd: ()-->(32), (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │    │    │    │    │    │    ├── ordering: +2,+4,+5 opt(32) [actual: +2,+4,+5]
- │    │    │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    │    │    ├── index-join cards
- │    │    │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
- │    │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(2,4,5)=19000, null(2,4,5)=0]
- │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │    │    │    │    │    │    │    ├── ordering: +2,+4,+5
- │    │    │    │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    │    │    │    └── scan cards@cardsnamesetnumber
- │    │    │    │    │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
- │    │    │    │    │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
- │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
- │    │    │    │    │    │    │         ├── key: (1)
- │    │    │    │    │    │    │         ├── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
- │    │    │    │    │    │    │         ├── ordering: +2,+4,+5
- │    │    │    │    │    │    │         └── limit hint: 100.00
- │    │    │    │    │    │    └── projections
- │    │    │    │    │    │         └── 1 [as="lookup_join_const_col_@9":32]
- │    │    │    │    │    └── filters (true)
- │    │    │    │    └── projections
- │    │    │    │         ├── 1 [as="lookup_join_const_col_@20":38]
- │    │    │    │         └── false [as="lookup_join_const_col_@21":39]
- │    │    │    └── filters (true)
- │    │    └── aggregations
- │    │         ├── sum [as=sum:30, outer=(24)]
- │    │         │    └── quantity:24
- │    │         ├── const-agg [as=id:1, outer=(1)]
- │    │         │    └── id:1
- │    │         ├── const-agg [as=rarity:3, outer=(3)]
- │    │         │    └── rarity:3
- │    │         ├── const-agg [as=isfoil:6, outer=(6)]
- │    │         │    └── isfoil:6
- │    │         ├── const-agg [as=cardsinfo.buyprice:11, outer=(11)]
- │    │         │    └── cardsinfo.buyprice:11
- │    │         ├── const-agg [as=cardsinfo.sellprice:12, outer=(12)]
- │    │         │    └── cardsinfo.sellprice:12
- │    │         ├── const-agg [as=discount:13, outer=(13)]
- │    │         │    └── discount:13
- │    │         ├── const-agg [as=desiredinventory:14, outer=(14)]
- │    │         │    └── desiredinventory:14
- │    │         ├── const-agg [as=actualinventory:15, outer=(15)]
- │    │         │    └── actualinventory:15
- │    │         ├── const-agg [as=maxinventory:16, outer=(16)]
- │    │         │    └── maxinventory:16
- │    │         └── const-agg [as=cardsinfo.version:17, outer=(17)]
- │    │              └── cardsinfo.version:17
- │    └── 50
- └── projections
-      └── COALESCE(sum:30, 0) [as=value:31, outer=(30)]
+ └── project
+      ├── columns: value:31 id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      ├── immutable
+      ├── stats: [rows=49.9764]
+      ├── key: (17,31)
+      ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
+      ├── group-by (hash)
+      │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:30
+      │    ├── grouping columns: cardsinfo.cardid:10!null
+      │    ├── immutable
+      │    ├── stats: [rows=49.9764, distinct(10)=49.9764, null(10)=0]
+      │    ├── key: (10)
+      │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,30), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    ├── left-join (lookup transactiondetails@detailscardidindex)
+      │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null transactiondetails.dealerid:20 isbuy:21 transactiondate:22 transactiondetails.cardid:23 quantity:24
+      │    │    ├── lookup expression
+      │    │    │    └── filters
+      │    │    │         ├── (transactiondate:22 >= '2020-02-28 00:00:00+00') AND (transactiondate:22 <= '2020-03-01 00:00:00+00') [outer=(22), constraints=(/22: [/'2020-02-28 00:00:00+00' - /'2020-03-01 00:00:00+00']; tight)]
+      │    │    │         ├── "lookup_join_const_col_@20":38 = transactiondetails.dealerid:20 [outer=(20,38), constraints=(/20: (/NULL - ]; /38: (/NULL - ]), fd=(20)==(38), (38)==(20)]
+      │    │    │         ├── "lookup_join_const_col_@21":39 = isbuy:21 [outer=(21,39), constraints=(/21: (/NULL - ]; /39: (/NULL - ]), fd=(21)==(39), (39)==(21)]
+      │    │    │         └── id:1 = transactiondetails.cardid:23 [outer=(1,23), constraints=(/1: (/NULL - ]; /23: (/NULL - ]), fd=(1)==(23), (23)==(1)]
+      │    │    ├── immutable
+      │    │    ├── stats: [rows=877.193, distinct(10)=49.9764, null(10)=0, distinct(23)=49.9764, null(23)=0]
+      │    │    ├── key: (10,22-24)
+      │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (10,22-24)-->(20,21), (1)==(10), (10)==(1)
+      │    │    ├── project
+      │    │    │    ├── columns: "lookup_join_const_col_@20":38!null "lookup_join_const_col_@21":39!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      │    │    │    ├── cardinality: [0 - 50]
+      │    │    │    ├── immutable
+      │    │    │    ├── stats: [rows=50]
+      │    │    │    ├── key: (10)
+      │    │    │    ├── fd: ()-->(9,38,39), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    │    │    ├── limit
+      │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      │    │    │    │    ├── internal-ordering: +2,+4,+5 opt(9)
+      │    │    │    │    ├── cardinality: [0 - 50]
+      │    │    │    │    ├── immutable
+      │    │    │    │    ├── stats: [rows=50, distinct(1)=49.9764, null(1)=0, distinct(10)=49.9764, null(10)=0]
+      │    │    │    │    ├── key: (10)
+      │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    │    │    │    ├── inner-join (lookup cardsinfo)
+      │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      │    │    │    │    │    ├── key columns: [32 1] = [9 10]
+      │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    ├── immutable
+      │    │    │    │    │    ├── stats: [rows=29618.5, distinct(1)=19000, null(1)=0, distinct(10)=19000, null(10)=0]
+      │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    │    │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
+      │    │    │    │    │    ├── limit hint: 50.00
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@9":32!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+      │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    ├── stats: [rows=19000]
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: ()-->(32), (1)-->(2-6), (2,4,5)~~>(1,3,6)
+      │    │    │    │    │    │    ├── ordering: +2,+4,+5 opt(32) [actual: +2,+4,+5]
+      │    │    │    │    │    │    ├── limit hint: 100.00
+      │    │    │    │    │    │    ├── index-join cards
+      │    │    │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+      │    │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
+      │    │    │    │    │    │    │    ├── ordering: +2,+4,+5
+      │    │    │    │    │    │    │    ├── limit hint: 100.00
+      │    │    │    │    │    │    │    └── scan cards@cardsnamesetnumber
+      │    │    │    │    │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
+      │    │    │    │    │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
+      │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
+      │    │    │    │    │    │    │         ├── key: (1)
+      │    │    │    │    │    │    │         ├── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
+      │    │    │    │    │    │    │         ├── ordering: +2,+4,+5
+      │    │    │    │    │    │    │         └── limit hint: 100.00
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── 1 [as="lookup_join_const_col_@9":32]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── 50
+      │    │    │    └── projections
+      │    │    │         ├── 1 [as="lookup_join_const_col_@20":38]
+      │    │    │         └── false [as="lookup_join_const_col_@21":39]
+      │    │    └── filters (true)
+      │    └── aggregations
+      │         ├── sum [as=sum:30, outer=(24)]
+      │         │    └── quantity:24
+      │         ├── const-agg [as=id:1, outer=(1)]
+      │         │    └── id:1
+      │         ├── const-agg [as=name:2, outer=(2)]
+      │         │    └── name:2
+      │         ├── const-agg [as=rarity:3, outer=(3)]
+      │         │    └── rarity:3
+      │         ├── const-agg [as=setname:4, outer=(4)]
+      │         │    └── setname:4
+      │         ├── const-agg [as=number:5, outer=(5)]
+      │         │    └── number:5
+      │         ├── const-agg [as=isfoil:6, outer=(6)]
+      │         │    └── isfoil:6
+      │         ├── const-agg [as=cardsinfo.buyprice:11, outer=(11)]
+      │         │    └── cardsinfo.buyprice:11
+      │         ├── const-agg [as=cardsinfo.sellprice:12, outer=(12)]
+      │         │    └── cardsinfo.sellprice:12
+      │         ├── const-agg [as=discount:13, outer=(13)]
+      │         │    └── discount:13
+      │         ├── const-agg [as=desiredinventory:14, outer=(14)]
+      │         │    └── desiredinventory:14
+      │         ├── const-agg [as=actualinventory:15, outer=(15)]
+      │         │    └── actualinventory:15
+      │         ├── const-agg [as=maxinventory:16, outer=(16)]
+      │         │    └── maxinventory:16
+      │         └── const-agg [as=cardsinfo.version:17, outer=(17)]
+      │              └── cardsinfo.version:17
+      └── projections
+           └── COALESCE(sum:30, 0) [as=value:31, outer=(30)]
 
 # Daily transaction query.
 #

--- a/pkg/sql/opt/xform/testdata/external/trading-mutation
+++ b/pkg/sql/opt/xform/testdata/external/trading-mutation
@@ -798,122 +798,126 @@ WHERE (Name, SetName, Number) > ('Shock', '7E', 248)
 ORDER BY Name, SetName, Number
 LIMIT 50
 ----
-project
+sort
  ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null buyprice:11!null sellprice:12!null desiredinventory:14!null actualinventory:15!null version:17!null discount:13!null maxinventory:16!null twodaysales:37
- ├── cardinality: [0 - 50]
  ├── immutable
- ├── stats: [rows=50]
+ ├── stats: [rows=49.9764]
  ├── key: (17,37)
  ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
  ├── ordering: +2,+4,+5
- ├── limit
- │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:36
- │    ├── internal-ordering: +2,+4,+5
- │    ├── cardinality: [0 - 50]
- │    ├── immutable
- │    ├── stats: [rows=50]
- │    ├── key: (10)
- │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,36), (17)-->(10-16), (1)==(10), (10)==(1)
- │    ├── ordering: +2,+4,+5
- │    ├── group-by (partial streaming)
- │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:36
- │    │    ├── grouping columns: name:2!null setname:4 number:5!null cardsinfo.cardid:10!null
- │    │    ├── internal-ordering: +2,+4,+5 opt(9)
- │    │    ├── immutable
- │    │    ├── stats: [rows=29618.5, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
- │    │    ├── key: (10)
- │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,36), (17)-->(10-16), (1)==(10), (10)==(1)
- │    │    ├── ordering: +2,+4,+5
- │    │    ├── limit hint: 50.00
- │    │    ├── left-join (lookup transactiondetails@detailscardidindex)
- │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null transactiondetails.dealerid:24 isbuy:25 transactiondate:26 transactiondetails.cardid:27 quantity:28
- │    │    │    ├── lookup expression
- │    │    │    │    └── filters
- │    │    │    │         ├── (transactiondate:26 >= '2020-02-28 00:00:00+00') AND (transactiondate:26 <= '2020-03-01 00:00:00+00') [outer=(26), constraints=(/26: [/'2020-02-28 00:00:00+00' - /'2020-03-01 00:00:00+00']; tight)]
- │    │    │    │         ├── "lookup_join_const_col_@24":44 = transactiondetails.dealerid:24 [outer=(24,44), constraints=(/24: (/NULL - ]; /44: (/NULL - ]), fd=(24)==(44), (44)==(24)]
- │    │    │    │         ├── "lookup_join_const_col_@25":45 = isbuy:25 [outer=(25,45), constraints=(/25: (/NULL - ]; /45: (/NULL - ]), fd=(25)==(45), (45)==(25)]
- │    │    │    │         └── id:1 = transactiondetails.cardid:27 [outer=(1,27), constraints=(/1: (/NULL - ]; /27: (/NULL - ]), fd=(1)==(27), (27)==(1)]
- │    │    │    ├── immutable
- │    │    │    ├── stats: [rows=519622, distinct(10)=19000, null(10)=0, distinct(27)=19000, null(27)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
- │    │    │    ├── key: (10,26-28)
- │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (10,26-28)-->(24,25), (1)==(10), (10)==(1)
- │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
- │    │    │    ├── limit hint: 877.19
- │    │    │    ├── project
- │    │    │    │    ├── columns: "lookup_join_const_col_@24":44!null "lookup_join_const_col_@25":45!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
- │    │    │    │    ├── immutable
- │    │    │    │    ├── stats: [rows=29618.5]
- │    │    │    │    ├── key: (10)
- │    │    │    │    ├── fd: ()-->(9,44,45), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
- │    │    │    │    ├── ordering: +2,+4,+5 opt(9,44,45) [actual: +2,+4,+5]
- │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    ├── inner-join (lookup cardsinfo)
- │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
- │    │    │    │    │    ├── key columns: [38 1] = [9 10]
- │    │    │    │    │    ├── lookup columns are key
- │    │    │    │    │    ├── immutable
- │    │    │    │    │    ├── stats: [rows=29618.5, distinct(1)=19000, null(1)=0, distinct(10)=19000, null(10)=0, distinct(2,4,5,10)=29618.5, null(2,4,5,10)=0]
- │    │    │    │    │    ├── key: (10)
- │    │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
- │    │    │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
- │    │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    │    ├── project
- │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@9":38!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
- │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    ├── stats: [rows=19000]
- │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    ├── fd: ()-->(38), (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │    │    │    │    │    │    ├── ordering: +2,+4,+5 opt(38) [actual: +2,+4,+5]
- │    │    │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    │    │    ├── index-join cards
- │    │    │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
- │    │    │    │    │    │    │    ├── immutable
- │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0, distinct(2,4,5)=19000, null(2,4,5)=0]
- │    │    │    │    │    │    │    ├── key: (1)
- │    │    │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
- │    │    │    │    │    │    │    ├── ordering: +2,+4,+5
- │    │    │    │    │    │    │    ├── limit hint: 100.00
- │    │    │    │    │    │    │    └── scan cards@cardsnamesetnumber
- │    │    │    │    │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
- │    │    │    │    │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
- │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
- │    │    │    │    │    │    │         ├── key: (1)
- │    │    │    │    │    │    │         ├── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
- │    │    │    │    │    │    │         ├── ordering: +2,+4,+5
- │    │    │    │    │    │    │         └── limit hint: 100.00
- │    │    │    │    │    │    └── projections
- │    │    │    │    │    │         └── 1 [as="lookup_join_const_col_@9":38]
- │    │    │    │    │    └── filters (true)
- │    │    │    │    └── projections
- │    │    │    │         ├── 1 [as="lookup_join_const_col_@24":44]
- │    │    │    │         └── false [as="lookup_join_const_col_@25":45]
- │    │    │    └── filters (true)
- │    │    └── aggregations
- │    │         ├── sum [as=sum:36, outer=(28)]
- │    │         │    └── quantity:28
- │    │         ├── const-agg [as=id:1, outer=(1)]
- │    │         │    └── id:1
- │    │         ├── const-agg [as=rarity:3, outer=(3)]
- │    │         │    └── rarity:3
- │    │         ├── const-agg [as=isfoil:6, outer=(6)]
- │    │         │    └── isfoil:6
- │    │         ├── const-agg [as=cardsinfo.buyprice:11, outer=(11)]
- │    │         │    └── cardsinfo.buyprice:11
- │    │         ├── const-agg [as=cardsinfo.sellprice:12, outer=(12)]
- │    │         │    └── cardsinfo.sellprice:12
- │    │         ├── const-agg [as=cardsinfo.discount:13, outer=(13)]
- │    │         │    └── cardsinfo.discount:13
- │    │         ├── const-agg [as=desiredinventory:14, outer=(14)]
- │    │         │    └── desiredinventory:14
- │    │         ├── const-agg [as=actualinventory:15, outer=(15)]
- │    │         │    └── actualinventory:15
- │    │         ├── const-agg [as=maxinventory:16, outer=(16)]
- │    │         │    └── maxinventory:16
- │    │         └── const-agg [as=cardsinfo.version:17, outer=(17)]
- │    │              └── cardsinfo.version:17
- │    └── 50
- └── projections
-      └── COALESCE(sum:36, 0) [as=value:37, outer=(36)]
+ └── project
+      ├── columns: value:37 id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      ├── immutable
+      ├── stats: [rows=49.9764]
+      ├── key: (17,37)
+      ├── fd: (1)-->(2-6,11-17), (2,4,5)~~>(1,3,6), (17)-->(1-6,11-16)
+      ├── group-by (hash)
+      │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null sum:36
+      │    ├── grouping columns: cardsinfo.cardid:10!null
+      │    ├── immutable
+      │    ├── stats: [rows=49.9764, distinct(10)=49.9764, null(10)=0]
+      │    ├── key: (10)
+      │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(1-6,11-17,36), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    ├── left-join (lookup transactiondetails@detailscardidindex)
+      │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null transactiondetails.dealerid:24 isbuy:25 transactiondate:26 transactiondetails.cardid:27 quantity:28
+      │    │    ├── lookup expression
+      │    │    │    └── filters
+      │    │    │         ├── (transactiondate:26 >= '2020-02-28 00:00:00+00') AND (transactiondate:26 <= '2020-03-01 00:00:00+00') [outer=(26), constraints=(/26: [/'2020-02-28 00:00:00+00' - /'2020-03-01 00:00:00+00']; tight)]
+      │    │    │         ├── "lookup_join_const_col_@24":44 = transactiondetails.dealerid:24 [outer=(24,44), constraints=(/24: (/NULL - ]; /44: (/NULL - ]), fd=(24)==(44), (44)==(24)]
+      │    │    │         ├── "lookup_join_const_col_@25":45 = isbuy:25 [outer=(25,45), constraints=(/25: (/NULL - ]; /45: (/NULL - ]), fd=(25)==(45), (45)==(25)]
+      │    │    │         └── id:1 = transactiondetails.cardid:27 [outer=(1,27), constraints=(/1: (/NULL - ]; /27: (/NULL - ]), fd=(1)==(27), (27)==(1)]
+      │    │    ├── immutable
+      │    │    ├── stats: [rows=877.193, distinct(10)=49.9764, null(10)=0, distinct(27)=49.9764, null(27)=0]
+      │    │    ├── key: (10,26-28)
+      │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (10,26-28)-->(24,25), (1)==(10), (10)==(1)
+      │    │    ├── project
+      │    │    │    ├── columns: "lookup_join_const_col_@24":44!null "lookup_join_const_col_@25":45!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      │    │    │    ├── cardinality: [0 - 50]
+      │    │    │    ├── immutable
+      │    │    │    ├── stats: [rows=50]
+      │    │    │    ├── key: (10)
+      │    │    │    ├── fd: ()-->(9,44,45), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    │    │    ├── limit
+      │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      │    │    │    │    ├── internal-ordering: +2,+4,+5 opt(9)
+      │    │    │    │    ├── cardinality: [0 - 50]
+      │    │    │    │    ├── immutable
+      │    │    │    │    ├── stats: [rows=50, distinct(1)=49.9764, null(1)=0, distinct(10)=49.9764, null(10)=0]
+      │    │    │    │    ├── key: (10)
+      │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    │    │    │    ├── inner-join (lookup cardsinfo)
+      │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null cardsinfo.dealerid:9!null cardsinfo.cardid:10!null cardsinfo.buyprice:11!null cardsinfo.sellprice:12!null cardsinfo.discount:13!null desiredinventory:14!null actualinventory:15!null maxinventory:16!null cardsinfo.version:17!null
+      │    │    │    │    │    ├── key columns: [38 1] = [9 10]
+      │    │    │    │    │    ├── lookup columns are key
+      │    │    │    │    │    ├── immutable
+      │    │    │    │    │    ├── stats: [rows=29618.5, distinct(1)=19000, null(1)=0, distinct(10)=19000, null(10)=0]
+      │    │    │    │    │    ├── key: (10)
+      │    │    │    │    │    ├── fd: ()-->(9), (1)-->(2-6), (2,4,5)~~>(1,3,6), (10)-->(11-17), (17)-->(10-16), (1)==(10), (10)==(1)
+      │    │    │    │    │    ├── ordering: +2,+4,+5 opt(9) [actual: +2,+4,+5]
+      │    │    │    │    │    ├── limit hint: 50.00
+      │    │    │    │    │    ├── project
+      │    │    │    │    │    │    ├── columns: "lookup_join_const_col_@9":38!null id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+      │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    ├── stats: [rows=19000]
+      │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    ├── fd: ()-->(38), (1)-->(2-6), (2,4,5)~~>(1,3,6)
+      │    │    │    │    │    │    ├── ordering: +2,+4,+5 opt(38) [actual: +2,+4,+5]
+      │    │    │    │    │    │    ├── limit hint: 100.00
+      │    │    │    │    │    │    ├── index-join cards
+      │    │    │    │    │    │    │    ├── columns: id:1!null name:2!null rarity:3 setname:4 number:5!null isfoil:6!null
+      │    │    │    │    │    │    │    ├── immutable
+      │    │    │    │    │    │    │    ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
+      │    │    │    │    │    │    │    ├── key: (1)
+      │    │    │    │    │    │    │    ├── fd: (1)-->(2-6), (2,4,5)~~>(1,3,6)
+      │    │    │    │    │    │    │    ├── ordering: +2,+4,+5
+      │    │    │    │    │    │    │    ├── limit hint: 100.00
+      │    │    │    │    │    │    │    └── scan cards@cardsnamesetnumber
+      │    │    │    │    │    │    │         ├── columns: id:1!null name:2!null setname:4 number:5!null
+      │    │    │    │    │    │    │         ├── constraint: /2/4/5: [/'Shock'/'7E'/249 - ]
+      │    │    │    │    │    │    │         ├── stats: [rows=19000, distinct(1)=19000, null(1)=0, distinct(2)=13000, null(2)=0]
+      │    │    │    │    │    │    │         ├── key: (1)
+      │    │    │    │    │    │    │         ├── fd: (1)-->(2,4,5), (2,4,5)~~>(1)
+      │    │    │    │    │    │    │         ├── ordering: +2,+4,+5
+      │    │    │    │    │    │    │         └── limit hint: 100.00
+      │    │    │    │    │    │    └── projections
+      │    │    │    │    │    │         └── 1 [as="lookup_join_const_col_@9":38]
+      │    │    │    │    │    └── filters (true)
+      │    │    │    │    └── 50
+      │    │    │    └── projections
+      │    │    │         ├── 1 [as="lookup_join_const_col_@24":44]
+      │    │    │         └── false [as="lookup_join_const_col_@25":45]
+      │    │    └── filters (true)
+      │    └── aggregations
+      │         ├── sum [as=sum:36, outer=(28)]
+      │         │    └── quantity:28
+      │         ├── const-agg [as=id:1, outer=(1)]
+      │         │    └── id:1
+      │         ├── const-agg [as=name:2, outer=(2)]
+      │         │    └── name:2
+      │         ├── const-agg [as=rarity:3, outer=(3)]
+      │         │    └── rarity:3
+      │         ├── const-agg [as=setname:4, outer=(4)]
+      │         │    └── setname:4
+      │         ├── const-agg [as=number:5, outer=(5)]
+      │         │    └── number:5
+      │         ├── const-agg [as=isfoil:6, outer=(6)]
+      │         │    └── isfoil:6
+      │         ├── const-agg [as=cardsinfo.buyprice:11, outer=(11)]
+      │         │    └── cardsinfo.buyprice:11
+      │         ├── const-agg [as=cardsinfo.sellprice:12, outer=(12)]
+      │         │    └── cardsinfo.sellprice:12
+      │         ├── const-agg [as=cardsinfo.discount:13, outer=(13)]
+      │         │    └── cardsinfo.discount:13
+      │         ├── const-agg [as=desiredinventory:14, outer=(14)]
+      │         │    └── desiredinventory:14
+      │         ├── const-agg [as=actualinventory:15, outer=(15)]
+      │         │    └── actualinventory:15
+      │         ├── const-agg [as=maxinventory:16, outer=(16)]
+      │         │    └── maxinventory:16
+      │         └── const-agg [as=cardsinfo.version:17, outer=(17)]
+      │              └── cardsinfo.version:17
+      └── projections
+           └── COALESCE(sum:36, 0) [as=value:37, outer=(36)]
 
 # Daily transaction query.
 #

--- a/pkg/sql/opt/xform/testdata/rules/limit
+++ b/pkg/sql/opt/xform/testdata/rules/limit
@@ -3085,7 +3085,7 @@ ALTER TABLE t93410_2 INJECT STATISTICS '[
 ----
 
 # A streaming group-by with no TopK operation should be generated.
-opt expect=GenerateStreamingGroupByLimitOrderingHint
+opt expect=GenerateStreamingGroupByLimitOrderingHint disable=PushLimitOrOffsetIntoGroupBy
 SELECT
   DISTINCT
   t1.col1,
@@ -3277,7 +3277,7 @@ top-k
            └── array_remove(array_agg:27, NULL) [as=col6s:28, outer=(27), immutable]
 
 # A distinct-on which satisfies the required ordering should be used.
-opt expect=GenerateStreamingGroupByLimitOrderingHint
+opt expect=GenerateStreamingGroupByLimitOrderingHint disable=PushLimitOrOffsetIntoGroupBy
 SELECT
   DISTINCT ON (t1.col5, t1.col9) t2.col2
 FROM
@@ -3395,7 +3395,7 @@ project
 # A query which normally would produce a streaming group-by with no TopK
 # operation produces a TopK if the GenerateStreamingGroupByLimitOrderingHint
 # rule is disabled.
-opt expect-not=GenerateStreamingGroupByLimitOrderingHint set=optimizer_use_limit_ordering_for_streaming_group_by=false
+opt expect-not=GenerateStreamingGroupByLimitOrderingHint set=optimizer_use_limit_ordering_for_streaming_group_by=false disable=PushLimitOrOffsetIntoGroupBy
 SELECT
   DISTINCT
   t1.col1,


### PR DESCRIPTION
#### opt: add offset variants for some limit rules

This commit adds some variants of existing rules for Limit operators
to handle Offset operators as well. This is trivial for
`PushOffsetIntoOrdinality`, but `PushOffsetIntoJoinLeft` and its mirror
require an additional restriction that the join does not duplicate input
rows. See the rule comments for details.

Epic: None

Release note: None

#### opt: add rule to push limit through group-by

This commit adds a new norm rule `PushLimitOrOffsetIntoGroupBy`, which
is able to push a limit past a GroupBy or DistinctOn when it can prove
that groups that reach the grouping operator correspond directly with
rows from a child/descendant expression. See the comments for
`TryPushLimitOrOffsetIntoGroupByInput` for details.

Fixes #151257

Release note (performance improvement): The optimizer can now push Limit
and Offset operators below GroupBy and Distinct in some cases. This can
significantly improve execution time by processing less rows.