### PR TITLE
pg_regress: accept new diffs

### DIFF
--- a/pkg/cmd/roachtest/testdata/pg_regress/aggregates.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/aggregates.diffs
@@ -1348,7 +1348,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- Ensure that we never choose to provide presorted input to an Aggref with
  -- a volatile function in the ORDER BY / DISTINCT clause.  We want to ensure
  -- these sorts are performed individually rather than at the query level.
-@@ -1527,34 +1306,76 @@
+@@ -1527,34 +1306,78 @@
    sum(unique1 order by two, random(), random() + 1)
  from tenk1
  group by ten;
@@ -1418,6 +1418,8 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
 +array_agg(jsonb[]) -> jsonb[][]
 +array_agg(varbit) -> varbit[]
 +array_agg(varbit[]) -> varbit[][]
++array_agg(ltree) -> ltree[]
++array_agg(ltree[]) -> ltree[][]
 +array_agg(anyenum) -> anyenum[]
 +array_agg(anyenum[]) -> anyenum[][]
 +array_agg(tuple) -> tuple[]
@@ -1444,7 +1446,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  --
  -- Test combinations of DISTINCT and/or ORDER BY
  --
-@@ -1595,246 +1416,186 @@
+@@ -1595,246 +1418,186 @@
  
  select array_agg(distinct a order by a)
    from (values (1),(2),(1),(3),(null),(2)) v(a);
@@ -1788,7 +1790,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- string_agg tests
  select string_agg(a,',') from (values('aaaa'),('bbbb'),('cccc')) g(a);
     string_agg   
-@@ -1862,25 +1623,29 @@
+@@ -1862,25 +1625,29 @@
  
  -- check some implicit casting cases, as per bug #5564
  select string_agg(distinct f1, ',' order by f1) from varchar_tbl;  -- ok
@@ -1834,7 +1836,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- string_agg bytea tests
  create table bytea_test_table(v bytea);
  select string_agg(v, '') from bytea_test_table;
-@@ -1922,11 +1687,60 @@
+@@ -1922,11 +1689,60 @@
  select (case x % 4 when 1 then null else x end), x % 10
  from generate_series(1,5000) x;
  set parallel_setup_cost TO 0;
@@ -1895,7 +1897,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- create a view as we otherwise have to repeat this query a few times.
  create view v_pagg_test AS
  select
-@@ -1954,66 +1768,92 @@
+@@ -1954,66 +1770,92 @@
  	) a1
  ) a2
  group by y;
@@ -2033,7 +2035,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  drop table pagg_test;
  -- FILTER tests
  select min(unique1) filter (where unique1 > 100) from tenk1;
-@@ -2023,13 +1863,9 @@
+@@ -2023,13 +1865,9 @@
  (1 row)
  
  select sum(1/ten) filter (where ten > 0) from tenk1;
@@ -2049,7 +2051,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
   ten | sum 
  -----+-----
     0 |    
-@@ -2045,17 +1881,14 @@
+@@ -2045,17 +1883,14 @@
  (10 rows)
  
  select ten, sum(distinct four) filter (where four > 10) from onek a
@@ -2074,7 +2076,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  select max(foo COLLATE "C") filter (where (bar collate "POSIX") > '0')
  from (values ('a', 'b')) AS v(foo,bar);
   max 
-@@ -2064,11 +1897,7 @@
+@@ -2064,11 +1899,7 @@
  (1 row)
  
  select any_value(v) filter (where v > 2) from (values (1), (2), (3)) as v (v);
@@ -2087,7 +2089,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- outer reference in FILTER (PostgreSQL extension)
  select (select count(*)
          from (values (1)) t0(inner_c))
-@@ -2117,11 +1946,10 @@
+@@ -2117,11 +1948,10 @@
  select aggfns(distinct a,b,c order by a,c using ~<~,b) filter (where a > 1)
      from (values (1,3,'foo'),(0,null,null),(2,2,'bar'),(3,1,'baz')) v(a,b,c),
      generate_series(1,2) i;
@@ -2103,7 +2105,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- check handling of bare boolean Var in FILTER
  select max(0) filter (where b1) from bool_test;
   max 
-@@ -2137,78 +1965,49 @@
+@@ -2137,78 +1967,49 @@
  
  -- check for correct detection of nested-aggregate errors in FILTER
  select max(unique1) filter (where sum(ten) > 0) from tenk1;
@@ -2198,7 +2200,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  select percentile_disc(0.5) within group (order by thousand) from tenk1;
   percentile_disc 
  -----------------
-@@ -2217,161 +2016,97 @@
+@@ -2217,161 +2018,97 @@
  
  select rank(3) within group (order by x)
  from (values (1),(1),(2),(2),(3),(3),(4)) v(x);
@@ -2404,7 +2406,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- deparse and multiple features:
  create view aggordview1 as
  select ten,
-@@ -2380,73 +2115,83 @@
+@@ -2380,73 +2117,83 @@
         rank(5,'AZZZZ',50) within group (order by hundred, string4 desc, hundred)
    from tenk1
   group by ten order by ten;
@@ -2540,7 +2542,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create type avg_state as (total bigint, count bigint);
  create or replace function avg_transfn(state avg_state, n int) returns avg_state as
  $$
-@@ -2469,6 +2214,10 @@
+@@ -2469,6 +2216,10 @@
  	return null;
  end
  $$ language plpgsql;
@@ -2551,7 +2553,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create function avg_finalfn(state avg_state) returns int4 as
  $$
  begin
-@@ -2479,6 +2228,10 @@
+@@ -2479,6 +2230,10 @@
  	end if;
  end
  $$ language plpgsql;
@@ -2562,7 +2564,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create function sum_finalfn(state avg_state) returns int4 as
  $$
  begin
-@@ -2489,106 +2242,70 @@
+@@ -2489,106 +2244,70 @@
  	end if;
  end
  $$ language plpgsql;
@@ -2695,7 +2697,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- test that aggs with the same sfunc and initcond share the same agg state
  create aggregate my_sum_init(int4)
  (
-@@ -2597,6 +2314,12 @@
+@@ -2597,6 +2316,12 @@
     finalfunc = sum_finalfn,
     initcond = '(10,0)'
  );
@@ -2708,7 +2710,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create aggregate my_avg_init(int4)
  (
     stype = avg_state,
-@@ -2604,6 +2327,12 @@
+@@ -2604,6 +2329,12 @@
     finalfunc = avg_finalfn,
     initcond = '(10,0)'
  );
@@ -2721,7 +2723,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create aggregate my_avg_init2(int4)
  (
     stype = avg_state,
-@@ -2611,30 +2340,28 @@
+@@ -2611,30 +2342,28 @@
     finalfunc = avg_finalfn,
     initcond = '(4,0)'
  );
@@ -2766,7 +2768,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create or replace function sum_transfn(state int4, n int4) returns int4 as
  $$
  declare new_state int4;
-@@ -2664,29 +2391,35 @@
+@@ -2664,29 +2393,35 @@
  	end if;
  end
  $$ language plpgsql;
@@ -2811,7 +2813,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- test that the aggregate transition logic correctly handles
  -- transition / combine functions returning NULL
  -- First test the case of a normal transition function returning NULL
-@@ -2701,6 +2434,8 @@
+@@ -2701,6 +2436,8 @@
      END IF;
      RETURN NULL;
  END$$;
@@ -2820,7 +2822,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE AGGREGATE balk(int4)
  (
      SFUNC = balkifnull(int8, int4),
-@@ -2708,13 +2443,16 @@
+@@ -2708,13 +2445,16 @@
      PARALLEL = SAFE,
      INITCOND = '0'
  );
@@ -2842,7 +2844,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- Secondly test the case of a parallel aggregate combiner function
  -- returning NULL. For that use normal transition function, but a
  -- combiner function returning NULL.
-@@ -2730,6 +2468,23 @@
+@@ -2730,6 +2470,23 @@
      END IF;
      RETURN NULL;
  END$$;
@@ -2866,7 +2868,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE AGGREGATE balk(int4)
  (
      SFUNC = int4_sum(int8, int4),
-@@ -2738,26 +2493,27 @@
+@@ -2738,26 +2495,27 @@
      PARALLEL = SAFE,
      INITCOND = '0'
  );
@@ -2908,7 +2910,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  ROLLBACK;
  -- test multiple usage of an aggregate whose finalfn returns a R/W datum
  BEGIN;
-@@ -2767,6 +2523,8 @@
+@@ -2767,6 +2525,8 @@
      RETURN array_fill(y[1], ARRAY[4]);
  END;
  $$;
@@ -2917,7 +2919,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE FUNCTION rwagg_finalfunc(x anyarray) RETURNS anyarray
  LANGUAGE plpgsql STRICT IMMUTABLE AS $$
  DECLARE
-@@ -2777,11 +2535,25 @@
+@@ -2777,11 +2537,25 @@
      RETURN res;
  END;
  $$;
@@ -2943,7 +2945,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  CREATE FUNCTION eatarray(x real[]) RETURNS real[]
  LANGUAGE plpgsql STRICT IMMUTABLE AS $$
  BEGIN
-@@ -2789,21 +2561,44 @@
+@@ -2789,21 +2563,44 @@
      RETURN x;
  END;
  $$;
@@ -2993,7 +2995,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- variance(int4) covers numeric_poly_combine
  -- sum(int8) covers int8_avg_combine
  -- regr_count(float8, float8) covers int8inc_float8_float8 and aggregates with > 1 arg
-@@ -2813,36 +2608,17 @@
+@@ -2813,36 +2610,17 @@
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1) u;
@@ -3036,7 +3038,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- variance(int8) covers numeric_combine
  -- avg(numeric) covers numeric_avg_combine
  EXPLAIN (COSTS OFF, VERBOSE)
-@@ -2851,46 +2627,22 @@
+@@ -2851,46 +2629,22 @@
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1
        UNION ALL SELECT * FROM tenk1) u;
@@ -3091,7 +3093,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  -- Ensure that the STRICT checks for aggregates does not take NULLness
  -- of ORDER BY columns into account. See bug report around
  -- 2a505161-2727-2473-7c46-591ed108ac52@email.cz
-@@ -2929,27 +2681,46 @@
+@@ -2929,27 +2683,46 @@
  -- does not lead to array overflow due to unexpected duplicate hash keys
  -- see CAFeeJoKKu0u+A_A9R9316djW-YW3-+Gtgvy3ju655qRHR3jtdA@mail.gmail.com
  set enable_memoize to off;
@@ -3150,7 +3152,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  select unique1, count(*), sum(twothousand) from tenk1
  group by unique1
  having sum(fivethous) > 4975
-@@ -3007,36 +2778,84 @@
+@@ -3007,36 +2780,84 @@
  (48 rows)
  
  set work_mem to default;
@@ -3244,7 +3246,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create table agg_group_2 as
  select * from
    (values (100), (300), (500)) as r(a),
-@@ -3047,30 +2866,58 @@
+@@ -3047,30 +2868,58 @@
      from agg_data_2k
      where g < r.a
      group by g/2) as s;
@@ -3310,7 +3312,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/aggregates.out --
  create table agg_hash_2 as
  select * from
    (values (100), (300), (500)) as r(a),
-@@ -3081,15 +2928,43 @@
+@@ -3081,15 +2930,43 @@
      from agg_data_2k
      where g < r.a
      group by g/2) as s;

--- a/pkg/cmd/roachtest/testdata/pg_regress/create_function_sql.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/create_function_sql.diffs
@@ -820,7 +820,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_function_s
  
  -- Regression tests for bugs:
  -- Check that arguments that are R/W expanded datums aren't corrupted by
-@@ -674,70 +758,60 @@
+@@ -674,70 +758,61 @@
  CREATE FUNCTION double_append(anyarray, anyelement) RETURNS SETOF anyarray
  LANGUAGE SQL IMMUTABLE AS
  $$ SELECT array_append($1, $2) || array_append($1, $2) $$;
@@ -847,6 +847,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/create_function_s
 +array_append(timetz[], timetz) -> timetz[]
 +array_append(jsonb[], jsonb) -> jsonb[]
 +array_append(varbit[], varbit) -> varbit[]
++array_append(ltree[], ltree) -> ltree[]
 +array_append(anyenum[], anyenum) -> anyenum[]
 +array_append(tuple[], tuple) -> tuple[]
 +

--- a/pkg/cmd/roachtest/testdata/pg_regress/polymorphism.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/polymorphism.diffs
@@ -332,61 +332,63 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  --
  -- Polymorphic aggregate tests
  --
-@@ -289,6 +260,53 @@
+@@ -289,6 +260,55 @@
  -- dual polymorphic transfn
  CREATE FUNCTION tfp(anyarray,anyelement) RETURNS anyarray AS
  'select $1 || $2' LANGUAGE SQL;
 +ERROR:  ambiguous binary operator: <anyelement[]> || <anyelement>
 +HINT:  candidates are:
++||(ltree[], ltree[]) -> ltree[]
 +||(varbit[], varbit[]) -> varbit[]
 +||(jsonb[], jsonb[]) -> jsonb[]
 +||(timetz[], timetz[]) -> timetz[]
-+||(time[], time[]) -> time[]
 +||(bool[], bool) -> bool[]
-+||(refcursor[], refcursor[]) -> refcursor[]
++||(time[], time[]) -> time[]
 +||(box2d[], box2d) -> box2d[]
-+||(pg_lsn[], pg_lsn[]) -> pg_lsn[]
++||(refcursor[], refcursor[]) -> refcursor[]
 +||(int[], int) -> int[]
-+||(inet[], inet[]) -> inet[]
++||(pg_lsn[], pg_lsn[]) -> pg_lsn[]
 +||(float[], float) -> float[]
-+||(uuid[], uuid[]) -> uuid[]
++||(inet[], inet[]) -> inet[]
 +||(decimal[], decimal) -> decimal[]
-+||(oid[], oid[]) -> oid[]
++||(uuid[], uuid[]) -> uuid[]
 +||(date[], date) -> date[]
-+||(timestamptz[], timestamptz[]) -> timestamptz[]
++||(oid[], oid[]) -> oid[]
 +||(timestamp[], timestamp) -> timestamp[]
-+||(bytes[], bytes[]) -> bytes[]
++||(timestamptz[], timestamptz[]) -> timestamptz[]
 +||(interval[], interval) -> interval[]
-+||(string[], string[]) -> string[]
++||(bytes[], bytes[]) -> bytes[]
 +||(geography[], geography) -> geography[]
-+||(geometry[], geometry[]) -> geometry[]
++||(string[], string[]) -> string[]
 +||(geometry[], geometry) -> geometry[]
-+||(geography[], geography[]) -> geography[]
++||(geometry[], geometry[]) -> geometry[]
 +||(string[], string) -> string[]
-+||(interval[], interval[]) -> interval[]
++||(geography[], geography[]) -> geography[]
 +||(bytes[], bytes) -> bytes[]
-+||(timestamp[], timestamp[]) -> timestamp[]
++||(interval[], interval[]) -> interval[]
 +||(timestamptz[], timestamptz) -> timestamptz[]
-+||(date[], date[]) -> date[]
++||(timestamp[], timestamp[]) -> timestamp[]
 +||(oid[], oid) -> oid[]
-+||(decimal[], decimal[]) -> decimal[]
++||(date[], date[]) -> date[]
 +||(uuid[], uuid) -> uuid[]
-+||(float[], float[]) -> float[]
++||(decimal[], decimal[]) -> decimal[]
 +||(inet[], inet) -> inet[]
-+||(int[], int[]) -> int[]
++||(float[], float[]) -> float[]
 +||(pg_lsn[], pg_lsn) -> pg_lsn[]
-+||(box2d[], box2d[]) -> box2d[]
++||(int[], int[]) -> int[]
 +||(refcursor[], refcursor) -> refcursor[]
-+||(bool[], bool[]) -> bool[]
++||(box2d[], box2d[]) -> box2d[]
 +||(time[], time) -> time[]
-+||(varbit[], varbit) -> varbit[]
++||(bool[], bool[]) -> bool[]
 +||(timetz[], timetz) -> timetz[]
++||(ltree[], ltree) -> ltree[]
 +||(jsonb[], jsonb) -> jsonb[]
++||(varbit[], varbit) -> varbit[]
 +
  -- dual non-polymorphic transfn
  CREATE FUNCTION tfnp(int[],int) RETURNS int[] AS
  'select $1 || $2' LANGUAGE SQL;
-@@ -301,6 +319,36 @@
+@@ -301,6 +321,36 @@
  -- multi-arg polymorphic
  CREATE FUNCTION sum3(anyelement,anyelement,anyelement) returns anyelement AS
  'select $1+$2+$3' language sql strict;
@@ -423,7 +425,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- finalfn polymorphic
  CREATE FUNCTION ffp(anyarray) RETURNS anyarray AS
  'select $1' LANGUAGE SQL;
-@@ -323,28 +371,58 @@
+@@ -323,28 +373,58 @@
  -- should CREATE
  CREATE AGGREGATE myaggp01a(*) (SFUNC = stfnp, STYPE = int4[],
    FINALFUNC = ffp, INITCOND = '{}');
@@ -488,7 +490,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  --    Case2 (R = P) && ((B = P) || (B = N))
  --    -------------------------------------
  --    S    tf1      B    tf2
-@@ -353,103 +431,226 @@
+@@ -353,103 +433,226 @@
  -- should CREATE
  CREATE AGGREGATE myaggp05a(BASETYPE = int, SFUNC = tfnp, STYPE = int[],
    FINALFUNC = ffp, INITCOND = '{}');
@@ -736,7 +738,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  --     Case3 (R = N) && (B = A)
  --     ------------------------
  --     S    tf1
-@@ -458,28 +659,58 @@
+@@ -458,28 +661,58 @@
  -- should CREATE
  CREATE AGGREGATE myaggn01a(*) (SFUNC = stfnp, STYPE = int4[],
    FINALFUNC = ffnp, INITCOND = '{}');
@@ -801,7 +803,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  --    Case4 (R = N) && ((B = P) || (B = N))
  --    -------------------------------------
  --    S    tf1      B    tf2
-@@ -488,107 +719,235 @@
+@@ -488,107 +721,235 @@
  -- should CREATE
  CREATE AGGREGATE myaggn05a(BASETYPE = int, SFUNC = tfnp, STYPE = int[],
    FINALFUNC = ffnp, INITCOND = '{}');
@@ -1059,7 +1061,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- create test data for polymorphic aggregates
  create temp table t(f1 int, f2 int[], f3 text);
  insert into t values(1,array[1],'a');
-@@ -601,220 +960,66 @@
+@@ -601,220 +962,66 @@
  insert into t values(3,array[3],'b');
  -- test the successfully created polymorphic aggregates
  select f3, myaggp01a(*) from t group by f3 order by f3;
@@ -1306,7 +1308,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select q2, sql_if(q2 > 0, q2, q2 + 1) from int8_tbl;
          q2         |      sql_if       
  -------------------+-------------------
-@@ -832,20 +1037,18 @@
+@@ -832,20 +1039,18 @@
      stype = anyarray,
      initcond = '{}'
  );
@@ -1335,56 +1337,58 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- another kind of polymorphic aggregate
  create function add_group(grp anyarray, ad anyelement, size integer)
    returns anyarray
-@@ -861,30 +1064,137 @@
+@@ -861,30 +1066,141 @@
  end;
  $$
    language plpgsql immutable;
 +ERROR:  ambiguous binary operator: <anyelement[]> || <anyelement> (returning <anyelement[]>)
 +HINT:  candidates are:
++||(ltree[], ltree[]) -> ltree[]
 +||(varbit[], varbit[]) -> varbit[]
 +||(jsonb[], jsonb[]) -> jsonb[]
 +||(timetz[], timetz[]) -> timetz[]
-+||(time[], time[]) -> time[]
 +||(bool[], bool) -> bool[]
-+||(refcursor[], refcursor[]) -> refcursor[]
++||(time[], time[]) -> time[]
 +||(box2d[], box2d) -> box2d[]
-+||(pg_lsn[], pg_lsn[]) -> pg_lsn[]
++||(refcursor[], refcursor[]) -> refcursor[]
 +||(int[], int) -> int[]
-+||(inet[], inet[]) -> inet[]
++||(pg_lsn[], pg_lsn[]) -> pg_lsn[]
 +||(float[], float) -> float[]
-+||(uuid[], uuid[]) -> uuid[]
++||(inet[], inet[]) -> inet[]
 +||(decimal[], decimal) -> decimal[]
-+||(oid[], oid[]) -> oid[]
++||(uuid[], uuid[]) -> uuid[]
 +||(date[], date) -> date[]
-+||(timestamptz[], timestamptz[]) -> timestamptz[]
++||(oid[], oid[]) -> oid[]
 +||(timestamp[], timestamp) -> timestamp[]
-+||(bytes[], bytes[]) -> bytes[]
++||(timestamptz[], timestamptz[]) -> timestamptz[]
 +||(interval[], interval) -> interval[]
-+||(string[], string[]) -> string[]
++||(bytes[], bytes[]) -> bytes[]
 +||(geography[], geography) -> geography[]
-+||(geometry[], geometry[]) -> geometry[]
++||(string[], string[]) -> string[]
 +||(geometry[], geometry) -> geometry[]
-+||(geography[], geography[]) -> geography[]
++||(geometry[], geometry[]) -> geometry[]
 +||(string[], string) -> string[]
-+||(interval[], interval[]) -> interval[]
++||(geography[], geography[]) -> geography[]
 +||(bytes[], bytes) -> bytes[]
-+||(timestamp[], timestamp[]) -> timestamp[]
++||(interval[], interval[]) -> interval[]
 +||(timestamptz[], timestamptz) -> timestamptz[]
-+||(date[], date[]) -> date[]
++||(timestamp[], timestamp[]) -> timestamp[]
 +||(oid[], oid) -> oid[]
-+||(decimal[], decimal[]) -> decimal[]
++||(date[], date[]) -> date[]
 +||(uuid[], uuid) -> uuid[]
-+||(float[], float[]) -> float[]
++||(decimal[], decimal[]) -> decimal[]
 +||(inet[], inet) -> inet[]
-+||(int[], int[]) -> int[]
++||(float[], float[]) -> float[]
 +||(pg_lsn[], pg_lsn) -> pg_lsn[]
-+||(box2d[], box2d[]) -> box2d[]
++||(int[], int[]) -> int[]
 +||(refcursor[], refcursor) -> refcursor[]
-+||(bool[], bool[]) -> bool[]
++||(box2d[], box2d[]) -> box2d[]
 +||(time[], time) -> time[]
-+||(varbit[], varbit) -> varbit[]
++||(bool[], bool[]) -> bool[]
 +||(timetz[], timetz) -> timetz[]
++||(ltree[], ltree) -> ltree[]
 +||(jsonb[], jsonb) -> jsonb[]
++||(varbit[], varbit) -> varbit[]
 +
  create aggregate build_group(anyelement, integer) (
    SFUNC = add_group,
@@ -1431,55 +1435,57 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  'select $1 || $2' language sql immutable;
 +ERROR:  ambiguous binary operator: <anyelement[]> || <anyelement>
 +HINT:  candidates are:
++||(ltree[], ltree[]) -> ltree[]
 +||(varbit[], varbit[]) -> varbit[]
 +||(jsonb[], jsonb[]) -> jsonb[]
 +||(timetz[], timetz[]) -> timetz[]
-+||(time[], time[]) -> time[]
 +||(bool[], bool) -> bool[]
-+||(refcursor[], refcursor[]) -> refcursor[]
++||(time[], time[]) -> time[]
 +||(box2d[], box2d) -> box2d[]
-+||(pg_lsn[], pg_lsn[]) -> pg_lsn[]
++||(refcursor[], refcursor[]) -> refcursor[]
 +||(int[], int) -> int[]
-+||(inet[], inet[]) -> inet[]
++||(pg_lsn[], pg_lsn[]) -> pg_lsn[]
 +||(float[], float) -> float[]
-+||(uuid[], uuid[]) -> uuid[]
++||(inet[], inet[]) -> inet[]
 +||(decimal[], decimal) -> decimal[]
-+||(oid[], oid[]) -> oid[]
++||(uuid[], uuid[]) -> uuid[]
 +||(date[], date) -> date[]
-+||(timestamptz[], timestamptz[]) -> timestamptz[]
++||(oid[], oid[]) -> oid[]
 +||(timestamp[], timestamp) -> timestamp[]
-+||(bytes[], bytes[]) -> bytes[]
++||(timestamptz[], timestamptz[]) -> timestamptz[]
 +||(interval[], interval) -> interval[]
-+||(string[], string[]) -> string[]
++||(bytes[], bytes[]) -> bytes[]
 +||(geography[], geography) -> geography[]
-+||(geometry[], geometry[]) -> geometry[]
++||(string[], string[]) -> string[]
 +||(geometry[], geometry) -> geometry[]
-+||(geography[], geography[]) -> geography[]
++||(geometry[], geometry[]) -> geometry[]
 +||(string[], string) -> string[]
-+||(interval[], interval[]) -> interval[]
++||(geography[], geography[]) -> geography[]
 +||(bytes[], bytes) -> bytes[]
-+||(timestamp[], timestamp[]) -> timestamp[]
++||(interval[], interval[]) -> interval[]
 +||(timestamptz[], timestamptz) -> timestamptz[]
-+||(date[], date[]) -> date[]
++||(timestamp[], timestamp[]) -> timestamp[]
 +||(oid[], oid) -> oid[]
-+||(decimal[], decimal[]) -> decimal[]
++||(date[], date[]) -> date[]
 +||(uuid[], uuid) -> uuid[]
-+||(float[], float[]) -> float[]
++||(decimal[], decimal[]) -> decimal[]
 +||(inet[], inet) -> inet[]
-+||(int[], int[]) -> int[]
++||(float[], float[]) -> float[]
 +||(pg_lsn[], pg_lsn) -> pg_lsn[]
-+||(box2d[], box2d[]) -> box2d[]
++||(int[], int[]) -> int[]
 +||(refcursor[], refcursor) -> refcursor[]
-+||(bool[], bool[]) -> bool[]
++||(box2d[], box2d[]) -> box2d[]
 +||(time[], time) -> time[]
-+||(varbit[], varbit) -> varbit[]
++||(bool[], bool[]) -> bool[]
 +||(timetz[], timetz) -> timetz[]
++||(ltree[], ltree) -> ltree[]
 +||(jsonb[], jsonb) -> jsonb[]
++||(varbit[], varbit) -> varbit[]
 +
  create function first_el(anyarray) returns anyelement as
  'select $1[1]' language sql strict immutable;
  create aggregate first_el_agg_f8(float8) (
-@@ -892,186 +1202,228 @@
+@@ -892,186 +1208,228 @@
    STYPE = float8[],
    FINALFUNC = first_el
  );
@@ -1825,7 +1831,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- test pg_typeof() function
  select pg_typeof(null);           -- unknown
   pg_typeof 
-@@ -1082,7 +1434,7 @@
+@@ -1082,7 +1440,7 @@
  select pg_typeof(0);              -- integer
   pg_typeof 
  -----------
@@ -1834,7 +1840,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  (1 row)
  
  select pg_typeof(0.0);            -- numeric
-@@ -1100,7 +1452,7 @@
+@@ -1100,7 +1458,7 @@
  select pg_typeof('x');            -- unknown
   pg_typeof 
  -----------
@@ -1843,7 +1849,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  (1 row)
  
  select pg_typeof('' || '');       -- text
-@@ -1112,7 +1464,7 @@
+@@ -1112,7 +1470,7 @@
  select pg_typeof(pg_typeof(0));   -- regtype
   pg_typeof 
  -----------
@@ -1852,7 +1858,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  (1 row)
  
  select pg_typeof(array[1.2,55.5]); -- numeric[]
-@@ -1122,11 +1474,7 @@
+@@ -1122,11 +1480,7 @@
  (1 row)
  
  select pg_typeof(myleast(10, 1, 20, 33));  -- polymorphic input
@@ -1865,7 +1871,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- test functions with default parameters
  -- test basic functionality
  create function dfunc(a int = 1, int = 2) returns int as $$
-@@ -1151,14 +1499,12 @@
+@@ -1151,14 +1505,12 @@
  (1 row)
  
  select dfunc(10, 20, 30);  -- fail
@@ -1882,7 +1888,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  drop function dfunc(int, int);  -- ok
  -- fail: defaults must be at end of argument list
  create function dfunc(a int = 1, b int) returns int as $$
-@@ -1169,21 +1515,29 @@
+@@ -1169,21 +1521,29 @@
  create function dfunc(a int = 1, out sum int, b int = 2) as $$
    select $1 + $2;
  $$ language sql;
@@ -1923,7 +1929,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- check implicit coercion
  create function dfunc(a int DEFAULT 1.0, int DEFAULT '-1') returns int as $$
    select $1 + $2;
-@@ -1198,10 +1552,7 @@
+@@ -1198,10 +1558,7 @@
    select $1 || ', ' || $2;
  $$ language sql;
  select dfunc();  -- fail: which dfunc should be called? int or text
@@ -1935,7 +1941,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select dfunc('Hi');  -- ok
     dfunc   
  -----------
-@@ -1237,20 +1588,17 @@
+@@ -1237,20 +1594,17 @@
  -- Now, dfunc(nargs = 2) and dfunc(nargs = 4) are ambiguous when called
  -- with 0 to 2 arguments.
  select dfunc();  -- fail
@@ -1965,7 +1971,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select dfunc(1, 2, 3);  -- ok
   dfunc 
  -------
-@@ -1274,84 +1622,79 @@
+@@ -1274,84 +1628,79 @@
  create function dfunc(anyelement = 'World'::text) returns text as $$
    select 'Hello, ' || $1::text;
  $$ language sql;
@@ -2102,7 +2108,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- Ambiguity should be reported only if there's not a better match available
  create function dfunc(int = 1, int = 2, int = 3) returns int as $$
    select 3;
-@@ -1364,10 +1707,10 @@
+@@ -1364,10 +1713,10 @@
  $$ language sql;
  -- dfunc(narg=2) and dfunc(narg=3) are ambiguous
  select dfunc(1);  -- fail
@@ -2117,7 +2123,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- but this works since the ambiguous functions aren't preferred anyway
  select dfunc('Hi');
   dfunc 
-@@ -1392,27 +1735,22 @@
+@@ -1392,27 +1741,22 @@
  (1 row)
  
  select (dfunc(a := 10, b := 20, c := 30)).*;
@@ -2158,7 +2164,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  HINT:  No function matches the given name and argument types. You might need to add explicit type casts.
  select * from dfunc(1,2);
   a | b | c | d 
-@@ -1421,40 +1759,40 @@
+@@ -1421,40 +1765,40 @@
  (1 row)
  
  select * from dfunc(1,2,c := 3);
@@ -2226,7 +2232,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  drop function dfunc(int, int, int, int);
  -- test with different parameter types
  create function dfunc(a varchar, b numeric, c date = current_date)
-@@ -1464,106 +1802,83 @@
+@@ -1464,106 +1808,83 @@
  select (dfunc('Hello World', 20, '2009-07-25'::date)).*;
        a      | b  |     c      
  -------------+----+------------
@@ -2375,7 +2381,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  --fail, named parameters are not unique
  create function testpolym(a int, a int) returns int as $$ select 1;$$ language sql;
  ERROR:  parameter name "a" used more than once
-@@ -1608,47 +1923,40 @@
+@@ -1608,47 +1929,40 @@
  (1 row)
  
  select dfunc(a := 1, b := 2);
@@ -2451,7 +2457,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select dfunc('a'::text, 'b', false); -- full positional notation
   dfunc 
  -------
-@@ -1656,11 +1964,10 @@
+@@ -1656,11 +1970,10 @@
  (1 row)
  
  select dfunc('a'::text, 'b', flag := false); -- mixed notation
@@ -2467,7 +2473,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select dfunc('a'::text, 'b', true); -- full positional notation
   dfunc 
  -------
-@@ -1668,54 +1975,46 @@
+@@ -1668,54 +1981,46 @@
  (1 row)
  
  select dfunc('a'::text, 'b', flag := true); -- mixed notation
@@ -2554,7 +2560,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select dfunc('a'::text, 'b', false); -- full positional notation
   dfunc 
  -------
-@@ -1723,11 +2022,10 @@
+@@ -1723,11 +2028,10 @@
  (1 row)
  
  select dfunc('a'::text, 'b', flag => false); -- mixed notation
@@ -2570,7 +2576,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  select dfunc('a'::text, 'b', true); -- full positional notation
   dfunc 
  -------
-@@ -1735,37 +2033,32 @@
+@@ -1735,37 +2039,32 @@
  (1 row)
  
  select dfunc('a'::text, 'b', flag => true); -- mixed notation
@@ -2628,7 +2634,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  -- need DO to protect the -- from psql
  do $$
    declare r integer;
-@@ -1775,39 +2068,43 @@
+@@ -1775,39 +2074,43 @@
      raise info 'r = %', r;
    end;
  $$;
@@ -2696,7 +2702,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/polymorphism.out 
  drop function dfunc(anyelement, anyelement, bool);
  --
  -- Tests for ANYCOMPATIBLE polymorphism family
-@@ -1816,283 +2113,213 @@
+@@ -1816,283 +2119,213 @@
  returns anycompatible as $$
    select greatest($1, $2)
  $$ language sql;

--- a/pkg/cmd/roachtest/testdata/pg_regress/privileges.diffs
+++ b/pkg/cmd/roachtest/testdata/pg_regress/privileges.diffs
@@ -4497,7 +4497,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  DROP TABLE atest1;
  DROP TABLE atest2;
  DROP TABLE atest3;
-@@ -2680,108 +4209,219 @@
+@@ -2680,108 +4209,214 @@
  DROP TABLE atest5;
  DROP TABLE atest6;
  DROP TABLE atestc;
@@ -4730,7 +4730,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  -- clean up
  DROP TABLE lock_table;
  DROP USER regress_locktable_user;
-@@ -2791,24 +4431,17 @@
+@@ -2791,24 +4426,17 @@
  \c -
  CREATE ROLE regress_readallstats;
  SELECT has_table_privilege('regress_readallstats','pg_backend_memory_contexts','SELECT'); -- no
@@ -4759,7 +4759,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT has_table_privilege('regress_readallstats','pg_shmem_allocations','SELECT'); -- yes
   has_table_privilege 
  ---------------------
-@@ -2818,11 +4451,7 @@
+@@ -2818,11 +4446,7 @@
  -- run query to ensure that functions within views can be executed
  SET ROLE regress_readallstats;
  SELECT COUNT(*) >= 0 AS ok FROM pg_backend_memory_contexts;
@@ -4772,7 +4772,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  SELECT COUNT(*) >= 0 AS ok FROM pg_shmem_allocations;
   ok 
  ----
-@@ -2838,28 +4467,48 @@
+@@ -2838,28 +4462,48 @@
  CREATE ROLE regress_group_indirect_manager;
  CREATE ROLE regress_group_member;
  GRANT regress_group TO regress_group_direct_manager WITH INHERIT FALSE, ADMIN TRUE;
@@ -4831,7 +4831,7 @@ diff -U3 --label=/mnt/data1/postgres/src/test/regress/expected/privileges.out --
  DROP ROLE regress_group;
  DROP ROLE regress_group_direct_manager;
  DROP ROLE regress_group_indirect_manager;
-@@ -2871,22 +4520,59 @@
+@@ -2871,22 +4515,59 @@
  CREATE SCHEMA regress_roleoption;
  GRANT CREATE, USAGE ON SCHEMA regress_roleoption TO PUBLIC;
  GRANT regress_roleoption_donor TO regress_roleoption_protagonist WITH INHERIT TRUE, SET FALSE;


### PR DESCRIPTION
* ltree patches moved some type outputs around
* a change to pg_regress output moved diffs down 6 rows.

Fixes: #151625
Release note: None