### PR TITLE
logictest: remove disabling buffered writes in a couple of tests

### DIFF
--- a/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
+++ b/pkg/sql/logictest/testdata/logic_test/crdb_internal_default_privileges
@@ -1,7 +1,3 @@
-# TODO(#144279): remove this.
-statement ok
-SET kv_transaction_buffered_writes_enabled = false;
-
 statement ok
 ALTER DEFAULT PRIVILEGES GRANT SELECT ON TABLES TO PUBLIC;
 ALTER DEFAULT PRIVILEGES GRANT USAGE ON TYPES TO PUBLIC;

--- a/pkg/sql/logictest/testdata/logic_test/schema_repair
+++ b/pkg/sql/logictest/testdata/logic_test/schema_repair
@@ -1,7 +1,3 @@
-# TODO(#144279): remove this.
-statement ok
-SET kv_transaction_buffered_writes_enabled = false;
-
 subtest lost_table_data
 
 # This test will intentionally corrupt descriptors, so the initial version


### PR DESCRIPTION
I was trying to see whether another change that addresses "span with results after resume span" error fixes the issue because of which we disabled write buffering, but I can no longer reproduce the issue on master at all, so it seems like it's already been fixed.

Fixes: #144279.

Release note: None