### PR TITLE
logictest: improve testing of RowsAffected for DELETEs

### DIFF
--- a/pkg/ccl/logictestccl/testdata/logic_test/fk_read_committed
+++ b/pkg/ccl/logictestccl/testdata/logic_test/fk_read_committed
@@ -22,10 +22,10 @@ UPDATE jars SET j = j + 4
 query error violates foreign key constraint
 DELETE FROM jars WHERE j = 2
 
-statement ok
+statement count 1
 DELETE FROM cookies WHERE c = 1
 
-statement ok
+statement count 1
 DELETE FROM jars WHERE j = 2
 
 # Test that we do not use parallel FK checks under RC (see #111888).
@@ -204,10 +204,10 @@ SELECT * FROM child_150282;
 4 4
 
 # Test the fk delete fast path
-statement ok
+statement count 1
 DELETE FROM parent_150282;
 
-statement ok
+statement count 0
 DELETE FROM child_150282;
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
+++ b/pkg/ccl/logictestccl/testdata/logic_test/multi_region_remote_access_error
@@ -491,7 +491,7 @@ UPDATE messages_rbr SET account_id = -account_id WHERE account_id NOT IN (SELECT
 # Delete does not fail when accessing all rows in messages_rbr because lookup
 # join does not error out the lookup table in phase 1.
 retry
-statement ok
+statement count 0
 DELETE FROM messages_rbt WHERE account_id NOT IN (SELECT account_id FROM messages_rbr)
 
 # Delete should fail accessing all rows in messages_rbr.
@@ -1476,7 +1476,7 @@ DELETE FROM xy;
 statement ok
 INSERT INTO xy (z, x, y) SELECT z, x, y FROM xyz;
 
-statement ok
+statement count 2
 DELETE FROM xy WHERE x=1;
 
 statement ok
@@ -1522,7 +1522,7 @@ statement error pq: Query has no home region\. Try running the query from region
 UPDATE xy set x=3 WHERE x = 1;
 
 # Deleting a local row is allowed.
-statement ok
+statement count 1
 DELETE FROM xy WHERE x = 1;
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
+++ b/pkg/ccl/logictestccl/testdata/logic_test/partitioning_implicit
@@ -956,8 +956,10 @@ CREATE UNIQUE INDEX uniq_on_t ON t(v) PARTITION BY LIST (partition_by) (
    PARTITION two VALUES IN (2)
 )
 
-statement ok
+statement count 1
 DELETE FROM t WHERE partition_by = 2;
+
+statement ok
 CREATE UNIQUE INDEX uniq_on_t ON t(v) PARTITION BY LIST (partition_by) (
    PARTITION one VALUES IN (1),
    PARTITION two VALUES IN (2)
@@ -979,8 +981,10 @@ INSERT INTO t VALUES (1, 1), (2, 1);
 statement error could not create unique constraint "uniq_on_t"\nDETAIL: Key \(v\)=\(1\) is duplicated
 CREATE UNIQUE INDEX uniq_on_t ON t(v)
 
-statement ok
+statement count 1
 DELETE FROM t WHERE partition_by = 2;
+
+statement ok
 CREATE UNIQUE INDEX uniq_on_t ON t(v)
 
 # Tests adding a new partial UNIQUE index with implicit partitioning.
@@ -999,8 +1003,10 @@ CREATE UNIQUE INDEX uniq_on_t ON t(a) PARTITION BY LIST (partition_by) (
    PARTITION two VALUES IN (2)
 ) WHERE b > 0
 
-statement ok
+statement count 1
 DELETE FROM t WHERE partition_by = 1 AND a = 1;
+
+statement ok
 CREATE UNIQUE INDEX uniq_on_t ON t(a) PARTITION BY LIST (partition_by) (
    PARTITION one VALUES IN (1),
    PARTITION two VALUES IN (2)
@@ -1023,6 +1029,8 @@ INSERT INTO t VALUES (1, 1, 1), (1, 2, 2), (2, 1, 1), (2, 2, -2);
 statement error could not create unique constraint "uniq_on_t"\nDETAIL: Key \(a\)=\(1\) is duplicated
 CREATE UNIQUE INDEX uniq_on_t ON t(a) WHERE b > 0
 
-statement ok
+statement count 1
 DELETE FROM t WHERE partition_by = 1 AND a = 1;
+
+statement ok
 CREATE UNIQUE INDEX uniq_on_t ON t(a) WHERE b > 0

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cte
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cte
@@ -129,7 +129,7 @@ CREATE FUNCTION f() RETURNS INT LANGUAGE PLpgSQL AS $$
 $$;
 
 # Avoid causing an error due to too many rows returned.
-statement ok
+statement count 3
 DELETE FROM ab WHERE a > 1;
 
 query I

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_cursor
@@ -369,7 +369,7 @@ SELECT f();
 statement ok
 ABORT;
 
-statement ok
+statement count 0
 DELETE FROM xy WHERE x <> 1 AND x <> 3;
 
 # Testing bound cursors.
@@ -652,7 +652,7 @@ CREATE OR REPLACE FUNCTION f() RETURNS INT AS $$
   END
 $$ LANGUAGE PLpgSQL;
 
-statement ok
+statement count 0
 DELETE FROM xy WHERE x <> 1 AND x <> 3;
 
 # Testing unnamed cursors.

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_into
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_into
@@ -51,7 +51,7 @@ SELECT f();
 3
 
 # If the INTO query returns no rows, the target variables are set to NULL.
-statement ok
+statement count 2
 DELETE FROM xy WHERE true;
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_txn
+++ b/pkg/ccl/logictestccl/testdata/logic_test/plpgsql_txn
@@ -300,7 +300,7 @@ NOTICE: 2
 NOTICE: 5
 NOTICE: 5
 
-statement ok
+statement count 1
 DELETE FROM t WHERE x > 2;
 
 query T noticetrace
@@ -325,8 +325,10 @@ SELECT * FROM t;
 
 subtest exceptions
 
-statement ok
+statement count 3
 DELETE FROM t WHERE True;
+
+statement ok
 INSERT INTO t VALUES (1);
 
 statement ok
@@ -540,7 +542,7 @@ subtest retries
 
 # NOTE: logictest configurations will ensure this test gets coverage for both
 # serializable and read-committed isolation.
-statement ok
+statement count 1
 DELETE FROM t WHERE x <> 1;
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row
@@ -343,8 +343,10 @@ INSERT INTO multi_region_test_db.regional_by_row_table (crdb_region, pk, pk2, a,
 statement error could not create unique constraint "uniq_idx"\nDETAIL: Key \(a\)=\(5\) is duplicated
 CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a)
 
-statement ok
+statement count 1
 DELETE FROM regional_by_row_table WHERE pk = 5;
+
+statement ok
 CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a)
 
 query TTB colnames
@@ -375,8 +377,10 @@ INSERT INTO multi_region_test_db.regional_by_row_table (crdb_region, pk, pk2, a,
 statement error could not create unique constraint "uniq_idx"\nDETAIL: Key \(a\)=\(5\) is duplicated
 CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a) WHERE b > 0
 
-statement ok
+statement count 1
 DELETE FROM regional_by_row_table WHERE pk = 5;
+
+statement ok
 CREATE UNIQUE INDEX uniq_idx ON regional_by_row_table(a) WHERE b > 0
 
 query TI
@@ -447,7 +451,7 @@ INSERT INTO regional_by_row_table (pk, pk2, a, b) VALUES (1000, 1, 1000, 2000)
 statement error Key \(pk2\)=\(1\) already exists\.
 ALTER TABLE regional_by_row_table ALTER PRIMARY KEY USING COLUMNS (pk2)
 
-statement ok
+statement count 1
 DELETE FROM regional_by_row_table WHERE pk = 1000
 
 statement ok

--- a/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
+++ b/pkg/ccl/logictestccl/testdata/logic_test/regional_by_row_foreign_key
@@ -1560,7 +1560,7 @@ k  v   child_region    parent_cascade_region
 5  50  ap-southeast-2  ap-southeast-2
 6  60  us-east-1       us-east-1
 
-statement ok
+statement count 2
 DELETE FROM parent_cascade WHERE k = 3 OR k = 4;
 
 query IITT colnames
@@ -1594,8 +1594,10 @@ DROP FUNCTION display_child;
 statement ok
 DROP TABLE child;
 
-statement ok
+statement count 4
 DELETE FROM parent_cascade WHERE true;
+
+statement ok
 INSERT INTO parent_cascade (k, crdb_region) (SELECT k, crdb_region FROM parent_rbr);
 
 statement ok
@@ -1634,7 +1636,7 @@ k1  k2  v   child_region    parent_rbr_region  parent_cascade_region
 5   5   50  ap-southeast-2  ap-southeast-2     ap-southeast-2
 6   6   60  us-east-1       us-east-1          us-east-1
 
-statement ok
+statement count 2
 DELETE FROM parent_cascade WHERE k = 3 OR k = 4;
 
 query IIITTT colnames

--- a/pkg/ccl/logictestccl/testdata/logic_test/triggers
+++ b/pkg/ccl/logictestccl/testdata/logic_test/triggers
@@ -1421,7 +1421,7 @@ CREATE FUNCTION g() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
   END
 $$;
 
-statement ok
+statement count 0
 DELETE FROM xy WHERE True;
 
 # Test a basic INSERT trigger.
@@ -1539,7 +1539,7 @@ SELECT * FROM xy;
 5  -6
 7  -8
 
-statement ok
+statement count 4
 DELETE FROM xy WHERE True;
 
 statement ok
@@ -1609,7 +1609,7 @@ SELECT * FROM xy;
 3  14
 5  230
 
-statement ok
+statement count 2
 DELETE FROM xy WHERE True;
 INSERT INTO xy VALUES (1, 2), (3, 4);
 
@@ -1654,7 +1654,7 @@ SELECT * FROM xy;
 3  150
 5  16
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE x = 5;
 
 # UPSERT with ON CONFLICT syntax. Note that the effect of the INSERT trigger
@@ -1694,7 +1694,7 @@ SELECT * FROM xy;
 3  23
 5  25
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE x = 5;
 
 # UPSERT with explicit syntax.
@@ -1714,7 +1714,7 @@ SELECT * FROM xy;
 3  24
 5  16
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE x = 5;
 
 # The old version of conflicting rows can be accessed via the relation's name.
@@ -1797,7 +1797,7 @@ DROP TRIGGER foo ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 2
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -1944,7 +1944,7 @@ DROP TABLE nullable;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 2
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -2020,7 +2020,7 @@ DROP TRIGGER foo2 ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 0
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -2149,7 +2149,7 @@ DROP TRIGGER foo ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 4
 DELETE FROM xy WHERE True;
 
 # The return value of an AFTER trigger is ignored.
@@ -2180,7 +2180,7 @@ DROP TRIGGER foo ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -2253,7 +2253,7 @@ DROP TRIGGER foo2 ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 0
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -2306,7 +2306,7 @@ DROP TRIGGER bar ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 2
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -2395,8 +2395,10 @@ SELECT * FROM t2;
 2  1
 4  1
 
-statement ok
+statement count 3
 DELETE FROM t1 WHERE True;
+
+statement count 2
 DELETE FROM t2 WHERE True;
 
 statement ok
@@ -2458,8 +2460,10 @@ SELECT * FROM t2;
 2  1
 4  1
 
-statement ok
+statement count 3
 DELETE FROM t1 WHERE True;
+
+statement count 2
 DELETE FROM t2 WHERE True;
 
 # Test mutually cyclical BEFORE and AFTER triggers.
@@ -2515,8 +2519,10 @@ SELECT * FROM t2;
 2  1
 4  1
 
-statement ok
+statement count 3
 DELETE FROM t1 WHERE True;
+
+statement count 2
 DELETE FROM t2 WHERE True;
 
 statement ok
@@ -2571,7 +2577,7 @@ SELECT * FROM t1;
 4  1
 5  1
 
-statement ok
+statement count 5
 DELETE FROM t1 WHERE True;
 
 statement ok
@@ -2620,7 +2626,7 @@ SELECT * FROM t1;
 4  1
 5  1
 
-statement ok
+statement count 5
 DELETE FROM t1 WHERE True;
 
 statement ok
@@ -2697,8 +2703,10 @@ NOTICE: AFTER DELETE ON child: (2,20) -> <NULL>
 NOTICE: AFTER DELETE ON child: (3,20) -> <NULL>
 NOTICE: AFTER DELETE ON child: (4,30) -> <NULL>
 
-statement ok
+statement count 1
 DELETE FROM child WHERE True;
+
+statement count 1
 DELETE FROM parent WHERE True;
 
 statement ok
@@ -2764,8 +2772,10 @@ NOTICE: AFTER DELETE ON child: (4,30) -> <NULL>
 statement ok
 DROP TRIGGER foo ON ab;
 
-statement ok
+statement count 1
 DELETE FROM child WHERE True;
+
+statement count 1
 DELETE FROM parent WHERE True;
 
 statement ok
@@ -2815,9 +2825,13 @@ DROP TRIGGER foo ON ab;
 statement ok
 DROP FUNCTION h;
 
-statement ok
+statement count 8
 DELETE FROM ab WHERE True;
+
+statement count 1
 DELETE FROM child WHERE True;
+
+statement count 1
 DELETE FROM parent WHERE True;
 
 # FK checks happen before AFTER triggers that were fired by the main query.
@@ -2911,9 +2925,13 @@ CREATE FUNCTION filter() RETURNS TRIGGER LANGUAGE PLpgSQL AS $$
   END
 $$;
 
-statement ok
+statement count 4
 DELETE FROM child WHERE True;
+
+statement count 3
 DELETE FROM parent WHERE True;
+
+statement ok
 INSERT INTO parent VALUES (1), (2), (3);
 INSERT INTO child VALUES (1, 1), (2, 2), (3, 2), (4, 3);
 
@@ -2932,7 +2950,7 @@ SET unsafe_allow_triggers_modifying_cascades = true;
 statement ok
 UPDATE parent SET k = k + 10 WHERE k < 3;
 
-statement ok
+statement count 0
 DELETE FROM parent WHERE k < 3;
 
 statement ok
@@ -2941,9 +2959,13 @@ RESET unsafe_allow_triggers_modifying_cascades;
 statement ok
 DROP TRIGGER mod ON child;
 
-statement ok
+statement count 4
 DELETE FROM child WHERE True;
+
+statement count 3
 DELETE FROM parent WHERE True;
+
+statement ok
 INSERT INTO parent VALUES (1), (2), (3);
 INSERT INTO child VALUES (1, 1), (2, 2), (3, 2), (4, 3);
 
@@ -2962,7 +2984,7 @@ SET unsafe_allow_triggers_modifying_cascades = true;
 statement ok
 UPDATE parent SET k = k + 10 WHERE k < 3;
 
-statement ok
+statement count 0
 DELETE FROM parent WHERE k < 3;
 
 statement ok
@@ -2971,7 +2993,7 @@ RESET unsafe_allow_triggers_modifying_cascades;
 statement ok
 DROP TRIGGER filter ON child;
 
-statement ok
+statement count 4
 DELETE FROM child WHERE True;
 DELETE FROM parent WHERE True;
 INSERT INTO parent VALUES (1), (2), (3);
@@ -3222,7 +3244,7 @@ DROP TRIGGER c_trig ON xy;
 statement ok
 DROP TRIGGER d_trig ON xy;
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE True;
 
 subtest after_row_order
@@ -3265,7 +3287,7 @@ DROP FUNCTION g;
 statement ok
 DROP FUNCTION h;
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE True;
 
 subtest before_after_row_order
@@ -3317,7 +3339,7 @@ DROP TRIGGER bar ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 3
 DELETE FROM xy WHERE True;
 
 # ==============================================================================
@@ -4253,7 +4275,7 @@ DROP TRIGGER bar ON xy;
 statement ok
 DROP FUNCTION g;
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE true;
 
 # ==============================================================================

--- a/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
+++ b/pkg/ccl/logictestccl/testdata/logic_test/udf_plpgsql
@@ -1559,7 +1559,7 @@ SELECT * FROM kv;
 3    4
 100  100
 
-statement ok
+statement count 1
 DELETE FROM kv WHERE k = 100;
 
 statement ok
@@ -1663,7 +1663,7 @@ SELECT f(-1)
 ----
 NOTICE: outside IF
 
-statement ok
+statement count 0
 DELETE FROM xy WHERE x >= 100;
 
 # Testing rollback behavior for EXCEPTION blocks.
@@ -1706,7 +1706,7 @@ SELECT * FROM xy;
 3     4
 -200  -200
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE x <> 1 AND x <> 3;
 
 # The error raised in the exception handler should prevent the second insert
@@ -1779,7 +1779,7 @@ SELECT * FROM xy;
 3     4
 -100  -100
 
-statement ok
+statement count 1
 DELETE FROM xy WHERE x <> 1 AND x <> 3;
 
 # Test interaction with IF statements.
@@ -1840,7 +1840,7 @@ SELECT * FROM xy;
 100   100
 -200  -200
 
-statement ok
+statement count 2
 DELETE FROM xy WHERE x <> 1 AND x <> 3;
 
 # Test interaction with loops.
@@ -1892,7 +1892,7 @@ SELECT * FROM xy;
 202  202
 204  204
 
-statement ok
+statement count 3
 DELETE FROM xy WHERE x <> 1 AND x <> 3;
 
 # Catching a Transaction Retry error is not supported, because such errors
@@ -2442,7 +2442,7 @@ SELECT f();
 ----
 0
 
-statement ok
+statement count 1
 DELETE FROM t_text WHERE True;
 INSERT INTO t_text VALUES ('False');
 

--- a/pkg/sql/logictest/testdata/logic_test/aggregate
+++ b/pkg/sql/logictest/testdata/logic_test/aggregate
@@ -1099,7 +1099,7 @@ SELECT bool_and(b), bool_or(b) FROM bools
 ----
 false true
 
-statement ok
+statement count 3
 DELETE FROM bools WHERE b
 
 query BB
@@ -3046,8 +3046,10 @@ count_1  count_lower  count_upper  concat
 3        3            3            bbb
 
 # Tests for selecting any columns when grouping by the PK.
-statement ok
+statement count 2
 DELETE FROM ab WHERE true;
+
+statement ok
 INSERT INTO ab VALUES (1,1), (2,1), (3,3), (4, 7)
 
 query I rowsort
@@ -3347,7 +3349,7 @@ SELECT bit_or(v), bit_or(b) FROM vals
 
 # Testing bit aggregate functions over a sequence with all nulls.
 
-statement ok
+statement count 7
 DELETE FROM vals
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alter_column_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_column_type
@@ -1540,7 +1540,7 @@ INSERT INTO stored1 VALUES (2147483648),(2147483647);
 statement error pq: validate check constraint: integer out of range for type int4
 ALTER TABLE stored1 ALTER COLUMN COMP1 SET DATA TYPE INT4;
 
-statement ok
+statement count 1
 DELETE FROM stored1 WHERE a = 2147483648;
 
 statement ok
@@ -1683,7 +1683,7 @@ virt1  CREATE TABLE public.virt1 (
 statement error pq: validate check constraint: integer out of range for type int2
 ALTER TABLE virt1 ALTER COLUMN v1 SET DATA TYPE INT2;
 
-statement ok
+statement count 1
 DELETE FROM virt1 WHERE c1 = 2147483647;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/alter_primary_key
+++ b/pkg/sql/logictest/testdata/logic_test/alter_primary_key
@@ -1366,7 +1366,7 @@ ALTER TABLE t54629 ALTER PRIMARY KEY USING COLUMNS (c);
 statement ok
 INSERT INTO t54629 VALUES (1);
 
-statement ok
+statement count 1
 DELETE FROM t54629 WHERE c = 1
 
 statement ok
@@ -1384,7 +1384,7 @@ DROP INDEX t54629_a_key CASCADE;
 statement ok
 INSERT INTO t54629 VALUES (1, 1);
 
-statement ok
+statement count 1
 DELETE FROM t54629 WHERE c = 1;
 
 # Validate ALTER ADD PRIMARY KEY idempotence for #59307

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -1735,19 +1735,19 @@ statement error column "g" does not exist
 ALTER TABLE unique_without_index ADD CONSTRAINT bad_partial_unique UNIQUE WITHOUT INDEX (f) WHERE g > 0
 
 # The unique constraint prevents new duplicate values.
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error pgcode 23505 pq: duplicate key value violates unique constraint "my_unique_f"\nDETAIL: Key \(f\)=\(1\) already exists\.
 INSERT INTO unique_without_index (f) VALUES (1), (1)
 
 # There is no unique constraint on e, yet, so this insert succeeds.
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 INSERT INTO unique_without_index (e, f) VALUES (1, 1), (1, 2)
 
 # But trying to add a unique constraint now fails.
 # Note that we omit the constraint name in the expected error message because if the declarative schema changer is used,
 # the constraint name, at the time of validation failure, is still a place-holder name.
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
 ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX (e)
 
@@ -1757,7 +1757,7 @@ ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e UNIQUE WITHOUT INDEX
 ALTER TABLE unique_without_index ADD CONSTRAINT my_unique_e2 UNIQUE WITHOUT INDEX (e) NOT VALID
 
 # Trying to validate one of the constraints will fail.
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL: Key \(e\)=\(1\) is duplicated\.
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
 
@@ -1769,7 +1769,7 @@ statement ok
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
 
 # All these constraints are already valid, so validation should succeed.
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_b;
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT unique_a_b;

--- a/pkg/sql/logictest/testdata/logic_test/alter_table
+++ b/pkg/sql/logictest/testdata/logic_test/alter_table
@@ -127,7 +127,7 @@ INSERT INTO t (a, f) VALUES (-2, 9)
 statement error validation of CHECK "a > 0:::INT8" failed on row: a=-2, f=9, b=NULL, c=NULL
 ALTER TABLE t ADD CONSTRAINT check_a CHECK (a > 0)
 
-statement ok
+statement count 1
 DELETE FROM t WHERE a = -2
 
 statement ok
@@ -1041,7 +1041,7 @@ INSERT INTO t VALUES (1), (NULL)
 statement error (.*validation of CHECK "a IS NOT NULL" failed on row: a=NULL, rowid=\d+|pq: validation of column "a" NOT NULL failed on row: a=NULL, rowid=\d+)
 ALTER TABLE t ALTER COLUMN a SET NOT NULL
 
-statement ok
+statement count 1
 DELETE FROM t WHERE a IS NULL
 
 statement ok
@@ -1120,7 +1120,7 @@ INSERT INTO t VALUES (20)
 statement error pq: validation of CHECK "a < 16:::INT8" failed on row: a=17
 ALTER TABLE t VALIDATE CONSTRAINT check_a1
 
-statement ok
+statement count 1
 DELETE FROM t WHERE a = 17
 
 statement ok
@@ -1762,7 +1762,8 @@ statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL
 ALTER TABLE unique_without_index VALIDATE CONSTRAINT my_unique_e
 
 # But after we delete a row, validation should succeed.
-statement ok
+skipif config #126592 weak-iso-level-configs
+statement count 1
 DELETE FROM unique_without_index WHERE e = 1 AND f = 1;
 
 statement ok
@@ -1826,7 +1827,7 @@ statement error pgcode 23505 pq: could not create unique constraint ".*"\nDETAIL
 ALTER TABLE unique_without_index_partial VALIDATE CONSTRAINT uniq_a_1
 
 # But after we delete a row, validation should succeed.
-statement ok
+statement count 1
 DELETE FROM unique_without_index_partial WHERE a = 1 AND b = 3 AND c = -3;
 
 statement ok
@@ -4814,7 +4815,7 @@ ALTER TABLE y DROP CONSTRAINT y_computed_col_fkey;
 statement ok
 ALTER TABLE y ADD FOREIGN KEY (computed_col) REFERENCES x ON DELETE CASCADE;
 
-statement ok
+statement count 2
 DELETE FROM x WHERE A IN (0,2);
 
 query II rowsort

--- a/pkg/sql/logictest/testdata/logic_test/alter_type
+++ b/pkg/sql/logictest/testdata/logic_test/alter_type
@@ -317,7 +317,7 @@ hello
 
 # Once the use of "yo" has been removed, we should be able to remove it from the
 # enum
-statement ok
+statement count 1
 DELETE FROM use_greetings WHERE use_greetings.v = 'yo'
 
 statement ok
@@ -345,7 +345,7 @@ ALTER TYPE alphabets DROP VALUE 'b'
 statement error pq: could not remove enum value "c" as it is being used by "uses_alphabets"
 ALTER TYPE alphabets DROP VALUE 'c'
 
-statement ok
+statement count 1
 DELETE FROM uses_alphabets WHERE k = 1
 
 statement ok
@@ -545,7 +545,7 @@ statement error could not remove enum value "d" as it is being used by table "te
 ALTER TYPE alphabets_60004 DROP VALUE 'd'
 
 # Remove the row that uses 'd' in it and then try dropping.
-statement ok
+statement count 1
 DELETE FROM using_alphabets_60004 WHERE k = 2
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/array
+++ b/pkg/sql/logictest/testdata/logic_test/array
@@ -517,7 +517,7 @@ SELECT b FROM a
 ----
 {1,2,3}
 
-statement ok
+statement count 1
 DELETE FROM a
 
 statement ok
@@ -528,7 +528,7 @@ SELECT b FROM a
 ----
 NULL
 
-statement ok
+statement count 1
 DELETE FROM a
 
 statement ok
@@ -539,7 +539,7 @@ SELECT b FROM a
 ----
 {}
 
-statement ok
+statement count 1
 DELETE FROM a;
 
 # Make sure arrays originating from ARRAY_AGG work as expected.
@@ -578,7 +578,7 @@ INSERT INTO a VALUES (ARRAY['foo'])
 statement error could not parse "foo" as type int
 INSERT INTO a VALUES (ARRAY[1, 'foo'])
 
-statement ok
+statement count 1
 DELETE FROM a
 
 statement ok
@@ -600,7 +600,7 @@ NULL
 
 # NULL values
 
-statement ok
+statement count 3
 DELETE FROM a
 
 statement ok
@@ -614,7 +614,7 @@ SELECT * FROM a
 {1,NULL}
 {NULL,NULL}
 
-statement ok
+statement count 4
 DELETE FROM a
 
 # Test with arrays bigger than 8 elements so the NULL bitmap has to be larger than a byte
@@ -684,7 +684,7 @@ SELECT b FROM a
 
 # Test NULLs with strings
 
-statement ok
+statement count 1
 DELETE FROM a
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/bit
+++ b/pkg/sql/logictest/testdata/logic_test/bit
@@ -168,8 +168,11 @@ SELECT x.b, ~x.b AS comp FROM bits x WHERE b IS NOT NULL
 0110  1001
 0011  1100
 
+statement count 17
+DELETE FROM bits
+
 statement ok
-DELETE FROM bits; INSERT INTO bits(c) VALUES (B'0'), (B'1')
+INSERT INTO bits(c) VALUES (B'0'), (B'1')
 
 query TT rowsort
 SELECT x.c, ~x.c AS comp FROM bits x

--- a/pkg/sql/logictest/testdata/logic_test/buffered_writes
+++ b/pkg/sql/logictest/testdata/logic_test/buffered_writes
@@ -120,7 +120,7 @@ BEGIN;
 statement ok
 INSERT INTO t2 VALUES (1);
 
-statement ok
+statement count 1
 DELETE FROM t2 WHERE k = 1;
 
 statement ok
@@ -211,9 +211,13 @@ SELECT * FROM t4
 9  900
 
 # Throw in some Deletes.
-statement ok
+statement count 1
 DELETE FROM t4 WHERE k = 1;
+
+statement count 1
 DELETE FROM t4 WHERE k = 2;
+
+statement count 1
 DELETE FROM t4 WHERE k = 3;
 
 query II rowsort
@@ -473,7 +477,7 @@ statement ok
 UPDATE t5 SET v = 2 WHERE pk = 1
 
 # Force a flush before commit with DeleteRange
-statement ok
+statement count 0
 DELETE FROM t5 WHERE pk > 5
 
 statement ok
@@ -540,7 +544,7 @@ statement ok
 UPDATE t7 SET v = 3 WHERE pk = 3
 
 # Force a flush before commit with DeleteRange
-statement ok
+statement count 0
 DELETE FROM t7 WHERE pk > 5
 
 statement ok
@@ -578,7 +582,7 @@ statement ok
 ROLLBACK TO rollback_target_2
 
 # Force a flush before commit with DeleteRange
-statement ok
+statement count 0
 DELETE FROM t7 WHERE pk > 5
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/cascade
+++ b/pkg/sql/logictest/testdata/logic_test/cascade
@@ -23,7 +23,7 @@ SELECT * FROM child
 10  1
 20  2
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p >= 2
 
 query II rowsort
@@ -32,7 +32,7 @@ SELECT * FROM child
 1   1
 10  1
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p <= 2
 
 query II
@@ -55,22 +55,22 @@ INSERT INTO child VALUES (10, 1), (11, 1), (20, 2), (21, 2);
 statement ok
 INSERT INTO grandchild VALUES (100, 10), (101, 10), (110, 11);
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p = 2
 
 statement error delete on table "child" violates foreign key constraint "grandchild_c_fkey" on table "grandchild"\nDETAIL: Key \(c\)\=\(1[01]\) is still referenced from table "grandchild"
 DELETE FROM parent WHERE p = 1
 
-statement ok
+statement count 2
 DELETE FROM grandchild WHERE c = 10
 
 statement error delete on table "child" violates foreign key constraint "grandchild_c_fkey" on table "grandchild"\nDETAIL: Key \(c\)=\(11\) is still referenced from table "grandchild"
 DELETE FROM parent WHERE p = 1
 
-statement ok
+statement count 1
 DELETE FROM grandchild WHERE c = 11
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p = 1
 
 statement ok
@@ -92,7 +92,7 @@ INSERT INTO child VALUES (10, 1), (11, 1), (20, 2), (21, 2);
 statement ok
 INSERT INTO grandchild VALUES (100, 10), (101, 10), (110, 11), (200, 20)
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p = 1
 
 query II rowsort
@@ -106,7 +106,7 @@ SELECT * FROM grandchild
 ----
 200  20
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p = 2
 
 query II
@@ -174,7 +174,7 @@ SELECT a,b,c FROM child_multi_2
 2  20  200
 3  30  300
 
-statement ok
+statement count 1
 DELETE FROM parent_multi WHERE pa = 1
 
 query III rowsort
@@ -197,7 +197,7 @@ SELECT a,b,c FROM child_multi_2
 2  20  200
 3  30  300
 
-statement ok
+statement count 1
 DELETE FROM parent_multi WHERE pb = 20
 
 query III rowsort
@@ -217,7 +217,7 @@ SELECT a,b,c FROM child_multi_2
 3  30  300
 
 # Deleting NULLs should not cause any changes in a child.
-statement ok
+statement count 1
 DELETE FROM parent_multi WHERE pa IS NULL
 
 query III rowsort
@@ -248,7 +248,7 @@ statement ok
 INSERT INTO self VALUES (1, NULL);
 INSERT INTO self SELECT x, x-1 FROM generate_series(2, 10) AS g(x)
 
-statement ok
+statement count 1
 DELETE FROM self WHERE a = 4
 
 query II rowsort
@@ -258,7 +258,7 @@ SELECT * FROM self
 2   1
 3   2
 
-statement ok
+statement count 1
 DELETE FROM self WHERE a = 1
 
 query II
@@ -333,7 +333,7 @@ statement error pq: update on table "a" violates foreign key constraint "b_updat
 UPDATE a SET id = 1000 WHERE id = 4;
 
 # 5. ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 5;
 
 query I
@@ -359,7 +359,7 @@ statement error pq: duplicate key value violates unique constraint "a_pkey"\nDET
 UPDATE a SET id = 1 WHERE id = 1006;
 
 # 7. ON DELETE SET NULL
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 7;
 
 query IIIIIIIIII
@@ -377,7 +377,7 @@ SELECT * FROM b;
 1  2  3  4  5  1006  NULL  NULL  9  10
 
 # 9. ON DELETE SET DEFAULT
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 9
 
 query IIIIIIIIII
@@ -459,7 +459,7 @@ INSERT INTO c2 VALUES
 INSERT INTO c3 VALUES ('b2-pk1'), ('b2-pk2');
 
 # ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'a-pk1';
 
 query IIIIII
@@ -519,7 +519,7 @@ INSERT INTO c1 VALUES ('pk1');
 INSERT INTO c2 VALUES ('pk1');
 
 # ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'pk1';
 
 query IIIII
@@ -608,7 +608,7 @@ INSERT INTO c2 VALUES
 ;
 
 # ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'a-pk1';
 
 query IIIII
@@ -697,7 +697,7 @@ INSERT INTO c2 VALUES
 ;
 
 # ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'a-pk1';
 
 query IIIII
@@ -802,7 +802,7 @@ INSERT INTO self VALUES (2, 1);
 INSERT INTO self VALUES (3, 2);
 INSERT INTO self VALUES (4, 3);
 
-statement ok
+statement count 1
 DELETE FROM self WHERE id = 1;
 
 query I
@@ -833,7 +833,7 @@ INSERT INTO self VALUES (4, 3);
 statement ok
 UPDATE self SET other_id = 4 WHERE id = 1;
 
-statement ok
+statement count 1
 DELETE FROM self WHERE id = 1;
 
 query I
@@ -879,7 +879,7 @@ INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk3', 'loop_a-pk3');
 statement ok
 UPDATE loop_a SET cascade_delete = 'loop_b-pk3' WHERE id = 'loop_a-pk1';
 
-statement ok
+statement count 1
 DELETE FROM loop_a WHERE id = 'loop_a-pk1';
 
 query II
@@ -925,7 +925,7 @@ INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk2', 'loop_a-pk2');
 INSERT INTO loop_a (id, cascade_delete) VALUES ('loop_a-pk3', 'loop_b-pk2');
 INSERT INTO loop_b (id, cascade_delete) VALUES ('loop_b-pk3', 'loop_a-pk3');
 
-statement ok
+statement count 1
 DELETE FROM loop_a WHERE id = 'loop_a-pk1';
 
 query II
@@ -957,7 +957,7 @@ INSERT INTO self_x2 (x, y, z) VALUES ('pk1', NULL, NULL);
 INSERT INTO self_x2 (x, y, z) VALUES ('pk2', 'pk1', NULL);
 INSERT INTO self_x2 (x, y, z) VALUES ('pk3', 'pk2', 'pk1');
 
-statement ok
+statement count 1
 DELETE FROM self_x2 WHERE x = 'pk1';
 
 query I
@@ -1015,7 +1015,7 @@ INSERT INTO c (id, a_id) VALUES ('c1', 'a1');
 INSERT INTO d (id, c_id) VALUES ('d1', 'c1');
 INSERT INTO e (id, b_id, d_id) VALUES ('e1', 'b1', 'd1');
 
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'a1';
 
 query IIIII
@@ -1049,7 +1049,7 @@ statement ok
 INSERT INTO a VALUES (1), (2), (3);
 INSERT INTO b VALUES (1, 1), (2, NULL), (3, 2), (4, 1), (5, NULL);
 
-statement ok
+statement count 3
 DELETE FROM a;
 
 query II rowsort
@@ -1521,7 +1521,7 @@ INSERT INTO d1 VALUES ('d1-pk1', 'original');
 statement error pq: update on table "c2" violates foreign key constraint "d1_update_restrict_fkey" on table "d1"\nDETAIL: Key \(update_cascade\)=\('original'\) is still referenced from table "d1"\.
 UPDATE a SET id = 'updated' WHERE id = 'original';
 
-statement ok
+statement count 1
 DELETE FROM d1 WHERE id = 'd1-pk1';
 
 # Test a primary key restrict.
@@ -2080,7 +2080,7 @@ INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');
 INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
 
 # ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'delete_me';
 
 query TT rowsort
@@ -2164,7 +2164,7 @@ INSERT INTO c3 VALUES
 
 # This query expects to cascade the deletion in a into b1 and b2, but not into
 # the c tables which have ON DELETE SET NULL instead.
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'a-pk1';
 
 query TT rowsort
@@ -2269,7 +2269,7 @@ INSERT INTO c VALUES
  ,('c4-b2', 'untouched')
 ;
 
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'delete-me';
 
 query I
@@ -2616,7 +2616,7 @@ INSERT INTO b3 VALUES ('b3-pk1', 'delete_me'), ('b3-pk2', 'untouched');
 INSERT INTO b4 VALUES ('b4-pk1', 'delete_me'), ('b4-pk2', 'delete_me');
 
 # ON DELETE CASCADE
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'delete_me';
 
 query TT rowsort
@@ -2744,7 +2744,7 @@ INSERT INTO c3 VALUES
 
 # This query expects to cascade the deletion in a into b1 and b2, but not into
 # the c tables which have ON DELETE SET DEFAULT instead.
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'a-pk1';
 
 query TT rowsort
@@ -2921,7 +2921,7 @@ INSERT INTO c VALUES
  ,('c4-b2', 'untouched')
 ;
 
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'delete-me';
 
 query T rowsort
@@ -2980,7 +2980,7 @@ INSERT INTO c VALUES
 ;
 
 # Cascade the delete in a to the SET DEFAULT in b to the CASCADE in c
-statement ok
+statement count 1
 DELETE FROM a WHERE id = 'delete-me';
 
 query TT rowsort
@@ -3464,7 +3464,7 @@ INSERT INTO example VALUES (20, NULL);
 INSERT INTO example VALUES (30, 20);
 INSERT INTO example VALUES (NULL, 30);
 
-statement ok
+statement count 1
 DELETE FROM example where a = 30;
 
 query II colnames
@@ -3510,7 +3510,7 @@ NULL 1
 3    3
 
 # Remove everything from a. x=3,y=3 should be the only cascading values.
-statement ok
+statement count 4
 DELETE FROM a;
 
 # A match consisting of only NULLs is not cascaded.
@@ -3595,7 +3595,7 @@ NULL NULL
 3    3
 
 # Remove everything from a. x=3,y=3 should be the only cascading value.
-statement ok
+statement count 4
 DELETE FROM a;
 
 # A match consisting of only NULLs is not cascaded.
@@ -3726,7 +3726,7 @@ INSERT INTO b VALUES (2,2), (3,3);
 INSERT INTO c VALUES (2,2), (3,3);
 
 # This will populate b and c with (null, null) where (2,2) used to be.
-statement ok
+statement count 1
 DELETE FROM a WHERE x = 2;
 
 # We can't cascade the null value though to c, since it would break MATCH FULL.
@@ -4071,7 +4071,7 @@ COMMIT;
 statement ok
 RESET autocommit_before_ddl
 
-statement ok
+statement count 2
 DELETE FROM parent WHERE p = 1
 
 query II rowsort
@@ -4089,7 +4089,7 @@ NULL  3
 3     3
 3     3
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE q = 2
 
 query II rowsort
@@ -4105,7 +4105,7 @@ NULL  3
 3     3
 3     3
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE true
 
 query II rowsort
@@ -4166,7 +4166,7 @@ statement ok
 CREATE TABLE a (a INT UNIQUE);
 CREATE TABLE b (b INT, FOREIGN KEY (b) REFERENCES a (a) ON DELETE CASCADE);
 
-statement ok
+statement count 0
 DELETE FROM a WHERE EXISTS (SELECT a FROM a)
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
+++ b/pkg/sql/logictest/testdata/logic_test/case_sensitive_names
@@ -81,7 +81,7 @@ INSERT INTO a(x) VALUES(1)
 statement ok
 UPDATE a SET x = 42
 
-statement ok
+statement count 1
 DELETE FROM a
 
 statement ok
@@ -159,7 +159,7 @@ INSERT INTO "B"(x) VALUES(1)
 statement ok
 UPDATE "B" SET x = 42
 
-statement ok
+statement count 1
 DELETE FROM "B"
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/cast
+++ b/pkg/sql/logictest/testdata/logic_test/cast
@@ -46,7 +46,7 @@ EXECUTE insert_c('foo')
 statement error value too long for type CHAR
 EXECUTE insert_c('foo'::STRING)
 
-statement ok
+statement count 4
 DELETE FROM assn_cast
 
 statement ok
@@ -105,7 +105,7 @@ INSERT INTO assn_cast(qc) VALUES (1234)
 statement ok
 PREPARE insert_qc AS INSERT INTO assn_cast(qc) VALUES ($1)
 
-statement ok
+statement count 11
 DELETE FROM assn_cast
 
 statement ok
@@ -349,7 +349,7 @@ SELECT * FROM assn_cast_dec_default
 # Tests for assignment casts in UPDATEs.
 subtest assignment_casts_update
 
-statement ok
+statement count 32
 DELETE FROM assn_cast
 
 statement ok
@@ -634,7 +634,7 @@ SELECT k, concat('"', c, '"') FROM assn_cast_upsert
 2  ""
 3  ""
 
-statement ok
+statement count 3
 DELETE FROM assn_cast_upsert
 
 statement ok
@@ -1227,8 +1227,10 @@ statement error integer out of range for type int2
 SELECT _int4::INT2 FROM t64429
 
 # Also check the negative overflow.
-statement ok
+statement count 1
 DELETE FROM t64429 WHERE true;
+
+statement ok
 INSERT INTO t64429 VALUES (-3000000000, -300000);
 
 statement error integer out of range for type int2

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index1
@@ -143,7 +143,7 @@ SELECT b, a FROM t ORDER BY b, a
 
 # Delete and try again
 
-statement ok
+statement count 2
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
 query TI

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_index2
@@ -143,7 +143,7 @@ SELECT b, a FROM t ORDER BY b, a
 
 # Delete and try again
 
-statement ok
+statement count 6
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
 query TI

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_normalization
@@ -14,7 +14,7 @@ SELECT a FROM t WHERE a = (b'Am\xc3\xa9lie' COLLATE fr)
 ----
 Amélie
 
-statement ok
+statement count 1
 DELETE FROM t
 
 # Insert Amélie in NFC form.

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex1
@@ -100,7 +100,7 @@ SELECT b, a FROM t ORDER BY b, a
 
 # Delete and try again
 
-statement ok
+statement count 2
 DELETE FROM t WHERE a > ('a' COLLATE da) AND a < ('c' COLLATE da)
 
 query TI

--- a/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
+++ b/pkg/sql/logictest/testdata/logic_test/collatedstring_uniqueindex2
@@ -100,7 +100,7 @@ SELECT b, a FROM t ORDER BY b, a
 
 # Delete and try again
 
-statement ok
+statement count 6
 DELETE FROM t WHERE a > ('a' COLLATE de) AND a < ('c' COLLATE de)
 
 query TI

--- a/pkg/sql/logictest/testdata/logic_test/comment_on
+++ b/pkg/sql/logictest/testdata/logic_test/comment_on
@@ -484,7 +484,7 @@ SELECT * FROM crdb_internal.invalid_objects ORDER BY id;
 ----
 111  test  public  t_99316  invalid comment type: 4294967122 on object ID: 111
 
-statement ok
+statement count 1
 DELETE FROM system.comments WHERE type = 4294967122
 
 statement ok
@@ -572,7 +572,7 @@ SELECT * FROM crdb_internal.invalid_objects ORDER BY id;
 1      system  ·  ·  invalid comment type: 32 on object ID: 1
 11111  ·       ·  ·  comment exists for non-existent descriptor 11111
 
-statement ok
+statement count 2
 DELETE FROM system.comments WHERE type=32;
 
 query ITTTT

--- a/pkg/sql/logictest/testdata/logic_test/computed
+++ b/pkg/sql/logictest/testdata/logic_test/computed
@@ -180,10 +180,10 @@ SELECT c, d FROM x
 ----
 1 3
 
-statement ok
+statement count 1
 DELETE FROM x
 
-statement ok
+statement count 0
 DELETE FROM x
 
 statement ok
@@ -527,7 +527,7 @@ statement ok
 INSERT INTO c_delete_cascade VALUES (2), (3);
 INSERT INTO c_delete_set VALUES (2, 2), (3, 3);
 
-statement ok
+statement count 1
 DELETE FROM p WHERE p = 3
 
 query II colnames,rowsort

--- a/pkg/sql/logictest/testdata/logic_test/constrained_stats
+++ b/pkg/sql/logictest/testdata/logic_test/constrained_stats
@@ -1,5 +1,9 @@
 # LogicTest: local fakedist
 
+# Speed up job adoption.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '10ms'
+
 # Tests for creating partial table statistics with a WHERE clause.
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal
@@ -1738,8 +1738,10 @@ ORDER BY role, inheriting_member
 admin  real_user  true  false
 admin  root       true  true
 
-statement ok
+statement count 1
 DELETE FROM system.users WHERE username = 'non_cached_user';
+
+statement count 1
 DELETE FROM system.role_members WHERE member = 'non_cached_user';
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -1134,7 +1134,7 @@ ALTER DEFAULT PRIVILEGES IN SCHEMA public GRANT INSERT ON TABLES TO roach_a;
 
 # Create some descriptor corruptions with an orphaned role that is being granted
 # a default privilege.
-statement ok
+statement count 1
 DELETE FROM system.users WHERE username = 'roach_a';
 
 # Force the role membership cache to be updated.
@@ -1169,11 +1169,11 @@ SET ROLE root;
 
 # Create a descriptor corruption with an orphaned role that is granting a
 # default privilege.
-statement ok
+statement count 1
 DELETE FROM system.users WHERE username = 'roach_d';
 
 # Create a descriptor corruption with all orphaned roles.
-statement ok
+statement count 1
 DELETE FROM system.users WHERE username = 'roach_c';
 
 # We see that roach_c and roach_d still exist in our default privileges on our

--- a/pkg/sql/logictest/testdata/logic_test/dangerous_statements
+++ b/pkg/sql/logictest/testdata/logic_test/dangerous_statements
@@ -16,10 +16,10 @@ UPDATE foo SET x = 3 ORDER BY x LIMIT 1
 statement error rejected.*: DELETE without WHERE or LIMIT clause
 DELETE FROM foo
 
-statement ok
+statement count 0
 DELETE FROM foo WHERE x = 2
 
-statement ok
+statement count 0
 DELETE FROM foo ORDER BY x LIMIT 1
 
 statement error rejected.*: SELECT FOR UPDATE without WHERE or LIMIT clause

--- a/pkg/sql/logictest/testdata/logic_test/datetime
+++ b/pkg/sql/logictest/testdata/logic_test/datetime
@@ -336,7 +336,7 @@ SELECT count(DISTINCT (v)) FROM kv
 
 # Test that transaction_timestamp() is consistent in transaction
 # spanning multiple batches of statements.
-statement ok
+statement count 9
 DELETE FROM kv
 
 statement ok
@@ -392,7 +392,7 @@ SELECT count(DISTINCT (v)) FROM kv
 ----
 2
 
-statement ok
+statement count 3
 DELETE FROM kv
 
 let $old_default_transaction_isolation

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -519,7 +519,7 @@ SELECT * FROM u_c;
 # Test if DELETE FROM ... USING works with LATERAL.
 
 statement ok
-DELETE FROM u_a USING u_b, LATERAL (SELECT u_c.a, u_c.b, u_c.c FROM u_c WHERE u_b.b = u_c.b) AS other WHERE other.c = 1 AND u_a.c = 35
+DELETE FROM u_a USING u_b, LATERAL (SELECT u_c.a, u_c.b, u_c.c FROM u_c WHERE u_b.b = u_c.b) AS other WHERE other.c = 1 AND u_a.c = 45
 
 query ITI rowsort
 SELECT * FROM u_a
@@ -529,7 +529,6 @@ SELECT * FROM u_a
 3  c  15
 4  d  20
 8  d  40
-9  d  45
 
 # Test if DELETE FROM ... USING works with partial indexes.
 

--- a/pkg/sql/logictest/testdata/logic_test/delete
+++ b/pkg/sql/logictest/testdata/logic_test/delete
@@ -307,7 +307,7 @@ statement ok
 BEGIN TRANSACTION ISOLATION LEVEL SERIALIZABLE;
 ALTER TABLE family ADD COLUMN z INT CREATE FAMILY
 
-statement ok
+statement count 1
 DELETE FROM family WHERE x=2
 
 statement ok
@@ -336,7 +336,7 @@ SELECT cluster_logical_timestamp()
 statement ok
 COMMIT
 
-statement ok
+statement count 3
 DELETE FROM a WHERE a <= 3
 
 query I rowsort
@@ -394,7 +394,7 @@ statement ok
 INSERT INTO u_c VALUES (1, 'a', 10), (2, 'b', 50), (3, 'c', 50), (4, 'd', 40)
 
 # Test a join with a filter.
-statement ok
+statement count 1
 DELETE FROM u_a USING u_b WHERE c = u_b.a AND u_b.b = 'd'
 
 query ITI rowsort
@@ -408,7 +408,7 @@ SELECT * FROM u_a;
 statement ok
 INSERT INTO u_a VALUES (5, 'd', 5), (6, 'e', 6)
 
-statement ok
+statement count 2
 DELETE FROM u_a USING u_a u_a2 WHERE u_a.a = u_a2.c
 
 query ITI rowsort
@@ -423,7 +423,7 @@ SELECT * FROM u_a;
 statement ok
 INSERT INTO u_c VALUES (30, 'a', 1)
 
-statement ok
+statement count 1
 DELETE FROM u_a USING u_b, u_c WHERE u_a.c = u_b.a AND u_a.c = u_c.a
 
 query ITI rowsort
@@ -518,7 +518,7 @@ SELECT * FROM u_c;
 
 # Test if DELETE FROM ... USING works with LATERAL.
 
-statement ok
+statement count 1
 DELETE FROM u_a USING u_b, LATERAL (SELECT u_c.a, u_c.b, u_c.c FROM u_c WHERE u_b.b = u_c.b) AS other WHERE other.c = 1 AND u_a.c = 45
 
 query ITI rowsort
@@ -541,7 +541,7 @@ CREATE TABLE pindex (
 statement ok
 INSERT INTO pindex VALUES (1.0), (2.0), (3.0), (4.0), (5.0), (8.0)
 
-statement ok
+statement count 1
 DELETE FROM pindex USING (VALUES (5.0), (6.0)) v(b) WHERE pindex.a = v.b
 
 query F rowsort
@@ -559,7 +559,7 @@ SELECT a FROM pindex@pindex_a_idx WHERE a > 3
 4.00
 8.00
 
-statement ok
+statement count 2
 DELETE FROM pindex USING (VALUES (2.0), (4.0)) v(b) WHERE pindex.a = v.b RETURNING v.b
 
 query F rowsort

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
@@ -174,7 +174,7 @@ __auto_partial__  {c}           76         4               0           (c IS NUL
 __auto_partial__  {d}           276        3               16          (d IS NULL) OR ((d < 1:::DECIMAL) OR (d > 1:::DECIMAL))
 
 # Delete more than 5% of the table.
-statement ok
+statement count 60
 DELETE FROM data WHERE a > 11
 
 query TTIIIT colnames,retry

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_partial_stats
@@ -1,5 +1,9 @@
 # LogicTest: !metamorphic-batch-sizes
 
+# Speed up job adoption.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '10ms'
+
 # Test a simple update and insert case for partial statistics
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -105,7 +105,7 @@ __auto__         {c}           1050       10              0
 __auto__         {d}           1050       3               365
 
 # Delete more than 20% of the table.
-statement ok
+statement count 500
 DELETE FROM data WHERE c > 5
 
 query TTIII colnames,retry
@@ -149,7 +149,7 @@ __auto__         {x}           0          0               0
 __auto__         {y}           0          0               0
 
 # Test fast path delete.
-statement ok
+statement count 550
 DELETE FROM copy WHERE true
 
 query TTII colnames,retry

--- a/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_automatic_stats
@@ -1,5 +1,9 @@
 # LogicTest: !metamorphic-batch-sizes
 
+# Speed up job adoption.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '10ms'
+
 # Enable automatic stats for this table.
 statement ok
 CREATE TABLE data (a INT, b INT, c FLOAT, d DECIMAL, PRIMARY KEY (a, b, c), INDEX d_idx (d)) WITH (sql_stats_automatic_collection_enabled = true)

--- a/pkg/sql/logictest/testdata/logic_test/distsql_join
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_join
@@ -15,7 +15,7 @@ SELECT l.k, l.v, r.k, r.v FROM (SELECT * FROM distsql_mj_test ORDER BY k, v) l I
 0  1  0  1
 2  4  2  4
 
-statement ok
+statement count 4
 DELETE FROM distsql_mj_test WHERE TRUE;
 
 statement ok
@@ -26,7 +26,7 @@ query IIII rowsort
 SELECT l.k, l.v, r.k, r.v FROM (SELECT * FROM distsql_mj_test ORDER BY k, v) l INNER JOIN (SELECT * FROM distsql_mj_test ORDER BY k, v) r ON l.k = r.k AND l.v = r.v
 ----
 
-statement ok
+statement count 3
 DELETE FROM distsql_mj_test WHERE TRUE;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -389,7 +389,7 @@ NULL             {c}           256        4               0           true
 NULL             {d}           256        4               0           true
 NULL             {e}           256        2               0           true
 
-statement ok
+statement count 10
 DELETE FROM system.table_statistics
 
 # Restore the old stats.
@@ -1246,7 +1246,7 @@ FROM [SHOW STATISTICS USING JSON FOR TABLE et]
 let $json_stats
 SHOW STATISTICS USING JSON FOR TABLE et
 
-statement ok
+statement count 45
 DELETE FROM system.table_statistics
 
 # Restore the old stats.
@@ -3870,7 +3870,7 @@ INSERT INTO t67050 VALUES ('a'), ('b'), ('c')
 statement ok
 ANALYZE t67050
 
-statement ok
+statement count 1
 DELETE FROM t67050 WHERE x = 'a'
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/distsql_stats
+++ b/pkg/sql/logictest/testdata/logic_test/distsql_stats
@@ -2,6 +2,10 @@
 
 skip under race
 
+# Speed up job adoption.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '10ms'
+
 # Disable histogram collection.
 statement ok
 SET CLUSTER SETTING sql.stats.histogram_collection.enabled = false

--- a/pkg/sql/logictest/testdata/logic_test/enums
+++ b/pkg/sql/logictest/testdata/logic_test/enums
@@ -2061,7 +2061,7 @@ WHERE stat->>'columns' = '["a"]'
 
 # Now drop the enum value that is the first bucket in the 2-bucket histogram.
 
-statement ok
+statement count 2
 DELETE FROM t154461 WHERE a = 'e'
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/family
+++ b/pkg/sql/logictest/testdata/logic_test/family
@@ -76,7 +76,7 @@ SELECT * FROM abcd
 1 2 3    4
 5 9 NULL 10
 
-statement ok
+statement count 1
 DELETE FROM abcd where c = 3
 
 query IIII
@@ -118,7 +118,7 @@ SELECT * FROM abcd WHERE a = 2
 ----
 2 NULL NULL 5
 
-statement ok
+statement count 1
 DELETE FROM abcd WHERE a = 2
 
 query IIII

--- a/pkg/sql/logictest/testdata/logic_test/fk
+++ b/pkg/sql/logictest/testdata/logic_test/fk
@@ -71,7 +71,7 @@ INSERT INTO parent (p, u) VALUES (1, 10), (2, 20)
 statement ok
 INSERT INTO child VALUES (1, 1)
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE p = 2
 
 statement error delete on table "parent" violates foreign key constraint "child_p_fkey" on table "child"\nDETAIL: Key \(p\)=\(1\) is still referenced from table "child"\.
@@ -118,10 +118,10 @@ INSERT INTO child2 VALUES
 statement error delete on table "parent2" violates foreign key constraint "child2_p1_p2_fkey" on table "child2"\nDETAIL: Key \(p1, p2\)=\(10, 100\) is still referenced from table "child2"\.
 DELETE FROM parent2 WHERE p1 = 10 AND p2 = 100
 
-statement ok
+statement count 1
 DELETE FROM child2 WHERE p1 = 10 AND p2 = 100
 
-statement ok
+statement count 1
 DELETE FROM parent2 WHERE p1 = 10 AND p2 = 100
 
 statement ok
@@ -459,7 +459,7 @@ SHOW CONSTRAINTS FROM "user content".review_stats
 ----
 review_stats  review_stats_pkey  PRIMARY KEY  PRIMARY KEY (id ASC)  true
 
-statement ok
+statement count 2
 DELETE FROM "user content"."customer reviews"
 
 statement error pgcode 23503 insert on table "orders" violates foreign key constraint "orders_product_fkey"\nDETAIL: Key \(product\)=\('790'\) is not present in table "products"
@@ -863,7 +863,7 @@ statement error pgcode 23503 foreign key
 DELETE FROM employees WHERE id = 2
 
 # Deleting all the rows works - we are checking the FKs after the mutation.
-statement ok
+statement count 4
 DELETE FROM employees WHERE id > 1
 
 statement ok
@@ -1122,7 +1122,7 @@ INSERT INTO a VALUES (2, 1, 1), (3, 1, 2)
 statement ok
 INSERT INTO a VALUES (4, 2, 2)
 
-statement ok
+statement count 1
 DELETE FROM b WHERE id = 3
 
 statement error pgcode 23503 violates foreign key
@@ -1131,10 +1131,10 @@ DELETE FROM b WHERE id = 2
 statement error pgcode 23503 violates foreign key
 DELETE FROM a WHERE id = 1
 
-statement ok
+statement count 2
 DELETE FROM a WHERE id > 2
 
-statement ok
+statement count 1
 DELETE FROM b WHERE id = 2
 
 statement ok
@@ -1315,10 +1315,10 @@ INSERT INTO test20042 (x, y, z) VALUES ('pk1', 'k1', null);
 statement ok
 INSERT INTO test20042 (x, y, z) VALUES ('pk2', 'k2 ', 'k1');
 
-statement ok
+statement count 1
 DELETE FROM test20042 WHERE x = 'pk2';
 
-statement ok
+statement count 1
 DELETE FROM test20042 WHERE x = 'pk1';
 
 subtest 20045
@@ -1339,13 +1339,13 @@ INSERT INTO test20045 (x, y, z) VALUES ('pk2', 'pk1', NULL);
 statement ok
 INSERT INTO test20045 (x, y, z) VALUES ('pk3', 'pk2', 'pk1');
 
-statement ok
+statement count 1
 DELETE FROM test20045 WHERE x = 'pk3';
 
-statement ok
+statement count 1
 DELETE FROM test20045 WHERE x = 'pk2';
 
-statement ok
+statement count 1
 DELETE FROM test20045 WHERE x = 'pk1';
 
 ## Delete cascade without privileges
@@ -1398,7 +1398,7 @@ GRANT DELETE ON d.b TO testuser;
 
 user testuser
 
-statement ok
+statement count 1
 DELETE FROM d.a WHERE id = 'a1';
 
 user root
@@ -1693,7 +1693,7 @@ SELECT * FROM no_default_table
 id  ref1  ref2
 6   2     1
 
-statement ok
+statement count 1
 DELETE FROM a WHERE id1=1
 
 query III colnames
@@ -3050,7 +3050,7 @@ CREATE TABLE t2(
 statement ok
 INSERT INTO t2(x) VALUES (1), (null)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE x IS NULL
 
 statement ok
@@ -3129,10 +3129,10 @@ UPDATE parent SET p = 3 WHERE p = 10
 statement ok
 UPDATE child SET p = 3 WHERE p = 1
 
-statement ok
+statement count 1
 DELETE FROM child
 
-statement ok
+statement count 2
 DELETE FROM parent
 
 statement ok
@@ -3375,7 +3375,7 @@ SELECT user_id_1, user_id_2, text FROM messages ORDER BY message_id ASC
 30  10  lucy is a good user
 
 # Delete from users should work as well
-statement ok
+statement count 1
 DELETE FROM users WHERE id = 30
 
 # See that it propagates.
@@ -3437,7 +3437,7 @@ SELECT user_id_1, user_id_2, text FROM messages ORDER BY message_id ASC
 40  10  youre tearing me apart lisa!
 
 # Delete should still be okay since the cascade from id1 should "win".
-statement ok
+statement count 1
 DELETE FROM users WHERE id = 20
 
 query IIT
@@ -3474,7 +3474,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk1 FOREIGN KEY (a) REFERENCES t1 ON DELETE NO ACT
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -3516,7 +3516,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCAD
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -3557,7 +3557,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NU
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -3599,7 +3599,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE CASCAD
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -3640,7 +3640,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DE
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -3681,7 +3681,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET NU
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -3804,7 +3804,7 @@ ALTER TABLE t2 ADD CONSTRAINT fk2 FOREIGN KEY (a) REFERENCES t1 ON DELETE SET DE
 statement ok
 insert into t1 values (123); insert into t2 values (123)
 
-statement ok
+statement count 1
 DELETE FROM t1 WHERE a = 123
 
 query I
@@ -4712,7 +4712,7 @@ skipif config local-legacy-schema-changer
 statement error job .* was paused before it completed with reason: pause point "schemachanger.before.exec" hit
 CREATE TABLE grandchild80828 (parent_id INT NOT NULL REFERENCES child80828(pid) ON DELETE CASCADE);
 
-statement ok
+statement count 1
 DELETE FROM parent80828 WHERE id = 1;
 
 # Clear the pause point.

--- a/pkg/sql/logictest/testdata/logic_test/inv_stats
+++ b/pkg/sql/logictest/testdata/logic_test/inv_stats
@@ -1,5 +1,9 @@
 # LogicTest: 5node 3node-tenant
 
+# Speed up job adoption.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '10ms'
+
 # Tests that verify we retrieve the stats correctly. Note that we can't create
 # statistics if distsql mode is OFF.
 

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index
@@ -243,7 +243,7 @@ SELECT * FROM d WHERE b @>'[{"a": {"b": [1]}}]' ORDER BY a;
 ----
 16  [{"a": {"b": [1, [2]]}}, "d"]
 
-statement ok
+statement count 1
 DELETE FROM d WHERE a=1;
 
 query IT
@@ -259,7 +259,7 @@ EXECUTE query ('a', '"b"')
 ----
 7  {"a": "b", "c": "d"}
 
-statement ok
+statement count 1
 DELETE FROM d WHERE a=6;
 
 query IT
@@ -704,7 +704,7 @@ SELECT * FROM del_cascade_test ORDER BY delete_cascade;
 2  {"a": "b", "c": "d"}
 3  ["b", "c"]
 
-statement ok
+statement count 1
 DELETE FROM update_test WHERE j @> '["c"]'
 
 query IT

--- a/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
+++ b/pkg/sql/logictest/testdata/logic_test/inverted_index_multi_column
@@ -219,7 +219,7 @@ SELECT * FROM t@idx WHERE i IN (1, 2, 3) AND s IN ('foo', 'baz') AND j @> '{"x":
 3  baz  {"num": 3, "x": "y"}
 
 # Delete a row.
-statement ok
+statement count 1
 DELETE FROM t WHERE i = 3
 
 query ITT
@@ -431,7 +431,7 @@ SELECT id, foo, bar FROM d@idx where foo = '"foo"' AND bar->0 <@ '[0]' ORDER BY 
 5  "foo"  [[0], [7, 8, 9, 10]]
 
 # Testing deleting
-statement ok
+statement count 1
 DELETE FROM d WHERE  id = 5
 
 query ITT

--- a/pkg/sql/logictest/testdata/logic_test/json
+++ b/pkg/sql/logictest/testdata/logic_test/json
@@ -213,7 +213,7 @@ SELECT array_agg(bar ORDER BY pk) FROM foo
 ----
 {"{\"a\": \"b\"}","[1, 2, 3]","\"hello\"",1.000,true,false,NULL,"{\"x\": [1, 2, 3]}","{\"x\": {\"y\": \"z\"}}"}
 
-statement ok
+statement count 9
 DELETE FROM foo
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/lock_timeout
+++ b/pkg/sql/logictest/testdata/logic_test/lock_timeout
@@ -124,7 +124,7 @@ DELETE FROM t
 statement error pgcode 55P03 canceling statement due to lock timeout on row \(k\)=\(1\) in t@t_pkey
 DELETE FROM t WHERE k = 1
 
-statement ok
+statement count 1
 DELETE FROM t WHERE k = 2
 
 skipif config weak-iso-level-configs
@@ -132,5 +132,5 @@ statement error pgcode 55P03 canceling statement due to lock timeout on row \(k\
 DELETE FROM t WHERE v = 9
 
 onlyif config weak-iso-level-configs
-statement ok
+statement count 0
 DELETE FROM t WHERE v = 9

--- a/pkg/sql/logictest/testdata/logic_test/new_schema_changer
+++ b/pkg/sql/logictest/testdata/logic_test/new_schema_changer
@@ -1109,7 +1109,7 @@ CREATE VIEW v4ev AS (SELECT name FROM V1EV);
 statement ok
 CREATE VIEW v3ev AS (SELECT name FROM V2EV);
 
-statement ok
+statement nocount ok
 DELETE FROM system.eventlog;
 
 statement ok
@@ -1134,7 +1134,7 @@ CREATE VIEW v1ev AS (SELECT name FROM T1EV);
 statement ok
 CREATE VIEW v4ev AS (SELECT name FROM V1EV);
 
-statement ok
+statement nocount ok
 DELETE FROM system.eventlog;
 
 statement ok
@@ -1153,7 +1153,7 @@ ORDER BY timestamp, info DESC;
 statement ok
 CREATE TABLE fooev (i INT PRIMARY KEY);
 
-statement ok
+statement nocount ok
 DELETE FROM system.eventlog;
 
 statement ok
@@ -1198,7 +1198,7 @@ CREATE INDEX "'t1-esc-index'" ON "'db1-a'"."'t1-esc'"(name)
 statement error index with name "'t1-esc-index'" already exists
 CREATE INDEX "'t1-esc-index'" ON "'db1-a'"."'t1-esc'"(name)
 
-statement ok
+statement nocount ok
 delete from system.eventlog;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/numeric_references
+++ b/pkg/sql/logictest/testdata/logic_test/numeric_references
@@ -143,7 +143,7 @@ SELECT * FROM [$num_ref_id as num_ref_alias]
 4     40    400
 5     NULL  NULL
 
-statement ok
+statement count 1
 DELETE FROM [$num_ref_id AS num_ref_alias]@bc WHERE p=5
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/on_update
+++ b/pkg/sql/logictest/testdata/logic_test/on_update
@@ -410,7 +410,7 @@ pk3  z
 statement ok
 ALTER TABLE test_table_enum ALTER COLUMN k DROP ON UPDATE
 
-statement ok
+statement count 1
 DELETE FROM test_table_enum WHERE p = 'pk2'
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/overflow
+++ b/pkg/sql/logictest/testdata/logic_test/overflow
@@ -9,7 +9,7 @@ INSERT INTO large_numbers VALUES (9223372036854775807),(1)
 statement error integer out of range
 SELECT sum_int(a) FROM large_numbers
 
-statement ok
+statement count 2
 DELETE FROM large_numbers
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
+++ b/pkg/sql/logictest/testdata/logic_test/parallel_stmts_compat
@@ -37,7 +37,7 @@ UPDATE kv SET v = k WHERE k = 3 RETURNING NOTHING
 statement error duplicate key value violates unique constraint "kv_pkey"\nDETAIL: Key \(k\)=\(1\) already exists\.
 UPDATE kv SET k = 1 WHERE k = 2 RETURNING NOTHING
 
-statement ok
+statement count 1
 DELETE FROM kv WHERE k = 1 RETURNING NOTHING
 
 statement ok
@@ -46,10 +46,10 @@ INSERT INTO fk VALUES (2)
 statement error delete on table "kv" violates foreign key constraint "fk_f_fkey" on table "fk"\nDETAIL: Key \(k\)=\(2\) is still referenced from table "fk"
 DELETE FROM kv WHERE k = 2 RETURNING NOTHING
 
-statement ok
+statement count 1
 DELETE FROM fk
 
-statement ok
+statement count 1
 DELETE FROM kv
 
 
@@ -214,10 +214,10 @@ SELECT k, v FROM kv ORDER BY k
 statement ok
 BEGIN
 
-statement ok
+statement count 1
 DELETE FROM kv WHERE k = 1 RETURNING NOTHING
 
-statement ok
+statement count 0
 DELETE FROM kv WHERE k = 5 RETURNING NOTHING
 
 statement ok
@@ -238,7 +238,7 @@ INSERT INTO fk VALUES (2)
 statement ok
 BEGIN
 
-statement ok
+statement count 0
 DELETE FROM kv WHERE k = 1 RETURNING NOTHING
 
 statement error delete on table "kv" violates foreign key constraint "fk_f_fkey" on table "fk"\nDETAIL: Key \(k\)=\(2\) is still referenced from table "fk"
@@ -257,7 +257,7 @@ SELECT k, v FROM kv ORDER BY k
 3  3
 4  8
 
-statement ok
+statement count 1
 DELETE FROM fk
 
 
@@ -297,7 +297,7 @@ SELECT k, v FROM kv ORDER BY k
 5  9
 6  10
 
-statement ok
+statement count 1
 DELETE FROM kv WHERE k = 2 RETURNING NOTHING
 
 statement ok
@@ -350,7 +350,7 @@ ROLLBACK
 
 # RETURNING NOTHING can be prepared and executed.
 
-statement ok
+statement count 5
 DELETE FROM kv
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -2194,7 +2194,7 @@ CREATE TABLE t61414_c (
   FAMILY (k, a, c)
 )
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 UPSERT INTO t61414_c (k, a, b, d) VALUES (1, 2, 3, 4)
 

--- a/pkg/sql/logictest/testdata/logic_test/partial_index
+++ b/pkg/sql/logictest/testdata/logic_test/partial_index
@@ -553,7 +553,7 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 
 # Delete a row in both partial indexes.
 
-statement ok
+statement count 1
 DELETE FROM d WHERE k = 1
 
 query IIRTB rowsort
@@ -572,7 +572,7 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 
 # Delete a row in one partial index.
 
-statement ok
+statement count 1
 DELETE FROM d WHERE k = 2
 
 query IIRTB rowsort
@@ -590,7 +590,7 @@ SELECT * FROM d@f_b_s_foo_idx WHERE b AND s = 'foo'
 
 # Delete a row not in either partial index.
 
-statement ok
+statement count 1
 DELETE FROM d WHERE k = 200
 
 query IIRTB rowsort
@@ -809,8 +809,10 @@ SELECT * FROM u
 1  -1
 
 # Deleting and re-inserting a conflicting row is successful.
-statement ok
+statement count 1
 DELETE FROM u WHERE a = 2;
+
+statement ok
 INSERT INTO u VALUES (2, 2);
 
 # Updating a row in the unique partial index to conflict with another row fails.
@@ -839,7 +841,7 @@ SELECT * FROM u
 3  3
 2  -2
 
-statement ok
+statement count 3
 DELETE FROM u
 
 # Tests for ON CONFLICT DO NOTHING.
@@ -877,7 +879,7 @@ SELECT * FROM u
 1  -100
 1  -1000
 
-statement ok
+statement count 3
 DELETE FROM u WHERE b IN (-10, -100, -1000)
 
 # Inserting multiple rows that conflict with each other inserts some of the
@@ -968,7 +970,7 @@ SELECT * FROM u
 statement ok
 DROP INDEX i2
 
-statement ok
+statement count 8
 DELETE from u
 
 # Tests for ON CONFLICT (a) [WHERE ...] DO NOTHING.
@@ -991,7 +993,7 @@ CREATE UNIQUE INDEX i2 ON u (b) WHERE 1 = 1;
 statement ok
 INSERT INTO u VALUES (1, 1) ON CONFLICT (b) DO NOTHING;
 
-statement ok
+statement count 1
 DELETE FROM u;
 
 statement ok
@@ -1055,7 +1057,7 @@ ON CONFLICT (a) WHERE b < (CASE WHEN now() > '1980-01-01' THEN 0 ELSE 100 END) D
 statement ok
 DROP INDEX i2
 
-statement ok
+statement count 2
 DELETE FROM u
 
 # Tests for ON CONFLICT DO UPDATE.
@@ -1111,7 +1113,7 @@ SELECT * FROM u
 1  -100
 1  -1000
 
-statement ok
+statement count 3
 DELETE FROM u WHERE b IN (-10, -100, -1000)
 
 # Inserting one row conflicting and one non-conflicting row updates the first
@@ -1153,7 +1155,7 @@ INSERT INTO u VALUES (1, -1) ON CONFLICT (a) WHERE b > 0 DO UPDATE SET a = 100
 statement ok
 DROP INDEX i2
 
-statement ok
+statement count 3
 DELETE from u
 
 # Test partial indexes with lookup joins.
@@ -1252,7 +1254,7 @@ SELECT * FROM enum_table@i WHERE b IN ('foo', 'bar')
 2  bar
 3  foo
 
-statement ok
+statement count 1
 DELETE FROM enum_table WHERE a = 2
 
 query IT rowsort
@@ -1341,7 +1343,7 @@ SELECT * FROM inv@i WHERE j @> '{"x": "y"}' AND s IN ('foo', 'bar') ORDER BY k
 1  {"num": 1, "x": "y"}  foo
 3  {"num": 3, "x": "y"}  bar
 
-statement ok
+statement count 1
 DELETE FROM inv WHERE k = 3
 
 query ITT
@@ -1624,7 +1626,7 @@ SELECT * FROM vec@i WHERE s IN ('foo', 'bar') ORDER BY v <-> '[5,5]' LIMIT 1
 4  [5,6]  bar
 
 # Delete bar row and ensure it is not returned.
-statement ok
+statement count 1
 DELETE FROM vec WHERE k = 4
 
 query ITT
@@ -1760,7 +1762,7 @@ SELECT * FROM virt@idx WHERE c = 10
 1  0  10
 3  0  10
 
-statement ok
+statement count 1
 DELETE FROM virt WHERE a = 1
 
 query III rowsort
@@ -1822,7 +1824,7 @@ SELECT * FROM virt@idx WHERE c = 10
 
 # Tests for unique partial indexes with predicates that reference virtual
 # computed columns.
-statement ok
+statement count 8
 DELETE FROM virt;
 
 statement ok
@@ -1903,7 +1905,7 @@ SELECT * FROM t52318 WHERE b > 5
 ----
 6  7
 
-statement ok
+statement count 2
 DELETE FROM t52318
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/pg_catalog
+++ b/pkg/sql/logictest/testdata/logic_test/pg_catalog
@@ -2836,7 +2836,7 @@ node
 root
 testuser
 
-statement ok
+statement count 1
 DELETE FROM system.users WHERE username = 'non_cached_user'
 
 ## rolreplication from pg_catalog.pg_authid and pg_catalog.pg_roles

--- a/pkg/sql/logictest/testdata/logic_test/privileges_table
+++ b/pkg/sql/logictest/testdata/logic_test/privileges_table
@@ -33,10 +33,10 @@ INSERT INTO t VALUES (1, 1), (2, 2)
 statement ok
 SELECT * from t
 
-statement ok
+statement count 2
 DELETE FROM t
 
-statement ok
+statement count 0
 DELETE FROM t where k = 1
 
 statement ok
@@ -247,10 +247,10 @@ SELECT * FROM t
 statement ok
 SELECT 1
 
-statement ok
+statement count 2
 DELETE FROM t
 
-statement ok
+statement count 0
 DELETE FROM t where k = 1
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/procedure_cte
+++ b/pkg/sql/logictest/testdata/logic_test/procedure_cte
@@ -76,7 +76,7 @@ CREATE PROCEDURE p(OUT ret INT) LANGUAGE SQL AS $$
 $$;
 
 # Avoid causing an error due to too many rows returned.
-statement ok
+statement count 3
 DELETE FROM ab WHERE a > 1;
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/role
+++ b/pkg/sql/logictest/testdata/logic_test/role
@@ -1082,7 +1082,7 @@ CREATE ROLE rolej
 # Testing LOGIN and VALID UNTIL role privilege
 user root
 
-statement ok
+statement count 15
 DELETE FROM system.role_options WHERE NOT username in ('root', 'admin')
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/row_level_security
+++ b/pkg/sql/logictest/testdata/logic_test/row_level_security
@@ -1373,7 +1373,7 @@ statement ok
 set role buck
 
 # Try to delete the row. The delete policy will prevent us from reading the row.
-statement ok
+statement count 0
 DELETE FROM bbteams;
 
 query TT
@@ -1396,7 +1396,7 @@ create policy restrict_delete on bbteams for delete to buck using (is_valid(leag
 statement ok
 set role buck
 
-statement ok
+statement count 1
 DELETE FROM bbteams WHERE team != 'pirates';
 
 query TT
@@ -2243,7 +2243,7 @@ INSERT INTO child VALUES ('bedroom', 4);
 statement ok
 ALTER TABLE parent NO FORCE ROW LEVEL SECURITY;
 
-statement ok
+statement count 1
 DELETE FROM parent WHERE key = 1;
 
 statement ok
@@ -2452,7 +2452,7 @@ SELECT a, b FROM trunc ORDER BY a;
 3  c
 
 # This should not delete anything because the expression for delete is false.
-statement ok
+statement count 0
 DELETE FROM trunc;
 
 query IT
@@ -2550,7 +2550,7 @@ SELECT a, b FROM trunc ORDER BY a;
 7  a
 9  c
 
-statement ok
+statement count 0
 DELETE FROM trunc;
 
 query IT
@@ -3663,7 +3663,7 @@ query I
 delete from cnt where counter is not null returning counter;
 ----
 
-statement ok
+statement count 0
 delete from cnt;
 
 query I
@@ -3682,7 +3682,7 @@ query I
 delete from cnt where counter > 0 returning counter;
 ----
 
-statement ok
+statement count 0
 delete from cnt;
 
 statement ok
@@ -3704,7 +3704,7 @@ query I
 delete from cnt where counter > 0 returning counter;
 ----
 
-statement ok
+statement count 0
 delete from cnt;
 
 statement ok
@@ -3732,7 +3732,7 @@ query I
 DELETE FROM cnt WHERE counter > 0 RETURNING counter;
 ----
 
-statement ok
+statement count 0
 DELETE FROM cnt;
 
 statement ok
@@ -4503,7 +4503,7 @@ SELECT comment, c FROM ups WHERE pk = 3;
 ----
 original value 2
 
-statement ok
+statement count 1
 DELETE FROM ups WHERE pk = 3;
 
 statement ok
@@ -5814,7 +5814,7 @@ statement ok
 RESET row_security;
 
 # Test DELETE and UPSERT.
-statement ok
+statement count 1
 DELETE FROM accounts WHERE id = 1;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
+++ b/pkg/sql/logictest/testdata/logic_test/schema_change_in_txn
@@ -1830,7 +1830,7 @@ SELECT * FROM self_ref_fk
 
 # Check that the cascade delete takes effect and there are now no rows.
 
-statement ok
+statement count 1
 DELETE FROM self_ref_fk WHERE id = 1;
 
 query II rowsort

--- a/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
+++ b/pkg/sql/logictest/testdata/logic_test/statement_hint_builtins
@@ -63,7 +63,7 @@ SELECT count(*) FROM system.statement_hints WHERE fingerprint = 'SELECT * FROM x
 ----
 1
 
-statement ok
+statement count 3
 DELETE FROM system.statement_hints WHERE true;
 
 query I
@@ -161,7 +161,7 @@ WHERE feature_name = 'sql.session.statement-hints'
 ----
 6
 
-statement ok
+statement count 1
 DELETE FROM system.statement_hints WHERE true
 
 statement ok
@@ -526,7 +526,7 @@ trying planning with injected hints
 # Try removing an injected hint between prepare and execute.
 
 # (Re-use p1.)
-statement ok
+statement count 1
 DELETE FROM system.statement_hints WHERE row_id = $hint_p1
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/stats
+++ b/pkg/sql/logictest/testdata/logic_test/stats
@@ -2,6 +2,10 @@
 
 skip under race
 
+# Speed up job adoption.
+statement ok
+SET CLUSTER SETTING jobs.registry.interval.adopt = '10ms'
+
 # Note that we disable the "forced disk spilling" config because the histograms
 # are dropped if the stats collection reaches the memory budget limit.
 

--- a/pkg/sql/logictest/testdata/logic_test/storing
+++ b/pkg/sql/logictest/testdata/logic_test/storing
@@ -97,7 +97,7 @@ INSERT INTO t14601 VALUES
   ('b', FALSE),
   ('c', FALSE)
 
-statement ok
+statement count 1
 DELETE FROM t14601 WHERE a > 'a' AND a < 'c'
 
 query T
@@ -156,7 +156,7 @@ a  false
 b  false
 c  false
 
-statement ok
+statement count 3
 DELETE FROM t14601a
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
+++ b/pkg/sql/logictest/testdata/logic_test/strict_ddl_atomicity
@@ -40,7 +40,7 @@ SELECT * FROM unrelated
 ----
 1
 
-statement ok
+statement count 1
 DELETE FROM testing WHERE k = 5
 
 # Now try again with the strict setting

--- a/pkg/sql/logictest/testdata/logic_test/system
+++ b/pkg/sql/logictest/testdata/logic_test/system
@@ -509,7 +509,7 @@ query ITTT
 SELECT row_id, fingerprint, hint, created_at FROM system.statement_hints WHERE fingerprint = 'baz' ORDER BY row_id
 ----
 
-statement ok
+statement count 1
 DELETE FROM system.statement_hints WHERE fingerprint = 'foo'
 
 query ITTT

--- a/pkg/sql/logictest/testdata/logic_test/system_columns
+++ b/pkg/sql/logictest/testdata/logic_test/system_columns
@@ -71,7 +71,7 @@ SELECT * FROM t
 let $del_ts
 SELECT crdb_internal_mvcc_timestamp FROM t WHERE x = 2
 
-statement ok
+statement count 1
 DELETE FROM t WHERE crdb_internal_mvcc_timestamp = $del_ts
 
 query III

--- a/pkg/sql/logictest/testdata/logic_test/table
+++ b/pkg/sql/logictest/testdata/logic_test/table
@@ -625,7 +625,7 @@ SELECT estimated_row_count FROM [SHOW TABLES] where table_name = 't1'
 ----
 1024
 
-statement ok
+statement count 24
 DELETE FROM rowtest.t1 WHERE a > 1000;
 
 statement ok

--- a/pkg/sql/logictest/testdata/logic_test/udf_cte
+++ b/pkg/sql/logictest/testdata/logic_test/udf_cte
@@ -94,7 +94,7 @@ CREATE FUNCTION f() RETURNS INT LANGUAGE SQL AS $$
 $$;
 
 # Avoid causing an error due to too many rows returned.
-statement ok
+statement count 3
 DELETE FROM ab WHERE a > 1;
 
 query I

--- a/pkg/sql/logictest/testdata/logic_test/udf_in_index
+++ b/pkg/sql/logictest/testdata/logic_test/udf_in_index
@@ -202,7 +202,7 @@ SELECT * FROM test_tbl_t@t_idx2;
 statement error cannot drop function "test_tbl_partial_f" because other objects \(\[test.public.test_tbl_t\]\) still depend on it
 DROP FUNCTION test_tbl_partial_f;
 
-statement ok
+statement count 3
 DELETE FROM test_tbl_t WHERE true;
 
 # Test expression index with UDF in expression.

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -1,6 +1,6 @@
 # LogicTest: !weak-iso-level-configs
 # READ COMMITTED and REPEATABLE READ do not work with UNIQUE WITHOUT INDEX
-# constraints. See https://github.com/cockroachdb/cockroach/issues/110873.
+# constraints. See https://github.com/cockroachdb/cockroach/issues/126592.
 
 statement ok
 SET experimental_enable_unique_without_index_constraints = true

--- a/pkg/sql/logictest/testdata/logic_test/unique
+++ b/pkg/sql/logictest/testdata/logic_test/unique
@@ -772,8 +772,10 @@ k  a  b
 # On conflict do update with a partial unique constraint.
 
 # Clear the table and insert new rows.
-statement ok
+statement count 12
 DELETE FROM uniq_partial;
+
+statement ok
 INSERT INTO uniq_partial VALUES (1, 1), (2, 2), (1, -1)
 
 # Insert non-conflicting rows.
@@ -867,7 +869,7 @@ statement ok
 UPDATE uniq_fk_child SET d = NULL WHERE a = 2
 
 # Now this should succeed and set e to NULL due to ON DELETE SET NULL.
-statement ok
+statement count 1
 DELETE FROM uniq_fk_parent WHERE a = 2
 
 query IIIII colnames,rowsort

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -56,7 +56,7 @@ a  b  v
 1  1  2
 2  2  4
 
-statement ok
+statement count 2
 DELETE FROM t WHERE a > 0
 
 statement ok
@@ -75,7 +75,7 @@ a  b   v
 3  30  33
 4  40  44
 
-statement ok
+statement count 1
 DELETE FROM t WHERE v = 33
 
 query III colnames,rowsort
@@ -160,7 +160,7 @@ SELECT a, b, v, x FROM (VALUES (1), (2), (10), (5)) AS u(x) INNER LOOKUP JOIN t_
 4  6  10  10
 5  0  5   5
 
-statement ok
+statement count 1
 DELETE FROM t_idx WHERE v = 6
 
 query IIIII colnames,rowsort
@@ -172,7 +172,7 @@ a  b  c  v   w
 4  6  4  10  5
 5  0  5  5   6
 
-statement ok
+statement count 2
 DELETE FROM t_idx WHERE a+b = 10
 
 query IIIII colnames,rowsort
@@ -1210,7 +1210,7 @@ statement ok
 INSERT INTO c_delete_cascade VALUES (2), (3);
 INSERT INTO c_delete_set VALUES (2, 2), (3, 3);
 
-statement ok
+statement count 1
 DELETE FROM p WHERE p = 3
 
 query II colnames,rowsort

--- a/pkg/sql/logictest/testdata/logic_test/virtual_columns
+++ b/pkg/sql/logictest/testdata/logic_test/virtual_columns
@@ -721,27 +721,27 @@ CREATE TABLE uniq_no_index (
   UNIQUE WITHOUT INDEX (v)
 )
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 INSERT INTO uniq_no_index VALUES (1, 10), (2, 20)
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 INSERT INTO uniq_no_index VALUES (3, 8)
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPDATE uniq_no_index SET b=b+11 WHERE a < 2
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPSERT INTO uniq_no_index VALUES (2, 30), (5, 6)
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 INSERT INTO uniq_no_index VALUES (5, 6) ON CONFLICT (v) DO UPDATE SET b=15
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 query III colnames,rowsort
 SELECT * FROM uniq_no_index
 ----
@@ -758,23 +758,23 @@ CREATE TABLE uniq_no_index_multi (
   UNIQUE WITHOUT INDEX (v, c)
 )
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 INSERT INTO uniq_no_index_multi VALUES (1, 1, 1), (2, 4, 2), (3, 3, 3)
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 INSERT INTO uniq_no_index_multi VALUES (4, 2, 2)
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPDATE uniq_no_index_multi SET c=2 WHERE a=3
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement ok
 UPSERT INTO uniq_no_index_multi VALUES (3, 3, 10)
 
-skipif config #110873 weak-iso-level-configs
+skipif config #126592 weak-iso-level-configs
 statement error duplicate key value violates unique constraint
 UPSERT INTO uniq_no_index_multi VALUES (3, 3, 2)
 

--- a/pkg/sql/logictest/testdata/logic_test/window
+++ b/pkg/sql/logictest/testdata/logic_test/window
@@ -1985,7 +1985,7 @@ INSERT INTO kv VALUES (12, -1, DEFAULT, DEFAULT, DEFAULT, DEFAULT)
 query error argument of nth_value\(\) must be greater than zero
 SELECT k, nth_value(v, v) OVER () FROM kv ORDER BY 1
 
-statement ok
+statement count 1
 DELETE FROM kv WHERE k = 12
 
 query error FILTER specified but rank\(\) is not an aggregate function

--- a/pkg/sql/opt/exec/execbuilder/relational.go
+++ b/pkg/sql/opt/exec/execbuilder/relational.go
@@ -3452,7 +3452,7 @@ func (b *Builder) buildLocking(toLock opt.TableID, locking opt.Locking) (opt.Loc
 		}
 		if locking.Form == tree.LockPredicate {
 			return opt.Locking{}, unimplemented.NewWithIssuef(
-				110873, "explicit unique checks are not yet supported under read committed isolation",
+				126592, "explicit unique checks are not yet supported under read committed isolation",
 			)
 		}
 		// Check if we can actually use shared locks here, or we need to use

--- a/pkg/sql/opt/exec/execbuilder/testdata/insert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/insert
@@ -723,7 +723,7 @@ Put /Table/117/2/2/1/0 -> /BYTES/0x3306
 CPut /Table/117/3/3/0 -> /BYTES/0x892304
 CPut /Table/117/4/4/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE k = 1;
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_index
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_index
@@ -319,10 +319,10 @@ Del /Table/114/2/3/2/0
 # ---------------------------------------------------------
 
 # Clear the tables.
-statement ok
+statement count 0
 DELETE FROM t
 
-statement ok
+statement count 0
 DELETE FROM u
 
 # Insert a row that matches no partial index.
@@ -472,10 +472,10 @@ Put /Table/113/4/"foo"/22/0 -> /BYTES/
 # ---------------------------------------------------------
 
 # Clear the tables.
-statement ok
+statement count 4
 DELETE FROM t
 
-statement ok
+statement count 1
 DELETE FROM u
 
 # Insert a row that matches no partial index.
@@ -559,10 +559,10 @@ Scan /Table/114/1/2/0
 # ---------------------------------------------------------
 
 # Clear the tables.
-statement ok
+statement count 3
 DELETE FROM t
 
-statement ok
+statement count 2
 DELETE FROM u
 
 # Insert a non-conflicting row that matches no partial indexes.
@@ -676,10 +676,10 @@ Put /Table/114/2/4/2/0 -> /BYTES/
 # ---------------------------------------------------------
 
 # Clear the tables.
-statement ok
+statement count 2
 DELETE FROM t
 
-statement ok
+statement count 2
 DELETE FROM u
 
 # Insert a non-conflicting row that matches no partial indexes.
@@ -745,10 +745,10 @@ Put /Table/113/3/11/9/0 -> /BYTES/
 # ---------------------------------------------------------
 
 # Clear the tables.
-statement ok
+statement count 1
 DELETE FROM t
 
-statement ok
+statement count 0
 DELETE FROM u
 
 # Upsert a non-conflicting row that matches no partial indexes.

--- a/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
+++ b/pkg/sql/opt/exec/execbuilder/testdata/partial_stats
@@ -1372,7 +1372,7 @@ RESET CLUSTER SETTING sql.stats.histogram_samples.count
 statement ok
 SET optimizer_use_merged_partial_statistics = off
 
-statement ok
+statement count 5
 DELETE FROM ka
 
 statement ok
@@ -1454,7 +1454,7 @@ statement ok
 GRANT node TO root;
 
 # Keep only partial stats on the target table.
-statement ok
+statement count 1
 DELETE FROM system.table_statistics WHERE name NOT LIKE '%partial%' AND "tableID" = 'ka'::REGCLASS::OID;
 
 query TT

--- a/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
+++ b/pkg/sql/opt/exec/execbuilder/testdata/schema_change_in_txn
@@ -63,7 +63,7 @@ Del (locking) /Table/106/1/102/1/1
 CPut /Table/106/1/202/0 -> /TUPLE/2:2:Decimal/1000.2/1:3:Bytes/empty
 CPut /Table/106/1/202/1/1 -> /TUPLE/4:4:Decimal/0.00/2:6:Decimal/1202.2
 
-statement ok
+statement count 1
 DELETE FROM t WHERE a=201
 
 statement ok

--- a/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
+++ b/pkg/sql/opt/exec/execbuilder/testdata/sql_activity_stats_compaction
@@ -15,7 +15,7 @@ SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ - '2h'::I
 let $current_agg_ts
 SELECT concat('''', date_trunc('hour', '2022-05-04 16:10'::TIMESTAMPTZ)::STRING, '''::TIMESTAMPTZ')
 
-statement ok
+statement count 0
 DELETE FROM system.table_statistics WHERE true;
 
 
@@ -572,5 +572,5 @@ RESET CLUSTER SETTING sql.stats.flush.interval
 statement ok
 REVOKE node FROM root;
 
-statement ok
+statement count 1
 DELETE FROM system.users WHERE username = 'node';

--- a/pkg/sql/opt/exec/execbuilder/testdata/update
+++ b/pkg/sql/opt/exec/execbuilder/testdata/update
@@ -1120,8 +1120,10 @@ quality of service: regular
                   execution time: 0µs
                   size: 1 column, 1 row
 
-statement ok
+statement count 1
 DELETE FROM t137352 WHERE true;
+
+statement ok
 INSERT INTO t137352 VALUES (1, 10, 3);
 
 query T kvtrace
@@ -1193,8 +1195,10 @@ quality of service: regular
               execution time: 0µs
               size: 1 column, 1 row
 
-statement ok
+statement count 1
 DELETE FROM t137352 WHERE true;
+
+statement ok
 INSERT INTO t137352 VALUES (1, 2, 3);
 
 query T kvtrace
@@ -1302,8 +1306,10 @@ quality of service: regular
                       table: t137352@t137352_pkey
                       spans: [/1 - /1]
 
-statement ok
+statement count 1
 DELETE FROM t137352 WHERE true;
+
+statement ok
 INSERT INTO t137352 VALUES (1, 1, 1);
 
 query T kvtrace
@@ -1375,8 +1381,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Same as above, but the second column family is set to NULL.
@@ -1393,8 +1401,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Both primary and non-unique secondary indexes are scanned and locked.
@@ -1435,8 +1445,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Same as above, but the second column family is set to NULL.
@@ -1454,8 +1466,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Both primary and unique secondary (on nullable column) indexes are scanned and
@@ -1497,8 +1511,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Same as above, but the second column family is set to NULL.
@@ -1516,8 +1532,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Both primary and unique secondary (on non-nullable column) indexes are scanned
@@ -1559,8 +1577,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Same as above, but the second column family is set to NULL.
@@ -1578,8 +1598,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # The filter is not pushed down into the scan, so no index is locked.
@@ -1617,8 +1639,10 @@ CPut /Table/119/3/4/0 -> /BYTES/0x892306
 Del (locking) /Table/119/4/4/0
 CPut /Table/119/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160 WHERE true;
+
+statement ok
 INSERT INTO t139160 VALUES (1, 2, 3, 4, 5);
 
 # Same as above, but the second column family is set to NULL.
@@ -1684,8 +1708,10 @@ CPut /Table/120/3/4/1/1 -> /TUPLE/2:2:Int/3
 Del (locking) /Table/120/4/4/0
 CPut /Table/120/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160_families WHERE true;
+
+statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4, 5);
 
 query T kvtrace
@@ -1708,8 +1734,10 @@ CPut /Table/120/3/4/1/1 -> /TUPLE/2:2:Int/3
 Del (locking) /Table/120/4/4/0
 CPut /Table/120/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160_families WHERE true;
+
+statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4, 5);
 
 query T kvtrace
@@ -1732,8 +1760,10 @@ CPut /Table/120/3/4/1/1 -> /TUPLE/2:2:Int/3
 Del (locking) /Table/120/4/4/0
 CPut /Table/120/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160_families WHERE true;
+
+statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4, 5);
 
 query T kvtrace
@@ -1761,8 +1791,10 @@ statement ok
 SET use_cputs_on_non_unique_indexes = true;
 SET optimizer_use_lock_elision_multiple_families = true;
 
-statement ok
+statement count 1
 DELETE FROM t139160_families WHERE true;
+
+statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4, 5);
 
 query T kvtrace
@@ -1784,8 +1816,10 @@ CPut /Table/120/3/4/1/1 -> /TUPLE/2:2:Int/3
 Del (locking) /Table/120/4/4/0
 CPut /Table/120/4/5/0 -> /BYTES/0x89
 
-statement ok
+statement count 1
 DELETE FROM t139160_families WHERE true;
+
+statement ok
 INSERT INTO t139160_families VALUES (1, 2, 3, 4, 5);
 SET optimizer_enable_lock_elision = false;
 

--- a/pkg/sql/opt/exec/execbuilder/testdata/upsert
+++ b/pkg/sql/opt/exec/execbuilder/testdata/upsert
@@ -1235,7 +1235,7 @@ CPut /Table/123/2/11/0 -> /BYTES/0x89
 statement ok
 DEALLOCATE p
 
-statement ok
+statement count 1
 DELETE FROM t137352 WHERE true
 
 statement ok


### PR DESCRIPTION
**logictest: speed up some tests with stats**

This commit decreases the job adoption interval in a few files that we have multiple table statistics collections in. This matters most for `distsql_stats` where we have many erroneous test cases, but I added it somewhat liberally to all stats-specific files. This should speed these files up.

**logictest: adjust one query to actually delete something**

One of the test cases added in 74ed574b4ff335ace9fb6fe8da4d966e10665039 is a DELETE query that didn't delete anything - adjust it.

**logictest: update stale issue number around RC predicate locking**

Issue #110873 has been closed and issue #126592 is tracking the remainder of the work.

**logictest: improve testing of RowsAffected for DELETEs**

This commit updates the logic test framework to require usage of `statement count N` directive instead of `statement ok` for "simple" DELETEs, with the goal of improving the test coverage of RowsAffected values. Further work includes expanding this to other DML stmts, supporting "complex" DELETEs (e.g. with CTEs), and updating SQLite suite. `statement nocount ok` can be used to opt out of this requirement e.g. because the count is non-deterministic (this should be very rare, like when operating with system tables).

🤖 Generated with [Claude Code](https://claude.ai/code)

Addresses: #151800.
Epic: None
Release note: None